### PR TITLE
mimirpb: optimize label sorting in timeseries type

### DIFF
--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -8,10 +8,11 @@ package mimirpb
 import (
 	"fmt"
 	"io"
-	"sort"
 	"strings"
 	"sync"
 	"unsafe"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/zeropool"
@@ -136,8 +137,8 @@ func (p *PreallocTimeseries) SortLabelsIfNeeded() {
 		return
 	}
 
-	sort.Slice(p.Labels, func(i, j int) bool {
-		return p.Labels[i].Name < p.Labels[j].Name
+	slices.SortFunc(p.Labels, func(a, b LabelAdapter) bool {
+		return a.Name < b.Name
 	})
 	p.clearUnmarshalData()
 }

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -7,6 +7,7 @@ package mimirpb
 
 import (
 	"crypto/rand"
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -424,4 +425,43 @@ func TestPreallocTimeseries_SetLabels(t *testing.T) {
 
 	require.Equal(t, []LabelAdapter{{Name: "__name__", Value: "hello"}, {Name: "lbl", Value: "world"}}, p.Labels)
 	require.Nil(t, p.marshalledData)
+}
+
+func BenchmarkPreallocTimeseries_SortLabelsIfNeeded(b *testing.B) {
+	bcs := []int{10, 100, 1_000, 10_000, 100_000, 1_000_000}
+
+	for _, lbCount := range bcs {
+		b.Run(fmt.Sprintf("num_labels=%d", lbCount), func(b *testing.B) {
+			// Generate unordered labels set.
+			lbs := make([]labels.Label, 0, lbCount)
+			for i := 0; i < lbCount; i++ {
+				lbName := fmt.Sprintf("lbl_%d", lbCount-i)
+				lbValue := fmt.Sprintf("val_%d", lbCount-i)
+				lbs = append(lbs, labels.Label{Name: lbName, Value: lbValue})
+			}
+			unorderedLabels := FromLabelsToLabelAdapters(lbs)
+
+			p := PreallocTimeseries{
+				TimeSeries: &TimeSeries{},
+			}
+
+			// Copy unordered labels set for each benchmark iteration.
+			benchmarkUnorderedLabels := make([][]LabelAdapter, b.N)
+			for i := 0; i < b.N; i++ {
+				benchmarkLabels := make([]LabelAdapter, len(unorderedLabels))
+				copy(benchmarkLabels, unorderedLabels)
+				benchmarkUnorderedLabels[i] = benchmarkLabels
+			}
+
+			// Warmup.
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			// Run benchmark.
+			for i := 0; i < b.N; i++ {
+				p.SetLabels(benchmarkUnorderedLabels[i])
+				p.SortLabelsIfNeeded()
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

After reviewing the profile of one of the aggregators in ops, we have noticed that approximately `18%` of the total process allocations originate from the `(*PreallocTimeseries).SortLabelsIfNeeded` method, specifically when calling the `sort.Slice` function responsible for performing the sorting.

![Screenshot 2023-06-23 at 11 05 59](https://github.com/grafana/mimir/assets/888899/6ca749d2-d40d-43ed-950d-5f6eb13dc95b)

This appears to be primarily due to the fact that `sort.Slice` uses reflection to perform the sorting, which results in an overhead of additional allocations.

This PR replaces the usage of that call with its counterpart `sort.SortFunc`, which is type-oriented and therefore does not need to make use of `reflect` package internally.

Additionally, as part of this PR, a new bechmark named `BenchmarkPreallocTimeseries_SortLabelsIfNeeded`  is included to validate this change. The preliminary results are provided below.

```
name                                                        old time/op    new time/op    delta
PreallocTimeseries_SortLabelsIfNeeded/num_labels=10-8          708ns ± 1%     284ns ± 6%   -59.89%  (p=0.000 n=9+9)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=100-8        8.85µs ± 2%    4.94µs ± 0%   -44.17%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=1000-8        116µs ± 0%      67µs ± 0%   -42.04%  (p=0.000 n=9+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=10000-8      1.45ms ± 0%    0.87ms ± 0%   -40.07%  (p=0.000 n=10+9)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=100000-8     18.5ms ± 1%    11.1ms ± 0%   -39.75%  (p=0.000 n=9+9)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=1000000-8     231ms ± 0%     143ms ± 0%   -38.17%  (p=0.000 n=10+9)

name                                                        old alloc/op   new alloc/op   delta
PreallocTimeseries_SortLabelsIfNeeded/num_labels=10-8           104B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=100-8          104B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=1000-8         104B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=10000-8        104B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=100000-8       104B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=1000000-8      104B ± 0%        0B       -100.00%  (p=0.000 n=10+10)

name                                                        old allocs/op  new allocs/op  delta
PreallocTimeseries_SortLabelsIfNeeded/num_labels=10-8           3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=100-8          3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=1000-8         3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=10000-8        3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=100000-8       3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
PreallocTimeseries_SortLabelsIfNeeded/num_labels=1000000-8      3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

What can be deduced from them is that after applying the change the sorting is approximately `50%` faster, by reducing total allocations to zero.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
