### PR TITLE
store-gateway: reduce syscalls for looking up symbols

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -52,6 +52,7 @@ import (
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 	"github.com/grafana/mimir/pkg/util"
 	util_math "github.com/grafana/mimir/pkg/util/math"
+	"github.com/grafana/mimir/pkg/util/pool"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
@@ -1639,23 +1640,24 @@ type symbolizedLabel struct {
 // decodeSeries decodes a series entry from the given byte slice decoding all chunk metas of the series.
 // If skipChunks is specified decodeSeries does not return any chunks, but only labels and only if at least single chunk is within time range.
 // decodeSeries returns false, when there are no series data for given time range.
-func decodeSeries(b []byte, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool) (ok bool, err error) {
-	*lset = (*lset)[:0]
+func decodeSeries(b []byte, lsetPool *pool.SlabPool[symbolizedLabel], chks *[]chunks.Meta, skipChunks bool) (ok bool, lset []symbolizedLabel, err error) {
+
 	*chks = (*chks)[:0]
 
 	d := encoding.Decbuf{B: b}
 
 	// Read labels without looking up symbols.
 	k := d.Uvarint()
+	lset = lsetPool.Get(k)[:0]
 	for i := 0; i < k; i++ {
 		lno := uint32(d.Uvarint())
 		lvo := uint32(d.Uvarint())
-		*lset = append(*lset, symbolizedLabel{name: lno, value: lvo})
+		lset = append(lset, symbolizedLabel{name: lno, value: lvo})
 	}
 	// Read the chunks meta data.
 	k = d.Uvarint()
 	if k == 0 {
-		return false, d.Err()
+		return false, nil, d.Err()
 	}
 
 	// First t0 is absolute, rest is just diff so different type is used (Uvarint64).
@@ -1674,7 +1676,7 @@ func decodeSeries(b []byte, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipCh
 		// Found a chunk.
 		if skipChunks {
 			// We are not interested in chunks and we know there is at least one, that's enough to return series.
-			return true, nil
+			return true, lset, nil
 		}
 
 		*chks = append(*chks, chunks.Meta{
@@ -1685,7 +1687,7 @@ func decodeSeries(b []byte, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipCh
 
 		mint = maxt
 	}
-	return len(*chks) > 0, d.Err()
+	return len(*chks) > 0, lset, d.Err()
 }
 
 func maybeNilShard(shard *sharding.ShardSelector) sharding.ShardSelector {

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -48,9 +48,10 @@ type expandedPostingsPromise func(ctx context.Context) ([]storage.SeriesRef, []*
 // bucketIndexReader is a custom index reader (not conforming index.Reader interface) that reads index that is stored in
 // object storage without having to fully download it.
 type bucketIndexReader struct {
-	block            *bucketBlock
-	postingsStrategy postingsSelectionStrategy
-	dec              *index.Decoder
+	block             *bucketBlock
+	postingsStrategy  postingsSelectionStrategy
+	dec               *index.Decoder
+	indexHeaderReader indexheader.Reader
 }
 
 func newBucketIndexReader(block *bucketBlock, postingsStrategy postingsSelectionStrategy) *bucketIndexReader {
@@ -60,6 +61,7 @@ func newBucketIndexReader(block *bucketBlock, postingsStrategy postingsSelection
 		dec: &index.Decoder{
 			LookupSymbol: block.indexHeaderReader.LookupSymbol,
 		},
+		indexHeaderReader: block.indexHeaderReader,
 	}
 	return r
 }
@@ -745,7 +747,7 @@ func (l *bucketIndexLoadedSeries) addSeries(ref storage.SeriesRef, data []byte) 
 	l.seriesMx.Unlock()
 }
 
-// unsafeLoadSeries populates the given symbolized labels for the series identified by the reference the series has at least one chunk in the block.
+// unsafeLoadSeries returns symbolized labels for the series identified by the reference if the series has at least one chunk in the block.
 // unsafeLoadSeries also populates the given chunk metas slice if skipChunks is set to false. The returned chunkMetas will be in the same
 // order as in the index, which at this point is ordered by minTime and by their ref. The returned chunk metas are all the chunk for the series.
 // unsafeLoadSeries returns false, when there are no series data.
@@ -753,12 +755,12 @@ func (l *bucketIndexLoadedSeries) addSeries(ref storage.SeriesRef, data []byte) 
 // Error is returned on decoding error or if the reference does not resolve to a known series.
 //
 // It's NOT safe to call this function concurrently with addSeries().
-func (l *bucketIndexLoadedSeries) unsafeLoadSeries(ref storage.SeriesRef, lset *[]symbolizedLabel, chks *[]chunks.Meta, skipChunks bool, stats *queryStats) (ok bool, err error) {
+func (l *bucketIndexLoadedSeries) unsafeLoadSeries(ref storage.SeriesRef, chks *[]chunks.Meta, skipChunks bool, stats *queryStats, lsetPool *pool.SlabPool[symbolizedLabel]) (ok bool, _ []symbolizedLabel, err error) {
 	b, ok := l.series[ref]
 	if !ok {
-		return false, errors.Errorf("series %d not found", ref)
+		return false, nil, errors.Errorf("series %d not found", ref)
 	}
 	stats.seriesProcessed++
 	stats.seriesProcessedSizeSum += len(b)
-	return decodeSeries(b, lset, chks, skipChunks)
+	return decodeSeries(b, lsetPool, chks, skipChunks)
 }

--- a/pkg/storegateway/indexheader/encoding/encoding.go
+++ b/pkg/storegateway/indexheader/encoding/encoding.go
@@ -105,6 +105,13 @@ func (d *Decbuf) ResetAt(off int) {
 		return
 	}
 
+	// If we are trying to reset at a position which is already buffered,
+	// we can avoid resetting the fileReader and just discard some of the buffer instead.
+	if dist := off - d.Position(); dist >= 0 && dist < d.r.buffered() {
+		d.E = d.r.skip(dist)
+		return
+	}
+
 	d.E = d.r.resetAt(off)
 }
 

--- a/pkg/storegateway/indexheader/encoding/reader.go
+++ b/pkg/storegateway/indexheader/encoding/reader.go
@@ -161,6 +161,11 @@ func (f *fileReader) position() int {
 	return f.pos
 }
 
+// buffered returns the number of bytes that can be read from the fileReader which are already in memory.
+func (f *fileReader) buffered() int {
+	return f.buf.Buffered()
+}
+
 // close cleans up the underlying resources used by this fileReader.
 func (f *fileReader) close() error {
 	// Note that we don't do anything to clean up the buffer before returning it to the pool here:

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -36,6 +36,8 @@ type Reader interface {
 	// Error is return if the symbol can't be found.
 	LookupSymbol(o uint32) (string, error)
 
+	SymbolsReader() (streamindex.SymbolsReader, error)
+
 	// LabelValuesOffsets returns all label values and the offsets for their posting lists for given label name or error.
 	// The returned label values are sorted lexicographically (which the same as sorted by posting offset).
 	// The ranges of each posting list are the same as returned by PostingsOffset.

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -176,6 +176,19 @@ func (r *LazyBinaryReader) LookupSymbol(o uint32) (string, error) {
 	return r.reader.LookupSymbol(o)
 }
 
+// SymbolsReader implements Reader.
+func (r *LazyBinaryReader) SymbolsReader() (streamindex.SymbolsReader, error) {
+	r.readerMx.RLock()
+	defer r.readerMx.RUnlock()
+
+	if err := r.load(); err != nil {
+		return nil, err
+	}
+
+	r.usedAt.Store(time.Now().UnixNano())
+	return r.reader.SymbolsReader()
+}
+
 // LabelValuesOffsets implements Reader.
 func (r *LazyBinaryReader) LabelValuesOffsets(name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error) {
 	r.readerMx.RLock()

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -80,7 +80,7 @@ type seriesChunksSet struct {
 	seriesChunksPool *pool.SlabPool[storepb.AggrChunk]
 
 	// chunksReleaser releases the memory used to allocate series chunks.
-	chunksReleaser chunksReleaser
+	chunksReleaser releaser
 }
 
 // newSeriesChunksSet creates a new seriesChunksSet. The series slice is pre-allocated with
@@ -115,8 +115,9 @@ func newSeriesChunksSet(seriesCapacity int, seriesReleasable bool) seriesChunksS
 	}
 }
 
-type chunksReleaser interface {
-	// Release the memory used to allocate series chunks.
+type releaser interface {
+	// Release should release resources associated with this releaser instance.
+	// It is not safe to use any resources from this releaser after calling Release.
 	Release()
 }
 

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/hashcache"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/thanos-io/objstore/tracing"
+	"golang.org/x/exp/slices"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/sharding"
@@ -35,6 +36,18 @@ import (
 
 var (
 	seriesChunkRefsSetPool = pool.Interface(&sync.Pool{
+		// Intentionally return nil if the pool is empty, so that the caller can preallocate
+		// the slice with the right size.
+		New: nil,
+	})
+
+	symbolizedSeriesChunkRefsSetsPool = pool.Interface(&sync.Pool{
+		// Intentionally return nil if the pool is empty, so that the caller can preallocate
+		// the slice with the right size.
+		New: nil,
+	})
+
+	symbolizedLabelsPool = pool.Interface(&sync.Pool{
 		// Intentionally return nil if the pool is empty, so that the caller can preallocate
 		// the slice with the right size.
 		New: nil,
@@ -71,6 +84,44 @@ type seriesChunkRefsSet struct {
 
 	// releasable holds whether the series slice (but not its content) can be released to a memory pool.
 	releasable bool
+}
+
+type symbolizedSeriesChunkRefsSet struct {
+	// series sorted by labels.
+	series []symbolizedSeriesChunkRefs
+
+	labelsPool *pool.SlabPool[symbolizedLabel]
+}
+
+func newSymbolizedSeriesChunkRefsSet(capacity int) symbolizedSeriesChunkRefsSet {
+	var prealloc []symbolizedSeriesChunkRefs
+
+	if reused := symbolizedSeriesChunkRefsSetsPool.Get(); reused != nil {
+		prealloc = *(reused.(*[]symbolizedSeriesChunkRefs))
+	}
+
+	if prealloc == nil {
+		prealloc = make([]symbolizedSeriesChunkRefs, 0, capacity)
+	}
+
+	return symbolizedSeriesChunkRefsSet{
+		series:     prealloc,
+		labelsPool: pool.NewSlabPool[symbolizedLabel](symbolizedLabelsPool, 1024),
+	}
+}
+
+// release the internal series slice to a memory pool.
+//
+// This function is not idempotent. Calling it twice would introduce subtle bugs.
+func (b symbolizedSeriesChunkRefsSet) release() {
+	b.labelsPool.Release()
+	reuse := b.series[:0]
+	symbolizedSeriesChunkRefsSetsPool.Put(&reuse)
+}
+
+type symbolizedSeriesChunkRefs struct {
+	lset         []symbolizedLabel
+	chunksRanges []seriesChunkRefsRange
 }
 
 // newSeriesChunkRefsSet creates a new seriesChunkRefsSet with the given capacity.
@@ -675,8 +726,7 @@ type loadingSeriesChunkRefsSetIterator struct {
 	chunkRangesPerSeries int
 	logger               log.Logger
 
-	symbolizedLsetBuffer []symbolizedLabel
-	chunkMetasBuffer     []chunks.Meta
+	chunkMetasBuffer []chunks.Meta
 
 	err        error
 	currentSet seriesChunkRefsSet
@@ -817,54 +867,25 @@ func (s *loadingSeriesChunkRefsSetIterator) Next() bool {
 	// However, if the hash is already in the cache, then we can remove all postings for series
 	// not belonging to the shard.
 	if s.shard != nil {
-		var unsafeStats queryStats
-		nextPostings = filterPostingsByCachedShardHash(nextPostings, s.shard, s.seriesHasher, &unsafeStats)
-		loadStats.merge(&unsafeStats)
+		nextPostings = filterPostingsByCachedShardHash(nextPostings, s.shard, s.seriesHasher, loadStats)
 	}
 
-	loadedSeries, err := s.indexr.preloadSeries(ctx, nextPostings, s.stats)
+	symbolizedSet, err := s.symbolizedSet(ctx, nextPostings, loadStats)
 	if err != nil {
-		s.err = errors.Wrap(err, "preload series")
+		s.err = err
+		return false
+	}
+	defer symbolizedSet.release() // We only retain the slices of chunk ranges from this set. These are still not pooled, and it's ok to retain them.
+
+	nextSet, err := s.stringifiedSet(symbolizedSet)
+	if err != nil {
+		s.err = err
 		return false
 	}
 
-	// This can be released by the caller because loadingSeriesChunkRefsSetIterator doesn't retain it
-	// after Next() will be called again.
-	nextSet := newSeriesChunkRefsSet(len(nextPostings), true)
-	var builder labels.ScratchBuilder
+	nextSet = s.filterSeries(nextSet, nextPostings, loadStats)
 
-	for _, id := range nextPostings {
-		lset, metas, err := s.loadSeries(id, loadedSeries, loadStats, &builder)
-		if err != nil {
-			s.err = errors.Wrap(err, "read series")
-			return false
-		}
-		if lset.Len() == 0 {
-			// An empty label set means the series had no chunks in this block, so we skip it.
-			continue
-		}
-		var ranges []seriesChunkRefsRange
-		if !s.skipChunks {
-			clampLastChunkLength(nextSet.series, metas)
-			ranges = metasToRanges(partitionChunks(metas, s.chunkRangesPerSeries, minChunksPerRange), s.blockID, s.minTime, s.maxTime)
-			if len(ranges) == 0 {
-				// There are no chunks for this series in the requested time range; skip it
-				continue
-			}
-		}
-		if !shardOwned(s.shard, s.seriesHasher, id, lset, loadStats) {
-			continue
-		}
-		nextSet.series = append(nextSet.series, seriesChunkRefs{
-			lset:         lset,
-			chunksRanges: ranges,
-		})
-	}
-
-	if nextSet.len() == 0 {
-		// The next set we attempted to build is empty, so we can directly release it.
-		nextSet.release()
-
+	if len(nextSet.series) == 0 {
 		// Try with the next set of postings.
 		return s.Next()
 	}
@@ -876,21 +897,65 @@ func (s *loadingSeriesChunkRefsSetIterator) Next() bool {
 	return true
 }
 
+func (s *loadingSeriesChunkRefsSetIterator) symbolizedSet(ctx context.Context, postings []storage.SeriesRef, stats *queryStats) (_ symbolizedSeriesChunkRefsSet, err error) {
+	symbolizedSet := newSymbolizedSeriesChunkRefsSet(len(postings))
+	defer func() {
+		if err != nil {
+			symbolizedSet.release()
+		}
+	}()
+
+	loadedSeries, err := s.indexr.preloadSeries(ctx, postings, s.stats)
+	if err != nil {
+		return symbolizedSeriesChunkRefsSet{}, errors.Wrap(err, "preload series")
+	}
+
+	for _, id := range postings {
+		var (
+			metas  []chunks.Meta
+			series symbolizedSeriesChunkRefs
+		)
+		series.lset, metas, err = s.loadSeries(id, loadedSeries, stats, symbolizedSet.labelsPool)
+		if err != nil {
+			return symbolizedSeriesChunkRefsSet{}, errors.Wrap(err, "read series")
+		}
+		if !s.skipChunks {
+			clampLastChunkLength(symbolizedSet.series, metas)
+			series.chunksRanges = metasToRanges(partitionChunks(metas, s.chunkRangesPerSeries, minChunksPerRange), s.blockID, s.minTime, s.maxTime)
+		}
+		symbolizedSet.series = append(symbolizedSet.series, series)
+	}
+	return symbolizedSet, nil
+}
+
+func (s *loadingSeriesChunkRefsSetIterator) stringifiedSet(symbolizedSet symbolizedSeriesChunkRefsSet) (seriesChunkRefsSet, error) {
+	if len(symbolizedSet.series) > 256 {
+		// This approach comes with some overhead in data structures.
+		// It starts making more sense with more label values only.
+		return s.singlePassStringify(symbolizedSet)
+	}
+
+	return s.multiLookupStringify(symbolizedSet)
+}
+
 // clampLastChunkLength checks the length of the last chunk in the last range of the last series.
 // If the length of that chunk is larger than the difference with the first chunk ref in metas
 // then the length is clamped at that difference.
 // clampLastChunkLength assumes that the chunks are sorted by their refs
 // (currently this is equivalent to also being sorted by their minTime) and that all series belong to the same block.
 // clampLastChunkLength is a noop if metas or series is empty.
-func clampLastChunkLength(series []seriesChunkRefs, nextSeriesChunkMetas []chunks.Meta) {
+func clampLastChunkLength(series []symbolizedSeriesChunkRefs, nextSeriesChunkMetas []chunks.Meta) {
 	if len(series) == 0 || len(nextSeriesChunkMetas) == 0 {
 		return
 	}
+	var lastSeriesRanges = series[len(series)-1].chunksRanges
+	if len(lastSeriesRanges) == 0 {
+		return
+	}
 	var (
-		lastSeriesRanges = series[len(series)-1].chunksRanges
-		lastRange        = lastSeriesRanges[len(lastSeriesRanges)-1]
-		lastSeriesChunk  = lastRange.refs[len(lastRange.refs)-1]
-		firstRef         = nextSeriesChunkMetas[0].Ref
+		lastRange       = lastSeriesRanges[len(lastSeriesRanges)-1]
+		lastSeriesChunk = lastRange.refs[len(lastRange.refs)-1]
+		firstRef        = nextSeriesChunkMetas[0].Ref
 	)
 
 	// We only compare the segment file of the series because they all come from the same block.
@@ -902,6 +967,27 @@ func clampLastChunkLength(series []seriesChunkRefs, nextSeriesChunkMetas []chunk
 	if diffWithNextChunk > 0 && lastSeriesChunk.length > diffWithNextChunk {
 		lastRange.refs[len(lastRange.refs)-1].length = diffWithNextChunk
 	}
+}
+
+// filterSeries filters out series that don't belong to this shard (if sharding is configured) or that don't have any
+// chunk ranges and skipChunks=false. Empty chunks ranges indicates that the series doesn't have any chunk ranges in the
+// requested time range.
+func (s *loadingSeriesChunkRefsSetIterator) filterSeries(set seriesChunkRefsSet, postings []storage.SeriesRef, stats *queryStats) seriesChunkRefsSet {
+	writeIdx := 0
+	for sIdx, series := range set.series {
+		// An empty label set means the series had no chunks in this block, so we skip it.
+		// No chunk ranges means the series doesn't have a single chunk range in the requested range.
+		if len(series.lset) == 0 || (!s.skipChunks && len(series.chunksRanges) == 0) {
+			continue
+		}
+		if !shardOwned(s.shard, s.seriesHasher, postings[sIdx], series.lset, stats) {
+			continue
+		}
+		set.series[writeIdx] = set.series[sIdx]
+		writeIdx++
+	}
+	set.series = set.series[:writeIdx]
+	return set
 }
 
 const (
@@ -1025,18 +1111,84 @@ func (s *loadingSeriesChunkRefsSetIterator) Err() error {
 }
 
 // loadSeries returns a for chunks. It is not safe to use the returned []chunks.Meta after calling loadSeries again
-func (s *loadingSeriesChunkRefsSetIterator) loadSeries(ref storage.SeriesRef, loadedSeries *bucketIndexLoadedSeries, stats *queryStats, builder *labels.ScratchBuilder) (labels.Labels, []chunks.Meta, error) {
-	ok, err := loadedSeries.unsafeLoadSeries(ref, &s.symbolizedLsetBuffer, &s.chunkMetasBuffer, s.skipChunks, stats)
+func (s *loadingSeriesChunkRefsSetIterator) loadSeries(ref storage.SeriesRef, loadedSeries *bucketIndexLoadedSeries, stats *queryStats, lsetPool *pool.SlabPool[symbolizedLabel]) ([]symbolizedLabel, []chunks.Meta, error) {
+	ok, lbls, err := loadedSeries.unsafeLoadSeries(ref, &s.chunkMetasBuffer, s.skipChunks, stats, lsetPool)
 	if !ok || err != nil {
-		return labels.EmptyLabels(), nil, errors.Wrap(err, "loadSeries")
+		return nil, nil, errors.Wrap(err, "loadSeries")
 	}
 
-	lset, err := s.indexr.LookupLabelsSymbols(s.symbolizedLsetBuffer, builder)
+	return lbls, s.chunkMetasBuffer, nil
+}
+
+func (s *loadingSeriesChunkRefsSetIterator) singlePassStringify(symbolizedSet symbolizedSeriesChunkRefsSet) (seriesChunkRefsSet, error) {
+	// Some conservative map pre-allocation; the goal is to get an order of magnitude size of the map, so we minimize map growth.
+	symbols := make(map[uint32]string, len(symbolizedSet.series)/2)
+	maxLabelsPerSeries := 0
+
+	for _, series := range symbolizedSet.series {
+		if numLabels := len(series.lset); maxLabelsPerSeries < numLabels {
+			maxLabelsPerSeries = numLabels
+		}
+		for _, symRef := range series.lset {
+			symbols[symRef.value] = ""
+			symbols[symRef.name] = ""
+		}
+	}
+
+	allSymbols := make([]uint32, 0, len(symbols))
+	for sym := range symbols {
+		allSymbols = append(allSymbols, sym)
+	}
+	slices.Sort(allSymbols)
+
+	symReader, err := s.indexr.indexHeaderReader.SymbolsReader()
 	if err != nil {
-		return labels.EmptyLabels(), nil, errors.Wrap(err, "lookup labels symbols")
+		return seriesChunkRefsSet{}, err
+	}
+	defer symReader.Close()
+	for _, sym := range allSymbols {
+		symbols[sym], err = symReader.Read(sym)
+		if err != nil {
+			return seriesChunkRefsSet{}, err
+		}
 	}
 
-	return lset, s.chunkMetasBuffer, nil
+	// This can be released by the caller because loadingSeriesChunkRefsSetIterator doesn't retain it after Next() is called again.
+	set := newSeriesChunkRefsSet(len(symbolizedSet.series), true)
+
+	labelsBuilder := labels.NewScratchBuilder(maxLabelsPerSeries)
+	for _, series := range symbolizedSet.series {
+		labelsBuilder.Reset()
+		for _, symRef := range series.lset {
+			labelsBuilder.Add(symbols[symRef.name], symbols[symRef.value])
+		}
+
+		set.series = append(set.series, seriesChunkRefs{
+			lset:         labelsBuilder.Labels(),
+			chunksRanges: series.chunksRanges,
+		})
+	}
+
+	return set, nil
+}
+
+func (s *loadingSeriesChunkRefsSetIterator) multiLookupStringify(symbolizedSet symbolizedSeriesChunkRefsSet) (seriesChunkRefsSet, error) {
+	// This can be released by the caller because loadingSeriesChunkRefsSetIterator doesn't retain it after Next() is called again.
+	set := newSeriesChunkRefsSet(len(symbolizedSet.series), true)
+
+	labelsBuilder := labels.NewScratchBuilder(16)
+	for _, series := range symbolizedSet.series {
+		lset, err := s.indexr.LookupLabelsSymbols(series.lset, &labelsBuilder)
+		if err != nil {
+			return seriesChunkRefsSet{}, err
+		}
+
+		set.series = append(set.series, seriesChunkRefs{
+			lset:         lset,
+			chunksRanges: series.chunksRanges,
+		})
+	}
+	return set, nil
 }
 
 type filteringSeriesChunkRefsSetIterator struct {

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"sort"
 	"testing"
@@ -1098,7 +1099,7 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 }
 
 func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
-	newTestBlock := prepareTestBlock(test.NewTB(t), func(t testing.TB, appender storage.Appender) {
+	defaultTestBlockFactory := prepareTestBlock(test.NewTB(t), func(t testing.TB, appender storage.Appender) {
 		for i := 0; i < 100; i++ {
 			_, err := appender.Append(0, labels.FromStrings("l1", fmt.Sprintf("v%d", i)), int64(i*10), 0)
 			assert.NoError(t, err)
@@ -1106,7 +1107,17 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 		assert.NoError(t, appender.Commit())
 	})
 
+	const largerTestBlockSeriesCount = 100_000
+	largerTestBlockFactory := prepareTestBlock(test.NewTB(t), func(t testing.TB, appender storage.Appender) {
+		for i := 0; i < largerTestBlockSeriesCount; i++ {
+			_, err := appender.Append(0, labels.FromStrings("l1", fmt.Sprintf("v%d", i)), int64(i*10), 0)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, appender.Commit())
+	})
+
 	testCases := map[string]struct {
+		blockFactory func() *bucketBlock // if nil, defaultTestBlockFactory is used
 		shard        *sharding.ShardSelector
 		matchers     []*labels.Matcher
 		seriesHasher seriesHasher
@@ -1252,6 +1263,50 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 				}},
 			},
 		},
+		"works with many series in a single batch": {
+			blockFactory: largerTestBlockFactory,
+			minT:         0,
+			maxT:         math.MaxInt64,
+			skipChunks:   true, // There is still no easy way to assert on the refs of 100K chunks, so we skip them.
+			batchSize:    largerTestBlockSeriesCount,
+			matchers:     []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", ".*")},
+			expectedSets: func() []seriesChunkRefsSet {
+				set := newSeriesChunkRefsSet(largerTestBlockSeriesCount, true)
+				for i := 0; i < largerTestBlockSeriesCount; i++ {
+					set.series = append(set.series, seriesChunkRefs{lset: labels.FromStrings("l1", fmt.Sprintf("v%d", i))})
+				}
+				// The order of series in the block is by their labels, so we need to sort what we generated.
+				sort.Slice(set.series, func(i, j int) bool {
+					return labels.Compare(set.series[i].lset, set.series[j].lset) < 0
+				})
+				return []seriesChunkRefsSet{set}
+			}(),
+		},
+		"works with many series in many batches batch": {
+			blockFactory: largerTestBlockFactory,
+			minT:         0,
+			maxT:         math.MaxInt64,
+			skipChunks:   true, // There is still no easy way to assert on the refs of 100K chunks, so we skip them.
+			batchSize:    5000,
+			matchers:     []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", ".*")},
+			expectedSets: func() []seriesChunkRefsSet {
+				series := make([]seriesChunkRefs, 0, largerTestBlockSeriesCount)
+				for i := 0; i < largerTestBlockSeriesCount; i++ {
+					series = append(series, seriesChunkRefs{lset: labels.FromStrings("l1", fmt.Sprintf("v%d", i))})
+				}
+				// The order of series in the block is by their labels, so we need to sort what we generated.
+				sort.Slice(series, func(i, j int) bool {
+					return labels.Compare(series[i].lset, series[j].lset) < 0
+				})
+
+				const numBatches = largerTestBlockSeriesCount / 5000
+				sets := make([]seriesChunkRefsSet, numBatches)
+				for setIdx := 0; setIdx < numBatches; setIdx++ {
+					sets[setIdx].series = series[setIdx*largerTestBlockSeriesCount/numBatches : (setIdx+1)*largerTestBlockSeriesCount/numBatches]
+				}
+				return sets
+			}(),
+		},
 	}
 
 	for testName, testCase := range testCases {
@@ -1260,7 +1315,11 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			t.Parallel()
 
 			// Setup
-			block := newTestBlock()
+			blockFactory := defaultTestBlockFactory
+			if testCase.blockFactory != nil {
+				blockFactory = testCase.blockFactory
+			}
+			block := blockFactory()
 			indexr := block.indexReader(selectAllStrategy{})
 			postings, _, err := indexr.ExpandedPostings(context.Background(), testCase.matchers, newSafeQueryStats())
 			require.NoError(t, err)


### PR DESCRIPTION
#### Context

Related to https://github.com/grafana/mimir/issues/4593#issuecomment-1550928468


A symbol in this context is a string stored in the TSDB index. Every timeseries in the TSDB index has a reference to the symbols in its labels instead of the actual strings. The symbols table (mapping from symbol reference to string) is also present in the index header that the store-gateway stores locally.

For series requests the current way of reading symbols is as follows: for each symbol (label name or label value)
* the lazy index header reader acquires a read lock on all index header readers and checks `time.Now()` ([code](https://github.com/grafana/mimir/blob/db5713d7c2fde8ac1c22f51919e43e7821060e8e/pkg/storegateway/indexheader/lazy_binary_reader.go#L168-L175))
* label names: these are already cached in a go map in memory so looking them up is cheap ([code](https://github.com/grafana/mimir/blob/baaf4d22ee29916e3a70e1a47245e56223dbf163/pkg/storegateway/indexheader/stream_binary_reader.go#L46-L48))
* label values: 
	* there is a cache of 1024 symbols per block which keeps some symbols ([code](https://github.com/grafana/mimir/blob/baaf4d22ee29916e3a70e1a47245e56223dbf163/pkg/storegateway/indexheader/stream_binary_reader.go#L51-L55))
	* on a cache miss the index header reader obtains a file reader to the index header, offsets to a offset near the requested symbol in the symbols table, reads the symbol and returns it, closes the file reader or returns it to a buffer (currently the buffer has a size of 1)

#### Opportunities for improvement

* Frequent calls to `time.Now()` and `RWMutex.RLock()/RUnlock()`; these are relative expensive to the point that time.Now accounts for 1% of CPU; the mutex is also global
* Frequent file opens; opening a file is a syscall which can be expensive
* Random file reads; symbols are read in the other they appear in the series and in the order that series appear; we end up reading from all over the symbols table when populating the symbols of series

When there are requests returning more series about 16% of CPU is spent looking up symbols for said series. See https://github.com/grafana/mimir/issues/4593#issuecomment-1550928468

#### What this PR does

It tries to address the challenges above. The flow for label names is generally the same.

For label values:

* On requests that have less than 256 series: do the same as we currently do - single file reader per label value symbol
	* See [this comment](https://github.com/grafana/mimir/pull/5073#issuecomment-1560966374) for why 256 was chosen
* On requests that have more than 256 series: 
	* open a single file reader per set/batch (5000 series at the moment)
	* create a sorted list of symbols references to look up and a map from symbol reference to string
	* look up the symbol strings in sequence to reduce random reads and populate the map
	* for each symbol reference in each series lookup in the map and get a string
	* close file reader or return to buffer

#### Benchmark

Ran on linux/amd64 with an HDD

<details>
<summary>BenchmarkOpenBlockSeriesChunkRefsSetsIterator</summary>

```
goos: linux
goarch: amd64
pkg: github.com/grafana/mimir/pkg/storegateway
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                                                                                  │ store-gateway-clean-up-chunks-fetching-deprecate-bucketed-chunks-pool-4996-942e16cfc.txt │ Clean-up-symbolization-67b7a0af7.txt │
                                                                                                  │                                          sec/op                                          │    sec/op      vs base               │
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X"-4                                                                                                                25.49µ ± ∞ ¹    25.31µ ± ∞ ¹        ~ (p=1.000 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",j="foo"-4                                                                                                        75.31µ ± ∞ ¹    97.49µ ± ∞ ¹        ~ (p=0.886 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",j!="foo"-4                                                                                                       105.2µ ± ∞ ¹    101.8µ ± ∞ ¹        ~ (p=0.886 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~"XXX|YYY"-4                                                                                                         12.48µ ± ∞ ¹    13.61µ ± ∞ ¹        ~ (p=0.486 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~"X.+"-4                                                                                                            12.460µ ± ∞ ¹    5.059µ ± ∞ ¹  -59.40% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"X|Y|Z"-4                                                                                                           59.72µ ± ∞ ¹    59.08µ ± ∞ ¹        ~ (p=0.486 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1"-4                                                                                                               2584.3m ± ∞ ¹    417.2m ± ∞ ¹  -83.86% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",j="foo"-4                                                                                                       2395.0m ± ∞ ¹    307.9m ± ∞ ¹  -87.14% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",n="1"-4                                                                                                       2400.2m ± ∞ ¹    305.8m ± ∞ ¹  -87.26% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",j!="foo"-4                                                                                                      2415.0m ± ∞ ¹    298.5m ± ∞ ¹  -87.64% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~".*"-4                                                                                                              10.951 ± ∞ ¹     8.137 ± ∞ ¹        ~ (p=0.057 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~".+"-4                                                                                                               14.11 ± ∞ ¹     11.15 ± ∞ ¹  -20.99% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"^.+$",j=~"X.+"-4                                                                                                   23.32m ± ∞ ¹    23.70m ± ∞ ¹        ~ (p=0.200 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~""-4                                                                                                                 3.021 ± ∞ ¹     3.014 ± ∞ ¹        ~ (p=0.486 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i!=""-4                                                                                                                 13.71 ± ∞ ¹     11.35 ± ∞ ¹  -17.22% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".*",j="foo"-4                                                                                               2364.6m ± ∞ ¹    322.7m ± ∞ ¹  -86.35% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",i=~"^.+$",j="foo"-4                                                                                              48.09µ ± ∞ ¹    48.00µ ± ∞ ¹        ~ (p=0.886 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".*",i!="2",j="foo"-4                                                                                        2433.9m ± ∞ ¹    338.8m ± ∞ ¹  -86.08% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!=""-4                                                                                                           5.140 ± ∞ ¹     2.963 ± ∞ ¹  -42.36% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!="",j="foo"-4                                                                                                   4.913 ± ∞ ¹     3.005 ± ∞ ¹  -38.83% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!="",j=~"X.+"-4                                                                                                 23.84m ± ∞ ¹    23.17m ± ∞ ¹        ~ (p=0.114 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!="",j=~"XXX|YYY"-4                                                                                             33.52µ ± ∞ ¹    33.84µ ± ∞ ¹        ~ (p=0.486 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~"X|Y|Z",j="foo"-4                                                                                             105.5µ ± ∞ ¹    104.6µ ± ∞ ¹        ~ (p=0.686 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".+",j="foo"-4                                                                                                 4.920 ± ∞ ¹     2.882 ± ∞ ¹  -41.43% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~"1.+",j="foo"-4                                                                                               564.7m ± ∞ ¹    338.7m ± ∞ ¹  -40.03% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".+",i!="2",j="foo"-4                                                                                          4.931 ± ∞ ¹     2.888 ± ∞ ¹  -41.42% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".+",i!~"2.*",j="foo"-4                                                                                        4.976 ± ∞ ¹     3.162 ± ∞ ¹  -36.45% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"-4                                                                                 47.25µ ± ∞ ¹    47.40µ ± ∞ ¹        ~ (p=0.486 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"0xxx|1xxx|2xxx"-4                                                                                                  710.8µ ± ∞ ¹    679.1µ ± ∞ ¹   -4.46% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"(0|1|2)xxx"-4                                                                                                      699.7µ ± ∞ ¹    691.7µ ± ∞ ¹        ~ (p=0.686 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"[0-2]xxx"-4                                                                                                        707.1µ ± ∞ ¹    721.5µ ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i!~[0-2]xxx-4                                                                                                          11.119 ± ∞ ¹     8.666 ± ∞ ¹  -22.06% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~".*",_i!~[0-2]xxx-4                                                                                                 11.197 ± ∞ ¹     8.579 ± ∞ ¹  -23.38% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"<unique_prefix>.+"-4                                                                                               271.7µ ± ∞ ¹    267.9µ ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~"<unique_prefix>.+"-4                                                                                         3.268m ± ∞ ¹    3.222m ± ∞ ¹        ~ (p=0.200 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!~"<unique_prefix>.+"-4                                                                                        2560.9m ± ∞ ¹    418.5m ± ∞ ¹  -83.66% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",p="foo",i=~"<unique_prefix>.+"-4                                                                               32.64m ± ∞ ¹    31.48m ± ∞ ¹        ~ (p=0.114 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",n=~".+",i=~"<unique_prefix>.+"-4                                                                               103.2m ± ∞ ¹    106.2m ± ∞ ¹   +2.91% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",n=~".*",i=~"<unique_prefix>.+"-4                                                                               28.88m ± ∞ ¹    27.92m ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~".*",n=~".*",i=~"<unique_prefix>.+"-4                                                                               319.2µ ± ∞ ¹    318.1µ ± ∞ ¹        ~ (p=1.000 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~".+",n=~".+",i=~"<unique_prefix>.+"-4                                                                               144.8m ± ∞ ¹    141.1m ± ∞ ¹   -2.56% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/p!=""-4                                                                                                                 3.947 ± ∞ ¹     1.801 ± ∞ ¹  -54.37% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X"-4                                                                                                                   25.30µ ± ∞ ¹    25.54µ ± ∞ ¹   +0.94% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",j="foo"-4                                                                                                           47.18µ ± ∞ ¹    46.33µ ± ∞ ¹        ~ (p=0.114 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",j!="foo"-4                                                                                                          46.60µ ± ∞ ¹    47.02µ ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~"XXX|YYY"-4                                                                                                            5.300µ ± ∞ ¹    5.338µ ± ∞ ¹        ~ (p=0.686 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~"X.+"-4                                                                                                                5.195µ ± ∞ ¹    5.230µ ± ∞ ¹        ~ (p=0.486 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"X|Y|Z"-4                                                                                                              58.57µ ± ∞ ¹    60.69µ ± ∞ ¹   +3.62% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1"-4                                                                                                                  2538.1m ± ∞ ¹    429.6m ± ∞ ¹  -83.08% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",j="foo"-4                                                                                                          4718.2m ± ∞ ¹    315.1m ± ∞ ¹  -93.32% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",n="1"-4                                                                                                          5363.1m ± ∞ ¹    305.9m ± ∞ ¹  -94.30% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",j!="foo"-4                                                                                                         2650.1m ± ∞ ¹    301.3m ± ∞ ¹  -88.63% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~".*"-4                                                                                                                 11.161 ± ∞ ¹     8.570 ± ∞ ¹  -23.21% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~".+"-4                                                                                                                  13.56 ± ∞ ¹     17.80 ± ∞ ¹        ~ (p=1.000 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"^.+$",j=~"X.+"-4                                                                                                      23.17m ± ∞ ¹    23.43m ± ∞ ¹        ~ (p=0.886 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~""-4                                                                                                                    3.006 ± ∞ ¹     3.058 ± ∞ ¹        ~ (p=0.057 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i!=""-4                                                                                                                    13.73 ± ∞ ¹     11.39 ± ∞ ¹  -17.04% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".*",j="foo"-4                                                                                                  2352.1m ± ∞ ¹    324.9m ± ∞ ¹  -86.19% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",i=~"^.+$",j="foo"-4                                                                                                 46.72µ ± ∞ ¹    48.81µ ± ∞ ¹        ~ (p=0.057 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".*",i!="2",j="foo"-4                                                                                           2378.9m ± ∞ ¹    336.8m ± ∞ ¹  -85.84% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!=""-4                                                                                                              5.029 ± ∞ ¹     3.010 ± ∞ ¹  -40.15% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!="",j="foo"-4                                                                                                      4.945 ± ∞ ¹     2.883 ± ∞ ¹  -41.70% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!="",j=~"X.+"-4                                                                                                    22.55m ± ∞ ¹    23.17m ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!="",j=~"XXX|YYY"-4                                                                                                34.63µ ± ∞ ¹    33.95µ ± ∞ ¹        ~ (p=0.057 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~"X|Y|Z",j="foo"-4                                                                                                106.6µ ± ∞ ¹    105.4µ ± ∞ ¹        ~ (p=0.114 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".+",j="foo"-4                                                                                                    4.917 ± ∞ ¹     2.886 ± ∞ ¹  -41.30% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~"1.+",j="foo"-4                                                                                                  571.1m ± ∞ ¹    335.9m ± ∞ ¹  -41.18% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".+",i!="2",j="foo"-4                                                                                             4.918 ± ∞ ¹     2.866 ± ∞ ¹  -41.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".+",i!~"2.*",j="foo"-4                                                                                           4.961 ± ∞ ¹     3.141 ± ∞ ¹  -36.69% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"-4                                                                                    47.67µ ± ∞ ¹    47.69µ ± ∞ ¹        ~ (p=0.886 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"0xxx|1xxx|2xxx"-4                                                                                                     688.6µ ± ∞ ¹    709.0µ ± ∞ ¹        ~ (p=0.057 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"(0|1|2)xxx"-4                                                                                                         687.7µ ± ∞ ¹    686.2µ ± ∞ ¹        ~ (p=0.886 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"[0-2]xxx"-4                                                                                                           693.9µ ± ∞ ¹    705.5µ ± ∞ ¹        ~ (p=0.686 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i!~[0-2]xxx-4                                                                                                             11.067 ± ∞ ¹     8.906 ± ∞ ¹  -19.53% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~".*",_i!~[0-2]xxx-4                                                                                                    11.363 ± ∞ ¹     8.585 ± ∞ ¹  -24.45% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"<unique_prefix>.+"-4                                                                                                  276.0µ ± ∞ ¹    267.5µ ± ∞ ¹        ~ (p=0.057 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~"<unique_prefix>.+"-4                                                                                            3.236m ± ∞ ¹    3.221m ± ∞ ¹        ~ (p=0.886 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!~"<unique_prefix>.+"-4                                                                                           2496.0m ± ∞ ¹    421.8m ± ∞ ¹  -83.10% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",p="foo",i=~"<unique_prefix>.+"-4                                                                                  30.94m ± ∞ ¹    32.15m ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",n=~".+",i=~"<unique_prefix>.+"-4                                                                                  102.0m ± ∞ ¹    105.3m ± ∞ ¹   +3.23% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",n=~".*",i=~"<unique_prefix>.+"-4                                                                                  29.23m ± ∞ ¹    27.78m ± ∞ ¹        ~ (p=0.114 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~".*",n=~".*",i=~"<unique_prefix>.+"-4                                                                                  314.8µ ± ∞ ¹    321.6µ ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~".+",n=~".+",i=~"<unique_prefix>.+"-4                                                                                  139.7m ± ∞ ¹    145.8m ± ∞ ¹   +4.37% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/p!=""-4                                                                                                                    3.907 ± ∞ ¹     1.730 ± ∞ ¹  -55.74% (p=0.029 n=4)
geomean                                                                                                                                                                         39.68m          24.86m        -37.35%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                                                  │ store-gateway-clean-up-chunks-fetching-deprecate-bucketed-chunks-pool-4996-942e16cfc.txt │ Clean-up-symbolization-67b7a0af7.txt │
                                                                                                  │                                           B/op                                           │     B/op       vs base               │
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X"-4                                                                                                               2.182Ki ± ∞ ¹   2.166Ki ± ∞ ¹   -0.72% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",j="foo"-4                                                                                                       2.839Ki ± ∞ ¹   2.823Ki ± ∞ ¹   -0.57% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",j!="foo"-4                                                                                                      2.839Ki ± ∞ ¹   2.823Ki ± ∞ ¹   -0.55% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~"XXX|YYY"-4                                                                                                        1.852Ki ± ∞ ¹   1.836Ki ± ∞ ¹   -0.84% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~"X.+"-4                                                                                                            1.797Ki ± ∞ ¹   1.781Ki ± ∞ ¹   -0.87% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"X|Y|Z"-4                                                                                                          2.775Ki ± ∞ ¹   2.760Ki ± ∞ ¹   -0.56% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1"-4                                                                                                               169.9Mi ± ∞ ¹   145.2Mi ± ∞ ¹  -14.54% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",j="foo"-4                                                                                                      114.55Mi ± ∞ ¹   92.60Mi ± ∞ ¹  -19.16% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",n="1"-4                                                                                                      114.78Mi ± ∞ ¹   92.59Mi ± ∞ ¹  -19.33% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",j!="foo"-4                                                                                                     114.83Mi ± ∞ ¹   92.48Mi ± ∞ ¹  -19.46% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~".*"-4                                                                                                             3.227Gi ± ∞ ¹   3.286Gi ± ∞ ¹   +1.85% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~".+"-4                                                                                                             3.376Gi ± ∞ ¹   3.437Gi ± ∞ ¹   +1.79% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"^.+$",j=~"X.+"-4                                                                                                  10.69Mi ± ∞ ¹   10.69Mi ± ∞ ¹        ~ (p=0.886 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~""-4                                                                                                               224.7Mi ± ∞ ¹   224.7Mi ± ∞ ¹        ~ (p=0.200 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i!=""-4                                                                                                               3.377Gi ± ∞ ¹   3.436Gi ± ∞ ¹   +1.77% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".*",j="foo"-4                                                                                              117.61Mi ± ∞ ¹   95.72Mi ± ∞ ¹  -18.61% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",i=~"^.+$",j="foo"-4                                                                                             3.011Ki ± ∞ ¹   2.995Ki ± ∞ ¹   -0.52% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".*",i!="2",j="foo"-4                                                                                       119.23Mi ± ∞ ¹   97.08Mi ± ∞ ¹  -18.57% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!=""-4                                                                                                         356.6Mi ± ∞ ¹   332.7Mi ± ∞ ¹   -6.73% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!="",j="foo"-4                                                                                                 301.7Mi ± ∞ ¹   279.6Mi ± ∞ ¹   -7.33% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!="",j=~"X.+"-4                                                                                                10.69Mi ± ∞ ¹   10.69Mi ± ∞ ¹        ~ (p=0.886 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!="",j=~"XXX|YYY"-4                                                                                            3.776Ki ± ∞ ¹   3.761Ki ± ∞ ¹   -0.41% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~"X|Y|Z",j="foo"-4                                                                                            5.028Ki ± ∞ ¹   5.012Ki ± ∞ ¹   -0.31% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".+",j="foo"-4                                                                                               301.8Mi ± ∞ ¹   280.1Mi ± ∞ ¹   -7.19% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~"1.+",j="foo"-4                                                                                              45.41Mi ± ∞ ¹   43.31Mi ± ∞ ¹   -4.62% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".+",i!="2",j="foo"-4                                                                                        303.2Mi ± ∞ ¹   281.1Mi ± ∞ ¹   -7.28% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".+",i!~"2.*",j="foo"-4                                                                                      306.4Mi ± ∞ ¹   287.1Mi ± ∞ ¹   -6.30% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"-4                                                                                3.214Ki ± ∞ ¹   3.198Ki ± ∞ ¹   -0.49% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"0xxx|1xxx|2xxx"-4                                                                                                 149.3Ki ± ∞ ¹   150.0Ki ± ∞ ¹   +0.47% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"(0|1|2)xxx"-4                                                                                                     148.9Ki ± ∞ ¹   149.7Ki ± ∞ ¹   +0.49% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"[0-2]xxx"-4                                                                                                       148.9Ki ± ∞ ¹   149.5Ki ± ∞ ¹   +0.44% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i!~[0-2]xxx-4                                                                                                         3.224Gi ± ∞ ¹   3.284Gi ± ∞ ¹   +1.87% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~".*",_i!~[0-2]xxx-4                                                                                                3.227Gi ± ∞ ¹   3.287Gi ± ∞ ¹   +1.86% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"<unique_prefix>.+"-4                                                                                              49.87Ki ± ∞ ¹   50.19Ki ± ∞ ¹   +0.64% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~"<unique_prefix>.+"-4                                                                                        1.270Mi ± ∞ ¹   1.271Mi ± ∞ ¹        ~ (p=0.114 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!~"<unique_prefix>.+"-4                                                                                        169.9Mi ± ∞ ¹   145.2Mi ± ∞ ¹  -14.56% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",p="foo",i=~"<unique_prefix>.+"-4                                                                              18.45Mi ± ∞ ¹   18.45Mi ± ∞ ¹   +0.04% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",n=~".+",i=~"<unique_prefix>.+"-4                                                                              57.46Mi ± ∞ ¹   57.46Mi ± ∞ ¹        ~ (p=1.000 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",n=~".*",i=~"<unique_prefix>.+"-4                                                                              12.31Mi ± ∞ ¹   12.31Mi ± ∞ ¹        ~ (p=0.486 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~".*",n=~".*",i=~"<unique_prefix>.+"-4                                                                              56.54Ki ± ∞ ¹   56.90Ki ± ∞ ¹   +0.65% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~".+",n=~".+",i=~"<unique_prefix>.+"-4                                                                              75.84Mi ± ∞ ¹   75.84Mi ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/p!=""-4                                                                                                               700.2Mi ± ∞ ¹   690.8Mi ± ∞ ¹   -1.35% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X"-4                                                                                                                  2.182Ki ± ∞ ¹   2.166Ki ± ∞ ¹   -0.72% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",j="foo"-4                                                                                                          2.838Ki ± ∞ ¹   2.822Ki ± ∞ ¹   -0.57% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",j!="foo"-4                                                                                                         2.839Ki ± ∞ ¹   2.823Ki ± ∞ ¹   -0.57% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~"XXX|YYY"-4                                                                                                           1.852Ki ± ∞ ¹   1.836Ki ± ∞ ¹   -0.84% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~"X.+"-4                                                                                                               1.797Ki ± ∞ ¹   1.781Ki ± ∞ ¹   -0.87% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"X|Y|Z"-4                                                                                                             2.775Ki ± ∞ ¹   2.760Ki ± ∞ ¹   -0.55% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1"-4                                                                                                                  169.7Mi ± ∞ ¹   145.5Mi ± ∞ ¹  -14.31% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",j="foo"-4                                                                                                         114.66Mi ± ∞ ¹   92.57Mi ± ∞ ¹  -19.27% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",n="1"-4                                                                                                         114.93Mi ± ∞ ¹   92.47Mi ± ∞ ¹  -19.54% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",j!="foo"-4                                                                                                        114.83Mi ± ∞ ¹   92.48Mi ± ∞ ¹  -19.46% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~".*"-4                                                                                                                3.227Gi ± ∞ ¹   3.287Gi ± ∞ ¹   +1.87% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~".+"-4                                                                                                                3.376Gi ± ∞ ¹   3.436Gi ± ∞ ¹   +1.77% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"^.+$",j=~"X.+"-4                                                                                                     10.69Mi ± ∞ ¹   10.69Mi ± ∞ ¹        ~ (p=0.486 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~""-4                                                                                                                  224.7Mi ± ∞ ¹   224.7Mi ± ∞ ¹        ~ (p=0.686 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i!=""-4                                                                                                                  3.377Gi ± ∞ ¹   3.436Gi ± ∞ ¹   +1.76% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".*",j="foo"-4                                                                                                 117.67Mi ± ∞ ¹   95.71Mi ± ∞ ¹  -18.66% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",i=~"^.+$",j="foo"-4                                                                                                3.011Ki ± ∞ ¹   2.995Ki ± ∞ ¹   -0.52% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".*",i!="2",j="foo"-4                                                                                          119.20Mi ± ∞ ¹   97.07Mi ± ∞ ¹  -18.57% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!=""-4                                                                                                            356.7Mi ± ∞ ¹   332.6Mi ± ∞ ¹   -6.75% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!="",j="foo"-4                                                                                                    301.8Mi ± ∞ ¹   280.1Mi ± ∞ ¹   -7.17% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!="",j=~"X.+"-4                                                                                                   10.69Mi ± ∞ ¹   10.69Mi ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!="",j=~"XXX|YYY"-4                                                                                               3.776Ki ± ∞ ¹   3.761Ki ± ∞ ¹   -0.41% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~"X|Y|Z",j="foo"-4                                                                                               5.028Ki ± ∞ ¹   5.012Ki ± ∞ ¹   -0.33% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".+",j="foo"-4                                                                                                  301.8Mi ± ∞ ¹   279.8Mi ± ∞ ¹   -7.28% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~"1.+",j="foo"-4                                                                                                 45.39Mi ± ∞ ¹   43.25Mi ± ∞ ¹   -4.72% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".+",i!="2",j="foo"-4                                                                                           303.3Mi ± ∞ ¹   281.5Mi ± ∞ ¹   -7.17% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".+",i!~"2.*",j="foo"-4                                                                                         306.4Mi ± ∞ ¹   287.7Mi ± ∞ ¹   -6.09% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"-4                                                                                   3.214Ki ± ∞ ¹   3.198Ki ± ∞ ¹   -0.49% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"0xxx|1xxx|2xxx"-4                                                                                                    149.3Ki ± ∞ ¹   149.9Ki ± ∞ ¹   +0.38% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"(0|1|2)xxx"-4                                                                                                        148.9Ki ± ∞ ¹   149.5Ki ± ∞ ¹   +0.40% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"[0-2]xxx"-4                                                                                                          148.9Ki ± ∞ ¹   149.6Ki ± ∞ ¹   +0.42% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i!~[0-2]xxx-4                                                                                                            3.224Gi ± ∞ ¹   3.284Gi ± ∞ ¹   +1.88% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~".*",_i!~[0-2]xxx-4                                                                                                   3.227Gi ± ∞ ¹   3.286Gi ± ∞ ¹   +1.84% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"<unique_prefix>.+"-4                                                                                                 49.87Ki ± ∞ ¹   50.25Ki ± ∞ ¹   +0.77% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~"<unique_prefix>.+"-4                                                                                           1.269Mi ± ∞ ¹   1.270Mi ± ∞ ¹   +0.09% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!~"<unique_prefix>.+"-4                                                                                           170.0Mi ± ∞ ¹   145.4Mi ± ∞ ¹  -14.51% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",p="foo",i=~"<unique_prefix>.+"-4                                                                                 18.45Mi ± ∞ ¹   18.45Mi ± ∞ ¹   +0.04% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",n=~".+",i=~"<unique_prefix>.+"-4                                                                                 57.45Mi ± ∞ ¹   57.46Mi ± ∞ ¹        ~ (p=0.686 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",n=~".*",i=~"<unique_prefix>.+"-4                                                                                 12.31Mi ± ∞ ¹   12.31Mi ± ∞ ¹   +0.06% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~".*",n=~".*",i=~"<unique_prefix>.+"-4                                                                                 56.53Ki ± ∞ ¹   56.92Ki ± ∞ ¹   +0.69% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~".+",n=~".+",i=~"<unique_prefix>.+"-4                                                                                 75.83Mi ± ∞ ¹   75.84Mi ± ∞ ¹        ~ (p=0.343 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/p!=""-4                                                                                                                  699.8Mi ± ∞ ¹   690.7Mi ± ∞ ¹   -1.30% (p=0.029 n=4)
geomean                                                                                                                                                                        4.958Mi         4.757Mi         -4.04%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                                                  │ store-gateway-clean-up-chunks-fetching-deprecate-bucketed-chunks-pool-4996-942e16cfc.txt │ Clean-up-symbolization-67b7a0af7.txt  │
                                                                                                  │                                        allocs/op                                         │  allocs/op    vs base                 │
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X"-4                                                                                                                 36.00 ± ∞ ¹    36.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",j="foo"-4                                                                                                         44.00 ± ∞ ¹    44.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",j!="foo"-4                                                                                                        44.00 ± ∞ ¹    44.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~"XXX|YYY"-4                                                                                                          31.00 ± ∞ ¹    31.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~"X.+"-4                                                                                                              31.00 ± ∞ ¹    31.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"X|Y|Z"-4                                                                                                            46.00 ± ∞ ¹    46.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1"-4                                                                                                               1411.2k ± ∞ ¹   906.7k ± ∞ ¹  -35.75% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",j="foo"-4                                                                                                       1004.3k ± ∞ ¹   504.8k ± ∞ ¹  -49.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",n="1"-4                                                                                                       1004.3k ± ∞ ¹   504.8k ± ∞ ¹  -49.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",j!="foo"-4                                                                                                      1004.9k ± ∞ ¹   504.8k ± ∞ ¹  -49.77% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~".*"-4                                                                                                              20.91M ± ∞ ¹   20.30M ± ∞ ¹   -2.94% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~".+"-4                                                                                                              23.66M ± ∞ ¹   23.05M ± ∞ ¹   -2.60% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"^.+$",j=~"X.+"-4                                                                                                   100.0k ± ∞ ¹   100.0k ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~""-4                                                                                                                2.750M ± ∞ ¹   2.750M ± ∞ ¹        ~ (p=0.686 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i!=""-4                                                                                                                23.66M ± ∞ ¹   23.05M ± ∞ ¹   -2.60% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".*",j="foo"-4                                                                                               1004.4k ± ∞ ¹   504.8k ± ∞ ¹  -49.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",i=~"^.+$",j="foo"-4                                                                                               44.00 ± ∞ ¹    44.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".*",i!="2",j="foo"-4                                                                                        1004.4k ± ∞ ¹   504.9k ± ∞ ¹  -49.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!=""-4                                                                                                          4.161M ± ∞ ¹   3.657M ± ∞ ¹  -12.12% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!="",j="foo"-4                                                                                                  3.754M ± ∞ ¹   3.255M ± ∞ ¹  -13.31% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!="",j=~"X.+"-4                                                                                                 100.1k ± ∞ ¹   100.1k ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!="",j=~"XXX|YYY"-4                                                                                              61.00 ± ∞ ¹    61.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~"X|Y|Z",j="foo"-4                                                                                              82.00 ± ∞ ¹    82.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".+",j="foo"-4                                                                                                3.754M ± ∞ ¹   3.255M ± ∞ ¹  -13.30% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~"1.+",j="foo"-4                                                                                               417.4k ± ∞ ¹   361.9k ± ∞ ¹  -13.28% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".+",i!="2",j="foo"-4                                                                                         3.754M ± ∞ ¹   3.255M ± ∞ ¹  -13.30% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~".+",i!~"2.*",j="foo"-4                                                                                       3.948M ± ∞ ¹   3.504M ± ∞ ¹  -11.24% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"-4                                                                                  44.00 ± ∞ ¹    44.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"0xxx|1xxx|2xxx"-4                                                                                                   901.0 ± ∞ ¹    899.0 ± ∞ ¹   -0.22% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"(0|1|2)xxx"-4                                                                                                       900.0 ± ∞ ¹    898.0 ± ∞ ¹   -0.22% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"[0-2]xxx"-4                                                                                                         900.0 ± ∞ ¹    898.0 ± ∞ ¹   -0.22% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i!~[0-2]xxx-4                                                                                                          20.91M ± ∞ ¹   20.30M ± ∞ ¹   -2.94% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~".*",_i!~[0-2]xxx-4                                                                                                 20.91M ± ∞ ¹   20.30M ± ∞ ¹   -2.94% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/i=~"<unique_prefix>.+"-4                                                                                                378.0 ± ∞ ¹    376.0 ± ∞ ¹   -0.53% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i=~"<unique_prefix>.+"-4                                                                                          265.0 ± ∞ ¹    264.0 ± ∞ ¹   -0.38% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/n="1",i!~"<unique_prefix>.+"-4                                                                                        1411.2k ± ∞ ¹   906.8k ± ∞ ¹  -35.75% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",p="foo",i=~"<unique_prefix>.+"-4                                                                                313.0 ± ∞ ¹    316.5 ± ∞ ¹   +1.12% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",n=~".+",i=~"<unique_prefix>.+"-4                                                                               1.396k ± ∞ ¹   1.397k ± ∞ ¹        ~ (p=0.429 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j="foo",n=~".*",i=~"<unique_prefix>.+"-4                                                                                324.0 ± ∞ ¹    324.5 ± ∞ ¹        ~ (p=0.771 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~".*",n=~".*",i=~"<unique_prefix>.+"-4                                                                                412.0 ± ∞ ¹    410.0 ± ∞ ¹   -0.49% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/j=~".+",n=~".+",i=~"<unique_prefix>.+"-4                                                                               1.537k ± ∞ ¹   1.538k ± ∞ ¹        ~ (p=0.200 n=4)
OpenBlockSeriesChunkRefsSetsIterator/without_index_cache/p!=""-4                                                                                                                4.656M ± ∞ ¹   4.134M ± ∞ ¹  -11.21% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X"-4                                                                                                                    36.00 ± ∞ ¹    36.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",j="foo"-4                                                                                                            44.00 ± ∞ ¹    44.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",j!="foo"-4                                                                                                           44.00 ± ∞ ¹    44.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~"XXX|YYY"-4                                                                                                             31.00 ± ∞ ¹    31.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~"X.+"-4                                                                                                                 31.00 ± ∞ ¹    31.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"X|Y|Z"-4                                                                                                               46.00 ± ∞ ¹    46.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1"-4                                                                                                                  1411.1k ± ∞ ¹   906.7k ± ∞ ¹  -35.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",j="foo"-4                                                                                                          1004.4k ± ∞ ¹   504.8k ± ∞ ¹  -49.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",n="1"-4                                                                                                          1004.3k ± ∞ ¹   504.8k ± ∞ ¹  -49.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",j!="foo"-4                                                                                                         1004.9k ± ∞ ¹   504.8k ± ∞ ¹  -49.77% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~".*"-4                                                                                                                 20.91M ± ∞ ¹   20.30M ± ∞ ¹   -2.94% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~".+"-4                                                                                                                 23.66M ± ∞ ¹   23.05M ± ∞ ¹   -2.60% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"^.+$",j=~"X.+"-4                                                                                                      100.0k ± ∞ ¹   100.0k ± ∞ ¹        ~ (p=1.000 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~""-4                                                                                                                   2.750M ± ∞ ¹   2.750M ± ∞ ¹        ~ (p=0.829 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i!=""-4                                                                                                                   23.66M ± ∞ ¹   23.05M ± ∞ ¹   -2.60% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".*",j="foo"-4                                                                                                  1004.3k ± ∞ ¹   504.8k ± ∞ ¹  -49.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",i=~"^.+$",j="foo"-4                                                                                                  44.00 ± ∞ ¹    44.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".*",i!="2",j="foo"-4                                                                                           1004.3k ± ∞ ¹   504.8k ± ∞ ¹  -49.73% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!=""-4                                                                                                             4.161M ± ∞ ¹   3.657M ± ∞ ¹  -12.12% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!="",j="foo"-4                                                                                                     3.754M ± ∞ ¹   3.255M ± ∞ ¹  -13.30% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!="",j=~"X.+"-4                                                                                                    100.1k ± ∞ ¹   100.1k ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!="",j=~"XXX|YYY"-4                                                                                                 61.00 ± ∞ ¹    61.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~"X|Y|Z",j="foo"-4                                                                                                 82.00 ± ∞ ¹    82.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".+",j="foo"-4                                                                                                   3.754M ± ∞ ¹   3.255M ± ∞ ¹  -13.31% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~"1.+",j="foo"-4                                                                                                  417.4k ± ∞ ¹   361.9k ± ∞ ¹  -13.29% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".+",i!="2",j="foo"-4                                                                                            3.754M ± ∞ ¹   3.255M ± ∞ ¹  -13.30% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~".+",i!~"2.*",j="foo"-4                                                                                          3.948M ± ∞ ¹   3.504M ± ∞ ¹  -11.24% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="X",i=~"^.+$",i!~"^.*2.*$",j="foo"-4                                                                                     44.00 ± ∞ ¹    44.00 ± ∞ ¹        ~ (p=1.000 n=4) ²
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"0xxx|1xxx|2xxx"-4                                                                                                      901.0 ± ∞ ¹    899.0 ± ∞ ¹   -0.22% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"(0|1|2)xxx"-4                                                                                                          900.0 ± ∞ ¹    898.0 ± ∞ ¹   -0.22% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"[0-2]xxx"-4                                                                                                            900.0 ± ∞ ¹    898.0 ± ∞ ¹   -0.22% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i!~[0-2]xxx-4                                                                                                             20.91M ± ∞ ¹   20.30M ± ∞ ¹   -2.94% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~".*",_i!~[0-2]xxx-4                                                                                                    20.91M ± ∞ ¹   20.30M ± ∞ ¹   -2.94% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/i=~"<unique_prefix>.+"-4                                                                                                   378.0 ± ∞ ¹    376.0 ± ∞ ¹   -0.53% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i=~"<unique_prefix>.+"-4                                                                                             265.0 ± ∞ ¹    263.0 ± ∞ ¹        ~ (p=0.057 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/n="1",i!~"<unique_prefix>.+"-4                                                                                           1411.2k ± ∞ ¹   906.8k ± ∞ ¹  -35.74% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",p="foo",i=~"<unique_prefix>.+"-4                                                                                   313.5 ± ∞ ¹    317.0 ± ∞ ¹   +1.12% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",n=~".+",i=~"<unique_prefix>.+"-4                                                                                  1.395k ± ∞ ¹   1.397k ± ∞ ¹        ~ (p=0.486 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j="foo",n=~".*",i=~"<unique_prefix>.+"-4                                                                                   323.5 ± ∞ ¹    325.5 ± ∞ ¹        ~ (p=0.086 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~".*",n=~".*",i=~"<unique_prefix>.+"-4                                                                                   412.0 ± ∞ ¹    410.0 ± ∞ ¹   -0.49% (p=0.029 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/j=~".+",n=~".+",i=~"<unique_prefix>.+"-4                                                                                  1.536k ± ∞ ¹   1.540k ± ∞ ¹        ~ (p=0.286 n=4)
OpenBlockSeriesChunkRefsSetsIterator/with_index_cache/p!=""-4                                                                                                                   4.656M ± ∞ ¹   4.134M ± ∞ ¹  -11.21% (p=0.029 n=4)
geomean                                                                                                                                                                         25.36k         22.30k        -12.09%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
```

</details>

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
