### PR TITLE
Helm: allow to override memcached extended options, mount volumes

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,6 +33,9 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Ruler: configure the ruler storage cache when the metadata cache is enabled. #5326 #5334
 * [ENHANCEMENT] Helm: support metricRelabelings in the monitoring serviceMonitor resources. #5340
 * [ENHANCEMENT] Service Account: allow adding labels to the service account. #5355
+* [ENHANCEMENT] Memcached: enable providing additional extended options (`-o/--extend`) via `<cache-section>.extraExtendedOptions`. #5353
+* [ENHANCEMENT] Memcached exporter: enable adding additional CLI arguments via `memcachedExporter.extraArgs`. #5353
+* [ENHANCEMENT] Memcached: allow mounting additional volumes to the memcached and exporter containers via `<cache-section>.extraVolumes` and `<cache-section>.extraVolumeMounts`. #5353
 
 ## 4.5.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,7 +33,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Ruler: configure the ruler storage cache when the metadata cache is enabled. #5326 #5334
 * [ENHANCEMENT] Helm: support metricRelabelings in the monitoring serviceMonitor resources. #5340
 * [ENHANCEMENT] Service Account: allow adding labels to the service account. #5355
-* [ENHANCEMENT] Memcached: enable providing additional extended options (`-o/--extend`) via `<cache-section>.extraExtendedOptions`. #5353
+* [ENHANCEMENT] Memcached: enable providing additional extended options (`-o/--extended`) via `<cache-section>.extraExtendedOptions`. #5353
 * [ENHANCEMENT] Memcached exporter: enable adding additional CLI arguments via `memcachedExporter.extraArgs`. #5353
 * [ENHANCEMENT] Memcached: allow mounting additional volumes to the memcached and exporter containers via `<cache-section>.extraVolumes` and `<cache-section>.extraVolumeMounts`. #5353
 

--- a/operations/helm/charts/mimir-distributed/ci/offline/enterprise-https-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/enterprise-https-values.yaml
@@ -1,0 +1,228 @@
+# Pin kube version so results are the same for running in CI and locally where the installed kube version may be different.
+kubeVersionOverride: "1.20"
+
+enterprise:
+  enabled: true
+
+mimir:
+  structuredConfig:
+    admin_api:
+      leader_election:
+        client_config: &grpc_client_tls_config
+          tls_enabled: true
+          tls_cert_path: /certs/tls.crt
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          tls_insecure_skip_verify: false
+
+    common:
+      storage:
+        s3:
+          endpoint: s3.dualstack.us-east-2.amazonaws.com
+
+    alertmanager_storage:
+      backend: s3
+      s3:
+        bucket_name: alertmanager
+
+    ruler:
+      tenant_federation:
+        enabled: true
+      ruler_client: *grpc_client_tls_config
+      alertmanager_client: *grpc_client_tls_config
+
+    tenant_federation:
+      enabled: true
+
+    frontend:
+      results_cache:
+        memcached:
+          <<: *grpc_client_tls_config
+      grpc_client_config: *grpc_client_tls_config
+
+    ingester:
+      ring:
+        kvstore:
+          store: memberlist
+        tokens_file_path: /data/tokens
+
+    # This configures how the store-gateway synchronizes blocks stored in the bucket. It uses Minio by default for getting started (configured via flags) but this should be changed for production deployments.
+    blocks_storage:
+      backend: s3
+      s3:
+        bucket_name: blocks
+      bucket_store:
+        sync_dir: /data/tsdb-sync
+
+    ruler_storage:
+      backend: s3
+      s3:
+        bucket_name: ruler
+
+    admin_client:
+      storage:
+        type: s3
+        s3:
+          bucket_name: admin-api
+
+    gateway:
+      proxy:
+        admin_api: &tls_frontend
+          url: https://gem-mimir-admin-api:8080
+          tls_enabled: true
+          tls_cert_path: /certs/tls.crt
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          tls_insecure_skip_verify: false
+        alertmanager:
+          <<: *tls_frontend
+          url: https://gem-mimir-alertmanager-headless:8080
+        compactor:
+          <<: *tls_frontend
+          url: https://gem-mimir-compactor-headless:8080
+        distributor:
+          <<: *tls_frontend
+          url: dns:///gem-mimir-distributor-headless:9095
+        ingester:
+          <<: *tls_frontend
+          url: https://gem-mimir-ingester-headless:8080
+        query_frontend:
+          <<: *tls_frontend
+          url: https://gem-mimir-query-frontend:8080
+        ruler:
+          <<: *tls_frontend
+          url: https://gem-mimir-ruler:8080
+        store_gateway:
+          <<: *tls_frontend
+          url: https://gem-mimir-store-gateway-headless:8080
+        default:
+          <<: *tls_frontend
+          url: https://gem-mimir-admin-api:8080
+    instrumentation:
+      distributor_client: *grpc_client_tls_config
+    querier:
+      store_gateway_client: *grpc_client_tls_config
+    query_scheduler:
+      grpc_client_config: *grpc_client_tls_config
+    alertmanager:
+      alertmanager_client: *grpc_client_tls_config
+    ingester_client:
+      grpc_client_config: *grpc_client_tls_config
+    frontend_worker:
+      grpc_client_config: *grpc_client_tls_config
+    memberlist: *grpc_client_tls_config
+
+    cluster_name: gem
+
+    server:
+      http_tls_config:
+        cert_file: /certs/tls.crt
+        key_file: /certs/tls.key
+        client_auth_type: VerifyClientCertIfGiven
+
+      grpc_tls_config:
+        cert_file: /certs/tls.crt
+        key_file: /certs/tls.key
+        client_auth_type: VerifyClientCertIfGiven
+
+alertmanager:
+  extraVolumes: &extra_volume
+    - name: tls-certs
+      secret:
+        secretName: tls-certs
+  extraVolumeMounts: &extra_volume_mount
+    - name: tls-certs
+      mountPath: /certs
+      readOnly: true
+  readinessProbe: &readiness_probe
+    httpGet:
+      path: /ready
+      port: http-metrics
+      scheme: HTTPS
+
+distributor:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+
+ingester:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+
+ruler:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+
+querier:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+
+query_frontend:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+
+query_scheduler:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+
+store_gateway:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+
+compactor:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+
+chunks-cache:
+  enabled: true
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+
+results-cache:
+  enabled: true
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+
+
+index-cache:
+  enabled: true
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+
+metadata-cache:
+  enabled: true
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+
+minio:
+  enabled: false
+
+overrides_exporter:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+  livenessProbe: *readiness_probe
+
+license:
+  external: true
+  secretName: gem-license
+
+tokengenJob:
+  enable: false
+
+admin_api:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe
+
+gateway:
+  extraVolumes: *extra_volume
+  extraVolumeMounts: *extra_volume_mount
+  readinessProbe: *readiness_probe

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -87,20 +87,14 @@ spec:
             - containerPort: {{ .port }}
               name: client
           args:
-            {{- if .args }}
-            {{- range $key, $value := .args }}
-            - "-{{ $key }}{{ if $value }} {{ $value }}{{ end }}"
-            {{- end }}
-            {{- else }}
             - -m {{ .allocatedMemory }}
-            - --extended=modern,track_sizes
+            - --extended=modern,track_sizes{{ with .extraExtendedOptions }},{{ . }}{{ end }}
             - -I {{ .maxItemMemory }}m
             - -c 16384
             - -v
             - -u {{ .port }}
             {{- range $key, $value := .extraArgs }}
             - "-{{ $key }}{{ if $value }} {{ $value }}{{ end }}"
-            {{- end }}
             {{- end }}
           env:
             {{- with $.ctx.Values.global.extraEnv }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -58,6 +58,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .extraVolumes }}
+      volumes:
+      {{ toYaml .extraVolumes | indent 8}}
+      {{- end }}
       containers:
         {{- if .extraContainers }}
         {{ toYaml .extraContainers | nindent 8 }}
@@ -83,6 +87,11 @@ spec:
             - containerPort: {{ .port }}
               name: client
           args:
+            {{- if .args }}
+            {{- range $key, $value := .args }}
+            - "-{{ $key }}{{ if $value }} {{ $value }}{{ end }}"
+            {{- end }}
+            {{- else }}
             - -m {{ .allocatedMemory }}
             - --extended=modern,track_sizes
             - -I {{ .maxItemMemory }}m
@@ -91,6 +100,7 @@ spec:
             - -u {{ .port }}
             {{- range $key, $value := .extraArgs }}
             - "-{{ $key }}{{ if $value }} {{ $value }}{{ end }}"
+            {{- end }}
             {{- end }}
           env:
             {{- with $.ctx.Values.global.extraEnv }}
@@ -102,6 +112,10 @@ spec:
             {{- end }}
           securityContext:
             {{- toYaml $.ctx.Values.memcached.containerSecurityContext | nindent 12 }}
+          {{- if .extraVolumeMounts }}
+          volumeMounts:
+              {{ toYaml .extraVolumeMounts | nindent 12}}
+          {{- end }}
 
       {{- if $.ctx.Values.memcachedExporter.enabled }}
         - name: exporter
@@ -115,10 +129,17 @@ spec:
           args:
             - "--memcached.address=localhost:{{ .port }}"
             - "--web.listen-address=0.0.0.0:9150"
+            {{- range $key, $value := $.ctx.Values.memcachedExporter.extraArgs }}
+            - "--{{ $key }}{{ if $value }}={{ $value }}{{ end }}"
+            {{- end }}
           resources:
             {{- toYaml $.ctx.Values.memcachedExporter.resources | nindent 12 }}
           securityContext:
             {{- toYaml $.ctx.Values.memcachedExporter.containerSecurityContext | nindent 12 }}
+          {{- if .extraVolumeMounts }}
+          volumeMounts:
+            {{ toYaml .extraVolumeMounts | nindent 12}}
+          {{- end }}
       {{- end }}
 {{- end -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -60,7 +60,7 @@ spec:
       {{- end }}
       {{- if .extraVolumes }}
       volumes:
-      {{ toYaml .extraVolumes | indent 8}}
+        {{- toYaml .extraVolumes | nindent 8 }}
       {{- end }}
       containers:
         {{- if .extraContainers }}
@@ -108,7 +108,7 @@ spec:
             {{- toYaml $.ctx.Values.memcached.containerSecurityContext | nindent 12 }}
           {{- if .extraVolumeMounts }}
           volumeMounts:
-              {{ toYaml .extraVolumeMounts | nindent 12}}
+            {{- toYaml .extraVolumeMounts | nindent 12 }}
           {{- end }}
 
       {{- if $.ctx.Values.memcachedExporter.enabled }}
@@ -132,7 +132,7 @@ spec:
             {{- toYaml $.ctx.Values.memcachedExporter.containerSecurityContext | nindent 12 }}
           {{- if .extraVolumeMounts }}
           volumeMounts:
-            {{ toYaml .extraVolumeMounts | nindent 12}}
+            {{- toYaml .extraVolumeMounts | nindent 12 }}
           {{- end }}
       {{- end }}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1659,6 +1659,17 @@ memcachedExporter:
       drop: [ALL]
     allowPrivilegeEscalation: false
 
+  # -- Extra args to add to the exporter container.
+  # Example:
+  # extraArgs:
+  #   memcached.tls.enable: true
+  #   memcached.tls.cert-file: /certs/cert.crt
+  #   memcached.tls.key-file: /certs/cert.key
+  #   memcached.tls.ca-file: /certs/ca.crt
+  #   memcached.tls.insecure-skip-verify: false
+  #   memcached.tls.server-name: memcached
+  extraArgs: {}
+
 chunks-cache:
   # -- Specifies whether memcached based chunks-cache should be enabled
   enabled: false
@@ -1712,11 +1723,35 @@ chunks-cache:
   statefulStrategy:
     type: RollingUpdate
 
+  # -- Override default CLI args for chunks-cache memcached container.
+  # Example:
+  # args:
+  #   o: modern,track_sizes
+  #   I: 1m
+  #   U: 11211
+  args: {}
+
   # -- Additional CLI args for chunks-cache
   extraArgs: {}
 
   # -- Additional containers to be added to the chunks-cache pod.
   extraContainers: []
+
+  # -- Additional volumes to be added to the chunks-cache pod (applies to both memcached and exporter containers).
+  # Example:
+  # extraVolumes:
+  # - name: extra-volume
+  #   secret:
+  #    secretName: extra-volume-secret
+  extraVolumes: []
+
+  # -- Additional volume mounts to be added to the chunks-cache pod (applies to both memcached and exporter containers).
+  # Example:
+  # extraVolumeMounts:
+  # - name: extra-volume
+  #   mountPath: /etc/extra-volume
+  #   readOnly: true
+  extraVolumeMounts: []
 
   # -- Resource requests and limits for the chunks-cache
   # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
@@ -1780,11 +1815,35 @@ index-cache:
   statefulStrategy:
     type: RollingUpdate
 
+  # -- Override default CLI args for index-cache memcached container.
+  # Example:
+  # args:
+  #   o: modern,track_sizes
+  #   I: 1m
+  #   U: 11211
+  args: {}
+
   # -- Additional CLI args for index-cache
   extraArgs: {}
 
   # -- Additional containers to be added to the index-cache pod.
   extraContainers: []
+
+  # -- Additional volumes to be added to the index-cache pod (applies to both memcached and exporter containers).
+  # Example:
+  # extraVolumes:
+  # - name: extra-volume
+  #   secret:
+  #    secretName: extra-volume-secret
+  extraVolumes: []
+
+  # -- Additional volume mounts to be added to the index-cache pod (applies to both memcached and exporter containers).
+  # Example:
+  # extraVolumeMounts:
+  # - name: extra-volume
+  #   mountPath: /etc/extra-volume
+  #   readOnly: true
+  extraVolumeMounts: []
 
   # -- Resource requests and limits for the index-cache
   # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
@@ -1848,11 +1907,35 @@ metadata-cache:
   statefulStrategy:
     type: RollingUpdate
 
+  # -- Override default CLI args for metadata-cache memcached container.
+  # Example:
+  # args:
+  #   o: modern,track_sizes
+  #   I: 1m
+  #   U: 11211
+  args: {}
+
   # -- Additional CLI args for metadata-cache
   extraArgs: {}
 
   # -- Additional containers to be added to the metadata-cache pod.
   extraContainers: []
+
+  # -- Additional volumes to be added to the metadata-cache pod (applies to both memcached and exporter containers).
+  # Example:
+  # extraVolumes:
+  # - name: extra-volume
+  #   secret:
+  #    secretName: extra-volume-secret
+  extraVolumes: []
+
+  # -- Additional volume mounts to be added to the metadata-cache pod (applies to both memcached and exporter containers).
+  # Example:
+  # extraVolumeMounts:
+  # - name: extra-volume
+  #   mountPath: /etc/extra-volume
+  #   readOnly: true
+  extraVolumeMounts: []
 
   # -- Resource requests and limits for the metadata-cache
   # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
@@ -1916,11 +1999,35 @@ results-cache:
   statefulStrategy:
     type: RollingUpdate
 
+  # -- Override default CLI args for results-cache memcached container.
+  # Example:
+  # args:
+  #   o: modern,track_sizes
+  #   I: 1m
+  #   U: 11211
+  args: {}
+
   # -- Additional CLI args for results-cache
   extraArgs: {}
 
   # -- Additional containers to be added to the results-cache pod.
   extraContainers: []
+
+  # -- Additional volumes to be added to the results-cache pod (applies to both memcached and exporter containers).
+  # Example:
+  # extraVolumes:
+  # - name: extra-volume
+  #   secret:
+  #    secretName: extra-volume-secret
+  extraVolumes: []
+
+  # -- Additional volume mounts to be added to the results-cache pod (applies to both memcached and exporter containers).
+  # Example:
+  # extraVolumeMounts:
+  # - name: extra-volume
+  #   mountPath: /etc/extra-volume
+  #   readOnly: true
+  extraVolumeMounts: []
 
   # -- Resource requests and limits for the results-cache
   # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1725,7 +1725,7 @@ chunks-cache:
 
   # -- Add extended options for chunks-cache memcached container. The format is the same as for the memcached -o/--extend flag.
   # Example:
-  # extraExtendedOptions: 'tls,modern,track_sizes'
+  # extraExtendedOptions: 'tls,no_hashexpand'
   extraExtendedOptions: ''
 
   # -- Additional CLI args for chunks-cache

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1723,13 +1723,10 @@ chunks-cache:
   statefulStrategy:
     type: RollingUpdate
 
-  # -- Override default CLI args for chunks-cache memcached container.
+  # -- Add extended options for chunks-cache memcached container. The format is the same as for the memcached -o/--extend flag.
   # Example:
-  # args:
-  #   o: modern,track_sizes
-  #   I: 1m
-  #   U: 11211
-  args: {}
+  # extraExtendedOptions: 'tls,modern,track_sizes'
+  extraExtendedOptions: ''
 
   # -- Additional CLI args for chunks-cache
   extraArgs: {}
@@ -1815,13 +1812,10 @@ index-cache:
   statefulStrategy:
     type: RollingUpdate
 
-  # -- Override default CLI args for index-cache memcached container.
+  # -- Add extended options for index-cache memcached container. The format is the same as for the memcached -o/--extend flag.
   # Example:
-  # args:
-  #   o: modern,track_sizes
-  #   I: 1m
-  #   U: 11211
-  args: {}
+  # extraExtendedOptions: 'tls,modern,track_sizes'
+  extraExtendedOptions: ''
 
   # -- Additional CLI args for index-cache
   extraArgs: {}
@@ -1907,13 +1901,10 @@ metadata-cache:
   statefulStrategy:
     type: RollingUpdate
 
-  # -- Override default CLI args for metadata-cache memcached container.
+  # -- Add extended options for metadata-cache memcached container. The format is the same as for the memcached -o/--extend flag.
   # Example:
-  # args:
-  #   o: modern,track_sizes
-  #   I: 1m
-  #   U: 11211
-  args: {}
+  # extraExtendedOptions: 'tls,modern,track_sizes'
+  extraExtendedOptions: ''
 
   # -- Additional CLI args for metadata-cache
   extraArgs: {}
@@ -1999,13 +1990,10 @@ results-cache:
   statefulStrategy:
     type: RollingUpdate
 
-  # -- Override default CLI args for results-cache memcached container.
+  # -- Add extended options for results-cache memcached container. The format is the same as for the memcached -o/--extend flag.
   # Example:
-  # args:
-  #   o: modern,track_sizes
-  #   I: 1m
-  #   U: 11211
-  args: {}
+  # extraExtendedOptions: 'tls,modern,track_sizes'
+  extraExtendedOptions: ''
 
   # -- Additional CLI args for results-cache
   extraArgs: {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -1,0 +1,66 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enterprise-https-values-rollout-operator
+  labels:
+    helm.sh/chart: rollout-operator-0.5.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/version: "v0.5.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rollout-operator
+      app.kubernetes.io/instance: enterprise-https-values
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rollout-operator
+        app.kubernetes.io/instance: enterprise-https-values
+    spec:
+      serviceAccountName: enterprise-https-values-rollout-operator
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: rollout-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          image: "grafana/rollout-operator:v0.5.0"
+          imagePullPolicy: IfNotPresent
+          args:
+          - -kubernetes.namespace=citestns
+          ports:
+            - name: http-metrics
+              containerPort: 8001
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: "1"
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: enterprise-https-values-rollout-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - watch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - update

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: enterprise-https-values-rollout-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: enterprise-https-values-rollout-operator
+subjects:
+- kind: ServiceAccount
+  name: enterprise-https-values-rollout-operator

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: enterprise-https-values-rollout-operator
+  labels:
+    helm.sh/chart: rollout-operator-0.5.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/version: "v0.5.0"
+    app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -1,0 +1,134 @@
+---
+# Source: mimir-distributed/templates/admin-api/admin-api-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {}
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: admin-api
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  name: enterprise-https-values-mimir-admin-api
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: admin-api
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: admin-api
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+      containers:
+        - name: admin-api
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=admin-api"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+              
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: license
+              mountPath: /license
+            - name: storage
+              mountPath: "/data"
+              subPath: 
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: admin-api
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/admin-api/admin-api-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/admin-api/admin-api-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/admin-api/admin-api-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-admin-api
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: admin-api
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: admin-api
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/admin-api/admin-api-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/admin-api/admin-api-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/admin-api/admin-api-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-admin-api
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: admin-api
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: admin-api

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
@@ -1,0 +1,21 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: enterprise-https-values-mimir-alertmanager-fallback-config
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {} 
+  namespace: "citestns"
+data:
+  alertmanager_fallback_config.yaml: |
+    receivers:
+        - name: default-receiver
+    route:
+        receiver: default-receiver

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-alertmanager
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: alertmanager
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -1,0 +1,151 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-alertmanager
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: alertmanager
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: enterprise-https-values-mimir-alertmanager
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "1Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: alertmanager
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        - name: tmp
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}
+        - name: alertmanager-fallback-config
+          configMap:
+            name: enterprise-https-values-mimir-alertmanager-fallback-config
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+      containers:
+        - name: alertmanager
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=alertmanager"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+            
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: license
+              mountPath: /license
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: alertmanager-fallback-config
+              mountPath: /configs/
+            - name: tmp
+              mountPath: /tmp
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -1,0 +1,36 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-alertmanager-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+    - port: 9094
+      protocol: TCP
+      name: cluster
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: alertmanager

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-alertmanager
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: alertmanager

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/chunks-cache/chunks-cache-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-chunks-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: chunks-cache
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: chunks-cache
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-chunks-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: chunks-cache
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: enterprise-https-values-mimir-chunks-cache
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: chunks-cache
+      annotations:
+
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+      containers:
+        - name: memcached
+          image: memcached:1.6.19-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 9830Mi
+            requests:
+              cpu: 500m
+              memory: 9830Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 8192
+            - --extended=modern,track_sizes
+            - -I 1m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+          envFrom:
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+        - name: exporter
+          image: prom/memcached-exporter:v0.11.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-chunks-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: chunks-cache
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: chunks-cache

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/compactor/compactor-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/compactor/compactor-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/compactor/compactor-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-compactor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: compactor
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -1,0 +1,142 @@
+---
+# Source: mimir-distributed/templates/compactor/compactor-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-compactor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: compactor
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: enterprise-https-values-mimir-compactor
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: compactor
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 240
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: compactor
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=compactor"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+            
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: license
+              mountPath: /license
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/compactor/compactor-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-compactor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: compactor

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -1,0 +1,134 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enterprise-https-values-mimir-distributor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: distributor
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: distributor
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=distributor"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+              
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: license
+              mountPath: /license
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+              subPath: 
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: distributor
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-distributor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: distributor
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-distributor-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: distributor

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-distributor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: distributor

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -1,0 +1,122 @@
+---
+# Source: mimir-distributed/templates/gateway/gateway-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {}
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/managed-by: Helm
+  name: enterprise-https-values-mimir-gateway
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: gateway
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: gateway
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+              
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: license
+              mountPath: /license
+            - name: tmp
+              mountPath: /data
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          resources:
+            {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: gateway
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        - name: tmp
+          emptyDir: {}
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}
+        - name: tls-certs
+          secret:
+            secretName: tls-certs

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/gateway/gateway-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/gateway/gateway-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/gateway/gateway-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-gateway
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: gateway
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/gateway/gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-gateway
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 8080
+      protocol: TCP
+      name: legacy-http-metrics
+      targetPort: http-metrics
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: gateway

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-gossip-ring
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: gossip-ring
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: gossip-ring
+      port: 7946
+      protocol: TCP
+      targetPort: 7946
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/index-cache/index-cache-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-index-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: index-cache
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: index-cache
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-index-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: index-cache
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: enterprise-https-values-mimir-index-cache
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: index-cache
+      annotations:
+
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+      containers:
+        - name: memcached
+          image: memcached:1.6.19-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 2458Mi
+            requests:
+              cpu: 500m
+              memory: 2458Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 2048
+            - --extended=modern,track_sizes
+            - -I 5m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+          envFrom:
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+        - name: exporter
+          image: prom/memcached-exporter:v0.11.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-index-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: index-cache
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: index-cache

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-ingester
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: ingester
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -1,0 +1,456 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-ingester-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-a"
+    rollout-group: ingester
+    zone: zone-a
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: ingester
+      rollout-group: ingester
+      zone: zone-a
+  updateStrategy:
+    type: OnDelete
+  serviceName: enterprise-https-values-mimir-ingester-headless
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: memberlist
+        name: "ingester-zone-a"
+        rollout-group: ingester
+        zone: zone-a
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: ingester
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 240
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: ingester
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ingester"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-ingester.ring.instance-availability-zone=zone-a"
+          volumeMounts:
+            
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: license
+              mountPath: /license
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+---
+# Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-ingester-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-b"
+    rollout-group: ingester
+    zone: zone-b
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: ingester
+      rollout-group: ingester
+      zone: zone-b
+  updateStrategy:
+    type: OnDelete
+  serviceName: enterprise-https-values-mimir-ingester-headless
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: memberlist
+        name: "ingester-zone-b"
+        rollout-group: ingester
+        zone: zone-b
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: ingester
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 240
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: ingester
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ingester"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-ingester.ring.instance-availability-zone=zone-b"
+          volumeMounts:
+            
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: license
+              mountPath: /license
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+---
+# Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-ingester-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-c"
+    rollout-group: ingester
+    zone: zone-c
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: ingester
+      rollout-group: ingester
+      zone: zone-c
+  updateStrategy:
+    type: OnDelete
+  serviceName: enterprise-https-values-mimir-ingester-headless
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: memberlist
+        name: "ingester-zone-c"
+        rollout-group: ingester
+        zone: zone-c
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: ingester
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 240
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: ingester
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ingester"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-ingester.ring.instance-availability-zone=zone-c"
+          volumeMounts:
+            
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: license
+              mountPath: /license
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-ingester-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -1,0 +1,105 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-ingester-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-a"
+    rollout-group: ingester
+    zone: zone-a
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    rollout-group: ingester
+    zone: zone-a
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-ingester-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-b"
+    rollout-group: ingester
+    zone: zone-b
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    rollout-group: ingester
+    zone: zone-b
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-ingester-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-c"
+    rollout-group: ingester
+    zone: zone-c
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ingester
+    rollout-group: ingester
+    zone: zone-c

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/metadata-cache/metadata-cache-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-metadata-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: metadata-cache
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: metadata-cache
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-metadata-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: metadata-cache
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: enterprise-https-values-mimir-metadata-cache
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metadata-cache
+      annotations:
+
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+      containers:
+        - name: memcached
+          image: memcached:1.6.19-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 614Mi
+            requests:
+              cpu: 500m
+              memory: 614Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 512
+            - --extended=modern,track_sizes
+            - -I 1m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+          envFrom:
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+        - name: exporter
+          image: prom/memcached-exporter:v0.11.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-metadata-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: metadata-cache
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: metadata-cache

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -1,0 +1,303 @@
+---
+# Source: mimir-distributed/templates/mimir-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: enterprise-https-values-mimir-config
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+data:
+  mimir.yaml: |
+    
+    activity_tracker:
+      filepath: /active-query-tracker/activity.log
+    admin_api:
+      leader_election:
+        client_config:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+        enabled: true
+        ring:
+          kvstore:
+            store: memberlist
+    admin_client:
+      storage:
+        s3:
+          bucket_name: admin-api
+        type: s3
+    alertmanager:
+      alertmanager_client:
+        tls_cert_path: /certs/tls.crt
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+        tls_key_path: /certs/tls.key
+        tls_server_name: gem.grafana.com
+      data_dir: /data
+      enable_api: true
+      external_url: /alertmanager
+      fallback_config_file: /configs/alertmanager_fallback_config.yaml
+    alertmanager_storage:
+      backend: s3
+      s3:
+        bucket_name: alertmanager
+    auth:
+      type: enterprise
+    blocks_storage:
+      backend: s3
+      bucket_store:
+        chunks_cache:
+          backend: memcached
+          memcached:
+            addresses: dns+enterprise-https-values-mimir-chunks-cache.citestns.svc:11211
+            max_idle_connections: 150
+            max_item_size: 1048576
+            timeout: 450ms
+        index_cache:
+          backend: memcached
+          memcached:
+            addresses: dns+enterprise-https-values-mimir-index-cache.citestns.svc:11211
+            max_idle_connections: 150
+            max_item_size: 5242880
+        metadata_cache:
+          backend: memcached
+          memcached:
+            addresses: dns+enterprise-https-values-mimir-metadata-cache.citestns.svc:11211
+            max_idle_connections: 150
+            max_item_size: 1048576
+        sync_dir: /data/tsdb-sync
+      s3:
+        bucket_name: blocks
+      tsdb:
+        dir: /data/tsdb
+        head_compaction_interval: 15m
+        wal_replay_concurrency: 3
+    cluster_name: gem
+    common:
+      storage:
+        s3:
+          endpoint: s3.dualstack.us-east-2.amazonaws.com
+    compactor:
+      compaction_interval: 30m
+      data_dir: /data
+      deletion_delay: 2h
+      first_level_compaction_wait_period: 25m
+      max_closing_blocks_concurrency: 2
+      max_opening_blocks_concurrency: 4
+      sharding_ring:
+        wait_stability_min_duration: 1m
+      symbols_flushers_concurrency: 4
+    frontend:
+      cache_results: true
+      grpc_client_config:
+        tls_cert_path: /certs/tls.crt
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+        tls_key_path: /certs/tls.key
+        tls_server_name: gem.grafana.com
+      parallelize_shardable_queries: true
+      query_sharding_target_series_per_shard: 2500
+      results_cache:
+        backend: memcached
+        memcached:
+          addresses: dns+enterprise-https-values-mimir-results-cache.citestns.svc:11211
+          max_item_size: 5242880
+          timeout: 500ms
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+      scheduler_address: enterprise-https-values-mimir-query-scheduler-headless.citestns.svc:9095
+    frontend_worker:
+      grpc_client_config:
+        max_send_msg_size: 419430400
+        tls_cert_path: /certs/tls.crt
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+        tls_key_path: /certs/tls.key
+        tls_server_name: gem.grafana.com
+      scheduler_address: enterprise-https-values-mimir-query-scheduler-headless.citestns.svc:9095
+    gateway:
+      proxy:
+        admin_api:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          url: https://gem-mimir-admin-api:8080
+        alertmanager:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          url: https://gem-mimir-alertmanager-headless:8080
+        compactor:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          url: https://gem-mimir-compactor-headless:8080
+        default:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          url: https://gem-mimir-admin-api:8080
+        distributor:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          url: dns:///gem-mimir-distributor-headless:9095
+        ingester:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          url: https://gem-mimir-ingester-headless:8080
+        query_frontend:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          url: https://gem-mimir-query-frontend:8080
+        ruler:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          url: https://gem-mimir-ruler:8080
+        store_gateway:
+          tls_cert_path: /certs/tls.crt
+          tls_enabled: true
+          tls_insecure_skip_verify: false
+          tls_key_path: /certs/tls.key
+          tls_server_name: gem.grafana.com
+          url: https://gem-mimir-store-gateway-headless:8080
+    ingester:
+      ring:
+        final_sleep: 0s
+        kvstore:
+          store: memberlist
+        num_tokens: 512
+        tokens_file_path: /data/tokens
+        unregister_on_shutdown: false
+        zone_awareness_enabled: true
+    ingester_client:
+      grpc_client_config:
+        max_recv_msg_size: 104857600
+        max_send_msg_size: 104857600
+        tls_cert_path: /certs/tls.crt
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+        tls_key_path: /certs/tls.key
+        tls_server_name: gem.grafana.com
+    instrumentation:
+      distributor_client:
+        address: dns:///enterprise-https-values-mimir-distributor-headless.citestns.svc.cluster.local:9095
+        tls_cert_path: /certs/tls.crt
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+        tls_key_path: /certs/tls.key
+        tls_server_name: gem.grafana.com
+      enabled: true
+    license:
+      path: /license/license.jwt
+    limits:
+      max_cache_freshness: 10m
+      max_query_parallelism: 240
+      max_total_query_length: 12000h
+    memberlist:
+      abort_if_cluster_join_fails: false
+      compression_enabled: false
+      join_members:
+      - dns+enterprise-https-values-mimir-gossip-ring.citestns.svc.cluster.local:7946
+      tls_cert_path: /certs/tls.crt
+      tls_enabled: true
+      tls_insecure_skip_verify: false
+      tls_key_path: /certs/tls.key
+      tls_server_name: gem.grafana.com
+    querier:
+      max_concurrent: 16
+      store_gateway_client:
+        tls_cert_path: /certs/tls.crt
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+        tls_key_path: /certs/tls.key
+        tls_server_name: gem.grafana.com
+    query_scheduler:
+      grpc_client_config:
+        tls_cert_path: /certs/tls.crt
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+        tls_key_path: /certs/tls.key
+        tls_server_name: gem.grafana.com
+      max_outstanding_requests_per_tenant: 800
+    ruler:
+      alertmanager_client:
+        tls_cert_path: /certs/tls.crt
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+        tls_key_path: /certs/tls.key
+        tls_server_name: gem.grafana.com
+      alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.enterprise-https-values-mimir-alertmanager-headless.citestns.svc.cluster.local/alertmanager
+      enable_api: true
+      rule_path: /data
+      ruler_client:
+        tls_cert_path: /certs/tls.crt
+        tls_enabled: true
+        tls_insecure_skip_verify: false
+        tls_key_path: /certs/tls.key
+        tls_server_name: gem.grafana.com
+      tenant_federation:
+        enabled: true
+    ruler_storage:
+      backend: s3
+      cache:
+        backend: memcached
+        memcached:
+          addresses: dns+enterprise-https-values-mimir-metadata-cache.citestns.svc:11211
+          max_item_size: 1048576
+      s3:
+        bucket_name: ruler
+    runtime_config:
+      file: /var/mimir/runtime.yaml
+    server:
+      grpc_server_max_concurrent_streams: 1000
+      grpc_server_max_connection_age: 2m
+      grpc_server_max_connection_age_grace: 5m
+      grpc_server_max_connection_idle: 1m
+      grpc_tls_config:
+        cert_file: /certs/tls.crt
+        client_auth_type: VerifyClientCertIfGiven
+        key_file: /certs/tls.key
+      http_tls_config:
+        cert_file: /certs/tls.crt
+        client_auth_type: VerifyClientCertIfGiven
+        key_file: /certs/tls.key
+    store_gateway:
+      sharding_ring:
+        kvstore:
+          prefix: multi-zone/
+        tokens_file_path: /data/tokens
+        unregister_on_shutdown: false
+        wait_stability_min_duration: 1m
+        zone_awareness_enabled: true
+    tenant_federation:
+      enabled: true
+    usage_stats:
+      installation_mode: helm

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -1,0 +1,6 @@
+---
+# Source: mimir-distributed/templates/minio/create-bucket-job.yaml
+# Minio provides post-install hook to create bucket
+# however the hook won't be executed if helm install is run
+# with --wait flag. Hence this job is a workaround for that.
+# See https://github.com/grafana/mimir/issues/2464

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -1,0 +1,126 @@
+---
+# Source: mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {}
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/managed-by: Helm
+  name: enterprise-https-values-mimir-overrides-exporter
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: overrides-exporter
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: overrides-exporter
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: overrides-exporter
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=overrides-exporter"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+              
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: license
+              mountPath: /license
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+              subPath: 
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 45
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-overrides-exporter
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: overrides-exporter
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-overrides-exporter
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: overrides-exporter

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/templates/podsecuritypolicy.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: enterprise-https-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -1,0 +1,133 @@
+---
+# Source: mimir-distributed/templates/querier/querier-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enterprise-https-values-mimir-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: querier
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: querier
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=querier"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+              
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: license
+              mountPath: /license
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+              subPath: 
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: querier
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/querier/querier-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: querier
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/querier/querier-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: querier

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -1,0 +1,128 @@
+---
+# Source: mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enterprise-https-values-mimir-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: query-frontend
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: query-frontend
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: query-frontend
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=query-frontend"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+              
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: license
+              mountPath: /license
+            - name: config
+              mountPath: /etc/mimir
+            - name: storage
+              mountPath: /data
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: query-frontend
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: query-frontend
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-frontend

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -1,0 +1,132 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enterprise-https-values-mimir-query-scheduler
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: query-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: query-scheduler
+      annotations:
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: query-scheduler
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=query-scheduler"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-server.grpc.keepalive.max-connection-age=2562047h" # 100000 days, effectively infinity
+            - "-server.grpc.keepalive.max-connection-age-grace=2562047h" # 100000 days, effectively infinity
+          volumeMounts:
+              
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: license
+              mountPath: /license
+            - name: config
+              mountPath: /etc/mimir
+            - name: storage
+              mountPath: /data
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: query-scheduler
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-query-scheduler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: query-scheduler
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-query-scheduler-headless
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-scheduler

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-query-scheduler
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: query-scheduler

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/results-cache/results-cache-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-results-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: results-cache
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: results-cache
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -1,0 +1,112 @@
+---
+# Source: mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-results-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: results-cache
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: enterprise-https-values-mimir-results-cache
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: results-cache
+      annotations:
+
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+      containers:
+        - name: memcached
+          image: memcached:1.6.19-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 614Mi
+            requests:
+              cpu: 500m
+              memory: 614Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 512
+            - --extended=modern,track_sizes
+            - -I 5m
+            - -c 16384
+            - -v
+            - -u 11211
+          env:
+          envFrom:
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+        - name: exporter
+          image: prom/memcached-exporter:v0.11.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-results-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: results-cache
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: results-cache

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/role.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/role.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: enterprise-https-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [enterprise-https-values-mimir]

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+---
+# Source: mimir-distributed/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: enterprise-https-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: enterprise-https-values-mimir
+subjects:
+- kind: ServiceAccount
+  name: enterprise-https-values-mimir
+- kind: ServiceAccount
+  name: enterprise-https-values-mimir-distributed

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -1,0 +1,137 @@
+---
+# Source: mimir-distributed/templates/ruler/ruler-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enterprise-https-values-mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: ruler
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: ruler
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ruler"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+              
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: license
+              mountPath: /license
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+              subPath: 
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: ruler
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ruler/ruler-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ruler/ruler-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/ruler/ruler-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: ruler
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -1,0 +1,26 @@
+---
+# Source: mimir-distributed/templates/ruler/ruler-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: ruler

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/runtime-configmap.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/runtime-configmap.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/templates/runtime-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: enterprise-https-values-mimir-runtime
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+data:
+  runtime.yaml: |
+    
+    {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/serviceaccount.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: mimir-distributed/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: enterprise-https-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: enterprise-https-values-mimir-store-gateway
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: store-gateway
+  maxUnavailable: 1

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -1,0 +1,465 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-store-gateway-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-a"
+    rollout-group: store-gateway
+    zone: zone-a
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: store-gateway
+      rollout-group: store-gateway
+      zone: zone-a
+  updateStrategy:
+    type: OnDelete
+  serviceName: enterprise-https-values-mimir-store-gateway-headless
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: memberlist
+        name: "store-gateway-zone-a"
+        rollout-group: store-gateway
+        zone: zone-a
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: store-gateway
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 240
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: store-gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-store-gateway.sharding-ring.instance-availability-zone=zone-a"
+          volumeMounts:
+            
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: license
+              mountPath: /license
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
+          envFrom:
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-store-gateway-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-b"
+    rollout-group: store-gateway
+    zone: zone-b
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: store-gateway
+      rollout-group: store-gateway
+      zone: zone-b
+  updateStrategy:
+    type: OnDelete
+  serviceName: enterprise-https-values-mimir-store-gateway-headless
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: memberlist
+        name: "store-gateway-zone-b"
+        rollout-group: store-gateway
+        zone: zone-b
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: store-gateway
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 240
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: store-gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-store-gateway.sharding-ring.instance-availability-zone=zone-b"
+          volumeMounts:
+            
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: license
+              mountPath: /license
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
+          envFrom:
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: enterprise-https-values-mimir-store-gateway-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-c"
+    rollout-group: store-gateway
+    zone: zone-c
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: enterprise-https-values
+      app.kubernetes.io/component: store-gateway
+      rollout-group: store-gateway
+      zone: zone-c
+  updateStrategy:
+    type: OnDelete
+  serviceName: enterprise-https-values-mimir-store-gateway-headless
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: enterprise-https-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: memberlist
+        name: "store-gateway-zone-c"
+        rollout-group: store-gateway
+        zone: zone-c
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: enterprise-https-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: enterprise-https-values
+            app.kubernetes.io/component: store-gateway
+      tolerations:
+        []
+      terminationGracePeriodSeconds: 240
+      volumes:
+        - name: config
+          configMap:
+            name: enterprise-https-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: license
+          secret:
+            secretName: gem-license
+        - name: runtime-config
+          configMap:
+            name: enterprise-https-values-mimir-runtime
+        
+        - name: tls-certs
+          secret:
+            secretName: tls-certs
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: store-gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-store-gateway.sharding-ring.instance-availability-zone=zone-c"
+          volumeMounts:
+            
+            - mountPath: /certs
+              name: tls-certs
+              readOnly: true
+            - name: config
+              mountPath: /etc/mimir
+            - name: license
+              mountPath: /license
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+              scheme: HTTPS
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
+          envFrom:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-store-gateway-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -1,0 +1,105 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-store-gateway-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-a"
+    rollout-group: store-gateway
+    zone: zone-a
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    rollout-group: store-gateway
+    zone: zone-a
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-store-gateway-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-b"
+    rollout-group: store-gateway
+    zone: zone-b
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    rollout-group: store-gateway
+    zone: zone-b
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-mimir-store-gateway-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-c"
+    rollout-group: store-gateway
+    zone: zone-c
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/component: store-gateway
+    rollout-group: store-gateway
+    zone: zone-c


### PR DESCRIPTION
#### What this PR does

I was trying to configure memcached with TLS and met two blockers
* not being able to add to the existing extensions (`modern,track_sizes`) as CLI flags
* not being able to mount a volume to the memcached pods with the certificates

The same applied to the memcached exporter. This PR addresses these.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
