### PR TITLE
Improve traces for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [ENHANCEMENT] Use new data structure for labels, to reduce memory consumption. #3555
 * [ENHANCEMENT] Update alpine base image to 3.18.2. #5276
 * [ENHANCEMENT] Ruler: add `cortex_ruler_sync_rules_duration_seconds` metric, tracking the time spent syncing all rule groups owned by the ruler instance. #5311
+* [ENHANCEMENT] Ingester and querier: improve level of detail in traces emitted for queries that hit ingesters. #5315
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 
 ### Mixin

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -192,11 +192,11 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 	queryLimiter := limiter.QueryLimiterFromContextWithFallback(ctx)
 	reqStats := stats.FromContext(ctx)
 
-	queryIngester := func(ctx context.Context, ing *ring.InstanceDesc, cleanupContext context.CancelFunc) (ingesterQueryResult, error) {
+	queryIngester := func(ctx context.Context, ing *ring.InstanceDesc, cancelContext context.CancelFunc) (ingesterQueryResult, error) {
 		log, ctx := spanlogger.NewWithLogger(ctx, d.log, "Distributor.queryIngesterStream")
 		cleanup := func() {
 			log.Span.Finish()
-			cleanupContext()
+			cancelContext()
 		}
 
 		var stream ingester_client.Ingester_QueryStreamClient

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/mimir/pkg/util/limiter"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
@@ -76,24 +77,35 @@ func (s *SeriesChunksStreamReader) StartBuffering() {
 	ctxDone := s.client.Context().Done()
 
 	go func() {
+		log, _ := spanlogger.NewWithLogger(s.client.Context(), s.log, "SeriesChunksStreamReader.StartBuffering")
+
 		defer func() {
 			s.Close()
 
 			close(s.seriesBatchChan)
 			close(s.errorChan)
+			log.Span.Finish()
 		}()
 
+		onError := func(err error) {
+			s.errorChan <- err
+			log.Error(err)
+		}
+
 		totalSeries := 0
+		totalChunks := 0
 
 		for {
 			msg, err := s.client.Recv()
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					if totalSeries < s.expectedSeriesCount {
-						s.errorChan <- fmt.Errorf("expected to receive %v series, but got EOF after receiving %v series", s.expectedSeriesCount, totalSeries)
+						onError(fmt.Errorf("expected to receive %v series, but got EOF after receiving %v series", s.expectedSeriesCount, totalSeries))
+					} else {
+						level.Debug(log).Log("msg", "finished streaming", "series", totalSeries, "chunks", totalChunks)
 					}
 				} else {
-					s.errorChan <- err
+					onError(err)
 				}
 
 				return
@@ -105,7 +117,7 @@ func (s *SeriesChunksStreamReader) StartBuffering() {
 
 			totalSeries += len(msg.StreamingSeriesChunks)
 			if totalSeries > s.expectedSeriesCount {
-				s.errorChan <- fmt.Errorf("expected to receive only %v series, but received at least %v series", s.expectedSeriesCount, totalSeries)
+				onError(fmt.Errorf("expected to receive only %v series, but received at least %v series", s.expectedSeriesCount, totalSeries))
 				return
 			}
 
@@ -121,14 +133,16 @@ func (s *SeriesChunksStreamReader) StartBuffering() {
 			}
 
 			if err := s.queryLimiter.AddChunks(chunkCount); err != nil {
-				s.errorChan <- err
+				onError(err)
 				return
 			}
 
 			if err := s.queryLimiter.AddChunkBytes(chunkBytes); err != nil {
-				s.errorChan <- err
+				onError(err)
 				return
 			}
+
+			totalChunks += chunkCount
 
 			select {
 			case <-ctxDone:
@@ -139,7 +153,7 @@ func (s *SeriesChunksStreamReader) StartBuffering() {
 				// So, here, we try to send the series to the buffer if we can, but if the context is cancelled, then we give up.
 				// This only works correctly if the context is cancelled when the query request is complete or cancelled,
 				// which is true at the time of writing.
-				s.errorChan <- s.client.Context().Err()
+				onError(s.client.Context().Err())
 				return
 			case s.seriesBatchChan <- msg.StreamingSeriesChunks:
 				// Batch enqueued successfully, nothing else to do for this batch.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1527,7 +1527,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 	if streamType == QueryStreamChunks {
 		if req.StreamingChunksBatchSize > 0 {
 			level.Debug(spanlog).Log("msg", "using executeStreamingQuery")
-			numSeries, numSamples, err = i.executeStreamingQuery(ctx, db, int64(from), int64(through), matchers, shard, stream, req.StreamingChunksBatchSize)
+			numSeries, numSamples, err = i.executeStreamingQuery(ctx, db, int64(from), int64(through), matchers, shard, stream, req.StreamingChunksBatchSize, spanlog)
 		} else {
 			level.Debug(spanlog).Log("msg", "using executeChunksQuery")
 			numSeries, numSamples, err = i.executeChunksQuery(ctx, db, int64(from), int64(through), matchers, shard, stream)
@@ -1726,7 +1726,7 @@ func (i *Ingester) executeChunksQuery(ctx context.Context, db *userTSDB, from, t
 	return numSeries, numSamples, nil
 }
 
-func (i *Ingester) executeStreamingQuery(ctx context.Context, db *userTSDB, from, through int64, matchers []*labels.Matcher, shard *sharding.ShardSelector, stream client.Ingester_QueryStreamServer, batchSize uint64) (numSeries, numSamples int, _ error) {
+func (i *Ingester) executeStreamingQuery(ctx context.Context, db *userTSDB, from, through int64, matchers []*labels.Matcher, shard *sharding.ShardSelector, stream client.Ingester_QueryStreamServer, batchSize uint64, spanlog *spanlogger.SpanLogger) (numSeries, numSamples int, _ error) {
 	var q storage.ChunkQuerier
 	var err error
 	if i.limits.OutOfOrderTimeWindow(db.userID) > 0 {
@@ -1741,17 +1741,21 @@ func (i *Ingester) executeStreamingQuery(ctx context.Context, db *userTSDB, from
 	// The querier must remain open until we've finished streaming chunks.
 	defer q.Close()
 
-	allSeries, seriesCount, err := i.sendStreamingQuerySeries(q, from, through, matchers, shard, stream)
+	allSeries, numSeries, err := i.sendStreamingQuerySeries(q, from, through, matchers, shard, stream)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	numSamples, err = i.sendStreamingQueryChunks(allSeries, stream, batchSize)
+	level.Debug(spanlog).Log("msg", "finished sending series", "series", numSeries)
+
+	numSamples, numChunks, numBatches, err := i.sendStreamingQueryChunks(allSeries, stream, batchSize)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	return seriesCount, numSamples, nil
+	level.Debug(spanlog).Log("msg", "finished sending chunks", "chunks", numChunks, "batches", numBatches)
+
+	return numSeries, numSamples, nil
 }
 
 // chunkSeriesNode is used a build a linked list of slices of series.
@@ -1857,12 +1861,14 @@ func (i *Ingester) sendStreamingQuerySeries(q storage.ChunkQuerier, from, throug
 	return allSeriesList, seriesCount, nil
 }
 
-func (i *Ingester) sendStreamingQueryChunks(allSeries *chunkSeriesNode, stream client.Ingester_QueryStreamServer, batchSize uint64) (int, error) {
+func (i *Ingester) sendStreamingQueryChunks(allSeries *chunkSeriesNode, stream client.Ingester_QueryStreamServer, batchSize uint64) (int, int, int, error) {
 	var (
 		it             chunks.Iterator
 		seriesIdx      = -1
 		currNode       = allSeries
 		numSamples     = 0
+		numChunks      = 0
+		numBatches     = 0
 		seriesInBatch  = make([]client.QueryStreamSeriesChunks, 0, batchSize)
 		batchSizeBytes = 0
 	)
@@ -1882,18 +1888,19 @@ func (i *Ingester) sendStreamingQueryChunks(allSeries *chunkSeriesNode, stream c
 				// It is not guaranteed that chunk returned by iterator is populated.
 				// For now just return error. We could also try to figure out how to read the chunk.
 				if meta.Chunk == nil {
-					return 0, errors.Errorf("unfilled chunk returned from TSDB chunk querier")
+					return 0, 0, 0, errors.Errorf("unfilled chunk returned from TSDB chunk querier")
 				}
 
 				ch, err := client.ChunkFromMeta(meta)
 				if err != nil {
-					return 0, err
+					return 0, 0, 0, err
 				}
 
 				seriesChunks.Chunks = append(seriesChunks.Chunks, ch)
 				numSamples += meta.Chunk.NumSamples()
 			}
 
+			numChunks += len(seriesChunks.Chunks)
 			msgSize := seriesChunks.Size()
 
 			if (batchSizeBytes > 0 && batchSizeBytes+msgSize > queryStreamBatchMessageSize) || len(seriesInBatch) >= int(batchSize) {
@@ -1902,11 +1909,12 @@ func (i *Ingester) sendStreamingQueryChunks(allSeries *chunkSeriesNode, stream c
 					StreamingSeriesChunks: seriesInBatch,
 				})
 				if err != nil {
-					return 0, err
+					return 0, 0, 0, err
 				}
 
 				seriesInBatch = seriesInBatch[:0]
 				batchSizeBytes = 0
+				numBatches++
 			}
 
 			seriesInBatch = append(seriesInBatch, seriesChunks)
@@ -1924,11 +1932,12 @@ func (i *Ingester) sendStreamingQueryChunks(allSeries *chunkSeriesNode, stream c
 			StreamingSeriesChunks: seriesInBatch,
 		})
 		if err != nil {
-			return 0, err
+			return 0, 0, 0, err
 		}
+		numBatches++
 	}
 
-	return numSamples, nil
+	return numSamples, numChunks, numBatches, nil
 }
 
 func (i *Ingester) getTSDB(userID string) *userTSDB {


### PR DESCRIPTION
#### What this PR does

This PR makes a number of small improvements to the traces emitted while querying:

* When streaming chunks is enabled, ingesters now emit events after sending all series labels and after sending all chunks, and these events include the number of series, chunks and batches of chunks sent, as appropriate.
* When streaming chunks from an ingester, queriers now emit a span specifically while streaming chunks from ingesters (ie. the time from when the first batch of chunks is read from the stream until the last batch is read from the stream)
* Queriers now emit a parent span for query calls to each ingester, with the span emitted for the gRPC call and the span introduced above as children. This parent span is emitted regardless of whether streaming is enabled or not.

This is what a trace of a sample query that hits two ingesters now looks like:

<img width="1349" alt="Screenshot 2023-06-23 at 3 35 57 pm" src="https://github.com/grafana/mimir/assets/4017646/cc149ecb-fcce-40b1-8dcb-367613b68235">

Note to reviewers: I'd suggest reviewing each commit separately.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
