### PR TITLE
Do not check for blocks marked for deletion in Syncer.GarbageCollect()

### DIFF
--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -129,8 +129,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		require.NoError(t, err)
 
 		blocksMarkedForDeletion := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
-		ignoreDeletionMarkFilter := NewExcludeMarkedForDeletionFilter(nil)
-		sy, err := NewMetaSyncer(nil, nil, bkt, metaFetcher, duplicateBlocksFilter, ignoreDeletionMarkFilter, blocksMarkedForDeletion)
+		sy, err := NewMetaSyncer(nil, nil, bkt, metaFetcher, duplicateBlocksFilter, blocksMarkedForDeletion)
 		require.NoError(t, err)
 
 		// Do one initial synchronization with the bucket.
@@ -239,7 +238,7 @@ func TestGroupCompactE2E(t *testing.T) {
 		require.NoError(t, err)
 
 		blocksMarkedForDeletion := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
-		sy, err := NewMetaSyncer(nil, nil, bkt, metaFetcher, duplicateBlocksFilter, ignoreDeletionMarkFilter, blocksMarkedForDeletion)
+		sy, err := NewMetaSyncer(nil, nil, bkt, metaFetcher, duplicateBlocksFilter, blocksMarkedForDeletion)
 		require.NoError(t, err)
 
 		comp, err := tsdb.NewLeveledCompactor(ctx, reg, logger, []int64{1000, 3000}, nil, nil, true)
@@ -480,7 +479,7 @@ func createBlock(ctx context.Context, t testing.TB, prepareDir string, b blockge
 	return
 }
 
-// Regression test for #2459 issue.
+// Regression test for Thanos issue #2459.
 func TestGarbageCollectDoesntCreateEmptyBlocksWithDeletionMarksOnly(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
 
@@ -532,7 +531,7 @@ func TestGarbageCollectDoesntCreateEmptyBlocksWithDeletionMarksOnly(t *testing.T
 		})
 		require.NoError(t, err)
 
-		sy, err := NewMetaSyncer(nil, nil, bkt, metaFetcher, duplicateBlocksFilter, ignoreDeletionMarkFilter, blocksMarkedForDeletion)
+		sy, err := NewMetaSyncer(nil, nil, bkt, metaFetcher, duplicateBlocksFilter, blocksMarkedForDeletion)
 		require.NoError(t, err)
 
 		// Do one initial synchronization with the bucket.

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -741,7 +741,6 @@ func (c *MultitenantCompactor) compactUser(ctx context.Context, userID string) e
 		userBucket,
 		fetcher,
 		deduplicateBlocksFilter,
-		excludeMarkedForDeletionFilter,
 		c.blocksMarkedForDeletion,
 	)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does
The compactor's `Syncer.GarbageCollect()` checks if a duplicated block is part of the list of blocks marked for deletion before marking it, so that we don't issue any object storage API call if it's already marked. However, in Mimir today we exclude every block marked for deletion (with no deletion delay applied) **before** calling the deduplicate blocks filter ([code](https://github.com/grafana/mimir/blob/b6566fff9d410f589b58904472fe4912e17e0a8c/pkg/compactor/compactor.go#L720-L721)), so I can't see any possible way for a block marked for deletion to also be returned by the deduplicate blocks filter.

Along with @pstibrany, I checked where this code originated. It originated Thanos thanos ([PR](https://github.com/thanos-io/thanos/pull/2136)), but it made sense at that time because the "exclude blocks for deletion" filter was applying the deletion delay, so the deduplicate blocks filter could have returned blocks already marked for deletion too. This is no more the case in Mimir.

This PR will simplify #5063.

#### Which issue(s) this PR fixes or relates to

Part of #5056.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
