### PR TITLE
Refactor analyzer

### DIFF
--- a/pkg/mimirtool/commands/analyse_grafana.go
+++ b/pkg/mimirtool/commands/analyse_grafana.go
@@ -98,6 +98,14 @@ func AnalyzeGrafana(ctx context.Context, c *sdk.Client, folders []string) (*anal
 		}
 		analyze.ParseMetricsInBoard(output, board)
 	}
+
+	var metricsUsed model.LabelValues
+	for metric := range output.OverallMetrics {
+		metricsUsed = append(metricsUsed, model.LabelValue(metric))
+	}
+	sort.Sort(metricsUsed)
+	output.MetricsUsed = metricsUsed
+
 	return output, nil
 }
 
@@ -111,13 +119,6 @@ func unmarshalDashboard(data []byte, link sdk.FoundBoard) (minisdk.Board, error)
 }
 
 func writeOut(mig *analyze.MetricsInGrafana, outputFile string) error {
-	var metricsUsed model.LabelValues
-	for metric := range mig.OverallMetrics {
-		metricsUsed = append(metricsUsed, model.LabelValue(metric))
-	}
-	sort.Sort(metricsUsed)
-
-	mig.MetricsUsed = metricsUsed
 	out, err := json.MarshalIndent(mig, "", "  ")
 	if err != nil {
 		return err

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -54,30 +54,10 @@ func (cmd *PrometheusAnalyzeCommand) run(_ *kingpin.ParseContext) error {
 		return err
 	}
 
-	metricNames, err := cmd.queryMetricNames(v1api)
+	metricsInPrometheus, err := IdentifyMetricsInPrometheus(metricsUsed, v1api, cmd.concurrency, cmd.readTimeout)
 	if err != nil {
 		return err
 	}
-
-	log.Debugln("Starting to analyze metrics in use")
-	inUseMetricsAnalysisResult, err := cmd.analyze(v1api, metricsUsed, func(model.LabelValue) bool { return false })
-	if err != nil {
-		return err
-	}
-	log.Infof("%d active series are being used in dashboards", inUseMetricsAnalysisResult.cardinality)
-
-	log.Debugln("Starting to analyze metrics not in use")
-	metricsNotInUseResult, err := cmd.analyze(v1api, metricNames, func(metric model.LabelValue) bool {
-		return inUseMetricsAnalysisResult.stats[metric].totalCount > 0
-	})
-	if err != nil {
-		return err
-	}
-	log.Infof("%d active series are NOT being used in dashboards", metricsNotInUseResult.cardinality)
-
-	metricsInPrometheus := cmd.result(inUseMetricsAnalysisResult, metricsNotInUseResult)
-	log.Infof("%d in use active series metric count", len(metricsInPrometheus.InUseMetricCounts))
-	log.Infof("%d not in use active series metric count", len(metricsInPrometheus.AdditionalMetricCounts))
 
 	return cmd.write(metricsInPrometheus)
 }
@@ -128,8 +108,8 @@ func (cmd *PrometheusAnalyzeCommand) newAPI() (v1.API, error) {
 	return v1.NewAPI(client), nil
 }
 
-func (cmd *PrometheusAnalyzeCommand) queryMetricNames(api v1.API) (model.LabelValues, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), cmd.readTimeout)
+func queryMetricNames(api v1.API, readTimeout time.Duration) (model.LabelValues, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), readTimeout)
 	defer cancel()
 
 	var metricNames model.LabelValues
@@ -146,7 +126,8 @@ func (cmd *PrometheusAnalyzeCommand) queryMetricNames(api v1.API) (model.LabelVa
 	return metricNames, nil
 }
 
-func (cmd *PrometheusAnalyzeCommand) analyze(api v1.API, metrics model.LabelValues, skip func(model.LabelValue) bool) (analyzeResult, error) {
+// AnalyzePrometheus analyze prometheus through the given provided API and return the list metrics used in it.
+func AnalyzePrometheus(api v1.API, metrics model.LabelValues, skip func(model.LabelValue) bool, jobConcurrency int, readTimeout time.Duration) (AnalyzeResult, error) {
 	var (
 		stats        = make(stats)
 		metricErrors []string
@@ -154,13 +135,13 @@ func (cmd *PrometheusAnalyzeCommand) analyze(api v1.API, metrics model.LabelValu
 		mutex        sync.Mutex
 	)
 
-	err := concurrency.ForEachJob(context.Background(), len(metrics), cmd.concurrency, func(ctx context.Context, idx int) error {
+	err := concurrency.ForEachJob(context.Background(), len(metrics), jobConcurrency, func(ctx context.Context, idx int) error {
 		metric := metrics[idx]
 		if skip(metric) {
 			return nil
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, cmd.readTimeout)
+		ctx, cancel := context.WithTimeout(ctx, readTimeout)
 		defer cancel()
 
 		var result model.Value
@@ -203,17 +184,48 @@ func (cmd *PrometheusAnalyzeCommand) analyze(api v1.API, metrics model.LabelValu
 		return nil
 	})
 	if err != nil {
-		return analyzeResult{}, err
+		return AnalyzeResult{}, err
 	}
 
-	return analyzeResult{
+	return AnalyzeResult{
 		stats:        stats,
 		cardinality:  cardinality,
 		metricErrors: metricErrors,
 	}, nil
 }
 
-func (cmd *PrometheusAnalyzeCommand) result(inUse, notInUse analyzeResult) analyze.MetricsInPrometheus {
+// IdentifyMetricsInPrometheus analyze prometheus metrics against metrics used metricsUsed and metricNames. It returns stats about used/unused timeseries.
+func IdentifyMetricsInPrometheus(metricsUsed model.LabelValues, v1api v1.API, jobConcurrency int, readTimeout time.Duration) (analyze.MetricsInPrometheus, error) {
+	log.Debugln("Starting to analyze metrics in use")
+	var metricsInPrometheus analyze.MetricsInPrometheus
+
+	inUseMetricsAnalysisResult, err := AnalyzePrometheus(v1api, metricsUsed, func(model.LabelValue) bool { return false }, jobConcurrency, readTimeout)
+	if err != nil {
+		return metricsInPrometheus, err
+	}
+	log.Infof("%d active series are being used in dashboards", inUseMetricsAnalysisResult.cardinality)
+
+	log.Debugln("Starting to analyze metrics not in use")
+	metricNames, err := queryMetricNames(v1api, readTimeout)
+	if err != nil {
+		return metricsInPrometheus, err
+	}
+	metricsNotInUseResult, err := AnalyzePrometheus(v1api, metricNames, func(metric model.LabelValue) bool {
+		return inUseMetricsAnalysisResult.stats[metric].totalCount > 0
+	}, jobConcurrency, readTimeout)
+	if err != nil {
+		return metricsInPrometheus, err
+	}
+	log.Infof("%d active series are NOT being used in dashboards", metricsNotInUseResult.cardinality)
+
+	metricsInPrometheus = result(inUseMetricsAnalysisResult, metricsNotInUseResult)
+	log.Infof("%d in use active series metric count", len(metricsInPrometheus.InUseMetricCounts))
+	log.Infof("%d not in use active series metric count", len(metricsInPrometheus.AdditionalMetricCounts))
+
+	return metricsInPrometheus, nil
+}
+
+func result(inUse, notInUse AnalyzeResult) analyze.MetricsInPrometheus {
 	return analyze.MetricsInPrometheus{
 		InUseActiveSeries:      inUse.cardinality,
 		AdditionalActiveSeries: notInUse.cardinality,
@@ -240,13 +252,13 @@ type stat struct {
 
 type stats map[model.LabelValue]stat
 
-type analyzeResult struct {
+type AnalyzeResult struct {
 	stats        stats
 	cardinality  uint64
 	metricErrors []string
 }
 
-func (a analyzeResult) metricsCounts() []analyze.MetricCount {
+func (a AnalyzeResult) metricsCounts() []analyze.MetricCount {
 	var metricCount []analyze.MetricCount
 
 	for metric, counts := range a.stats {

--- a/pkg/mimirtool/commands/analyse_ruler.go
+++ b/pkg/mimirtool/commands/analyse_ruler.go
@@ -64,17 +64,18 @@ func AnalyzeRuler(c client.Config) (*analyze.MetricsInRuler, error) {
 			}
 		}
 	}
+
+	var metricsUsed model.LabelValues
+	for metric := range output.OverallMetrics {
+		metricsUsed = append(metricsUsed, model.LabelValue(metric))
+	}
+	sort.Sort(metricsUsed)
+	output.MetricsUsed = metricsUsed
+
 	return output, nil
 }
 
 func writeOutRuleMetrics(mir *analyze.MetricsInRuler, outputFile string) error {
-	var metricsUsed model.LabelValues
-	for metric := range mir.OverallMetrics {
-		metricsUsed = append(metricsUsed, model.LabelValue(metric))
-	}
-	sort.Sort(metricsUsed)
-
-	mir.MetricsUsed = metricsUsed
 	out, err := json.MarshalIndent(mir, "", "  ")
 	if err != nil {
 		return err


### PR DESCRIPTION
#### What this PR does

This is the second step for refactoring mimirtool's analyzers. The purpose is to enable Mimir's users to reuse mimirtool to industrialize metrics usage analysis via vendoring in downstream applications.

With it the refactoring is complete and users can reuse it. Below is an example of a quick and dirty prototype

```go
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"log"
	"net/url"
	"time"

	"github.com/grafana-tools/sdk"
	"github.com/grafana/mimir/pkg/mimirtool/client"
	"github.com/prometheus/common/model"

	mimirtoolClient "github.com/grafana/mimir/pkg/mimirtool/client"
	analyzer "github.com/grafana/mimir/pkg/mimirtool/commands"

	"github.com/prometheus/client_golang/api"
	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
	"github.com/prometheus/common/config"
)

func main() {
	ctx := context.Background()

	c, err := sdk.NewClient(
		"https://grafana.xxxxxx/",
		"xxxxxx",
		sdk.DefaultHTTPClient,
	)
	if err != nil {
		log.Fatal(err)
	}
	metricsInGrafana, err := analyzer.AnalyzeGrafana(ctx, c, []string{})
	if err != nil {
		log.Fatal(err)
	}

	clientConfig := mimirtoolClient.Config{
		User:    "xxxx",
		Key:     "xxxxxx",
		Address: "https://xxxx.mimir.xxxxx",
	}

	metricsInRuler, err := analyzer.AnalyzeRuler(clientConfig)
	if err != nil {
		log.Fatal(err)
	}

	var metricsUsed model.LabelValues
	metricsUsed = append(metricsUsed, metricsInGrafana.MetricsUsed...)
	metricsUsed = append(metricsUsed, metricsInRuler.MetricsUsed...)

	v1api, err := newAPI(clientConfig.User, clientConfig.Key, clientConfig.Address, "/prometheus")
	if err != nil {
		log.Fatal(err)
	}

	result, err := analyzer.IdentifyMetricsInPrometheus(metricsUsed, v1api, 8, time.Second*30)
	if err != nil {
		log.Fatal(err)
	}

	buf, err := json.MarshalIndent(result, "", "  ")
	if err != nil {
		log.Fatal(err)
	}
	fmt.Print(string(buf))
}

func newAPI(username, password, address, prometheusHTTPPrefix string) (v1.API, error) {
	rt := api.DefaultRoundTripper
	rt = config.NewUserAgentRoundTripper(client.UserAgent, rt)
	if username != "" {
		rt = config.NewBasicAuthRoundTripper(username, config.Secret(password), "", rt)
	}

	address, err := url.JoinPath(address, prometheusHTTPPrefix)
	if err != nil {
		return nil, err
	}
	client, err := api.NewClient(api.Config{
		Address:      address,
		RoundTripper: rt,
	})
	if err != nil {
		return nil, err
	}

	return v1.NewAPI(client), nil
}
```

In the prototype we see that we can wrap the complete analysis in a one-liner.
See also: https://github.com/grafana/mimir/pull/5027#issuecomment-1570044424

#### Which issue(s) this PR fixes or relates to

This is a followup on  #5027

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
