### PR TITLE
Fix flaky TestSeriesChunksStreamReader_ChunksLimits test.

### DIFF
--- a/pkg/ingester/client/streaming_test.go
+++ b/pkg/ingester/client/streaming_test.go
@@ -251,7 +251,7 @@ func TestSeriesChunksStreamReader_ChunksLimits(t *testing.T) {
 				require.EqualError(t, err, testCase.expectedError)
 			}
 
-			require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed")
+			require.Eventually(t, mockClient.closed.Load, time.Second, 10*time.Millisecond, "expected gRPC client to be closed")
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes a test that occasionally flakes due to a race condition.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
