### PR TITLE
docs: use correct values section for setting up ingress

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -210,7 +210,7 @@ Verify that an ingress controller is set up in the Kubernetes cluster, for examp
    b. Add the following to your `custom.yaml` Helm values file:
 
    ```yaml
-   nginx:
+   gateway:
      ingress:
        enabled: true
        ingressClassName: nginx

--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -210,7 +210,10 @@ Verify that an ingress controller is set up in the Kubernetes cluster, for examp
    b. Add the following to your `custom.yaml` Helm values file:
 
    ```yaml
+   nginx:
+     enabled: false
    gateway:
+     enabledNonEnterprise: true
      ingress:
        enabled: true
        ingressClassName: nginx


### PR DESCRIPTION
@krajorama pointed out that the docs for setting up ingress are outdated as of #3181 

the nginx section was deprecated and the gateway section should be used