### PR TITLE
storage/chunk: TestChunk with smaller sizes

### DIFF
--- a/pkg/storage/chunk/chunk_test.go
+++ b/pkg/storage/chunk/chunk_test.go
@@ -64,7 +64,7 @@ func TestLen(t *testing.T) {
 var step = int(15 * time.Second / time.Millisecond)
 
 func TestChunk(t *testing.T) {
-	const maxSamples = 2048
+	const maxSamples = 240 // Twice as big as current TSDB
 
 	for _, enc := range []Encoding{PrometheusXorChunk, PrometheusHistogramChunk, PrometheusFloatHistogramChunk} {
 		for samples := maxSamples / 10; samples < maxSamples; samples += maxSamples / 10 {


### PR DESCRIPTION
#### What this PR does

Going up to 2040 samples per chunk resulted in this test taking around five minutes to run with `-race`.
Since TSDB is currently hard-coded to stop at 120 samples, this seems unnecessary. Stopping at 216 takes it down to about 8 seconds.

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated
