### PR TITLE
Chore: remove unused ThanosMeta data

### DIFF
--- a/pkg/storage/tsdb/block/meta.go
+++ b/pkg/storage/tsdb/block/meta.go
@@ -14,14 +14,11 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/runutil"
-	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
-	"github.com/prometheus/prometheus/tsdb/tombstones"
 	"gopkg.in/yaml.v3"
 )
 
@@ -76,18 +73,6 @@ type ThanosMeta struct {
 	// Useful to avoid API call to get size of each file, as well as for debugging purposes.
 	// Optional, added in v0.17.0.
 	Files []File `json:"files,omitempty"`
-
-	// Rewrites is present when any rewrite (deletion, relabel etc) were applied to this block. Optional.
-	Rewrites []Rewrite `json:"rewrites,omitempty"`
-}
-
-type Rewrite struct {
-	// ULIDs of all source head blocks that went into the block.
-	Sources []ulid.ULID `json:"sources,omitempty"`
-	// Deletions if applied (in order).
-	DeletionsApplied []DeletionRequest `json:"deletions_applied,omitempty"`
-	// Relabels if applied.
-	RelabelsApplied []*relabel.Config `json:"relabels_applied,omitempty"`
 }
 
 type Matchers []*labels.Matcher
@@ -98,12 +83,6 @@ func (m *Matchers) UnmarshalYAML(value *yaml.Node) (err error) {
 		return errors.Wrapf(err, "parse metric selector %v", value.Value)
 	}
 	return nil
-}
-
-type DeletionRequest struct {
-	Matchers  Matchers             `json:"matchers" yaml:"matchers"`
-	Intervals tombstones.Intervals `json:"intervals,omitempty" yaml:"intervals,omitempty"`
-	RequestID string               `json:"request_id,omitempty" yaml:"request_id,omitempty"`
 }
 
 type File struct {


### PR DESCRIPTION
#### What this PR does
While working on https://github.com/grafana/mimir/pull/5063 I noticed we have few structs inherited by Thanos but never used by Mimir. In this PR I'm proposing to cleanup them.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
