### PR TITLE
Remove `-pdb` suffix from PodDisruptionBudget object names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 * [CHANGE] Ruler: changed ruler autoscaling policy, extended scale down period from 60s to 600s. #4786
 * [CHANGE] Update to v0.5.0 rollout-operator. #4893
 * [CHANGE] Backend: add `alertmanager_args` to `mimir-backend` when running in read-write deployment mode. Remove hardcoded `filesystem` alertmanager storage. This moves alertmanager's data-dir to `/data/alertmanager` by default. #4907 #4921
-* [CHANGE] Remove `-pdb` suffix from `PodDisruptionBudget` names. #5109
+* [CHANGE] Remove `-pdb` suffix from `PodDisruptionBudget` names. This will create new `PodDisruptionBudget` resources. Make sure to prune the old resources; otherwise, rollouts will be blocked. #5109
 * [ENHANCEMENT] Ingester: configure `-blocks-storage.tsdb.head-compaction-interval=15m` to spread TSDB head compaction over a wider time range. #4870
 * [ENHANCEMENT] Ingester: configure `-blocks-storage.tsdb.wal-replay-concurrency` to CPU request minus 1. #4864
 * [ENHANCEMENT] Compactor: configure `-compactor.first-level-compaction-wait-period` to TSDB head compaction interval plus 10 minutes. #4872

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 * [CHANGE] Ruler: changed ruler autoscaling policy, extended scale down period from 60s to 600s. #4786
 * [CHANGE] Update to v0.5.0 rollout-operator. #4893
 * [CHANGE] Backend: add `alertmanager_args` to `mimir-backend` when running in read-write deployment mode. Remove hardcoded `filesystem` alertmanager storage. This moves alertmanager's data-dir to `/data/alertmanager` by default. #4907 #4921
+* [CHANGE] Remove `-pdb` suffix from `PodDisruptionBudget` names. #5109
 * [ENHANCEMENT] Ingester: configure `-blocks-storage.tsdb.head-compaction-interval=15m` to spread TSDB head compaction over a wider time range. #4870
 * [ENHANCEMENT] Ingester: configure `-blocks-storage.tsdb.wal-replay-concurrency` to CPU request minus 1. #4864
 * [ENHANCEMENT] Compactor: configure `-compactor.first-level-compaction-wait-period` to TSDB head compaction interval plus 10 minutes. #4872

--- a/operations/compare-helm-with-jsonnet/jsonnet/01-ignore/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/jsonnet/01-ignore/kustomization.yaml
@@ -21,7 +21,7 @@ patches:
 
   # TODO: Helm does not create an alertmanager pdb
   - target:
-      name: 'mimir-alertmanager-pdb'
+      name: 'mimir-alertmanager'
       kind: PodDisruptionBudget
     patch: *deletePatch
 

--- a/operations/compare-helm-with-jsonnet/jsonnet/03-rename/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/jsonnet/03-rename/kustomization.yaml
@@ -2,22 +2,6 @@ resources:
   - ../02-configs-and-k8s-defaults
 patches:
   - target:
-      kind: 'PodDisruptionBudget'
-      name: 'mimir-ingester-pdb'
-    patch: |-
-      - op: replace
-        path: /metadata/name
-        value: mimir-ingester
-
-  - target:
-      kind: 'PodDisruptionBudget'
-      name: 'mimir-store-gateway-pdb'
-    patch: |-
-      - op: replace
-        path: /metadata/name
-        value: mimir-store-gateway
-
-  - target:
       kind: 'Service'
       name: 'mimir-distributor'
     patch: |-

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-rollout-pdb
-  name: ingester-rollout-pdb
+    name: ingester-rollout
+  name: ingester-rollout
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-rollout-pdb
-  name: store-gateway-rollout-pdb
+    name: store-gateway-rollout
+  name: store-gateway-rollout
   namespace: default
 spec:
   maxUnavailable: 1

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-rollout-pdb
-  name: ingester-rollout-pdb
+    name: ingester-rollout
+  name: ingester-rollout
   namespace: default
 spec:
   maxUnavailable: 1
@@ -59,8 +59,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-rollout-pdb
-  name: store-gateway-rollout-pdb
+    name: store-gateway-rollout
+  name: store-gateway-rollout
   namespace: default
 spec:
   maxUnavailable: 1

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-rollout-pdb
-  name: ingester-rollout-pdb
+    name: ingester-rollout
+  name: ingester-rollout
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-rollout-pdb
-  name: store-gateway-rollout-pdb
+    name: store-gateway-rollout
+  name: store-gateway-rollout
   namespace: default
 spec:
   maxUnavailable: 1

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 0
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-rollout-pdb
-  name: ingester-rollout-pdb
+    name: ingester-rollout
+  name: ingester-rollout
   namespace: default
 spec:
   maxUnavailable: 1
@@ -46,8 +46,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2
@@ -59,8 +59,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-rollout-pdb
-  name: store-gateway-rollout-pdb
+    name: store-gateway-rollout
+  name: store-gateway-rollout
   namespace: default
 spec:
   maxUnavailable: 1

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: alertmanager-pdb
-  name: alertmanager-pdb
+    name: alertmanager
+  name: alertmanager
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -33,8 +33,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -7,8 +7,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ingester-pdb
-  name: ingester-pdb
+    name: ingester
+  name: ingester
   namespace: default
 spec:
   maxUnavailable: 1
@@ -20,8 +20,8 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-pdb
-  name: store-gateway-pdb
+    name: store-gateway
+  name: store-gateway
   namespace: default
 spec:
   maxUnavailable: 2

--- a/operations/mimir/common.libsonnet
+++ b/operations/mimir/common.libsonnet
@@ -90,7 +90,7 @@
   // Utility to create a PodDisruptionBudget for a Mimir deployment.
   newMimirPdb(deploymentName, maxUnavailable=1)::
     local podDisruptionBudget = $.policy.v1.podDisruptionBudget;
-    local pdbName = '%s-pdb' % deploymentName;
+    local pdbName = deploymentName;
 
     podDisruptionBudget.new(pdbName) +
     podDisruptionBudget.mixin.metadata.withLabels({ name: pdbName }) +

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -148,8 +148,8 @@
     $.newIngesterZoneService($.ingester_zone_c_statefulset),
 
   ingester_rollout_pdb: if !multi_zone_ingesters_deployed then null else
-    podDisruptionBudget.new('ingester-rollout-pdb') +
-    podDisruptionBudget.mixin.metadata.withLabels({ name: 'ingester-rollout-pdb' }) +
+    podDisruptionBudget.new('ingester-rollout') +
+    podDisruptionBudget.mixin.metadata.withLabels({ name: 'ingester-rollout' }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ 'rollout-group': 'ingester' }) +
     podDisruptionBudget.mixin.spec.withMaxUnavailable(1),
 
@@ -290,8 +290,8 @@
     service.mixin.metadata.withLabels({ name: name }),
 
   store_gateway_rollout_pdb: if !multi_zone_store_gateways_deployed then null else
-    podDisruptionBudget.new('store-gateway-rollout-pdb') +
-    podDisruptionBudget.mixin.metadata.withLabels({ name: 'store-gateway-rollout-pdb' }) +
+    podDisruptionBudget.new('store-gateway-rollout') +
+    podDisruptionBudget.mixin.metadata.withLabels({ name: 'store-gateway-rollout' }) +
     podDisruptionBudget.mixin.spec.selector.withMatchLabels({ 'rollout-group': 'store-gateway' }) +
     podDisruptionBudget.mixin.spec.withMaxUnavailable(1),
 


### PR DESCRIPTION
#### What this PR does

This PR removes the `-pdb` suffix from PodDisruptionBudget object names generated by Jsonnet.

This makes the Jsonnet-generated PDBs consistent with the corresponding Helm-generated PDBs, and follows the naming convention for all other objects.

I don't believe there are any backwards compatibility or migration issues introduced by doing this. The only risk I can see is if a Kubernetes node was drained while this change was being applied to a cluster: if the old PDB has been removed and the new one has not yet been created, Kubernetes could stop all pods on a node. However, this risk is mitigated by our topology spread constraints that ensure no one node is running a critical number of pods for any one workload.

#### Which issue(s) this PR fixes or relates to

Split from https://github.com/grafana/mimir/pull/5098

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
