### PR TITLE
Allow Memcached StatefulSets chose between AntiAffinity and TopologySpreadConstraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * [ENHANCEMENT] Store-gateway: set `GOMEMLIMIT` to the memory request value. This should reduce the likelihood the store-gateway may go out of memory, at the cost of an higher CPU utilization due to more frequent garbage collections when the memory utilization gets closer or above the configured requested memory. #4971
 * [ENHANCEMENT] Store-gateway: add `store_gateway_lazy_loading_enabled` configuration option which combines disabled lazy-loading and reducing blocks sync concurrency. Reducing blocks sync concurrency improves startup times with disabled lazy loading on HDDs. #5025
 * [BUGFIX] Backend: configure `-ruler.alertmanager-url` to `mimir-backend` when running in read-write deployment mode. #4892
+* [ENHANCEMENT] Memcached: don't overwrite upsteam memcached statefulset jsonnet to allow chosing between antiAffinity and topologySpreadConstraints.
 
 ### Mimirtool
 

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -106,6 +106,9 @@
     // this improves startup times when running on HDDs instead of SSDs as it reduces random reads.
     store_gateway_lazy_loading_enabled: true,
 
+    // Number of memcached replicas for each memcached statefulset
+    memcached_replicas: 3,
+
     cache_frontend_enabled: true,
     cache_frontend_max_item_size_mb: 5,
     cache_frontend_backend: 'memcached',

--- a/operations/mimir/memcached.libsonnet
+++ b/operations/mimir/memcached.libsonnet
@@ -10,14 +10,8 @@ memcached {
   memcached+:: {
     cpu_limits:: null,
     deployment: {},
-    statefulSet:
-      statefulSet.new(self.name, 3, [
-        self.memcached_container,
-        self.memcached_exporter,
-      ], []) +
-      statefulSet.mixin.spec.withServiceName(self.name) +
-      (if !std.isObject($._config.node_selector) then {} else statefulSet.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
-      $.util.antiAffinity,
+    statefulSet+:
+      (if !std.isObject($._config.node_selector) then {} else statefulSet.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)),
 
     service:
       $.util.serviceFor(self.statefulSet) +


### PR DESCRIPTION
#### What this PR does

For some reason the Jsonnet implementation of the memcached deployment overwrites the default memcached StatfulSet. The upstream [memcached jsonnet library](https://github.com/grafana/jsonnet-libs/blob/master/memcached/memcached.libsonnet#L67-L83) implements this just fine and has the feature to chose between AntiAffinity and TopologySpreadConstraints. The only additional thing needed that the Mimir Jsonnet adds is the ability to add a node selector, which can be added to maintain this functionality.

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
