### PR TITLE
Backport 5187 to release 2.9

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -15,10 +15,23 @@ jobs:
       ct_check_version_increment: false
       helm_version: v3.8.2
 
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Get build image from Makefile
+        id: build_image_step
+        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+    outputs:
+      build_image: ${{ steps.build_image_step.outputs.build_image }}
+
   conftest:
     runs-on: ubuntu-latest
+    needs:
+      - prepare
     container:
-      image: grafana/mimir-build-image:felix-update-go-to-1.20.5-31cf42ae2
+      image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
helm-ci: do not hardcode build image version (#5187)

Based on #5184

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>
(cherry picked from commit f59d4d988a4de314fbd10303593305c44d4079d6)