### PR TITLE
Chore: remove hardcoded go version

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -16,20 +16,34 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Get build image from Makefile
+        id: build_image_step
+        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"    
+    outputs:
+      build_image: ${{ steps.build_image_step.outputs.build_image }}
+
+  goversion:
+    runs-on: ubuntu-latest
+    needs: prepare
+    container: 
+      image: ${{ needs.prepare.outputs.build_image }}
+    steps:
+      - name: Get Go Version
         id: go-version
-        run: echo "version=$(make TTY= print-go-version)" >> "$GITHUB_OUTPUT"    
+        run: |
+          version=$(go version | awk '{print $3}' | sed 's/go//')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
     outputs:
       version: ${{ steps.go-version.outputs.version }}
 
   compare-manifests:
     runs-on: ubuntu-latest
     needs:
-      - prepare
+      - goversion
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: ${{ needs.prepare.outputs.version }}
+        go-version: ${{ needs.goversion.outputs.version }}
     - uses: helm/kind-action@v1.7.0
     - name: Download yq
       uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -27,11 +27,12 @@ jobs:
     container: 
       image: ${{ needs.prepare.outputs.build_image }}
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
       - name: Get Go Version
         id: go-version
         run: |
-          version=$(go version | awk '{print $3}' | sed 's/go//')
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "version=$(make BUILD_IN_CONTAINER=false print-go-version)" >> "$GITHUB_OUTPUT"
     outputs:
       version: ${{ steps.go-version.outputs.version }}
 

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -10,13 +10,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Get go version from Makefile
+        id: go_version_step
+        run: echo "go_version=$(make print-go-version)" >> "$GITHUB_OUTPUT"
+    outputs:
+      go_version: ${{ steps.go_version_step.outputs.go_version }}
   compare-manifests:
     runs-on: ubuntu-latest
+    needs:
+      - prepare
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.5'
+        go-version: ${{ needs.prepare.outputs.go_version }}
     - uses: helm/kind-action@v1.7.0
     - name: Download yq
       uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -15,20 +15,35 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Get go version from Makefile
-        id: go_version_step
-        run: echo "go_version=$(make print-go-version)" >> "$GITHUB_OUTPUT"
+      - name: Get build image from Makefile
+        id: build_image_step
+        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"    
     outputs:
-      go_version: ${{ steps.go_version_step.outputs.go_version }}
+      build_image: ${{ steps.build_image_step.outputs.build_image }}
+
+  goversion:
+    runs-on: ubuntu-latest
+    needs: prepare
+    container: 
+      image: ${{ needs.prepare.outputs.build_image }}
+    steps:
+      - name: Get Go Version
+        id: go-version
+        run: |
+          version=$(go version | awk '{print $3}' | sed 's/go//')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+    outputs:
+      version: ${{ steps.go-version.outputs.version }}
+
   compare-manifests:
     runs-on: ubuntu-latest
     needs:
-      - prepare
+      - goversion
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: ${{ needs.prepare.outputs.go_version }}
+        go-version: ${{ needs.goversion.outputs.version }}
     - uses: helm/kind-action@v1.7.0
     - name: Download yq
       uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get build image from Makefile
         id: build_image_step
-        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"    
+        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
     outputs:
       build_image: ${{ steps.build_image_step.outputs.build_image }}
 
@@ -27,8 +27,9 @@ jobs:
     container: 
       image: ${{ needs.prepare.outputs.build_image }}
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - name: Run Git Config
+        run: git config --global --add safe.directory '*'
       - name: Get Go Version
         id: go-version
         run: |
@@ -38,8 +39,7 @@ jobs:
 
   compare-manifests:
     runs-on: ubuntu-latest
-    needs:
-      - goversion
+    needs: goversion
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -16,34 +16,20 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Get build image from Makefile
-        id: build_image_step
-        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"    
-    outputs:
-      build_image: ${{ steps.build_image_step.outputs.build_image }}
-
-  goversion:
-    runs-on: ubuntu-latest
-    needs: prepare
-    container: 
-      image: ${{ needs.prepare.outputs.build_image }}
-    steps:
-      - name: Get Go Version
         id: go-version
-        run: |
-          version=$(go version | awk '{print $3}' | sed 's/go//')
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(make TTY= print-go-version)" >> "$GITHUB_OUTPUT"    
     outputs:
       version: ${{ steps.go-version.outputs.version }}
 
   compare-manifests:
     runs-on: ubuntu-latest
     needs:
-      - goversion
+      - prepare
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: ${{ needs.goversion.outputs.version }}
+        go-version: ${{ needs.prepare.outputs.version }}
     - uses: helm/kind-action@v1.7.0
     - name: Download yq
       uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -22,11 +22,14 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Get build image from Makefile
-        id: build_image_step
-        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+      - name: Get variables from Makefile
+        id: get_variables_step
+        run: |
+          echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+          echo "go_version=$(make print-go-version)" >> "$GITHUB_OUTPUT"
     outputs:
-      build_image: ${{ steps.build_image_step.outputs.build_image }}
+      build_image: ${{ steps.get_variables_step.outputs.build_image }}
+      go_version: ${{ steps.get_variables_step.outputs.go_version }}
 
   lint:
     runs-on: ubuntu-latest
@@ -302,7 +305,7 @@ jobs:
           path: ./images.tar
 
   integration:
-    needs: build
+    needs: [prepare, build]
     runs-on: ubuntu-latest
     strategy:
       # Do not abort other groups when one fails.
@@ -315,7 +318,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
+          go-version: ${{ needs.prepare.outputs.go_version }}
           cache: false # We manage caching ourselves below to maintain consistency with the other jobs that don't use setup-go.
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -34,8 +34,9 @@ jobs:
     container: 
       image: ${{ needs.prepare.outputs.build_image }}
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - name: Run Git Config
+        run: git config --global --add safe.directory '*'
       - name: Get Go Version
         id: go-version
         run: |
@@ -45,8 +46,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    needs:
-      - prepare
+    needs: prepare
     container:
       image: ${{ needs.prepare.outputs.build_image }}
     steps:

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -24,12 +24,23 @@ jobs:
         uses: actions/checkout@v3
       - name: Get build image from Makefile
         id: build_image_step
-        run: |
-          echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
-          echo "go_version=$(make print-go-version TTY=)" >> "$GITHUB_OUTPUT"
+        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
     outputs:
       build_image: ${{ steps.build_image_step.outputs.build_image }}
-      go_version: ${{ steps.build_image_step.outputs.go_version }}
+
+  goversion:
+    runs-on: ubuntu-latest
+    needs: prepare
+    container: 
+      image: ${{ needs.prepare.outputs.build_image }}
+    steps:
+      - name: Get Go Version
+        id: go-version
+        run: |
+          version=$(go version | awk '{print $3}' | sed 's/go//')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+    outputs:
+      version: ${{ steps.go-version.outputs.version }}
 
   lint:
     runs-on: ubuntu-latest
@@ -305,7 +316,7 @@ jobs:
           path: ./images.tar
 
   integration:
-    needs: [prepare, build]
+    needs: [goversion, build]
     runs-on: ubuntu-latest
     strategy:
       # Do not abort other groups when one fails.
@@ -318,7 +329,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ needs.prepare.outputs.go_version }}
+          go-version: ${{ needs.goversion.outputs.version }}
           cache: false # We manage caching ourselves below to maintain consistency with the other jobs that don't use setup-go.
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -34,11 +34,12 @@ jobs:
     container: 
       image: ${{ needs.prepare.outputs.build_image }}
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
       - name: Get Go Version
         id: go-version
         run: |
-          version=$(go version | awk '{print $3}' | sed 's/go//')
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "version=$(make BUILD_IN_CONTAINER=false print-go-version)" >> "$GITHUB_OUTPUT"
     outputs:
       version: ${{ steps.go-version.outputs.version }}
 

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -22,14 +22,25 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Get variables from Makefile
-        id: get_variables_step
-        run: |
-          echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
-          echo "go_version=$(make print-go-version)" >> "$GITHUB_OUTPUT"
+      - name: Get build image from Makefile
+        id: build_image_step
+        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
     outputs:
-      build_image: ${{ steps.get_variables_step.outputs.build_image }}
-      go_version: ${{ steps.get_variables_step.outputs.go_version }}
+      build_image: ${{ steps.build_image_step.outputs.build_image }}
+
+  goversion:
+    runs-on: ubuntu-latest
+    needs: prepare
+    container: 
+      image: ${{ needs.prepare.outputs.build_image }}
+    steps:
+      - name: Get Go Version
+        id: go-version
+        run: |
+          version=$(go version | awk '{print $3}' | sed 's/go//')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+    outputs:
+      version: ${{ steps.go-version.outputs.version }}
 
   lint:
     runs-on: ubuntu-latest
@@ -305,7 +316,7 @@ jobs:
           path: ./images.tar
 
   integration:
-    needs: [prepare, build]
+    needs: [goversion, build]
     runs-on: ubuntu-latest
     strategy:
       # Do not abort other groups when one fails.
@@ -318,7 +329,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ needs.prepare.outputs.go_version }}
+          go-version: ${{ needs.goversion.outputs.version }}
           cache: false # We manage caching ourselves below to maintain consistency with the other jobs that don't use setup-go.
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -24,23 +24,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Get build image from Makefile
         id: build_image_step
-        run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+          echo "go_version=$(make print-go-version TTY=)" >> "$GITHUB_OUTPUT"
     outputs:
       build_image: ${{ steps.build_image_step.outputs.build_image }}
-
-  goversion:
-    runs-on: ubuntu-latest
-    needs: prepare
-    container: 
-      image: ${{ needs.prepare.outputs.build_image }}
-    steps:
-      - name: Get Go Version
-        id: go-version
-        run: |
-          version=$(go version | awk '{print $3}' | sed 's/go//')
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-    outputs:
-      version: ${{ steps.go-version.outputs.version }}
+      go_version: ${{ steps.build_image_step.outputs.go_version }}
 
   lint:
     runs-on: ubuntu-latest
@@ -316,7 +305,7 @@ jobs:
           path: ./images.tar
 
   integration:
-    needs: [goversion, build]
+    needs: [prepare, build]
     runs-on: ubuntu-latest
     strategy:
       # Do not abort other groups when one fails.
@@ -329,7 +318,7 @@ jobs:
       - name: Upgrade golang
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ needs.goversion.outputs.version }}
+          go-version: ${{ needs.prepare.outputs.go_version }}
           cache: false # We manage caching ourselves below to maintain consistency with the other jobs that don't use setup-go.
       - name: Check out repository
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ GOVOLUMES=	-v mimir-go-cache:/go/cache \
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:$(CONTAINER_MOUNT_OPTIONS)
 
-exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests: fetch-build-image
+exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version: fetch-build-image
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) $@;
 
@@ -322,6 +322,9 @@ format: ## Run gofmt and goimports.
 
 test: ## Run all unit tests.
 	go test -timeout 30m ./...
+
+print-go-version: ## Print the go version.
+	@go version | awk '{print $$3}' | sed 's/go//'
 
 test-with-race: ## Run all unit tests with data race detect.
 	go test -tags netgo -timeout 30m -race -count 1 ./...

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ LATEST_BUILD_IMAGE_TAG ?= update-golangci-lint-d48f951b3
 # as it currently disallows TTY devices. This value needs to be overridden
 # in any custom cloudbuild.yaml files
 TTY := --tty
+
 MIMIR_VERSION := github.com/grafana/mimir/pkg/util/version
 
 REGO_POLICIES_PATH=operations/policies
@@ -207,10 +208,9 @@ GOVOLUMES=	-v mimir-go-cache:/go/cache \
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:$(CONTAINER_MOUNT_OPTIONS)
 
-exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests: fetch-build-image
+exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version: fetch-build-image
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) $@;
-
 else
 
 exes: $(EXES)
@@ -233,6 +233,10 @@ endif
 
 lint-packaging-scripts: packaging/nfpm/mimir/postinstall.sh packaging/nfpm/mimir/preremove.sh
 	shellcheck $?
+
+print-go-version: ## Print the go version.
+	$(eval GOVERSION := $(shell go version | awk '{print $$3}' | sed 's/go//'))
+	@echo $(GOVERSION)
 
 lint: ## Run lints to check for style issues.
 lint: check-makefiles

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,6 @@ LATEST_BUILD_IMAGE_TAG ?= update-golangci-lint-d48f951b3
 # as it currently disallows TTY devices. This value needs to be overridden
 # in any custom cloudbuild.yaml files
 TTY := --tty
-
 MIMIR_VERSION := github.com/grafana/mimir/pkg/util/version
 
 REGO_POLICIES_PATH=operations/policies
@@ -208,9 +207,10 @@ GOVOLUMES=	-v mimir-go-cache:/go/cache \
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:$(CONTAINER_MOUNT_OPTIONS)
 
-exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version: fetch-build-image
+exes $(EXES) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests: fetch-build-image
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) $@;
+
 else
 
 exes: $(EXES)
@@ -233,10 +233,6 @@ endif
 
 lint-packaging-scripts: packaging/nfpm/mimir/postinstall.sh packaging/nfpm/mimir/preremove.sh
 	shellcheck $?
-
-print-go-version: ## Print the go version.
-	$(eval GOVERSION := $(shell go version | awk '{print $$3}' | sed 's/go//'))
-	@echo $(GOVERSION)
 
 lint: ## Run lints to check for style issues.
 lint: check-makefiles

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ IMAGE_TAG ?= $(if $(IMAGE_TAG_FROM_GIT_TAG),$(IMAGE_TAG_FROM_GIT_TAG),$(shell ./
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 UPTODATE := .uptodate
-
+GO_VERSION := "1.20.5"
 # path to jsonnetfmt
 JSONNET_FMT := jsonnetfmt
 
@@ -133,12 +133,15 @@ fetch-build-image: ## Fetch latest the docker build image. It can be used instea
 push-multiarch-build-image: ## Push the docker build image.
 	@echo
 	# Build and push mimir build image for linux/amd64 and linux/arm64
-	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --progress=plain --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(BUILD_IMAGE):$(IMAGE_TAG) mimir-build-image/
+	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --progress=plain --build-arg=GO_VERSION=${GO_VERSION} --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(BUILD_IMAGE):$(IMAGE_TAG) mimir-build-image/
 
 .PHONY: print-build-image
 print-build-image:
 	@echo $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG)
 
+.PHONY: print-go-version
+print-go-version:
+	@echo $(GO_VERSION)
 # We don't want find to scan inside a bunch of directories, to accelerate the
 # 'make: Entering directory '/go/src/github.com/grafana/mimir' phase.
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o -name packaging -prune -o -name mimir-mixin-tools -prune -o -name trafficdump -prune -o

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ IMAGE_TAG ?= $(if $(IMAGE_TAG_FROM_GIT_TAG),$(IMAGE_TAG_FROM_GIT_TAG),$(shell ./
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 UPTODATE := .uptodate
-GO_VERSION := "1.20.5"
+
 # path to jsonnetfmt
 JSONNET_FMT := jsonnetfmt
 
@@ -133,15 +133,12 @@ fetch-build-image: ## Fetch latest the docker build image. It can be used instea
 push-multiarch-build-image: ## Push the docker build image.
 	@echo
 	# Build and push mimir build image for linux/amd64 and linux/arm64
-	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --progress=plain --build-arg=GO_VERSION=${GO_VERSION} --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(BUILD_IMAGE):$(IMAGE_TAG) mimir-build-image/
+	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --progress=plain --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(BUILD_IMAGE):$(IMAGE_TAG) mimir-build-image/
 
 .PHONY: print-build-image
 print-build-image:
 	@echo $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG)
 
-.PHONY: print-go-version
-print-go-version:
-	@echo $(GO_VERSION)
 # We don't want find to scan inside a bunch of directories, to accelerate the
 # 'make: Entering directory '/go/src/github.com/grafana/mimir' phase.
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o -name packaging -prune -o -name mimir-mixin-tools -prune -o -name trafficdump -prune -o

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -7,12 +7,12 @@
 set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-
+GO_VERSION=$(make -s -f ../../Makefile print-go-version)
 # Make sure docker-compose.yml is up-to-date.
 cd $SCRIPT_DIR && make
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
 CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/mimir ${SCRIPT_DIR}/../../cmd/mimir
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build distributor-1
+docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build --build-arg GO_VERSION=${GO_VERSION} distributor-1
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -7,12 +7,12 @@
 set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-GO_VERSION=$(make -s -f ../../Makefile print-go-version)
+BUILD_IMAGE=$(make -s -f ${SCRIPT_DIR}/../../Makefile print-build-image)
 # Make sure docker-compose.yml is up-to-date.
 cd $SCRIPT_DIR && make
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
 CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/mimir ${SCRIPT_DIR}/../../cmd/mimir
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build --build-arg GO_VERSION=${GO_VERSION} distributor-1
+docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build --build-arg BUILD_IMAGE=${BUILD_IMAGE} distributor-1
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -1,6 +1,6 @@
 
-ARG GO_VERSION=please-use-compose-up-to-build-images
-FROM golang:${GO_VERSION}
+ARG BUILD_IMAGE=use-compose-up-to-build-image
+FROM ${BUILD_IMAGE}
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
 

--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -1,4 +1,3 @@
-
 ARG BUILD_IMAGE # Use ./compose-up.sh to build this image.
 FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0

--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.20.5
+
+ARG GO_VERSION=please-use-compose-up-to-build-images
+FROM golang:${GO_VERSION}
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
 

--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -1,6 +1,6 @@
 
-ARG BUILD_IMAGE=use-compose-up-to-build-image
-FROM ${BUILD_IMAGE}
+ARG BUILD_IMAGE # Use ./compose-up.sh to build this image.
+FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
 

--- a/development/mimir-read-write-mode/compose-up.sh
+++ b/development/mimir-read-write-mode/compose-up.sh
@@ -4,6 +4,7 @@
 set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GO_VERSION=$(make -s -f ../../Makefile print-go-version)
 
 # Make sure docker-compose.yml is up-to-date.
 cd $SCRIPT_DIR && make
@@ -11,5 +12,5 @@ cd $SCRIPT_DIR && make
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
 CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/mimir ${SCRIPT_DIR}/../../cmd/mimir
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build mimir-write-1
+docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build --build-arg GO_VERSION=${GO_VERSION} mimir-write-1
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/mimir-read-write-mode/compose-up.sh
+++ b/development/mimir-read-write-mode/compose-up.sh
@@ -4,7 +4,7 @@
 set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-GO_VERSION=$(make -s -f ../../Makefile print-go-version)
+BUILD_IMAGE=$(make -s -f ${SCRIPT_DIR}/../../Makefile print-build-image)
 
 # Make sure docker-compose.yml is up-to-date.
 cd $SCRIPT_DIR && make
@@ -12,5 +12,5 @@ cd $SCRIPT_DIR && make
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
 CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/mimir ${SCRIPT_DIR}/../../cmd/mimir
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build --build-arg GO_VERSION=${GO_VERSION} mimir-write-1
+docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build --build-arg BUILD_IMAGE=${BUILD_IMAGE} mimir-write-1
 docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@

--- a/development/mimir-read-write-mode/dev.dockerfile
+++ b/development/mimir-read-write-mode/dev.dockerfile
@@ -1,5 +1,5 @@
-ARG BUILD_IMAGE=use-compose-up-to-build-image
-FROM ${BUILD_IMAGE}
+ARG BUILD_IMAGE # Use ./compose-up.sh to build this image.
+FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
 

--- a/development/mimir-read-write-mode/dev.dockerfile
+++ b/development/mimir-read-write-mode/dev.dockerfile
@@ -1,5 +1,5 @@
-ARG GO_VERSION=please-use-compose-up-to-build-images
-FROM golang:${GO_VERSION}
+ARG BUILD_IMAGE=use-compose-up-to-build-image
+FROM ${BUILD_IMAGE}
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
 

--- a/development/mimir-read-write-mode/dev.dockerfile
+++ b/development/mimir-read-write-mode/dev.dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.20.5
+ARG GO_VERSION=please-use-compose-up-to-build-images
+FROM golang:${GO_VERSION}
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
 

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -2,10 +2,10 @@
 # Provenance-includes-location: https://github.com/cortexproject/cortex/build-image/Dockerfile
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
-
+ARG GO_VERSION=please-use-make-to-build-images
 FROM k8s.gcr.io/kustomize/kustomize:v4.5.5 as kustomize
 FROM alpine/helm:3.11.1 as helm
-FROM golang:1.20.5-bullseye
+FROM golang:${GO_VERSION}-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -2,7 +2,6 @@
 # Provenance-includes-location: https://github.com/cortexproject/cortex/build-image/Dockerfile
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
-
 FROM k8s.gcr.io/kustomize/kustomize:v4.5.5 as kustomize
 FROM alpine/helm:3.11.1 as helm
 FROM golang:1.20.5-bullseye

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -2,6 +2,7 @@
 # Provenance-includes-location: https://github.com/cortexproject/cortex/build-image/Dockerfile
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
+
 FROM k8s.gcr.io/kustomize/kustomize:v4.5.5 as kustomize
 FROM alpine/helm:3.11.1 as helm
 FROM golang:1.20.5-bullseye

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -2,10 +2,10 @@
 # Provenance-includes-location: https://github.com/cortexproject/cortex/build-image/Dockerfile
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
-ARG GO_VERSION=please-use-make-to-build-images
+
 FROM k8s.gcr.io/kustomize/kustomize:v4.5.5 as kustomize
 FROM alpine/helm:3.11.1 as helm
-FROM golang:${GO_VERSION}-bullseye
+FROM golang:1.20.5-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Summary

This pull request aims to centralize the Go version settings in the Mimir project. To achieve this we retrieve the Go version always from mimir-build-image.

#### Details:

Previously, the Go version setting was scattered across different parts of the Mimir project, making it difficult to manage and update consistently. By centralizing the Go version definition in the Makefile, we establish a single source of truth for the project's Go version.

This change simplifies the process of updating the Go version in the future, as it can now be modified in just one place. Additionally, any component or module that needs to reference the Go version can retrieve it from the centralized location defined in the Makefile.

The next step could be implementing a linter to enforce the rule of forbidding the use of the Go version outside dockerfile of mimir-build-image. This linter will scan the project files when PR and report any violations, ensuring that the Go version is only used in the designated place.

Please review this pull request and provide your feedback.

#### Checklist

- n/a Tests updated
- n/a Documentation added
- n/a `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
