### PR TITLE
Retrieve build image from Makefile rather than duplicating it in GitHub Actions workflow file.

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -17,10 +17,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Get build image from Makefile
+        id: build_image_step
+        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+    outputs:
+      build_image: ${{ steps.build_image_step.outputs.build_image }}
+
   lint:
     runs-on: ubuntu-latest
+    needs:
+      - prepare
     container:
-      image: grafana/mimir-build-image:charleskorn-poddisruptionbudget-ba2264123
+      image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -85,8 +98,10 @@ jobs:
 
   lint-jsonnet:
     runs-on: ubuntu-latest
+    needs:
+      - prepare
     container:
-      image: grafana/mimir-build-image:charleskorn-poddisruptionbudget-ba2264123
+      image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -113,8 +128,10 @@ jobs:
 
   lint-helm:
     runs-on: ubuntu-latest
+    needs:
+      - prepare
     container:
-      image: grafana/mimir-build-image:charleskorn-poddisruptionbudget-ba2264123
+      image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -142,8 +159,10 @@ jobs:
       matrix:
         test_group_id:    [0, 1, 2, 3]
         test_group_total: [4]
+    needs:
+      - prepare
     container:
-      image: grafana/mimir-build-image:charleskorn-poddisruptionbudget-ba2264123
+      image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -177,8 +196,10 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    needs:
+      - prepare
     container:
-      image: grafana/mimir-build-image:charleskorn-poddisruptionbudget-ba2264123
+      image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -263,12 +284,12 @@ jobs:
           ./.github/workflows/scripts/run-integration-tests-group.sh --index ${{ matrix.test_group_id }} --total ${{ matrix.test_group_total }}
 
   deploy:
-    needs: [build, test, lint, integration]
+    needs: [prepare, build, test, lint, integration]
     # Only deploy images on pushes to the grafana/mimir repo, which either are tag pushes or weekly release branch pushes.
     if: (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r') ) && github.event_name == 'push' && github.repository == 'grafana/mimir'
     runs-on: ubuntu-latest
     container:
-      image: grafana/mimir-build-image:charleskorn-poddisruptionbudget-ba2264123
+      image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,10 @@ push-multiarch-build-image: ## Push the docker build image.
 	# Build and push mimir build image for linux/amd64 and linux/arm64
 	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --progress=plain --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(BUILD_IMAGE):$(IMAGE_TAG) mimir-build-image/
 
+.PHONY: print-build-image
+print-build-image:
+	@echo $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG)
+
 # We don't want find to scan inside a bunch of directories, to accelerate the
 # 'make: Entering directory '/go/src/github.com/grafana/mimir' phase.
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o -name packaging -prune -o -name mimir-mixin-tools -prune -o -name trafficdump -prune -o

--- a/docs/internal/contributing/how-to-upgrade-golang-version.md
+++ b/docs/internal/contributing/how-to-upgrade-golang-version.md
@@ -4,7 +4,6 @@ To upgrade the Golang version:
    - Upgrade Golang version in `mimir-build-image/Dockerfile`
    - Build new image `make mimir-build-image/.uptodate`
    - Publish the new image to `grafana/mimir-build-image` (requires a maintainer)
-   - Update the Docker image tag in `.github/workflows/*`
 2. Upgrade integration tests version
    - Update the Golang version installed in the `integration` job in `.github/workflows/*`
 3. Upgrade the reference to the latest build image called `LATEST_BUILD_IMAGE_TAG` in `Makefile`

--- a/docs/internal/how-to-update-the-build-image.md
+++ b/docs/internal/how-to-update-the-build-image.md
@@ -4,5 +4,5 @@ The build image currently can only be updated by a Grafana Mimir maintainer. If 
 2. Make sure to have [Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/). Docker Desktop and major distributions have it in the docker package.
 3. On Linux you'll need some extra qemu packages as well: `sudo apt-get install qemu qemu-user-static binfmt-support debootstrap`. And set up docker buildx: `docker buildx create --name armBuilder ; docker buildx use armBuilder`.
 4. Build and publish the image by using `make push-multiarch-build-image`. This will build and push multiplatform docker image (for Linux/amd64 and Linux/arm64).
-5. Replace the image tag in `.github/workflows/*` (_there may be multiple references_) and Makefile (variable `LATEST_BUILD_IMAGE_TAG`).
+5. Replace the image tag in Makefile (variable `LATEST_BUILD_IMAGE_TAG`).
 6. Open a PR and make sure the CI with the new build image passes


### PR DESCRIPTION
#### What this PR does

This PR modifies our GitHub Actions workflow to load the build image tag from `Makefile`, rather than having it specified in multiple places.

If this works well, we could likely also use a similar technique to set the Go version for the `setup-go` step for the integration tests by checking the version of Go used in the build image.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
