### PR TITLE
remove newline when globalEnv is set

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -82,10 +82,10 @@ spec:
             {{- toYaml .Values.overrides_exporter.containerSecurityContext | nindent 12 }}
           env:
             {{- with .Values.global.extraEnv }}
-              {{ toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.overrides_exporter.env }}
-              {{ toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -56,10 +56,10 @@ spec:
             {{- end }}
           env:
             {{- with .Values.global.extraEnv }}
-              {{ toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.smoke_test.env }}
-              {{ toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}


### PR DESCRIPTION
#### What this PR does

Remove a newline in smoketest and overrides_exporter helm chart when global.extraEnv is set.

```
$ helm template . --set 'global.extraEnv[0].name'=k1 --set 'global.extraEnv[0].value'=v1

-----
# Source: mimir-distributed/templates/smoke-test/smoke-test-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: release-name-mimir-smoke-test
  labels:
    helm.sh/chart: mimir-distributed-4.5.0-weekly.243
    app.kubernetes.io/name: mimir
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: smoke-test
    app.kubernetes.io/version: "r243"
    app.kubernetes.io/managed-by: Helm
  annotations:
    "helm.sh/hook": test
  namespace: "default"
spec:
  backoffLimit: 5
  completions: 1
  parallelism: 1
  selector:
  template:
    metadata:
      labels:
        helm.sh/chart: mimir-distributed-4.5.0-weekly.243
        app.kubernetes.io/name: mimir
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "r243"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: smoke-test
    spec:
      serviceAccountName: release-name-mimir
      securityContext:
        fsGroup: 10001
        runAsGroup: 10001
        runAsNonRoot: true
        runAsUser: 10001
        seccompProfile:
          type: RuntimeDefault
      initContainers:
        []
      containers:
        - name: smoke-test
          image: "grafana/mimir-continuous-test:r243-edb845a"
          imagePullPolicy: IfNotPresent
          args:
            - "-tests.smoke-test"
            - "-tests.write-endpoint=http://release-name-mimir-nginx.default.svc:80"
            - "-tests.read-endpoint=http://release-name-mimir-nginx.default.svc:80/prometheus"
            - "-tests.tenant-id="
            - "-tests.write-read-series-test.num-series=1000"
            - "-tests.write-read-series-test.max-query-age=48h"
            - "-server.metrics-port=8080"
          volumeMounts:
          env:

            - name: k1
              value: v1
          envFrom:
      restartPolicy: OnFailure
      volumes:
```
There is a extra space after spec.template.spec.containers.env



