### PR TITLE
store-gateway tests: increase gRPC receive message size

### DIFF
--- a/pkg/storegateway/bucket_store_server_test.go
+++ b/pkg/storegateway/bucket_store_server_test.go
@@ -101,7 +101,10 @@ func (s *storeTestServer) Series(ctx context.Context, req *storepb.SeriesRequest
 	)
 
 	// Create a gRPC connection to the server.
-	conn, err = grpc.Dial(s.serverListener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err = grpc.Dial(s.serverListener.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(1024*1024*1024)),
+	)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Some of the largest test cases of BenchmarkBucketStore_Series failed because the result is larger than the default gRPC message size of 4MiB. This PR sets the limit in tests to 1GiB.
