### PR TITLE
Share values common to all streaming series selected in a query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 * [ENHANCEMENT] Ruler: trigger a synchronization of tenant's rule groups as soon as they change the rules configuration via API. This synchronization is in addition of the periodic syncing done every `-ruler.poll-interval`. The new behavior is enabled by default, but can be disabled with `-ruler.sync-rules-on-changes-enabled=false` (configurable on a per-tenant basis too). #4975 #5053
 * [ENHANCEMENT] Distributor: Improve invalid tenant shard size error message. #5024
 * [ENHANCEMENT] Store-gateway: record index header loading time separately in `cortex_bucket_store_series_request_stage_duration_seconds{stage="load_index_header"}`. Now index header loading will be visible in the "Mimir / Queries" dashboard in the "Series request p99/average latency" panels. #5011 #5062
-* [ENHANCEMENT] Querier and ingester: add experimental support for streaming chunks from ingesters to queriers while evaluating queries. This can be enabled with `-querier.prefer-streaming-chunks=true`. #4886 #5078
+* [ENHANCEMENT] Querier and ingester: add experimental support for streaming chunks from ingesters to queriers while evaluating queries. This can be enabled with `-querier.prefer-streaming-chunks=true`. #4886 #5078 #5094
 * [ENHANCEMENT] Update Docker base images from `alpine:3.17.3` to `alpine:3.18.0`. #5065
 * [ENHANCEMENT] Compactor: reduced the number of "object exists" API calls issued by the compactor to the object storage when syncing block's `meta.json` files. #5063
 * [BUGFIX] Metadata API: Mimir will now return an empty object when no metadata is available, matching Prometheus. #4782

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -39,16 +39,18 @@ func TestStreamingChunkSeries_HappyPath(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	queryStats := &stats.Stats{}
 	series := streamingChunkSeries{
-		labels:            labels.FromStrings("the-name", "the-value"),
-		chunkIteratorFunc: chunkIteratorFunc,
-		mint:              1000,
-		maxt:              6000,
+		labels: labels.FromStrings("the-name", "the-value"),
 		sources: []client.StreamingSeriesSource{
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{{SeriesIndex: 0, Chunks: []client.Chunk{chunkUniqueToFirstSource, chunkPresentInBothSources}}})},
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{{SeriesIndex: 0, Chunks: []client.Chunk{chunkUniqueToSecondSource, chunkPresentInBothSources}}})},
 		},
-		queryChunkMetrics: stats.NewQueryChunkMetrics(reg),
-		queryStats:        queryStats,
+		config: &streamingChunkSeriesConfig{
+			chunkIteratorFunc: chunkIteratorFunc,
+			mint:              1000,
+			maxt:              6000,
+			queryChunkMetrics: stats.NewQueryChunkMetrics(reg),
+			queryStats:        queryStats,
+		},
 	}
 
 	iterator := series.Iterator(nil)
@@ -75,16 +77,18 @@ func TestStreamingChunkSeries_StreamReaderReturnsError(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	queryStats := &stats.Stats{}
 	series := streamingChunkSeries{
-		labels:            labels.FromStrings("the-name", "the-value"),
-		chunkIteratorFunc: nil,
-		mint:              1000,
-		maxt:              6000,
+		labels: labels.FromStrings("the-name", "the-value"),
 		// Create a stream reader that will always return an error because we'll try to read a series when it has no series to read.
 		sources: []client.StreamingSeriesSource{
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{})},
 		},
-		queryChunkMetrics: stats.NewQueryChunkMetrics(reg),
-		queryStats:        queryStats,
+		config: &streamingChunkSeriesConfig{
+			chunkIteratorFunc: nil,
+			mint:              1000,
+			maxt:              6000,
+			queryChunkMetrics: stats.NewQueryChunkMetrics(reg),
+			queryStats:        queryStats,
+		},
 	}
 
 	iterator := series.Iterator(nil)


### PR DESCRIPTION
#### What this PR does

This PR modifies `streamingChunkSeries` to share fields common to all series selected by the query. This reduces per-series memory consumption for series streamed from ingesters to queriers.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/4886

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
