### PR TITLE
development: microservices mode docker compose scripts add compatibility for newer compose and address shellcheck linting

### DIFF
--- a/development/mimir-microservices-mode/compose-down.sh
+++ b/development/mimir-microservices-mode/compose-down.sh
@@ -4,6 +4,15 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-SCRIPT_DIR=$(cd `dirname $0` && pwd)
+# newer compose is a subcommand of `docker`, not a hyphenated standalone command
+docker_compose() {
+    if [ -x "$(command -v docker-compose)" ]; then
+        docker-compose "$@"
+    else
+        docker compose "$@"
+    fi
+}
 
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml down
+SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
+
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -6,13 +6,22 @@
 
 set -e
 
-SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-BUILD_IMAGE=$(make -s -f ${SCRIPT_DIR}/../../Makefile print-build-image)
+# newer compose is a subcommand of `docker`, not a hyphenated standalone command
+docker_compose() {
+    if [ -x "$(command -v docker-compose)" ]; then
+        docker-compose "$@"
+    else
+        docker compose "$@"
+    fi
+}
+
+SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
+BUILD_IMAGE=$(make -s -f "${SCRIPT_DIR}"/../../Makefile print-build-image)
 # Make sure docker-compose.yml is up-to-date.
-cd $SCRIPT_DIR && make
+cd "$SCRIPT_DIR" && make
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
-CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/mimir ${SCRIPT_DIR}/../../cmd/mimir
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build --build-arg BUILD_IMAGE=${BUILD_IMAGE} distributor-1
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" distributor-1
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/development/mimir-monolithic-mode-with-swift-storage/compose-down.sh
+++ b/development/mimir-monolithic-mode-with-swift-storage/compose-down.sh
@@ -4,6 +4,15 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-SCRIPT_DIR=$(cd `dirname $0` && pwd)
+# newer compose is a subcommand of `docker`, not a hyphenated standalone command
+docker_compose() {
+    if [ -x "$(command -v docker-compose)" ]; then
+        docker-compose "$@"
+    else
+        docker compose "$@"
+    fi
+}
 
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml down
+SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
+
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down

--- a/development/mimir-monolithic-mode-with-swift-storage/compose-up.sh
+++ b/development/mimir-monolithic-mode-with-swift-storage/compose-up.sh
@@ -4,8 +4,19 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-SCRIPT_DIR=$(cd `dirname $0` && pwd)
+set -e
 
-CGO_ENABLED=0 GOOS=linux go build -o ${SCRIPT_DIR}/mimir ${SCRIPT_DIR}/../../cmd/mimir && \
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build mimir-1 && \
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@
+# newer compose is a subcommand of `docker`, not a hyphenated standalone command
+docker_compose() {
+    if [ -x "$(command -v docker-compose)" ]; then
+        docker-compose "$@"
+    else
+        docker compose "$@"
+    fi
+}
+
+SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
+
+CGO_ENABLED=0 GOOS=linux go build -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir && \
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build mimir-1 && \
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
+++ b/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
 
   consul:
-    image: consul
+    image: consul:1.15  # latest tag not supported
     command: [ "agent", "-dev" ,"-client=0.0.0.0", "-log-level=info" ]
     ports:
       - 8500:8500

--- a/development/mimir-monolithic-mode/compose-down.sh
+++ b/development/mimir-monolithic-mode/compose-down.sh
@@ -4,6 +4,15 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-SCRIPT_DIR=$(cd `dirname $0` && pwd)
+# newer compose is a subcommand of `docker`, not a hyphenated standalone command
+docker_compose() {
+    if [ -x "$(command -v docker-compose)" ]; then
+        docker-compose "$@"
+    else
+        docker compose "$@"
+    fi
+}
 
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml down
+SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
+
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down

--- a/development/mimir-monolithic-mode/compose-up.sh
+++ b/development/mimir-monolithic-mode/compose-up.sh
@@ -4,8 +4,19 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-SCRIPT_DIR=$(cd `dirname $0` && pwd)
+set -e
 
-CGO_ENABLED=0 GOOS=linux go build -o ${SCRIPT_DIR}/mimir ${SCRIPT_DIR}/../../cmd/mimir && \
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build mimir-1 && \
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@
+# newer compose is a subcommand of `docker`, not a hyphenated standalone command
+docker_compose() {
+    if [ -x "$(command -v docker-compose)" ]; then
+        docker-compose "$@"
+    else
+        docker compose "$@"
+    fi
+}
+
+SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
+
+CGO_ENABLED=0 GOOS=linux go build -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir && \
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build mimir-1 && \
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
 
   consul:
-    image: consul
+    image: consul:1.15  # latest tag not supported
     command: [ "agent", "-dev" ,"-client=0.0.0.0", "-log-level=info" ]
     ports:
       - 8500:8500

--- a/development/mimir-read-write-mode/compose-down.sh
+++ b/development/mimir-read-write-mode/compose-down.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 # SPDX-License-Identifier: AGPL-3.0-only
 
-SCRIPT_DIR=$(cd `dirname $0` && pwd)
+# newer compose is a subcommand of `docker`, not a hyphenated standalone command
+docker_compose() {
+    if [ -x "$(command -v docker-compose)" ]; then
+        docker-compose "$@"
+    else
+        docker compose "$@"
+    fi
+}
 
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml down
+SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
+
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down

--- a/development/mimir-read-write-mode/compose-up.sh
+++ b/development/mimir-read-write-mode/compose-up.sh
@@ -3,14 +3,23 @@
 
 set -e
 
-SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-BUILD_IMAGE=$(make -s -f ${SCRIPT_DIR}/../../Makefile print-build-image)
+# newer compose is a subcommand of `docker`, not a hyphenated standalone command
+docker_compose() {
+    if [ -x "$(command -v docker-compose)" ]; then
+        docker-compose "$@"
+    else
+        docker compose "$@"
+    fi
+}
+
+SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
+BUILD_IMAGE=$(make -s -f "${SCRIPT_DIR}"/../../Makefile print-build-image)
 
 # Make sure docker-compose.yml is up-to-date.
-cd $SCRIPT_DIR && make
+cd "$SCRIPT_DIR" && make
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
-CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o ${SCRIPT_DIR}/mimir ${SCRIPT_DIR}/../../cmd/mimir
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml build --build-arg BUILD_IMAGE=${BUILD_IMAGE} mimir-write-1
-docker-compose -f ${SCRIPT_DIR}/docker-compose.yml up $@
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" mimir-write-1
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds bash fn to call 'docker compose' if 'docker-compose' is not available.
This pattern could be flipped, trying to call 'docker compose' first if it's available, since that is the new one. But I think most users are on systems still with `docker-compose`, plus the order doesn't _really_ matter.

Also address shellcheck warnings, adding quoting around shell variable expansion. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
