### PR TITLE
Fix issue where dashboard panels that show percentages sometimes have axes that go from 0% to 10000%.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * [ENHANCEMENT] Dashboards: fix holes in graph for lightly loaded clusters #4915
 * [ENHANCEMENT] Dashboards: allow configuring additional services for the Rollout Progress dashboard. #5007
 * [BUGFIX] Dashboards: show cancelled requests in a different color to successful requests in throughput panels on dashboards. #5039
+* [BUGFIX] Dashboards: fix dashboard panels that showed percentages with axes from 0 to 10000%. #5084
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -1885,6 +1885,8 @@ data:
                       "datasource": "$datasource",
                       "fieldConfig": {
                          "defaults": {
+                            "max": 1,
+                            "min": 0,
                             "noValue": "0",
                             "unit": "percentunit"
                          }
@@ -6037,6 +6039,8 @@ data:
                       "datasource": "$datasource",
                       "fieldConfig": {
                          "defaults": {
+                            "max": 1,
+                            "min": 0,
                             "noValue": "0",
                             "unit": "percentunit"
                          }
@@ -7395,6 +7399,8 @@ data:
                       "datasource": "$datasource",
                       "fieldConfig": {
                          "defaults": {
+                            "max": 1,
+                            "min": 0,
                             "noValue": "0",
                             "unit": "percentunit"
                          }
@@ -7516,6 +7522,8 @@ data:
                       "datasource": "$datasource",
                       "fieldConfig": {
                          "defaults": {
+                            "max": 1,
+                            "min": 0,
                             "noValue": "0",
                             "unit": "percentunit"
                          }
@@ -24022,6 +24030,8 @@ data:
                       "datasource": "$datasource",
                       "fieldConfig": {
                          "defaults": {
+                            "max": 1,
+                            "min": 0,
                             "noValue": "0",
                             "unit": "percentunit"
                          }
@@ -24707,6 +24717,8 @@ data:
                       "datasource": "$datasource",
                       "fieldConfig": {
                          "defaults": {
+                            "max": 1,
+                            "min": 0,
                             "noValue": "0",
                             "unit": "percentunit"
                          }
@@ -31057,6 +31069,8 @@ data:
                       "datasource": "$datasource",
                       "fieldConfig": {
                          "defaults": {
+                            "max": 1,
+                            "min": 0,
                             "noValue": "0",
                             "unit": "percentunit"
                          }

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
@@ -1005,6 +1005,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor.json
@@ -1419,6 +1419,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-object-store.json
@@ -114,6 +114,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }
@@ -235,6 +237,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -3354,6 +3354,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }
@@ -4039,6 +4041,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
@@ -1943,6 +1943,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -1005,6 +1005,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -1419,6 +1419,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
@@ -114,6 +114,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }
@@ -235,6 +237,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -3354,6 +3354,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }
@@ -4039,6 +4041,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -1943,6 +1943,8 @@
                   "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
+                        "max": 1,
+                        "min": 0,
                         "noValue": "0",
                         "unit": "percentunit"
                      }

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -780,7 +780,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     .addPanel(
       $.timeseriesPanel('Error rate') +
       $.queryPanel('sum by(operation) (rate(thanos_objstore_bucket_operation_failures_total{%s,component="%s"}[$__rate_interval])) / sum by(operation) (rate(thanos_objstore_bucket_operations_total{%s,component="%s"}[$__rate_interval])) >= 0' % [$.namespaceMatcher(), component, $.namespaceMatcher(), component], '{{operation}}') +
-      { fieldConfig: { defaults: { noValue: '0', unit: 'percentunit' } } }
+      { fieldConfig: { defaults: { noValue: '0', unit: 'percentunit', min: 0, max: 1 } } }
     )
     .addPanel(
       $.panel('Latency of op: Attributes') +

--- a/operations/mimir-mixin/dashboards/object-store.libsonnet
+++ b/operations/mimir-mixin/dashboards/object-store.libsonnet
@@ -16,7 +16,7 @@ local filename = 'mimir-object-store.json';
       .addPanel(
         $.timeseriesPanel('Error rate / component') +
         $.queryPanel('sum by(component) (rate(thanos_objstore_bucket_operation_failures_total{%s}[$__rate_interval])) / sum by(component) (rate(thanos_objstore_bucket_operations_total{%s}[$__rate_interval])) >= 0' % [$.namespaceMatcher(), $.namespaceMatcher()], '{{component}}') +
-        { fieldConfig: { defaults: { noValue: '0', unit: 'percentunit' } } }
+        { fieldConfig: { defaults: { noValue: '0', unit: 'percentunit', min: 0, max: 1 } } }
       )
     )
     .addRow(
@@ -30,7 +30,7 @@ local filename = 'mimir-object-store.json';
       .addPanel(
         $.timeseriesPanel('Error rate / operation') +
         $.queryPanel('sum by(operation) (rate(thanos_objstore_bucket_operation_failures_total{%s}[$__rate_interval])) / sum by(operation) (rate(thanos_objstore_bucket_operations_total{%s}[$__rate_interval])) >= 0' % [$.namespaceMatcher(), $.namespaceMatcher()], '{{operation}}') +
-        { fieldConfig: { defaults: { noValue: '0', unit: 'percentunit' } } }
+        { fieldConfig: { defaults: { noValue: '0', unit: 'percentunit', min: 0, max: 1 } } }
       )
     )
     .addRow(


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where some dashboard panels that show percentages have axes that go to 10000%, for example:

<img width="758" alt="Screenshot 2023-05-26 at 4 32 33 pm" src="https://github.com/grafana/mimir/assets/4017646/4cba2788-d4c7-444e-b61a-e509800b834c">

<img width="350" alt="Screenshot 2023-05-26 at 4 36 42 pm" src="https://github.com/grafana/mimir/assets/4017646/ec525e08-b1f4-489c-b0cf-23a1ef3ff59a">

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
