### PR TITLE
Add thanos_store_bucket_cache_getrange_fetched_requests_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Querier: Refine error messages for per-tenant query limits, informing the user of the preferred strategy for not hitting the limit, in addition to how they may tweak the limit. #5059
 * [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. For now this optimization can be disabled by setting `-distributor.write-requests-buffer-pooling-enabled` to `false`. #5195
 * [ENHANCEMENT] Querier: add experimental `-querier.minimize-ingester-requests` option to initially query only the minimum set of ingesters required to reach quorum. #5202
+* [ENHANCEMENT] Store-gateway: add `thanos_store_bucket_cache_getrange_fetched_requests_total` metric tracking the total number of requests issued either to the cache or the bucket to fetch chunks. For requests issued to the cache, it counts the number of cache keys looked up, including cache misses. #5252
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 
 ### Mixin


### PR DESCRIPTION
#### What this PR does

I'm running an investigation on bucket operations issued by the store-gateway and I realised we have no metric to count the number of requests issued to fetch chunks (vs index lookups). In this PR I propose to add `thanos_store_bucket_cache_getrange_fetched_requests_total` which allows to count the number of operations we issue to the bucket to fetch chunks, after having looked up the cache.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
