### PR TITLE
Remove deprecated flags for release 2.9

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2451,17 +2451,6 @@
               "fieldFlag": "ingester.ring.final-sleep",
               "fieldType": "duration",
               "fieldCategory": "advanced"
-            },
-            {
-              "kind": "field",
-              "name": "readiness_check_ring_health",
-              "required": false,
-              "desc": "When enabled the readiness probe succeeds only after all instances are ACTIVE and healthy in the ring, otherwise only the instance itself is checked. This option should be disabled if in your cluster multiple instances can be rolled out simultaneously, otherwise rolling updates may be slowed down.",
-              "fieldValue": null,
-              "fieldDefaultValue": false,
-              "fieldFlag": "ingester.ring.readiness-check-ring-health",
-              "fieldType": "boolean",
-              "fieldCategory": "deprecated"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1309,8 +1309,6 @@ Usage of ./cmd/mimir/mimir:
     	Observe tokens after generating to resolve collisions. Useful when using gossiping ring.
   -ingester.ring.prefix string
     	The prefix for the keys in the store. Should end with a /. (default "collectors/")
-  -ingester.ring.readiness-check-ring-health
-    	[deprecated] When enabled the readiness probe succeeds only after all instances are ACTIVE and healthy in the ring, otherwise only the instance itself is checked. This option should be disabled if in your cluster multiple instances can be rolled out simultaneously, otherwise rolling updates may be slowed down.
   -ingester.ring.replication-factor int
     	Number of ingesters that each time series is replicated to. This option needs be set on ingesters, distributors, queriers and rulers when running in microservices mode. (default 3)
   -ingester.ring.store string

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -129,15 +129,6 @@ The following features are currently experimental:
 Deprecated features are usable up until the release that indicates their removal.
 For details about what _deprecated_ means, see [Parameter lifecycle]({{< relref "../references/configuration-parameters/index.md#parameter-lifecycle" >}}).
 
-The following features are currently deprecated and will be **removed in Mimir 2.9**:
-
-- Compactor
-  - `-compactor.consistency-delay`
-- Store-gateway
-  - `-blocks-storage.bucket-store.consistency-delay`
-- Ingester
-  - `-ingester.ring.readiness-check-ring-health`
-
 The following features are currently deprecated and will be **removed in Mimir 2.10**:
 
 - Ingester

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -898,14 +898,6 @@ ring:
   # CLI flag: -ingester.ring.final-sleep
   [final_sleep: <duration> | default = 0s]
 
-  # (deprecated) When enabled the readiness probe succeeds only after all
-  # instances are ACTIVE and healthy in the ring, otherwise only the instance
-  # itself is checked. This option should be disabled if in your cluster
-  # multiple instances can be rolled out simultaneously, otherwise rolling
-  # updates may be slowed down.
-  # CLI flag: -ingester.ring.readiness-check-ring-health
-  [readiness_check_ring_health: <boolean> | default = false]
-
 # (advanced) Period at which metadata we have not seen will remain in memory
 # before being deleted.
 # CLI flag: -ingester.metadata-retain-period

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -180,10 +180,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.IgnoreSeriesLimitForMetricNames, "ingester.ignore-series-limit-for-metric-names", "", "Comma-separated list of metric names, for which the -ingester.max-global-series-per-metric limit will be ignored. Does not affect the -ingester.max-global-series-per-user limit.")
 }
 
-func (cfg *Config) Validate(logger log.Logger) error {
-	return cfg.IngesterRing.Validate(logger)
-}
-
 func (cfg *Config) getIgnoreSeriesLimitForMetricNamesMap() map[string]struct{} {
 	if cfg.IgnoreSeriesLimitForMetricNames == "" {
 		return nil

--- a/pkg/ingester/ingester_ring_test.go
+++ b/pkg/ingester/ingester_ring_test.go
@@ -53,7 +53,6 @@ func TestRingConfig_CustomConfigToLifecyclerConfig(t *testing.T) {
 	cfg.ObservePeriod = 10 * time.Minute
 	cfg.MinReadyDuration = 3 * time.Minute
 	cfg.FinalSleep = 2 * time.Minute
-	cfg.DeprecatedReadinessCheckRingHealth = false
 	cfg.ListenPort = 10
 
 	// The lifecycler config should be generated based upon the ingester ring config
@@ -75,7 +74,7 @@ func TestRingConfig_CustomConfigToLifecyclerConfig(t *testing.T) {
 	expected.TokensFilePath = cfg.TokensFilePath
 	expected.Zone = cfg.InstanceZone
 	expected.UnregisterOnShutdown = cfg.UnregisterOnShutdown
-	expected.ReadinessCheckRingHealth = cfg.DeprecatedReadinessCheckRingHealth
+	expected.ReadinessCheckRingHealth = false
 	expected.Addr = cfg.InstanceAddr
 	expected.Port = cfg.InstancePort
 	expected.ID = cfg.InstanceID

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -245,9 +245,6 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.IngesterClient.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid ingester_client config")
 	}
-	if err := c.Ingester.Validate(log); err != nil {
-		return errors.Wrap(err, "invalid ingester config")
-	}
 	if err := c.Worker.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid frontend_worker config")
 	}

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -169,7 +169,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.LimitsConfig.RegisterFlags(f)
 	c.Worker.RegisterFlags(f)
 	c.Frontend.RegisterFlags(f, logger)
-	c.BlocksStorage.RegisterFlags(f, logger)
+	c.BlocksStorage.RegisterFlags(f)
 	c.Compactor.RegisterFlags(f, logger)
 	c.StoreGateway.RegisterFlags(f, logger)
 	c.TenantFederation.RegisterFlags(f)

--- a/pkg/storage/tsdb/caching_config.go
+++ b/pkg/storage/tsdb/caching_config.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/cache"
-	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/regexp"
 	"github.com/oklog/ulid"
@@ -41,14 +40,12 @@ type ChunksCacheConfig struct {
 	FineGrainedChunksCachingEnabled bool          `yaml:"fine_grained_chunks_caching_enabled" category:"experimental"`
 }
 
-func (cfg *ChunksCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string, logger log.Logger) {
+func (cfg *ChunksCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.StringVar(&cfg.Backend, prefix+"backend", "", fmt.Sprintf("Backend for chunks cache, if not empty. Supported values: %s.", strings.Join(supportedCacheBackends, ", ")))
 
 	cfg.Memcached.RegisterFlagsWithPrefix(prefix+"memcached.", f)
 	cfg.Redis.RegisterFlagsWithPrefix(prefix+"redis.", f)
 
-	// TODO: Deprecated in Mimir 2.7, remove in Mimir 2.9
-	flagext.DeprecatedFlag(f, prefix+"subrange-size", fmt.Sprintf("Deprecated, %d bytes is now always used. Size of each subrange that bucket object is split into for better caching.", subrangeSize), logger)
 	f.IntVar(&cfg.MaxGetRangeRequests, prefix+"max-get-range-requests", 3, "Maximum number of sub-GetRange requests that a single GetRange request can be split into when fetching chunks. Zero or negative value = unlimited number of sub-requests.")
 	f.DurationVar(&cfg.AttributesTTL, prefix+"attributes-ttl", 168*time.Hour, "TTL for caching object attributes for chunks. If the metadata cache is configured, attributes will be stored under this cache backend, otherwise attributes are stored in the chunks cache backend.")
 	f.IntVar(&cfg.AttributesInMemoryMaxItems, prefix+"attributes-in-memory-max-items", 50000, "Maximum number of object attribute items to keep in a first level in-memory LRU cache. Metadata will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache.")

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -163,7 +163,7 @@ func (d *DurationList) ToMilliseconds() []int64 {
 // RegisterFlags registers the TSDB flags
 func (cfg *BlocksStorageConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.Bucket.RegisterFlagsWithPrefixAndDefaultDirectory("blocks-storage.", "blocks", f)
-	cfg.BucketStore.RegisterFlags(f, logger)
+	cfg.BucketStore.RegisterFlags(f)
 	cfg.TSDB.RegisterFlags(f)
 }
 
@@ -396,7 +396,7 @@ var validSeriesSelectionStrategies = []string{
 }
 
 // RegisterFlags registers the BucketStore flags
-func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
+func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.IndexCache.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.index-cache.")
 	cfg.ChunksCache.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.chunks-cache.")
 	cfg.MetadataCache.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.metadata-cache.")

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -398,7 +398,7 @@ var validSeriesSelectionStrategies = []string{
 // RegisterFlags registers the BucketStore flags
 func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.IndexCache.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.index-cache.")
-	cfg.ChunksCache.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.chunks-cache.", logger)
+	cfg.ChunksCache.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.chunks-cache.")
 	cfg.MetadataCache.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.metadata-cache.")
 	cfg.BucketIndex.RegisterFlagsWithPrefix(f, bucketIndexFlagPrefix)
 	cfg.IndexHeader.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.index-header.")

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -161,7 +161,7 @@ func (d *DurationList) ToMilliseconds() []int64 {
 }
 
 // RegisterFlags registers the TSDB flags
-func (cfg *BlocksStorageConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
+func (cfg *BlocksStorageConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.Bucket.RegisterFlagsWithPrefixAndDefaultDirectory("blocks-storage.", "blocks", f)
 	cfg.BucketStore.RegisterFlags(f)
 	cfg.TSDB.RegisterFlags(f)

--- a/pkg/storage/tsdb/config_test.go
+++ b/pkg/storage/tsdb/config_test.go
@@ -145,7 +145,6 @@ func TestConfig_Validate(t *testing.T) {
 
 func TestConfig_DurationList(t *testing.T) {
 	t.Parallel()
-	nopLogger := log.NewNopLogger()
 
 	tests := map[string]struct {
 		cfg            BlocksStorageConfig
@@ -156,7 +155,7 @@ func TestConfig_DurationList(t *testing.T) {
 			cfg:            BlocksStorageConfig{},
 			expectedRanges: []int64{7200000},
 			f: func(c *BlocksStorageConfig) {
-				c.RegisterFlags(&flag.FlagSet{}, nopLogger)
+				c.RegisterFlags(&flag.FlagSet{})
 			},
 		},
 		"parse ranges correctly": {
@@ -176,8 +175,8 @@ func TestConfig_DurationList(t *testing.T) {
 			cfg:            BlocksStorageConfig{},
 			expectedRanges: []int64{7200000},
 			f: func(c *BlocksStorageConfig) {
-				c.RegisterFlags(&flag.FlagSet{}, nopLogger)
-				c.RegisterFlags(&flag.FlagSet{}, nopLogger)
+				c.RegisterFlags(&flag.FlagSet{})
+				c.RegisterFlags(&flag.FlagSet{})
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This removes flags that were deprecated in 2.7.

#### Which issue(s) this PR fixes or relates to

Relates to #5112

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
