### PR TITLE
Add missing heading to store-gateway docs to fix broken page table of contents

### DIFF
--- a/docs/sources/mimir/references/architecture/components/store-gateway.md
+++ b/docs/sources/mimir/references/architecture/components/store-gateway.md
@@ -12,6 +12,8 @@ weight: 70
 The store-gateway component, which is stateful, queries blocks from [long-term storage]({{< relref "../../../get-started/about-grafana-mimir-architecture/index.md#long-term-storage" >}}).
 On the read path, the [querier]({{< relref "querier.md" >}}) and the [ruler]({{< relref "ruler/index.md" >}}) use the store-gateway when handling the query, whether the query comes from a user or from when a rule is being evaluated.
 
+## Bucket index
+
 To find the right blocks to look up at query time, the store-gateway requires a view of the bucket in long-term storage.
 The store-gateway keeps the bucket view updated using one of the following options:
 


### PR DESCRIPTION
#### What this PR does

This PR fixes the issue where the table of contents for the store-gateway docs page is displayed with unusual formatting:

![Screenshot 2023-05-25 at 8 54 25 am](https://github.com/grafana/mimir/assets/4017646/03a467f2-c6fd-4ec9-af6c-6edb725c473b)

This is caused by a missing heading in the hierarchy of headings, so this PR adds the missing heading.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
