### PR TITLE
Rename `streamingChunkSeriesConfig` to `streamingChunkSeriesContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 * [ENHANCEMENT] Ruler: trigger a synchronization of tenant's rule groups as soon as they change the rules configuration via API. This synchronization is in addition of the periodic syncing done every `-ruler.poll-interval`. The new behavior is enabled by default, but can be disabled with `-ruler.sync-rules-on-changes-enabled=false` (configurable on a per-tenant basis too). #4975 #5053 #5115
 * [ENHANCEMENT] Distributor: Improve invalid tenant shard size error message. #5024
 * [ENHANCEMENT] Store-gateway: record index header loading time separately in `cortex_bucket_store_series_request_stage_duration_seconds{stage="load_index_header"}`. Now index header loading will be visible in the "Mimir / Queries" dashboard in the "Series request p99/average latency" panels. #5011 #5062
-* [ENHANCEMENT] Querier and ingester: add experimental support for streaming chunks from ingesters to queriers while evaluating queries. This can be enabled with `-querier.prefer-streaming-chunks=true`. #4886 #5078 #5094
+* [ENHANCEMENT] Querier and ingester: add experimental support for streaming chunks from ingesters to queriers while evaluating queries. This can be enabled with `-querier.prefer-streaming-chunks=true`. #4886 #5078 #5094 #5126
 * [ENHANCEMENT] Update Docker base images from `alpine:3.17.3` to `alpine:3.18.0`. #5065
 * [ENHANCEMENT] Compactor: reduced the number of "object exists" API calls issued by the compactor to the object storage when syncing block's `meta.json` files. #5063
 * [ENHANCEMENT] Distributor: Push request rate limits (`-distributor.request-rate-limit` and `-distributor.request-burst-size`) and their associated YAML configuration are now stable. #5124

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -178,7 +178,7 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 
 	if len(results.StreamingSeries) > 0 {
 		streamingSeries := make([]storage.Series, 0, len(results.StreamingSeries))
-		streamingChunkSeriesConfig := &streamingChunkSeriesConfig{
+		streamingChunkSeriesConfig := &streamingChunkSeriesContext{
 			chunkIteratorFunc: q.chunkIterFn,
 			mint:              minT,
 			maxt:              maxT,
@@ -190,7 +190,7 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 			streamingSeries = append(streamingSeries, &streamingChunkSeries{
 				labels:  s.Labels,
 				sources: s.Sources,
-				config:  streamingChunkSeriesConfig,
+				context: streamingChunkSeriesConfig,
 			})
 		}
 

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -44,7 +44,7 @@ func TestStreamingChunkSeries_HappyPath(t *testing.T) {
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{{SeriesIndex: 0, Chunks: []client.Chunk{chunkUniqueToFirstSource, chunkPresentInBothSources}}})},
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{{SeriesIndex: 0, Chunks: []client.Chunk{chunkUniqueToSecondSource, chunkPresentInBothSources}}})},
 		},
-		config: &streamingChunkSeriesConfig{
+		context: &streamingChunkSeriesContext{
 			chunkIteratorFunc: chunkIteratorFunc,
 			mint:              1000,
 			maxt:              6000,
@@ -82,7 +82,7 @@ func TestStreamingChunkSeries_StreamReaderReturnsError(t *testing.T) {
 		sources: []client.StreamingSeriesSource{
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{})},
 		},
-		config: &streamingChunkSeriesConfig{
+		context: &streamingChunkSeriesContext{
 			chunkIteratorFunc: nil,
 			mint:              1000,
 			maxt:              6000,


### PR DESCRIPTION
#### What this PR does

This PR renames `streamingChunkSeriesConfig` to `streamingChunkSeriesContext`, as per [this suggestion](https://github.com/grafana/mimir/pull/5094#discussion_r1211346203) received after merging #5094.

#### Which issue(s) this PR fixes or relates to

Addresses feedback from #5094 received after merging.

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
