### PR TITLE
Fix breaking change introduced after #5362 was created

### DIFF
--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -106,7 +106,7 @@ func TestStreamingChunkSeries_CreateIteratorTwice(t *testing.T) {
 			chunkIteratorFunc: streamingChunkSeriesTestIteratorFunc,
 			mint:              1000,
 			maxt:              6000,
-			queryChunkMetrics: stats.NewQueryChunkMetrics(prometheus.NewPedanticRegistry()),
+			queryMetrics:      stats.NewQueryMetrics(prometheus.NewPedanticRegistry()),
 			queryStats:        &stats.Stats{},
 		},
 	}


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue introduced by #5362. 

The original PR was built successfully by CI when the PR was raised, but a breaking change was introduced before #5362 was merged that did not retrigger the build for #5362.

#### Which issue(s) this PR fixes or relates to

#5362

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
