### PR TITLE
activeseries tests: check for hash collisions

### DIFF
--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func copyFn(l labels.Labels) labels.Labels { return l }
@@ -86,12 +85,21 @@ func TestActiveSeries_UpdateSeries_WithMatchers(t *testing.T) {
 	assert.True(t, valid)
 }
 
-func TestActiveSeries_ShouldCorrectlyHandleHashCollisions(t *testing.T) {
-	// These two series have the same XXHash; for algo see https://github.com/Cyan4973/xxHash/issues/54#issuecomment-414061026
-	ls1 := labels.FromStrings("_z~!!a+0", "interesting_data_here_", "zzzzz%!z", "more_interesting_data_here")
-	ls2 := labels.FromStrings("_z-m\xaew\xa3\xc0", "interesting_data_here_", "zzzzz\xa5|z", "more_interesting_data_here")
+func labelsWithHashCollision() (labels.Labels, labels.Labels) {
+	// These two series have the same XXHash; thanks to https://github.com/pstibrany/labels_hash_collisions
+	ls1 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "l6CQ5y")
+	ls2 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
 
-	require.True(t, ls1.Hash() == ls2.Hash())
+	if ls1.Hash() != ls2.Hash() {
+		panic("This code needs to be updated: find new labels with colliding hash values.")
+	}
+
+	return ls1, ls2
+}
+
+func TestActiveSeries_ShouldCorrectlyHandleHashCollisions(t *testing.T) {
+	ls1, ls2 := labelsWithHashCollision()
+
 	c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 	c.UpdateSeries(ls1, ls1.Hash(), time.Now(), copyFn)
 	c.UpdateSeries(ls2, ls2.Hash(), time.Now(), copyFn)
@@ -102,12 +110,12 @@ func TestActiveSeries_ShouldCorrectlyHandleHashCollisions(t *testing.T) {
 }
 
 func TestActiveSeries_Purge_NoMatchers(t *testing.T) {
+	collision1, collision2 := labelsWithHashCollision()
 	series := []labels.Labels{
 		labels.FromStrings("a", "1"),
 		labels.FromStrings("a", "2"),
-		// The two following series have the same Fingerprint
-		labels.FromStrings("_", "ypfajYg2lsv", "__name__", "logs"),
-		labels.FromStrings("_", "KiqbryhzUpn", "__name__", "logs"),
+		collision1,
+		collision2,
 	}
 
 	// Run the same test for increasing TTL values
@@ -135,12 +143,12 @@ func TestActiveSeries_Purge_NoMatchers(t *testing.T) {
 }
 
 func TestActiveSeries_Purge_WithMatchers(t *testing.T) {
+	collision1, collision2 := labelsWithHashCollision()
 	series := []labels.Labels{
 		labels.FromStrings("a", "1"),
 		labels.FromStrings("a", "2"),
-		// The two following series have the same Fingerprint
-		labels.FromStrings("_", "ypfajYg2lsv", "__name__", "logs"),
-		labels.FromStrings("_", "KiqbryhzUpn", "__name__", "logs"),
+		collision1,
+		collision2,
 	}
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{"foo": `{_=~"y.*"}`}))
@@ -178,9 +186,7 @@ func TestActiveSeries_Purge_WithMatchers(t *testing.T) {
 }
 
 func TestActiveSeries_PurgeOpt(t *testing.T) {
-	metric := labels.NewBuilder(labels.FromStrings("__name__", "logs"))
-	ls1 := metric.Set("_", "ypfajYg2lsv").Labels()
-	ls2 := metric.Set("_", "KiqbryhzUpn").Labels()
+	ls1, ls2 := labelsWithHashCollision()
 
 	currentTime := time.Now()
 	c := NewActiveSeries(&Matchers{}, 59*time.Second)


### PR DESCRIPTION
#### What this PR does

Several tests appeared to want colliding hash values, but only one had been fixed to work.

Use nicer label values created by pstibrany, and use them in every test that needs them.

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated
