### PR TITLE
Remove go version in workflow

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -10,13 +10,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  compare-manifests:
+  prepare:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Get build image from Makefile
+        id: build_image_step
+        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+    outputs:
+      build_image: ${{ steps.build_image_step.outputs.build_image }}
+  
+  compare-manifests:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    steps:
     - uses: actions/checkout@v3
+    - name: Get Go Version
+      container: 
+        image: ${{ needs.prepare.outputs.build_image }}
+      id: go-version
+      run: echo ::set-output name=go-version::$(go version)
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.5'
+        go-version: ${{ needs.go-version.outputs.go-version }}
     - uses: helm/kind-action@v1.7.0
     - name: Download yq
       uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -274,7 +274,7 @@ jobs:
           path: ./images.tar
 
   integration:
-    needs: build
+    needs: [prepare, build] 
     runs-on: ubuntu-latest
     strategy:
       # Do not abort other groups when one fails.
@@ -284,10 +284,16 @@ jobs:
         test_group_id:    [0, 1, 2, 3, 4, 5]
         test_group_total: [6]
     steps:
+      - name: Get Go version
+        id: go-version
+        container:
+        image: ${{ needs.prepare.outputs.build_image }}
+        run: |
+          echo "go-version=$(go version)" >> "$GITHUB_OUTPUT"
       - name: Upgrade golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
+          go-version: ${{ steps.go-version.outputs.go-version }}
           cache: false # We manage caching ourselves below to maintain consistency with the other jobs that don't use setup-go.
       - name: Check out repository
         uses: actions/checkout@v3

--- a/docs/internal/contributing/how-to-upgrade-golang-version.md
+++ b/docs/internal/contributing/how-to-upgrade-golang-version.md
@@ -3,10 +3,8 @@ To upgrade the Golang version:
 1. Upgrade build image version
    - Upgrade Golang version in `mimir-build-image/Dockerfile`
    - Build new image `make mimir-build-image/.uptodate`
-   - Publish the new image to `grafana/mimir-build-image` (requires a maintainer)
-2. Upgrade integration tests version
-   - Update the Golang version installed in the `integration` job in `.github/workflows/*`
-3. Upgrade the reference to the latest build image called `LATEST_BUILD_IMAGE_TAG` in `Makefile`
+   - Publish the new image to `grafana/mimir-build-image` (requires timed access)
+2. Upgrade the reference to the latest build image called `LATEST_BUILD_IMAGE_TAG` in `Makefile`
 
 If the minimum supported Golang version should be upgraded as well:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This pull request aims to remove the Go version used in the GitHub Actions workflow, following the approach introduced by Charles in the pull request [LINK](https://github.com/grafana/mimir/pull/5184). By doing so, we can make the workflow version-free, improving maintainability and reducing the need for frequent updates as new Go versions are released.

The changes in this pull request include:
Refactoring the workflow file(s) to remove the hardcoded Go version.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
