### PR TITLE
WriteRequest: change function args to LabelAdapter

### DIFF
--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -206,10 +206,10 @@ func TestWriteRequestBufferingClient_PushConcurrent(t *testing.T) {
 }
 
 func createRequest(metricName string, seriesPerRequest int) *mimirpb.WriteRequest {
-	metrics := make([]labels.Labels, 0, seriesPerRequest)
+	metrics := make([][]mimirpb.LabelAdapter, 0, seriesPerRequest)
 	samples := make([]mimirpb.Sample, 0, seriesPerRequest)
 	for i := 0; i < seriesPerRequest; i++ {
-		metrics = append(metrics, labels.FromStrings(labels.MetricName, metricName, "cardinality", strconv.Itoa(i)))
+		metrics = append(metrics, []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: metricName}, {Name: "cardinality", Value: strconv.Itoa(i)}})
 		samples = append(samples, mimirpb.Sample{Value: float64(i), TimestampMs: time.Now().UnixMilli()})
 	}
 

--- a/pkg/mimirpb/compat.go
+++ b/pkg/mimirpb/compat.go
@@ -18,7 +18,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/util/jsonutil"
@@ -31,7 +30,7 @@ import (
 // method implies that only a single sample and optionally exemplar can be set for each series.
 //
 // For histograms use NewWriteRequest and Add* functions to build write request with Floats and Histograms
-func ToWriteRequest(lbls []labels.Labels, samples []Sample, exemplars []*Exemplar, metadata []*MetricMetadata, source WriteRequest_SourceEnum) *WriteRequest {
+func ToWriteRequest(lbls [][]LabelAdapter, samples []Sample, exemplars []*Exemplar, metadata []*MetricMetadata, source WriteRequest_SourceEnum) *WriteRequest {
 	return NewWriteRequest(metadata, source).AddFloatSeries(lbls, samples, exemplars)
 }
 
@@ -47,10 +46,10 @@ func NewWriteRequest(metadata []*MetricMetadata, source WriteRequest_SourceEnum)
 // AddFloatSeries converts matched slices of Labels, Samples, Exemplars into a WriteRequest
 // proto. It gets timeseries from the pool, so ReuseSlice() should be called when done. Note that this
 // method implies that only a single sample and optionally exemplar can be set for each series.
-func (req *WriteRequest) AddFloatSeries(lbls []labels.Labels, samples []Sample, exemplars []*Exemplar) *WriteRequest {
+func (req *WriteRequest) AddFloatSeries(lbls [][]LabelAdapter, samples []Sample, exemplars []*Exemplar) *WriteRequest {
 	for i, s := range samples {
 		ts := TimeseriesFromPool()
-		ts.Labels = append(ts.Labels, FromLabelsToLabelAdapters(lbls[i])...)
+		ts.Labels = append(ts.Labels, lbls[i]...)
 		ts.Samples = append(ts.Samples, s)
 
 		if exemplars != nil {
@@ -69,10 +68,10 @@ func (req *WriteRequest) AddFloatSeries(lbls []labels.Labels, samples []Sample, 
 // AddHistogramSeries converts matched slices of Labels, Histograms, Exemplars into a WriteRequest
 // proto. It gets timeseries from the pool, so ReuseSlice() should be called when done. Note that this
 // method implies that only a single sample and optionally exemplar can be set for each series.
-func (req *WriteRequest) AddHistogramSeries(lbls []labels.Labels, histograms []Histogram, exemplars []*Exemplar) *WriteRequest {
+func (req *WriteRequest) AddHistogramSeries(lbls [][]LabelAdapter, histograms []Histogram, exemplars []*Exemplar) *WriteRequest {
 	for i, s := range histograms {
 		ts := TimeseriesFromPool()
-		ts.Labels = append(ts.Labels, FromLabelsToLabelAdapters(lbls[i])...)
+		ts.Labels = append(ts.Labels, lbls[i]...)
 		ts.Histograms = append(ts.Histograms, s)
 
 		if exemplars != nil {

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -43,15 +43,15 @@ type PusherAppender struct {
 
 	ctx             context.Context
 	pusher          Pusher
-	labels          []labels.Labels
+	labels          [][]mimirpb.LabelAdapter
 	samples         []mimirpb.Sample
-	histogramLabels []labels.Labels
+	histogramLabels [][]mimirpb.LabelAdapter
 	histograms      []mimirpb.Histogram
 	userID          string
 }
 
 func (a *PusherAppender) Append(_ storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
-	a.labels = append(a.labels, l)
+	a.labels = append(a.labels, mimirpb.FromLabelsToLabelAdapters(l))
 	a.samples = append(a.samples, mimirpb.Sample{
 		TimestampMs: t,
 		Value:       v,
@@ -68,7 +68,7 @@ func (a *PusherAppender) UpdateMetadata(_ storage.SeriesRef, _ labels.Labels, _ 
 }
 
 func (a *PusherAppender) AppendHistogram(_ storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
-	a.histogramLabels = append(a.histogramLabels, l)
+	a.histogramLabels = append(a.histogramLabels, mimirpb.FromLabelsToLabelAdapters(l))
 	var hp mimirpb.Histogram
 	if h != nil {
 		hp = mimirpb.FromHistogramToHistogramProto(t, h)


### PR DESCRIPTION
#### What this PR does

This makes things consistent: all `WriteRequest` helper functions' arguments now come from package `mimirpb`.

Primary motivation for this change was to remove spurious overhead under `-tags stringlabels` from tests like `BenchmarkDistributor_Push`, where `ToWriteRequest` was converting `Labels` to `[]LabelAdapter` on every iteration.

The one place that used `ToWriteRequest` outside of tests is ruler, so it now has to make the `Labels` to `[]LabelAdapter` conversion explicitly.

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated
