### PR TITLE
Add TestRuler_NotifySyncRulesAsync_ShouldTriggerRulesSyncingAndCorrectlyHandleTheCaseTheTenantShardHasChanged

### DIFF
--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -1033,17 +1033,7 @@ func TestRuler_NotifySyncRulesAsync_ShouldTriggerRulesSyncingOnAllRulersWhenEnab
 
 			// Pre-condition check: each ruler should have an updated view over the ring.
 			for _, reg := range regs {
-				test.Poll(t, time.Second, nil, func() interface{} {
-					return prom_testutil.GatherAndCompare(reg, strings.NewReader(`
-				# HELP cortex_ring_members Number of members in the ring
-				# TYPE cortex_ring_members gauge
-				cortex_ring_members{name="ruler",state="ACTIVE"} 2
-				cortex_ring_members{name="ruler",state="JOINING"} 0
-				cortex_ring_members{name="ruler",state="LEAVING"} 0
-				cortex_ring_members{name="ruler",state="PENDING"} 0
-				cortex_ring_members{name="ruler",state="Unhealthy"} 0
-			`), "cortex_ring_members")
-				})
+				verifyRingMembersMetric(t, reg, 2)
 			}
 
 			t.Run("NotifySyncRulesAsync() should trigger a re-sync after the initial rule groups of a tenant have been configured", func(t *testing.T) {
@@ -1126,6 +1116,143 @@ func TestRuler_NotifySyncRulesAsync_ShouldTriggerRulesSyncingOnAllRulersWhenEnab
 	}
 }
 
+func TestRuler_NotifySyncRulesAsync_ShouldTriggerRulesSyncingAndCorrectlyHandleTheCaseTheTenantShardHasChanged(t *testing.T) {
+	const (
+		numRulers     = 2
+		numRuleGroups = 100
+		userID        = "user-1"
+		namespace     = "test"
+	)
+
+	var (
+		ctx          = context.Background()
+		logger       = log.NewNopLogger()
+		rulerAddrMap = map[string]*Ruler{}
+	)
+
+	// Create a filesystem backed storage.
+	bucketCfg := bucket.Config{StorageBackendConfig: bucket.StorageBackendConfig{Backend: "filesystem", Filesystem: filesystem.Config{Directory: t.TempDir()}}}
+	bucketClient, err := bucket.NewClient(ctx, bucketCfg, "ruler-storage", logger, nil)
+	require.NoError(t, err)
+
+	store := bucketclient.NewBucketRuleStore(bucketClient, nil, logger)
+
+	// Create an in-memory ring backend.
+	kvStore, cleanUp := consul.NewInMemoryClient(ring.GetCodec(), logger, nil)
+	t.Cleanup(func() { assert.NoError(t, cleanUp.Close()) })
+
+	// Init tenant limits: ruler shuffle sharding disabled.
+	tenantLimits := map[string]*validation.Limits{userID: validation.MockDefaultLimits()}
+	tenantLimits[userID].RulerTenantShardSize = 0
+
+	// Create rulers. The rulers are configured with a very long polling interval
+	// so that they will not trigger after the initial sync. Once the ruler has started,
+	// the initial sync already occurred.
+	rulers := make([]*Ruler, numRulers)
+	regs := make([]*prometheus.Registry, numRulers)
+
+	for i := 0; i < len(rulers); i++ {
+		rulerAddr := fmt.Sprintf("ruler-%d", i)
+
+		rulerCfg := defaultRulerConfig(t)
+		rulerCfg.PollInterval = time.Hour
+		rulerCfg.rulerSyncQueuePollFrequency = 100 * time.Millisecond
+		rulerCfg.Ring.NumTokens = 128
+		rulerCfg.Ring.Common.InstanceID = rulerAddr
+		rulerCfg.Ring.Common.InstanceAddr = rulerAddr
+		rulerCfg.Ring.Common.KVStore = kv.Config{Mock: kvStore}
+
+		limits, err := validation.NewOverrides(*validation.MockDefaultLimits(), validation.NewMockTenantLimits(tenantLimits))
+		require.NoError(t, err)
+
+		regs[i] = prometheus.NewPedanticRegistry()
+		rulers[i] = prepareRuler(t, rulerCfg, store, withRulerAddrMap(rulerAddrMap), withRulerAddrAutomaticMapping(), withLimits(limits), withStart(), withPrometheusRegisterer(regs[i]))
+	}
+
+	// Pre-condition check: each ruler should have synced the rules once (at startup).
+	for _, reg := range regs {
+		verifySyncRulesMetric(t, reg, 1, 0)
+	}
+
+	// Pre-condition check: each ruler should have an updated view over the ring.
+	for _, reg := range regs {
+		verifyRingMembersMetric(t, reg, 2)
+	}
+
+	// Create some rule groups in the storage.
+	for i := 0; i < numRuleGroups; i++ {
+		groupID := fmt.Sprintf("group-%d", i)
+		record := fmt.Sprintf("count:metric_%d", i)
+		expr := fmt.Sprintf("count(metric_%d)", i)
+
+		require.NoError(t, store.SetRuleGroup(ctx, userID, namespace, createRuleGroup(groupID, userID, createRecordingRule(record, expr))))
+	}
+
+	// Call NotifySyncRulesAsync() on 1 ruler.
+	rulers[0].NotifySyncRulesAsync(userID)
+
+	// Wait until rules syncing triggered on both rulers (with reason "API change").
+	for _, reg := range regs {
+		verifySyncRulesMetric(t, reg, 1, 1)
+	}
+
+	// GetRules() should return all configured rule groups. We use test.Poll() because
+	// the per-tenant rules manager gets started asynchronously.
+	for _, ruler := range rulers {
+		test.Poll(t, time.Second, numRuleGroups, func() interface{} {
+			actualRuleGroups, err := ruler.GetRules(user.InjectOrgID(ctx, userID), AnyRule)
+			require.NoError(t, err)
+			return len(actualRuleGroups)
+		})
+	}
+
+	// We expect rule groups to have been sharded between the rulers.
+	actualRuleGroupsCount := 0
+	for _, ruler := range rulers {
+		actualRuleGroups, err := ruler.getLocalRules(userID, AnyRule)
+		require.NoError(t, err)
+		require.NotEmpty(t, actualRuleGroups)
+		actualRuleGroupsCount += len(actualRuleGroups)
+	}
+	assert.Equal(t, numRuleGroups, actualRuleGroupsCount)
+
+	// Change the tenant's ruler shard size to 1, so that only 1 ruler will load all the rule groups after the next sync.
+	tenantLimits[userID].RulerTenantShardSize = 1
+
+	// Call NotifySyncRulesAsync() on 1 ruler.
+	rulers[0].NotifySyncRulesAsync(userID)
+
+	// Wait until rules syncing triggered on both rulers (with reason "API change").
+	for _, reg := range regs {
+		verifySyncRulesMetric(t, reg, 1, 2)
+	}
+
+	// GetRules() should return all configured rule groups.
+	for _, ruler := range rulers {
+		actualRuleGroups, err := ruler.GetRules(user.InjectOrgID(ctx, userID), AnyRule)
+		require.NoError(t, err)
+		assert.Len(t, actualRuleGroups, numRuleGroups)
+	}
+
+	// We expect rule groups to have been loaded only from 1 ruler (not important which one).
+	var actualRuleGroupsCountPerRuler []int
+	for _, ruler := range rulers {
+		actualRuleGroups, err := ruler.getLocalRules(userID, AnyRule)
+		require.NoError(t, err)
+
+		if len(actualRuleGroups) > 0 {
+			actualRuleGroupsCountPerRuler = append(actualRuleGroupsCountPerRuler, len(actualRuleGroups))
+		}
+	}
+	assert.Equal(t, []int{numRuleGroups}, actualRuleGroupsCountPerRuler)
+
+	// Post-condition check: there should have been no other rules syncing other than the initial one
+	// and the one driven by the API.
+	for _, reg := range regs {
+		verifySyncRulesMetric(t, reg, 1, 2)
+	}
+}
+
 func TestRuler_NotifySyncRulesAsync_ShouldNotTriggerRulesSyncingOnAllRulersWhenDisabled(t *testing.T) {
 	const (
 		numRulers     = 2
@@ -1183,17 +1310,7 @@ func TestRuler_NotifySyncRulesAsync_ShouldNotTriggerRulesSyncingOnAllRulersWhenD
 
 	// Pre-condition check: each ruler should have an updated view over the ring.
 	for _, reg := range regs {
-		test.Poll(t, time.Second, nil, func() interface{} {
-			return prom_testutil.GatherAndCompare(reg, strings.NewReader(`
-				# HELP cortex_ring_members Number of members in the ring
-				# TYPE cortex_ring_members gauge
-				cortex_ring_members{name="ruler",state="ACTIVE"} 2
-				cortex_ring_members{name="ruler",state="JOINING"} 0
-				cortex_ring_members{name="ruler",state="LEAVING"} 0
-				cortex_ring_members{name="ruler",state="PENDING"} 0
-				cortex_ring_members{name="ruler",state="Unhealthy"} 0
-			`), "cortex_ring_members")
-		})
+		verifyRingMembersMetric(t, reg, 2)
 	}
 
 	// Create some rule groups in the storage.
@@ -1375,6 +1492,20 @@ func verifySyncRulesMetric(t *testing.T, reg prometheus.Gatherer, initialCount, 
 			cortex_ruler_sync_rules_total{reason="periodic"} 0
 			cortex_ruler_sync_rules_total{reason="ring-change"} 0
 		`, initialCount, apiChangeCount)), "cortex_ruler_sync_rules_total")
+	})
+}
+
+func verifyRingMembersMetric(t *testing.T, reg prometheus.Gatherer, activeCount int) {
+	test.Poll(t, time.Second, nil, func() interface{} {
+		return prom_testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+				# HELP cortex_ring_members Number of members in the ring
+				# TYPE cortex_ring_members gauge
+				cortex_ring_members{name="ruler",state="ACTIVE"} %d
+				cortex_ring_members{name="ruler",state="JOINING"} 0
+				cortex_ring_members{name="ruler",state="LEAVING"} 0
+				cortex_ring_members{name="ruler",state="PENDING"} 0
+				cortex_ring_members{name="ruler",state="Unhealthy"} 0
+			`, activeCount)), "cortex_ring_members")
 	})
 }
 


### PR DESCRIPTION
#### What this PR does
After merging #5115 I've got a doubt and I wanted to double check the case a tenant rule group is moved from a ruler to another one. In this PR I'm adding another test to simulate this case, reducing the tenant shard size while rulers are running.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
