### PR TITLE
Use slice of []mimirpb.Exemplar (not pointers)

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3796,7 +3796,7 @@ func TestDistributorValidation(t *testing.T) {
 		metadata           []*mimirpb.MetricMetadata
 		labels             []labels.Labels
 		samples            []mimirpb.Sample
-		exemplars          []*mimirpb.Exemplar
+		exemplars          []mimirpb.Exemplar
 		expectedStatusCode int32
 		expectedErr        string
 	}{
@@ -3808,7 +3808,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(now),
 				Value:       1,
 			}},
-			exemplars: []*mimirpb.Exemplar{{
+			exemplars: []mimirpb.Exemplar{{
 				Labels:      []mimirpb.LabelAdapter{{Name: "traceID", Value: "123abc"}},
 				TimestampMs: int64(now),
 				Value:       1,
@@ -3881,7 +3881,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(now),
 				Value:       1,
 			}},
-			exemplars: []*mimirpb.Exemplar{{
+			exemplars: []mimirpb.Exemplar{{
 				Labels:      nil,
 				TimestampMs: int64(now),
 				Value:       1,

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -254,7 +254,7 @@ func TestIngester_Push(t *testing.T) {
 				mimirpb.ToWriteRequest(
 					[]labels.Labels{metricLabels},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 10}},
-					[]*mimirpb.Exemplar{
+					[]mimirpb.Exemplar{
 						{
 							Labels:      []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}},
 							TimestampMs: 1000,


### PR DESCRIPTION
This code validates that the elements of provided slice are not nil,
however I couldn't find any references to why the would be nil.

`prompb.WriteRequest` specifies them as structs (not pointers), there
are no tests checking it, and I can't find any code path where they
would be nil.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
