### PR TITLE
store-gateway: always include `__name__` posting group in selection

### DIFF
--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -365,7 +365,7 @@ func (selectAllStrategy) selectPostings(groups []postingGroup) (selected, omitte
 // bytes for the series = 256 MB. So it will not fetch more than 256 MB of posting lists.
 //
 // We found that this strategy may cause increased API calls for cases where it omits the __name__ posting group.
-// Because of this now the strategy always selects the __name__ posting group regardless of its size.
+// Because of this, the strategy always selects the __name__ posting group regardless of its size.
 type worstCaseFetchedDataStrategy struct {
 	// postingListActualSizeFactor affects how posting lists are summed together.
 	// Postings lists have different sizes in the bucket and the cache.

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -418,7 +418,7 @@ func (s worstCaseFetchedDataStrategy) selectPostings(groups []postingGroup) (sel
 			// we don't overwrite the first group when we append to selected.
 			omitted[0], omitted[i] = omitted[i], omitted[0]
 			omitted = omitted[1:]
-			selected = append(selected, g)
+			selected = selected[:len(selected)+1]
 			break
 		}
 	}

--- a/pkg/storegateway/bucket_index_postings_test.go
+++ b/pkg/storegateway/bucket_index_postings_test.go
@@ -112,6 +112,24 @@ func TestWorstCaseFetchedDataStrategy(t *testing.T) {
 				{totalSize: 4 * 1024},
 			},
 		},
+		"two small, one large list, one with __name__": {
+			input: []postingGroup{
+				{totalSize: 64 * 1024 * 1024},
+				{totalSize: 64 * 1024 * 1024, keys: []labels.Label{{Name: labels.MetricName, Value: "foo"}}},
+				{totalSize: 256},
+				{totalSize: 128},
+			},
+			expectedSelected: []postingGroup{
+				// Even though the __name__ group is too large it is still selected
+				// in order to minimize the sparseness of the selected series.
+				{totalSize: 64 * 1024 * 1024, keys: []labels.Label{{Name: labels.MetricName, Value: "foo"}}},
+				{totalSize: 256},
+				{totalSize: 128},
+			},
+			expectedOmitted: []postingGroup{
+				{totalSize: 64 * 1024 * 1024},
+			},
+		},
 	}
 
 	for testName, testCase := range testCases {


### PR DESCRIPTION
#### What this PR does

Excluding the `__name__` posting group resulted in increased API calls because the selected series were more sparse in the index. The reason for this is that series are first sorted by the `__name__` label if they don't have any labels that start with an uppercase letter. Selecting sparse series results in more API calls because the series are more likely to belong to different metric names and be spread across the TSDB index.

This PR modifies the `worst-case` strategy to always include `__name__`. I opted for including this change in the existing `worstCaseFetchedDataStrategy` as opposed to wrapping `worstCaseFetchedDataStrategy` in a new strategy because it will make testing a bit easier and there's no need for modularity because we're eventually aiming to have only a single strategy. Open to feedback though.

#### Which issue(s) this PR fixes or relates to

Related to #4593 

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
