### PR TITLE
Helm: render helm tests in parallel

### DIFF
--- a/operations/helm/scripts/build.sh
+++ b/operations/helm/scripts/build.sh
@@ -73,12 +73,20 @@ for FILEPATH in $TESTS; do
   fi
 
   set -x
-  helm template "${ARGS[@]}"
+  helm template "${ARGS[@]}" &
   set +x
+done
+
+wait
+
+for FILEPATH in $TESTS; do
+  # Extract the filename (without extension).
+  TEST_NAME=$(basename -s '.yaml' "$FILEPATH")
+  INTERMEDIATE_OUTPUT_DIR="${INTERMEDIATE_PATH}/${TEST_NAME}-generated"
+  OUTPUT_DIR="${OUTPUT_PATH}/${TEST_NAME}-generated"
 
   echo "Removing mutable config checksum, helm chart, application, image tag version for clarity"
   cp -r "${INTERMEDIATE_OUTPUT_DIR}" "${OUTPUT_DIR}"
   rm "${OUTPUT_DIR}/${CHART_NAME}/templates/values-for-rego-tests.yaml"
   find "${OUTPUT_DIR}/${CHART_NAME}/templates" -type f -print0 | xargs -0 "${SED}" -E -i -- "/^\s+(checksum\/(alertmanager-fallback-)?config|(helm.sh\/)?chart|app.kubernetes.io\/version|image: \"grafana\/(mimir|mimir-continuous-test|enterprise-metrics)):/d"
-
 done

--- a/operations/helm/scripts/build.sh
+++ b/operations/helm/scripts/build.sh
@@ -87,7 +87,7 @@ for FILEPATH in $TESTS; do
   INTERMEDIATE_OUTPUT_DIR="${INTERMEDIATE_PATH}/${TEST_NAME}-generated"
   OUTPUT_DIR="${OUTPUT_PATH}/${TEST_NAME}-generated"
 
-  generate_manifests $TEST_NAME $INTERMEDIATE_OUTPUT_DIR $OUTPUT_DIR &
+  generate_manifests "$TEST_NAME" "$INTERMEDIATE_OUTPUT_DIR" "$OUTPUT_DIR" &
   pid=$!
   pids+=("$pid")
 done

--- a/operations/helm/scripts/build.sh
+++ b/operations/helm/scripts/build.sh
@@ -77,15 +77,15 @@ for FILEPATH in $TESTS; do
 
   helm template "${ARGS[@]}" 1>/dev/null &
   pid=$!
-  pids+=($pid)
-  echo "Launched helm template PID $pid 'helm template ${ARGS[@]}'"
+  pids+=("$pid")
+  echo "Launched helm template PID $pid 'helm template ${ARGS[*]}'"
 done
 
 # Wait for all child processes to finish. We turn off `set -e` because we want to check the exit code of each child process
 # and print a message if it's non-zero. set -e will otherwise cause the script to exit immediately if any child process has exited with non-zero exit code.
 set +e
 for p in "${pids[@]}"; do
-    wait $p
+    wait "$p"
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
         echo "helm template PID $p exited with non-zero exit code $exit_code. Aborting."

--- a/operations/helm/scripts/build.sh
+++ b/operations/helm/scripts/build.sh
@@ -74,7 +74,7 @@ function generate_manifests() {
     ARGS+=("--set-string" "kubeVersionOverride=${DEFAULT_KUBE_VERSION}")
   fi
 
-  echo "Launching helm template in PID $BASHPID 'helm template ${ARGS[*]}'"
+  echo "Rendering helm test $TEST_NAME in PID $BASHPID: 'helm template ${ARGS[*]}'"
   helm template "${ARGS[@]}" 1>/dev/null
   cp -r "${INTERMEDIATE_OUTPUT_DIR}" "${OUTPUT_DIR}"
   rm "${OUTPUT_DIR}/${CHART_NAME}/templates/values-for-rego-tests.yaml"
@@ -87,7 +87,8 @@ for FILEPATH in $TESTS; do
   INTERMEDIATE_OUTPUT_DIR="${INTERMEDIATE_PATH}/${TEST_NAME}-generated"
   OUTPUT_DIR="${OUTPUT_PATH}/${TEST_NAME}-generated"
 
-  generate_manifests "$TEST_NAME" "$INTERMEDIATE_OUTPUT_DIR" "$OUTPUT_DIR" &
+  # Prefix every stdout and stderr line from the test name. This makes the interleaved output of different tests easier to follow
+  generate_manifests "$TEST_NAME" "$INTERMEDIATE_OUTPUT_DIR" "$OUTPUT_DIR" > >(sed "s/^/$TEST_NAME (stdout): /") 2> >(sed "s/^/$TEST_NAME (stderr): /" >&2) &
   pid=$!
   pids+=("$pid")
 done


### PR DESCRIPTION
This runs the helm command in parallel for each test setup concurrently. On my M1 Mac with OrbStack (Docker Desktop alternative) this brought down build time from 32s to 9s.
