### PR TITLE
Track active series by ref instead of hash

### DIFF
--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -140,7 +140,7 @@ func (s *seriesStripe) getTotalAndUpdateMatching(matching []int) int {
 func (s *seriesStripe) updateSeriesTimestamp(now time.Time, series labels.Labels, ref uint64, labelsCopy func(labels.Labels) labels.Labels) {
 	nowNanos := now.UnixNano()
 
-	e := s.findEntryForSeries(ref, series)
+	e := s.findEntryForSeries(ref)
 	entryTimeSet := false
 	if e == nil {
 		e, entryTimeSet = s.findOrCreateEntryForSeries(ref, series, nowNanos, labelsCopy)
@@ -163,7 +163,7 @@ func (s *seriesStripe) updateSeriesTimestamp(now time.Time, series labels.Labels
 	}
 }
 
-func (s *seriesStripe) findEntryForSeries(ref uint64, series labels.Labels) *atomic.Int64 {
+func (s *seriesStripe) findEntryForSeries(ref uint64) *atomic.Int64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -40,7 +40,7 @@ type seriesStripe struct {
 	oldestEntryTs atomic.Int64
 
 	mu             sync.RWMutex
-	refs           map[uint64][]seriesEntry
+	refs           map[uint64]seriesEntry
 	active         int   // Number of active entries in this stripe. Only decreased during purge or clear.
 	activeMatching []int // Number of active entries in this stripe matching each matcher of the configured Matchers.
 }
@@ -87,10 +87,10 @@ func (c *ActiveSeries) CurrentConfig() CustomTrackersConfig {
 }
 
 // UpdateSeries updates series timestamp to 'now'. Function is called to make a copy of labels if entry doesn't exist yet.
-func (c *ActiveSeries) UpdateSeries(series labels.Labels, fp uint64, now time.Time, labelsCopy func(labels.Labels) labels.Labels) {
-	stripeID := fp % numStripes
+func (c *ActiveSeries) UpdateSeries(series labels.Labels, ref uint64, now time.Time, labelsCopy func(labels.Labels) labels.Labels) {
+	stripeID := ref % numStripes
 
-	c.stripes[stripeID].updateSeriesTimestamp(now, series, fp, labelsCopy)
+	c.stripes[stripeID].updateSeriesTimestamp(now, series, ref, labelsCopy)
 }
 
 // purge removes expired entries from the cache.
@@ -137,13 +137,13 @@ func (s *seriesStripe) getTotalAndUpdateMatching(matching []int) int {
 	return s.active
 }
 
-func (s *seriesStripe) updateSeriesTimestamp(now time.Time, series labels.Labels, fingerprint uint64, labelsCopy func(labels.Labels) labels.Labels) {
+func (s *seriesStripe) updateSeriesTimestamp(now time.Time, series labels.Labels, ref uint64, labelsCopy func(labels.Labels) labels.Labels) {
 	nowNanos := now.UnixNano()
 
-	e := s.findEntryForSeries(fingerprint, series)
+	e := s.findEntryForSeries(ref, series)
 	entryTimeSet := false
 	if e == nil {
-		e, entryTimeSet = s.findOrCreateEntryForSeries(fingerprint, series, nowNanos, labelsCopy)
+		e, entryTimeSet = s.findOrCreateEntryForSeries(ref, series, nowNanos, labelsCopy)
 	}
 
 	if !entryTimeSet {
@@ -163,30 +163,28 @@ func (s *seriesStripe) updateSeriesTimestamp(now time.Time, series labels.Labels
 	}
 }
 
-func (s *seriesStripe) findEntryForSeries(fingerprint uint64, series labels.Labels) *atomic.Int64 {
+func (s *seriesStripe) findEntryForSeries(ref uint64, series labels.Labels) *atomic.Int64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	// Check if already exists within the entries.
-	for _, entry := range s.refs[fingerprint] {
-		if labels.Equal(entry.lbs, series) {
-			return entry.nanos
-		}
+	entry, ok := s.refs[ref]
+	if !ok {
+		return nil
 	}
 
-	return nil
+	return entry.nanos
 }
 
-func (s *seriesStripe) findOrCreateEntryForSeries(fingerprint uint64, series labels.Labels, nowNanos int64, labelsCopy func(labels.Labels) labels.Labels) (*atomic.Int64, bool) {
+func (s *seriesStripe) findOrCreateEntryForSeries(ref uint64, series labels.Labels, nowNanos int64, labelsCopy func(labels.Labels) labels.Labels) (*atomic.Int64, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	// Check if already exists within the entries.
 	// This repeats findEntryForSeries(), but under write lock.
-	for _, entry := range s.refs[fingerprint] {
-		if labels.Equal(entry.lbs, series) {
-			return entry.nanos, false
-		}
+	entry, ok := s.refs[ref]
+	if ok {
+		return entry.nanos, false
 	}
 
 	matches := s.matchers.matches(series)
@@ -203,7 +201,7 @@ func (s *seriesStripe) findOrCreateEntryForSeries(fingerprint uint64, series lab
 		matches: matches,
 	}
 
-	s.refs[fingerprint] = append(s.refs[fingerprint], e)
+	s.refs[ref] = e
 
 	return e.nanos, true
 }
@@ -214,7 +212,7 @@ func (s *seriesStripe) clear() {
 	defer s.mu.Unlock()
 
 	s.oldestEntryTs.Store(0)
-	s.refs = map[uint64][]seriesEntry{}
+	s.refs = map[uint64]seriesEntry{}
 	s.active = 0
 	for i := range s.activeMatching {
 		s.activeMatching[i] = 0
@@ -227,7 +225,7 @@ func (s *seriesStripe) reinitialize(asm *Matchers) {
 	defer s.mu.Unlock()
 
 	s.oldestEntryTs.Store(0)
-	s.refs = map[uint64][]seriesEntry{}
+	s.refs = map[uint64]seriesEntry{}
 	s.active = 0
 	s.matchers = asm
 	s.activeMatching = resizeAndClear(len(asm.MatcherNames()), s.activeMatching)
@@ -247,55 +245,20 @@ func (s *seriesStripe) purge(keepUntil time.Time) {
 	s.activeMatching = resizeAndClear(len(s.activeMatching), s.activeMatching)
 
 	oldest := int64(math.MaxInt64)
-	for fp, entries := range s.refs {
-		// Since we do expect very few fingerprint collisions, we
-		// have an optimized implementation for the common case.
-		if len(entries) == 1 {
-			ts := entries[0].nanos.Load()
-			if ts < keepUntilNanos {
-				delete(s.refs, fp)
-				continue
-			}
-
-			s.active++
-			ml := entries[0].matches.len()
-			for i := 0; i < ml; i++ {
-				s.activeMatching[entries[0].matches.get(i)]++
-			}
-			if ts < oldest {
-				oldest = ts
-			}
+	for ref, entry := range s.refs {
+		ts := entry.nanos.Load()
+		if ts < keepUntilNanos {
+			delete(s.refs, ref)
 			continue
 		}
 
-		// We have more entries, which means there's a collision,
-		// so we have to iterate over the entries.
-		for i := 0; i < len(entries); {
-			ts := entries[i].nanos.Load()
-			if ts < keepUntilNanos {
-				entries = append(entries[:i], entries[i+1:]...)
-			} else {
-				if ts < oldest {
-					oldest = ts
-				}
-
-				i++
-			}
+		s.active++
+		ml := entry.matches.len()
+		for i := 0; i < ml; i++ {
+			s.activeMatching[entry.matches.get(i)]++
 		}
-
-		// Either update or delete the entries in the map
-		if cnt := len(entries); cnt == 0 {
-			delete(s.refs, fp)
-		} else {
-			s.active += cnt
-			for i := range entries {
-				ml := entries[i].matches.len()
-				for i := 0; i < ml; i++ {
-					s.activeMatching[entries[i].matches.get(i)]++
-				}
-			}
-
-			s.refs[fp] = entries
+		if ts < oldest {
+			oldest = ts
 		}
 	}
 

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -166,14 +166,7 @@ func (s *seriesStripe) updateSeriesTimestamp(now time.Time, series labels.Labels
 func (s *seriesStripe) findEntryForSeries(ref uint64) *atomic.Int64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	// Check if already exists within the entries.
-	entry, ok := s.refs[ref]
-	if !ok {
-		return nil
-	}
-
-	return entry.nanos
+	return s.refs[ref].nanos
 }
 
 func (s *seriesStripe) findOrCreateEntryForSeries(ref uint64, series labels.Labels, nowNanos int64, labelsCopy func(labels.Labels) labels.Labels) (*atomic.Int64, bool) {

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -22,8 +22,8 @@ func copyFn(l labels.Labels) labels.Labels { return l }
 const DefaultTimeout = 5 * time.Minute
 
 func TestActiveSeries_UpdateSeries_NoMatchers(t *testing.T) {
-	ls1 := labels.FromStrings("a", "1")
-	ls2 := labels.FromStrings("a", "2")
+	ref1, ls1 := uint64(1), labels.FromStrings("a", "1")
+	ref2, ls2 := uint64(2), labels.FromStrings("a", "2")
 
 	c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 	allActive, activeMatching, valid := c.Active(time.Now())
@@ -31,26 +31,26 @@ func TestActiveSeries_UpdateSeries_NoMatchers(t *testing.T) {
 	assert.Nil(t, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, ls1.Hash(), time.Now(), copyFn)
+	c.UpdateSeries(ls1, ref1, time.Now(), copyFn)
 	allActive, _, valid = c.Active(time.Now())
 	assert.Equal(t, 1, allActive)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, ls1.Hash(), time.Now(), copyFn)
+	c.UpdateSeries(ls1, ref1, time.Now(), copyFn)
 	allActive, _, valid = c.Active(time.Now())
 	assert.Equal(t, 1, allActive)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls2, ls2.Hash(), time.Now(), copyFn)
+	c.UpdateSeries(ls2, ref2, time.Now(), copyFn)
 	allActive, _, valid = c.Active(time.Now())
 	assert.Equal(t, 2, allActive)
 	assert.True(t, valid)
 }
 
 func TestActiveSeries_UpdateSeries_WithMatchers(t *testing.T) {
-	ls1 := labels.FromStrings("a", "1")
-	ls2 := labels.FromStrings("a", "2")
-	ls3 := labels.FromStrings("a", "3")
+	ref1, ls1 := uint64(1), labels.FromStrings("a", "1")
+	ref2, ls2 := uint64(2), labels.FromStrings("a", "2")
+	ref3, ls3 := uint64(3), labels.FromStrings("a", "3")
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{"foo": `{a=~"2|3"}`}))
 
@@ -60,25 +60,25 @@ func TestActiveSeries_UpdateSeries_WithMatchers(t *testing.T) {
 	assert.Equal(t, []int{0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, ls1.Hash(), time.Now(), copyFn)
+	c.UpdateSeries(ls1, ref1, time.Now(), copyFn)
 	allActive, activeMatching, valid = c.Active(time.Now())
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls2, ls2.Hash(), time.Now(), copyFn)
+	c.UpdateSeries(ls2, ref2, time.Now(), copyFn)
 	allActive, activeMatching, valid = c.Active(time.Now())
 	assert.Equal(t, 2, allActive)
 	assert.Equal(t, []int{1}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls3, ls3.Hash(), time.Now(), copyFn)
+	c.UpdateSeries(ls3, ref3, time.Now(), copyFn)
 	allActive, activeMatching, valid = c.Active(time.Now())
 	assert.Equal(t, 3, allActive)
 	assert.Equal(t, []int{2}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls3, ls3.Hash(), time.Now(), copyFn)
+	c.UpdateSeries(ls3, ref3, time.Now(), copyFn)
 	allActive, activeMatching, valid = c.Active(time.Now())
 	assert.Equal(t, 3, allActive)
 	assert.Equal(t, []int{2}, activeMatching)
@@ -99,10 +99,11 @@ func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 
 func TestActiveSeries_ShouldCorrectlyHandleHashCollisions(t *testing.T) {
 	ls1, ls2 := labelsWithHashCollision()
+	ref1, ref2 := uint64(1), uint64(2)
 
 	c := NewActiveSeries(&Matchers{}, DefaultTimeout)
-	c.UpdateSeries(ls1, ls1.Hash(), time.Now(), copyFn)
-	c.UpdateSeries(ls2, ls2.Hash(), time.Now(), copyFn)
+	c.UpdateSeries(ls1, ref1, time.Now(), copyFn)
+	c.UpdateSeries(ls2, ref2, time.Now(), copyFn)
 
 	allActive, _, valid := c.Active(time.Now())
 	assert.Equal(t, 2, allActive)
@@ -118,6 +119,8 @@ func TestActiveSeries_Purge_NoMatchers(t *testing.T) {
 		collision2,
 	}
 
+	refs := []uint64{1, 2, 3, 4}
+
 	// Run the same test for increasing TTL values
 	for ttl := 1; ttl <= len(series); ttl++ {
 		t.Run(fmt.Sprintf("ttl: %d", ttl), func(t *testing.T) {
@@ -125,7 +128,7 @@ func TestActiveSeries_Purge_NoMatchers(t *testing.T) {
 			c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 
 			for i := 0; i < len(series); i++ {
-				c.UpdateSeries(series[i], series[i].Hash(), time.Unix(int64(i), 0), copyFn)
+				c.UpdateSeries(series[i], refs[i], time.Unix(int64(i), 0), copyFn)
 			}
 
 			c.purge(time.Unix(int64(ttl), 0))
@@ -151,6 +154,8 @@ func TestActiveSeries_Purge_WithMatchers(t *testing.T) {
 		collision2,
 	}
 
+	refs := []uint64{1, 2, 3, 4}
+
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{"foo": `{_=~"y.*"}`}))
 
 	// Run the same test for increasing TTL values
@@ -164,7 +169,7 @@ func TestActiveSeries_Purge_WithMatchers(t *testing.T) {
 			expMatchingSeries := 0
 
 			for i, s := range series {
-				c.UpdateSeries(series[i], series[i].Hash(), time.Unix(int64(i), 0), copyFn)
+				c.UpdateSeries(series[i], refs[i], time.Unix(int64(i), 0), copyFn)
 
 				// if this series is matching, and they're within the ttl
 				if asm.matchers[0].Matches(s) && i >= ttl {
@@ -187,26 +192,27 @@ func TestActiveSeries_Purge_WithMatchers(t *testing.T) {
 
 func TestActiveSeries_PurgeOpt(t *testing.T) {
 	ls1, ls2 := labelsWithHashCollision()
+	ref1, ref2 := uint64(1), uint64(2)
 
 	currentTime := time.Now()
 	c := NewActiveSeries(&Matchers{}, 59*time.Second)
 
-	c.UpdateSeries(ls1, ls1.Hash(), currentTime.Add(-2*time.Minute), copyFn)
-	c.UpdateSeries(ls2, ls2.Hash(), currentTime, copyFn)
+	c.UpdateSeries(ls1, ref1, currentTime.Add(-2*time.Minute), copyFn)
+	c.UpdateSeries(ls2, ref2, currentTime, copyFn)
 
 	allActive, _, valid := c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, ls1.Hash(), currentTime.Add(-1*time.Minute), copyFn)
-	c.UpdateSeries(ls2, ls2.Hash(), currentTime, copyFn)
+	c.UpdateSeries(ls1, ref1, currentTime.Add(-1*time.Minute), copyFn)
+	c.UpdateSeries(ls2, ref2, currentTime, copyFn)
 
 	allActive, _, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.True(t, valid)
 
 	// This will *not* update the series, since there is already newer timestamp.
-	c.UpdateSeries(ls2, ls2.Hash(), currentTime.Add(-1*time.Minute), copyFn)
+	c.UpdateSeries(ls2, ref2, currentTime.Add(-1*time.Minute), copyFn)
 
 	allActive, _, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
@@ -214,10 +220,10 @@ func TestActiveSeries_PurgeOpt(t *testing.T) {
 }
 
 func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
-	ls1 := labels.FromStrings("a", "1")
-	ls2 := labels.FromStrings("a", "2")
-	ls3 := labels.FromStrings("a", "3")
-	ls4 := labels.FromStrings("a", "4")
+	ref1, ls1 := uint64(1), labels.FromStrings("a", "1")
+	ref2, ls2 := uint64(2), labels.FromStrings("a", "2")
+	ref3, ls3 := uint64(3), labels.FromStrings("a", "3")
+	ref4, ls4 := uint64(4), labels.FromStrings("a", "4")
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{"foo": `{a=~.*}`}))
 
@@ -229,7 +235,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 	assert.Equal(t, []int{0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, ls1.Hash(), currentTime, copyFn)
+	c.UpdateSeries(ls1, ref1, currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{1}, activeMatching)
@@ -241,8 +247,8 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 
 	// Adding timeout time to make Active results valid.
 	currentTime = currentTime.Add(DefaultTimeout)
-	c.UpdateSeries(ls1, ls1.Hash(), currentTime, copyFn)
-	c.UpdateSeries(ls2, ls2.Hash(), currentTime, copyFn)
+	c.UpdateSeries(ls1, ref1, currentTime, copyFn)
+	c.UpdateSeries(ls2, ref2, currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 2, allActive)
 	assert.Equal(t, []int{2}, activeMatching)
@@ -253,7 +259,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 
 	// Adding timeout time to make Active results valid.
 	currentTime = currentTime.Add(DefaultTimeout)
-	c.UpdateSeries(ls3, ls3.Hash(), currentTime, copyFn)
+	c.UpdateSeries(ls3, ref3, currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int(nil), activeMatching)
@@ -267,7 +273,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 
 	// Adding timeout time to make Active results valid.
 	currentTime = currentTime.Add(DefaultTimeout)
-	c.UpdateSeries(ls4, ls4.Hash(), currentTime, copyFn)
+	c.UpdateSeries(ls4, ref4, currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{0, 1}, activeMatching)
@@ -275,7 +281,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 }
 
 func TestActiveSeries_ReloadSeriesMatchers_LessMatchers(t *testing.T) {
-	ls1 := labels.FromStrings("a", "1")
+	ref1, ls1 := uint64(1), labels.FromStrings("a", "1")
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{
 		"foo": `{a=~.+}`,
@@ -289,7 +295,7 @@ func TestActiveSeries_ReloadSeriesMatchers_LessMatchers(t *testing.T) {
 	assert.Equal(t, []int{0, 0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, ls1.Hash(), currentTime, copyFn)
+	c.UpdateSeries(ls1, ref1, currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{1, 1}, activeMatching)
@@ -310,7 +316,7 @@ func TestActiveSeries_ReloadSeriesMatchers_LessMatchers(t *testing.T) {
 }
 
 func TestActiveSeries_ReloadSeriesMatchers_SameSizeNewLabels(t *testing.T) {
-	ls1 := labels.FromStrings("a", "1")
+	ref1, ls1 := uint64(1), labels.FromStrings("a", "1")
 
 	asm := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{
 		"foo": `{a=~.+}`,
@@ -325,7 +331,7 @@ func TestActiveSeries_ReloadSeriesMatchers_SameSizeNewLabels(t *testing.T) {
 	assert.Equal(t, []int{0, 0}, activeMatching)
 	assert.True(t, valid)
 
-	c.UpdateSeries(ls1, ls1.Hash(), currentTime, copyFn)
+	c.UpdateSeries(ls1, ref1, currentTime, copyFn)
 	allActive, activeMatching, valid = c.Active(currentTime)
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{1, 1}, activeMatching)
@@ -359,7 +365,7 @@ func BenchmarkActiveSeriesTest_single_series(b *testing.B) {
 
 func benchmarkActiveSeriesConcurrencySingleSeries(b *testing.B, goroutines int) {
 	series := labels.FromStrings("a", "a")
-	hash := series.Hash()
+	ref := uint64(1)
 
 	c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 
@@ -377,7 +383,7 @@ func benchmarkActiveSeriesConcurrencySingleSeries(b *testing.B, goroutines int) 
 
 			for ix := 0; ix < max; ix++ {
 				now = now.Add(time.Duration(ix) * time.Millisecond)
-				c.UpdateSeries(series, hash, now, copyFn)
+				c.UpdateSeries(series, ref, now, copyFn)
 			}
 		}()
 	}
@@ -414,7 +420,7 @@ func BenchmarkActiveSeries_UpdateSeries(b *testing.B) {
 			const nLabels = 10
 			builder := labels.NewScratchBuilder(nLabels)
 			series := make([]labels.Labels, tt.nSeries)
-			hash := make([]uint64, tt.nSeries)
+			refs := make([]uint64, tt.nSeries)
 			for s := 0; s < tt.nSeries; s++ {
 				builder.Reset()
 				for i := 0; i < nLabels; i++ {
@@ -422,7 +428,7 @@ func BenchmarkActiveSeries_UpdateSeries(b *testing.B) {
 					builder.Add(fmt.Sprintf("abcdefghijabcdefghi%d", i), fmt.Sprintf("abcdefghijabcdefghijabcdefghijabcd%d", s))
 				}
 				series[s] = builder.Labels()
-				hash[s] = series[s].Hash()
+				refs[s] = uint64(s)
 			}
 
 			now := time.Now().UnixNano()
@@ -432,7 +438,7 @@ func BenchmarkActiveSeries_UpdateSeries(b *testing.B) {
 				c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 				for round := 0; round <= tt.nRounds; round++ {
 					for ix := 0; ix < tt.nSeries; ix++ {
-						c.UpdateSeries(series[ix], hash[ix], time.Unix(0, now), copyFn)
+						c.UpdateSeries(series[ix], refs[ix], time.Unix(0, now), copyFn)
 						now++
 					}
 				}
@@ -457,8 +463,10 @@ func benchmarkPurge(b *testing.B, twice bool) {
 	c := NewActiveSeries(&Matchers{}, DefaultTimeout)
 
 	series := [numSeries]labels.Labels{}
+	refs := [numSeries]uint64{}
 	for s := 0; s < numSeries; s++ {
 		series[s] = labels.FromStrings("a", strconv.Itoa(s))
+		refs[s] = uint64(s)
 	}
 
 	for i := 0; i < b.N; i++ {
@@ -467,9 +475,9 @@ func benchmarkPurge(b *testing.B, twice bool) {
 		// Prepare series
 		for ix, s := range series {
 			if ix < numExpiresSeries {
-				c.UpdateSeries(s, s.Hash(), currentTime.Add(-DefaultTimeout), copyFn)
+				c.UpdateSeries(s, refs[ix], currentTime.Add(-DefaultTimeout), copyFn)
 			} else {
-				c.UpdateSeries(s, s.Hash(), currentTime, copyFn)
+				c.UpdateSeries(s, refs[ix], currentTime, copyFn)
 			}
 		}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1027,7 +1027,7 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 		}
 
 		if activeSeries != nil && stats.succeededSamplesCount > oldSucceededSamplesCount {
-			activeSeries.UpdateSeries(nonCopiedLabels, hash, startAppend, func(l labels.Labels) labels.Labels {
+			activeSeries.UpdateSeries(nonCopiedLabels, uint64(ref), startAppend, func(l labels.Labels) labels.Labels {
 				// we must already have copied the labels if succeededSamplesCount has been incremented.
 				return copiedLabels
 			})


### PR DESCRIPTION
#### What this PR does

This PR changes the active series tracker to use series refs rather than hashes. This has the following advantages:
1. We no longer need to handle hash conflicts, since series refs are guaranteed unique by the tsdb.
2. It's now trivial to implement a `Contains(ref)` method on the active series tracker, which I will use to enhance the cardinality API so we can compute active series in the label values cardinality api. (This will be a follow up PR: #5135 )

I've run a local Mimir cluster and simulated series churn using the mimir-continuous-test tool, and active series appears to work just as before. 

For completeness, I ran the existing benchmarks and got the following:

<details><summary>Details</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/ingester/activeseries
                                                      │  before.txt   │              after.txt               │
                                                      │    sec/op     │    sec/op     vs base                │
ActiveSeriesTest_single_series/50-10                     156.6n ±  4%   140.1n ±  8%  -10.51% (p=0.000 n=10)
ActiveSeriesTest_single_series/100-10                    155.2n ±  7%   141.6n ±  5%   -8.73% (p=0.000 n=10)
ActiveSeriesTest_single_series/500-10                    158.8n ±  3%   142.7n ±  2%  -10.14% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=1_series=100000-10      33.64m ±  6%   20.89m ± 10%  -37.91% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=1_series=1000000-10     599.1m ±  7%   412.2m ± 10%  -31.19% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=10_series=100000-10    191.96m ± 11%   66.05m ± 13%  -65.59% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=10_series=1000000-10     2.915 ±  4%    1.482 ±  4%  -49.14% (p=0.000 n=10)
ActiveSeries_Active_once-10                              170.5µ ±  5%   142.9µ ±  4%  -16.16% (p=0.000 n=10)
ActiveSeries_Active_twice-10                             174.4µ ±  6%   149.5µ ±  1%  -14.27% (p=0.000 n=10)
geomean                                                  477.6µ         333.5µ        -30.18%

                                                      │   before.txt    │               after.txt                │
                                                      │      B/op       │     B/op      vs base                  │
ActiveSeriesTest_single_series/50-10                      0.000 ±  0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
ActiveSeriesTest_single_series/100-10                     0.000 ±  0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
ActiveSeriesTest_single_series/500-10                     0.000 ±  0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
ActiveSeries_UpdateSeries/rounds=1_series=100000-10     18.70Mi ±  0%     22.02Mi ± 0%  +17.78% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=1_series=1000000-10    227.4Mi ±  0%     336.7Mi ± 0%  +48.09% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=10_series=100000-10    18.70Mi ±  0%     22.02Mi ± 0%  +17.76% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=10_series=1000000-10   227.4Mi ±  0%     336.7Mi ± 0%  +48.11% (p=0.000 n=10)
ActiveSeries_Active_once-10                               78.00 ±  8%       69.00 ± 1%  -11.54% (p=0.000 n=10)
ActiveSeries_Active_twice-10                              80.50 ± 12%       71.50 ± 2%  -11.18% (p=0.000 n=10)
geomean                                                               ²                 +10.17%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                      │   before.txt   │               after.txt               │
                                                      │   allocs/op    │  allocs/op   vs base                  │
ActiveSeriesTest_single_series/50-10                     0.000 ±  0%      0.000 ± 0%        ~ (p=1.000 n=10) ¹
ActiveSeriesTest_single_series/100-10                    0.000 ±  0%      0.000 ± 0%        ~ (p=1.000 n=10) ¹
ActiveSeriesTest_single_series/500-10                    0.000 ±  0%      0.000 ± 0%        ~ (p=1.000 n=10) ¹
ActiveSeries_UpdateSeries/rounds=1_series=100000-10     208.2k ±  0%     106.6k ± 0%  -48.79% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=1_series=1000000-10    2.021M ±  0%     1.021M ± 0%  -49.47% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=10_series=100000-10    208.2k ±  0%     106.6k ± 0%  -48.79% (p=0.000 n=10)
ActiveSeries_UpdateSeries/rounds=10_series=1000000-10   2.021M ±  0%     1.022M ± 0%  -49.46% (p=0.000 n=10)
ActiveSeries_Active_once-10                              3.000 ± 33%      3.000 ± 0%        ~ (p=0.087 n=10)
ActiveSeries_Active_twice-10                             5.000 ± 20%      4.000 ± 0%  -20.00% (p=0.011 n=10)
geomean                                                              ²                -27.76%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

```

</details> 

CPU usage is lower as expected, but allocated memory is slightly higher in `UpdateSeries` and lower in `Active`.

I've also consulted with @codesome about series refs to make sure this is a sane thing to do. Copying his response here (my questions in bold):

> **it seems like series refs in the head block are guaranteed to be unique across the lifetime of the process**

> That is right, but there is one small caveat. The same series can hold different series ref in the Head during the lifetime of the process, but at any given point, a series only has one ref. For example: {labels1} has ref=33, and then no samples came into that, so after the Head compaction the series was removed from Head. But then new samples started coming to it a little later, so a new series was created with new ref, but same labels, so now {labels1} has let's say ref=434 in the Head. 

> **but not necessarily after a restart**

> The series ID before and after restart can change. For example, taking the above example, if a restart happened and both series records for {labels1} existed in the WAL (ref 33 and ref 434), in this case the series created in the Head block for {labels1} will take the ref 33 here (since it comes first in the WAL). So after a restart, the ref for {labels1} changed from 434 to 33.

So it is possible that a single series may have multiple refs in two cases:
1. A series is removed from memory during head compaction. In this case, it will also be removed from the active series tracker first.
2. Ingesters restart and find multiple refs in the WAL. In this case, only the actual ref will be tracked in the active series tracker, since it starts empty and is filled by push requests over time.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/5135

#### Checklist

- [X] Tests updated
- [N/A] Documentation added
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
