### PR TITLE
Chore: remove utilizationScanner.String()

### DIFF
--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -4,7 +4,6 @@ package limiter
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
@@ -23,18 +22,12 @@ const (
 )
 
 type utilizationScanner interface {
-	fmt.Stringer
-
 	// Scan returns CPU time in seconds and memory utilization in bytes, or an error.
 	Scan() (float64, uint64, error)
 }
 
 type procfsScanner struct {
 	proc procfs.Proc
-}
-
-func (s procfsScanner) String() string {
-	return "/proc"
 }
 
 func (s procfsScanner) Scan() (float64, uint64, error) {
@@ -109,8 +102,7 @@ func (l *UtilizationBasedLimiter) update(_ context.Context) error {
 func (l *UtilizationBasedLimiter) compute(now time.Time) {
 	cpuTime, memUtil, err := l.utilizationScanner.Scan()
 	if err != nil {
-		level.Warn(l.logger).Log("msg", "failed to get CPU and memory stats", "method",
-			l.utilizationScanner.String(), "err", err.Error())
+		level.Warn(l.logger).Log("msg", "failed to get CPU and memory stats", "err", err.Error())
 		// Disable any limiting, since we can't tell resource utilization
 		l.limitingReason.Store("")
 		return

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -63,7 +63,3 @@ func (s *fakeUtilizationScanner) Scan() (float64, uint64, error) {
 	s.counter %= 60
 	return s.totalTime, s.memoryUtilization, nil
 }
-
-func (s *fakeUtilizationScanner) String() string {
-	return "fake"
-}


### PR DESCRIPTION
#### What this PR does
`utilizationScanner.String()` was introduced in a initial implementation that supported multiple ways to detect CPU/memory utilization (proc, cgroup v1 and cgroup v2). However, we currently support only proc so there's no much value adding it to logs. Removing it to cleanup code.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
