### PR TITLE
CI: use a single cache for tests

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -221,8 +221,8 @@ jobs:
       - name: Cache Go build cache
         uses: actions/cache@v3
         with:
-          # The '0' here is for historical reasons.
-          key: test-0-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
+          # Cache is shared between test groups.
+          key: test-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
           path: ${{ steps.gocache.outputs.path }}
       - name: Run Tests
         run: |
@@ -320,7 +320,8 @@ jobs:
       - name: Cache Go build cache
         uses: actions/cache@v3
         with:
-          key: integration-0-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
+          # Cache is shared between test groups.
+          key: integration-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
           path: ${{ steps.gocache.outputs.path }}
       - name: Download Archive with Docker Images
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -221,7 +221,8 @@ jobs:
       - name: Cache Go build cache
         uses: actions/cache@v3
         with:
-          key: test-${{ matrix.test_group_id }}-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
+          # The '0' here is for historical reasons.
+          key: test-0-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
           path: ${{ steps.gocache.outputs.path }}
       - name: Run Tests
         run: |
@@ -319,7 +320,7 @@ jobs:
       - name: Cache Go build cache
         uses: actions/cache@v3
         with:
-          key: integration-${{ matrix.test_group_id }}-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
+          key: integration-0-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
           path: ${{ steps.gocache.outputs.path }}
       - name: Download Archive with Docker Images
         uses: actions/download-artifact@v4


### PR DESCRIPTION
#### What this PR does

Change CI config to load and store the same cache key for all 4 groups of unit tests and another one for all 6 groups of integration tests.  Broadly the same set of files (mostly dependencies) will be compiled for every set of tests.

GitHub has a limit on the total amount of cache, which is about 1 day's worth in current usage.
https://github.com/grafana/mimir/actions/caches

#### Checklist

- NA Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
