### PR TITLE
Add option to query minimum set of ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [ENHANCEMENT] Query-frontend: added "response_size_bytes" field to "query stats" log. #5196
 * [ENHANCEMENT] Querier: Refine error messages for per-tenant query limits, informing the user of the preferred strategy for not hitting the limit, in addition to how they may tweak the limit. #5059
 * [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. For now this optimization can be disabled by setting `-distributor.write-requests-buffer-pooling-enabled` to `false`. #5195
+* [ENHANCEMENT] Querier: add experimental `-querier.minimize-ingester-requests` option to initially query only the minimum set of ingesters required to reach quorum. #5202
 * [BUGFIX] Querier: don't leak memory when processing query requests from query-frontends (ie. when the query-scheduler is disabled). #5199
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1675,12 +1675,12 @@
         },
         {
           "kind": "field",
-          "name": "minimise_ingester_requests",
+          "name": "minimize_ingester_requests",
           "required": false,
           "desc": "If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path.",
           "fieldValue": null,
           "fieldDefaultValue": false,
-          "fieldFlag": "querier.minimise-ingester-requests",
+          "fieldFlag": "querier.minimize-ingester-requests",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
         },

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1675,6 +1675,17 @@
         },
         {
           "kind": "field",
+          "name": "minimise_ingester_requests",
+          "required": false,
+          "desc": "If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "querier.minimise-ingester-requests",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "max_concurrent",
           "required": false,
           "desc": "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1587,7 +1587,7 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of split (by time) or partial (by shard) queries that will be scheduled in parallel by the query-frontend for a single input query. This limit is introduced to have a fairer query scheduling and avoid a single query over a large time range saturating all available queriers. (default 14)
   -querier.max-samples int
     	Maximum number of samples a single query can load into memory. This config option should be set on query-frontend too when query sharding is enabled. (default 50000000)
-  -querier.minimise-ingester-requests
+  -querier.minimize-ingester-requests
     	[experimental] If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path.
   -querier.prefer-streaming-chunks
     	[experimental] Request ingesters stream chunks. Ingesters will only respond with a stream of chunks if the target ingester supports this, and this preference will be ignored by ingesters that do not support this.

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1587,6 +1587,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of split (by time) or partial (by shard) queries that will be scheduled in parallel by the query-frontend for a single input query. This limit is introduced to have a fairer query scheduling and avoid a single query over a large time range saturating all available queriers. (default 14)
   -querier.max-samples int
     	Maximum number of samples a single query can load into memory. This config option should be set on query-frontend too when query sharding is enabled. (default 50000000)
+  -querier.minimise-ingester-requests
+    	[experimental] If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path.
   -querier.prefer-streaming-chunks
     	[experimental] Request ingesters stream chunks. Ingesters will only respond with a stream of chunks if the target ingester supports this, and this preference will be ignored by ingesters that do not support this.
   -querier.query-ingesters-within duration

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1080,8 +1080,8 @@ store_gateway_client:
 # ingesters queried only if needed due to failures from the initial set of
 # ingesters. Enabling this option reduces resource consumption for the happy
 # path at the cost of increased latency for the unhappy path.
-# CLI flag: -querier.minimise-ingester-requests
-[minimise_ingester_requests: <boolean> | default = false]
+# CLI flag: -querier.minimize-ingester-requests
+[minimize_ingester_requests: <boolean> | default = false]
 
 # The number of workers running in each querier process. This setting limits the
 # maximum number of concurrent queries in each querier.

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1075,6 +1075,14 @@ store_gateway_client:
 # CLI flag: -querier.streaming-chunks-per-ingester-buffer-size
 [streaming_chunks_per_ingester_series_buffer_size: <int> | default = 256]
 
+# (experimental) If true, when querying ingesters, only the minimum required
+# ingesters required to reach quorum will be queried initially, with other
+# ingesters queried only if needed due to failures from the initial set of
+# ingesters. Enabling this option reduces resource consumption for the happy
+# path at the cost of increased latency for the unhappy path.
+# CLI flag: -querier.minimise-ingester-requests
+[minimise_ingester_requests: <boolean> | default = false]
+
 # The number of workers running in each querier process. This setting limits the
 # maximum number of concurrent queries in each querier.
 # CLI flag: -querier.max-concurrent

--- a/integration/ingester_test.go
+++ b/integration/ingester_test.go
@@ -389,3 +389,94 @@ func TestIngesterQuerying(t *testing.T) {
 		})
 	}
 }
+
+func TestIngesterQueryingWithRequestMinimization(t *testing.T) {
+	for _, streamingEnabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("streaming enabled: %v", streamingEnabled), func(t *testing.T) {
+			s, err := e2e.NewScenario(networkName)
+			require.NoError(t, err)
+			defer s.Close()
+
+			baseFlags := map[string]string{
+				"-distributor.ingestion-tenant-shard-size": "0",
+				"-ingester.ring.heartbeat-period":          "1s",
+				"-ingester.ring.zone-awareness-enabled":    "true",
+				"-ingester.ring.replication-factor":        "3",
+				"-querier.minimize-ingester-requests":      "true",
+				"-querier.prefer-streaming-chunks":         strconv.FormatBool(streamingEnabled),
+			}
+
+			flags := mergeFlags(
+				BlocksStorageFlags(),
+				BlocksStorageS3Flags(),
+				baseFlags,
+			)
+
+			// Start dependencies.
+			consul := e2edb.NewConsul()
+			minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+			require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+			ingesterFlags := func(zone string) map[string]string {
+				return mergeFlags(flags, map[string]string{
+					"-ingester.ring.instance-availability-zone": zone,
+				})
+			}
+
+			// Start Mimir components.
+			distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+			ingester1 := e2emimir.NewIngester("ingester-1", consul.NetworkHTTPEndpoint(), ingesterFlags("zone-a"))
+			ingester2 := e2emimir.NewIngester("ingester-2", consul.NetworkHTTPEndpoint(), ingesterFlags("zone-b"))
+			ingester3 := e2emimir.NewIngester("ingester-3", consul.NetworkHTTPEndpoint(), ingesterFlags("zone-c"))
+			querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
+			require.NoError(t, s.StartAndWaitReady(distributor, ingester1, ingester2, ingester3, querier))
+
+			// Wait until distributor and querier have updated the ring.
+			for _, component := range []*e2emimir.MimirService{distributor, querier} {
+				require.NoError(t, component.WaitSumMetricsWithOptions(e2e.Equals(3), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+					labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+					labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+			}
+
+			client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
+			require.NoError(t, err)
+
+			// Push some data to the cluster.
+			seriesName := "test_series"
+			now := time.Now()
+			series, expectedVector, _ := generateFloatSeries(seriesName, now, prompb.Label{Name: "foo", Value: "bar"})
+
+			res, err := client.Push(series)
+			require.NoError(t, err)
+			require.Equal(t, 200, res.StatusCode)
+
+			// Verify we can query the data we just pushed.
+			queryResult, err := client.Query(seriesName, now)
+			require.NoError(t, err)
+			require.Equal(t, model.ValVector, queryResult.Type())
+			require.Equal(t, expectedVector, queryResult.(model.Vector))
+
+			// Check that we only queried two of the three ingesters.
+			totalQueryRequests := 0.0
+
+			for _, ingester := range []*e2emimir.MimirService{ingester1, ingester2, ingester3} {
+				sums, err := ingester.SumMetrics(
+					[]string{"cortex_request_duration_seconds"},
+					e2e.WithLabelMatchers(
+						labels.MustNewMatcher(labels.MatchEqual, "route", "/cortex.Ingester/QueryStream"),
+						labels.MustNewMatcher(labels.MatchEqual, "status_code", "success"),
+					),
+					e2e.SkipMissingMetrics,
+					e2e.WithMetricCount,
+				)
+
+				require.NoError(t, err)
+				queryRequests := sums[0]
+				require.LessOrEqual(t, queryRequests, 1.0)
+				totalQueryRequests += queryRequests
+			}
+
+			require.Equal(t, 2.0, totalQueryRequests)
+		})
+	}
+}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -165,7 +165,7 @@ type Config struct {
 	ShuffleShardingLookbackPeriod              time.Duration `yaml:"-"`
 	PreferStreamingChunks                      bool          `yaml:"-"`
 	StreamingChunksPerIngesterSeriesBufferSize uint64        `yaml:"-"`
-	MinimiseIngesterRequests                   bool          `yaml:"-"`
+	MinimizeIngesterRequests                   bool          `yaml:"-"`
 
 	// Limits for distributor
 	DefaultLimits    InstanceLimits         `yaml:"instance_limits"`

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -165,6 +165,7 @@ type Config struct {
 	ShuffleShardingLookbackPeriod              time.Duration `yaml:"-"`
 	PreferStreamingChunks                      bool          `yaml:"-"`
 	StreamingChunksPerIngesterSeriesBufferSize uint64        `yaml:"-"`
+	MinimiseIngesterRequests                   bool          `yaml:"-"`
 
 	// Limits for distributor
 	DefaultLimits    InstanceLimits         `yaml:"instance_limits"`

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -303,7 +303,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 		}
 	}
 
-	results, err := ring.DoUntilQuorum(ctx, replicationSet, d.cfg.MinimiseIngesterRequests, queryIngester, cleanup)
+	results, err := ring.DoUntilQuorum(ctx, replicationSet, d.cfg.MinimizeIngesterRequests, queryIngester, cleanup)
 	if err != nil {
 		return ingester_client.CombinedQueryStreamResponse{}, err
 	}

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -303,7 +303,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 		}
 	}
 
-	results, err := ring.DoUntilQuorum(ctx, replicationSet, false, queryIngester, cleanup)
+	results, err := ring.DoUntilQuorum(ctx, replicationSet, d.cfg.MinimiseIngesterRequests, queryIngester, cleanup)
 	if err != nil {
 		return ingester_client.CombinedQueryStreamResponse{}, err
 	}

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -355,7 +355,7 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 
 	t.Cfg.Distributor.PreferStreamingChunks = t.Cfg.Querier.PreferStreamingChunks
 	t.Cfg.Distributor.StreamingChunksPerIngesterSeriesBufferSize = t.Cfg.Querier.StreamingChunksPerIngesterSeriesBufferSize
-	t.Cfg.Distributor.MinimiseIngesterRequests = t.Cfg.Querier.MinimiseIngesterRequests
+	t.Cfg.Distributor.MinimizeIngesterRequests = t.Cfg.Querier.MinimizeIngesterRequests
 
 	t.Distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.Overrides, t.ActiveGroupsCleanup, t.Ring, canJoinDistributorsRing, t.Registerer, util_log.Logger)
 	if err != nil {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -355,6 +355,7 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 
 	t.Cfg.Distributor.PreferStreamingChunks = t.Cfg.Querier.PreferStreamingChunks
 	t.Cfg.Distributor.StreamingChunksPerIngesterSeriesBufferSize = t.Cfg.Querier.StreamingChunksPerIngesterSeriesBufferSize
+	t.Cfg.Distributor.MinimiseIngesterRequests = t.Cfg.Querier.MinimiseIngesterRequests
 
 	t.Distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.Overrides, t.ActiveGroupsCleanup, t.Ring, canJoinDistributorsRing, t.Registerer, util_log.Logger)
 	if err != nil {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -53,7 +53,7 @@ type Config struct {
 
 	PreferStreamingChunks                      bool   `yaml:"prefer_streaming_chunks" category:"experimental"`
 	StreamingChunksPerIngesterSeriesBufferSize uint64 `yaml:"streaming_chunks_per_ingester_series_buffer_size" category:"experimental"`
-	MinimiseIngesterRequests                   bool   `yaml:"minimise_ingester_requests" category:"experimental"`
+	MinimizeIngesterRequests                   bool   `yaml:"minimize_ingester_requests" category:"experimental"`
 
 	// PromQL engine config.
 	EngineConfig engine.Config `yaml:",inline"`
@@ -83,7 +83,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.QueryStoreAfter, queryStoreAfterFlag, 12*time.Hour, "The time after which a metric should be queried from storage and not just ingesters. 0 means all queries are sent to store. If this option is enabled, the time range of the query sent to the store-gateway will be manipulated to ensure the query end is not more recent than 'now - query-store-after'.")
 	f.BoolVar(&cfg.ShuffleShardingIngestersEnabled, "querier.shuffle-sharding-ingesters-enabled", true, fmt.Sprintf("Fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since -%s. If this setting is false or -%s is '0', queriers always query all ingesters (ingesters shuffle sharding on read path is disabled).", validation.QueryIngestersWithinFlag, validation.QueryIngestersWithinFlag))
 	f.BoolVar(&cfg.PreferStreamingChunks, "querier.prefer-streaming-chunks", false, "Request ingesters stream chunks. Ingesters will only respond with a stream of chunks if the target ingester supports this, and this preference will be ignored by ingesters that do not support this.")
-	f.BoolVar(&cfg.MinimiseIngesterRequests, "querier.minimise-ingester-requests", false, "If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path.")
+	f.BoolVar(&cfg.MinimizeIngesterRequests, "querier.minimize-ingester-requests", false, "If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path.")
 
 	// Why 256 series / ingester?
 	// Based on our testing, 256 series / ingester was a good balance between memory consumption and the CPU overhead of managing a batch of series.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -53,6 +53,7 @@ type Config struct {
 
 	PreferStreamingChunks                      bool   `yaml:"prefer_streaming_chunks" category:"experimental"`
 	StreamingChunksPerIngesterSeriesBufferSize uint64 `yaml:"streaming_chunks_per_ingester_series_buffer_size" category:"experimental"`
+	MinimiseIngesterRequests                   bool   `yaml:"minimise_ingester_requests" category:"experimental"`
 
 	// PromQL engine config.
 	EngineConfig engine.Config `yaml:",inline"`
@@ -82,6 +83,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.QueryStoreAfter, queryStoreAfterFlag, 12*time.Hour, "The time after which a metric should be queried from storage and not just ingesters. 0 means all queries are sent to store. If this option is enabled, the time range of the query sent to the store-gateway will be manipulated to ensure the query end is not more recent than 'now - query-store-after'.")
 	f.BoolVar(&cfg.ShuffleShardingIngestersEnabled, "querier.shuffle-sharding-ingesters-enabled", true, fmt.Sprintf("Fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since -%s. If this setting is false or -%s is '0', queriers always query all ingesters (ingesters shuffle sharding on read path is disabled).", validation.QueryIngestersWithinFlag, validation.QueryIngestersWithinFlag))
 	f.BoolVar(&cfg.PreferStreamingChunks, "querier.prefer-streaming-chunks", false, "Request ingesters stream chunks. Ingesters will only respond with a stream of chunks if the target ingester supports this, and this preference will be ignored by ingesters that do not support this.")
+	f.BoolVar(&cfg.MinimiseIngesterRequests, "querier.minimise-ingester-requests", false, "If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path.")
 
 	// Why 256 series / ingester?
 	// Based on our testing, 256 series / ingester was a good balance between memory consumption and the CPU overhead of managing a batch of series.


### PR DESCRIPTION
#### What this PR does

This PR adds experimental support for querying the minimal set of ingesters required to reach quorum.

With `-querier.minimize-ingester-requests=false` (the default), queriers behave as they do today: they send a request to all ingesters in the tenant's shard, wait until quorum is reached and then cancel any outstanding unnecessary requests.

With `-querier.minimize-ingester-requests=true`, queriers instead initially only send requests to the minimum number of ingesters required to reach quorum, and initiate requests to further ingesters if any of the initial requests fail. (If enough requests fail that quorum is impossible, all requests are cancelled as before, and no further requests are made.)

This reduces querier and ingester resource utilisation on the happy path, at the cost of increased latency on the unhappy path where one or more ingesters return an error, fail to respond, or respond slowly.

#### Which issue(s) this PR fixes or relates to

* https://github.com/grafana/dskit/pull/306
* https://github.com/grafana/mimir/pull/5016

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
