### PR TITLE
store-gateway: clean up spans

### DIFF
--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/pool"
-	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 const (
@@ -386,8 +385,7 @@ func (c *loadingSeriesChunksSetIterator) Next() (retHasNext bool) {
 	sp, ctx := tracing.StartSpan(c.ctx, "load_chunks")
 	defer sp.Finish()
 	defer func() {
-		spanLogger := spanlogger.FromContext(ctx, c.logger)
-		level.Debug(spanLogger).Log("msg", "loaded chunks", "num_series", c.At().len(), "err", c.Err())
+		sp.LogKV("msg", "loaded chunks", "num_series", c.At().len(), "err", c.Err())
 	}()
 
 	nextUnloaded := c.from.At()

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -841,8 +841,7 @@ func (s *loadingSeriesChunkRefsSetIterator) Next() bool {
 	sp, ctx := tracing.StartSpan(s.ctx, "load_series_and_chunk_refs")
 	defer sp.Finish()
 	defer func() {
-		spanLogger := spanlogger.FromContext(ctx, s.logger)
-		level.Debug(spanLogger).Log("msg", "loaded series and chunk refs", "block_id", s.blockID.String(), "series_count", s.At().len(), "err", s.Err())
+		sp.LogKV("msg", "loaded series and chunk refs", "block_id", s.blockID.String(), "series_count", s.At().len(), "err", s.Err())
 	}()
 
 	nextPostings := s.postingsSetIterator.At()

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1677,7 +1677,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				maxT,
 				2,
 				newSafeQueryStats(),
-				nil,
+				log.NewNopLogger(),
 			)
 			require.NoError(t, err)
 
@@ -1778,7 +1778,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_pendingMatchers(t *testing.T) {
 					block.meta.MaxTime,
 					2,
 					newSafeQueryStats(),
-					nil,
+					log.NewNopLogger(),
 				)
 				require.NoError(t, err)
 				allSets := readAllSeriesChunkRefsSet(iterator)
@@ -1841,7 +1841,7 @@ func BenchmarkOpenBlockSeriesChunkRefsSetsIterator(b *testing.B) {
 							block.meta.MaxTime,
 							2,
 							newSafeQueryStats(),
-							nil,
+							log.NewNopLogger(),
 						)
 						require.NoError(b, err)
 


### PR DESCRIPTION
While reviewing #5182 I realized that the spans we have in the store-gateway aren't very consistent and could use some more information. This PR does this. It leaves out the bucket_store_merge_all span, which is also somewhat incorrect, but that is being improved in #5182 (and I don't want to create extra conflicts with that PR).

For reference this is how the spans look like at present 
<img width="1465" alt="Screenshot 2023-06-20 at 14 45 27" src="https://github.com/grafana/mimir/assets/21020035/5563273f-8719-4070-bdfe-46573cd0d6ad">


