### PR TITLE
Querier: Pass on HTTP 503 status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377
+* [BUGFIX] Querier: Pass on HTTP 503 query response code. #5364
 
 ### Mixin
 

--- a/pkg/frontend/config.go
+++ b/pkg/frontend/config.go
@@ -65,7 +65,7 @@ func InitFrontend(cfg CombinedFrontendConfig, limits v1.Limits, grpcListenPort i
 		return rt, nil, nil, err
 
 	case cfg.FrontendV2.SchedulerAddress != "" || cfg.FrontendV2.QuerySchedulerDiscovery.Mode == schedulerdiscovery.ModeRing:
-		// Query-scheduler is enabled when its addressed is configured or is configured to use ring-based service discovery.
+		// Query-scheduler is enabled when its address is configured or ring-based service discovery is configured.
 		if cfg.FrontendV2.Addr == "" {
 			addr, err := util.GetFirstAddressOf(cfg.FrontendV2.InfNames)
 			if err != nil {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -460,7 +460,7 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 	t.Cfg.Worker.MaxConcurrentRequests = t.Cfg.Querier.EngineConfig.MaxConcurrent
 	t.Cfg.Worker.QuerySchedulerDiscovery = t.Cfg.QueryScheduler.ServiceDiscovery
 
-	// Create a internal HTTP handler that is configured with the Prometheus API routes and points
+	// Create an internal HTTP handler that is configured with the Prometheus API routes and points
 	// to a Prometheus API struct instantiated with the Mimir Queryable.
 	internalQuerierRouter := api.NewQuerierHandler(
 		t.Cfg.API,
@@ -487,7 +487,7 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 		internalQuerierRouter = t.Server.HTTPServer.Handler
 	} else {
 		// Monolithic mode requires a query-frontend endpoint for the worker. If no frontend and scheduler endpoint
-		// is configured, Mimir will default to using frontend on localhost on it's own GRPC listening port.
+		// is configured, Mimir will default to using frontend on localhost on it's own gRPC listening port.
 		if !t.Cfg.Worker.IsFrontendOrSchedulerConfigured() {
 			address := fmt.Sprintf("127.0.0.1:%d", t.Cfg.Server.GRPCListenPort)
 			level.Info(util_log.Logger).Log("msg", "The querier worker has not been configured with either the query-frontend or query-scheduler address. Because Mimir is running in monolithic mode, it's attempting an automatic worker configuration. If queries are unresponsive, consider explicitly configuring the query-frontend or query-scheduler address for querier worker.", "address", address)
@@ -505,7 +505,7 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 		internalQuerierRouter = t.API.AuthMiddleware.Wrap(internalQuerierRouter)
 	}
 
-	// If neither query-frontend or query-scheduler is in use, then no worker is needed.
+	// If neither query-frontend nor query-scheduler is in use, then no worker is needed.
 	if !t.Cfg.Worker.IsFrontendOrSchedulerConfigured() {
 		return nil, nil
 	}

--- a/pkg/querier/error_translate_queryable_test.go
+++ b/pkg/querier/error_translate_queryable_test.go
@@ -104,6 +104,12 @@ func TestApiStatusCodes(t *testing.T) {
 			expectedString: "test string",
 			expectedCode:   422,
 		},
+
+		{
+			err:            httpgrpc.Errorf(http.StatusServiceUnavailable, "test"),
+			expectedString: "timeout",
+			expectedCode:   http.StatusServiceUnavailable,
+		},
 	} {
 		for k, q := range map[string]storage.SampleAndChunkQueryable{
 			"error from queryable": errorTestQueryable{err: tc.err},


### PR DESCRIPTION
#### What this PR does
Modify the querier to no longer convert HTTP 503 query failures to HTTP 500, but instead pass on the HTTP 503 (service unavailable) code. This code may be returned when the ingester rejects a query due to request limiting.

Also some things I came across while debugging:
* Fix some comments
* Rename `requestCh` to `requestsCh` for consistency/readability

I've tested manually locally and in cloud, to verify that the HTTP status code 503 gets returned to clients when read requests are rejected due to utilization based ingester limiting.

TODO:
- [x] Test manually
  - [x] Locally
  - [x] Cloud
- [x] Add unit test(s)

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
