### PR TITLE
Use localhost:0 as bind address when creating listening socket.

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -29,7 +29,9 @@ func (fl *FakeLogger) Log(...interface{}) error {
 func TestNewApiWithoutSourceIPExtractor(t *testing.T) {
 	cfg := Config{}
 	serverCfg := server.Config{
-		MetricsNamespace: "without_source_ip_extractor",
+		HTTPListenAddress: "localhost",
+		GRPCListenAddress: "localhost",
+		MetricsNamespace:  "without_source_ip_extractor",
 	}
 	srv, err := server.New(serverCfg)
 	require.NoError(t, err)
@@ -42,8 +44,10 @@ func TestNewApiWithoutSourceIPExtractor(t *testing.T) {
 func TestNewApiWithSourceIPExtractor(t *testing.T) {
 	cfg := Config{}
 	serverCfg := server.Config{
-		LogSourceIPs:     true,
-		MetricsNamespace: "with_source_ip_extractor",
+		LogSourceIPs:      true,
+		HTTPListenAddress: "localhost",
+		GRPCListenAddress: "localhost",
+		MetricsNamespace:  "with_source_ip_extractor",
 	}
 	srv, err := server.New(serverCfg)
 	require.NoError(t, err)

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -46,7 +46,7 @@ func setupFrontend(t *testing.T, reg prometheus.Registerer, schedulerReplyFunc f
 }
 
 func setupFrontendWithConcurrencyAndServerOptions(t *testing.T, reg prometheus.Registerer, schedulerReplyFunc func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend, concurrency int, opts ...grpc.ServerOption) (*Frontend, *mockScheduler) {
-	l, err := net.Listen("tcp", "")
+	l, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
 	server := grpc.NewServer(opts...)

--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -27,7 +27,7 @@ func setupGrpc(t testing.TB) (*mockServer, *grpc.ClientConn) {
 	ingServ := &mockServer{}
 	RegisterIngesterServer(server, ingServ)
 
-	l, err := net.Listen("tcp", "127.0.0.1:")
+	l, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = l.Close()

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -59,6 +59,10 @@ import (
 
 func TestMimir(t *testing.T) {
 	cfg := Config{
+		Server: server.Config{
+			HTTPListenAddress: "localhost",
+			GRPCListenAddress: "localhost",
+		},
 		Ingester: ingester.Config{
 			BlocksStorageConfig: tsdb.BlocksStorageConfig{
 				Bucket: bucket.Config{

--- a/pkg/mimir/server_service_test.go
+++ b/pkg/mimir/server_service_test.go
@@ -17,7 +17,11 @@ import (
 )
 
 func TestServerStopViaContext(t *testing.T) {
-	serv, err := server.New(server.Config{Registerer: prometheus.NewPedanticRegistry()})
+	serv, err := server.New(server.Config{
+		HTTPListenAddress: "localhost",
+		GRPCListenAddress: "localhost",
+		Registerer:        prometheus.NewPedanticRegistry(),
+	})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -31,7 +35,11 @@ func TestServerStopViaContext(t *testing.T) {
 }
 
 func TestServerStopViaShutdown(t *testing.T) {
-	serv, err := server.New(server.Config{Registerer: prometheus.NewPedanticRegistry()})
+	serv, err := server.New(server.Config{
+		HTTPListenAddress: "localhost",
+		GRPCListenAddress: "localhost",
+		Registerer:        prometheus.NewPedanticRegistry(),
+	})
 	require.NoError(t, err)
 
 	s := NewServerService(serv, func() []services.Service { return nil })
@@ -45,7 +53,11 @@ func TestServerStopViaShutdown(t *testing.T) {
 }
 
 func TestServerStopViaStop(t *testing.T) {
-	serv, err := server.New(server.Config{Registerer: prometheus.NewPedanticRegistry()})
+	serv, err := server.New(server.Config{
+		HTTPListenAddress: "localhost",
+		GRPCListenAddress: "localhost",
+		Registerer:        prometheus.NewPedanticRegistry(),
+	})
 	require.NoError(t, err)
 
 	s := NewServerService(serv, func() []services.Service { return nil })

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -52,7 +52,7 @@ func setupScheduler(t *testing.T, reg prometheus.Registerer) (*Scheduler, schedu
 		_ = services.StopAndAwaitTerminated(context.Background(), s)
 	})
 
-	l, err := net.Listen("tcp", "")
+	l, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
 	go func() {
@@ -362,7 +362,7 @@ func TestSchedulerForwardsErrorToFrontend(t *testing.T) {
 		frontendGrpcServer := grpc.NewServer()
 		frontendv2pb.RegisterFrontendForQuerierServer(frontendGrpcServer, fm)
 
-		l, err := net.Listen("tcp", "")
+		l, err := net.Listen("tcp", "localhost:0")
 		require.NoError(t, err)
 
 		frontendAddress = l.Addr().String()

--- a/pkg/util/gziphandler/gzip_test.go
+++ b/pkg/util/gziphandler/gzip_test.go
@@ -273,7 +273,7 @@ func TestGzipHandlerContentLength(t *testing.T) {
 	// httptest.NewRecorder doesn't give you access to the Content-Length
 	// header so instead, we create a server on a random port and make
 	// a request to that instead
-	ln, err := net.Listen("tcp", "127.0.0.1:")
+	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed creating listen socket: %v", err)
 	}

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -155,13 +155,15 @@ func (p *Proxy) Start() error {
 	// Setup server first, so we can fail early if the ports are in use.
 	serv, err := server.New(server.Config{
 		// HTTP configs
+		HTTPListenAddress:             "localhost",
 		HTTPListenPort:                p.cfg.ServerHTTPServicePort,
 		HTTPServerReadTimeout:         1 * time.Minute,
 		HTTPServerWriteTimeout:        2 * time.Minute,
 		ServerGracefulShutdownTimeout: 0,
 
 		// gRPC configs
-		GRPCListenPort: p.cfg.ServerGRPCServicePort,
+		GRPCListenAddress: "localhost",
+		GRPCListenPort:    p.cfg.ServerGRPCServicePort,
 		// Same size configurations as in Mimir default gRPC configuration values
 		GPRCServerMaxRecvMsgSize:           100 * 1024 * 1024,
 		GRPCServerMaxSendMsgSize:           100 * 1024 * 1024,

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -26,7 +26,9 @@ import (
 var errMinBackends = errors.New("at least 1 backend is required")
 
 type ProxyConfig struct {
+	ServerHTTPServiceAddress       string
 	ServerHTTPServicePort          int
+	ServerGRPCServiceAddress       string
 	ServerGRPCServicePort          int
 	BackendEndpoints               string
 	PreferredBackend               string
@@ -39,8 +41,10 @@ type ProxyConfig struct {
 }
 
 func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
-	f.IntVar(&cfg.ServerHTTPServicePort, "server.http-service-port", 80, "The HTTP port where the query-tee service listens to HTTP requests.")
-	f.IntVar(&cfg.ServerGRPCServicePort, "server.grpc-service-port", 9095, "The GRPC port where the query-tee service listens to HTTP over gRPC messages.")
+	f.StringVar(&cfg.ServerHTTPServiceAddress, "server.http-service-address", "", "Bind address for server where query-tee service listens for HTTP requests.")
+	f.IntVar(&cfg.ServerHTTPServicePort, "server.http-service-port", 80, "The HTTP port where the query-tee service listens for HTTP requests.")
+	f.StringVar(&cfg.ServerGRPCServiceAddress, "server.grpc-service-address", "", "Bind address for server where query-tee service listens for HTTP over gRPC requests.")
+	f.IntVar(&cfg.ServerGRPCServicePort, "server.grpc-service-port", 9095, "The GRPC port where the query-tee service listens for HTTP over gRPC messages.")
 	f.StringVar(&cfg.BackendEndpoints, "backend.endpoints", "", "Comma separated list of backend endpoints to query.")
 	f.StringVar(&cfg.PreferredBackend, "backend.preferred", "", "The hostname of the preferred backend when selecting the response to send back to the client. If no preferred backend is configured then the query-tee will send back to the client the first successful response received without waiting for other backends.")
 	f.DurationVar(&cfg.BackendReadTimeout, "backend.read-timeout", 150*time.Second, "The timeout when reading the response from a backend.")
@@ -155,14 +159,14 @@ func (p *Proxy) Start() error {
 	// Setup server first, so we can fail early if the ports are in use.
 	serv, err := server.New(server.Config{
 		// HTTP configs
-		HTTPListenAddress:             "localhost",
+		HTTPListenAddress:             p.cfg.ServerHTTPServiceAddress,
 		HTTPListenPort:                p.cfg.ServerHTTPServicePort,
 		HTTPServerReadTimeout:         1 * time.Minute,
 		HTTPServerWriteTimeout:        2 * time.Minute,
 		ServerGracefulShutdownTimeout: 0,
 
 		// gRPC configs
-		GRPCListenAddress: "localhost",
+		GRPCListenAddress: p.cfg.ServerGRPCServiceAddress,
 		GRPCListenPort:    p.cfg.ServerGRPCServicePort,
 		// Same size configurations as in Mimir default gRPC configuration values
 		GPRCServerMaxRecvMsgSize:           100 * 1024 * 1024,

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -167,11 +167,13 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 
 			// Start the proxy.
 			cfg := ProxyConfig{
-				BackendEndpoints:      strings.Join(backendURLs, ","),
-				PreferredBackend:      strconv.Itoa(testData.preferredBackendIdx),
-				ServerHTTPServicePort: 0,
-				ServerGRPCServicePort: 0,
-				BackendReadTimeout:    time.Second,
+				BackendEndpoints:         strings.Join(backendURLs, ","),
+				PreferredBackend:         strconv.Itoa(testData.preferredBackendIdx),
+				ServerHTTPServiceAddress: "localhost",
+				ServerHTTPServicePort:    0,
+				ServerGRPCServiceAddress: "localhost",
+				ServerGRPCServicePort:    0,
+				BackendReadTimeout:       time.Second,
 			}
 
 			if len(backendURLs) == 2 {
@@ -323,7 +325,9 @@ func TestProxy_Passthrough(t *testing.T) {
 			cfg := ProxyConfig{
 				BackendEndpoints:               strings.Join(backendURLs, ","),
 				PreferredBackend:               strconv.Itoa(testData.preferredBackendIdx),
+				ServerHTTPServiceAddress:       "localhost",
 				ServerHTTPServicePort:          0,
+				ServerGRPCServiceAddress:       "localhost",
 				ServerGRPCServicePort:          0,
 				BackendReadTimeout:             time.Second,
 				PassThroughNonRegisteredRoutes: true,
@@ -395,11 +399,13 @@ func TestProxyHTTPGRPC(t *testing.T) {
 
 		// Start the proxy.
 		cfg := ProxyConfig{
-			BackendEndpoints:      strings.Join(backendURLs, ","),
-			PreferredBackend:      strconv.Itoa(0), // First backend server is preferred response
-			ServerHTTPServicePort: 0,
-			ServerGRPCServicePort: 0,
-			BackendReadTimeout:    time.Second,
+			BackendEndpoints:         strings.Join(backendURLs, ","),
+			PreferredBackend:         strconv.Itoa(0), // First backend server is preferred response
+			ServerHTTPServiceAddress: "localhost",
+			ServerHTTPServicePort:    0,
+			ServerGRPCServiceAddress: "localhost",
+			ServerGRPCServicePort:    0,
+			BackendReadTimeout:       time.Second,
 		}
 
 		p, err := NewProxy(cfg, log.NewNopLogger(), testRoutes, prometheus.NewRegistry())
@@ -447,11 +453,13 @@ func TestProxyHTTPGRPC(t *testing.T) {
 
 		// Start the proxy.
 		cfg := ProxyConfig{
-			BackendEndpoints:      strings.Join(backendURLs, ","),
-			PreferredBackend:      strconv.Itoa(0), // First backend server is preferred response
-			ServerHTTPServicePort: 0,
-			ServerGRPCServicePort: 0,
-			BackendReadTimeout:    time.Second,
+			BackendEndpoints:         strings.Join(backendURLs, ","),
+			PreferredBackend:         strconv.Itoa(0), // First backend server is preferred response
+			ServerHTTPServiceAddress: "localhost",
+			ServerHTTPServicePort:    0,
+			ServerGRPCServiceAddress: "localhost",
+			ServerGRPCServicePort:    0,
+			BackendReadTimeout:       time.Second,
 		}
 
 		p, err := NewProxy(cfg, log.NewNopLogger(), testRoutes, prometheus.NewRegistry())

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -377,9 +377,11 @@ func TestProxyHTTPGRPC(t *testing.T) {
 		// Start backend servers.
 		for _, backend := range backends {
 			server, err := server.New(server.Config{
-				HTTPListenPort: 0,
-				GRPCListenPort: 0,
-				Registerer:     prometheus.NewRegistry(),
+				HTTPListenAddress: "localhost",
+				HTTPListenPort:    0,
+				GRPCListenAddress: "localhost",
+				GRPCListenPort:    0,
+				Registerer:        prometheus.NewRegistry(),
 			})
 			require.NoError(t, err)
 			server.HTTP.Path(pathPrefix).Methods("GET").Handler(backend.handler)
@@ -427,9 +429,11 @@ func TestProxyHTTPGRPC(t *testing.T) {
 		// Start backend servers.
 		for _, backend := range backends {
 			server, err := server.New(server.Config{
-				HTTPListenPort: 0,
-				GRPCListenPort: 0,
-				Registerer:     prometheus.NewRegistry(),
+				HTTPListenAddress: "localhost",
+				HTTPListenPort:    0,
+				GRPCListenAddress: "localhost",
+				GRPCListenPort:    0,
+				Registerer:        prometheus.NewRegistry(),
 			})
 			require.NoError(t, err)
 			server.HTTP.Path(pathPrefix).Methods("GET").Handler(backend.handler)
@@ -498,11 +502,10 @@ func mockQueryResponse(path string, status int, res string) http.HandlerFunc {
 //   - http: HTTPListenAddr()
 //   - grpc: GRPCListenAddr()
 func getServerAddress(proto string, server *server.Server) string {
-	// server.Server has no address configured, so address is set as '[::]'
 	if proto == "http" {
-		return strings.ReplaceAll(server.HTTPListenAddr().String(), "[::]", "http://localhost")
+		return "http://" + server.HTTPListenAddr().String()
 	} else if proto == "grpc" {
-		return strings.ReplaceAll(server.GRPCListenAddr().String(), "[::]", "dns:///localhost")
+		return "dns:///" + server.GRPCListenAddr().String()
 	}
 
 	return ""


### PR DESCRIPTION
#### What this PR does

Trying to kill mac OS X firewall warning popup when running tests locally.

<img width="372" alt="Screenshot 2023-06-08 at 15 50 59" src="https://github.com/grafana/mimir/assets/895919/4bb3df2e-eb41-4787-94a9-4cdf6d01b18a">

Still haven't found all the places :(

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
