### PR TITLE
Docs: explain that series store samples in chunks

### DIFF
--- a/docs/sources/mimir/get-started/about-grafana-mimir-architecture/index.md
+++ b/docs/sources/mimir/get-started/about-grafana-mimir-architecture/index.md
@@ -91,6 +91,8 @@ Each on-disk block directory contains an index file, a file containing metadata,
 
 The TSDB block files contain samples for multiple series.
 The series inside the blocks are indexed by a per-block index, which indexes both metric names and labels to time series in the block files.
+Each series has its samples organized in chunks, which represent a specific time range of stored samples.
+Chunks may vary in length depending on specific configuration options and ingestion rate, usually storing around 120 samples per chunk.
 
 Grafana Mimir requires any of the following object stores for the block files:
 


### PR DESCRIPTION
#### What this PR does

Short explanation of the fact that series store samples in chunks, and their length.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
