### PR TITLE
Increase linter timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ linters-settings:
     errorf: false
 
 run:
-  timeout: 5m
+  timeout: 10m
 
   # List of build tags, all linters use it.
   build-tags:


### PR DESCRIPTION
#### What this PR does

`golangci-lint` is configured with a timeout of 5 minutes. However, this is occasionally not enough on CI ([example of a build that timed out](https://github.com/grafana/mimir/actions/runs/5172136060/jobs/9316193808), [example of the same commit passing after a retry](https://github.com/grafana/mimir/actions/runs/5172136060/jobs/9316466129)).

This PR increases the timeout to increase build stability to buy some time until we can investigate why linting is taking so long.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
