### PR TITLE
feat: add namespaces-regex and ignore-namespaces regex to mimirtool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 ### Mimirtool
 
 * [CHANGE] check rules: will fail on duplicate rules when `--strict` is provided. #5035
+* [FEATURE] sync/diff can now include/exclude namespaces based on a regular expression using `--namespaces-regex` and `--ignore-namespaces-regex`. #5100
 * [ENHANCEMENT] analyze prometheus: allow to specify `-prometheus-http-prefix`. #4966
 * [ENHANCEMENT] analyze grafana: allow to specify `--folder-title` to limit dashboards analysis based on their exact folder title. #4973
 

--- a/docs/sources/mimir/operators-guide/tools/mimirtool.md
+++ b/docs/sources/mimir/operators-guide/tools/mimirtool.md
@@ -336,6 +336,19 @@ mimirtool rules diff <file_path>...
 
 The format of the file is the same format as shown in [rules load](#load-rule-group).
 
+To restrict the affected namespaces, use the `--namespaces` and `--ignore-namespaces` parameters as well as their RegEx variants `--namespaces-regex` and `--ignore-namespaces-regex`.
+
+##### Configuration
+
+| Flag                         | Description                                                |
+| ---------------------------- | ---------------------------------------------------------- |
+| `--namespaces`               | comma-separated list of namespaces to check during a diff  |
+| `--ignored-namespaces`       | comma-separated list of namespaces to ignore during a diff |
+| `--namespaces-regex`         | regex matching namespaces to check during a diff           |
+| `--ignored-namespaces-regex` | regex matching namespaces to ignore during a diff          |
+
+Only one of the namespace selection flags can be specified.
+
 #### Sync
 
 The `sync` command compares rules against the rules in your Grafana Mimir cluster.
@@ -346,6 +359,17 @@ mimirtool rules sync <file_path>...
 ```
 
 The format of the file is the same format as shown in [rules load](#load-rule-group).
+
+##### Configuration
+
+| Flag                         | Description                                                |
+| ---------------------------- | ---------------------------------------------------------- |
+| `--namespaces`               | comma-separated list of namespaces to check during a sync  |
+| `--ignored-namespaces`       | comma-separated list of namespaces to ignore during a sync |
+| `--namespaces-regex`         | regex matching namespaces to check during a sync           |
+| `--ignored-namespaces-regex` | regex matching namespaces to ignore during a sync          |
+
+Only one of the namespace selection flags can be specified.
 
 ### Remote-read
 


### PR DESCRIPTION

#### What this PR does
This PR adds two parameters (`namespaces-regex`, `ignore-namespaces-regex`) to the `mimirtool` diff and sync commands. This allows the user to ignore (or include) a set of namespaces based on patterns.

Especially useful for Grafana Cloud, where we provision rules for integrations. These can then be ignored by passing `--ignore-namespaces-regex='integrations-.*'`.

#### Checklist

- [ ] ~Tests updated~
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
