### PR TITLE
Forward alias to manage/mimir-runbooks

### DIFF
--- a/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/operators-guide/mimir-runbooks/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ../manage/mimir-runbooks/
 title: "Grafana Mimir runbooks"
 menuTitle: "Runbooks"
 description: "Grafana Mimir runbooks."


### PR DESCRIPTION
#### What this PR does
People using the jsonnet mixins from main cannot get to their runbooks, because latest and next documentation links deviated.

Make a forward alias on the release branch to let the links work.

#### Which issue(s) this PR fixes or relates to

Fixes community feedback on slack.
https://grafana.slack.com/archives/C039863E8P7/p1687270900053379?thread_ts=1687268332.886079&cid=C039863E8P7

#### Checklist

- N/A Tests updated
- [X] Documentation added
- N/A (won't be done on main, more of a workaround) `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
