### PR TITLE
Reuse iterator in `batch.NewChunkMergeIterator`

### DIFF
--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -8,10 +8,11 @@ package batch
 import (
 	"fmt"
 
-	"github.com/grafana/mimir/pkg/storage/chunk"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
+	"github.com/grafana/mimir/pkg/storage/chunk"
 )
 
 // GenericChunk is a generic chunk used by the batch iterator, in order to make the batch

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/zeropool"
 
 	"github.com/grafana/mimir/pkg/storage/chunk"
 )
@@ -55,9 +56,23 @@ type iterator interface {
 	Err() error
 }
 
+var genericChunkSlicePool zeropool.Pool[[]GenericChunk]
+
+func getGenericChunkSlice(n int) []GenericChunk {
+	sn := genericChunkSlicePool.Get()
+	if sn == nil || cap(sn) < n {
+		return make([]GenericChunk, n)
+	}
+	return sn[:n]
+}
+
+func putGenericChunkSlice(sn []GenericChunk) {
+	genericChunkSlicePool.Put(sn)
+}
+
 // NewChunkMergeIterator returns a chunkenc.Iterator that merges Mimir chunks together.
 func NewChunkMergeIterator(it chunkenc.Iterator, chunks []chunk.Chunk, _, _ model.Time) chunkenc.Iterator {
-	converted := make([]GenericChunk, len(chunks))
+	converted := getGenericChunkSlice(len(chunks))
 	for i, c := range chunks {
 		converted[i] = NewGenericChunk(int64(c.From), int64(c.Through), c.Data.NewIterator)
 	}

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -56,19 +56,34 @@ type iterator interface {
 }
 
 // NewChunkMergeIterator returns a chunkenc.Iterator that merges Mimir chunks together.
-func NewChunkMergeIterator(chunks []chunk.Chunk, _, _ model.Time) chunkenc.Iterator {
+func NewChunkMergeIterator(it chunkenc.Iterator, chunks []chunk.Chunk, _, _ model.Time) chunkenc.Iterator {
 	converted := make([]GenericChunk, len(chunks))
 	for i, c := range chunks {
 		converted[i] = NewGenericChunk(int64(c.From), int64(c.Through), c.Data.NewIterator)
 	}
 
-	return NewGenericChunkMergeIterator(converted)
+	return NewGenericChunkMergeIterator(it, converted)
 }
 
 // NewGenericChunkMergeIterator returns a chunkenc.Iterator that merges generic chunks together.
-func NewGenericChunkMergeIterator(chunks []GenericChunk) chunkenc.Iterator {
-	iter := newMergeIterator(chunks)
-	return newIteratorAdapter(iter)
+func NewGenericChunkMergeIterator(it chunkenc.Iterator, chunks []GenericChunk) chunkenc.Iterator {
+	var (
+		iter    *mergeIterator
+		adapter *iteratorAdapter
+		ok      bool
+	)
+	if it != nil {
+		adapter, ok = it.(*iteratorAdapter)
+		if ok {
+			iter = newMergeIterator(adapter.underlying, chunks)
+		}
+	}
+
+	if iter == nil {
+		iter = newMergeIterator(nil, chunks)
+	}
+
+	return newIteratorAdapter(adapter, iter)
 }
 
 // iteratorAdapter turns a batchIterator into a chunkenc.Iterator.
@@ -80,7 +95,13 @@ type iteratorAdapter struct {
 	underlying iterator
 }
 
-func newIteratorAdapter(underlying iterator) chunkenc.Iterator {
+func newIteratorAdapter(it *iteratorAdapter, underlying iterator) chunkenc.Iterator {
+	if it != nil {
+		it.batchSize = 1
+		it.underlying = underlying
+		it.curr = chunk.Batch{}
+		return it
+	}
 	return &iteratorAdapter{
 		batchSize:  1,
 		underlying: underlying,

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -67,19 +67,12 @@ func NewChunkMergeIterator(it chunkenc.Iterator, chunks []chunk.Chunk, _, _ mode
 
 // NewGenericChunkMergeIterator returns a chunkenc.Iterator that merges generic chunks together.
 func NewGenericChunkMergeIterator(it chunkenc.Iterator, chunks []GenericChunk) chunkenc.Iterator {
-	var (
-		iter    *mergeIterator
-		adapter *iteratorAdapter
-		ok      bool
-	)
-	if it != nil {
-		adapter, ok = it.(*iteratorAdapter)
-		if ok {
-			iter = newMergeIterator(adapter.underlying, chunks)
-		}
-	}
+	var iter *mergeIterator
 
-	if iter == nil {
+	adapter, ok := it.(*iteratorAdapter)
+	if ok {
+		iter = newMergeIterator(adapter.underlying, chunks)
+	} else {
 		iter = newMergeIterator(nil, chunks)
 	}
 

--- a/pkg/querier/batch/batch_test.go
+++ b/pkg/querier/batch/batch_test.go
@@ -38,12 +38,12 @@ func BenchmarkNewChunkMergeIterator_CreateAndIterate(b *testing.B) {
 			scenario.duplicationFactor)
 
 		chunks := createChunks(b, scenario.numChunks, scenario.numSamplesPerChunk, scenario.duplicationFactor, chunk.PrometheusXorChunk)
-
+		var it chunkenc.Iterator
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 
 			for n := 0; n < b.N; n++ {
-				it := NewChunkMergeIterator(chunks, 0, 0)
+				it = NewChunkMergeIterator(it, chunks, 0, 0)
 				for it.Next() != chunkenc.ValNone {
 					it.At()
 				}
@@ -62,7 +62,7 @@ func TestSeekCorrectlyDealWithSinglePointChunks(t *testing.T) {
 	chunkTwo := mkChunk(t, model.Time(10*step/time.Millisecond), 1, chunk.PrometheusXorChunk)
 	chunks := []chunk.Chunk{chunkOne, chunkTwo}
 
-	sut := NewChunkMergeIterator(chunks, 0, 0)
+	sut := NewChunkMergeIterator(nil, chunks, 0, 0)
 
 	// Following calls mimics Prometheus's query engine behaviour for VectorSelector.
 	require.Equal(t, chunkenc.ValFloat, sut.Next())

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -35,10 +35,10 @@ func testChunkIter(t *testing.T, encoding chunk.Encoding) {
 	iter := &chunkIterator{}
 
 	iter.reset(chunk)
-	testIter(t, 100, newIteratorAdapter(iter), encoding)
+	testIter(t, 100, newIteratorAdapter(nil, iter), encoding)
 
 	iter.reset(chunk)
-	testSeek(t, 100, newIteratorAdapter(iter), encoding)
+	testSeek(t, 100, newIteratorAdapter(nil, iter), encoding)
 }
 
 func mkChunk(t require.TestingT, from model.Time, points int, encoding chunk.Encoding) chunk.Chunk {

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -28,18 +28,29 @@ type mergeIterator struct {
 	currErr error
 }
 
-func newMergeIterator(cs []GenericChunk) *mergeIterator {
-	css := partitionChunks(cs)
-	its := make([]*nonOverlappingIterator, 0, len(css))
-	for _, cs := range css {
-		its = append(its, newNonOverlappingIterator(cs))
+func newMergeIterator(it iterator, cs []GenericChunk) *mergeIterator {
+	c, ok := it.(*mergeIterator)
+	if ok {
+		c.nextBatchBuf[0] = chunk.Batch{}
+		c.currErr = nil
+	} else {
+		c = &mergeIterator{}
 	}
 
-	c := &mergeIterator{
-		its:        its,
-		h:          make(iteratorHeap, 0, len(its)),
-		batches:    make(batchStream, 0, len(its)),
-		batchesBuf: make(batchStream, len(its)),
+	css := partitionChunks(cs)
+	if cap(c.its) >= len(css) {
+		c.its = c.its[:len(css)]
+		c.h = c.h[:0]
+		c.batches = c.batches[:0]
+		c.batchesBuf = c.batchesBuf[:len(css)]
+	} else {
+		c.its = make([]*nonOverlappingIterator, len(css))
+		c.h = make(iteratorHeap, 0, len(c.its))
+		c.batches = make(batchStream, 0, len(c.its))
+		c.batchesBuf = make(batchStream, len(c.its))
+	}
+	for i, cs := range css {
+		c.its[i] = newNonOverlappingIterator(c.its[i], cs)
 	}
 
 	for _, iter := range c.its {

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -42,6 +42,8 @@ func newMergeIterator(it iterator, cs []GenericChunk) *mergeIterator {
 		c.its = c.its[:len(css)]
 		c.h = c.h[:0]
 		c.batches = c.batches[:0]
+		// We are not resetting the content of c.batchesBuf because they will be
+		// reset once we call mergeStreams() on them.
 		c.batchesBuf = c.batchesBuf[:len(css)]
 	} else {
 		c.its = make([]*nonOverlappingIterator, len(css))

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -28,7 +28,7 @@ type mergeIterator struct {
 	currErr error
 }
 
-func newMergeIterator(it iterator, gc []GenericChunk) *mergeIterator {
+func newMergeIterator(it iterator, cs []GenericChunk) *mergeIterator {
 	c, ok := it.(*mergeIterator)
 	if ok {
 		c.nextBatchBuf[0] = chunk.Batch{}
@@ -37,8 +37,7 @@ func newMergeIterator(it iterator, gc []GenericChunk) *mergeIterator {
 		c = &mergeIterator{}
 	}
 
-	css := partitionChunks(gc)
-	putGenericChunkSlice(gc)
+	css := partitionChunks(cs)
 	if cap(c.its) >= len(css) {
 		c.its = c.its[:len(css)]
 		c.h = c.h[:0]

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -28,7 +28,7 @@ type mergeIterator struct {
 	currErr error
 }
 
-func newMergeIterator(it iterator, cs []GenericChunk) *mergeIterator {
+func newMergeIterator(it iterator, gc []GenericChunk) *mergeIterator {
 	c, ok := it.(*mergeIterator)
 	if ok {
 		c.nextBatchBuf[0] = chunk.Batch{}
@@ -37,7 +37,8 @@ func newMergeIterator(it iterator, cs []GenericChunk) *mergeIterator {
 		c = &mergeIterator{}
 	}
 
-	css := partitionChunks(cs)
+	css := partitionChunks(gc)
+	putGenericChunkSlice(gc)
 	if cap(c.its) >= len(css) {
 		c.its = c.its[:len(css)]
 		c.h = c.h[:0]

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -21,11 +21,17 @@ func TestMergeIter(t *testing.T) {
 	chunk4 := mkGenericChunk(t, model.TimeFromUnix(75), 100, chunk.PrometheusXorChunk)
 	chunk5 := mkGenericChunk(t, model.TimeFromUnix(100), 100, chunk.PrometheusXorChunk)
 
-	iter := newMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testIter(t, 200, newIteratorAdapter(nil, iter), chunk.PrometheusXorChunk)
+	iter := NewGenericChunkMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+	testIter(t, 200, iter, chunk.PrometheusXorChunk)
+	iter = NewGenericChunkMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+	testSeek(t, 200, iter, chunk.PrometheusXorChunk)
 
-	iter = newMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testSeek(t, 200, newIteratorAdapter(nil, iter), chunk.PrometheusXorChunk)
+	// Re-use iterator.
+	iter = NewGenericChunkMergeIterator(iter, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+	testIter(t, 200, iter, chunk.PrometheusXorChunk)
+	iter = NewGenericChunkMergeIterator(iter, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+	testSeek(t, 200, iter, chunk.PrometheusXorChunk)
+
 }
 
 func TestMergeHarder(t *testing.T) {

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -21,11 +21,11 @@ func TestMergeIter(t *testing.T) {
 	chunk4 := mkGenericChunk(t, model.TimeFromUnix(75), 100, chunk.PrometheusXorChunk)
 	chunk5 := mkGenericChunk(t, model.TimeFromUnix(100), 100, chunk.PrometheusXorChunk)
 
-	iter := newMergeIterator([]GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testIter(t, 200, newIteratorAdapter(iter), chunk.PrometheusXorChunk)
+	iter := newMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+	testIter(t, 200, newIteratorAdapter(nil, iter), chunk.PrometheusXorChunk)
 
-	iter = newMergeIterator([]GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testSeek(t, 200, newIteratorAdapter(iter), chunk.PrometheusXorChunk)
+	iter = newMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+	testSeek(t, 200, newIteratorAdapter(nil, iter), chunk.PrometheusXorChunk)
 }
 
 func TestMergeHarder(t *testing.T) {
@@ -40,9 +40,9 @@ func TestMergeHarder(t *testing.T) {
 		chunks = append(chunks, mkGenericChunk(t, from, samples, chunk.PrometheusXorChunk))
 		from = from.Add(time.Duration(offset) * time.Second)
 	}
-	iter := newMergeIterator(chunks)
-	testIter(t, offset*numChunks+samples-offset, newIteratorAdapter(iter), chunk.PrometheusXorChunk)
+	iter := newMergeIterator(nil, chunks)
+	testIter(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter), chunk.PrometheusXorChunk)
 
-	iter = newMergeIterator(chunks)
-	testSeek(t, offset*numChunks+samples-offset, newIteratorAdapter(iter), chunk.PrometheusXorChunk)
+	iter = newMergeIterator(nil, chunks)
+	testSeek(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter), chunk.PrometheusXorChunk)
 }

--- a/pkg/querier/batch/non_overlapping.go
+++ b/pkg/querier/batch/non_overlapping.go
@@ -17,18 +17,14 @@ type nonOverlappingIterator struct {
 	iter   chunkIterator
 }
 
-// newNonOverlappingIterator returns a single iterator over an slice of sorted,
+// newNonOverlappingIterator returns a single iterator over a slice of sorted,
 // non-overlapping iterators.
-func newNonOverlappingIterator(reuse *nonOverlappingIterator, chunks []GenericChunk) *nonOverlappingIterator {
-	if reuse != nil {
-		reuse.chunks = chunks
-		reuse.curr = 0
-		reuse.iter.reset(reuse.chunks[0])
-		return reuse
+func newNonOverlappingIterator(it *nonOverlappingIterator, chunks []GenericChunk) *nonOverlappingIterator {
+	if it == nil {
+		it = &nonOverlappingIterator{}
 	}
-	it := &nonOverlappingIterator{
-		chunks: chunks,
-	}
+	it.chunks = chunks
+	it.curr = 0
 	it.iter.reset(it.chunks[0])
 	return it
 }

--- a/pkg/querier/batch/non_overlapping.go
+++ b/pkg/querier/batch/non_overlapping.go
@@ -19,7 +19,13 @@ type nonOverlappingIterator struct {
 
 // newNonOverlappingIterator returns a single iterator over an slice of sorted,
 // non-overlapping iterators.
-func newNonOverlappingIterator(chunks []GenericChunk) *nonOverlappingIterator {
+func newNonOverlappingIterator(reuse *nonOverlappingIterator, chunks []GenericChunk) *nonOverlappingIterator {
+	if reuse != nil {
+		reuse.chunks = chunks
+		reuse.curr = 0
+		reuse.iter.reset(reuse.chunks[0])
+		return reuse
+	}
 	it := &nonOverlappingIterator{
 		chunks: chunks,
 	}

--- a/pkg/querier/batch/non_overlapping_test.go
+++ b/pkg/querier/batch/non_overlapping_test.go
@@ -19,7 +19,17 @@ func TestNonOverlappingIter(t *testing.T) {
 		cs = append(cs, mkGenericChunk(t, model.TimeFromUnix(i*10), 10, chunk.PrometheusXorChunk))
 	}
 	testIter(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs)), chunk.PrometheusXorChunk)
-	testSeek(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs)), chunk.PrometheusXorChunk)
+	it := newNonOverlappingIterator(nil, cs)
+	adapter := newIteratorAdapter(nil, it)
+	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk)
+
+	// Do the same operations while re-using the iterators.
+	it = newNonOverlappingIterator(it, cs)
+	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it)
+	testIter(t, 10*100, adapter, chunk.PrometheusXorChunk)
+	it = newNonOverlappingIterator(it, cs)
+	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it)
+	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk)
 }
 
 func TestNonOverlappingIterSparse(t *testing.T) {

--- a/pkg/querier/batch/non_overlapping_test.go
+++ b/pkg/querier/batch/non_overlapping_test.go
@@ -18,8 +18,8 @@ func TestNonOverlappingIter(t *testing.T) {
 	for i := int64(0); i < 100; i++ {
 		cs = append(cs, mkGenericChunk(t, model.TimeFromUnix(i*10), 10, chunk.PrometheusXorChunk))
 	}
-	testIter(t, 10*100, newIteratorAdapter(newNonOverlappingIterator(cs)), chunk.PrometheusXorChunk)
-	testSeek(t, 10*100, newIteratorAdapter(newNonOverlappingIterator(cs)), chunk.PrometheusXorChunk)
+	testIter(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs)), chunk.PrometheusXorChunk)
+	testSeek(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs)), chunk.PrometheusXorChunk)
 }
 
 func TestNonOverlappingIterSparse(t *testing.T) {
@@ -31,6 +31,6 @@ func TestNonOverlappingIterSparse(t *testing.T) {
 		mkGenericChunk(t, model.TimeFromUnix(95), 1, chunk.PrometheusXorChunk),
 		mkGenericChunk(t, model.TimeFromUnix(96), 4, chunk.PrometheusXorChunk),
 	}
-	testIter(t, 100, newIteratorAdapter(newNonOverlappingIterator(cs)), chunk.PrometheusXorChunk)
-	testSeek(t, 100, newIteratorAdapter(newNonOverlappingIterator(cs)), chunk.PrometheusXorChunk)
+	testIter(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs)), chunk.PrometheusXorChunk)
+	testSeek(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs)), chunk.PrometheusXorChunk)
 }

--- a/pkg/querier/distributor_queryable_streaming.go
+++ b/pkg/querier/distributor_queryable_streaming.go
@@ -29,7 +29,7 @@ func (s *streamingChunkSeries) Labels() labels.Labels {
 	return s.labels
 }
 
-func (s *streamingChunkSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
+func (s *streamingChunkSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
 	var uniqueChunks []client.Chunk
 	totalChunks := 0
 
@@ -62,5 +62,5 @@ func (s *streamingChunkSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
 		return series.NewErrIterator(err)
 	}
 
-	return s.chunkIteratorFunc(chunks, model.Time(s.mint), model.Time(s.maxt))
+	return s.chunkIteratorFunc(it, chunks, model.Time(s.mint), model.Time(s.maxt))
 }

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestStreamingChunkSeries_HappyPath(t *testing.T) {
-	chunkIteratorFunc := func(chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator {
+	chunkIteratorFunc := func(_ chunkenc.Iterator, chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator {
 		return streamingChunkSeriesTestIterator{
 			chunks:  chunks,
 			from:    from,

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -8,7 +8,6 @@ package querier
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/mimir/pkg/querier/batch"
 	"math"
 	"strconv"
 	"testing"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/querier/batch"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/storage/chunk"
 	"github.com/grafana/mimir/pkg/util"

--- a/pkg/querier/iterators/chunk_merge_iterator.go
+++ b/pkg/querier/iterators/chunk_merge_iterator.go
@@ -30,7 +30,6 @@ type chunkMergeIterator struct {
 }
 
 // NewChunkMergeIterator creates a chunkenc.Iterator for a set of chunks.
-// TODO: reuse iterators.
 func NewChunkMergeIterator(_ chunkenc.Iterator, cs []chunk.Chunk, _, _ model.Time) chunkenc.Iterator {
 	its := buildIterators(cs)
 	c := &chunkMergeIterator{

--- a/pkg/querier/iterators/chunk_merge_iterator.go
+++ b/pkg/querier/iterators/chunk_merge_iterator.go
@@ -30,7 +30,8 @@ type chunkMergeIterator struct {
 }
 
 // NewChunkMergeIterator creates a chunkenc.Iterator for a set of chunks.
-func NewChunkMergeIterator(cs []chunk.Chunk, _, _ model.Time) chunkenc.Iterator {
+// TODO: reuse iterators.
+func NewChunkMergeIterator(_ chunkenc.Iterator, cs []chunk.Chunk, _, _ model.Time) chunkenc.Iterator {
 	its := buildIterators(cs)
 	c := &chunkMergeIterator{
 		currTime: -1,

--- a/pkg/querier/iterators/chunk_merge_iterator_test.go
+++ b/pkg/querier/iterators/chunk_merge_iterator_test.go
@@ -66,7 +66,7 @@ func TestChunkMergeIterator(t *testing.T) {
 				for _, bounds := range tc.chunkBounds {
 					chunks = append(chunks, mkChunk(t, bounds.mint, bounds.maxt, 1*time.Millisecond, encoding.enc))
 				}
-				iter := NewChunkMergeIterator(chunks, 0, 0)
+				iter := NewChunkMergeIterator(nil, chunks, 0, 0)
 				for i := tc.mint; i < tc.maxt; i++ {
 					encoding.assertSample(t, i, iter, iter.Next())
 				}
@@ -77,7 +77,7 @@ func TestChunkMergeIterator(t *testing.T) {
 }
 
 func TestChunkMergeIteratorMixed(t *testing.T) {
-	iter := NewChunkMergeIterator([]chunk.Chunk{
+	iter := NewChunkMergeIterator(nil, []chunk.Chunk{
 		mkChunk(t, 0, 75, 1*time.Millisecond, chunk.PrometheusXorChunk),
 		mkChunk(t, 50, 150, 1*time.Millisecond, chunk.PrometheusHistogramChunk),
 		mkChunk(t, 125, 200, 1*time.Millisecond, chunk.PrometheusFloatHistogramChunk),
@@ -115,7 +115,7 @@ func TestChunkMergeIteratorSeek(t *testing.T) {
 			maxt := int64(200)
 
 			for i := mint; i < maxt; i += 20 {
-				iter := NewChunkMergeIterator(chunks, 0, 0)
+				iter := NewChunkMergeIterator(nil, chunks, 0, 0)
 				valueType := iter.Seek(i)
 				encoding.assertSample(t, i, iter, valueType)
 
@@ -154,7 +154,7 @@ func TestChunkMergeIteratorSeekMixed(t *testing.T) {
 	}
 
 	for i := mint; i < maxt; i += 10 {
-		iter := NewChunkMergeIterator(chunks, 0, 0)
+		iter := NewChunkMergeIterator(nil, chunks, 0, 0)
 		assertSample(t, i, iter, iter.Seek(i))
 
 		for j := i + 1; j < maxt; j++ {

--- a/pkg/querier/matrix.go
+++ b/pkg/querier/matrix.go
@@ -16,7 +16,8 @@ import (
 	"github.com/grafana/mimir/pkg/util/modelutil"
 )
 
-func mergeChunks(chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator {
+// TODO: reuse iterators.
+func mergeChunks(_ chunkenc.Iterator, chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator {
 	var (
 		samples          = make([][]model.SamplePair, 0, len(chunks))
 		histograms       [][]mimirpb.Histogram

--- a/pkg/querier/matrix.go
+++ b/pkg/querier/matrix.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/mimir/pkg/util/modelutil"
 )
 
-// TODO: reuse iterators.
 func mergeChunks(_ chunkenc.Iterator, chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator {
 	var (
 		samples          = make([][]model.SamplePair, 0, len(chunks))

--- a/pkg/querier/partitioner.go
+++ b/pkg/querier/partitioner.go
@@ -16,7 +16,7 @@ import (
 	seriesset "github.com/grafana/mimir/pkg/storage/series"
 )
 
-type chunkIteratorFunc func(chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator
+type chunkIteratorFunc func(reuse chunkenc.Iterator, chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator
 
 // Series in the returned set are sorted alphabetically by labels.
 func partitionChunks(chunks []chunk.Chunk, mint, maxt int64, iteratorFunc chunkIteratorFunc) storage.SeriesSet {
@@ -53,8 +53,8 @@ func (s *chunkSeries) Labels() labels.Labels {
 }
 
 // Iterator returns a new iterator of the data of the series.
-func (s *chunkSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
-	return s.chunkIteratorFunc(s.chunks, model.Time(s.mint), model.Time(s.maxt))
+func (s *chunkSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
+	return s.chunkIteratorFunc(it, s.chunks, model.Time(s.mint), model.Time(s.maxt))
 }
 
 // Chunks implements SeriesWithChunks interface.


### PR DESCRIPTION
#### What this PR does

Implements the re-use of iterator for `batch.NewChunkMergeIterator`. Although querier uses two other chunk iterators, since this one is enabled by default (and I guess most commonly), I gave this one a try first.

~While this benchmark verifies the re-use of iterators is working for this one, it was not trivial to verify that at the query level, it is indeed passing down the used iterator for re-use - I need some help verifying this.~ See https://github.com/grafana/mimir/pull/5097#issuecomment-1567008742


Here are the benchmark results (without the chunk pool that was added and later removed from this PR):
```
benchmark                                                                                                        old ns/op     new ns/op     delta
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1-10     3184123       3214727       +0.96%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3-10     9495067       9539729       +0.47%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_1-10      320369        321496        +0.35%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_3-10      949704        955471        +0.61%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_1-10        4313          3685          -14.56%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_3-10        12090         10822         -10.49%

benchmark                                                                                                        old allocs     new allocs     delta
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1-10     1013           1004           -0.89%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3-10     3023           3008           -0.50%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_1-10      113            104            -7.96%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_3-10      323            308            -4.64%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_1-10        14             5              -64.29%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_3-10        26             11             -57.69%

benchmark                                                                                                        old bytes     new bytes     delta
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1-10     75192         73200         -2.65%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3-10     289689        285184        -1.56%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_1-10      9816          7824          -20.29%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_100_samples_per_chunk:_100_duplication_factor:_3-10      35064         30560         -12.85%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_1-10        2112          120           -94.32%
BenchmarkNewChunkMergeIterator_CreateAndIterate/chunks:_1_samples_per_chunk:_100_duplication_factor:_3-10        4976          472           -90.51%
```


#### Which issue(s) this PR fixes or relates to

Addresses the useful part of https://github.com/grafana/mimir/pull/4886/files/6c4ec7372d19c84ee2072285fd653333f7338589#r1201931006

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
