### PR TITLE
development: microservices mode docker compose open memberlist ports

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -218,6 +218,7 @@ std.manifestYamlDoc({
     hostname: options.name,
     // Only publish HTTP and debug port, but not gRPC one.
     ports: ['%d:%d' % [options.httpPort, options.httpPort]] +
+           ['%d:%d' % [options.memberlistBindPort, options.memberlistBindPort]] +
            if $._config.debug then [
              '%d:%d' % [options.debugPort, options.debugPort],
            ] else [],
@@ -267,6 +268,9 @@ std.manifestYamlDoc({
   memcached:: {
     memcached: {
       image: 'memcached:1.6.19-alpine',
+      ports: [
+        '11211:11211',
+      ]
     },
   },
 

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -270,7 +270,7 @@ std.manifestYamlDoc({
       image: 'memcached:1.6.19-alpine',
       ports: [
         '11211:11211',
-      ]
+      ],
     },
   },
 

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -20,6 +20,7 @@
     "image": "mimir"
     "ports":
       - "8031:8031"
+      - "10031:10031"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -44,6 +45,7 @@
     "image": "mimir"
     "ports":
       - "8032:8032"
+      - "10032:10032"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -68,6 +70,7 @@
     "image": "mimir"
     "ports":
       - "8033:8033"
+      - "10033:10033"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -92,6 +95,7 @@
     "image": "mimir"
     "ports":
       - "8006:8006"
+      - "10006:10006"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -115,6 +119,7 @@
     "image": "mimir"
     "ports":
       - "8000:8000"
+      - "10000:10000"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -138,6 +143,7 @@
     "image": "mimir"
     "ports":
       - "8001:8001"
+      - "10001:10001"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -173,6 +179,7 @@
     "image": "mimir"
     "ports":
       - "8002:8002"
+      - "10002:10002"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -198,6 +205,7 @@
     "image": "mimir"
     "ports":
       - "8003:8003"
+      - "10003:10003"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -223,6 +231,8 @@
       - "9900:9900"
   "memcached":
     "image": "memcached:1.6.19-alpine"
+    "ports":
+      - "11211:11211"
   "memcached-exporter":
     "command":
       - "--memcached.address=memcached:11211"
@@ -289,6 +299,7 @@
     "image": "mimir"
     "ports":
       - "8004:8004"
+      - "10004:10004"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -313,6 +324,7 @@
     "image": "mimir"
     "ports":
       - "8007:8007"
+      - "10007:10007"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -337,6 +349,7 @@
     "image": "mimir"
     "ports":
       - "8011:8011"
+      - "10011:10011"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -361,6 +374,7 @@
     "image": "mimir"
     "ports":
       - "8021:8021"
+      - "10021:10021"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -385,6 +399,7 @@
     "image": "mimir"
     "ports":
       - "8022:8022"
+      - "10022:10022"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -409,6 +424,7 @@
     "image": "mimir"
     "ports":
       - "8008:8008"
+      - "10008:10008"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -433,6 +449,7 @@
     "image": "mimir"
     "ports":
       - "8009:8009"
+      - "10009:10009"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"


### PR DESCRIPTION
#### What this PR does
I generally prefer to not have the component(s) I am developing on in a container for ease/speed of iteration, hooking up debuggers etc.
Dependencies can remain in containers for ease of use, treating them as a black box.

Opening the memberlist ports for each service allows running an uncontainerized component against the containerized dependencies, with memberlist enabled.

This PR also opens the memcached port for the same reasons.

#### Checklist

- [ ] Tests updated: N/A
- [ ] Documentation added: N/A
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`: N/A
