### PR TITLE
query-tee: proxy Content-Type response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Query-tee
 
+* [CHANGE] Proxy `Content-Type` response header from backend. Previously `Content-Type: text/plain; charset=utf-8` was returned on all requests. #5183
+
 ### Documentation
 
 ### Tools

--- a/docs/sources/mimir/operators-guide/tools/query-tee.md
+++ b/docs/sources/mimir/operators-guide/tools/query-tee.md
@@ -86,6 +86,7 @@ A request sent from the query-tee to a backend includes HTTP basic authenticatio
 ### Backend response selection
 
 The query-tee enables you to configure a preferred backend that selects the response to send back to the client.
+The query-tee returns the `Content-Type` header, HTTP status code, and body of the response from the preferred backend.
 The preferred backend can be configured via `-backend.preferred=<hostname>`.
 The value of the preferred backend configuration option must be the hostname of one of the configured backends.
 

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -65,6 +65,7 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if downstreamRes.err != nil {
 		http.Error(w, downstreamRes.err.Error(), http.StatusInternalServerError)
 	} else {
+		w.Header().Set("Content-Type", downstreamRes.contentType)
 		w.WriteHeader(downstreamRes.status)
 		if _, err := w.Write(downstreamRes.body); err != nil {
 			level.Warn(p.logger).Log("msg", "Unable to write response", "err", err)

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -331,6 +331,7 @@ func Test_ProxyEndpoint_Comparison(t *testing.T) {
 			endpoint.ServeHTTP(resp, req)
 			require.Equal(t, "preferred response", resp.Body.String())
 			require.Equal(t, scenario.preferredResponseStatusCode, resp.Code)
+			require.Equal(t, scenario.preferredResponseContentType, resp.Header().Get("Content-Type"))
 
 			// The HTTP request above will return as soon as the primary response is received, but this doesn't guarantee that the response comparison has been completed.
 			// Wait for the response comparison to complete before checking the logged messages.


### PR DESCRIPTION
#### What this PR does

The query-tee doesn't proxy the content-type HTTP header. This breaks some integrations, such as Grafana Alerting.


#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
