### PR TITLE
fix: added documentation alias for `about-runtime-configuration`

### DIFF
--- a/docs/sources/mimir/configure/about-runtime-configuration.md
+++ b/docs/sources/mimir/configure/about-runtime-configuration.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../configuring/about-runtime-configuration/
+  - ../operators-guide/configure/about-runtime-configuration/
 description:
   Runtime configuration enables you to change a subset of configurations
   without restarting Grafana Mimir.


### PR DESCRIPTION
#### What this PR does

- Satisfies some external links to `about-runtime-configuration`

#### Checklist

- [x] ~Tests updated~ 
- [x] ~Documentation added~
- [x] ~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~
