### PR TITLE
Scrape both classic and native histograms in docker compose

### DIFF
--- a/development/mimir-microservices-mode/config/prometheus.yaml
+++ b/development/mimir-microservices-mode/config/prometheus.yaml
@@ -38,6 +38,7 @@ scrape_configs:
         target_label: 'container'
         regex: '(.+?)(-\d+)?'
         replacement: '${1}'
+    scrape_classic_histograms: true
 
 remote_write:
   - url: http://distributor-1:8000/api/v1/push
@@ -47,4 +48,3 @@ remote_write:
 rule_files:
   - '/etc/mixin/mimir-alerts.yaml'
   - '/etc/mixin/mimir-rules.yaml'
-

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -296,12 +296,11 @@ std.manifestYamlDoc({
 
   prometheus:: {
     prometheus: {
-      image: 'prom/prometheus:v2.40.6',
+      image: 'prom/prometheus:v2.45.0',
       command: [
         '--config.file=/etc/prometheus/prometheus.yaml',
         '--enable-feature=exemplar-storage',
-        // This option enables native histogram support in prometheus, which is disabled by default since it doesn't scape classic histograms used by the recording rules and dashboards
-        // '--enable-feature=native-histograms',
+        '--enable-feature=native-histograms',
       ],
       volumes: [
         './config:/etc/prometheus',

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -271,7 +271,8 @@
     "command":
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--enable-feature=exemplar-storage"
-    "image": "prom/prometheus:v2.40.6"
+      - "--enable-feature=native-histograms"
+    "image": "prom/prometheus:v2.45.0"
     "ports":
       - "9090:9090"
     "volumes":

--- a/development/mimir-monolithic-mode-with-swift-storage/config/prometheus.yaml
+++ b/development/mimir-monolithic-mode-with-swift-storage/config/prometheus.yaml
@@ -9,11 +9,13 @@ scrape_configs:
       - targets: ['mimir-1:8001']
         labels:
           container: 'mimir-1'
+    scrape_classic_histograms: true
   - job_name: mimir-2
     static_configs:
       - targets: ['mimir-2:8002']
         labels:
           container: 'mimir-2'
+    scrape_classic_histograms: true
 
 remote_write:
   - url: http://mimir-1:8001/api/v1/push

--- a/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
+++ b/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   prometheus:
 
-    image: prom/prometheus:v2.40.6
+    image: prom/prometheus:v2.45.0
     command: ["--config.file=/etc/prometheus/prometheus.yaml", "--enable-feature=native-histograms"]
     volumes:
       - ./config:/etc/prometheus

--- a/development/mimir-monolithic-mode/config/prometheus.yaml
+++ b/development/mimir-monolithic-mode/config/prometheus.yaml
@@ -9,11 +9,13 @@ scrape_configs:
       - targets: ['mimir-1:8001']
         labels:
           container: 'mimir-1'
+    scrape_classic_histograms: true
   - job_name: mimir-2
     static_configs:
       - targets: ['mimir-2:8002']
         labels:
           container: 'mimir-2'
+    scrape_classic_histograms: true
 
 remote_write:
   - url: http://mimir-1:8001/api/v1/push

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - .data-minio:/data:delegated
 
   prometheus:
-    image: prom/prometheus:v2.40.6
+    image: prom/prometheus:v2.45.0
     command: ["--config.file=/etc/prometheus/prometheus.yaml", "--enable-feature=native-histograms"]
     volumes:
       - ./config:/etc/prometheus


### PR DESCRIPTION
#### What this PR does

Now that the option to scrape both kinds of histograms is released in Prometheus, re-enable native histograms in our docker compose setups so we won't break our older dashboards and can still use the newer histograms.

#### Which issue(s) this PR fixes or relates to

Reverts change in https://github.com/grafana/mimir/pull/5080

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
