### PR TITLE
Configure TLS for alertmanager client by reading from Vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
 * [ENHANCEMENT] Go: updated to 1.21.1. #5955
 * [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. All the discarded samples will still be tracked by the `cortex_discarded_samples_total` metric. #5584 #6014
+* [ENHANCEMENT] Ruler: Fetch secrets used to configure TLS on the Alertmanager client from Vault when `-vault.enabled` is true. #5239
 * [BUGFIX] Ingester: fix spurious `not found` errors on label values API during head compaction. #5957
 
 ### Mixin

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"flag"
 	"net/url"
-	reflect "reflect"
 	"strings"
 	"sync"
 
@@ -163,7 +162,7 @@ func amConfigWithSD(rulerConfig *Config, url *url.URL, sdConfig discovery.Config
 
 	// Whether to use TLS or not.
 	if rulerConfig.Notifier.TLSEnabled {
-		if rulerConfig.Notifier.TLS.Reader == nil || reflect.ValueOf(rulerConfig.Notifier.TLS.Reader).IsNil() {
+		if rulerConfig.Notifier.TLS.Reader == nil {
 			amConfig.HTTPClientConfig.TLSConfig = config_util.TLSConfig{
 				CAFile:             rulerConfig.Notifier.TLS.CAPath,
 				CertFile:           rulerConfig.Notifier.TLS.CertPath,

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -115,7 +115,11 @@ func buildNotifierConfig(rulerConfig *Config, resolver cache.AddressProvider) (*
 			sdConfig = staticTarget(url)
 		}
 
-		amConfigs = append(amConfigs, amConfigWithSD(rulerConfig, url, sdConfig))
+		amCfgWithSD, err := amConfigWithSD(rulerConfig, url, sdConfig)
+		if err != nil {
+			return nil, err
+		}
+		amConfigs = append(amConfigs, amCfgWithSD)
 	}
 
 	promConfig := &config.Config{
@@ -127,7 +131,7 @@ func buildNotifierConfig(rulerConfig *Config, resolver cache.AddressProvider) (*
 	return promConfig, nil
 }
 
-func amConfigWithSD(rulerConfig *Config, url *url.URL, sdConfig discovery.Config) *config.AlertmanagerConfig {
+func amConfigWithSD(rulerConfig *Config, url *url.URL, sdConfig discovery.Config) (*config.AlertmanagerConfig, error) {
 	amConfig := &config.AlertmanagerConfig{
 		APIVersion:              config.AlertmanagerAPIVersionV2,
 		Scheme:                  url.Scheme,
@@ -158,14 +162,42 @@ func amConfigWithSD(rulerConfig *Config, url *url.URL, sdConfig discovery.Config
 
 	// Whether to use TLS or not.
 	if rulerConfig.Notifier.TLSEnabled {
-		amConfig.HTTPClientConfig.TLSConfig = config_util.TLSConfig{
-			CAFile:             rulerConfig.Notifier.TLS.CAPath,
-			CertFile:           rulerConfig.Notifier.TLS.CertPath,
-			KeyFile:            rulerConfig.Notifier.TLS.KeyPath,
-			InsecureSkipVerify: rulerConfig.Notifier.TLS.InsecureSkipVerify,
-			ServerName:         rulerConfig.Notifier.TLS.ServerName,
+		if rulerConfig.Notifier.TLS.Reader != nil {
+			cert, err := rulerConfig.Notifier.TLS.Reader.ReadSecret(rulerConfig.Notifier.TLS.CertPath)
+			if err != nil {
+				return nil, err
+			}
+
+			key, err := rulerConfig.Notifier.TLS.Reader.ReadSecret(rulerConfig.Notifier.TLS.KeyPath)
+			if err != nil {
+				return nil, err
+			}
+
+			var ca []byte
+			if rulerConfig.Notifier.TLS.CAPath != "" {
+				ca, err = rulerConfig.Notifier.TLS.Reader.ReadSecret(rulerConfig.Notifier.TLS.CAPath)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			amConfig.HTTPClientConfig.TLSConfig = config_util.TLSConfig{
+				CA:                 string(ca),
+				Cert:               string(cert),
+				Key:                config_util.Secret(key),
+				InsecureSkipVerify: rulerConfig.Notifier.TLS.InsecureSkipVerify,
+				ServerName:         rulerConfig.Notifier.TLS.ServerName,
+			}
+		} else {
+			amConfig.HTTPClientConfig.TLSConfig = config_util.TLSConfig{
+				CAFile:             rulerConfig.Notifier.TLS.CAPath,
+				CertFile:           rulerConfig.Notifier.TLS.CertPath,
+				KeyFile:            rulerConfig.Notifier.TLS.KeyPath,
+				InsecureSkipVerify: rulerConfig.Notifier.TLS.InsecureSkipVerify,
+				ServerName:         rulerConfig.Notifier.TLS.ServerName,
+			}
 		}
 	}
 
-	return amConfig
+	return amConfig, nil
 }

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"flag"
 	"net/url"
+	reflect "reflect"
 	"strings"
 	"sync"
 
@@ -162,7 +163,15 @@ func amConfigWithSD(rulerConfig *Config, url *url.URL, sdConfig discovery.Config
 
 	// Whether to use TLS or not.
 	if rulerConfig.Notifier.TLSEnabled {
-		if rulerConfig.Notifier.TLS.Reader != nil {
+		if rulerConfig.Notifier.TLS.Reader == nil || reflect.ValueOf(rulerConfig.Notifier.TLS.Reader).IsNil() {
+			amConfig.HTTPClientConfig.TLSConfig = config_util.TLSConfig{
+				CAFile:             rulerConfig.Notifier.TLS.CAPath,
+				CertFile:           rulerConfig.Notifier.TLS.CertPath,
+				KeyFile:            rulerConfig.Notifier.TLS.KeyPath,
+				InsecureSkipVerify: rulerConfig.Notifier.TLS.InsecureSkipVerify,
+				ServerName:         rulerConfig.Notifier.TLS.ServerName,
+			}
+		} else {
 			cert, err := rulerConfig.Notifier.TLS.Reader.ReadSecret(rulerConfig.Notifier.TLS.CertPath)
 			if err != nil {
 				return nil, err
@@ -185,14 +194,6 @@ func amConfigWithSD(rulerConfig *Config, url *url.URL, sdConfig discovery.Config
 				CA:                 string(ca),
 				Cert:               string(cert),
 				Key:                config_util.Secret(key),
-				InsecureSkipVerify: rulerConfig.Notifier.TLS.InsecureSkipVerify,
-				ServerName:         rulerConfig.Notifier.TLS.ServerName,
-			}
-		} else {
-			amConfig.HTTPClientConfig.TLSConfig = config_util.TLSConfig{
-				CAFile:             rulerConfig.Notifier.TLS.CAPath,
-				CertFile:           rulerConfig.Notifier.TLS.CertPath,
-				KeyFile:            rulerConfig.Notifier.TLS.KeyPath,
 				InsecureSkipVerify: rulerConfig.Notifier.TLS.InsecureSkipVerify,
 				ServerName:         rulerConfig.Notifier.TLS.ServerName,
 			}


### PR DESCRIPTION
Allows the ability to configure TLS for the alertmanager client in the Ruler, by reading secrets from Vault if present. This is now possible due to recent changes in `prometheus/common` that allow the passing of certificates and keys inline as part of the TLSConfig. 