### PR TITLE
Expose `newQueryFrontendScaledObject` and `removeReplicasFromSpec` in Jsonnet library

### DIFF
--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -161,7 +161,7 @@
     ],
   }),
 
-  local newQueryFrontendScaledObject(name, cpu_requests, memory_requests, min_replicas, max_replicas, memory_target_utilization) = self.newScaledObject(
+  newQueryFrontendScaledObject(name, cpu_requests, memory_requests, min_replicas, max_replicas, memory_target_utilization):: self.newScaledObject(
     name, $._config.namespace, {
       min_replica_count: min_replicas,
       max_replica_count: max_replicas,
@@ -212,7 +212,7 @@
   // Helper methods
   //
 
-  local removeReplicasFromSpec = {
+  removeReplicasFromSpec:: {
     spec+: {
       // Remove the "replicas" field so that Flux doesn't reconcile it.
       replicas+:: null,
@@ -245,11 +245,11 @@
 
   querier_deployment: overrideSuperIfExists(
     'querier_deployment',
-    if !$._config.autoscaling_querier_enabled then {} else removeReplicasFromSpec
+    if !$._config.autoscaling_querier_enabled then {} else $.removeReplicasFromSpec
   ),
 
   query_frontend_scaled_object: if !$._config.autoscaling_query_frontend_enabled then null else
-    newQueryFrontendScaledObject(
+    $.newQueryFrontendScaledObject(
       name='query-frontend',
       cpu_requests=$.query_frontend_container.resources.requests.cpu,
       memory_requests=$.query_frontend_container.resources.requests.memory,
@@ -259,7 +259,7 @@
     ),
   query_frontend_deployment: overrideSuperIfExists(
     'query_frontend_deployment',
-    if $._config.autoscaling_query_frontend_enabled then removeReplicasFromSpec else
+    if $._config.autoscaling_query_frontend_enabled then $.removeReplicasFromSpec else
       if ($._config.query_sharding_enabled && $._config.autoscaling_querier_enabled) then
         queryFrontendReplicas($._config.autoscaling_querier_max_replicas) else
         {}
@@ -300,11 +300,11 @@
 
   ruler_querier_deployment: overrideSuperIfExists(
     'ruler_querier_deployment',
-    if !$._config.autoscaling_ruler_querier_enabled then {} else removeReplicasFromSpec
+    if !$._config.autoscaling_ruler_querier_enabled then {} else $.removeReplicasFromSpec
   ),
 
   ruler_query_frontend_scaled_object: if !$._config.autoscaling_ruler_query_frontend_enabled || !$._config.ruler_remote_evaluation_enabled then null else
-    newQueryFrontendScaledObject(
+    $.newQueryFrontendScaledObject(
       name='ruler-query-frontend',
       cpu_requests=$.ruler_query_frontend_container.resources.requests.cpu,
       memory_requests=$.ruler_query_frontend_container.resources.requests.memory,
@@ -314,7 +314,7 @@
     ),
   ruler_query_frontend_deployment: overrideSuperIfExists(
     'ruler_query_frontend_deployment',
-    if $._config.autoscaling_ruler_query_frontend_enabled then removeReplicasFromSpec else
+    if $._config.autoscaling_ruler_query_frontend_enabled then $.removeReplicasFromSpec else
       if ($._config.query_sharding_enabled && $._config.autoscaling_ruler_querier_enabled) then
         queryFrontendReplicas($._config.autoscaling_ruler_querier_max_replicas) else
         {}
@@ -363,7 +363,7 @@
 
   distributor_deployment: overrideSuperIfExists(
     'distributor_deployment',
-    if !$._config.autoscaling_distributor_enabled then {} else removeReplicasFromSpec
+    if !$._config.autoscaling_distributor_enabled then {} else $.removeReplicasFromSpec
   ),
 
   // Ruler
@@ -413,7 +413,7 @@
 
   ruler_deployment: overrideSuperIfExists(
     'ruler_deployment',
-    if !$._config.autoscaling_ruler_enabled then {} else removeReplicasFromSpec
+    if !$._config.autoscaling_ruler_enabled then {} else $.removeReplicasFromSpec
   ),
 
   // Utility used to override a field only if exists in super.

--- a/operations/mimir/read-write-deployment/autoscaling.libsonnet
+++ b/operations/mimir/read-write-deployment/autoscaling.libsonnet
@@ -9,13 +9,6 @@
   // Helper methods
   //
 
-  local removeReplicasFromSpec = {
-    spec+: {
-      // Remove the "replicas" field so that Flux doesn't reconcile it.
-      replicas+:: null,
-    },
-  },
-
   read_scaled_object: if !$._config.autoscaling_mimir_read_enabled then null else
     // NOTE(jhesketh): this reuses the newQuerierScaledObject from operations/mimir/autoscaling.libsonnet
     //                 as the scaling metric (cortex_query_scheduler_inflight_requests) is expected to
@@ -31,7 +24,7 @@
   mimir_read_deployment: if !$._config.is_read_write_deployment_mode then null else (
     super.mimir_read_deployment + (
       if !$._config.autoscaling_mimir_read_enabled then {} else
-        removeReplicasFromSpec
+        $.removeReplicasFromSpec
     )
   ),
 }


### PR DESCRIPTION
#### What this PR does

This PR exposes two helpers from the Jsonnet library to downstream consumers: `newQueryFrontendScaledObject` and `removeReplicasFromSpec`:

* `newQueryFrontendScaledObject` is useful when creating a parallel query path for testing query path changes
* `removeReplicasFromSpec` is useful when adding autoscaling to a deployment and was already duplicated in the Jsonnet library

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
