### PR TITLE
Use classic histograms in mimir-microservices-mode

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -296,7 +296,8 @@ std.manifestYamlDoc({
       command: [
         '--config.file=/etc/prometheus/prometheus.yaml',
         '--enable-feature=exemplar-storage',
-        '--enable-feature=native-histograms',
+        // This option enables native histogram support in prometheus, which is disabled by default since it doesn't scape classic histograms used by the recording rules and dashboards
+        // '--enable-feature=native-histograms',
       ],
       volumes: [
         './config:/etc/prometheus',

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -261,7 +261,6 @@
     "command":
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--enable-feature=exemplar-storage"
-      - "--enable-feature=native-histograms"
     "image": "prom/prometheus:v2.40.6"
     "ports":
       - "9090:9090"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Use classic histograms in mimir-microservices-mode. This will allow dashboards that require classic histograms to continue working until prometheus support for scraping classic and native histograms is added.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
