### PR TITLE
Upgrade golangci-lint to v1.52.2

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -18,7 +18,7 @@ jobs:
   conftest:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-to-1.20.4-3f4099fd0
+      image: grafana/mimir-build-image:charleskorn-golangci-lint-upgrade-beafb9184
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-to-1.20.4-3f4099fd0
+      image: grafana/mimir-build-image:charleskorn-golangci-lint-upgrade-beafb9184
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
   lint-jsonnet:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-to-1.20.4-3f4099fd0
+      image: grafana/mimir-build-image:charleskorn-golangci-lint-upgrade-beafb9184
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -92,7 +92,7 @@ jobs:
   lint-helm:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-to-1.20.4-3f4099fd0
+      image: grafana/mimir-build-image:charleskorn-golangci-lint-upgrade-beafb9184
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -121,7 +121,7 @@ jobs:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
     container:
-      image: grafana/mimir-build-image:update-go-to-1.20.4-3f4099fd0
+      image: grafana/mimir-build-image:charleskorn-golangci-lint-upgrade-beafb9184
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -156,7 +156,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-to-1.20.4-3f4099fd0
+      image: grafana/mimir-build-image:charleskorn-golangci-lint-upgrade-beafb9184
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -246,7 +246,7 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:update-go-to-1.20.4-3f4099fd0
+      image: grafana/mimir-build-image:charleskorn-golangci-lint-upgrade-beafb9184
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,3 +36,8 @@ run:
     - netgo
     - requires_docker
     - requires_libpcap
+
+issues:
+  exclude-rules:
+    - linters: [revive]
+      text: "if-return"

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= update-go-to-1.20.4-3f4099fd0
+LATEST_BUILD_IMAGE_TAG ?= charleskorn-golangci-lint-upgrade-beafb9184
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/cmd/metaconvert/main.go
+++ b/cmd/metaconvert/main.go
@@ -42,9 +42,8 @@ func main() {
 	cfg := config{}
 
 	cfg.LogLevel.RegisterFlags(flag.CommandLine)
-	initLogger := log.NewDefaultLogger(cfg.LogLevel, cfg.LogFormat)
 	cfg.LogFormat.RegisterFlags(flag.CommandLine)
-	cfg.BucketConfig.RegisterFlags(flag.CommandLine, initLogger)
+	cfg.BucketConfig.RegisterFlags(flag.CommandLine)
 
 	flag.BoolVar(&cfg.DryRun, "dry-run", false, "Don't make changes; only report what needs to be done")
 	flag.StringVar(&cfg.Tenant, "tenant", "", "Tenant to process")

--- a/integration/ca/ca.go
+++ b/integration/ca/ca.go
@@ -58,10 +58,7 @@ func writeExclusivePEMFile(path, marker string, mode os.FileMode, data []byte) (
 	}
 	defer runutil.CloseWithErrCapture(&err, f, "write pem file")
 
-	if err := pem.Encode(f, &pem.Block{Type: marker, Bytes: data}); err != nil {
-		return err
-	}
-	return nil
+	return pem.Encode(f, &pem.Block{Type: marker, Bytes: data})
 }
 
 func (ca *CA) WriteCACertificate(path string) error {

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -15,9 +15,8 @@ import (
 )
 
 const (
-	httpPort   = 8080
-	grpcPort   = 9095
-	GossipPort = 9094
+	httpPort = 8080
+	grpcPort = 9095
 )
 
 // GetDefaultImage returns the Docker image to use to run Mimir.
@@ -54,7 +53,7 @@ func getExtraFlags() map[string]string {
 func newMimirServiceFromOptions(name string, defaultFlags, flags map[string]string, options ...Option) *MimirService {
 	o := newOptions(options)
 	serviceFlags := o.MapFlags(e2e.MergeFlags(defaultFlags, flags, getExtraFlags()))
-	binaryName := getBinaryNameForBackwardsCompatibility(o.Image)
+	binaryName := getBinaryNameForBackwardsCompatibility()
 
 	return NewMimirService(
 		name,
@@ -150,7 +149,7 @@ func NewIngester(name string, consulAddress string, flags map[string]string, opt
 	)
 }
 
-func getBinaryNameForBackwardsCompatibility(image string) string {
+func getBinaryNameForBackwardsCompatibility() string {
 	return "mimir"
 }
 
@@ -277,7 +276,7 @@ func NewAlertmanagerWithTLS(name string, flags map[string]string, options ...Opt
 		"-target":    "alertmanager",
 		"-log.level": "warn",
 	}, flags, getExtraFlags()))
-	binaryName := getBinaryNameForBackwardsCompatibility(o.Image)
+	binaryName := getBinaryNameForBackwardsCompatibility()
 
 	return NewMimirService(
 		name,

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -35,7 +35,7 @@ RUN GOARCH=$(go env GOARCH) && \
     curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.51.2
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.52.2
 
 ENV SKOPEO_VERSION=v1.10.0
 RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -132,6 +132,7 @@ func init() {
 		// Since this is not a "normal" Alertmanager which reads its config
 		// from disk, we just accept and ignore web-based reload signals. Config
 		// updates are only applied externally via ApplyConfig().
+		// nolint:revive // We want to drain the channel, we don't need to do anything inside the loop body.
 		for range webReload {
 		}
 	}()

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -47,7 +47,7 @@ type stubReplicator struct{}
 func (*stubReplicator) ReplicateStateForUser(context.Context, string, *clusterpb.Part) error {
 	return nil
 }
-func (*stubReplicator) GetPositionForUser(userID string) int {
+func (*stubReplicator) GetPositionForUser(string) int {
 	return 0
 }
 func (*stubReplicator) ReadFullStateForUser(context.Context, string) ([]*clusterpb.FullState, error) {

--- a/pkg/alertmanager/alertstore/config.go
+++ b/pkg/alertmanager/alertstore/config.go
@@ -8,8 +8,6 @@ package alertstore
 import (
 	"flag"
 
-	"github.com/go-kit/log"
-
 	"github.com/grafana/mimir/pkg/alertmanager/alertstore/local"
 	"github.com/grafana/mimir/pkg/storage/bucket"
 )
@@ -21,10 +19,10 @@ type Config struct {
 }
 
 // RegisterFlags registers the backend storage config.
-func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	prefix := "alertmanager-storage."
 
 	cfg.StorageBackendConfig.ExtraBackends = []string{local.Name}
 	cfg.Local.RegisterFlagsWithPrefix(prefix, f)
-	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "alertmanager", f, logger)
+	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "alertmanager", f)
 }

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -96,32 +96,32 @@ func (f *Store) GetAlertConfig(_ context.Context, user string) (alertspb.AlertCo
 }
 
 // SetAlertConfig implements alertstore.AlertStore.
-func (f *Store) SetAlertConfig(_ context.Context, cfg alertspb.AlertConfigDesc) error {
+func (f *Store) SetAlertConfig(_ context.Context, _ alertspb.AlertConfigDesc) error {
 	return errReadOnly
 }
 
 // DeleteAlertConfig implements alertstore.AlertStore.
-func (f *Store) DeleteAlertConfig(_ context.Context, user string) error {
+func (f *Store) DeleteAlertConfig(_ context.Context, _ string) error {
 	return errReadOnly
 }
 
 // ListUsersWithFullState implements alertstore.AlertStore.
-func (f *Store) ListUsersWithFullState(ctx context.Context) ([]string, error) {
+func (f *Store) ListUsersWithFullState(_ context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
 // GetFullState implements alertstore.AlertStore.
-func (f *Store) GetFullState(ctx context.Context, user string) (alertspb.FullStateDesc, error) {
+func (f *Store) GetFullState(_ context.Context, _ string) (alertspb.FullStateDesc, error) {
 	return alertspb.FullStateDesc{}, alertspb.ErrNotFound
 }
 
 // SetFullState implements alertstore.AlertStore.
-func (f *Store) SetFullState(ctx context.Context, user string, cfg alertspb.FullStateDesc) error {
+func (f *Store) SetFullState(_ context.Context, _ string, _ alertspb.FullStateDesc) error {
 	return errState
 }
 
 // DeleteFullState implements alertstore.AlertStore.
-func (f *Store) DeleteFullState(ctx context.Context, user string) error {
+func (f *Store) DeleteFullState(_ context.Context, _ string) error {
 	return errState
 }
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -1125,7 +1125,7 @@ func (am *MultitenantAlertmanager) getPerUserDirectories() map[string]string {
 }
 
 // ReadState implements the Alertmanager service.
-func (am *MultitenantAlertmanager) ReadState(ctx context.Context, req *alertmanagerpb.ReadStateRequest) (*alertmanagerpb.ReadStateResponse, error) {
+func (am *MultitenantAlertmanager) ReadState(ctx context.Context, _ *alertmanagerpb.ReadStateRequest) (*alertmanagerpb.ReadStateResponse, error) {
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2286,15 +2286,15 @@ type passthroughAlertmanagerClient struct {
 	server alertmanagerpb.AlertmanagerServer
 }
 
-func (am *passthroughAlertmanagerClient) UpdateState(ctx context.Context, in *clusterpb.Part, opts ...grpc.CallOption) (*alertmanagerpb.UpdateStateResponse, error) {
+func (am *passthroughAlertmanagerClient) UpdateState(ctx context.Context, in *clusterpb.Part, _ ...grpc.CallOption) (*alertmanagerpb.UpdateStateResponse, error) {
 	return am.server.UpdateState(ctx, in)
 }
 
-func (am *passthroughAlertmanagerClient) ReadState(ctx context.Context, in *alertmanagerpb.ReadStateRequest, opts ...grpc.CallOption) (*alertmanagerpb.ReadStateResponse, error) {
+func (am *passthroughAlertmanagerClient) ReadState(ctx context.Context, in *alertmanagerpb.ReadStateRequest, _ ...grpc.CallOption) (*alertmanagerpb.ReadStateResponse, error) {
 	return am.server.ReadState(ctx, in)
 }
 
-func (am *passthroughAlertmanagerClient) HandleRequest(ctx context.Context, in *httpgrpc.HTTPRequest, opts ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+func (am *passthroughAlertmanagerClient) HandleRequest(ctx context.Context, in *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 	return am.server.HandleRequest(ctx, in)
 }
 
@@ -2342,31 +2342,31 @@ type mockAlertManagerLimits struct {
 	maxAlertsSizeBytes             int
 }
 
-func (m *mockAlertManagerLimits) AlertmanagerMaxConfigSize(tenant string) int {
+func (m *mockAlertManagerLimits) AlertmanagerMaxConfigSize(string) int {
 	return m.maxConfigSize
 }
 
-func (m *mockAlertManagerLimits) AlertmanagerMaxTemplatesCount(tenant string) int {
+func (m *mockAlertManagerLimits) AlertmanagerMaxTemplatesCount(string) int {
 	return m.maxTemplatesCount
 }
 
-func (m *mockAlertManagerLimits) AlertmanagerMaxTemplateSize(tenant string) int {
+func (m *mockAlertManagerLimits) AlertmanagerMaxTemplateSize(string) int {
 	return m.maxSizeOfTemplate
 }
 
-func (m *mockAlertManagerLimits) AlertmanagerReceiversBlockCIDRNetworks(user string) []flagext.CIDR {
+func (m *mockAlertManagerLimits) AlertmanagerReceiversBlockCIDRNetworks(string) []flagext.CIDR {
 	panic("implement me")
 }
 
-func (m *mockAlertManagerLimits) AlertmanagerReceiversBlockPrivateAddresses(user string) bool {
+func (m *mockAlertManagerLimits) AlertmanagerReceiversBlockPrivateAddresses(string) bool {
 	panic("implement me")
 }
 
-func (m *mockAlertManagerLimits) NotificationRateLimit(_ string, integration string) rate.Limit {
+func (m *mockAlertManagerLimits) NotificationRateLimit(string, string) rate.Limit {
 	return m.emailNotificationRateLimit
 }
 
-func (m *mockAlertManagerLimits) NotificationBurstSize(_ string, integration string) int {
+func (m *mockAlertManagerLimits) NotificationBurstSize(string, string) int {
 	return m.emailNotificationBurst
 }
 

--- a/pkg/alertmanager/rate_limited_notifier_test.go
+++ b/pkg/alertmanager/rate_limited_notifier_test.go
@@ -71,7 +71,7 @@ func runNotifications(t *testing.T, rateLimitedNotifier *rateLimitedNotifier, co
 
 type mockNotifier struct{}
 
-func (m *mockNotifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, error) {
+func (m *mockNotifier) Notify(context.Context, ...*types.Alert) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/alertmanager/state_persister_test.go
+++ b/pkg/alertmanager/state_persister_test.go
@@ -45,7 +45,7 @@ func newFakePersistableState() *fakePersistableState {
 	}
 }
 
-func (f *fakePersistableState) WaitReady(ctx context.Context) error {
+func (f *fakePersistableState) WaitReady(context.Context) error {
 	<-f.readyc
 	return nil
 }
@@ -62,7 +62,7 @@ type fakeStore struct {
 	writes    []fakeStoreWrite
 }
 
-func (f *fakeStore) SetFullState(ctx context.Context, user string, desc alertspb.FullStateDesc) error {
+func (f *fakeStore) SetFullState(_ context.Context, user string, desc alertspb.FullStateDesc) error {
 	f.writesMtx.Lock()
 	defer f.writesMtx.Unlock()
 	f.writes = append(f.writes, fakeStoreWrite{user, desc})

--- a/pkg/alertmanager/state_replication_test.go
+++ b/pkg/alertmanager/state_replication_test.go
@@ -63,7 +63,7 @@ func newFakeReplicator() *fakeReplicator {
 	}
 }
 
-func (f *fakeReplicator) ReplicateStateForUser(ctx context.Context, userID string, p *clusterpb.Part) error {
+func (f *fakeReplicator) ReplicateStateForUser(_ context.Context, userID string, p *clusterpb.Part) error {
 	f.mtx.Lock()
 	f.results[userID] = p
 	f.mtx.Unlock()

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/server"
 
@@ -365,12 +364,9 @@ type Distributor interface {
 	UserStatsHandler(w http.ResponseWriter, r *http.Request)
 }
 
-// RegisterQueryable registers the the default routes associated with the querier
+// RegisterQueryable registers the default routes associated with the querier
 // module.
-func (a *API) RegisterQueryable(
-	queryable storage.SampleAndChunkQueryable,
-	distributor Distributor,
-) {
+func (a *API) RegisterQueryable(distributor Distributor) {
 	// these routes are always registered to the default server
 	a.RegisterRoute("/api/v1/user_stats", http.HandlerFunc(distributor.UserStatsHandler), true, true, "GET")
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -22,7 +22,7 @@ import (
 
 type FakeLogger struct{}
 
-func (fl *FakeLogger) Log(keyvals ...interface{}) error {
+func (fl *FakeLogger) Log(...interface{}) error {
 	return nil
 }
 
@@ -31,10 +31,10 @@ func TestNewApiWithoutSourceIPExtractor(t *testing.T) {
 	serverCfg := server.Config{
 		MetricsNamespace: "without_source_ip_extractor",
 	}
-	server, err := server.New(serverCfg)
+	srv, err := server.New(serverCfg)
 	require.NoError(t, err)
 
-	api, err := New(cfg, serverCfg, server, &FakeLogger{})
+	api, err := New(cfg, serverCfg, srv, &FakeLogger{})
 	require.NoError(t, err)
 	require.Nil(t, api.sourceIPs)
 }
@@ -45,10 +45,10 @@ func TestNewApiWithSourceIPExtractor(t *testing.T) {
 		LogSourceIPs:     true,
 		MetricsNamespace: "with_source_ip_extractor",
 	}
-	server, err := server.New(serverCfg)
+	srv, err := server.New(serverCfg)
 	require.NoError(t, err)
 
-	api, err := New(cfg, serverCfg, server, &FakeLogger{})
+	api, err := New(cfg, serverCfg, srv, &FakeLogger{})
 	require.NoError(t, err)
 	require.NotNil(t, api.sourceIPs)
 }

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1041,15 +1041,15 @@ func (m *mockConfigProvider) CompactorBlockUploadMaxBlockSizeBytes(user string) 
 	return m.blockUploadMaxBlockSizeBytes[user]
 }
 
-func (m *mockConfigProvider) S3SSEType(user string) string {
+func (m *mockConfigProvider) S3SSEType(string) string {
 	return ""
 }
 
-func (m *mockConfigProvider) S3SSEKMSKeyID(userID string) string {
+func (m *mockConfigProvider) S3SSEKMSKeyID(string) string {
 	return ""
 }
 
-func (m *mockConfigProvider) S3SSEKMSEncryptionContext(userID string) string {
+func (m *mockConfigProvider) S3SSEKMSEncryptionContext(string) string {
 	return ""
 }
 

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -953,7 +953,7 @@ func (f *NoCompactionMarkFilter) NoCompactMarkedBlocks() map[ulid.ULID]struct{} 
 
 // Filter finds blocks that should not be compacted, and fills f.noCompactMarkedMap. If f.removeNoCompactBlocks is true,
 // blocks are also removed from metas. (Thanos version of the filter doesn't do removal).
-func (f *NoCompactionMarkFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, modified block.GaugeVec) error {
+func (f *NoCompactionMarkFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, _ block.GaugeVec) error {
 	noCompactMarkedMap := make(map[ulid.ULID]struct{})
 
 	// Find all no-compact markers in the storage.
@@ -1017,7 +1017,7 @@ func (f *ExcludeMarkedForDeletionFilter) DeletionMarkBlocks() map[ulid.ULID]stru
 
 // Filter filters out blocks that are marked for deletion.
 // It also builds the map returned by DeletionMarkBlocks() method.
-func (f *ExcludeMarkedForDeletionFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, modified block.GaugeVec) error {
+func (f *ExcludeMarkedForDeletionFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, _ block.GaugeVec) error {
 	deletionMarkMap := make(map[ulid.ULID]struct{})
 
 	// Find all markers in the storage.

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -155,7 +155,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.Var(&cfg.DisabledTenants, "compactor.disabled-tenants", "Comma separated list of tenants that cannot be compacted by this compactor. If specified, and compactor would normally pick given tenant for compaction (via -compactor.enabled-tenants or sharding), it will be ignored instead.")
 }
 
-func (cfg *Config) Validate(logger log.Logger) error {
+func (cfg *Config) Validate() error {
 	// Each block range period should be divisible by the previous one.
 	for i := 1; i < len(cfg.BlockRanges); i++ {
 		if cfg.BlockRanges[i]%cfg.BlockRanges[i-1] != 0 {
@@ -281,10 +281,8 @@ func NewMultitenantCompactor(compactorCfg Config, storageCfg mimir_tsdb.BlocksSt
 		return bucket.NewClient(ctx, storageCfg.Bucket, "compactor", logger, registerer)
 	}
 
-	// Configure the compactor and grouper factories.
-	if compactorCfg.BlocksGrouperFactory != nil && compactorCfg.BlocksCompactorFactory != nil {
-		// Nothing to do because it was already set by a downstream project.
-	} else {
+	// Configure the compactor and grouper factories only if they weren't already set by a downstream project.
+	if compactorCfg.BlocksGrouperFactory == nil || compactorCfg.BlocksCompactorFactory == nil {
 		configureSplitAndMergeCompactor(&compactorCfg)
 	}
 

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -138,7 +138,7 @@ func TestConfig_Validate(t *testing.T) {
 			flagext.DefaultValues(cfg)
 			testData.setup(cfg)
 
-			if actualErr := cfg.Validate(log.NewNopLogger()); testData.expected != "" {
+			if actualErr := cfg.Validate(); testData.expected != "" {
 				assert.EqualError(t, actualErr, testData.expected)
 			} else {
 				assert.NoError(t, actualErr)

--- a/pkg/compactor/shard_aware_deduplicate_filter.go
+++ b/pkg/compactor/shard_aware_deduplicate_filter.go
@@ -33,7 +33,7 @@ func NewShardAwareDeduplicateFilter() *ShardAwareDeduplicateFilter {
 
 // Filter filters out from metas, the initial map of blocks, all the blocks that are contained in other, compacted, blocks.
 // The removed blocks are source blocks of the blocks that remain in metas after the filtering is executed.
-func (f *ShardAwareDeduplicateFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, modified block.GaugeVec) error {
+func (f *ShardAwareDeduplicateFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, _ block.GaugeVec) error {
 	f.duplicateIDs = f.duplicateIDs[:0]
 
 	metasByResolution := make(map[int64][]*metadata.Meta)

--- a/pkg/compactor/split_merge_compactor.go
+++ b/pkg/compactor/split_merge_compactor.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 )
 
-func splitAndMergeGrouperFactory(ctx context.Context, cfg Config, cfgProvider ConfigProvider, userID string, logger log.Logger, reg prometheus.Registerer) Grouper {
+func splitAndMergeGrouperFactory(_ context.Context, cfg Config, cfgProvider ConfigProvider, userID string, logger log.Logger, _ prometheus.Registerer) Grouper {
 	return NewSplitAndMergeGrouper(
 		userID,
 		cfg.BlockRanges.ToMilliseconds(),

--- a/pkg/continuoustest/manager_test.go
+++ b/pkg/continuoustest/manager_test.go
@@ -24,12 +24,12 @@ func (d *dummyTest) Name() string {
 }
 
 // Init implements Test.
-func (d *dummyTest) Init(ctx context.Context, now time.Time) error {
+func (d *dummyTest) Init(_ context.Context, _ time.Time) error {
 	return nil
 }
 
 // Run implements Test.
-func (d *dummyTest) Run(ctx context.Context, now time.Time) error {
+func (d *dummyTest) Run(_ context.Context, _ time.Time) error {
 	d.runs++
 	return d.err
 }

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -149,7 +149,7 @@ func (t *WriteReadSeriesTest) RunInner(ctx context.Context, now time.Time, write
 		}
 
 		series := generateSeries(metricName, timestamp, t.cfg.NumSeries)
-		if err := t.writeSamples(ctx, metricName, typeLabel, timestamp, series, records); err != nil {
+		if err := t.writeSamples(ctx, typeLabel, timestamp, series, records); err != nil {
 			errs.Add(err)
 			break
 		}
@@ -175,7 +175,7 @@ func (t *WriteReadSeriesTest) RunInner(ctx context.Context, now time.Time, write
 	}
 }
 
-func (t *WriteReadSeriesTest) writeSamples(ctx context.Context, metricName, typeLabel string, timestamp time.Time, series []prompb.TimeSeries, records *MetricHistory) error {
+func (t *WriteReadSeriesTest) writeSamples(ctx context.Context, typeLabel string, timestamp time.Time, series []prompb.TimeSeries, records *MetricHistory) error {
 	sp, ctx := spanlogger.NewWithLogger(ctx, t.logger, "WriteReadSeriesTest.writeSamples")
 	defer sp.Finish()
 	logger := log.With(sp, "timestamp", timestamp.String(), "num_series", t.cfg.NumSeries)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3299,7 +3299,7 @@ func (i *mockIngester) series() map[uint32]*mimirpb.PreallocTimeseries {
 	return result
 }
 
-func (i *mockIngester) Check(ctx context.Context, in *grpc_health_v1.HealthCheckRequest, opts ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
+func (i *mockIngester) Check(context.Context, *grpc_health_v1.HealthCheckRequest, ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
 	i.Lock()
 	defer i.Unlock()
 
@@ -3312,7 +3312,7 @@ func (i *mockIngester) Close() error {
 	return nil
 }
 
-func (i *mockIngester) Push(ctx context.Context, req *mimirpb.WriteRequest, opts ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
+func (i *mockIngester) Push(ctx context.Context, req *mimirpb.WriteRequest, _ ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
 	time.Sleep(i.pushDelay)
 
 	i.Lock()
@@ -3388,7 +3388,7 @@ func makeWireChunk(c chunk.EncodedChunk) client.Chunk {
 	return chunk
 }
 
-func (i *mockIngester) QueryStream(ctx context.Context, req *client.QueryRequest, opts ...grpc.CallOption) (client.Ingester_QueryStreamClient, error) {
+func (i *mockIngester) QueryStream(_ context.Context, req *client.QueryRequest, _ ...grpc.CallOption) (client.Ingester_QueryStreamClient, error) {
 	time.Sleep(i.queryDelay)
 
 	i.Lock()
@@ -3500,7 +3500,7 @@ func (i *mockIngester) QueryStream(ctx context.Context, req *client.QueryRequest
 	}, nil
 }
 
-func (i *mockIngester) MetricsForLabelMatchers(ctx context.Context, req *client.MetricsForLabelMatchersRequest, opts ...grpc.CallOption) (*client.MetricsForLabelMatchersResponse, error) {
+func (i *mockIngester) MetricsForLabelMatchers(_ context.Context, req *client.MetricsForLabelMatchersRequest, _ ...grpc.CallOption) (*client.MetricsForLabelMatchersResponse, error) {
 	i.Lock()
 	defer i.Unlock()
 
@@ -3526,7 +3526,7 @@ func (i *mockIngester) MetricsForLabelMatchers(ctx context.Context, req *client.
 	return &response, nil
 }
 
-func (i *mockIngester) LabelNames(ctx context.Context, req *client.LabelNamesRequest, opts ...grpc.CallOption) (*client.LabelNamesResponse, error) {
+func (i *mockIngester) LabelNames(_ context.Context, req *client.LabelNamesRequest, _ ...grpc.CallOption) (*client.LabelNamesResponse, error) {
 	i.Lock()
 	defer i.Unlock()
 
@@ -3554,7 +3554,7 @@ func (i *mockIngester) LabelNames(ctx context.Context, req *client.LabelNamesReq
 	return &response, nil
 }
 
-func (i *mockIngester) MetricsMetadata(ctx context.Context, req *client.MetricsMetadataRequest, opts ...grpc.CallOption) (*client.MetricsMetadataResponse, error) {
+func (i *mockIngester) MetricsMetadata(context.Context, *client.MetricsMetadataRequest, ...grpc.CallOption) (*client.MetricsMetadataResponse, error) {
 	i.Lock()
 	defer i.Unlock()
 
@@ -3621,7 +3621,7 @@ func (s *labelNamesAndValuesMockStream) Recv() (*client.LabelNamesAndValuesRespo
 	return result, nil
 }
 
-func (i *mockIngester) LabelValuesCardinality(ctx context.Context, req *client.LabelValuesCardinalityRequest, opts ...grpc.CallOption) (client.Ingester_LabelValuesCardinalityClient, error) {
+func (i *mockIngester) LabelValuesCardinality(_ context.Context, req *client.LabelValuesCardinalityRequest, _ ...grpc.CallOption) (client.Ingester_LabelValuesCardinalityClient, error) {
 	i.Lock()
 	defer i.Unlock()
 
@@ -3716,7 +3716,7 @@ func (i *noopIngester) Close() error {
 	return nil
 }
 
-func (i *noopIngester) Push(ctx context.Context, req *mimirpb.WriteRequest, opts ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
+func (i *noopIngester) Push(context.Context, *mimirpb.WriteRequest, ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
 	return nil, nil
 }
 
@@ -3739,11 +3739,11 @@ func (s *stream) Recv() (*client.QueryStreamResponse, error) {
 	return result, nil
 }
 
-func (i *mockIngester) AllUserStats(ctx context.Context, in *client.UserStatsRequest, opts ...grpc.CallOption) (*client.UsersStatsResponse, error) {
+func (i *mockIngester) AllUserStats(context.Context, *client.UserStatsRequest, ...grpc.CallOption) (*client.UsersStatsResponse, error) {
 	return &i.stats, nil
 }
 
-func (i *mockIngester) UserStats(ctx context.Context, in *client.UserStatsRequest, opts ...grpc.CallOption) (*client.UserStatsResponse, error) {
+func (i *mockIngester) UserStats(context.Context, *client.UserStatsRequest, ...grpc.CallOption) (*client.UserStatsResponse, error) {
 	if !i.happy {
 		return nil, errFail
 	}

--- a/pkg/distributor/instance_count_test.go
+++ b/pkg/distributor/instance_count_test.go
@@ -13,17 +13,17 @@ import (
 
 type nopDelegate struct{}
 
-func (n nopDelegate) OnRingInstanceRegister(lifecycler *ring.BasicLifecycler, ringDesc ring.Desc, instanceExists bool, instanceID string, instanceDesc ring.InstanceDesc) (ring.InstanceState, ring.Tokens) {
+func (n nopDelegate) OnRingInstanceRegister(_ *ring.BasicLifecycler, _ ring.Desc, _ bool, _ string, instanceDesc ring.InstanceDesc) (ring.InstanceState, ring.Tokens) {
 	return instanceDesc.State, instanceDesc.GetTokens()
 }
 
-func (n nopDelegate) OnRingInstanceTokens(lifecycler *ring.BasicLifecycler, tokens ring.Tokens) {
+func (n nopDelegate) OnRingInstanceTokens(*ring.BasicLifecycler, ring.Tokens) {
 }
 
-func (n nopDelegate) OnRingInstanceStopping(lifecycler *ring.BasicLifecycler) {
+func (n nopDelegate) OnRingInstanceStopping(*ring.BasicLifecycler) {
 }
 
-func (n nopDelegate) OnRingInstanceHeartbeat(lifecycler *ring.BasicLifecycler, ringDesc *ring.Desc, instanceDesc *ring.InstanceDesc) {
+func (n nopDelegate) OnRingInstanceHeartbeat(*ring.BasicLifecycler, *ring.Desc, *ring.InstanceDesc) {
 }
 
 func TestHealthyInstanceDelegate_OnRingInstanceHeartbeat(t *testing.T) {

--- a/pkg/distributor/rate_strategy.go
+++ b/pkg/distributor/rate_strategy.go
@@ -100,11 +100,11 @@ func newInfiniteRateStrategy() limiter.RateLimiterStrategy {
 	return &infiniteStrategy{}
 }
 
-func (s *infiniteStrategy) Limit(tenantID string) float64 {
+func (s *infiniteStrategy) Limit(_ string) float64 {
 	return float64(rate.Inf)
 }
 
-func (s *infiniteStrategy) Burst(tenantID string) int {
+func (s *infiniteStrategy) Burst(_ string) int {
 	// Burst is ignored when limit = rate.Inf
 	return 0
 }

--- a/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
+++ b/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
@@ -91,7 +91,7 @@ type visitor struct {
 }
 
 // Visit implements parser.Visitor
-func (v *visitor) Visit(node parser.Node, path []parser.Node) (parser.Visitor, error) {
+func (v *visitor) Visit(node parser.Node, _ []parser.Node) (parser.Visitor, error) {
 	// if the visitor has already seen a predicate success, don't overwrite
 	if v.result {
 		return nil, nil

--- a/pkg/frontend/querymiddleware/instrumentation.go
+++ b/pkg/frontend/querymiddleware/instrumentation.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -17,7 +16,7 @@ import (
 )
 
 // newInstrumentMiddleware can be inserted into the middleware chain to expose timing information.
-func newInstrumentMiddleware(name string, metrics *instrumentMiddlewareMetrics, logger log.Logger) Middleware {
+func newInstrumentMiddleware(name string, metrics *instrumentMiddlewareMetrics) Middleware {
 	var durationCol instrument.Collector
 
 	// Support the case metrics shouldn't be tracked (ie. unit tests).
@@ -70,7 +69,7 @@ type noopCollector struct{}
 func (c *noopCollector) Register() {}
 
 // Before implements instrument.Collector.
-func (c *noopCollector) Before(ctx context.Context, method string, start time.Time) {}
+func (c *noopCollector) Before(context.Context, string, time.Time) {}
 
 // After implements instrument.Collector.
-func (c *noopCollector) After(ctx context.Context, method, statusCode string, start time.Time) {}
+func (c *noopCollector) After(context.Context, string, string, time.Time) {}

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -447,10 +447,6 @@ func (m mockLimits) MaxQueryLookback(string) time.Duration {
 	return m.maxQueryLookback
 }
 
-func (m mockLimits) MaxQueryLength(string) time.Duration {
-	return m.maxQueryLength
-}
-
 func (m mockLimits) MaxTotalQueryLength(string) time.Duration {
 	if m.maxTotalQueryLength == time.Duration(0) {
 		return m.maxQueryLength
@@ -489,31 +485,31 @@ func (m mockLimits) SplitInstantQueriesByInterval(string) time.Duration {
 	return m.splitInstantQueriesInterval
 }
 
-func (m mockLimits) CompactorSplitAndMergeShards(userID string) int {
+func (m mockLimits) CompactorSplitAndMergeShards(string) int {
 	return m.compactorShards
 }
 
-func (m mockLimits) CompactorBlocksRetentionPeriod(userID string) time.Duration {
+func (m mockLimits) CompactorBlocksRetentionPeriod(string) time.Duration {
 	return m.compactorBlocksRetentionPeriod
 }
 
-func (m mockLimits) OutOfOrderTimeWindow(userID string) time.Duration {
+func (m mockLimits) OutOfOrderTimeWindow(string) time.Duration {
 	return m.outOfOrderTimeWindow
 }
 
-func (m mockLimits) ResultsCacheTTL(userID string) time.Duration {
+func (m mockLimits) ResultsCacheTTL(string) time.Duration {
 	return m.resultsCacheTTL
 }
 
-func (m mockLimits) ResultsCacheTTLForOutOfOrderTimeWindow(userID string) time.Duration {
+func (m mockLimits) ResultsCacheTTLForOutOfOrderTimeWindow(string) time.Duration {
 	return m.resultsCacheOutOfOrderWindowTTL
 }
 
-func (m mockLimits) CreationGracePeriod(userID string) time.Duration {
+func (m mockLimits) CreationGracePeriod(string) time.Duration {
 	return m.creationGracePeriod
 }
 
-func (m mockLimits) NativeHistogramsIngestionEnabled(userID string) bool {
+func (m mockLimits) NativeHistogramsIngestionEnabled(string) bool {
 	return m.nativeHistogramsIngestionEnabled
 }
 

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -41,52 +41,52 @@ func newEmptyPrometheusResponse() *PrometheusResponse {
 
 // WithID clones the current `PrometheusRangeQueryRequest` with the provided ID.
 func (q *PrometheusRangeQueryRequest) WithID(id int64) Request {
-	new := *q
-	new.Id = id
-	return &new
+	newRequest := *q
+	newRequest.Id = id
+	return &newRequest
 }
 
 // WithStartEnd clones the current `PrometheusRangeQueryRequest` with a new `start` and `end` timestamp.
 func (q *PrometheusRangeQueryRequest) WithStartEnd(start int64, end int64) Request {
-	new := *q
-	new.Start = start
-	new.End = end
-	return &new
+	newRequest := *q
+	newRequest.Start = start
+	newRequest.End = end
+	return &newRequest
 }
 
 // WithQuery clones the current `PrometheusRangeQueryRequest` with a new query.
 func (q *PrometheusRangeQueryRequest) WithQuery(query string) Request {
-	new := *q
-	new.Query = query
-	return &new
+	newRequest := *q
+	newRequest.Query = query
+	return &newRequest
 }
 
 // WithTotalQueriesHint clones the current `PrometheusRangeQueryRequest` with an
 // added Hint value for TotalQueries.
 func (q *PrometheusRangeQueryRequest) WithTotalQueriesHint(totalQueries int32) Request {
-	new := *q
-	if new.Hints == nil {
-		new.Hints = &Hints{TotalQueries: totalQueries}
+	newRequest := *q
+	if newRequest.Hints == nil {
+		newRequest.Hints = &Hints{TotalQueries: totalQueries}
 	} else {
-		*new.Hints = *(q.Hints)
-		new.Hints.TotalQueries = totalQueries
+		*newRequest.Hints = *(q.Hints)
+		newRequest.Hints.TotalQueries = totalQueries
 	}
-	return &new
+	return &newRequest
 }
 
 // WithEstimatedSeriesCountHint clones the current `PrometheusRangeQueryRequest`
 // with an added Hint value for EstimatedCardinality.
 func (q *PrometheusRangeQueryRequest) WithEstimatedSeriesCountHint(count uint64) Request {
-	new := *q
-	if new.Hints == nil {
-		new.Hints = &Hints{
+	newRequest := *q
+	if newRequest.Hints == nil {
+		newRequest.Hints = &Hints{
 			CardinalityEstimate: &Hints_EstimatedSeriesCount{count},
 		}
 	} else {
-		*new.Hints = *(q.Hints)
-		new.Hints.CardinalityEstimate = &Hints_EstimatedSeriesCount{count}
+		*newRequest.Hints = *(q.Hints)
+		newRequest.Hints.CardinalityEstimate = &Hints_EstimatedSeriesCount{count}
 	}
-	return &new
+	return &newRequest
 }
 
 // LogToSpan logs the current `PrometheusRangeQueryRequest` parameters to the specified span.
@@ -112,45 +112,45 @@ func (r *PrometheusInstantQueryRequest) GetStep() int64 {
 }
 
 func (r *PrometheusInstantQueryRequest) WithID(id int64) Request {
-	new := *r
-	new.Id = id
-	return &new
+	newRequest := *r
+	newRequest.Id = id
+	return &newRequest
 }
 
-func (r *PrometheusInstantQueryRequest) WithStartEnd(startTime int64, endTime int64) Request {
-	new := *r
-	new.Time = startTime
-	return &new
+func (r *PrometheusInstantQueryRequest) WithStartEnd(startTime int64, _ int64) Request {
+	newRequest := *r
+	newRequest.Time = startTime
+	return &newRequest
 }
 
 func (r *PrometheusInstantQueryRequest) WithQuery(s string) Request {
-	new := *r
-	new.Query = s
-	return &new
+	newRequest := *r
+	newRequest.Query = s
+	return &newRequest
 }
 
 func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32) Request {
-	new := *r
-	if new.Hints == nil {
-		new.Hints = &Hints{TotalQueries: totalQueries}
+	newRequest := *r
+	if newRequest.Hints == nil {
+		newRequest.Hints = &Hints{TotalQueries: totalQueries}
 	} else {
-		*new.Hints = *(r.Hints)
-		new.Hints.TotalQueries = totalQueries
+		*newRequest.Hints = *(r.Hints)
+		newRequest.Hints.TotalQueries = totalQueries
 	}
-	return &new
+	return &newRequest
 }
 
 func (r *PrometheusInstantQueryRequest) WithEstimatedSeriesCountHint(count uint64) Request {
-	new := *r
-	if new.Hints == nil {
-		new.Hints = &Hints{
+	newRequest := *r
+	if newRequest.Hints == nil {
+		newRequest.Hints = &Hints{
 			CardinalityEstimate: &Hints_EstimatedSeriesCount{count},
 		}
 	} else {
-		*new.Hints = *(r.Hints)
-		new.Hints.CardinalityEstimate = &Hints_EstimatedSeriesCount{count}
+		*newRequest.Hints = *(r.Hints)
+		newRequest.Hints.CardinalityEstimate = &Hints_EstimatedSeriesCount{count}
 	}
-	return &new
+	return &newRequest
 }
 
 func (r *PrometheusInstantQueryRequest) LogToSpan(sp opentracing.Span) {

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -752,8 +752,8 @@ func requireValidSamples(t *testing.T, result []SampleStream) {
 				return
 			}
 		}
-		for _, histogram := range stream.Histograms {
-			if !math.IsNaN(histogram.Histogram.Sum) {
+		for _, h := range stream.Histograms {
+			if !math.IsNaN(h.Histogram.Sum) {
 				return
 			}
 		}
@@ -1997,11 +1997,11 @@ func (m *querierMock) Select(sorted bool, _ *storage.SelectHints, matchers ...*l
 	return newSeriesIteratorMock(filtered)
 }
 
-func (m *querierMock) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (m *querierMock) LabelValues(_ string, _ ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, nil
 }
 
-func (m *querierMock) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (m *querierMock) LabelNames(_ ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, nil
 }
 

--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -95,7 +95,7 @@ type mockShardedQueryable struct {
 }
 
 // Querier impls storage.Queryable
-func (q *mockShardedQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+func (q *mockShardedQueryable) Querier(_ context.Context, _, _ int64) (storage.Querier, error) {
 	return q, nil
 }
 
@@ -186,12 +186,12 @@ func (s *shardLabelSeries) Labels() labels.Labels {
 }
 
 // LabelValues impls storage.Querier
-func (q *mockShardedQueryable) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (q *mockShardedQueryable) LabelValues(_ string, _ ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, errors.Errorf("unimplemented")
 }
 
 // LabelNames returns all the unique label names present in the block in sorted order.
-func (q *mockShardedQueryable) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (q *mockShardedQueryable) LabelNames(_ ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, errors.Errorf("unimplemented")
 }
 

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -358,14 +358,14 @@ type accumulator struct {
 }
 
 func mergeCacheExtentsWithAccumulator(extents []Extent, acc *accumulator) ([]Extent, error) {
-	any, err := types.MarshalAny(acc.Response)
+	marshalled, err := types.MarshalAny(acc.Response)
 	if err != nil {
 		return nil, err
 	}
 	return append(extents, Extent{
 		Start:            acc.Extent.Start,
 		End:              acc.Extent.End,
-		Response:         any,
+		Response:         marshalled,
 		TraceId:          acc.Extent.TraceId,
 		QueryTimestampMs: acc.QueryTimestampMs,
 	}), nil
@@ -383,14 +383,14 @@ func newAccumulator(base Extent) (*accumulator, error) {
 }
 
 func toExtent(ctx context.Context, req Request, res Response, queryTime time.Time) (Extent, error) {
-	any, err := types.MarshalAny(res)
+	marshalled, err := types.MarshalAny(res)
 	if err != nil {
 		return Extent{}, err
 	}
 	return Extent{
 		Start:            req.GetStart(),
 		End:              req.GetEnd(),
-		Response:         any,
+		Response:         marshalled,
 		TraceId:          jaegerTraceID(ctx),
 		QueryTimestampMs: queryTime.UnixMilli(),
 	}, nil
@@ -473,11 +473,11 @@ func filterRecentCacheExtents(req Request, maxCacheFreshness time.Duration, extr
 				return nil, err
 			}
 			extracted := extractor.Extract(extents[i].Start, maxCacheTime, res)
-			any, err := types.MarshalAny(extracted)
+			marshalled, err := types.MarshalAny(extracted)
 			if err != nil {
 				return nil, err
 			}
-			extents[i].Response = any
+			extents[i].Response = marshalled
 		}
 	}
 	return extents, nil

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -108,14 +108,14 @@ func mkExtent(start, end int64) Extent {
 
 func mkExtentWithStepAndQueryTime(start, end, step, queryTime int64) Extent {
 	res := mkAPIResponse(start, end, step)
-	any, err := types.MarshalAny(res)
+	marshalled, err := types.MarshalAny(res)
 	if err != nil {
 		panic(err)
 	}
 	return Extent{
 		Start:            start,
 		End:              end,
-		Response:         any,
+		Response:         marshalled,
 		QueryTimestampMs: queryTime,
 	}
 }

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -189,7 +189,7 @@ func newQueryTripperware(
 		newLimitsMiddleware(limits, log),
 	}
 	if cfg.AlignQueriesWithStep {
-		queryRangeMiddleware = append(queryRangeMiddleware, newInstrumentMiddleware("step_align", metrics, log), newStepAlignMiddleware())
+		queryRangeMiddleware = append(queryRangeMiddleware, newInstrumentMiddleware("step_align", metrics), newStepAlignMiddleware())
 	}
 
 	var c cache.Cache
@@ -215,7 +215,7 @@ func newQueryTripperware(
 			splitter = ConstSplitter(cfg.SplitQueriesByInterval)
 		}
 
-		queryRangeMiddleware = append(queryRangeMiddleware, newInstrumentMiddleware("split_by_interval_and_results_cache", metrics, log), newSplitAndCacheMiddleware(
+		queryRangeMiddleware = append(queryRangeMiddleware, newInstrumentMiddleware("split_by_interval_and_results_cache", metrics), newSplitAndCacheMiddleware(
 			cfg.SplitQueriesByInterval > 0,
 			cfg.CacheResults,
 			cfg.SplitQueriesByInterval,
@@ -246,12 +246,12 @@ func newQueryTripperware(
 			cardinalityEstimationMiddleware := newCardinalityEstimationMiddleware(c, log, registerer)
 			queryRangeMiddleware = append(
 				queryRangeMiddleware,
-				newInstrumentMiddleware("cardinality_estimation", metrics, log),
+				newInstrumentMiddleware("cardinality_estimation", metrics),
 				cardinalityEstimationMiddleware,
 			)
 			queryInstantMiddleware = append(
 				queryInstantMiddleware,
-				newInstrumentMiddleware("cardinality_estimation", metrics, log),
+				newInstrumentMiddleware("cardinality_estimation", metrics),
 				cardinalityEstimationMiddleware,
 			)
 		}
@@ -265,20 +265,20 @@ func newQueryTripperware(
 		)
 
 		queryRangeMiddleware = append(queryRangeMiddleware,
-			newInstrumentMiddleware("querysharding", metrics, log),
+			newInstrumentMiddleware("querysharding", metrics),
 			queryshardingMiddleware,
 		)
 		queryInstantMiddleware = append(
 			queryInstantMiddleware,
-			newInstrumentMiddleware("querysharding", metrics, log),
+			newInstrumentMiddleware("querysharding", metrics),
 			queryshardingMiddleware,
 		)
 	}
 
 	if cfg.MaxRetries > 0 {
 		retryMiddlewareMetrics := newRetryMiddlewareMetrics(registerer)
-		queryRangeMiddleware = append(queryRangeMiddleware, newInstrumentMiddleware("retry", metrics, log), newRetryMiddleware(log, cfg.MaxRetries, retryMiddlewareMetrics))
-		queryInstantMiddleware = append(queryInstantMiddleware, newInstrumentMiddleware("retry", metrics, log), newRetryMiddleware(log, cfg.MaxRetries, retryMiddlewareMetrics))
+		queryRangeMiddleware = append(queryRangeMiddleware, newInstrumentMiddleware("retry", metrics), newRetryMiddleware(log, cfg.MaxRetries, retryMiddlewareMetrics))
+		queryInstantMiddleware = append(queryInstantMiddleware, newInstrumentMiddleware("retry", metrics), newRetryMiddleware(log, cfg.MaxRetries, retryMiddlewareMetrics))
 	}
 
 	return func(next http.RoundTripper) http.RoundTripper {

--- a/pkg/frontend/querymiddleware/sharded_queryable.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable.go
@@ -50,7 +50,7 @@ func newShardedQueryable(req Request, next Handler) *shardedQueryable {
 }
 
 // Querier implements storage.Queryable.
-func (q *shardedQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+func (q *shardedQueryable) Querier(ctx context.Context, _, _ int64) (storage.Querier, error) {
 	return &shardedQuerier{ctx: ctx, req: q.req, handler: q.handler, responseHeaders: q.responseHeaders}, nil
 }
 
@@ -133,12 +133,12 @@ func (q *shardedQuerier) handleEmbeddedQueries(queries []string, hints *storage.
 }
 
 // LabelValues implements storage.LabelQuerier.
-func (q *shardedQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (q *shardedQuerier) LabelValues(_ string, _ ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, errNotImplemented
 }
 
 // LabelNames implements storage.LabelQuerier.
-func (q *shardedQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (q *shardedQuerier) LabelNames(_ ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, errNotImplemented
 }
 

--- a/pkg/frontend/v1/queue_test.go
+++ b/pkg/frontend/v1/queue_test.go
@@ -170,7 +170,7 @@ func (p *processServerMock) Recv() (*frontendv1pb.ClientToFrontend, error) {
 
 func (p *processServerMock) SetHeader(_ metadata.MD) error  { return nil }
 func (p *processServerMock) SendHeader(_ metadata.MD) error { return nil }
-func (p *processServerMock) SetTrailer(md metadata.MD)      {}
+func (p *processServerMock) SetTrailer(_ metadata.MD)       {}
 func (p *processServerMock) Context() context.Context       { return p.ctx }
-func (p *processServerMock) SendMsg(m interface{}) error    { return nil }
-func (p *processServerMock) RecvMsg(m interface{}) error    { return nil }
+func (p *processServerMock) SendMsg(_ interface{}) error    { return nil }
+func (p *processServerMock) RecvMsg(_ interface{}) error    { return nil }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -107,7 +107,6 @@ const (
 	memoryTenantsStatsName                 = "ingester_inmemory_tenants"
 	appendedSamplesStatsName               = "ingester_appended_samples"
 	appendedExemplarsStatsName             = "ingester_appended_exemplars"
-	appendedHistogramsStatsName            = "ingester_appended_histograms"
 	tenantsWithOutOfOrderEnabledStatName   = "ingester_ooo_enabled_tenants"
 	minOutOfOrderTimeWindowSecondsStatName = "ingester_ooo_min_window"
 	maxOutOfOrderTimeWindowSecondsStatName = "ingester_ooo_max_window"
@@ -1267,7 +1266,7 @@ func (i *Ingester) MetricsForLabelMatchers(ctx context.Context, req *client.Metr
 	return result, nil
 }
 
-func (i *Ingester) UserStats(ctx context.Context, req *client.UserStatsRequest) (*client.UserStatsResponse, error) {
+func (i *Ingester) UserStats(ctx context.Context, _ *client.UserStatsRequest) (*client.UserStatsResponse, error) {
 	if err := i.checkRunning(); err != nil {
 		return nil, err
 	}
@@ -1285,7 +1284,7 @@ func (i *Ingester) UserStats(ctx context.Context, req *client.UserStatsRequest) 
 	return createUserStats(db), nil
 }
 
-func (i *Ingester) AllUserStats(ctx context.Context, req *client.UserStatsRequest) (*client.UsersStatsResponse, error) {
+func (i *Ingester) AllUserStats(context.Context, *client.UserStatsRequest) (*client.UsersStatsResponse, error) {
 	if err := i.checkRunning(); err != nil {
 		return nil, err
 	}
@@ -2537,7 +2536,7 @@ func (i *Ingester) unsetPrepareShutdown() {
 // ShutdownHandler triggers the following set of operations in order:
 //   - Change the state of ring to stop accepting writes.
 //   - Flush all the chunks.
-func (i *Ingester) ShutdownHandler(w http.ResponseWriter, r *http.Request) {
+func (i *Ingester) ShutdownHandler(w http.ResponseWriter, _ *http.Request) {
 	originalFlush := i.lifecycler.FlushOnShutdown()
 	// We want to flush the chunks if transfer fails irrespective of original flag.
 	i.lifecycler.SetFlushOnShutdown(true)
@@ -2672,7 +2671,7 @@ func (i *Ingester) purgeUserMetricsMetadata() {
 }
 
 // MetricsMetadata returns all the metric metadata of a user.
-func (i *Ingester) MetricsMetadata(ctx context.Context, req *client.MetricsMetadataRequest) (*client.MetricsMetadataResponse, error) {
+func (i *Ingester) MetricsMetadata(ctx context.Context, _ *client.MetricsMetadataRequest) (*client.MetricsMetadataResponse, error) {
 	if err := i.checkRunning(); err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1168,11 +1168,6 @@ func TestIngester_Push_DecreaseInactiveSeries(t *testing.T) {
 }
 
 func BenchmarkIngesterPush(b *testing.B) {
-	limits := defaultLimitsTestConfig()
-	benchmarkIngesterPush(b, limits, false)
-}
-
-func benchmarkIngesterPush(b *testing.B, limits validation.Limits, errorsExpected bool) {
 	registry := prometheus.NewRegistry()
 	ctx := user.InjectOrgID(context.Background(), userID)
 
@@ -1219,9 +1214,7 @@ func benchmarkIngesterPush(b *testing.B, limits validation.Limits, errorsExpecte
 				allSamples[i].TimestampMs = startTime + int64(iter*samples+j+1)
 			}
 			_, err := ingester.Push(ctx, mimirpb.ToWriteRequest(allLabels, allSamples, nil, nil, mimirpb.API))
-			if !errorsExpected {
-				require.NoError(b, err)
-			}
+			require.NoError(b, err)
 		}
 	}
 }
@@ -2984,7 +2977,7 @@ type mockQueryStreamServer struct {
 	ctx context.Context
 }
 
-func (m *mockQueryStreamServer) Send(response *client.QueryStreamResponse) error {
+func (m *mockQueryStreamServer) Send(*client.QueryStreamResponse) error {
 	return nil
 }
 

--- a/pkg/ingester/label_names_and_values_test.go
+++ b/pkg/ingester/label_names_and_values_test.go
@@ -281,10 +281,10 @@ func TestLabelNamesAndValues_ContextCancellation(t *testing.T) {
 
 type infinitePostings struct{}
 
-func (ip infinitePostings) Next() bool                    { return true }
-func (ip infinitePostings) Seek(v storage.SeriesRef) bool { return true }
-func (ip infinitePostings) At() storage.SeriesRef         { return 0 }
-func (ip infinitePostings) Err() error                    { return nil }
+func (ip infinitePostings) Next() bool                  { return true }
+func (ip infinitePostings) Seek(storage.SeriesRef) bool { return true }
+func (ip infinitePostings) At() storage.SeriesRef       { return 0 }
+func (ip infinitePostings) Err() error                  { return nil }
 
 func TestCountLabelValueSeries_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -175,10 +175,10 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.TenantFederation.RegisterFlags(f)
 
 	c.Ruler.RegisterFlags(f, logger)
-	c.RulerStorage.RegisterFlags(f, logger)
+	c.RulerStorage.RegisterFlags(f)
 	c.Vault.RegisterFlags(f)
 	c.Alertmanager.RegisterFlags(f, logger)
-	c.AlertmanagerStorage.RegisterFlags(f, logger)
+	c.AlertmanagerStorage.RegisterFlags(f)
 	c.RuntimeConfig.RegisterFlags(f)
 	c.MemberlistKV.RegisterFlags(f)
 	c.ActivityTracker.RegisterFlags(f)
@@ -186,7 +186,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.UsageStats.RegisterFlags(f)
 	c.OverridesExporter.RegisterFlags(f, logger)
 
-	c.Common.RegisterFlags(f, logger)
+	c.Common.RegisterFlags(f)
 }
 
 func (c *Config) CommonConfigInheritance() CommonConfigInheritance {
@@ -257,7 +257,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.StoreGateway.Validate(c.LimitsConfig); err != nil {
 		return errors.Wrap(err, "invalid store-gateway config")
 	}
-	if err := c.Compactor.Validate(log); err != nil {
+	if err := c.Compactor.Validate(); err != nil {
 		return errors.Wrap(err, "invalid compactor config")
 	}
 	if err := c.AlertmanagerStorage.Validate(); err != nil {
@@ -284,6 +284,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.ValidateLimits(c.LimitsConfig); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -626,8 +627,8 @@ type CommonConfigInheritance struct {
 }
 
 // RegisterFlags registers flag.
-func (c *CommonConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
-	c.Storage.RegisterFlagsWithPrefix("common.storage.", f, logger)
+func (c *CommonConfig) RegisterFlags(f *flag.FlagSet) {
+	c.Storage.RegisterFlagsWithPrefix("common.storage.", f)
 }
 
 // configWithCustomCommonUnmarshaler unmarshals config with custom unmarshaler for the `common` field.

--- a/pkg/mimir/mimir_config_test.go
+++ b/pkg/mimir/mimir_config_test.go
@@ -61,7 +61,7 @@ type customExtendedConfig struct {
 
 func (c *customExtendedConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.MimirConfig.RegisterFlags(f, logger)
-	c.CustomStorage.RegisterFlagsWithPrefix("custom-storage", f, logger)
+	c.CustomStorage.RegisterFlagsWithPrefix("custom-storage", f)
 }
 
 func (c *customExtendedConfig) CommonConfigInheritance() mimir.CommonConfigInheritance {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -383,7 +383,7 @@ func (t *Mimir) initQueryable() (serv services.Service, err error) {
 	t.MetadataSupplier = t.Distributor
 
 	// Register the default endpoints that are always enabled for the querier module
-	t.API.RegisterQueryable(t.QuerierQueryable, t.Distributor)
+	t.API.RegisterQueryable(t.Distributor)
 
 	return nil, nil
 }

--- a/pkg/mimir/tracing.go
+++ b/pkg/mimir/tracing.go
@@ -61,7 +61,7 @@ func NewOpenTelemetryProviderBridge(tracer opentracing.Tracer) *OpenTelemetryPro
 // name will be used instead.
 //
 // This method must be concurrency safe.
-func (p *OpenTelemetryProviderBridge) Tracer(instrumentationName string, opts ...trace.TracerOption) trace.Tracer {
+func (p *OpenTelemetryProviderBridge) Tracer(_ string, _ ...trace.TracerOption) trace.Tracer {
 	return NewOpenTelemetryTracerBridge(p.tracer, p)
 }
 

--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -637,12 +637,12 @@ func TestPrometheusSampleHistogramInSyncWithMimirPbSampleHistogram(t *testing.T)
 // are compatible with https://go.dev/ref/spec#Conversions
 // and https://go.dev/ref/spec#Assignability
 // More strict than necessary but is checked in compile time.
-func TestPrometheusLabelsInSyncWithMimirPbLabelAdapter(t *testing.T) {
+func TestPrometheusLabelsInSyncWithMimirPbLabelAdapter(_ *testing.T) {
 	_ = labels.Label(LabelAdapter{})
 }
 
 // Check that Prometheus histogram.Span and MimirPb BucketSpan types
 // are compatible, same as above.
-func TestPrometheusHistogramSpanInSyncWithMimirPbBucketSpan(t *testing.T) {
+func TestPrometheusHistogramSpanInSyncWithMimirPbBucketSpan(_ *testing.T) {
 	_ = histogram.Span(BucketSpan{})
 }

--- a/pkg/mimirtool/commands/access_control.go
+++ b/pkg/mimirtool/commands/access_control.go
@@ -30,7 +30,7 @@ func (a *AccessControlCommand) Register(app *kingpin.Application, envVars EnvVar
 	generateHeaderCmd.Flag("rule", "The access control rules (Prometheus selectors). Set it multiple times to set multiple rules.").Required().StringsVar(&a.ACLs)
 }
 
-func (a *AccessControlCommand) generateHeader(k *kingpin.ParseContext) error {
+func (a *AccessControlCommand) generateHeader(_ *kingpin.ParseContext) error {
 	for _, acl := range a.ACLs {
 		_, err := parser.ParseMetricSelector(acl)
 		if err != nil {

--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -88,7 +88,7 @@ func (a *AlertmanagerCommand) Register(app *kingpin.Application, envVars EnvVarN
 	verifyalertCmd.Arg("template-files", "The template files to verify").ExistingFilesVar(&a.TemplateFiles)
 }
 
-func (a *AlertmanagerCommand) setup(k *kingpin.ParseContext) error {
+func (a *AlertmanagerCommand) setup(_ *kingpin.ParseContext) error {
 	cli, err := client.New(a.ClientConfig)
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func (a *AlertmanagerCommand) setup(k *kingpin.ParseContext) error {
 	return nil
 }
 
-func (a *AlertmanagerCommand) getConfig(k *kingpin.ParseContext) error {
+func (a *AlertmanagerCommand) getConfig(_ *kingpin.ParseContext) error {
 	cfg, templates, err := a.cli.GetAlertmanagerConfig(context.Background())
 	if err != nil {
 		if errors.Is(err, client.ErrResourceNotFound) {
@@ -113,7 +113,7 @@ func (a *AlertmanagerCommand) getConfig(k *kingpin.ParseContext) error {
 	return p.PrintAlertmanagerConfig(cfg, templates)
 }
 
-func (a *AlertmanagerCommand) readAlertManagerConfig(k *kingpin.ParseContext) (string, map[string]string, error) {
+func (a *AlertmanagerCommand) readAlertManagerConfig() (string, map[string]string, error) {
 	content, err := os.ReadFile(a.AlertmanagerConfigFile)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "unable to load config file: "+a.AlertmanagerConfigFile)
@@ -136,20 +136,20 @@ func (a *AlertmanagerCommand) readAlertManagerConfig(k *kingpin.ParseContext) (s
 	return cfg, templates, nil
 }
 
-func (a *AlertmanagerCommand) verifyAlertmanagerConfig(k *kingpin.ParseContext) error {
-	_, _, err := a.readAlertManagerConfig(k)
+func (a *AlertmanagerCommand) verifyAlertmanagerConfig(_ *kingpin.ParseContext) error {
+	_, _, err := a.readAlertManagerConfig()
 	return err
 }
 
-func (a *AlertmanagerCommand) loadConfig(k *kingpin.ParseContext) error {
-	cfg, templates, err := a.readAlertManagerConfig(k)
+func (a *AlertmanagerCommand) loadConfig(_ *kingpin.ParseContext) error {
+	cfg, templates, err := a.readAlertManagerConfig()
 	if err != nil {
 		return err
 	}
 	return a.cli.CreateAlertmanagerConfig(context.Background(), cfg, templates)
 }
 
-func (a *AlertmanagerCommand) deleteConfig(k *kingpin.ParseContext) error {
+func (a *AlertmanagerCommand) deleteConfig(_ *kingpin.ParseContext) error {
 	err := a.cli.DeleteAlermanagerConfig(context.Background())
 	if err != nil && !errors.Is(err, client.ErrResourceNotFound) {
 		return err
@@ -203,7 +203,7 @@ type metric struct {
 	Metric map[string]string `json:"metric"`
 }
 
-func (a *AlertCommand) verifyConfig(k *kingpin.ParseContext) error {
+func (a *AlertCommand) verifyConfig(_ *kingpin.ParseContext) error {
 	var empty interface{}
 	if a.IgnoreString != "" {
 		a.IgnoreAlerts = make(map[string]interface{})

--- a/pkg/mimirtool/commands/analyse_dashboards.go
+++ b/pkg/mimirtool/commands/analyse_dashboards.go
@@ -21,7 +21,7 @@ type DashboardAnalyzeCommand struct {
 	outputFile    string
 }
 
-func (cmd *DashboardAnalyzeCommand) run(k *kingpin.ParseContext) error {
+func (cmd *DashboardAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 	output := &analyze.MetricsInGrafana{}
 	output.OverallMetrics = make(map[string]struct{})
 

--- a/pkg/mimirtool/commands/analyse_grafana.go
+++ b/pkg/mimirtool/commands/analyse_grafana.go
@@ -48,7 +48,7 @@ func (f folderTitles) IsCumulative() bool {
 	return true
 }
 
-func (cmd *GrafanaAnalyzeCommand) run(k *kingpin.ParseContext) error {
+func (cmd *GrafanaAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 	output := &analyze.MetricsInGrafana{}
 	output.OverallMetrics = make(map[string]struct{})
 

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -43,7 +43,7 @@ type PrometheusAnalyzeCommand struct {
 	concurrency        int
 }
 
-func (cmd *PrometheusAnalyzeCommand) run(k *kingpin.ParseContext) error {
+func (cmd *PrometheusAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 	metricsUsed, err := cmd.parseUsedMetrics()
 	if err != nil {
 		return err

--- a/pkg/mimirtool/commands/analyse_rulefiles.go
+++ b/pkg/mimirtool/commands/analyse_rulefiles.go
@@ -18,7 +18,7 @@ type RuleFileAnalyzeCommand struct {
 	outputFile    string
 }
 
-func (cmd *RuleFileAnalyzeCommand) run(k *kingpin.ParseContext) error {
+func (cmd *RuleFileAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 
 	output := &analyze.MetricsInRuler{}
 	output.OverallMetrics = make(map[string]struct{})

--- a/pkg/mimirtool/commands/analyse_ruler.go
+++ b/pkg/mimirtool/commands/analyse_ruler.go
@@ -26,7 +26,7 @@ type RulerAnalyzeCommand struct {
 	outputFile   string
 }
 
-func (cmd *RulerAnalyzeCommand) run(k *kingpin.ParseContext) error {
+func (cmd *RulerAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 	output := &analyze.MetricsInRuler{}
 	output.OverallMetrics = make(map[string]struct{})
 

--- a/pkg/mimirtool/commands/backfill.go
+++ b/pkg/mimirtool/commands/backfill.go
@@ -94,7 +94,7 @@ func (c *BackfillCommand) Register(app *kingpin.Application, envVars EnvVarNames
 		DurationVar(&c.sleepTime)
 }
 
-func (c *BackfillCommand) backfill(k *kingpin.ParseContext) error {
+func (c *BackfillCommand) backfill(_ *kingpin.ParseContext) error {
 	logrus.WithFields(logrus.Fields{
 		"blocks": c.blocks.String(),
 		"user":   c.clientConfig.ID,

--- a/pkg/mimirtool/commands/bucket_validation.go
+++ b/pkg/mimirtool/commands/bucket_validation.go
@@ -104,14 +104,14 @@ func (b *BucketValidationCommand) Register(app *kingpin.Application, _ EnvVarNam
 	bvCmd.Flag("bucket-config-help", "Help text explaining how to use the -bucket-config parameter").BoolVar(&b.bucketConfigHelp)
 }
 
-func (b *BucketValidationCommand) validate(k *kingpin.ParseContext) error {
+func (b *BucketValidationCommand) validate(_ *kingpin.ParseContext) error {
 	b.logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	if b.bucketConfigHelp {
-		b.printBucketConfigHelp(b.logger)
+		b.printBucketConfigHelp()
 		return nil
 	}
 
-	err := b.parseBucketConfig(b.logger)
+	err := b.parseBucketConfig()
 	if err != nil {
 		return errors.Wrap(err, "error when parsing bucket config")
 	}
@@ -163,9 +163,9 @@ func (b *BucketValidationCommand) validate(k *kingpin.ParseContext) error {
 	return nil
 }
 
-func (b *BucketValidationCommand) printBucketConfigHelp(logger log.Logger) {
+func (b *BucketValidationCommand) printBucketConfigHelp() {
 	fs := flag.NewFlagSet("bucket-config", flag.ContinueOnError)
-	b.cfg.RegisterFlags(fs, logger)
+	b.cfg.RegisterFlags(fs)
 
 	fmt.Fprintf(fs.Output(), `
 The following help text describes the arguments
@@ -179,9 +179,9 @@ mimirtool bucket-validation --bucket-config='-backend=s3 -s3.endpoint=localhost:
 	fs.Usage()
 }
 
-func (b *BucketValidationCommand) parseBucketConfig(logger log.Logger) error {
+func (b *BucketValidationCommand) parseBucketConfig() error {
 	fs := flag.NewFlagSet("bucket-config", flag.ContinueOnError)
-	b.cfg.RegisterFlags(fs, logger)
+	b.cfg.RegisterFlags(fs)
 	err := fs.Parse(strings.Split(b.bucketConfig, " "))
 	if err != nil {
 		return err

--- a/pkg/mimirtool/commands/loadgen.go
+++ b/pkg/mimirtool/commands/loadgen.go
@@ -115,7 +115,7 @@ func (c *LoadgenCommand) setup(_ *kingpin.ParseContext, reg prometheus.Registere
 	return nil
 }
 
-func (c *LoadgenCommand) run(k *kingpin.ParseContext) error {
+func (c *LoadgenCommand) run(_ *kingpin.ParseContext) error {
 	if c.writeURL == "" && c.queryURL == "" {
 		return errors.New("either a -write-url or -query-url flag must be provided to run the loadgen command")
 	}

--- a/pkg/mimirtool/commands/logger.go
+++ b/pkg/mimirtool/commands/logger.go
@@ -16,7 +16,7 @@ type LoggerConfig struct {
 	Level string
 }
 
-func (l *LoggerConfig) registerLogLevel(pc *kingpin.ParseContext) error {
+func (l *LoggerConfig) registerLogLevel(_ *kingpin.ParseContext) error {
 	var logLevel logrus.Level
 	switch l.Level {
 	case "debug":

--- a/pkg/mimirtool/commands/push_gateway.go
+++ b/pkg/mimirtool/commands/push_gateway.go
@@ -34,7 +34,7 @@ func (l *PushGatewayConfig) Register(app *kingpin.Application, _ EnvVarNames) {
 	app.Flag("push-gateway.interval", "interval to forward metrics to the push gateway").Default("1m").DurationVar(&l.Interval)
 }
 
-func (l *PushGatewayConfig) setup(pc *kingpin.ParseContext) error {
+func (l *PushGatewayConfig) setup(_ *kingpin.ParseContext) error {
 	if l.Endpoint == nil || l.JobName == "" {
 		logrus.Debugln("push-gateway not configured")
 		return nil

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -272,7 +272,7 @@ func (c *RemoteReadCommand) prepare() (query func(context.Context) ([]*prompb.Ti
 	}, from, to, nil
 }
 
-func (c *RemoteReadCommand) dump(k *kingpin.ParseContext) error {
+func (c *RemoteReadCommand) dump(_ *kingpin.ParseContext) error {
 	query, _, _, err := c.prepare()
 	if err != nil {
 		return err
@@ -305,7 +305,7 @@ func (c *RemoteReadCommand) dump(k *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *RemoteReadCommand) stats(k *kingpin.ParseContext) error {
+func (c *RemoteReadCommand) stats(_ *kingpin.ParseContext) error {
 	query, _, _, err := c.prepare()
 	if err != nil {
 		return err
@@ -387,7 +387,7 @@ func (c *RemoteReadCommand) stats(k *kingpin.ParseContext) error {
 	return nil
 }
 
-func (c *RemoteReadCommand) export(k *kingpin.ParseContext) error {
+func (c *RemoteReadCommand) export(_ *kingpin.ParseContext) error {
 	query, from, to, err := c.prepare()
 	if err != nil {
 		return err

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -370,7 +370,7 @@ func (r *RuleCommand) setupFiles() error {
 	return nil
 }
 
-func (r *RuleCommand) listRules(k *kingpin.ParseContext) error {
+func (r *RuleCommand) listRules(_ *kingpin.ParseContext) error {
 	rules, err := r.cli.ListRules(context.Background(), "")
 	if err != nil {
 		log.Fatalf("Unable to read rules from Grafana Mimir, %v", err)
@@ -381,7 +381,7 @@ func (r *RuleCommand) listRules(k *kingpin.ParseContext) error {
 	return p.PrintRuleSet(rules, r.Format, os.Stdout)
 }
 
-func (r *RuleCommand) printRules(k *kingpin.ParseContext) error {
+func (r *RuleCommand) printRules(_ *kingpin.ParseContext) error {
 	rules, err := r.cli.ListRules(context.Background(), "")
 	if err != nil {
 		if errors.Is(err, client.ErrResourceNotFound) {
@@ -395,7 +395,7 @@ func (r *RuleCommand) printRules(k *kingpin.ParseContext) error {
 	return p.PrintRuleGroups(rules)
 }
 
-func (r *RuleCommand) getRuleGroup(k *kingpin.ParseContext) error {
+func (r *RuleCommand) getRuleGroup(_ *kingpin.ParseContext) error {
 	group, err := r.cli.GetRuleGroup(context.Background(), r.Namespace, r.RuleGroup)
 	if err != nil {
 		if errors.Is(err, client.ErrResourceNotFound) {
@@ -409,7 +409,7 @@ func (r *RuleCommand) getRuleGroup(k *kingpin.ParseContext) error {
 	return p.PrintRuleGroup(*group)
 }
 
-func (r *RuleCommand) deleteRuleGroup(k *kingpin.ParseContext) error {
+func (r *RuleCommand) deleteRuleGroup(_ *kingpin.ParseContext) error {
 	err := r.cli.DeleteRuleGroup(context.Background(), r.Namespace, r.RuleGroup)
 	if err != nil && !errors.Is(err, client.ErrResourceNotFound) {
 		log.Fatalf("Unable to delete rule group from Grafana Mimir, %v", err)
@@ -417,7 +417,7 @@ func (r *RuleCommand) deleteRuleGroup(k *kingpin.ParseContext) error {
 	return nil
 }
 
-func (r *RuleCommand) loadRules(k *kingpin.ParseContext) error {
+func (r *RuleCommand) loadRules(_ *kingpin.ParseContext) error {
 	nss, err := rules.ParseFiles(r.Backend, r.RuleFilesList)
 	if err != nil {
 		return errors.Wrap(err, "load operation unsuccessful, unable to parse rules files")
@@ -474,7 +474,7 @@ func (r *RuleCommand) shouldCheckNamespace(namespace string) bool {
 	return !ignored
 }
 
-func (r *RuleCommand) diffRules(k *kingpin.ParseContext) error {
+func (r *RuleCommand) diffRules(_ *kingpin.ParseContext) error {
 	err := r.setupFiles()
 	if err != nil {
 		return errors.Wrap(err, "diff operation unsuccessful, unable to load rules files")
@@ -537,7 +537,7 @@ func (r *RuleCommand) diffRules(k *kingpin.ParseContext) error {
 	return p.PrintComparisonResult(changes, r.Verbose)
 }
 
-func (r *RuleCommand) syncRules(k *kingpin.ParseContext) error {
+func (r *RuleCommand) syncRules(_ *kingpin.ParseContext) error {
 	// Check the configuration.
 	if r.SyncConcurrency < 1 || r.SyncConcurrency > maxSyncConcurrency {
 		return fmt.Errorf("the configured concurrency (%d) must be a value between 1 and %d", r.SyncConcurrency, maxSyncConcurrency)
@@ -650,7 +650,7 @@ func (r *RuleCommand) executeChanges(ctx context.Context, changes []rules.Namesp
 	return nil
 }
 
-func (r *RuleCommand) prepare(k *kingpin.ParseContext) error {
+func (r *RuleCommand) prepare(_ *kingpin.ParseContext) error {
 	err := r.setupFiles()
 	if err != nil {
 		return errors.Wrap(err, "prepare operation unsuccessful, unable to load rules files")
@@ -688,7 +688,7 @@ func (r *RuleCommand) prepare(k *kingpin.ParseContext) error {
 	return nil
 }
 
-func (r *RuleCommand) lint(k *kingpin.ParseContext) error {
+func (r *RuleCommand) lint(_ *kingpin.ParseContext) error {
 	err := r.setupFiles()
 	if err != nil {
 		return errors.Wrap(err, "prepare operation unsuccessful, unable to load rules files")
@@ -829,7 +829,7 @@ func save(nss map[string]rules.RuleNamespace, i bool) error {
 	return nil
 }
 
-func (r *RuleCommand) deleteNamespace(k *kingpin.ParseContext) error {
+func (r *RuleCommand) deleteNamespace(_ *kingpin.ParseContext) error {
 	err := r.cli.DeleteNamespace(context.Background(), r.Namespace)
 	if err != nil && !errors.Is(err, client.ErrResourceNotFound) {
 		log.Fatalf("Unable to delete namespace from Grafana Mimir, %v", err)

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -207,7 +207,7 @@ func (i *mockIterator) Timestamp() int64 {
 	return 0
 }
 
-func (i *mockIterator) Batch(size int, valueType chunkenc.ValueType) chunk.Batch {
+func (i *mockIterator) Batch(_ int, valueType chunkenc.ValueType) chunk.Batch {
 	batch := chunk.Batch{
 		Length:    chunk.BatchSize,
 		ValueType: valueType,

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1562,9 +1562,8 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 
 func TestBlocksStoreQuerier_MaxLabelsQueryRange(t *testing.T) {
 	const (
-		engineLookbackDelta = 5 * time.Minute
-		thirtyDays          = 30 * 24 * time.Hour
-		sevenDays           = 7 * 24 * time.Hour
+		thirtyDays = 30 * 24 * time.Hour
+		sevenDays  = 7 * 24 * time.Hour
 	)
 	now := time.Now()
 
@@ -1904,7 +1903,7 @@ type storeGatewayClientMock struct {
 	mockedLabelValuesErr      error
 }
 
-func (m *storeGatewayClientMock) Series(ctx context.Context, in *storepb.SeriesRequest, opts ...grpc.CallOption) (storegatewaypb.StoreGateway_SeriesClient, error) {
+func (m *storeGatewayClientMock) Series(context.Context, *storepb.SeriesRequest, ...grpc.CallOption) (storegatewaypb.StoreGateway_SeriesClient, error) {
 	seriesClient := &storeGatewaySeriesClientMock{
 		mockedResponses: m.mockedSeriesResponses,
 	}
@@ -1960,7 +1959,7 @@ type cancelerStoreGatewayClientMock struct {
 	cancel        func()
 }
 
-func (m *cancelerStoreGatewayClientMock) Series(ctx context.Context, in *storepb.SeriesRequest, opts ...grpc.CallOption) (storegatewaypb.StoreGateway_SeriesClient, error) {
+func (m *cancelerStoreGatewayClientMock) Series(ctx context.Context, _ *storepb.SeriesRequest, _ ...grpc.CallOption) (storegatewaypb.StoreGateway_SeriesClient, error) {
 	if m.produceSeries {
 		series := &cancelerStoreGatewaySeriesClientMock{
 			ctx:    ctx,
@@ -2049,14 +2048,14 @@ func mockHintsResponse(ids ...ulid.ULID) *storepb.SeriesResponse {
 		hints.AddQueriedBlock(id)
 	}
 
-	any, err := types.MarshalAny(hints)
+	marshalled, err := types.MarshalAny(hints)
 	if err != nil {
 		panic(err)
 	}
 
 	return &storepb.SeriesResponse{
 		Result: &storepb.SeriesResponse_Hints{
-			Hints: any,
+			Hints: marshalled,
 		},
 	}
 }
@@ -2067,12 +2066,12 @@ func mockNamesHints(ids ...ulid.ULID) *types.Any {
 		hints.AddQueriedBlock(id)
 	}
 
-	any, err := types.MarshalAny(hints)
+	marshalled, err := types.MarshalAny(hints)
 	if err != nil {
 		panic(err)
 	}
 
-	return any
+	return marshalled
 }
 
 func mockValuesHints(ids ...ulid.ULID) *types.Any {
@@ -2081,12 +2080,12 @@ func mockValuesHints(ids ...ulid.ULID) *types.Any {
 		hints.AddQueriedBlock(id)
 	}
 
-	any, err := types.MarshalAny(hints)
+	marshalled, err := types.MarshalAny(hints)
 	if err != nil {
 		panic(err)
 	}
 
-	return any
+	return marshalled
 }
 
 func namesFromSeries(series ...labels.Labels) []string {

--- a/pkg/querier/duplicates_test.go
+++ b/pkg/querier/duplicates_test.go
@@ -130,11 +130,11 @@ func (m testQuerier) Select(_ bool, _ *storage.SelectHints, _ ...*labels.Matcher
 	return m.ts
 }
 
-func (m testQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (m testQuerier) LabelValues(string, ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, nil
 }
 
-func (m testQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (m testQuerier) LabelNames(...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, nil
 }
 

--- a/pkg/querier/error_translate_queryable.go
+++ b/pkg/querier/error_translate_queryable.go
@@ -78,10 +78,6 @@ func TranslateToPromqlAPIError(err error) error {
 // Input error may be nil.
 type ErrTranslateFn func(err error) error
 
-func NewErrorTranslateQueryable(q storage.Queryable) storage.Queryable {
-	return NewErrorTranslateQueryableWithFn(q, TranslateToPromqlAPIError)
-}
-
 func NewErrorTranslateQueryableWithFn(q storage.Queryable, fn ErrTranslateFn) storage.Queryable {
 	return errorTranslateQueryable{q: q, fn: fn}
 }

--- a/pkg/querier/error_translate_queryable_test.go
+++ b/pkg/querier/error_translate_queryable_test.go
@@ -173,11 +173,11 @@ type errorTestQueryable struct {
 	err error
 }
 
-func (t errorTestQueryable) ChunkQuerier(ctx context.Context, mint, maxt int64) (storage.ChunkQuerier, error) {
+func (t errorTestQueryable) ChunkQuerier(context.Context, int64, int64) (storage.ChunkQuerier, error) {
 	return nil, t.err
 }
 
-func (t errorTestQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+func (t errorTestQueryable) Querier(context.Context, int64, int64) (storage.Querier, error) {
 	if t.q != nil {
 		return t.q, nil
 	}
@@ -189,11 +189,11 @@ type errorTestQuerier struct {
 	err error
 }
 
-func (t errorTestQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (t errorTestQuerier) LabelValues(string, ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, t.err
 }
 
-func (t errorTestQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+func (t errorTestQuerier) LabelNames(...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, t.err
 }
 
@@ -201,7 +201,7 @@ func (t errorTestQuerier) Close() error {
 	return nil
 }
 
-func (t errorTestQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+func (t errorTestQuerier) Select(bool, *storage.SelectHints, ...*labels.Matcher) storage.SeriesSet {
 	if t.s != nil {
 		return t.s
 	}

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1021,13 +1021,10 @@ func (m *errDistributor) LabelNamesAndValues(_ context.Context, _ []*labels.Matc
 
 var errDistributorError = fmt.Errorf("errDistributorError")
 
-func (m *errDistributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
+func (m *errDistributor) QueryStream(context.Context, model.Time, model.Time, ...*labels.Matcher) (*client.QueryStreamResponse, error) {
 	return nil, errDistributorError
 }
-func (m *errDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
-	return nil, errDistributorError
-}
-func (m *errDistributor) QueryExemplars(ctx context.Context, from, to model.Time, matchers ...[]*labels.Matcher) (*client.ExemplarQueryResponse, error) {
+func (m *errDistributor) QueryExemplars(context.Context, model.Time, model.Time, ...[]*labels.Matcher) (*client.ExemplarQueryResponse, error) {
 	return nil, errDistributorError
 }
 func (m *errDistributor) LabelValuesForLabelName(context.Context, model.Time, model.Time, model.LabelName, ...*labels.Matcher) ([]string, error) {
@@ -1036,15 +1033,15 @@ func (m *errDistributor) LabelValuesForLabelName(context.Context, model.Time, mo
 func (m *errDistributor) LabelNames(context.Context, model.Time, model.Time, ...*labels.Matcher) ([]string, error) {
 	return nil, errDistributorError
 }
-func (m *errDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error) {
+func (m *errDistributor) MetricsForLabelMatchers(context.Context, model.Time, model.Time, ...*labels.Matcher) ([]labels.Labels, error) {
 	return nil, errDistributorError
 }
 
-func (m *errDistributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetadata, error) {
+func (m *errDistributor) MetricsMetadata(context.Context) ([]scrape.MetricMetadata, error) {
 	return nil, errDistributorError
 }
 
-func (m *errDistributor) LabelValuesCardinality(ctx context.Context, labelNames []model.LabelName, matchers []*labels.Matcher) (uint64, *client.LabelValuesCardinalityResponse, error) {
+func (m *errDistributor) LabelValuesCardinality(context.Context, []model.LabelName, []*labels.Matcher) (uint64, *client.LabelValuesCardinalityResponse, error) {
 	return 0, nil, errDistributorError
 }
 
@@ -1054,15 +1051,11 @@ func (d *emptyDistributor) LabelNamesAndValues(_ context.Context, _ []*labels.Ma
 	return nil, errors.New("method is not implemented")
 }
 
-func (d *emptyDistributor) Query(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (model.Matrix, error) {
-	return nil, nil
-}
-
-func (d *emptyDistributor) QueryStream(ctx context.Context, from, to model.Time, matchers ...*labels.Matcher) (*client.QueryStreamResponse, error) {
+func (d *emptyDistributor) QueryStream(context.Context, model.Time, model.Time, ...*labels.Matcher) (*client.QueryStreamResponse, error) {
 	return &client.QueryStreamResponse{}, nil
 }
 
-func (d *emptyDistributor) QueryExemplars(ctx context.Context, from, to model.Time, matchers ...[]*labels.Matcher) (*client.ExemplarQueryResponse, error) {
+func (d *emptyDistributor) QueryExemplars(context.Context, model.Time, model.Time, ...[]*labels.Matcher) (*client.ExemplarQueryResponse, error) {
 	return nil, nil
 }
 
@@ -1074,15 +1067,15 @@ func (d *emptyDistributor) LabelNames(context.Context, model.Time, model.Time, .
 	return nil, nil
 }
 
-func (d *emptyDistributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, matchers ...*labels.Matcher) ([]labels.Labels, error) {
+func (d *emptyDistributor) MetricsForLabelMatchers(context.Context, model.Time, model.Time, ...*labels.Matcher) ([]labels.Labels, error) {
 	return nil, nil
 }
 
-func (d *emptyDistributor) MetricsMetadata(ctx context.Context) ([]scrape.MetricMetadata, error) {
+func (d *emptyDistributor) MetricsMetadata(context.Context) ([]scrape.MetricMetadata, error) {
 	return nil, nil
 }
 
-func (d *emptyDistributor) LabelValuesCardinality(ctx context.Context, labelNames []model.LabelName, matchers []*labels.Matcher) (uint64, *client.LabelValuesCardinalityResponse, error) {
+func (d *emptyDistributor) LabelValuesCardinality(context.Context, []model.LabelName, []*labels.Matcher) (uint64, *client.LabelValuesCardinalityResponse, error) {
 	return 0, nil, nil
 }
 
@@ -1299,7 +1292,7 @@ func newMockBlocksStorageQueryable(querier storage.Querier) *mockBlocksStorageQu
 }
 
 // Querier implements storage.Queryable.
-func (m *mockBlocksStorageQueryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+func (m *mockBlocksStorageQueryable) Querier(context.Context, int64, int64) (storage.Querier, error) {
 	return m.querier, nil
 }
 

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -48,7 +48,7 @@ type mockQuerier struct {
 	seriesSet storage.SeriesSet
 }
 
-func (m mockQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+func (m mockQuerier) Select(_ bool, sp *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
 	if sp == nil {
 		panic("mockQuerier: select params must be set")
 	}
@@ -60,7 +60,7 @@ type mockChunkQuerier struct {
 	seriesSet storage.SeriesSet
 }
 
-func (m mockChunkQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
+func (m mockChunkQuerier) Select(_ bool, sp *storage.SelectHints, _ ...*labels.Matcher) storage.ChunkSeriesSet {
 	if sp == nil {
 		panic("mockChunkQuerier: select params must be set")
 	}

--- a/pkg/querier/store_gateway_client_test.go
+++ b/pkg/querier/store_gateway_client_test.go
@@ -55,7 +55,7 @@ func Test_newStoreGatewayClientFactory(t *testing.T) {
 		stream, err := client.(*storeGatewayClient).Series(ctx, &storepb.SeriesRequest{})
 		assert.NoError(t, err)
 
-		// Read the entire response from the stream.
+		// nolint:revive // Read the entire response from the stream.
 		for _, err = stream.Recv(); err == nil; {
 		}
 	}
@@ -74,7 +74,7 @@ func Test_newStoreGatewayClientFactory(t *testing.T) {
 
 type mockStoreGatewayServer struct{}
 
-func (m *mockStoreGatewayServer) Series(_ *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer) error {
+func (m *mockStoreGatewayServer) Series(_ *storepb.SeriesRequest, _ storegatewaypb.StoreGateway_SeriesServer) error {
 	return nil
 }
 

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -170,7 +170,7 @@ func (m *mockSeriesSet) Warnings() storage.Warnings {
 }
 
 // Select implements the storage.Querier interface.
-func (m mockTenantQuerier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+func (m mockTenantQuerier) Select(_ bool, _ *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	log, _ := spanlogger.NewWithLogger(m.ctx, m.logger, "mockTenantQuerier.select")
 	defer log.Span.Finish()
 	var matrix model.Matrix

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -115,7 +115,7 @@ type PusherAppendable struct {
 	failedWrites prometheus.Counter
 }
 
-func NewPusherAppendable(pusher Pusher, userID string, limits RulesLimits, totalWrites, failedWrites prometheus.Counter) *PusherAppendable {
+func NewPusherAppendable(pusher Pusher, userID string, totalWrites, failedWrites prometheus.Counter) *PusherAppendable {
 	return &PusherAppendable{
 		pusher:       pusher,
 		userID:       userID,
@@ -287,7 +287,7 @@ func DefaultTenantManagerFactory(
 		wrappedQueryFunc = RecordAndReportRuleQueryMetrics(wrappedQueryFunc, queryTime, logger)
 
 		return rules.NewManager(&rules.ManagerOptions{
-			Appendable:                 NewPusherAppendable(p, userID, overrides, totalWrites, failedWrites),
+			Appendable:                 NewPusherAppendable(p, userID, totalWrites, failedWrites),
 			Queryable:                  embeddedQueryable,
 			QueryFunc:                  wrappedQueryFunc,
 			Context:                    user.InjectOrgID(ctx, userID),

--- a/pkg/ruler/manager_metrics_test.go
+++ b/pkg/ruler/manager_metrics_test.go
@@ -280,8 +280,9 @@ func TestMetricsArePerUser(t *testing.T) {
 	ch := make(chan prometheus.Metric)
 
 	defer func() {
-		// drain the channel, so that collecting gouroutine can stop.
+		// drain the channel, so that collecting goroutine can stop.
 		// This is useful if test fails.
+		// nolint:revive // We want to drain the channel.
 		for range ch {
 		}
 	}()

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/notifier"
-	"github.com/prometheus/prometheus/rules"
 	promRules "github.com/prometheus/prometheus/rules"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -359,7 +358,7 @@ func (m *managerMock) Stop() {
 	close(m.done)
 }
 
-func (m *managerMock) Update(interval time.Duration, files []string, externalLabels labels.Labels, externalURL string, groupEvalIterationFunc rules.GroupEvalIterationFunc) error {
+func (m *managerMock) Update(time.Duration, []string, labels.Labels, string, promRules.GroupEvalIterationFunc) error {
 	return nil
 }
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -950,7 +950,7 @@ func (r *Ruler) GetRules(ctx context.Context, rulesTypeFilter RulesRequest_RuleT
 }
 
 // SyncRules implements the gRPC Ruler service.
-func (r *Ruler) SyncRules(ctx context.Context, req *SyncRulesRequest) (*SyncRulesResponse, error) {
+func (r *Ruler) SyncRules(_ context.Context, req *SyncRulesRequest) (*SyncRulesResponse, error) {
 	r.inboundSyncQueue.enqueue(req.GetUserIds()...)
 	return &SyncRulesResponse{}, nil
 }

--- a/pkg/ruler/rulestore/bucketclient/bucket_client_test.go
+++ b/pkg/ruler/rulestore/bucketclient/bucket_client_test.go
@@ -435,7 +435,7 @@ type mockBucket struct {
 	names []string
 }
 
-func (mb mockBucket) Iter(_ context.Context, dir string, f func(string) error, options ...objstore.IterOption) error {
+func (mb mockBucket) Iter(_ context.Context, _ string, f func(string) error, _ ...objstore.IterOption) error {
 	for _, n := range mb.names {
 		if err := f(n); err != nil {
 			return err

--- a/pkg/ruler/rulestore/config.go
+++ b/pkg/ruler/rulestore/config.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/go-kit/log"
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/flagext"
@@ -32,12 +31,12 @@ type Config struct {
 }
 
 // RegisterFlags registers the backend storage config.
-func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	prefix := "ruler-storage."
 
 	cfg.StorageBackendConfig.ExtraBackends = []string{local.Name}
 	cfg.Local.RegisterFlagsWithPrefix(prefix, f)
-	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "ruler", f, logger)
+	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "ruler", f)
 
 	f.StringVar(&cfg.Cache.Backend, prefix+"cache.backend", "", fmt.Sprintf("Backend for ruler storage cache, if not empty. The cache is supported for any storage backend except %q. Supported values: %s.", local.Name, strings.Join(supportedCacheBackends, ", ")))
 	cfg.Cache.Memcached.RegisterFlagsWithPrefix(prefix+"cache.memcached.", f)

--- a/pkg/ruler/rulestore/local/local.go
+++ b/pkg/ruler/rulestore/local/local.go
@@ -49,7 +49,7 @@ func NewLocalRulesClient(cfg Config, loader promRules.GroupLoader) (*Client, err
 	}, nil
 }
 
-func (l *Client) ListAllUsers(ctx context.Context) ([]string, error) {
+func (l *Client) ListAllUsers(_ context.Context) ([]string, error) {
 	root := l.cfg.Directory
 	infos, err := os.ReadDir(root)
 	if err != nil {
@@ -95,22 +95,22 @@ func (l *Client) LoadRuleGroups(_ context.Context, _ map[string]rulespb.RuleGrou
 }
 
 // GetRuleGroup implements RuleStore
-func (l *Client) GetRuleGroup(ctx context.Context, userID, namespace, group string) (*rulespb.RuleGroupDesc, error) {
+func (l *Client) GetRuleGroup(_ context.Context, _, _, _ string) (*rulespb.RuleGroupDesc, error) {
 	return nil, errors.New("GetRuleGroup unsupported in rule local store")
 }
 
 // SetRuleGroup implements RuleStore
-func (l *Client) SetRuleGroup(ctx context.Context, userID, namespace string, group *rulespb.RuleGroupDesc) error {
+func (l *Client) SetRuleGroup(_ context.Context, _, _ string, _ *rulespb.RuleGroupDesc) error {
 	return errors.New("SetRuleGroup unsupported in rule local store")
 }
 
 // DeleteRuleGroup implements RuleStore
-func (l *Client) DeleteRuleGroup(ctx context.Context, userID, namespace string, group string) error {
+func (l *Client) DeleteRuleGroup(_ context.Context, _, _, _ string) error {
 	return errors.New("DeleteRuleGroup unsupported in rule local store")
 }
 
 // DeleteNamespace implements RulerStore
-func (l *Client) DeleteNamespace(ctx context.Context, userID, namespace string) error {
+func (l *Client) DeleteNamespace(_ context.Context, _, _ string) error {
 	return errors.New("DeleteNamespace unsupported in rule local store")
 }
 

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -93,7 +93,7 @@ func (m *mockRuleStore) ListRuleGroupsForUserAndNamespace(_ context.Context, use
 	return result, nil
 }
 
-func (m *mockRuleStore) LoadRuleGroups(ctx context.Context, groupsToLoad map[string]rulespb.RuleGroupList) (rulespb.RuleGroupList, error) {
+func (m *mockRuleStore) LoadRuleGroups(_ context.Context, groupsToLoad map[string]rulespb.RuleGroupList) (rulespb.RuleGroupList, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -142,7 +142,7 @@ func (m *mockRuleStore) GetRuleGroup(_ context.Context, userID string, namespace
 	return nil, rulestore.ErrGroupNotFound
 }
 
-func (m *mockRuleStore) SetRuleGroup(ctx context.Context, userID string, namespace string, group *rulespb.RuleGroupDesc) error {
+func (m *mockRuleStore) SetRuleGroup(_ context.Context, userID string, namespace string, group *rulespb.RuleGroupDesc) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -167,7 +167,7 @@ func (m *mockRuleStore) SetRuleGroup(ctx context.Context, userID string, namespa
 	return nil
 }
 
-func (m *mockRuleStore) DeleteRuleGroup(ctx context.Context, userID string, namespace string, group string) error {
+func (m *mockRuleStore) DeleteRuleGroup(_ context.Context, userID string, namespace string, group string) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -191,7 +191,7 @@ func (m *mockRuleStore) DeleteRuleGroup(ctx context.Context, userID string, name
 	return nil
 }
 
-func (m *mockRuleStore) DeleteNamespace(ctx context.Context, userID, namespace string) error {
+func (m *mockRuleStore) DeleteNamespace(_ context.Context, userID, namespace string) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 

--- a/pkg/storage/bucket/azure/config.go
+++ b/pkg/storage/bucket/azure/config.go
@@ -8,7 +8,6 @@ package azure
 import (
 	"flag"
 
-	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
 )
 
@@ -23,12 +22,12 @@ type Config struct {
 }
 
 // RegisterFlags registers the flags for Azure storage
-func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
-	cfg.RegisterFlagsWithPrefix("", f, logger)
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("", f)
 }
 
 // RegisterFlagsWithPrefix registers the flags for Azure storage
-func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet, logger log.Logger) {
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.StorageAccountName, prefix+"azure.account-name", "", "Azure storage account name")
 	f.Var(&cfg.StorageAccountKey, prefix+"azure.account-key", "Azure storage account key")
 	f.StringVar(&cfg.ContainerName, prefix+"azure.container-name", "", "Azure storage container name")

--- a/pkg/storage/bucket/client.go
+++ b/pkg/storage/bucket/client.go
@@ -81,15 +81,15 @@ func (cfg *StorageBackendConfig) supportedBackends() []string {
 }
 
 // RegisterFlags registers the backend storage config.
-func (cfg *StorageBackendConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
-	cfg.RegisterFlagsWithPrefix("", f, logger)
+func (cfg *StorageBackendConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("", f)
 }
 
-func (cfg *StorageBackendConfig) RegisterFlagsWithPrefixAndDefaultDirectory(prefix, dir string, f *flag.FlagSet, logger log.Logger) {
+func (cfg *StorageBackendConfig) RegisterFlagsWithPrefixAndDefaultDirectory(prefix, dir string, f *flag.FlagSet) {
 	cfg.RegisteredFlags = util.TrackRegisteredFlags(prefix, f, func(prefix string, f *flag.FlagSet) {
 		cfg.S3.RegisterFlagsWithPrefix(prefix, f)
 		cfg.GCS.RegisterFlagsWithPrefix(prefix, f)
-		cfg.Azure.RegisterFlagsWithPrefix(prefix, f, logger)
+		cfg.Azure.RegisterFlagsWithPrefix(prefix, f)
 		cfg.Swift.RegisterFlagsWithPrefix(prefix, f)
 		cfg.Filesystem.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, dir, f)
 
@@ -97,8 +97,8 @@ func (cfg *StorageBackendConfig) RegisterFlagsWithPrefixAndDefaultDirectory(pref
 	})
 }
 
-func (cfg *StorageBackendConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet, logger log.Logger) {
-	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "", f, logger)
+func (cfg *StorageBackendConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "", f)
 }
 
 func (cfg *StorageBackendConfig) Validate() error {
@@ -127,17 +127,17 @@ type Config struct {
 }
 
 // RegisterFlags registers the backend storage config.
-func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
-	cfg.RegisterFlagsWithPrefix("", f, logger)
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("", f)
 }
 
-func (cfg *Config) RegisterFlagsWithPrefixAndDefaultDirectory(prefix, dir string, f *flag.FlagSet, logger log.Logger) {
-	cfg.StorageBackendConfig.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, dir, f, logger)
+func (cfg *Config) RegisterFlagsWithPrefixAndDefaultDirectory(prefix, dir string, f *flag.FlagSet) {
+	cfg.StorageBackendConfig.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, dir, f)
 	f.StringVar(&cfg.StoragePrefix, prefix+"storage-prefix", "", "Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet letters.")
 }
 
-func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet, logger log.Logger) {
-	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "", f, logger)
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "", f)
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -121,11 +121,8 @@ func (cfg *Config) Validate() error {
 	if !util.StringsContain(supportedStorageClasses, cfg.StorageClass) && cfg.StorageClass != "" {
 		return errUnsupportedStorageClass
 	}
-	if err := cfg.SSE.Validate(); err != nil {
-		return err
-	}
 
-	return nil
+	return cfg.SSE.Validate()
 }
 
 // SSEConfig configures S3 server side encryption

--- a/pkg/storage/bucket/swift/bucket_client.go
+++ b/pkg/storage/bucket/swift/bucket_client.go
@@ -14,7 +14,7 @@ import (
 )
 
 // NewBucketClient creates a new Swift bucket client
-func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
+func NewBucketClient(cfg Config, _ string, logger log.Logger) (objstore.Bucket, error) {
 	bucketConfig := swift.Config{
 		AuthVersion:       cfg.AuthVersion,
 		AuthUrl:           cfg.AuthURL,

--- a/pkg/storage/chunk/json_helpers.go
+++ b/pkg/storage/chunk/json_helpers.go
@@ -87,6 +87,6 @@ func encodeModelTime(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	}
 }
 
-func modelTimeIsEmpty(ptr unsafe.Pointer) bool {
+func modelTimeIsEmpty(_ unsafe.Pointer) bool {
 	return false
 }

--- a/pkg/storage/chunk/prometheus_chunk.go
+++ b/pkg/storage/chunk/prometheus_chunk.go
@@ -76,11 +76,11 @@ func (p *prometheusXorChunk) Add(m model.SamplePair) (EncodedChunk, error) {
 	return nil, nil
 }
 
-func (p *prometheusXorChunk) AddHistogram(timestamp int64, h *histogram.Histogram) (EncodedChunk, error) {
+func (p *prometheusXorChunk) AddHistogram(_ int64, _ *histogram.Histogram) (EncodedChunk, error) {
 	return nil, fmt.Errorf("cannot add histogram to sample chunk")
 }
 
-func (p *prometheusXorChunk) AddFloatHistogram(timestamp int64, h *histogram.FloatHistogram) (EncodedChunk, error) {
+func (p *prometheusXorChunk) AddFloatHistogram(_ int64, _ *histogram.FloatHistogram) (EncodedChunk, error) {
 	return nil, fmt.Errorf("cannot add float histogram to sample chunk")
 }
 
@@ -107,11 +107,11 @@ func newPrometheusHistogramChunk() *prometheusHistogramChunk {
 	return &prometheusHistogramChunk{}
 }
 
-func (p *prometheusHistogramChunk) Add(sample model.SamplePair) (EncodedChunk, error) {
+func (p *prometheusHistogramChunk) Add(_ model.SamplePair) (EncodedChunk, error) {
 	return nil, fmt.Errorf("cannot add float sample to histogram chunk")
 }
 
-func (p *prometheusHistogramChunk) AddFloatHistogram(timestamp int64, h *histogram.FloatHistogram) (EncodedChunk, error) {
+func (p *prometheusHistogramChunk) AddFloatHistogram(_ int64, _ *histogram.FloatHistogram) (EncodedChunk, error) {
 	return nil, fmt.Errorf("cannot add float histogram to histogram chunk")
 }
 
@@ -155,11 +155,11 @@ func newPrometheusFloatHistogramChunk() *prometheusFloatHistogramChunk {
 	return &prometheusFloatHistogramChunk{}
 }
 
-func (p *prometheusFloatHistogramChunk) Add(sample model.SamplePair) (EncodedChunk, error) {
+func (p *prometheusFloatHistogramChunk) Add(_ model.SamplePair) (EncodedChunk, error) {
 	return nil, fmt.Errorf("cannot add float sample to histogram chunk")
 }
 
-func (p *prometheusFloatHistogramChunk) AddHistogram(timestamp int64, h *histogram.Histogram) (EncodedChunk, error) {
+func (p *prometheusFloatHistogramChunk) AddHistogram(_ int64, _ *histogram.Histogram) (EncodedChunk, error) {
 	return nil, fmt.Errorf("cannot add histogram sample to float histogram chunk")
 }
 
@@ -285,13 +285,13 @@ func (p *prometheusChunkIterator) Err() error {
 
 type errorIterator string
 
-func (e errorIterator) Scan() chunkenc.ValueType                         { return chunkenc.ValNone }
-func (e errorIterator) FindAtOrAfter(time model.Time) chunkenc.ValueType { return chunkenc.ValNone }
-func (e errorIterator) Value() model.SamplePair                          { panic("no values") }
-func (e errorIterator) AtHistogram() (int64, *histogram.Histogram)       { panic("no integer histograms") }
+func (e errorIterator) Scan() chunkenc.ValueType                      { return chunkenc.ValNone }
+func (e errorIterator) FindAtOrAfter(_ model.Time) chunkenc.ValueType { return chunkenc.ValNone }
+func (e errorIterator) Value() model.SamplePair                       { panic("no values") }
+func (e errorIterator) AtHistogram() (int64, *histogram.Histogram)    { panic("no integer histograms") }
 func (e errorIterator) AtFloatHistogram() (int64, *histogram.FloatHistogram) {
 	panic("no float histograms")
 }
-func (e errorIterator) Timestamp() int64                                   { panic("no samples") }
-func (e errorIterator) Batch(size int, valueType chunkenc.ValueType) Batch { panic("no values") }
-func (e errorIterator) Err() error                                         { return errors.New(string(e)) }
+func (e errorIterator) Timestamp() int64                        { panic("no samples") }
+func (e errorIterator) Batch(_ int, _ chunkenc.ValueType) Batch { panic("no values") }
+func (e errorIterator) Err() error                              { return errors.New(string(e)) }

--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -73,7 +73,7 @@ const (
 	MarkedForNoCompactionMeta = "marked-for-no-compact"
 )
 
-func NewFetcherMetrics(reg prometheus.Registerer, syncedExtraLabels, modifiedExtraLabels [][]string) *FetcherMetrics {
+func NewFetcherMetrics(reg prometheus.Registerer, syncedExtraLabels [][]string) *FetcherMetrics {
 	var m FetcherMetrics
 
 	m.Syncs = promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -166,7 +166,7 @@ func NewMetaFetcher(logger log.Logger, concurrency int, bkt objstore.Instrumente
 		bkt:         bkt,
 		cacheDir:    cacheDir,
 		cached:      map[ulid.ULID]*metadata.Meta{},
-		metrics:     NewFetcherMetrics(reg, nil, nil),
+		metrics:     NewFetcherMetrics(reg, nil),
 		filters:     filters,
 	}, nil
 }

--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -503,7 +503,7 @@ func (f *IgnoreDeletionMarkFilter) DeletionMarkBlocks() map[ulid.ULID]*metadata.
 
 // Filter filters out blocks that are marked for deletion after a given delay.
 // It also returns the blocks that can be deleted since they were uploaded delay duration before current time.
-func (f *IgnoreDeletionMarkFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced GaugeVec, modified GaugeVec) error {
+func (f *IgnoreDeletionMarkFilter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced GaugeVec, _ GaugeVec) error {
 	deletionMarkMap := make(map[ulid.ULID]*metadata.DeletionMark)
 
 	// Make a copy of block IDs to check, in order to avoid concurrency issues

--- a/pkg/storage/tsdb/bucketcache/caching_bucket.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket.go
@@ -255,13 +255,13 @@ func (cb *CachingBucket) Exists(ctx context.Context, name string) (bool, error) 
 	existsTime := time.Now()
 	ok, err := cb.Bucket.Exists(ctx, name)
 	if err == nil {
-		storeExistsCacheEntry(ctx, key, ok, existsTime, cfg.cache, cfg.existsTTL, cfg.doesntExistTTL)
+		storeExistsCacheEntry(key, ok, existsTime, cfg.cache, cfg.existsTTL, cfg.doesntExistTTL)
 	}
 
 	return ok, err
 }
 
-func storeExistsCacheEntry(ctx context.Context, cachingKey string, exists bool, ts time.Time, cache cache.Cache, existsTTL, doesntExistTTL time.Duration) {
+func storeExistsCacheEntry(cachingKey string, exists bool, ts time.Time, cache cache.Cache, existsTTL, doesntExistTTL time.Duration) {
 	var ttl time.Duration
 	if exists {
 		ttl = existsTTL - time.Since(ts)
@@ -330,13 +330,13 @@ func (cb *CachingBucket) Get(ctx context.Context, name string) (io.ReadCloser, e
 	if err != nil {
 		if cb.Bucket.IsObjNotFoundErr(err) {
 			// Cache that object doesn't exist.
-			storeExistsCacheEntry(ctx, existsKey, false, getTime, cfg.cache, cfg.existsTTL, cfg.doesntExistTTL)
+			storeExistsCacheEntry(existsKey, false, getTime, cfg.cache, cfg.existsTTL, cfg.doesntExistTTL)
 		}
 
 		return nil, err
 	}
 
-	storeExistsCacheEntry(ctx, existsKey, true, getTime, cfg.cache, cfg.existsTTL, cfg.doesntExistTTL)
+	storeExistsCacheEntry(existsKey, true, getTime, cfg.cache, cfg.existsTTL, cfg.doesntExistTTL)
 	return &getReader{
 		c:         cfg.cache,
 		r:         reader,

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -160,7 +160,7 @@ func (d *DurationList) ToMilliseconds() []int64 {
 
 // RegisterFlags registers the TSDB flags
 func (cfg *BlocksStorageConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
-	cfg.Bucket.RegisterFlagsWithPrefixAndDefaultDirectory("blocks-storage.", "blocks", f, logger)
+	cfg.Bucket.RegisterFlagsWithPrefixAndDefaultDirectory("blocks-storage.", "blocks", f)
 	cfg.BucketStore.RegisterFlags(f, logger)
 	cfg.TSDB.RegisterFlags(f)
 }

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -153,9 +153,9 @@ func (c noopCache) FetchExpandedPostings(_ context.Context, _ string, _ ulid.ULI
 	return nil, false
 }
 
-func (noopCache) StoreSeriesForPostings(userID string, blockID ulid.ULID, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey, v []byte) {
+func (noopCache) StoreSeriesForPostings(string, ulid.ULID, *sharding.ShardSelector, indexcache.PostingsKey, []byte) {
 }
-func (noopCache) FetchSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey) ([]byte, bool) {
+func (noopCache) FetchSeriesForPostings(context.Context, string, ulid.ULID, *sharding.ShardSelector, indexcache.PostingsKey) ([]byte, bool) {
 	return nil, false
 }
 

--- a/pkg/storegateway/bucket_index_metadata_fetcher.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher.go
@@ -51,7 +51,7 @@ func NewBucketIndexMetadataFetcher(
 		cfgProvider: cfgProvider,
 		logger:      logger,
 		filters:     filters,
-		metrics:     block.NewFetcherMetrics(reg, [][]string{{corruptedBucketIndex}, {noBucketIndex}, {minTimeExcludedMeta}}, nil),
+		metrics:     block.NewFetcherMetrics(reg, [][]string{{corruptedBucketIndex}, {noBucketIndex}, {minTimeExcludedMeta}}),
 	}
 }
 

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -755,11 +755,11 @@ type userShardingStrategy struct {
 	users []string
 }
 
-func (u *userShardingStrategy) FilterUsers(ctx context.Context, userIDs []string) ([]string, error) {
+func (u *userShardingStrategy) FilterUsers(context.Context, []string) ([]string, error) {
 	return u.users, nil
 }
 
-func (u *userShardingStrategy) FilterBlocks(ctx context.Context, userID string, metas map[ulid.ULID]*metadata.Meta, loaded map[ulid.ULID]struct{}, synced block.GaugeVec) error {
+func (u *userShardingStrategy) FilterBlocks(_ context.Context, userID string, metas map[ulid.ULID]*metadata.Meta, _ map[ulid.ULID]struct{}, _ block.GaugeVec) error {
 	if util.StringsContain(u.users, userID) {
 		return nil
 	}
@@ -952,7 +952,7 @@ type indexCacheMissingLabelValues struct {
 	indexcache.IndexCache
 }
 
-func (indexCacheMissingLabelValues) FetchLabelValues(ctx context.Context, userID string, blockID ulid.ULID, labelName string, matchersKey indexcache.LabelMatchersKey) ([]byte, bool) {
+func (indexCacheMissingLabelValues) FetchLabelValues(context.Context, string, ulid.ULID, string, indexcache.LabelMatchersKey) ([]byte, bool) {
 	return nil, false
 }
 

--- a/pkg/storegateway/metadata_fetcher_filters.go
+++ b/pkg/storegateway/metadata_fetcher_filters.go
@@ -93,7 +93,7 @@ func newMinTimeMetaFilter(limit time.Duration) *minTimeMetaFilter {
 	return &minTimeMetaFilter{limit: limit}
 }
 
-func (f *minTimeMetaFilter) Filter(_ context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, modified block.GaugeVec) error {
+func (f *minTimeMetaFilter) Filter(_ context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, _ block.GaugeVec) error {
 	if f.limit <= 0 {
 		return nil
 	}

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -1104,7 +1104,7 @@ func (f *chunkReaderMock) Close() error {
 	return nil
 }
 
-func (f *chunkReaderMock) addLoad(id chunks.ChunkRef, seriesEntry, chunkEntry int, length uint32) error {
+func (f *chunkReaderMock) addLoad(id chunks.ChunkRef, seriesEntry, chunkEntry int, _ uint32) error {
 	if f.addLoadErr != nil {
 		return f.addLoadErr
 	}
@@ -1138,11 +1138,11 @@ func generateSeriesEntriesWithChunks(t testing.TB, numSeries, numChunksPerSeries
 func generateSeriesEntriesWithChunksSize(t testing.TB, numSeries, numChunksPerSeries, chunkDataLenBytes int) []testBlockSeries {
 
 	out := make([]testBlockSeries, 0, numSeries)
-	labels := generateSeries([]int{numSeries})
+	lbls := generateSeries([]int{numSeries})
 
 	for i := 0; i < numSeries; i++ {
 		series := testBlockSeries{
-			lset: labels[i],
+			lset: lbls[i],
 			refs: make([]chunks.ChunkRef, 0, numChunksPerSeries),
 			chks: make([]storepb.AggrChunk, 0, numChunksPerSeries),
 		}
@@ -1304,7 +1304,7 @@ func newInMemoryChunksCache() chunkscache.Cache {
 	}
 }
 
-func (c *inMemoryChunksCache) FetchMultiChunks(ctx context.Context, userID string, ranges []chunkscache.Range, chunksPool *pool.SafeSlabPool[byte]) map[chunkscache.Range][]byte {
+func (c *inMemoryChunksCache) FetchMultiChunks(_ context.Context, userID string, ranges []chunkscache.Range, _ *pool.SafeSlabPool[byte]) map[chunkscache.Range][]byte {
 	hits := make(map[chunkscache.Range][]byte, len(ranges))
 	for _, r := range ranges {
 		if cached, ok := c.cached[userID][r]; ok {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -470,10 +470,10 @@ Outer:
 			if chksA[aChunksOffset].Compare(chksB[bChunksOffset]) < 0 {
 				toReturn.chunksRanges = append(toReturn.chunksRanges, chksA[aChunksOffset])
 				break
-			} else {
-				toReturn.chunksRanges = append(toReturn.chunksRanges, chksB[bChunksOffset])
-				bChunksOffset++
 			}
+
+			toReturn.chunksRanges = append(toReturn.chunksRanges, chksB[bChunksOffset])
+			bChunksOffset++
 		}
 	}
 

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -957,6 +957,7 @@ func TestDeduplicatingSeriesChunkRefsSetIterator_PropagatesErrors(t *testing.T) 
 		},
 	}))
 
+	// nolint:revive // We want to read through all series.
 	for chainedSet.Next() {
 	}
 
@@ -2379,7 +2380,7 @@ type forbiddenFetchMultiPostingsIndexCache struct {
 	t *testing.T
 }
 
-func (c forbiddenFetchMultiPostingsIndexCache) FetchMultiPostings(ctx context.Context, userID string, blockID ulid.ULID, keys []labels.Label) indexcache.BytesResult {
+func (c forbiddenFetchMultiPostingsIndexCache) FetchMultiPostings(context.Context, string, ulid.ULID, []labels.Label) indexcache.BytesResult {
 	assert.Fail(c.t, "index cache FetchMultiPostings should not be called")
 	return nil
 }
@@ -2446,12 +2447,12 @@ type mockSeriesHasher struct {
 	hashes map[string]uint64
 }
 
-func (a mockSeriesHasher) CachedHash(seriesID storage.SeriesRef, stats *queryStats) (uint64, bool) {
+func (a mockSeriesHasher) CachedHash(seriesID storage.SeriesRef, _ *queryStats) (uint64, bool) {
 	hash, isCached := a.cached[seriesID]
 	return hash, isCached
 }
 
-func (a mockSeriesHasher) Hash(seriesID storage.SeriesRef, lset labels.Labels, stats *queryStats) uint64 {
+func (a mockSeriesHasher) Hash(_ storage.SeriesRef, lset labels.Labels, _ *queryStats) uint64 {
 	return a.hashes[lset.String()]
 }
 
@@ -2777,6 +2778,6 @@ type mockIndexCacheEntry struct {
 	cached   bool
 }
 
-func (c mockIndexCache) FetchSeriesForPostings(ctx context.Context, userID string, blockID ulid.ULID, shard *sharding.ShardSelector, postingsKey indexcache.PostingsKey) ([]byte, bool) {
+func (c mockIndexCache) FetchSeriesForPostings(context.Context, string, ulid.ULID, *sharding.ShardSelector, indexcache.PostingsKey) ([]byte, bool) {
 	return c.fetchSeriesForPostingsResponse.contents, c.fetchSeriesForPostingsResponse.cached
 }

--- a/pkg/storegateway/sharding_strategy.go
+++ b/pkg/storegateway/sharding_strategy.go
@@ -193,7 +193,7 @@ func NewShardingMetadataFilterAdapter(userID string, strategy ShardingStrategy) 
 
 // Filter implements block.MetadataFilter.
 // This function is NOT safe for use by multiple goroutines concurrently.
-func (a *shardingMetadataFilterAdapter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, modified block.GaugeVec) error {
+func (a *shardingMetadataFilterAdapter) Filter(ctx context.Context, metas map[ulid.ULID]*metadata.Meta, synced block.GaugeVec, _ block.GaugeVec) error {
 	if err := a.strategy.FilterBlocks(ctx, a.userID, metas, a.lastBlocks, synced); err != nil {
 		return err
 	}

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -171,6 +171,6 @@ func (s *safeQueryStats) export() *queryStats {
 	s.unsafeStatsMx.Lock()
 	defer s.unsafeStatsMx.Unlock()
 
-	copy := *s.unsafeStats
-	return &copy
+	copied := *s.unsafeStats
+	return &copied
 }

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -25,7 +25,7 @@ var (
 // InitLogger initialises the global gokit logger (util_log.Logger) and overrides the
 // default logger for the server.
 func InitLogger(cfg *server.Config) {
-	l := newBasicLogger(cfg.LogLevel, cfg.LogFormat)
+	l := newBasicLogger(cfg.LogFormat)
 
 	// when using util_log.Logger, skip 5 stack frames.
 	logger := log.With(l, "caller", log.Caller(5))
@@ -36,7 +36,7 @@ func InitLogger(cfg *server.Config) {
 	cfg.Log = logging.GoKit(level.NewFilter(log.With(l, "caller", log.Caller(6)), cfg.LogLevel.Gokit))
 }
 
-func newBasicLogger(l logging.Level, format logging.Format) log.Logger {
+func newBasicLogger(format logging.Format) log.Logger {
 	var logger log.Logger
 	if format.String() == "json" {
 		logger = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
@@ -50,7 +50,7 @@ func newBasicLogger(l logging.Level, format logging.Format) log.Logger {
 
 // NewDefaultLogger creates a new gokit logger with the configured level and format
 func NewDefaultLogger(l logging.Level, format logging.Format) log.Logger {
-	logger := newBasicLogger(l, format)
+	logger := newBasicLogger(format)
 	return level.NewFilter(log.With(logger, "ts", log.DefaultTimestampUTC), l.Gokit)
 }
 

--- a/pkg/util/validation/validate_test.go
+++ b/pkg/util/validation/validate_test.go
@@ -26,15 +26,15 @@ type validateLabelsCfg struct {
 	maxLabelValueLength    int
 }
 
-func (v validateLabelsCfg) MaxLabelNamesPerSeries(userID string) int {
+func (v validateLabelsCfg) MaxLabelNamesPerSeries(_ string) int {
 	return v.maxLabelNamesPerSeries
 }
 
-func (v validateLabelsCfg) MaxLabelNameLength(userID string) int {
+func (v validateLabelsCfg) MaxLabelNameLength(_ string) int {
 	return v.maxLabelNameLength
 }
 
-func (v validateLabelsCfg) MaxLabelValueLength(userID string) int {
+func (v validateLabelsCfg) MaxLabelValueLength(_ string) int {
 	return v.maxLabelValueLength
 }
 
@@ -43,11 +43,11 @@ type validateMetadataCfg struct {
 	maxMetadataLength         int
 }
 
-func (vm validateMetadataCfg) EnforceMetadataMetricName(userID string) bool {
+func (vm validateMetadataCfg) EnforceMetadataMetricName(_ string) bool {
 	return vm.enforceMetadataMetricName
 }
 
-func (vm validateMetadataCfg) MaxMetadataLength(userID string) int {
+func (vm validateMetadataCfg) MaxMetadataLength(_ string) int {
 	return vm.maxMetadataLength
 }
 
@@ -348,11 +348,11 @@ type sampleValidationConfig struct {
 	maxNativeHistogramBuckets int
 }
 
-func (c sampleValidationConfig) CreationGracePeriod(userID string) time.Duration {
+func (c sampleValidationConfig) CreationGracePeriod(_ string) time.Duration {
 	return 0
 }
 
-func (c sampleValidationConfig) MaxNativeHistogramBuckets(userID string) int {
+func (c sampleValidationConfig) MaxNativeHistogramBuckets(_ string) int {
 	return c.maxNativeHistogramBuckets
 }
 

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -126,6 +126,6 @@ func newMockKVStore() *mockKVStore {
 	}
 }
 
-func (m *mockKVStore) Get(ctx context.Context, path string) (*hashivault.KVSecret, error) {
+func (m *mockKVStore) Get(_ context.Context, path string) (*hashivault.KVSecret, error) {
 	return m.values[path].secret, m.values[path].err
 }

--- a/tools/compaction-planner/main.go
+++ b/tools/compaction-planner/main.go
@@ -41,7 +41,7 @@ func main() {
 	logger := gokitlog.NewNopLogger()
 
 	// Loads bucket index, and plans compaction for all loaded meta files.
-	cfg.bucket.RegisterFlags(flag.CommandLine, logger)
+	cfg.bucket.RegisterFlags(flag.CommandLine)
 	cfg.blockRanges = mimir_tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour}
 	flag.Var(&cfg.blockRanges, "block-ranges", "List of compaction time ranges.")
 	flag.StringVar(&cfg.userID, "user", "", "User (tenant)")

--- a/tools/list-deduplicated-blocks/main.go
+++ b/tools/list-deduplicated-blocks/main.go
@@ -41,7 +41,7 @@ func main() {
 	}{}
 
 	logger := gokitlog.NewNopLogger()
-	cfg.bucket.RegisterFlags(flag.CommandLine, logger)
+	cfg.bucket.RegisterFlags(flag.CommandLine)
 	flag.StringVar(&cfg.userID, "user", "", "User (tenant)")
 	flag.Parse()
 

--- a/tools/listblocks/main.go
+++ b/tools/listblocks/main.go
@@ -46,7 +46,7 @@ type config struct {
 func main() {
 	logger := gokitlog.NewNopLogger()
 	cfg := config{}
-	cfg.bucket.RegisterFlags(flag.CommandLine, logger)
+	cfg.bucket.RegisterFlags(flag.CommandLine)
 	flag.StringVar(&cfg.userID, "user", "", "User (tenant)")
 	flag.BoolVar(&cfg.showDeleted, "show-deleted", false, "Show deleted blocks")
 	flag.BoolVar(&cfg.showLabels, "show-labels", false, "Show block labels")

--- a/tools/markblocks/main.go
+++ b/tools/markblocks/main.go
@@ -42,13 +42,13 @@ func main() {
 	ctx := context.Background()
 	logger := log.WithPrefix(log.NewLogfmtLogger(os.Stderr), "time", log.DefaultTimestampUTC)
 
-	cfg := parseFlags(logger)
+	cfg := parseFlags()
 	marker, filename := createMarker(cfg.mark, logger, cfg.details)
 	ulids := validateTenantAndBlocks(logger, cfg.tenantID, cfg.blocks)
 	uploadMarks(ctx, logger, ulids, marker, filename, cfg.dryRun, cfg.bucket, cfg.tenantID, cfg.allowPartialBlocks, cfg.concurrency)
 }
 
-func parseFlags(logger log.Logger) config {
+func parseFlags() config {
 	var cfg config
 
 	// We define two flag sets, one on basic straightforward flags of this cli, and the other one with all flags,
@@ -91,7 +91,7 @@ func parseFlags(logger log.Logger) config {
 	// We set only the `-backend` flag on the basicFlagSet, to make sure that user sees that there are more backends supported.
 	// Then we register all bucket flags on the full flag set, which is the flag set we're parsing.
 	basicFlagSet.StringVar(&cfg.bucket.Backend, "backend", bucket.Filesystem, fmt.Sprintf("Backend storage to use. Supported backends are: %s. Use -help-all to see help on backends configuration.", strings.Join(bucket.SupportedBackends, ", ")))
-	cfg.bucket.RegisterFlags(fullFlagSet, logger)
+	cfg.bucket.RegisterFlags(fullFlagSet)
 
 	fullFlagSet.IntVar(&cfg.concurrency, "concurrency", 16, "How many markers to upload concurrently.")
 


### PR DESCRIPTION
#### What this PR does

This PR upgrades `golangci-lint` to v1.52.2 and fixes all new linting warnings, primarily from the upgraded version of `revive`.

Some warnings are false positives (see https://github.com/mgechev/revive/issues/386) and have been ignored. The new `if-return` rule from `revive` enabled by default seemed unnecessary and has been disabled.

ℹ️ This PR will require a maintainer with permission to push the build image to Docker Hub to build and push the build image to Docker Hub and then update the image tag in the `Makefile` before merging (see [these instructions](https://github.com/grafana/mimir/blob/main/docs/internal/contributing/how-to-upgrade-golang-version.md)).

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
