### PR TITLE
Fix issue where queries that use the `timestamp()` function fail when streaming chunks from ingesters to queriers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [ENHANCEMENT] Ingester and querier: improve level of detail in traces emitted for queries that hit ingesters. #5315
 * [ENHANCEMENT] Querier: add `cortex_queries_rejected_total` metric that counts the number of queries rejected due to hitting a limit (eg. max series per query or max chunks per query). #5316
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
+* [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 
 ### Mixin
 

--- a/go.mod
+++ b/go.mod
@@ -249,7 +249,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230524115841-8d6690e86aa7
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230629041723-5c270e23eab7
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9 h1:WB3bGH2f1UN6
 github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20230524115841-8d6690e86aa7 h1:wKkL9GZGEs3N51Gc0/tiViGCwrmlaDzOjO79b6sAPl4=
-github.com/grafana/mimir-prometheus v0.0.0-20230524115841-8d6690e86aa7/go.mod h1:DHKRaRtZW8Ga+1p547p5hb/MVYgxt1QOXFN8L/fdsA4=
+github.com/grafana/mimir-prometheus v0.0.0-20230629041723-5c270e23eab7 h1:oEVaYg2/uhaY1KL7uzsYvNsmFxjwV7TC15fev5oPVGE=
+github.com/grafana/mimir-prometheus v0.0.0-20230629041723-5c270e23eab7/go.mod h1:DHKRaRtZW8Ga+1p547p5hb/MVYgxt1QOXFN8L/fdsA4=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=

--- a/integration/ingester_test.go
+++ b/integration/ingester_test.go
@@ -27,10 +27,44 @@ func TestIngesterQuerying(t *testing.T) {
 	queryEnd := time.Now().Round(time.Second)
 	queryStart := queryEnd.Add(-1 * time.Hour)
 	queryStep := 10 * time.Minute
+	timestampQuery := "timestamp(foobar)"
+
+	timestampsAlignedToQueryStep := model.Matrix{
+		{
+			Metric: model.Metric{},
+			Values: []model.SamplePair{
+				{
+					Timestamp: model.Time(queryStart.UnixMilli()),
+					Value:     model.SampleValue(queryStart.Unix()),
+				},
+				{
+					Timestamp: model.Time(queryStart.Add(queryStep).UnixMilli()),
+					Value:     model.SampleValue(queryStart.Add(queryStep).Unix()),
+				},
+				{
+					Timestamp: model.Time(queryStart.Add(queryStep * 2).UnixMilli()),
+					Value:     model.SampleValue(queryStart.Add(queryStep * 2).Unix()),
+				},
+				{
+					Timestamp: model.Time(queryStart.Add(queryStep * 3).UnixMilli()),
+					Value:     model.SampleValue(queryStart.Add(queryStep * 3).Unix()),
+				},
+				{
+					Timestamp: model.Time(queryStart.Add(queryStep * 4).UnixMilli()),
+					Value:     model.SampleValue(queryStart.Add(queryStep * 4).Unix()),
+				},
+				{
+					Timestamp: model.Time(queryStart.Add(queryStep * 5).UnixMilli()),
+					Value:     model.SampleValue(queryStart.Add(queryStep * 5).Unix()),
+				},
+			},
+		},
+	}
 
 	testCases := map[string]struct {
-		inSeries []prompb.TimeSeries
-		expected model.Matrix
+		inSeries                     []prompb.TimeSeries
+		expectedQueryResult          model.Matrix
+		expectedTimestampQueryResult model.Matrix
 	}{
 		"float series": {
 			inSeries: []prompb.TimeSeries{
@@ -69,7 +103,7 @@ func TestIngesterQuerying(t *testing.T) {
 					},
 				},
 			},
-			expected: model.Matrix{
+			expectedQueryResult: model.Matrix{
 				{
 					Metric: model.Metric{"__name__": "foobar"},
 					Values: []model.SamplePair{
@@ -100,6 +134,7 @@ func TestIngesterQuerying(t *testing.T) {
 					},
 				},
 			},
+			expectedTimestampQueryResult: timestampsAlignedToQueryStep,
 		},
 		"integer histogram series": {
 			inSeries: []prompb.TimeSeries{
@@ -120,7 +155,7 @@ func TestIngesterQuerying(t *testing.T) {
 					},
 				},
 			},
-			expected: model.Matrix{
+			expectedQueryResult: model.Matrix{
 				{
 					Metric: model.Metric{"__name__": "foobar"},
 					Histograms: []model.SampleHistogramPair{
@@ -151,6 +186,7 @@ func TestIngesterQuerying(t *testing.T) {
 					},
 				},
 			},
+			expectedTimestampQueryResult: timestampsAlignedToQueryStep,
 		},
 		"float histogram series": {
 			inSeries: []prompb.TimeSeries{
@@ -171,7 +207,7 @@ func TestIngesterQuerying(t *testing.T) {
 					},
 				},
 			},
-			expected: model.Matrix{
+			expectedQueryResult: model.Matrix{
 				{
 					Metric: model.Metric{"__name__": "foobar"},
 					Histograms: []model.SampleHistogramPair{
@@ -202,6 +238,7 @@ func TestIngesterQuerying(t *testing.T) {
 					},
 				},
 			},
+			expectedTimestampQueryResult: timestampsAlignedToQueryStep,
 		},
 		"series switching from float to integer histogram to float histogram": {
 			inSeries: []prompb.TimeSeries{
@@ -230,7 +267,7 @@ func TestIngesterQuerying(t *testing.T) {
 					},
 				},
 			},
-			expected: model.Matrix{
+			expectedQueryResult: model.Matrix{
 				{
 					Metric: model.Metric{"__name__": "foobar"},
 					Values: []model.SamplePair{
@@ -263,6 +300,7 @@ func TestIngesterQuerying(t *testing.T) {
 					},
 				},
 			},
+			expectedTimestampQueryResult: timestampsAlignedToQueryStep,
 		},
 		"series including float and native histograms at same timestamp": {
 			inSeries: []prompb.TimeSeries{
@@ -296,7 +334,7 @@ func TestIngesterQuerying(t *testing.T) {
 					},
 				},
 			},
-			expected: model.Matrix{
+			expectedQueryResult: model.Matrix{
 				{
 					Metric: model.Metric{"__name__": "foobar"},
 					Values: []model.SamplePair{
@@ -325,6 +363,107 @@ func TestIngesterQuerying(t *testing.T) {
 						{
 							Timestamp: model.Time(queryStart.Add(queryStep * 5).UnixMilli()),
 							Histogram: test.GenerateTestSampleHistogram(6),
+						},
+					},
+				},
+			},
+			expectedTimestampQueryResult: timestampsAlignedToQueryStep,
+		},
+		"float series where sample timestamps don't align with query step": {
+			inSeries: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: "foobar",
+						},
+					},
+					Samples: []prompb.Sample{
+						{
+							Timestamp: queryStart.Add(-2 * time.Second).UnixMilli(),
+							Value:     100,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep).Add(-2 * time.Second).UnixMilli(),
+							Value:     110,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 2).Add(-2 * time.Second).UnixMilli(),
+							Value:     120,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 3).Add(-2 * time.Second).UnixMilli(),
+							Value:     130,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 4).Add(-2 * time.Second).UnixMilli(),
+							Value:     140,
+						},
+						{
+							Timestamp: queryStart.Add(queryStep * 5).Add(-2 * time.Second).UnixMilli(),
+							Value:     150,
+						},
+					},
+				},
+			},
+			expectedQueryResult: model.Matrix{
+				{
+					Metric: model.Metric{"__name__": "foobar"},
+					Values: []model.SamplePair{
+						{
+							Timestamp: model.Time(queryStart.UnixMilli()),
+							Value:     model.SampleValue(100),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep).UnixMilli()),
+							Value:     model.SampleValue(110),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 2).UnixMilli()),
+							Value:     model.SampleValue(120),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 3).UnixMilli()),
+							Value:     model.SampleValue(130),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 4).UnixMilli()),
+							Value:     model.SampleValue(140),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 5).UnixMilli()),
+							Value:     model.SampleValue(150),
+						},
+					},
+				},
+			},
+			expectedTimestampQueryResult: model.Matrix{
+				{
+					Metric: model.Metric{},
+					Values: []model.SamplePair{
+						{
+							Timestamp: model.Time(queryStart.UnixMilli()),
+							Value:     model.SampleValue(queryStart.Add(-2 * time.Second).Unix()),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep).UnixMilli()),
+							Value:     model.SampleValue(queryStart.Add(queryStep).Add(-2 * time.Second).Unix()),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 2).UnixMilli()),
+							Value:     model.SampleValue(queryStart.Add(queryStep * 2).Add(-2 * time.Second).Unix()),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 3).UnixMilli()),
+							Value:     model.SampleValue(queryStart.Add(queryStep * 3).Add(-2 * time.Second).Unix()),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 4).UnixMilli()),
+							Value:     model.SampleValue(queryStart.Add(queryStep * 4).Add(-2 * time.Second).Unix()),
+						},
+						{
+							Timestamp: model.Time(queryStart.Add(queryStep * 5).UnixMilli()),
+							Value:     model.SampleValue(queryStart.Add(queryStep * 5).Add(-2 * time.Second).Unix()),
 						},
 					},
 				},
@@ -382,8 +521,14 @@ func TestIngesterQuerying(t *testing.T) {
 
 					result, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
 					require.NoError(t, err)
+					require.Equal(t, tc.expectedQueryResult, result)
 
-					require.Equal(t, tc.expected.String(), result.String())
+					// The PromQL engine does some special handling for the timestamp() function which previously
+					// caused queries to fail when streaming chunks was enabled, so check that this regression
+					// has not been reintroduced.
+					result, err = client.QueryRange(timestampQuery, queryStart, queryEnd, queryStep)
+					require.NoError(t, err)
+					require.Equal(t, tc.expectedTimestampQueryResult, result)
 				})
 			}
 		})

--- a/vendor/github.com/prometheus/prometheus/promql/engine.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine.go
@@ -1353,15 +1353,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 			unwrapParenExpr(&arg)
 			vs, ok := arg.(*parser.VectorSelector)
 			if ok {
-				return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
-					if vs.Timestamp != nil {
-						// This is a special case only for "timestamp" since the offset
-						// needs to be adjusted for every point.
-						vs.Offset = time.Duration(enh.Ts-*vs.Timestamp) * time.Millisecond
-					}
-					val, ws := ev.vectorSelector(vs, enh.Ts)
-					return call([]parser.Value{val}, e.Args, enh), ws
-				})
+				return ev.evalTimestampFunctionOverVectorSelector(vs, call, e)
 			}
 		}
 
@@ -1799,38 +1791,47 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 	panic(fmt.Errorf("unhandled expression of type: %T", expr))
 }
 
-// vectorSelector evaluates a *parser.VectorSelector expression.
-func (ev *evaluator) vectorSelector(node *parser.VectorSelector, ts int64) (Vector, storage.Warnings) {
-	ws, err := checkAndExpandSeriesSet(ev.ctx, node)
+func (ev *evaluator) evalTimestampFunctionOverVectorSelector(vs *parser.VectorSelector, call FunctionCall, e *parser.Call) (parser.Value, storage.Warnings) {
+	ws, err := checkAndExpandSeriesSet(ev.ctx, vs)
 	if err != nil {
 		ev.error(errWithWarnings{fmt.Errorf("expanding series: %w", err), ws})
 	}
-	vec := make(Vector, 0, len(node.Series))
-	it := storage.NewMemoizedEmptyIterator(durationMilliseconds(ev.lookbackDelta))
-	var chkIter chunkenc.Iterator
-	for i, s := range node.Series {
-		chkIter = s.Iterator(chkIter)
-		it.Reset(chkIter)
 
-		t, f, h, ok := ev.vectorSelectorSingle(it, node, ts)
-		if ok {
-			vec = append(vec, Sample{
-				Metric: node.Series[i].Labels(),
-				T:      t,
-				F:      f,
-				H:      h,
-			})
+	seriesIterators := make([]*storage.MemoizedSeriesIterator, len(vs.Series))
+	for i, s := range vs.Series {
+		it := s.Iterator(nil)
+		seriesIterators[i] = storage.NewMemoizedIterator(it, durationMilliseconds(ev.lookbackDelta))
+	}
 
-			ev.currentSamples++
-			ev.samplesStats.IncrementSamplesAtTimestamp(ts, 1)
-			if ev.currentSamples > ev.maxSamples {
-				ev.error(ErrTooManySamples(env))
-			}
+	return ev.rangeEval(nil, func(v []parser.Value, _ [][]EvalSeriesHelper, enh *EvalNodeHelper) (Vector, storage.Warnings) {
+		if vs.Timestamp != nil {
+			// This is a special case only for "timestamp" since the offset
+			// needs to be adjusted for every point.
+			vs.Offset = time.Duration(enh.Ts-*vs.Timestamp) * time.Millisecond
 		}
 
-	}
-	ev.samplesStats.UpdatePeak(ev.currentSamples)
-	return vec, ws
+		vec := make(Vector, 0, len(vs.Series))
+		for i, s := range vs.Series {
+			it := seriesIterators[i]
+			t, f, h, ok := ev.vectorSelectorSingle(it, vs, enh.Ts)
+			if ok {
+				vec = append(vec, Sample{
+					Metric: s.Labels(),
+					T:      t,
+					F:      f,
+					H:      h,
+				})
+
+				ev.currentSamples++
+				ev.samplesStats.IncrementSamplesAtTimestamp(enh.Ts, 1)
+				if ev.currentSamples > ev.maxSamples {
+					ev.error(ErrTooManySamples(env))
+				}
+			}
+		}
+		ev.samplesStats.UpdatePeak(ev.currentSamples)
+		return call([]parser.Value{vec}, e.Args, enh), ws
+	})
 }
 
 // vectorSelectorSingle evaluates an instant vector for the iterator of one time series.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -877,7 +877,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230524115841-8d6690e86aa7
+# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230629041723-5c270e23eab7
 ## explicit; go 1.19
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1475,7 +1475,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230524115841-8d6690e86aa7
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230629041723-5c270e23eab7
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6


### PR DESCRIPTION
#### What this PR does

This PR fixes the issue where queries that use the `timestamp()` function fail with an error like `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled.

This brings in the changes from https://github.com/grafana/mimir-prometheus/pull/506.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/4886

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
