### PR TITLE
Restore native histogram test cases for TestInstantQuerySplittingCorrectness

### DIFF
--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/latest/)
 
 For the full documentation, visit [Grafana mimir-distributed Helm chart documentation](https://grafana.com/docs/helm-charts/mimir-distributed/latest/).
 
-> **Note:** The documentation version is derived from the Helm chart version which is 4.5.0-weekly.240.
+> **Note:** The documentation version is derived from the Helm chart version which is 4.5.0-weekly.241.
 
 When upgrading from Helm chart version 3.x, please see [Migrate from single zone to zone-aware replication with Helm](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-from-single-zone-with-helm/).
 When upgrading from Helm chart version 2.1, please see [Upgrade the Grafana Mimir Helm chart from version 2.1 to 3.0](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-helm-chart-2.1-to-3.0/) as well.

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -94,18 +94,18 @@ func approximatelyEquals(t *testing.T, a, b *PrometheusResponse) {
 		for j := 0; j < len(a.Samples); j++ {
 			expected := a.Samples[j]
 			actual := b.Samples[j]
-			compareExpectedAndActual(t, expected.TimestampMs, actual.TimestampMs, expected.Value, actual.Value, j, a.Labels, "sample")
+			compareExpectedAndActual(t, expected.TimestampMs, actual.TimestampMs, expected.Value, actual.Value, j, a.Labels, "sample", 1e-12)
 		}
 
 		for j := 0; j < len(a.Histograms); j++ {
 			expected := a.Histograms[j]
 			actual := b.Histograms[j]
-			compareExpectedAndActual(t, expected.TimestampMs, actual.TimestampMs, expected.Histogram.Sum, actual.Histogram.Sum, j, a.Labels, "histogram")
+			compareExpectedAndActual(t, expected.TimestampMs, actual.TimestampMs, expected.Histogram.Sum, actual.Histogram.Sum, j, a.Labels, "histogram", 1e-2)
 		}
 	}
 }
 
-func compareExpectedAndActual(t *testing.T, expectedTs, actualTs int64, expectedVal, actualVal float64, j int, labels []mimirpb.LabelAdapter, sampleType string) {
+func compareExpectedAndActual(t *testing.T, expectedTs, actualTs int64, expectedVal, actualVal float64, j int, labels []mimirpb.LabelAdapter, sampleType string, tolerance float64) {
 	require.Equalf(t, expectedTs, actualTs, "%s timestamp at position %d for series %s", sampleType, j, labels)
 
 	if value.IsStaleNaN(expectedVal) {
@@ -119,7 +119,7 @@ func compareExpectedAndActual(t *testing.T, expectedTs, actualTs int64, expected
 		}
 		// InEpsilon means the relative error (see https://en.wikipedia.org/wiki/Relative_error#Example) must be less than epsilon (here 1e-12).
 		// The relative error is calculated using: abs(actual-expected) / abs(expected)
-		require.InEpsilonf(t, expectedVal, actualVal, 1e-12, "%s value at position %d with timestamp %d for series %s", sampleType, j, expectedTs, labels)
+		require.InEpsilonf(t, expectedVal, actualVal, tolerance, "%s value at position %d with timestamp %d for series %s", sampleType, j, expectedTs, labels)
 	}
 }
 

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -323,16 +323,15 @@ func TestInstantQuerySplittingCorrectness(t *testing.T) {
 					query:                `histogram_quantile(0.5, sum by(unique, le) (rate(metric_histogram_bucket{group_1="0"}[3m])))`,
 					expectedSplitQueries: 3,
 				},
-				// // Native Histograms
-				// // TODO(histograms): enable when https://github.com/prometheus/prometheus/issues/12250 is resolved
-				// "sum(rate) for native histogram": {
-				// 	query:                `sum(rate(metric_native_histogram[3m]))`,
-				// 	expectedSplitQueries: 3,
-				// },
-				// "sum(rate) grouping 'by' for native histogram": {
-				// 	query:                `sum by(group_1) (rate(metric_native_histogram[3m]))`,
-				// 	expectedSplitQueries: 3,
-				// },
+				// Native Histograms
+				"sum(rate) for native histogram": {
+					query:                `sum(rate(metric_native_histogram[3m]))`,
+					expectedSplitQueries: 3,
+				},
+				"sum(rate) grouping 'by' for native histogram": {
+					query:                `sum by(group_1) (rate(metric_native_histogram[3m]))`,
+					expectedSplitQueries: 3,
+				},
 				// Subqueries
 				"subquery sum_over_time": {
 					query:                   `sum_over_time(metric_counter[1h:5m])`,


### PR DESCRIPTION
#### What this PR does

Fixes a TODO by restoring native histogram test cases for TestInstantQuerySplittingCorrectness now that native histograms can use the division operator.

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/prometheus/prometheus/issues/12250

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
