### PR TITLE
jsonnet: Support metricType in ScaledObject triggers

### DIFF
--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1906,3 +1906,31 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"
     type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 30
+  minReplicaCount: 20
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test
+  triggers:
+  - metadata:
+      metricName: cortex_test_hpa_default
+      query: some_query_goes_here
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "123"
+    metricType: Value
+    type: prometheus

--- a/operations/mimir-tests/test-autoscaling.jsonnet
+++ b/operations/mimir-tests/test-autoscaling.jsonnet
@@ -51,4 +51,19 @@ mimir {
     // the KEDA threshold
     // Also specify CPU request as a string to make sure it works
     k.util.resourcesRequests('0.2', '1Gi'),
+
+  // Test ScaledObject with metric_type.
+  test_scaled_object: $.newScaledObject('test', $._config.namespace, {
+    min_replica_count: 20,
+    max_replica_count: 30,
+
+    triggers: [
+      {
+        metric_name: 'cortex_test_hpa_%s' % $._config.namespace,
+        metric_type: 'Value', // This is what we're testing.
+        query: 'some_query_goes_here',
+        threshold: '123',
+      },
+    ],
+  }),
 }

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -120,7 +120,13 @@
             // We also have to ensure that the threshold is an integer (represented as a string)
             threshold: std.toString(std.parseInt(trigger.threshold)),
           },
-        }
+        } + (
+          // Be aware that the default value for the trigger "metricType" field is "AverageValue"
+          // (see https://keda.sh/docs/2.9/concepts/scaling-deployments/#triggers), which means that KEDA will
+          // determine the target number of replicas by dividing the metric value by the threshold. This means in practice
+          // that we can sum together the values for the different replicas in our queries.
+          if std.objectHas(trigger, 'metric_type') then { metricType: trigger.metric_type } else {}
+        )
         for trigger in config.triggers
       ],
     },
@@ -371,10 +377,6 @@
       // As a result, we have made the decision to set the scale down periodSeconds to 600.
       scaledownPeriod: 600,
 
-      // Be aware that the default value for the trigger "metricType" field is "AverageValue"
-      // (see https://keda.sh/docs/2.9/concepts/scaling-deployments/#triggers), which means that KEDA will
-      // determine the target number of replicas by dividing the metric value by the threshold. This means in practice
-      // that we can sum together the values for the different replicas in our queries.
       triggers: [
         {
           metric_name: '%s_cpu_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],


### PR DESCRIPTION
#### What this PR does
This PR adds support for specifying `metric_type` in the ScaledObject trigger. Values allowed by KEDA are `AverageValue` (default), `Value` and `Utilization`, see https://keda.sh/docs/2.9/concepts/scaling-deployments/#triggers for details.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
