### PR TITLE
store-gateway: fix TSDB index v1 symbols lookup and caching

### DIFF
--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -34,6 +34,11 @@ const (
 	indexTOCLen  = 6*8 + crc32.Size
 	binaryTOCLen = 2*8 + crc32.Size
 	// headerLen represents number of bytes reserved of index header for header.
+	// At present, it is:
+	// - 4 bytes for MagicIndex
+	// - 1 byte for index header version
+	// - 1 byte for TSDB index version
+	// - 8 bytes for an offset in the TSDB index after the last posting list.
 	headerLen = 4 + 1 + 1 + 8
 
 	// MagicIndex are 4 bytes at the head of an index-header file.

--- a/pkg/storegateway/indexheader/index/symbols.go
+++ b/pkg/storegateway/indexheader/index/symbols.go
@@ -87,8 +87,9 @@ func (s *Symbols) Lookup(o uint32) (sym string, err error) {
 			d.SkipUvarintBytes()
 		}
 	} else {
-		// In v1, o is relative to the beginning of the whole index header file, so we
-		// need to adjust for the fact our view into the file starts at the beginning
+		// In v1, o is relative to the beginning of the whole index file,
+		// which is also the offset in the whole index header file.
+		// We need to adjust for the fact our view into the file starts at the beginning
 		// of the symbol table.
 		offsetInTable := int(o) - s.tableOffset
 		d.ResetAt(offsetInTable)
@@ -174,7 +175,10 @@ func (s *Symbols) reverseLookup(sym string, d streamencoding.Decbuf) (uint32, er
 	if s.version == index.FormatV2 {
 		return uint32(res), nil
 	}
-	return uint32(lastPosition), nil
+	// Since the symbols in v1 are relative to the start of the index
+	// and the Decbuf position is relative to the start of the Decbuf,
+	// we need to offset by the relative position of the symbols table in the index header.
+	return uint32(lastPosition + s.tableOffset), nil
 }
 
 func yoloString(b []byte) string {

--- a/pkg/storegateway/indexheader/index/symbols.go
+++ b/pkg/storegateway/indexheader/index/symbols.go
@@ -71,8 +71,7 @@ func NewSymbols(factory *streamencoding.DecbufFactory, version, offset int) (s *
 }
 
 // Lookup takes a symbol reference and returns the symbol string.
-// For TSDB index v1, the reference is expected to be the offset of the symbol in the index
-// relative to the beginning of the whole index header file (not the TSDB index file).
+// For TSDB index v1, the reference is expected to be the offset of the symbol in the index header file (not the TSDB index file).
 // For TSDB index v2, the reference is expected to be the sequence number of the symbol (starting at 0).
 func (s *Symbols) Lookup(o uint32) (sym string, err error) {
 	d := s.factory.NewDecbufAtUnchecked(s.tableOffset)
@@ -119,7 +118,10 @@ func (s *Symbols) ReverseLookup(sym string) (o uint32, err error) {
 }
 
 // ForEachSymbol performs a reverse lookup on each syms and passes the symbol and offset to f.
-// If the offset of a symbol cannot be looked up, iteration stops immediately and the error is
+// For TSDB index v1, the symbol reference is the offset of the symbol in the index header file (not the TSDB index file).
+// For TSDB index v2, the symbol reference is the sequence number of the symbol (starting at 0).
+//
+// If the reference of a symbol cannot be looked up, iteration stops immediately and the error is
 // returned. If f returns an error, iteration stops immediately and the error is returned.
 func (s *Symbols) ForEachSymbol(syms []string, f func(sym string, offset uint32) error) (err error) {
 	if len(s.offsets) == 0 {

--- a/pkg/storegateway/indexheader/index/symbols_test.go
+++ b/pkg/storegateway/indexheader/index/symbols_test.go
@@ -83,8 +83,8 @@ func TestSymbolsV1(t *testing.T) {
 		}
 
 		// Look beyond the last symbol
-		_, err = s.Lookup(uint32(symbolsTableSize + len(filePrefix) + 1))
-		require.Error(t, err)
+		_, err = s.Lookup(uint32(buf.Len() + 1))
+		require.ErrorIs(t, err, ErrSymbolNotFound)
 	})
 
 	t.Run("ReverseLookup", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestSymbolsV1(t *testing.T) {
 			require.Equal(t, ref, r)
 		}
 		_, err = s.ReverseLookup("100")
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrSymbolNotFound)
 	})
 
 	t.Run("ForEachSymbol", func(t *testing.T) {
@@ -145,7 +145,7 @@ func TestSymbolsV2(t *testing.T) {
 		require.Equal(t, string(rune(i)), s)
 	}
 	_, err = s.Lookup(100)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSymbolNotFound)
 
 	for i := 99; i >= 0; i-- {
 		r, err := s.ReverseLookup(string(rune(i)))
@@ -153,7 +153,7 @@ func TestSymbolsV2(t *testing.T) {
 		require.Equal(t, uint32(i), r)
 	}
 	_, err = s.ReverseLookup(string(rune(100)))
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSymbolNotFound)
 
 	// Use ForEachSymbol to build an offset -> symbol mapping and ensure
 	// that it matches the expected offsets and symbols.

--- a/pkg/storegateway/indexheader/index/symbols_test.go
+++ b/pkg/storegateway/indexheader/index/symbols_test.go
@@ -9,7 +9,6 @@ import (
 	"hash/crc32"
 	"os"
 	"path"
-	"sort"
 	"strconv"
 	"testing"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	streamencoding "github.com/grafana/mimir/pkg/storegateway/indexheader/encoding"
 	"github.com/grafana/mimir/pkg/util/test"
@@ -44,7 +44,7 @@ func TestSymbolsV1(t *testing.T) {
 		sortedSymbols[i] = strconv.Itoa(i)
 	}
 	// We must write the symbols sorted in the table, the TSDB index does the same.
-	sort.Strings(sortedSymbols[:])
+	slices.Sort(sortedSymbols[:])
 
 	buf := encoding.Encbuf{}
 	buf.PutUvarintStr(filePrefix)

--- a/pkg/storegateway/indexheader/index/symbols_test.go
+++ b/pkg/storegateway/indexheader/index/symbols_test.go
@@ -53,7 +53,8 @@ func TestSymbolsV1(t *testing.T) {
 	buf.PutBE32int(numSymbols)
 
 	for i, symbol := range sortedSymbols {
-		// The symbol reference in v1 is the offset of the string (and its varint length) in the symbols table.
+		// The symbol reference in v1 is the offset of the string (and its varint length) in the index header file,
+		// so we use the length of the buffer as the reference (i.e. length of the file).
 		symbolRef := uint32(buf.Len())
 		refToSymbol[symbolRef] = symbol
 		sortedSymbolRefs[i] = symbolRef

--- a/pkg/storegateway/indexheader/index/symbols_test.go
+++ b/pkg/storegateway/indexheader/index/symbols_test.go
@@ -9,6 +9,8 @@ import (
 	"hash/crc32"
 	"os"
 	"path"
+	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -25,7 +27,90 @@ func TestMain(m *testing.M) {
 	test.VerifyNoLeakTestMain(m)
 }
 
-func TestSymbols(t *testing.T) {
+func TestSymbolsV1(t *testing.T) {
+	const (
+		numSymbols       = 100
+		symbolsTableSize = 294         // excludes leading length field and the trailing crc32
+		tableLengthSize  = 4           // number of bytes which store the length of the symbols table
+		filePrefix       = "something" // simulate the file containing something other than the symbols table
+	)
+	var (
+		sortedSymbols    [numSymbols]string
+		sortedSymbolRefs [numSymbols]uint32
+		refToSymbol      = make(map[uint32]string, numSymbols)
+	)
+
+	for i := 0; i < numSymbols; i++ {
+		sortedSymbols[i] = strconv.Itoa(i)
+	}
+	// We must write the symbols sorted in the table, the TSDB index does the same.
+	sort.Strings(sortedSymbols[:])
+
+	buf := encoding.Encbuf{}
+	buf.PutUvarintStr(filePrefix)
+	symbolsStart := buf.Len()
+	buf.PutBE32int(symbolsTableSize)
+	buf.PutBE32int(numSymbols)
+
+	for i, symbol := range sortedSymbols {
+		// The symbol reference in v1 is the offset of the string (and its varint length) in the symbols table.
+		symbolRef := uint32(buf.Len())
+		refToSymbol[symbolRef] = symbol
+		sortedSymbolRefs[i] = symbolRef
+		buf.PutUvarintStr(symbol)
+	}
+	checksum := crc32.Checksum(buf.Get()[symbolsStart+tableLengthSize:], castagnoliTable)
+	buf.PutBE32(checksum)
+
+	dir := t.TempDir()
+	filePath := path.Join(dir, "index")
+	require.NoError(t, os.WriteFile(filePath, buf.Get(), 0700))
+
+	reg := prometheus.NewPedanticRegistry()
+	df := streamencoding.NewDecbufFactory(filePath, 0, log.NewNopLogger(), streamencoding.NewDecbufFactoryMetrics(reg))
+	s, err := NewSymbols(df, index.FormatV1, symbolsStart)
+	require.NoError(t, err)
+
+	// We store only 4 offsets to symbols.
+	require.Len(t, s.offsets, 4)
+
+	t.Run("Lookup", func(t *testing.T) {
+		for ref, symbol := range refToSymbol {
+			s, err := s.Lookup(ref)
+			require.NoError(t, err)
+			require.Equal(t, symbol, s)
+		}
+
+		// Look beyond the last symbol
+		_, err = s.Lookup(uint32(symbolsTableSize + len(filePrefix) + 1))
+		require.Error(t, err)
+	})
+
+	t.Run("ReverseLookup", func(t *testing.T) {
+		for ref, symbol := range refToSymbol {
+			r, err := s.ReverseLookup(symbol)
+			require.NoError(t, err)
+			require.Equal(t, ref, r)
+		}
+		_, err = s.ReverseLookup("100")
+		require.Error(t, err)
+	})
+
+	t.Run("ForEachSymbol", func(t *testing.T) {
+		// Use ForEachSymbol to build an offset -> symbol mapping and ensure
+		// that it matches the expected offsets and symbols.
+		actual := make(map[uint32]string)
+		err = s.ForEachSymbol(sortedSymbols[:], func(sym string, offset uint32) error {
+			actual[offset] = sym
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, refToSymbol, actual)
+	})
+}
+
+func TestSymbolsV2(t *testing.T) {
 	buf := encoding.Encbuf{}
 
 	// Add prefix to the buffer to simulate symbols as part of larger buffer.

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -44,6 +44,7 @@ type StreamBinaryReader struct {
 	symbols *streamindex.Symbols
 	// Cache of the label name symbol lookups,
 	// as there are not many and they are half of all lookups.
+	// The symbol reference is the prometheus TSDB symbol reference, not the index header symbol reference.
 	nameSymbols map[uint32]string
 	// Direct cache of values. This is much faster than an LRU cache and still provides
 	// a reasonable cache hit ratio.
@@ -139,7 +140,7 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, log
 
 	r.nameSymbols = make(map[uint32]string, len(labelNames))
 	if err = r.symbols.ForEachSymbol(labelNames, func(sym string, offset uint32) error {
-		r.nameSymbols[offset] = sym
+		r.nameSymbols[v1PromIndexSymbolRef(offset)] = sym
 		return nil
 	}); err != nil {
 		return nil, err
@@ -194,6 +195,10 @@ func (r *StreamBinaryReader) LookupSymbol(o uint32) (string, error) {
 		return s, nil
 	}
 
+	if r.indexVersion == index.FormatV1 {
+		o = v1IndexHeaderSymbolRef(o)
+	}
+
 	cacheIndex := o % valueSymbolsCacheSize
 	r.valueSymbolsMx.Lock()
 	if cached := r.valueSymbols[cacheIndex]; cached.index == o && cached.symbol != "" {
@@ -202,12 +207,6 @@ func (r *StreamBinaryReader) LookupSymbol(o uint32) (string, error) {
 		return v, nil
 	}
 	r.valueSymbolsMx.Unlock()
-
-	if r.indexVersion == index.FormatV1 {
-		// For v1 little trick is needed. Refs are actual offset inside index, not index-header. This is different
-		// of the header length difference between two files.
-		o += headerLen - index.HeaderLen
-	}
 
 	s, err := r.symbols.Lookup(o)
 	if err != nil {
@@ -220,6 +219,18 @@ func (r *StreamBinaryReader) LookupSymbol(o uint32) (string, error) {
 	r.valueSymbolsMx.Unlock()
 
 	return s, nil
+}
+
+// v1IndexHeaderSymbolRef transforms a TSDB index symbols reference into a symbol reference in our index header.
+// Prometheus refs are actual offset inside index, not index-header. This is different because of the header length difference between two files.
+func v1IndexHeaderSymbolRef(tsdbSymRef uint32) uint32 {
+	return tsdbSymRef + (headerLen - index.HeaderLen)
+}
+
+// v1PromIndexSymbolRef transforms an index header symbols reference into a TSDB index symbol reference.
+// Prometheus refs are actual offset inside index, not index-header. This is different because of the header length difference between two files.
+func v1PromIndexSymbolRef(indexHeaderSymRef uint32) uint32 {
+	return indexHeaderSymRef - (headerLen - index.HeaderLen)
 }
 
 func (r *StreamBinaryReader) LabelValuesOffsets(name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error) {

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -140,7 +140,10 @@ func newFileStreamBinaryReader(path string, postingOffsetsInMemSampling int, log
 
 	r.nameSymbols = make(map[uint32]string, len(labelNames))
 	if err = r.symbols.ForEachSymbol(labelNames, func(sym string, offset uint32) error {
-		r.nameSymbols[v1PromIndexSymbolRef(offset)] = sym
+		if r.indexVersion == index.FormatV1 {
+			offset = v1PromIndexSymbolRef(offset)
+		}
+		r.nameSymbols[offset] = sym
 		return nil
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
#### Context

* The symbol reference in prometheus' TSDB v1 index is an offset into the index file. In V2 it is the sequence number of the symbol.

#### What this PR does

While working on https://github.com/grafana/mimir/pull/5073 I noticed that the symbols offsets are slightly misaligned for V1 symbols. 

This PR fixes three bugs

* label names and values symbols caches were misaligned
	* __label names cache__ was using the index header offset to store the cache items, but using the TSDB index to look them up (difference of 9)
		* This results in mostly cache misses; but it also interacts with the other bug of returning symbols references relative to the start of the symbols table, not the whole index, so there can be incorrect values returned as well
	* __label values cache__ was using the TSDB offset to lookup and store cache items, but collision detection was using the index header offset; 
		* this results is 100% cache misses for label values
* label names cache was also populated incorrectly
	* the offsets there were offsets relative to the start of the symbols table, not relative to the index header or the TSDB index (difference of 5)

Here is some ascii art to better illustrate the implications of these bugs

```
offset in TSDB:          320 // this was the cache key for looking up label names 
offset in index header:  329 // the index header has 9 more bytes in its header than the TSDB index
offset in symbols table: 315 // excludes the TSDB index header of 5 bytes (magic+version); this was the cache key for storing label names


|__<8B>__|__<5B>_|________...___4fooo3bar
^        ^       ^              ^    ^
|        |       |              |    |
start of index header           |    |
         |       |              |    |
         start of TSDB index    |    |
                 |              |    |
                 start of symbols table
                                |    |
                                symbol with TSDB offset 315, length 4 and string fooo; this is the cache key for label names; this is looked up in the cache as symbol ref 315
                                     |
                                     symbol with TSDB offset 320, length 3 and string bar; this is cached as symbol ref 315
                                      
```

Testing - I am not aware of a way to generate a V1 index (maybe checking out prometheus at the time and running some code, sounds complicated?), so the changes wrt caching are untested. Only the changes in the Symbols struct covered by tests.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
