### PR TITLE
BenchmarkPreallocTimeseries_SortLabelsIfNeeded improvements

### DIFF
--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -421,9 +420,10 @@ func TestPreallocTimeseries_SetLabels(t *testing.T) {
 		},
 		marshalledData: []byte{1, 2, 3},
 	}
-	p.SetLabels(FromLabelsToLabelAdapters(labels.FromStrings("__name__", "hello", "lbl", "world")))
+	expected := []LabelAdapter{{Name: "__name__", Value: "hello"}, {Name: "lbl", Value: "world"}}
+	p.SetLabels(expected)
 
-	require.Equal(t, []LabelAdapter{{Name: "__name__", Value: "hello"}, {Name: "lbl", Value: "world"}}, p.Labels)
+	require.Equal(t, expected, p.Labels)
 	require.Nil(t, p.marshalledData)
 }
 

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -441,15 +441,15 @@ func BenchmarkPreallocTimeseries_SortLabelsIfNeeded(b *testing.B) {
 				unorderedLabels = append(unorderedLabels, LabelAdapter{Name: lbName, Value: lbValue})
 			}
 
-			b.Run("unordered", benchmarkSortLabelsIfNeeded(b, unorderedLabels))
+			b.Run("unordered", benchmarkSortLabelsIfNeeded(unorderedLabels))
 
 			slices.SortFunc(unorderedLabels, func(a, b LabelAdapter) bool { return a.Name < b.Name })
-			b.Run("ordered", benchmarkSortLabelsIfNeeded(b, unorderedLabels))
+			b.Run("ordered", benchmarkSortLabelsIfNeeded(unorderedLabels))
 		})
 	}
 }
 
-func benchmarkSortLabelsIfNeeded(b *testing.B, inputLabels []LabelAdapter) func(b *testing.B) {
+func benchmarkSortLabelsIfNeeded(inputLabels []LabelAdapter) func(b *testing.B) {
 	return func(b *testing.B) {
 		// Copy unordered labels set for each benchmark iteration.
 		benchmarkUnorderedLabels := make([][]LabelAdapter, b.N)

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -428,7 +428,7 @@ func TestPreallocTimeseries_SetLabels(t *testing.T) {
 }
 
 func BenchmarkPreallocTimeseries_SortLabelsIfNeeded(b *testing.B) {
-	bcs := []int{10, 100, 1_000, 10_000, 100_000, 1_000_000}
+	bcs := []int{10, 40, 100}
 
 	for _, lbCount := range bcs {
 		b.Run(fmt.Sprintf("num_labels=%d", lbCount), func(b *testing.B) {


### PR DESCRIPTION
#### What this PR does

Some improvements to `pkg/mimirpb/timeseries_test.go`.

Split into three commits, in decreasing order of importance.
* `BenchmarkPreallocTimeseries_SortLabelsIfNeeded`: use realistic numbers.  Default max labels is 30; we don't expect series with thousands.
* `TestPreallocTimeseries_SetLabels`: simplify test data. Most of `mimirpb` deals in `LabelAdapter` not `Labels` so make this test consistent. As a side-effect this removes the import of Prometheus `labels` from the file.
* `BenchmarkPreallocTimeseries_SortLabelsIfNeeded`: test ordered labels too.  The idea is the function is faster than just sorting every time, so we should check if that is the case.

I tried a couple of changes to `SortLabelsIfNeeded` - using `slices.IsSorted`, and omitting the whole pre-check, but both were worse than the existing code.

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated
