### PR TITLE
Guard against the same streaming series being read multiple times

### DIFF
--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
-var streamingChunkSeriesTestIteratorFunc = func(_ chunkenc.Iterator, chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator {
+func streamingChunkSeriesTestIteratorFunc(_ chunkenc.Iterator, chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator {
 	return streamingChunkSeriesTestIterator{
 		chunks:  chunks,
 		from:    from,

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -23,15 +23,15 @@ import (
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
-func TestStreamingChunkSeries_HappyPath(t *testing.T) {
-	chunkIteratorFunc := func(_ chunkenc.Iterator, chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator {
-		return streamingChunkSeriesTestIterator{
-			chunks:  chunks,
-			from:    from,
-			through: through,
-		}
+var streamingChunkSeriesTestIteratorFunc = func(_ chunkenc.Iterator, chunks []chunk.Chunk, from, through model.Time) chunkenc.Iterator {
+	return streamingChunkSeriesTestIterator{
+		chunks:  chunks,
+		from:    from,
+		through: through,
 	}
+}
 
+func TestStreamingChunkSeries_HappyPath(t *testing.T) {
 	chunkUniqueToFirstSource := createTestChunk(t, 1500, 1.23)
 	chunkUniqueToSecondSource := createTestChunk(t, 2000, 4.56)
 	chunkPresentInBothSources := createTestChunk(t, 2500, 7.89)
@@ -45,7 +45,7 @@ func TestStreamingChunkSeries_HappyPath(t *testing.T) {
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{{SeriesIndex: 0, Chunks: []client.Chunk{chunkUniqueToSecondSource, chunkPresentInBothSources}}})},
 		},
 		context: &streamingChunkSeriesContext{
-			chunkIteratorFunc: chunkIteratorFunc,
+			chunkIteratorFunc: streamingChunkSeriesTestIteratorFunc,
 			mint:              1000,
 			maxt:              6000,
 			queryChunkMetrics: stats.NewQueryChunkMetrics(reg),
@@ -94,6 +94,30 @@ func TestStreamingChunkSeries_StreamReaderReturnsError(t *testing.T) {
 	iterator := series.Iterator(nil)
 	require.NotNil(t, iterator)
 	require.EqualError(t, iterator.Err(), "attempted to read series at index 0 from stream, but the stream has already been exhausted")
+}
+
+func TestStreamingChunkSeries_CreateIteratorTwice(t *testing.T) {
+	series := streamingChunkSeries{
+		labels: labels.FromStrings("the-name", "the-value"),
+		sources: []client.StreamingSeriesSource{
+			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{{SeriesIndex: 0, Chunks: []client.Chunk{createTestChunk(t, 1500, 1.23)}}})},
+		},
+		context: &streamingChunkSeriesContext{
+			chunkIteratorFunc: streamingChunkSeriesTestIteratorFunc,
+			mint:              1000,
+			maxt:              6000,
+			queryChunkMetrics: stats.NewQueryChunkMetrics(prometheus.NewPedanticRegistry()),
+			queryStats:        &stats.Stats{},
+		},
+	}
+
+	iterator := series.Iterator(nil)
+	require.NotNil(t, iterator)
+	require.NoError(t, iterator.Err())
+
+	iterator = series.Iterator(iterator)
+	require.NotNil(t, iterator)
+	require.EqualError(t, iterator.Err(), `can't create iterator multiple times for the one streaming series ({the-name="the-value"})`)
 }
 
 func createTestChunk(t *testing.T, time int64, value float64) client.Chunk {
@@ -160,7 +184,7 @@ func (s streamingChunkSeriesTestIterator) AtT() int64 {
 }
 
 func (s streamingChunkSeriesTestIterator) Err() error {
-	panic("not implemented")
+	return nil
 }
 
 type mockQueryStreamClient struct {


### PR DESCRIPTION
#### What this PR does

This PR prevents confusing "attempted to read series at index 0 from stream, but the stream has already been exhausted" errors from being returned when a streaming series is read multiple times. This should never happen in the real world, but we've already encountered one issue where the PromQL engine recreates iterators for each series multiple times.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
