### PR TITLE
Add cortex_frontend_query_result_cache_requests_total and cortex_frontend_query_result_cache_hits_total metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * [CHANGE] Store-gateway: skip verifying index header integrity upon loading. To enable verification set `blocks_storage.bucket_store.index_header.verify_on_load: true`.
 * [CHANGE] Querier: change the default value of the experimental `-querier.streaming-chunks-per-ingester-buffer-size` flag to 256. #5203
 * [FEATURE] Cardinality API: Add a new `count_method` parameter which enables counting active series #5136
-* [FEATURE] Query-frontend: added experimental support to cache cardinality query responses. The cache will be used when `-query-frontend.cache-results` is enabled and `-query-frontend.results-cache-ttl-for-cardinality-query` set to a value greater than 0. #5212
+* [FEATURE] Query-frontend: added experimental support to cache cardinality query responses. The cache will be used when `-query-frontend.cache-results` is enabled and `-query-frontend.results-cache-ttl-for-cardinality-query` set to a value greater than 0. The following metrics have been added to track the query results cache hit ratio per `request_type`: #5212 #5235
+  * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality"}`
+  * `cortex_frontend_query_result_cache_hits_total{request_type="query_range|cardinality"}`
 * [ENHANCEMENT] Cardinality API: When zone aware replication is enabled, the label values cardinality API can now tolerate single zone failure #5178
 * [ENHANCEMENT] Distributor: optimize sending requests to ingesters when incoming requests don't need to be modified. For now this feature can be disabled by setting `-timeseries-unmarshal-caching-optimization-enabled=false`. #5137
 * [ENHANCEMENT] Add advanced CLI flags to control gRPC client behaviour: #5161

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -291,7 +291,7 @@ func newQueryTripperware(
 		// Inject the cardinality query cache roundtripper only if the query results cache is enabled.
 		cardinality := next
 		if cfg.CacheResults {
-			cardinality = newCardinalityQueryCacheRoundTripper(c, limits, next, log)
+			cardinality = newCardinalityQueryCacheRoundTripper(c, limits, next, log, registerer)
 		}
 
 		return RoundTripFunc(func(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
#### What this PR does
In #5212 I've added the optional and experimental support to lookup cardinality queries from the cache. However, we don't have a way to track the cache hit ratio specifically for the cardinality API endpoints. Reason is that today we measure the query-frontend cache hit ratio looking at the underlying memcache metrics (e.g. `thanos_cache_memcached_hits_total / thanos_cache_memcached_requests_total`) which are not split by request type / route (and not easy to do).

In this PR I propose to add a couple of new metrics which specifically track the query results cache cache hit ratio. I haven't changed the "Mimir / Queries" dashboard yet because I would like to see the new metrics deployed first before changing the dashboard (changes will be backward compatible).

Note to reviewers:
- The new metrics have been prefixed by `cortex_frontend_query_result_cache_`  to keep it consistent with other metrics we already have
- At this level we don't have `route` and propagating it would be quite tedious. On the other hand, I would prefer to not add logic to detect the route from the request `URL`, so I went to a simpler path which is a simple hardcoded `request_type` whose values could be `query_range` or `cardinality`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
