### PR TITLE
compactor: add more log lines for blocks clean-up

### DIFF
--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -165,7 +165,10 @@ func (c *BlocksCleaner) ticker(ctx context.Context) error {
 func (c *BlocksCleaner) runCleanup(ctx context.Context, async bool) {
 	// Wrap logger with some unique ID so if runCleanUp does run in parallel with itself, we can
 	// at least differentiate the logs in this function for each run.
-	logger := log.With(c.logger, "run_id", strconv.FormatInt(time.Now().Unix(), 10))
+	logger := log.With(c.logger,
+		"run_id", strconv.FormatInt(time.Now().Unix(), 10),
+		"task", "clean_up_users",
+	)
 
 	c.instrumentStartedCleanupRun(logger)
 
@@ -176,7 +179,7 @@ func (c *BlocksCleaner) runCleanup(ctx context.Context, async bool) {
 	}
 
 	doCleanup := func() {
-		err := c.cleanUsers(ctx, allUsers, isDeleted)
+		err := c.cleanUsers(ctx, allUsers, isDeleted, logger)
 		c.instrumentFinishedCleanupRun(err, logger)
 	}
 
@@ -234,7 +237,7 @@ func (c *BlocksCleaner) refreshOwnedUsers(ctx context.Context) ([]string, map[st
 }
 
 // cleanUsers must be concurrency-safe because some invocations may take longer and overlap with the next periodic invocation.
-func (c *BlocksCleaner) cleanUsers(ctx context.Context, allUsers []string, isDeleted map[string]bool) error {
+func (c *BlocksCleaner) cleanUsers(ctx context.Context, allUsers []string, isDeleted map[string]bool, logger log.Logger) error {
 	return c.singleFlight.ForEachNotInFlight(ctx, allUsers, func(ctx context.Context, userID string) error {
 		own, err := c.ownUser(userID)
 		if err != nil || !own {
@@ -242,16 +245,16 @@ func (c *BlocksCleaner) cleanUsers(ctx context.Context, allUsers []string, isDel
 			return errors.Wrap(err, "check own user")
 		}
 
+		userLogger := util_log.WithUserID(userID, logger)
 		if isDeleted[userID] {
-			return errors.Wrapf(c.deleteUserMarkedForDeletion(ctx, userID), "failed to delete user marked for deletion: %s", userID)
+			return errors.Wrapf(c.deleteUserMarkedForDeletion(ctx, userID, userLogger), "failed to delete user marked for deletion: %s", userID)
 		}
-		return errors.Wrapf(c.cleanUser(ctx, userID), "failed to delete blocks for user: %s", userID)
+		return errors.Wrapf(c.cleanUser(ctx, userID, userLogger), "failed to delete blocks for user: %s", userID)
 	})
 }
 
 // deleteUserMarkedForDeletion removes blocks and remaining data for tenant marked for deletion.
-func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userID string) error {
-	userLogger := util_log.WithUserID(userID, c.logger)
+func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userID string, userLogger log.Logger) error {
 	userBucket := bucket.NewUserBucketClient(userID, c.bucketClient, c.cfgProvider)
 
 	level.Info(userLogger).Log("msg", "deleting blocks for tenant marked for deletion")
@@ -352,27 +355,28 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userID 
 	return nil
 }
 
-func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string) (returnErr error) {
-	userLogger := util_log.WithUserID(userID, c.logger)
+func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, userLogger log.Logger) (returnErr error) {
 	userBucket := bucket.NewUserBucketClient(userID, c.bucketClient, c.cfgProvider)
 	startTime := time.Now()
 
 	level.Info(userLogger).Log("msg", "started blocks cleanup and maintenance")
 	defer func() {
 		if returnErr != nil {
-			level.Warn(userLogger).Log("msg", "failed blocks cleanup and maintenance", "err", returnErr)
+			level.Warn(userLogger).Log("msg", "failed blocks cleanup and maintenance", "err", returnErr, "duration", time.Since(startTime))
 		} else {
 			level.Info(userLogger).Log("msg", "completed blocks cleanup and maintenance", "duration", time.Since(startTime))
 		}
 	}()
 
 	// Read the bucket index.
-	idx, err := bucketindex.ReadIndex(ctx, c.bucketClient, userID, c.cfgProvider, c.logger)
+	idx, err := bucketindex.ReadIndex(ctx, c.bucketClient, userID, c.cfgProvider, userLogger)
 	if errors.Is(err, bucketindex.ErrIndexCorrupted) {
 		level.Warn(userLogger).Log("msg", "found a corrupted bucket index, recreating it")
 	} else if err != nil && !errors.Is(err, bucketindex.ErrIndexNotFound) {
 		return err
 	}
+
+	level.Info(userLogger).Log("msg", "fetched existing bucket index")
 
 	// Mark blocks for future deletion based on the retention period for the user.
 	// Note doing this before UpdateIndex, so it reads in the deletion marks.
@@ -386,7 +390,7 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string) (returnErr
 	}
 
 	// Generate an updated in-memory version of the bucket index.
-	w := bucketindex.NewUpdater(c.bucketClient, userID, c.cfgProvider, c.logger)
+	w := bucketindex.NewUpdater(c.bucketClient, userID, c.cfgProvider, userLogger)
 	idx, partials, err := w.UpdateIndex(ctx, idx)
 	if err != nil {
 		return err
@@ -406,6 +410,7 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string) (returnErr
 		}
 
 		c.cleanUserPartialBlocks(ctx, partials, idx, partialDeletionCutoffTime, userBucket, userLogger)
+		level.Info(userLogger).Log("msg", "cleaned up partial blocks", "partials", len(partials))
 	}
 
 	// Upload the updated index to the storage.
@@ -534,7 +539,6 @@ func (c *BlocksCleaner) applyUserRetentionPeriod(ctx context.Context, idx *bucke
 		return
 	}
 
-	level.Debug(userLogger).Log("msg", "applying retention", "retention", retention.String())
 	blocks := listBlocksOutsideRetentionPeriod(idx, time.Now().Add(-retention))
 
 	// Attempt to mark all blocks. It is not critical if a marking fails, as
@@ -545,6 +549,7 @@ func (c *BlocksCleaner) applyUserRetentionPeriod(ctx context.Context, idx *bucke
 			level.Warn(userLogger).Log("msg", "failed to mark block for deletion", "block", b.ID, "err", err)
 		}
 	}
+	level.Info(userLogger).Log("msg", "marked blocks for deletion", "num_blocks", len(blocks), "retention", retention.String())
 }
 
 // listBlocksOutsideRetentionPeriod determines the blocks which have aged past

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -734,7 +734,7 @@ func TestBlocksCleaner_ShouldRemovePartialBlocksOutsideDelayPeriod(t *testing.T)
 	checkBlock(t, "user-1", bucketClient, block1, false, false)
 	checkBlock(t, "user-1", bucketClient, block2, true, false)
 
-	require.NoError(t, cleaner.cleanUser(ctx, "user-1", log.NewNopLogger()))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-1", logger))
 
 	// check that no blocks were marked for deletion, because deletion delay is set to 0.
 	checkBlock(t, "user-1", bucketClient, block1, false, false)
@@ -744,7 +744,7 @@ func TestBlocksCleaner_ShouldRemovePartialBlocksOutsideDelayPeriod(t *testing.T)
 	// The delay time must be very short since these temporary files were just created
 	cfgProvider.userPartialBlockDelay["user-1"] = 1 * time.Nanosecond
 
-	require.NoError(t, cleaner.cleanUser(ctx, "user-1", log.NewNopLogger()))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-1", logger))
 
 	// check that first block was marked for deletion (partial block updated far in the past), but not the second one, because it's not partial.
 	checkBlock(t, "user-1", bucketClient, block1, false, true)
@@ -818,11 +818,11 @@ func TestBlocksCleaner_ShouldNotRemovePartialBlocksInsideDelayPeriod(t *testing.
 	cfgProvider.userPartialBlockDelay["user-1"] = 1 * time.Hour
 	cfgProvider.userPartialBlockDelay["user-2"] = 1 * time.Nanosecond
 
-	require.NoError(t, cleaner.cleanUser(ctx, "user-1", log.NewNopLogger()))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-1", logger))
 	checkBlock(t, "user-1", bucketClient, block1, false, false) // This block was updated too recently, so we don't mark it for deletion just yet.
 	checkBlock(t, "user-2", bucketClient, block2, true, false)  // No change for user-2.
 
-	require.NoError(t, cleaner.cleanUser(ctx, "user-2", log.NewNopLogger()))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-2", logger))
 	checkBlock(t, "user-1", bucketClient, block1, false, false) // No change for user-1
 	checkBlock(t, "user-2", bucketClient, block2, true, false)  // Block with corrupted meta is NOT marked for deletion.
 
@@ -884,7 +884,7 @@ func TestBlocksCleaner_ShouldNotRemovePartialBlocksIfConfiguredDelayIsInvalid(t 
 
 	// Run the cleanup.
 	cleaner := NewBlocksCleaner(cfg, bucketClient, tsdb.AllUsers, cfgProvider, logger, reg)
-	require.NoError(t, cleaner.cleanUser(ctx, "user-1", log.NewNopLogger()))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-1", logger))
 
 	// Ensure the block has NOT been marked for deletion.
 	checkBlock(t, "user-1", bucketClient, block1, false, false)

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -734,7 +734,7 @@ func TestBlocksCleaner_ShouldRemovePartialBlocksOutsideDelayPeriod(t *testing.T)
 	checkBlock(t, "user-1", bucketClient, block1, false, false)
 	checkBlock(t, "user-1", bucketClient, block2, true, false)
 
-	require.NoError(t, cleaner.cleanUser(ctx, "user-1"))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-1", log.NewNopLogger()))
 
 	// check that no blocks were marked for deletion, because deletion delay is set to 0.
 	checkBlock(t, "user-1", bucketClient, block1, false, false)
@@ -744,7 +744,7 @@ func TestBlocksCleaner_ShouldRemovePartialBlocksOutsideDelayPeriod(t *testing.T)
 	// The delay time must be very short since these temporary files were just created
 	cfgProvider.userPartialBlockDelay["user-1"] = 1 * time.Nanosecond
 
-	require.NoError(t, cleaner.cleanUser(ctx, "user-1"))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-1", log.NewNopLogger()))
 
 	// check that first block was marked for deletion (partial block updated far in the past), but not the second one, because it's not partial.
 	checkBlock(t, "user-1", bucketClient, block1, false, true)
@@ -818,11 +818,11 @@ func TestBlocksCleaner_ShouldNotRemovePartialBlocksInsideDelayPeriod(t *testing.
 	cfgProvider.userPartialBlockDelay["user-1"] = 1 * time.Hour
 	cfgProvider.userPartialBlockDelay["user-2"] = 1 * time.Nanosecond
 
-	require.NoError(t, cleaner.cleanUser(ctx, "user-1"))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-1", log.NewNopLogger()))
 	checkBlock(t, "user-1", bucketClient, block1, false, false) // This block was updated too recently, so we don't mark it for deletion just yet.
 	checkBlock(t, "user-2", bucketClient, block2, true, false)  // No change for user-2.
 
-	require.NoError(t, cleaner.cleanUser(ctx, "user-2"))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-2", log.NewNopLogger()))
 	checkBlock(t, "user-1", bucketClient, block1, false, false) // No change for user-1
 	checkBlock(t, "user-2", bucketClient, block2, true, false)  // Block with corrupted meta is NOT marked for deletion.
 
@@ -884,7 +884,7 @@ func TestBlocksCleaner_ShouldNotRemovePartialBlocksIfConfiguredDelayIsInvalid(t 
 
 	// Run the cleanup.
 	cleaner := NewBlocksCleaner(cfg, bucketClient, tsdb.AllUsers, cfgProvider, logger, reg)
-	require.NoError(t, cleaner.cleanUser(ctx, "user-1"))
+	require.NoError(t, cleaner.cleanUser(ctx, "user-1", log.NewNopLogger()))
 
 	// Ensure the block has NOT been marked for deletion.
 	checkBlock(t, "user-1", bucketClient, block1, false, false)
@@ -1058,5 +1058,5 @@ func (c *BlocksCleaner) runCleanupWithErr(ctx context.Context) error {
 		return err
 	}
 
-	return c.cleanUsers(ctx, allUsers, isDeleted)
+	return c.cleanUsers(ctx, allUsers, isDeleted, log.NewNopLogger())
 }

--- a/pkg/storage/tsdb/bucketindex/updater.go
+++ b/pkg/storage/tsdb/bucketindex/updater.go
@@ -96,7 +96,7 @@ func (w *Updater) updateBlocks(ctx context.Context, old []*Block) (blocks []*Blo
 		}
 	}
 
-	level.Info(w.logger).Log("msg", "listed all blocks in storage", "newly_discovered", len(discovered), "old_discovered", len(old))
+	level.Info(w.logger).Log("msg", "listed all blocks in storage", "newly_discovered", len(discovered), "existing", len(old))
 
 	// Remaining blocks are new ones and we have to fetch the meta.json for each of them, in order
 	// to find out if their upload has been completed (meta.json is uploaded last) and get the block


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR introduces some changes to make it easier to track the progress of a cleanup job. This is useful when some portion of the cleanup job takes very long.

* add duration to the lgo lines for a failed cleanup job
* propagate `run_id` log label to per-user runs; this makes it easier to track a single run which starts overlapping with following runs
* add log lines at different stages of updating the bucket index and carrying out blocks deletion
  * after fetching existing bucket index
  * after marking blocks for deletion
  * after fetching list of blocks
  * after updating meta.json for new blocks
  * after listing deletion markers
  * after updating deletion markers for new blocks
  * after cleaning up partial blocks


#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
