### PR TITLE
compactor: Add timeouts on blocks cleanup

### DIFF
--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -209,7 +209,7 @@ func (m *BlockDeletionMark) GetDeletionTime() time.Time {
 	return time.Unix(m.DeletionTime, 0)
 }
 
-// ThanosMeta returns the Thanos deletion mark.
+// ThanosDeletionMark returns the Thanos deletion mark.
 func (m *BlockDeletionMark) ThanosDeletionMark() *block.DeletionMark {
 	return &block.DeletionMark{
 		ID:           m.ID,

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -26,7 +26,7 @@ import (
 const (
 	// readIndexTimeout is the maximum allowed time when reading a single bucket index
 	// from the storage. It's hard-coded to a reasonably high value.
-	readIndexTimeout = 15 * time.Second
+	readIndexTimeout = time.Minute
 )
 
 type LoaderConfig struct {
@@ -195,12 +195,9 @@ func (l *Loader) checkCachedIndexesToUpdateAndDelete() (toUpdate, toDelete []str
 }
 
 func (l *Loader) updateCachedIndex(ctx context.Context, userID string) {
-	readCtx, cancel := context.WithTimeout(ctx, readIndexTimeout)
-	defer cancel()
-
 	l.loadAttempts.Inc()
 	startTime := time.Now()
-	idx, err := ReadIndex(readCtx, l.bkt, userID, l.cfgProvider, l.logger)
+	idx, err := ReadIndex(ctx, l.bkt, userID, l.cfgProvider, l.logger)
 	if err != nil && !errors.Is(err, ErrIndexNotFound) {
 		l.loadFailures.Inc()
 		level.Warn(l.logger).Log("msg", "unable to update bucket index", "user", userID, "err", err)

--- a/pkg/storage/tsdb/bucketindex/storage.go
+++ b/pkg/storage/tsdb/bucketindex/storage.go
@@ -25,7 +25,11 @@ var (
 )
 
 // ReadIndex reads, parses and returns a bucket index from the bucket.
+// ReadIndex has a one-minute timeout for completing the read against the bucket.
 func ReadIndex(ctx context.Context, bkt objstore.Bucket, userID string, cfgProvider bucket.TenantConfigProvider, logger log.Logger) (*Index, error) {
+	ctx, cancel := context.WithTimeout(ctx, readIndexTimeout)
+	defer cancel()
+
 	userBkt := bucket.NewUserBucketClient(userID, bkt, cfgProvider)
 
 	// Get the bucket index.

--- a/pkg/storage/tsdb/bucketindex/updater.go
+++ b/pkg/storage/tsdb/bucketindex/updater.go
@@ -124,6 +124,11 @@ func (w *Updater) updateBlocks(ctx context.Context, old []*Block) (blocks []*Blo
 }
 
 func (w *Updater) updateBlockIndexEntry(ctx context.Context, id ulid.ULID) (*Block, error) {
+	// Set a generous timeout for fetching the meta.json and getting the attributes of the same file.
+	// This protects against operations that can take unbounded time.
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
 	metaFile := path.Join(id.String(), block.MetaFilename)
 
 	// Get the block's meta.json file.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds 1-minute timeouts for fetching individual files during compactor user cleanup.
* reading meta.json for one block
* reading deletion or no-compact markers for one block

It has the side effect of setting a timeout to reading the bucket index for all consumers (compactor, store-gateway, querier). Previously the querier was using a 15-second timeout and the others were unbounded. Since this is already a very generous timeout, I don't expect it to have any negative effects on the other components.

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
