### PR TITLE
Pool buffers when sending write request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   * `-<prefix>.initial-connection-window-size`
 * [ENHANCEMENT] Query-frontend: added "response_size_bytes" field to "query stats" log. #5196
 * [ENHANCEMENT] Querier: Refine error messages for per-tenant query limits, informing the user of the preferred strategy for not hitting the limit, in addition to how they may tweak the limit. #5059
-* [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. For now this optimization can be disabled by setting `-distributor.write-request-buffer-pooling-enabled` to `false`. #5195
+* [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. For now this optimization can be disabled by setting `-distributor.write-requests-buffer-pooling-enabled` to `false`. #5195
 * [BUGFIX] Querier: don't leak memory when processing query requests from query-frontends (ie. when the query-scheduler is disabled). #5199
 
 ### Mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * `-<prefix>.initial-connection-window-size`
 * [ENHANCEMENT] Query-frontend: added "response_size_bytes" field to "query stats" log. #5196
 * [ENHANCEMENT] Querier: Refine error messages for per-tenant query limits, informing the user of the preferred strategy for not hitting the limit, in addition to how they may tweak the limit. #5059
+* [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. For now this optimization can be disabled by setting `-distributor.write-request-buffer-pooling-enabled` to `false`. #5195
 * [BUGFIX] Querier: don't leak memory when processing query requests from query-frontends (ie. when the query-scheduler is disabled). #5199
 
 ### Mixin

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1483,7 +1483,7 @@
           "required": false,
           "desc": "Enable pooling of buffers used for marshaling write requests.",
           "fieldValue": null,
-          "fieldDefaultValue": true,
+          "fieldDefaultValue": false,
           "fieldFlag": "distributor.write-requests-buffer-pooling-enabled",
           "fieldType": "boolean",
           "fieldCategory": "experimental"

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1476,6 +1476,17 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
+        },
+        {
+          "kind": "field",
+          "name": "write_requests_buffer_pooling_enabled",
+          "required": false,
+          "desc": "Enable pooling of buffers used for marshaling write requests.",
+          "fieldValue": null,
+          "fieldDefaultValue": true,
+          "fieldFlag": "distributor.write-request-buffer-pooling-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1484,7 +1484,7 @@
           "desc": "Enable pooling of buffers used for marshaling write requests.",
           "fieldValue": null,
           "fieldDefaultValue": true,
-          "fieldFlag": "distributor.write-request-buffer-pooling-enabled",
+          "fieldFlag": "distributor.write-requests-buffer-pooling-enabled",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
         }

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1159,6 +1159,8 @@ Usage of ./cmd/mimir/mimir:
     	The prefix for the keys in the store. Should end with a /. (default "collectors/")
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+  -distributor.write-request-buffer-pooling-enabled
+    	[experimental] Enable pooling of buffers used for marshaling write requests. (default true)
   -enable-go-runtime-metrics
     	Set to true to enable all Go runtime metrics, such as go_sched_* and go_memstats_*.
   -flusher.exit-after-flush

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1159,7 +1159,7 @@ Usage of ./cmd/mimir/mimir:
     	The prefix for the keys in the store. Should end with a /. (default "collectors/")
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
-  -distributor.write-request-buffer-pooling-enabled
+  -distributor.write-requests-buffer-pooling-enabled
     	[experimental] Enable pooling of buffers used for marshaling write requests. (default true)
   -enable-go-runtime-metrics
     	Set to true to enable all Go runtime metrics, such as go_sched_* and go_memstats_*.

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1160,7 +1160,7 @@ Usage of ./cmd/mimir/mimir:
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -distributor.write-requests-buffer-pooling-enabled
-    	[experimental] Enable pooling of buffers used for marshaling write requests. (default true)
+    	[experimental] Enable pooling of buffers used for marshaling write requests.
   -enable-go-runtime-metrics
     	Set to true to enable all Go runtime metrics, such as go_sched_* and go_memstats_*.
   -flusher.exit-after-flush

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -114,6 +114,7 @@ The following features are currently experimental:
 - Per-tenant Results cache TTL (`-query-frontend.results-cache-ttl`, `-query-frontend.results-cache-ttl-for-out-of-order-time-window`)
 - Fetching TLS secrets from Vault for various clients (`-vault.enabled`)
 - Timeseries Unmarshal caching optimization in distributor (`-timeseries-unmarshal-caching-optimization-enabled`)
+- Reusing buffers for marshalling write requests in distributors (`-distributor.write-request-buffer-pooling-enabled`)
 
 ## Deprecated features
 

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -114,7 +114,7 @@ The following features are currently experimental:
 - Per-tenant Results cache TTL (`-query-frontend.results-cache-ttl`, `-query-frontend.results-cache-ttl-for-out-of-order-time-window`)
 - Fetching TLS secrets from Vault for various clients (`-vault.enabled`)
 - Timeseries Unmarshal caching optimization in distributor (`-timeseries-unmarshal-caching-optimization-enabled`)
-- Reusing buffers for marshalling write requests in distributors (`-distributor.write-request-buffer-pooling-enabled`)
+- Reusing buffers for marshalling write requests in distributors (`-distributor.write-requests-buffer-pooling-enabled`)
 
 ## Deprecated features
 

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -771,7 +771,7 @@ instance_limits:
 
 # (experimental) Enable pooling of buffers used for marshaling write requests.
 # CLI flag: -distributor.write-requests-buffer-pooling-enabled
-[write_requests_buffer_pooling_enabled: <boolean> | default = true]
+[write_requests_buffer_pooling_enabled: <boolean> | default = false]
 ```
 
 ### ingester

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -768,6 +768,10 @@ instance_limits:
   # per-tenant. Additional requests will be rejected. 0 = unlimited.
   # CLI flag: -distributor.instance-limits.max-inflight-push-requests-bytes
   [max_inflight_push_requests_bytes: <int> | default = 0]
+
+# (experimental) Enable pooling of buffers used for marshaling write requests.
+# CLI flag: -distributor.write-request-buffer-pooling-enabled
+[write_requests_buffer_pooling_enabled: <boolean> | default = true]
 ```
 
 ### ingester

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -770,7 +770,7 @@ instance_limits:
   [max_inflight_push_requests_bytes: <int> | default = 0]
 
 # (experimental) Enable pooling of buffers used for marshaling write requests.
-# CLI flag: -distributor.write-request-buffer-pooling-enabled
+# CLI flag: -distributor.write-requests-buffer-pooling-enabled
 [write_requests_buffer_pooling_enabled: <boolean> | default = true]
 ```
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -189,7 +189,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 	f.IntVar(&cfg.MaxRecvMsgSize, "distributor.max-recv-msg-size", 100<<20, "Max message size in bytes that the distributors will accept for incoming push requests to the remote write API. If exceeded, the request will be rejected.")
 	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
-	f.BoolVar(&cfg.WriteRequestsBufferPoolingEnabled, "distributor.write-request-buffer-pooling-enabled", true, "Enable pooling of buffers used for marshaling write requests.")
+	f.BoolVar(&cfg.WriteRequestsBufferPoolingEnabled, "distributor.write-requests-buffer-pooling-enabled", true, "Enable pooling of buffers used for marshaling write requests.")
 
 	cfg.DefaultLimits.RegisterFlags(f)
 }

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -45,7 +45,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/util"
 	util_math "github.com/grafana/mimir/pkg/util/math"
-	pool2 "github.com/grafana/mimir/pkg/util/pool"
+	"github.com/grafana/mimir/pkg/util/pool"
 	"github.com/grafana/mimir/pkg/util/push"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -189,7 +189,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 	f.IntVar(&cfg.MaxRecvMsgSize, "distributor.max-recv-msg-size", 100<<20, "Max message size in bytes that the distributors will accept for incoming push requests to the remote write API. If exceeded, the request will be rejected.")
 	f.DurationVar(&cfg.RemoteTimeout, "distributor.remote-timeout", 2*time.Second, "Timeout for downstream ingesters.")
-	f.BoolVar(&cfg.WriteRequestsBufferPoolingEnabled, "distributor.write-requests-buffer-pooling-enabled", true, "Enable pooling of buffers used for marshaling write requests.")
+	f.BoolVar(&cfg.WriteRequestsBufferPoolingEnabled, "distributor.write-requests-buffer-pooling-enabled", false, "Enable pooling of buffers used for marshaling write requests.")
 
 	cfg.DefaultLimits.RegisterFlags(f)
 }
@@ -1132,7 +1132,7 @@ func (d *Distributor) push(ctx context.Context, pushReq *push.Request) (*mimirpb
 	cleanupInDefer = false
 
 	if d.cfg.WriteRequestsBufferPoolingEnabled {
-		slabPool := pool2.NewFastReleasingSlabPool[byte](&d.writeRequestBytePool, writeRequestSlabPoolSize)
+		slabPool := pool.NewFastReleasingSlabPool[byte](&d.writeRequestBytePool, writeRequestSlabPoolSize)
 		localCtx = ingester_client.WithSlabPool(localCtx, slabPool)
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -213,7 +213,6 @@ const (
 func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Overrides, activeGroupsCleanupService *util.ActiveGroupsCleanupService, ingestersRing ring.ReadRing, canJoinDistributorsRing bool, reg prometheus.Registerer, log log.Logger) (*Distributor, error) {
 	if cfg.IngesterClientFactory == nil {
 		cfg.IngesterClientFactory = func(addr string) (ring_client.PoolClient, error) {
-			clientConfig.WriteRequestsBufferPoolingEnabled = cfg.WriteRequestsBufferPoolingEnabled
 			return ingester_client.MakeIngesterClient(addr, clientConfig)
 		}
 	}

--- a/pkg/ingester/client/buffering_client.go
+++ b/pkg/ingester/client/buffering_client.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package client
 
 import (

--- a/pkg/ingester/client/buffering_client.go
+++ b/pkg/ingester/client/buffering_client.go
@@ -1,0 +1,158 @@
+package client
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/util/pool"
+)
+
+// bufferPoolingClient implements IngesterClient, but overrides Push method to add pooling of buffers used to marshal write requests.
+type bufferPoolingClient struct {
+	upstream HealthAndIngesterClient
+
+	conn *grpc.ClientConn
+}
+
+func NewWriteRequestBufferingClient(upstream HealthAndIngesterClient, conn *grpc.ClientConn) HealthAndIngesterClient {
+	return &bufferPoolingClient{
+		upstream: upstream,
+		conn:     conn,
+	}
+}
+
+// Push request is overridden from IngesterClient interface.
+func (c *bufferPoolingClient) Push(ctx context.Context, in *mimirpb.WriteRequest, opts ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
+	p := GetPool(ctx)
+	if p == nil {
+		return c.upstream.Push(ctx, in, opts...)
+	}
+
+	wr := &wrappedRequest{
+		WriteRequest: in,
+		slabPool:     p,
+	}
+	// We can return all buffers back to slabPool after this method is finished.
+	defer wr.ReturnBuffersToPool()
+
+	// Use underlying grpc client to invoke method with our wrapped request.
+	// This is a copy of (*ingesterClient).Push method, but passing the wrapped request.
+	// When this wrapped request is marshaled, it will use buffer from our pool.
+	out := new(mimirpb.WriteResponse)
+	err := c.conn.Invoke(ctx, "/cortex.Ingester/Push", wr, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+
+}
+
+func (c *bufferPoolingClient) QueryStream(ctx context.Context, in *QueryRequest, opts ...grpc.CallOption) (Ingester_QueryStreamClient, error) {
+	return c.upstream.QueryStream(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) QueryExemplars(ctx context.Context, in *ExemplarQueryRequest, opts ...grpc.CallOption) (*ExemplarQueryResponse, error) {
+	return c.upstream.QueryExemplars(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) LabelValues(ctx context.Context, in *LabelValuesRequest, opts ...grpc.CallOption) (*LabelValuesResponse, error) {
+	return c.upstream.LabelValues(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) LabelNames(ctx context.Context, in *LabelNamesRequest, opts ...grpc.CallOption) (*LabelNamesResponse, error) {
+	return c.upstream.LabelNames(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) UserStats(ctx context.Context, in *UserStatsRequest, opts ...grpc.CallOption) (*UserStatsResponse, error) {
+	return c.upstream.UserStats(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) AllUserStats(ctx context.Context, in *UserStatsRequest, opts ...grpc.CallOption) (*UsersStatsResponse, error) {
+	return c.upstream.AllUserStats(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) MetricsForLabelMatchers(ctx context.Context, in *MetricsForLabelMatchersRequest, opts ...grpc.CallOption) (*MetricsForLabelMatchersResponse, error) {
+	return c.upstream.MetricsForLabelMatchers(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) MetricsMetadata(ctx context.Context, in *MetricsMetadataRequest, opts ...grpc.CallOption) (*MetricsMetadataResponse, error) {
+	return c.upstream.MetricsMetadata(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) LabelNamesAndValues(ctx context.Context, in *LabelNamesAndValuesRequest, opts ...grpc.CallOption) (Ingester_LabelNamesAndValuesClient, error) {
+	return c.upstream.LabelNamesAndValues(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) LabelValuesCardinality(ctx context.Context, in *LabelValuesCardinalityRequest, opts ...grpc.CallOption) (Ingester_LabelValuesCardinalityClient, error) {
+	return c.upstream.LabelValuesCardinality(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) Check(ctx context.Context, in *grpc_health_v1.HealthCheckRequest, opts ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
+	return c.upstream.Check(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) Watch(ctx context.Context, in *grpc_health_v1.HealthCheckRequest, opts ...grpc.CallOption) (grpc_health_v1.Health_WatchClient, error) {
+	return c.upstream.Watch(ctx, in, opts...)
+}
+
+func (c *bufferPoolingClient) Close() error {
+	return c.upstream.Close()
+}
+
+type poolKey int
+
+var poolKeyValue poolKey = 1
+
+func WithPool(ctx context.Context, pool *pool.FastReleasingSlabPool[byte]) context.Context {
+	if pool != nil {
+		return context.WithValue(ctx, poolKeyValue, pool)
+	}
+	return ctx
+}
+
+func GetPool(ctx context.Context) *pool.FastReleasingSlabPool[byte] {
+	v := ctx.Value(poolKeyValue)
+	if p, ok := v.(*pool.FastReleasingSlabPool[byte]); ok {
+		return p
+	}
+	return nil
+}
+
+type wrappedRequest struct {
+	*mimirpb.WriteRequest
+
+	slabPool    *pool.FastReleasingSlabPool[byte]
+	slabId      int
+	moreSlabIds []int // In case Marshal gets called multiple times.
+}
+
+func (w *wrappedRequest) Marshal() ([]byte, error) {
+	size := w.WriteRequest.Size()
+	buf, slabId := w.slabPool.Get(size)
+
+	if w.slabId == 0 {
+		w.slabId = slabId
+	} else {
+		w.moreSlabIds = append(w.moreSlabIds, slabId)
+	}
+
+	n, err := w.WriteRequest.MarshalToSizedBuffer(buf[:size])
+	if err != nil {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+func (w *wrappedRequest) ReturnBuffersToPool() {
+	if w.slabId != 0 {
+		w.slabPool.Release(w.slabId)
+		w.slabId = 0
+	}
+	for _, s := range w.moreSlabIds {
+		w.slabPool.Release(s)
+	}
+	w.moreSlabIds = nil
+}

--- a/pkg/ingester/client/buffering_client.go
+++ b/pkg/ingester/client/buffering_client.go
@@ -99,7 +99,7 @@ type poolKey int
 
 var poolKeyValue poolKey = 1
 
-func WithPool(ctx context.Context, pool *pool.FastReleasingSlabPool[byte]) context.Context {
+func WithSlabPool(ctx context.Context, pool *pool.FastReleasingSlabPool[byte]) context.Context {
 	if pool != nil {
 		return context.WithValue(ctx, poolKeyValue, pool)
 	}

--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package client
 
 import (

--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -21,24 +21,23 @@ import (
 
 func setupGrpc(t testing.TB) (*mockServer, *grpc.ClientConn) {
 	server := grpc.NewServer()
-	l, err := net.Listen("tcp", "127.0.0.1:")
-	require.NoError(t, err)
 
 	ingServ := &mockServer{}
-
 	RegisterIngesterServer(server, ingServ)
 
-	go func() {
-		_ = server.Serve(l)
-	}()
-
+	l, err := net.Listen("tcp", "127.0.0.1:")
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = l.Close()
 	})
 
+	// Start gRPC server.
+	go func() {
+		_ = server.Serve(l)
+	}()
+
 	c, err := grpc.Dial(l.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
-
 	t.Cleanup(func() {
 		_ = c.Close()
 	})

--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -1,0 +1,250 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+	pool2 "github.com/grafana/mimir/pkg/util/pool"
+)
+
+func setupGrpc(t testing.TB) (*mockServer, *grpc.ClientConn) {
+	server := grpc.NewServer()
+	l, err := net.Listen("tcp", "127.0.0.1:")
+	require.NoError(t, err)
+
+	ingServ := &mockServer{}
+
+	RegisterIngesterServer(server, ingServ)
+
+	go func() {
+		_ = server.Serve(l)
+	}()
+
+	t.Cleanup(func() {
+		_ = l.Close()
+	})
+
+	c, err := grpc.Dial(l.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = c.Close()
+	})
+
+	return ingServ, c
+}
+
+func TestWriteRequestBufferingClient_Push(t *testing.T) {
+	serv, conn := setupGrpc(t)
+
+	bufferingClient := NewWriteRequestBufferingClient(NewIngesterClient(conn), conn)
+
+	var requestsToSends []*mimirpb.WriteRequest
+	for i := 0; i < 10; i++ {
+		requestsToSends = append(requestsToSends, createRequest("test", 100+10*i))
+	}
+
+	t.Run("push without pooling", func(t *testing.T) {
+		serv.clearRequests()
+
+		for _, r := range requestsToSends {
+			_, err := bufferingClient.Push(context.Background(), r)
+			require.NoError(t, err)
+		}
+
+		reqs := serv.requests()
+		require.Equal(t, reqs, requestsToSends)
+	})
+
+	t.Run("push with pooling", func(t *testing.T) {
+		serv.clearRequests()
+
+		pool := &pool2.TrackedPool{Parent: &sync.Pool{}}
+		slabPool := pool2.NewFastReleasingSlabPool[byte](pool, 512*1024)
+
+		ctx := WithPool(context.Background(), slabPool)
+
+		for _, r := range requestsToSends {
+			_, err := bufferingClient.Push(ctx, r)
+			require.NoError(t, err)
+		}
+
+		reqs := serv.requests()
+		require.Equal(t, reqs, requestsToSends)
+
+		// Verify that pool was used.
+		require.Greater(t, pool.Gets.Load(), int64(0))
+		require.Equal(t, int64(0), pool.Balance.Load())
+	})
+}
+
+func BenchmarkWriteRequestBufferingClient_Push(b *testing.B) {
+	bufferingClient := NewWriteRequestBufferingClient(&dummyIngesterClient{}, nil)
+	bufferingClient.pushRawFn = func(ctx context.Context, msg interface{}, opts ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
+		_, err := msg.(proto.Marshaler).Marshal()
+		return nil, err
+	}
+
+	req := createRequest("test", 100)
+
+	b.Run("push without pooling", func(b *testing.B) {
+		ctx := context.Background()
+		for i := 0; i < b.N; i++ {
+			_, err := bufferingClient.Push(ctx, req)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("push with pooling", func(b *testing.B) {
+		ctx := WithPool(context.Background(), pool2.NewFastReleasingSlabPool[byte](&sync.Pool{}, 512*1024))
+		for i := 0; i < b.N; i++ {
+			_, err := bufferingClient.Push(ctx, req)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func TestWriteRequestBufferingClient_PushConcurrent(t *testing.T) {
+	serv, conn := setupGrpc(t)
+
+	bufferingClient := NewWriteRequestBufferingClient(NewIngesterClient(conn), conn)
+	serv.trackSamples = true
+
+	pool := &pool2.TrackedPool{Parent: &sync.Pool{}}
+	slabPool := pool2.NewFastReleasingSlabPool[byte](pool, 512*1024)
+
+	ctx := WithPool(context.Background(), slabPool)
+
+	wg := sync.WaitGroup{}
+
+	const concurrency = 50
+	const requestsPerGoroutine = 100
+
+	for i := 0; i < concurrency; i++ {
+		metricName := fmt.Sprintf("test_%d", i)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			sentSamples := map[string][]mimirpb.Sample{}
+
+			req := createRequest(metricName, 100)
+
+			for i := 0; i < requestsPerGoroutine; i++ {
+				for _, ts := range req.Timeseries {
+					ser := mimirpb.FromLabelAdaptersToLabelsWithCopy(ts.Labels).String()
+					sentSamples[ser] = append(sentSamples[ser], ts.Samples...)
+				}
+
+				_, err := bufferingClient.Push(ctx, req)
+				require.NoError(t, err)
+			}
+
+			// Verify that mock server has all sent samples.
+			for ser, samples := range sentSamples {
+				receivedSamples := serv.getAndRemoveSamplesForSeries(ser)
+				// Each concurrent client is sending samples for its series in order, so we can do this equality check.
+				require.Equal(t, samples, receivedSamples)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify that pool usage.
+	require.Greater(t, pool.Gets.Load(), int64(0))
+	require.Equal(t, int64(0), pool.Balance.Load())
+}
+
+func createRequest(metricName string, seriesPerRequest int) *mimirpb.WriteRequest {
+	metrics := make([]labels.Labels, 0, seriesPerRequest)
+	samples := make([]mimirpb.Sample, 0, seriesPerRequest)
+	for i := 0; i < seriesPerRequest; i++ {
+		metrics = append(metrics, labels.FromStrings(labels.MetricName, metricName, "cardinality", strconv.Itoa(i)))
+		samples = append(samples, mimirpb.Sample{Value: float64(i), TimestampMs: time.Now().UnixMilli()})
+	}
+
+	req := mimirpb.ToWriteRequest(metrics, samples, nil, nil, mimirpb.API)
+	return req
+}
+
+type mockServer struct {
+	IngesterServer
+
+	trackSamples bool
+
+	mu               sync.Mutex
+	reqs             []*mimirpb.WriteRequest
+	samplesPerSeries map[string][]mimirpb.Sample
+}
+
+func (ms *mockServer) Push(_ context.Context, r *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	// Clear unmarshal data. We don't need it and it breaks equality check in test.
+	r.ClearTimeseriesUnmarshalData()
+	ms.reqs = append(ms.reqs, r)
+
+	if ms.trackSamples {
+		if ms.samplesPerSeries == nil {
+			ms.samplesPerSeries = map[string][]mimirpb.Sample{}
+		}
+
+		for _, ts := range r.Timeseries {
+			ser := mimirpb.FromLabelAdaptersToLabelsWithCopy(ts.Labels).String()
+			ms.samplesPerSeries[ser] = append(ms.samplesPerSeries[ser], ts.Samples...)
+		}
+	}
+
+	return &mimirpb.WriteResponse{}, nil
+}
+
+func (ms *mockServer) clearRequests() {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	ms.reqs = nil
+}
+
+func (ms *mockServer) requests() []*mimirpb.WriteRequest {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	return ms.reqs
+}
+
+func (ms *mockServer) getAndRemoveSamplesForSeries(series string) []mimirpb.Sample {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	res := ms.samplesPerSeries[series]
+	delete(ms.samplesPerSeries, series)
+	return res
+}
+
+type dummyIngesterClient struct {
+	IngesterClient
+}
+
+func (d *dummyIngesterClient) Push(ctx context.Context, in *mimirpb.WriteRequest, _ ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
+	_, err := in.Marshal()
+	return nil, err
+}

--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -74,7 +74,7 @@ func TestWriteRequestBufferingClient_Push(t *testing.T) {
 		pool := &pool2.TrackedPool{Parent: &sync.Pool{}}
 		slabPool := pool2.NewFastReleasingSlabPool[byte](pool, 512*1024)
 
-		ctx := WithPool(context.Background(), slabPool)
+		ctx := WithSlabPool(context.Background(), slabPool)
 
 		for _, r := range requestsToSends {
 			_, err := bufferingClient.Push(ctx, r)
@@ -108,7 +108,7 @@ func TestWriteRequestBufferingClient_Push_WithMultipleMarshalCalls(t *testing.T)
 	pool := &pool2.TrackedPool{Parent: &sync.Pool{}}
 	slabPool := pool2.NewFastReleasingSlabPool[byte](pool, 512*1024)
 
-	ctx := WithPool(context.Background(), slabPool)
+	ctx := WithSlabPool(context.Background(), slabPool)
 
 	_, err := bufferingClient.Push(ctx, req)
 	require.NoError(t, err)
@@ -140,7 +140,7 @@ func BenchmarkWriteRequestBufferingClient_Push(b *testing.B) {
 	})
 
 	b.Run("push with pooling", func(b *testing.B) {
-		ctx := WithPool(context.Background(), pool2.NewFastReleasingSlabPool[byte](&sync.Pool{}, 512*1024))
+		ctx := WithSlabPool(context.Background(), pool2.NewFastReleasingSlabPool[byte](&sync.Pool{}, 512*1024))
 		for i := 0; i < b.N; i++ {
 			_, err := bufferingClient.Push(ctx, req)
 			if err != nil {
@@ -159,7 +159,7 @@ func TestWriteRequestBufferingClient_PushConcurrent(t *testing.T) {
 	pool := &pool2.TrackedPool{Parent: &sync.Pool{}}
 	slabPool := pool2.NewFastReleasingSlabPool[byte](pool, 512*1024)
 
-	ctx := WithPool(context.Background(), slabPool)
+	ctx := WithSlabPool(context.Background(), slabPool)
 
 	wg := sync.WaitGroup{}
 

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -50,7 +50,7 @@ func MakeIngesterClient(addr string, cfg Config) (HealthAndIngesterClient, error
 
 	ingClient := NewIngesterClient(conn)
 	if cfg.WriteRequestsBufferPoolingEnabled {
-		ingClient = newWriteRequestBufferingClient(ingClient, conn)
+		ingClient = newBufferPoolingIngesterClient(ingClient, conn)
 	}
 
 	return &closableHealthAndIngesterClient{

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -49,9 +49,7 @@ func MakeIngesterClient(addr string, cfg Config) (HealthAndIngesterClient, error
 	}
 
 	ingClient := NewIngesterClient(conn)
-	if cfg.WriteRequestsBufferPoolingEnabled {
-		ingClient = newBufferPoolingIngesterClient(ingClient, conn)
-	}
+	ingClient = newBufferPoolingIngesterClient(ingClient, conn)
 
 	return &closableHealthAndIngesterClient{
 		IngesterClient: ingClient,
@@ -66,8 +64,7 @@ func (c *closableHealthAndIngesterClient) Close() error {
 
 // Config is the configuration struct for the ingester client
 type Config struct {
-	GRPCClientConfig                  grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between distributors and ingesters."`
-	WriteRequestsBufferPoolingEnabled bool              `yaml:"-"`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between distributors and ingesters."`
 }
 
 // RegisterFlags registers configuration settings used by the ingester client config.

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -50,7 +50,7 @@ func MakeIngesterClient(addr string, cfg Config) (HealthAndIngesterClient, error
 
 	ingClient := NewIngesterClient(conn)
 	if cfg.WriteRequestsBufferPoolingEnabled {
-		ingClient = NewWriteRequestBufferingClient(ingClient, conn)
+		ingClient = newWriteRequestBufferingClient(ingClient, conn)
 	}
 
 	return &closableHealthAndIngesterClient{

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -49,17 +49,15 @@ func MakeIngesterClient(addr string, cfg Config) (HealthAndIngesterClient, error
 	}
 
 	ingClient := NewIngesterClient(conn)
-	var res HealthAndIngesterClient
-	res = &closableHealthAndIngesterClient{
+	if cfg.WriteRequestsBufferPoolingEnabled {
+		ingClient = NewWriteRequestBufferingClient(ingClient, conn)
+	}
+
+	return &closableHealthAndIngesterClient{
 		IngesterClient: ingClient,
 		HealthClient:   grpc_health_v1.NewHealthClient(conn),
 		conn:           conn,
-	}
-
-	if cfg.WriteRequestsBufferPoolingEnabled {
-		res = NewWriteRequestBufferingClient(res, conn)
-	}
-	return res, nil
+	}, nil
 }
 
 func (c *closableHealthAndIngesterClient) Close() error {

--- a/pkg/ingester/client/mimir_util.go
+++ b/pkg/ingester/client/mimir_util.go
@@ -79,7 +79,10 @@ func containsChunk(a []Chunk, b Chunk) bool {
 	return false
 }
 
-func PushRaw(ctx context.Context, client IngesterClient, in interface{}, opts ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
+// PushRaw is a copy of (*ingesterClient).Push method, but accepting message with `interface{}` type instead of `*mimirpb.WriteRequest`.
+// Any message that can be marshaled into bytes by gRPC can be passed here.
+func PushRaw(ctx context.Context, client IngesterClient, msg interface{}, opts ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
+	// unwrap client to find *ingesterClient.
 	if c, ok := client.(*closableHealthAndIngesterClient); ok {
 		client = c.IngesterClient
 	}
@@ -89,7 +92,7 @@ func PushRaw(ctx context.Context, client IngesterClient, in interface{}, opts ..
 	}
 
 	out := new(mimirpb.WriteResponse)
-	err := c.cc.Invoke(ctx, "/cortex.Ingester/Push", in, out, opts...)
+	err := c.cc.Invoke(ctx, "/cortex.Ingester/Push", msg, out, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/client/mimir_util.go
+++ b/pkg/ingester/client/mimir_util.go
@@ -7,11 +7,6 @@ package client
 
 import (
 	context "context"
-	"fmt"
-
-	"google.golang.org/grpc"
-
-	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
 // SendQueryStream wraps the stream's Send() checking if the context is done
@@ -77,24 +72,4 @@ func containsChunk(a []Chunk, b Chunk) bool {
 		}
 	}
 	return false
-}
-
-// PushRaw is a copy of (*ingesterClient).Push method, but accepting message with `interface{}` type instead of `*mimirpb.WriteRequest`.
-// Any message that can be marshaled into bytes by gRPC can be passed here.
-func PushRaw(ctx context.Context, client IngesterClient, msg interface{}, opts ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
-	// unwrap client to find *ingesterClient.
-	if c, ok := client.(*closableHealthAndIngesterClient); ok {
-		client = c.IngesterClient
-	}
-	c, ok := client.(*ingesterClient)
-	if !ok {
-		return nil, fmt.Errorf("invalid ingester client: %T", client)
-	}
-
-	out := new(mimirpb.WriteResponse)
-	err := c.cc.Invoke(ctx, "/cortex.Ingester/Push", msg, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
 }

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -63,7 +63,7 @@ func (p *PreallocWriteRequest) Unmarshal(dAtA []byte) error {
 	return p.WriteRequest.Unmarshal(dAtA)
 }
 
-func (p *PreallocWriteRequest) ClearTimeseriesUnmarshalData() {
+func (p *WriteRequest) ClearTimeseriesUnmarshalData() {
 	for idx := range p.Timeseries {
 		p.Timeseries[idx].clearUnmarshalData()
 	}

--- a/pkg/util/pool/fast_releasing_pool.go
+++ b/pkg/util/pool/fast_releasing_pool.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package pool
 
 import (

--- a/pkg/util/pool/fast_releasing_pool.go
+++ b/pkg/util/pool/fast_releasing_pool.go
@@ -20,6 +20,7 @@ type trackedSlab[T any] struct {
 	nextFreeIndex int
 }
 
+// NewFastReleasingSlabPool returns new "fast-releasing" slab pool.
 func NewFastReleasingSlabPool[T any](delegate Interface, slabSize int) *FastReleasingSlabPool[T] {
 	return &FastReleasingSlabPool[T]{
 		delegate: delegate,

--- a/pkg/util/pool/fast_releasing_pool.go
+++ b/pkg/util/pool/fast_releasing_pool.go
@@ -25,7 +25,8 @@ func NewFastReleasingSlabPool[T any](delegate Interface, slabSize int) *FastRele
 	return &FastReleasingSlabPool[T]{
 		delegate: delegate,
 		slabSize: slabSize,
-		slabs:    []*trackedSlab[T]{nil}, // slabId = 0 is invalid.
+		// slabID = 0 is invalid, next valid slab we add will have index 1.
+		slabs: make([]*trackedSlab[T], 1, 10),
 	}
 }
 

--- a/pkg/util/pool/fast_releasing_pool.go
+++ b/pkg/util/pool/fast_releasing_pool.go
@@ -1,0 +1,118 @@
+package pool
+
+import "sync"
+
+// FastReleasingSlabPool is similar to SlabPool, but allows for fast release of slabs if they are not used anymore.
+type FastReleasingSlabPool[T any] struct {
+	delegate Interface
+	slabSize int
+
+	mtx       sync.Mutex
+	allSlabs  map[int]*trackedSlab[T]
+	freeSlabs map[int]*trackedSlab[T]
+	lastSlab  int
+}
+
+type trackedSlab[T any] struct {
+	slab          []T
+	references    int
+	nextFreeIndex int
+}
+
+func NewFastReleasingSlabPool[T any](delegate Interface, slabSize int) *FastReleasingSlabPool[T] {
+	return &FastReleasingSlabPool[T]{
+		delegate:  delegate,
+		slabSize:  slabSize,
+		allSlabs:  map[int]*trackedSlab[T]{},
+		freeSlabs: map[int]*trackedSlab[T]{},
+	}
+}
+
+func (b *FastReleasingSlabPool[T]) Release(slabId int) {
+	if slabId <= 0 {
+		return
+	}
+
+	var slabToRelease []T
+
+	defer func() {
+		if slabToRelease != nil {
+			b.delegate.Put(slabToRelease)
+		}
+	}()
+
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	ts := b.allSlabs[slabId]
+	if ts == nil || ts.references <= 0 {
+		panic("invalid reference count")
+	}
+
+	ts.references--
+	if ts.references == 0 {
+		delete(b.allSlabs, slabId)
+		delete(b.freeSlabs, slabId)
+	}
+}
+
+// Get returns a slice of T with the given length and capacity (both matches).
+func (b *FastReleasingSlabPool[T]) Get(size int) ([]T, int) {
+	const freeSlabChecks = 3
+
+	if size <= 0 {
+		return nil, 0
+	}
+
+	// If the requested size is bigger than the slab size, then the slice
+	// can't be handled by this pool and will be allocated outside it.
+	if size > b.slabSize {
+		return make([]T, size), 0
+	}
+
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+
+	slabId := 0
+	ts := (*trackedSlab[T])(nil)
+
+	count := 0
+	for sid, s := range b.freeSlabs {
+		if len(s.slab)-s.nextFreeIndex >= size {
+			slabId = sid
+			ts = s
+			break
+		}
+		count++
+		// No space found in few slabs, get a new one.
+		if count >= freeSlabChecks {
+			break
+		}
+	}
+
+	if slabId == 0 {
+		slab := b.delegate.Get().([]T)
+		if slab == nil {
+			slab = make([]T, 0, b.slabSize)
+		}
+
+		ts = &trackedSlab[T]{
+			slab: slab,
+		}
+		b.lastSlab++
+		slabId = b.lastSlab
+		b.allSlabs[slabId] = ts
+		b.freeSlabs[slabId] = ts
+	}
+
+	out := ts.slab[ts.nextFreeIndex : ts.nextFreeIndex+size : ts.nextFreeIndex+size]
+	ts.nextFreeIndex += size
+	ts.references++
+
+	if ts.nextFreeIndex >= len(ts.slab) {
+		// this slab is no longer free, remove it from free slabs.
+		delete(b.freeSlabs, slabId)
+	}
+
+	return out, slabId
+}

--- a/pkg/util/pool/fast_releasing_pool_test.go
+++ b/pkg/util/pool/fast_releasing_pool_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package pool
 
 import (

--- a/pkg/util/pool/fast_releasing_pool_test.go
+++ b/pkg/util/pool/fast_releasing_pool_test.go
@@ -157,7 +157,7 @@ func TestFastReleasingSlabPool_Fuzzy(t *testing.T) {
 	type assertion struct {
 		expected []byte
 		actual   []byte
-		slabId   int
+		slabID   int
 	}
 
 	delegatePool := &TrackedPool{Parent: &sync.Pool{}}
@@ -175,7 +175,7 @@ func TestFastReleasingSlabPool_Fuzzy(t *testing.T) {
 			// Get a random size between 1 and (slabSize + 10)
 			size := 1 + rnd.Intn(slabSize+9)
 
-			slice, slabId := slabPool.Get(size)
+			slice, slabID := slabPool.Get(size)
 
 			// Write some data to the slice.
 			expected := make([]byte, size)
@@ -188,7 +188,7 @@ func TestFastReleasingSlabPool_Fuzzy(t *testing.T) {
 			assertions = append(assertions, assertion{
 				expected: expected,
 				actual:   slice,
-				slabId:   slabId,
+				slabID:   slabID,
 			})
 		}
 
@@ -196,7 +196,7 @@ func TestFastReleasingSlabPool_Fuzzy(t *testing.T) {
 		for _, assertion := range assertions {
 			require.Equal(t, assertion.expected, assertion.actual)
 
-			slabPool.Release(assertion.slabId)
+			slabPool.Release(assertion.slabID)
 		}
 
 		require.Zero(t, delegatePool.Balance.Load())

--- a/pkg/util/pool/fast_releasing_pool_test.go
+++ b/pkg/util/pool/fast_releasing_pool_test.go
@@ -41,10 +41,5 @@ func TestNewFastReleasingSlabPool(t *testing.T) {
 
 	fmt.Println("total size:", totalSize, "slabs:", delegatePool.Gets.Load(), "balance:", delegatePool.Balance.Load())
 	require.Greater(t, delegatePool.Gets.Load(), int64(0))
-
-	// It is very likely that balance isn't zero at this point, although it could be.
-	require.GreaterOrEqual(t, delegatePool.Balance.Load(), int64(0))
-
-	s.ReleaseAll()
 	require.Equal(t, int64(0), delegatePool.Balance.Load())
 }

--- a/pkg/util/pool/fast_releasing_pool_test.go
+++ b/pkg/util/pool/fast_releasing_pool_test.go
@@ -1,0 +1,50 @@
+package pool
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFastReleasingSlabPool(t *testing.T) {
+	delegatePool := &TrackedPool{Parent: &sync.Pool{}}
+
+	const slabSize = 1024
+	const slabsToGet = 100
+
+	s := NewFastReleasingSlabPool[byte](delegatePool, slabSize)
+
+	seed := time.Now().UnixNano()
+	r := rand.New(rand.NewSource(seed))
+
+	totalSize := 0
+	var slabs []int
+	for i := 0; i < slabsToGet; i++ {
+		size := r.Intn(256) + 100
+		bs, si := s.Get(size)
+		slabs = append(slabs, si)
+
+		require.Equal(t, size, len(bs))
+		require.Equal(t, size, cap(bs))
+
+		totalSize += size
+	}
+
+	// Return all slabs
+	for _, si := range slabs {
+		s.Release(si)
+	}
+
+	fmt.Println("total size:", totalSize, "slabs:", delegatePool.Gets.Load(), "balance:", delegatePool.Balance.Load())
+	require.Greater(t, delegatePool.Gets.Load(), int64(0))
+
+	// It is very likely that balance isn't zero at this point, although it could be.
+	require.GreaterOrEqual(t, delegatePool.Balance.Load(), int64(0))
+
+	s.ReleaseAll()
+	require.Equal(t, int64(0), delegatePool.Balance.Load())
+}

--- a/pkg/util/pool/fast_releasing_pool_test.go
+++ b/pkg/util/pool/fast_releasing_pool_test.go
@@ -15,12 +15,12 @@ func TestFastReleasingSlabPool(t *testing.T) {
 		delegatePool := &TrackedPool{Parent: &sync.Pool{}}
 		slabPool := NewFastReleasingSlabPool[byte](delegatePool, 10)
 
-		sliceA, slabIdA := slabPool.Get(5)
+		sliceA, slabIDA := slabPool.Get(5)
 		require.Len(t, sliceA, 5)
 		require.Equal(t, 5, cap(sliceA))
 		copy(sliceA, "12345")
 
-		sliceB, slabIdB := slabPool.Get(5)
+		sliceB, slabIDB := slabPool.Get(5)
 		require.Len(t, sliceB, 5)
 		require.Equal(t, 5, cap(sliceB))
 		copy(sliceB, "67890")
@@ -33,21 +33,21 @@ func TestFastReleasingSlabPool(t *testing.T) {
 		require.Equal(t, 2, slabPool.slabs[1].references)
 		require.Equal(t, 10, slabPool.slabs[1].nextFreeIndex)
 
-		slabPool.Release(slabIdA)
+		slabPool.Release(slabIDA)
 
 		require.Equal(t, 2, len(slabPool.slabs))
 		require.Nil(t, slabPool.slabs[0])
 		require.Equal(t, 1, slabPool.slabs[1].references)
 		require.Equal(t, 10, slabPool.slabs[1].nextFreeIndex)
 
-		slabPool.Release(slabIdB)
+		slabPool.Release(slabIDB)
 
 		require.Equal(t, 2, len(slabPool.slabs))
 		require.Nil(t, slabPool.slabs[0])
 		require.Nil(t, slabPool.slabs[1])
 
 		// Allocating another slice needs a new slab.
-		sliceC, slabIdC := slabPool.Get(5)
+		sliceC, slabIDC := slabPool.Get(5)
 		require.Len(t, sliceC, 5)
 		require.Equal(t, 5, cap(sliceB))
 
@@ -57,7 +57,7 @@ func TestFastReleasingSlabPool(t *testing.T) {
 		require.Equal(t, 1, slabPool.slabs[2].references)
 		require.Equal(t, 5, slabPool.slabs[2].nextFreeIndex)
 
-		slabPool.Release(slabIdC)
+		slabPool.Release(slabIDC)
 
 		require.Equal(t, 3, len(slabPool.slabs))
 		require.Nil(t, slabPool.slabs[0])
@@ -65,14 +65,14 @@ func TestFastReleasingSlabPool(t *testing.T) {
 		require.Nil(t, slabPool.slabs[2])
 
 		require.Zero(t, delegatePool.Balance.Load())
-		require.Equal(t, int(delegatePool.Gets.Load()), 2)
+		require.Equal(t, 2, int(delegatePool.Gets.Load()))
 	})
 
 	t.Run("a new slab is created when the new slice doesn't fit on an existing one", func(t *testing.T) {
 		delegatePool := &TrackedPool{Parent: &sync.Pool{}}
 		slabPool := NewFastReleasingSlabPool[byte](delegatePool, 10)
 
-		sliceA, slabIdA := slabPool.Get(5)
+		sliceA, slabIDA := slabPool.Get(5)
 		assert.Len(t, sliceA, 5)
 		assert.Equal(t, 5, cap(sliceA))
 		copy(sliceA, "12345")
@@ -83,7 +83,7 @@ func TestFastReleasingSlabPool(t *testing.T) {
 		require.Equal(t, 1, slabPool.slabs[1].references)
 
 		// Size doesn't fit the existing slab, so a new one will be created.
-		sliceB, slabIdB := slabPool.Get(6)
+		sliceB, slabIDB := slabPool.Get(6)
 		assert.Len(t, sliceB, 6)
 		assert.Equal(t, 6, cap(sliceB))
 		copy(sliceB, "67890-")
@@ -98,7 +98,7 @@ func TestFastReleasingSlabPool(t *testing.T) {
 		require.Equal(t, 1, slabPool.slabs[2].references)
 
 		// Size fits in the last slab.
-		sliceC, slabIdC := slabPool.Get(3)
+		sliceC, slabIDC := slabPool.Get(3)
 		assert.Len(t, sliceC, 3)
 		assert.Equal(t, 3, cap(sliceC))
 		copy(sliceC, "abc")
@@ -113,7 +113,7 @@ func TestFastReleasingSlabPool(t *testing.T) {
 		require.Equal(t, 2, slabPool.slabs[2].references)
 
 		// Size fits in the previous last slab.
-		sliceD, slabIdD := slabPool.Get(3)
+		sliceD, slabIDD := slabPool.Get(3)
 		assert.Len(t, sliceD, 3)
 		assert.Equal(t, 3, cap(sliceD))
 		copy(sliceD, "def")
@@ -132,10 +132,10 @@ func TestFastReleasingSlabPool(t *testing.T) {
 		assert.Equal(t, "abc", string(sliceC))
 		assert.Equal(t, "def", string(sliceD))
 
-		slabPool.Release(slabIdA)
-		slabPool.Release(slabIdB)
-		slabPool.Release(slabIdC)
-		slabPool.Release(slabIdD)
+		slabPool.Release(slabIDA)
+		slabPool.Release(slabIDB)
+		slabPool.Release(slabIDC)
+		slabPool.Release(slabIDD)
 
 		require.Equal(t, 3, len(slabPool.slabs))
 		require.Nil(t, slabPool.slabs[0])

--- a/pkg/util/pool/pool_test.go
+++ b/pkg/util/pool/pool_test.go
@@ -123,7 +123,7 @@ func TestSlabPool_Fuzzy(t *testing.T) {
 
 	// Randomise the seed but log it in case we need to reproduce the test on failure.
 	seed := time.Now().UnixNano()
-	rand.Seed(seed)
+	rnd := rand.New(rand.NewSource(seed))
 	t.Log("random generator seed:", seed)
 
 	for r := 0; r < numRuns; r++ {
@@ -132,13 +132,13 @@ func TestSlabPool_Fuzzy(t *testing.T) {
 
 		for n := 0; n < numRequestsPerRun; n++ {
 			// Get a random size between 1 and (slabSize + 10)
-			size := 1 + rand.Intn(slabSize+9)
+			size := 1 + rnd.Intn(slabSize+9)
 
 			slice := slabPool.Get(size)
 
 			// Write some data to the slice.
 			expected := make([]byte, size)
-			_, err := rand.Read(expected)
+			_, err := rnd.Read(expected)
 			require.NoError(t, err)
 
 			copy(slice, expected)


### PR DESCRIPTION
#### What this PR does

When distributor receives a write request, distributor splits it into multiple smaller requests, and forward each of them to single ingester. In this step distributor needs to marshal protobuf messages. This PR adds pooling of buffers when doing this marshalling.

The actual pooling logic is implemented in a wrapper to `IngesterClient` (grpc interface for communicating with ingester).

Our benchmark in dev environment show about 7% reduction of CPU time with this change.

Result of benchmark in this PR shows reduction of allocations per `Push` call (for purpose of this benchmark, `Push` only calls message `Marshal`):

```
name                                                      time/op
WriteRequestBufferingClient_Push/push_without_pooling-10  7.18µs ± 0%
WriteRequestBufferingClient_Push/push_with_pooling-10     6.58µs ± 0%

name                                                      alloc/op
WriteRequestBufferingClient_Push/push_without_pooling-10  6.14kB ± 0%
WriteRequestBufferingClient_Push/push_with_pooling-10       175B ± 3%

name                                                      allocs/op
WriteRequestBufferingClient_Push/push_without_pooling-10    1.00 ± 0%
WriteRequestBufferingClient_Push/push_with_pooling-10       3.00 ± 0%
```

This PR also adds "fast releasing slab pool". Compared to existing "slab pool" implementation that already exists in Mimir codebase, "fast releasing" one can release individual slabs (pooled object) as soon as they are not used, instead of waiting for final `Release` call on the slab pool.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
