### PR TITLE
Clarify that `-ingester.client.*` flags are used by rulers too

### DIFF
--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2077,7 +2077,7 @@ The `ingester_client` block configures how the distributors connect to the inges
 
 ```yaml
 # Configures the gRPC client used to communicate with ingesters from
-# distributors and queriers.
+# distributors, queriers and rulers.
 # The CLI flags prefix for this block configuration is: ingester.client
 [grpc_client_config: <grpc_client>]
 ```

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -64,7 +64,7 @@ func (c *closableHealthAndIngesterClient) Close() error {
 
 // Config is the configuration struct for the ingester client
 type Config struct {
-	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with ingesters from distributors and queriers."`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with ingesters from distributors, queriers and rulers."`
 }
 
 // RegisterFlags registers configuration settings used by the ingester client config.


### PR DESCRIPTION
#### What this PR does

This PR addresses https://github.com/grafana/mimir/pull/5375#discussion_r1246279037.

#### Which issue(s) this PR fixes or relates to

#5375

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
