### PR TITLE
Play with Mimir tutorial - Grafana UI doesn't start in localhost because the port mapping is wrong

### DIFF
--- a/docs/sources/mimir/tutorials/play-with-grafana-mimir/docker-compose.yml
+++ b/docs/sources/mimir/tutorials/play-with-grafana-mimir/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - ../../../../../operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json:/var/lib/grafana/dashboards/mimir-top-tenants.json:ro
       - ../../../../../operations/mimir-mixin-compiled/dashboards/mimir-writes.json:/var/lib/grafana/dashboards/mimir-writes.json:ro
     ports:
-      - 9000:3000
+      - 3000:3000
 
   prometheus:
     image: prom/prometheus:latest

--- a/docs/sources/mimir/tutorials/play-with-grafana-mimir/index.md
+++ b/docs/sources/mimir/tutorials/play-with-grafana-mimir/index.md
@@ -38,7 +38,7 @@ In this tutorial, you'll:
 
 - Git
 - [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/)
-- Availability of both ports `9000` and `9009` on your host machine
+- Availability of both ports `3000` and `9009` on your host machine
 
 ## Download tutorial configuration
 
@@ -82,29 +82,29 @@ The diagram below illustrates the relationship between these components:
 
 The following ports will be exposed on the host:
 
-- Grafana on [`http://localhost:9000`](http://localhost:9000)
+- Grafana on [`http://localhost:3000`](http://localhost:3000)
 - Grafana Mimir on [`http://localhost:9009`](http://localhost:9009)
 
 To learn more about the Grafana Mimir configuration, you can review the configuration file `config/mimir.yaml`.
 
 ## Explore Grafana Mimir dashboards
 
-Open Grafana on your local host [`http://localhost:9000`](http://localhost:9000) and view dashboards showing the status
+Open Grafana on your local host [`http://localhost:3000`](http://localhost:3000) and view dashboards showing the status
 and health of your Grafana Mimir cluster. The dashboards query Grafana Mimir for the metrics they display.
 
 To start, we recommend looking at these dashboards:
 
-- [Writes](http://localhost:9000/d/8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes)
-- [Reads](http://localhost:9000/d/e327503188913dc38ad571c647eef643/mimir-reads)
-- [Queries](http://localhost:9000/d/b3abe8d5c040395cc36615cb4334c92d/mimir-queries)
-- [Object Store](http://localhost:9000/d/e1324ee2a434f4158c00a9ee279d3292/mimir-object-store)
+- [Writes](http://localhost:3000/d/8280707b8f16e7b87b840fc1cc92d4c5/mimir-writes)
+- [Reads](http://localhost:3000/d/e327503188913dc38ad571c647eef643/mimir-reads)
+- [Queries](http://localhost:3000/d/b3abe8d5c040395cc36615cb4334c92d/mimir-queries)
+- [Object Store](http://localhost:3000/d/e1324ee2a434f4158c00a9ee279d3292/mimir-object-store)
 
 A couple of caveats:
 
 - It typically takes a few minutes after Grafana Mimir starts to display meaningful metrics in the dashboards.
 - Because this tutorial runs Grafana Mimir without any query-scheduler, or memcached, the related panels are expected to be empty.
 
-The dashboards installed in the Grafana are taken from the Grafana Mimir mixin which packages up Grafana Labs' best practice dashboards, recording rules, and alerts for monitoring Grafana Mimir. To learn more about the mixin, check out the Grafana Mimir mixin documentation. To learn more about how Grafana is connecting to Grafana Mimir, review the [Mimir datasource](http://localhost:9000/datasources).
+The dashboards installed in the Grafana are taken from the Grafana Mimir mixin which packages up Grafana Labs' best practice dashboards, recording rules, and alerts for monitoring Grafana Mimir. To learn more about the mixin, check out the Grafana Mimir mixin documentation. To learn more about how Grafana is connecting to Grafana Mimir, review the [Mimir datasource](http://localhost:3000/datasources).
 
 ## Configure your first recording rule
 
@@ -112,7 +112,7 @@ Recording rules allow you to precompute frequently needed or computationally exp
 as a new set of time series. In this section you're going to configure a recording rule in Grafana Mimir using tooling
 offered by Grafana.
 
-1. Open [Grafana Alerting](http://localhost:9000/alerting/list).
+1. Open [Grafana Alerting](http://localhost:3000/alerting/list).
 2. Click "New alert rule", which also allows you to configure recording rules.
 3. Configure the recording rule:
    1. Select `Mimir or Loki recording rule` in the top selector.
@@ -126,7 +126,7 @@ offered by Grafana.
 Your `sum:up` recording rule will show the number of Mimir instances that are `up`, meaning reachable to be scraped. The
 rule is now being created in Grafana Mimir ruler and will be soon available for querying:
 
-1. Open [Grafana Explore](http://localhost:9000/explore?orgId=1&left=%7B%22datasource%22:%22Mimir%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22sum:up%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)
+1. Open [Grafana Explore](http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22:%22Mimir%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22sum:up%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)
    and query the resulting series from the recording rule, which may require up to one minute to display after configuration:
    ```
    sum:up
@@ -139,7 +139,7 @@ Alerting rules allow you to define alert conditions based on PromQL expressions 
 alerts to Grafana Mimir Alertmanager. In this section you're going to configure an alerting rule in Grafana Mimir using
 tooling offered by Grafana.
 
-1. Open [Grafana Alerting](http://localhost:9000/alerting/list).
+1. Open [Grafana Alerting](http://localhost:3000/alerting/list).
 2. Click to "New alert rule".
 3. Configure the alert rule:
    1. Select `Mimir or Loki alert` in the top selector.
@@ -151,7 +151,7 @@ tooling offered by Grafana.
    7. From the upper-right corner, click the **Save and exit** button.
 
 Your `MimirNotRunning` alert rule is now being created in Grafana Mimir ruler and is expected to fire when the number of
-Grafana Mimir instances is less than three. You can check its status by opening the [Grafana Alerting](http://localhost:9000/alerting/list)
+Grafana Mimir instances is less than three. You can check its status by opening the [Grafana Alerting](http://localhost:3000/alerting/list)
 page and expanding the "example-namespace > example-group" row. The status should be "Normal" since all three instances are currently running.
 
 To see the alert firing we can introduce an outage in the Grafana Mimir cluster:
@@ -160,13 +160,13 @@ To see the alert firing we can introduce an outage in the Grafana Mimir cluster:
    ```bash
    docker-compose kill mimir-3
    ```
-1. Open [Grafana Alerting](http://localhost:9000/alerting/list) and check out the state of the alert `MimirNotRunning`,
+1. Open [Grafana Alerting](http://localhost:3000/alerting/list) and check out the state of the alert `MimirNotRunning`,
    which should switch to "Pending" state in about one minute and to "Firing" state after another minute. _Note: since we abruptly
    terminated a Mimir instance, Grafana Alerting UI may temporarily show an error when querying rules: the error will
    auto resolve shortly, as soon as Grafana Mimir internal health checking detects the terminated instance as unhealthy._
 
 Grafana Mimir Alertmanager has not been configured yet to notify alerts through a notification channel. To configure the
-Alertmanager you can open the [Contact points](http://localhost:9000/alerting/notifications) page in Grafana and
+Alertmanager you can open the [Contact points](http://localhost:3000/alerting/notifications) page in Grafana and
 set your preferred notification channel. Note the email receiver doesn't work in this example because there's no
 SMTP server running.
 
@@ -181,7 +181,7 @@ To resolve the alert and recover from the outage, restart the Grafana Mimir inst
    ```bash
    docker-compose start mimir-3
    ```
-2. Open [Grafana Alerting](http://localhost:9000/alerting/list) and check out the state of the alert `MimirNotRunning`,
+2. Open [Grafana Alerting](http://localhost:3000/alerting/list) and check out the state of the alert `MimirNotRunning`,
    which should switch to "Normal" state in about one minute.
 
 ## Summary


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
If you follow the tutorial mentioned in the Grafana docs, you will see that the grafana UI won't start in localhost because the port mapping is wrong.
After making this change, all of the services are starting correctly and you can see all of the tutorial dashboards through the Grafana UI.


#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
