### PR TITLE
Add warmup period to CPU utilization moving average

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality"}`
   * `cortex_frontend_query_result_cache_hits_total{request_type="query_range|cardinality"}`
 * [FEATURE] Added `-<prefix>.s3.list-objects-version` flag to configure the S3 list objects version.
-* [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392
+* [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392 #5394
   * `-ingester.read-path-cpu-utilization-limit`
   * `-ingester.read-path-memory-utilization-limit`
 * [FEATURE] Ruler: Support filtering results from rule status endpoint by `file`, `rule_group` and `rule_name`. #5291

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -132,7 +132,7 @@ func (l *UtilizationBasedLimiter) compute(now time.Time) (currCPUUtil float64, c
 	// sliding window. During the warmup, the reported CPU utilization will be 0.
 	if l.firstUpdate.IsZero() {
 		l.firstUpdate = now
-	} else if now.Add(-resourceUtilizationSlidingWindow + 1).After(l.firstUpdate) {
+	} else if now.Sub(l.firstUpdate) >= resourceUtilizationSlidingWindow {
 		currCPUUtil = float64(l.cpuMovingAvg.Rate()) / 100
 	}
 

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -18,8 +18,11 @@ import (
 )
 
 const (
-	// Interval for updating resource (CPU/memory) utilization
+	// Interval for updating resource (CPU/memory) utilization.
 	resourceUtilizationUpdateInterval = time.Second
+
+	// How long is the sliding window used to compute the moving average.
+	resourceUtilizationSlidingWindow = 60 * time.Second
 )
 
 type utilizationScanner interface {
@@ -55,6 +58,8 @@ type UtilizationBasedLimiter struct {
 	cpuLimit float64
 	// Last CPU time counter
 	lastCPUTime float64
+	// The time of the first update
+	firstUpdate time.Time
 	// The time of the last update
 	lastUpdate     time.Time
 	cpuMovingAvg   *math.EwmaRate
@@ -65,7 +70,7 @@ type UtilizationBasedLimiter struct {
 func NewUtilizationBasedLimiter(cpuLimit float64, memoryLimit uint64, logger log.Logger) *UtilizationBasedLimiter {
 	// Calculate alpha for a minute long window
 	// https://github.com/VividCortex/ewma#choosing-alpha
-	alpha := 2 / (60/resourceUtilizationUpdateInterval.Seconds() + 1)
+	alpha := 2 / (resourceUtilizationSlidingWindow.Seconds()/resourceUtilizationUpdateInterval.Seconds() + 1)
 	l := &UtilizationBasedLimiter{
 		logger:      logger,
 		cpuLimit:    cpuLimit,
@@ -100,8 +105,10 @@ func (l *UtilizationBasedLimiter) update(_ context.Context) error {
 	return nil
 }
 
-func (l *UtilizationBasedLimiter) compute(now time.Time) {
-	cpuTime, memUtil, err := l.utilizationScanner.Scan()
+// compute and return the current CPU and memory utilization.
+// This function must be called at a regular interval (resourceUtilizationUpdateInterval) to get a predictable behaviour.
+func (l *UtilizationBasedLimiter) compute(now time.Time) (currCPUUtil float64, currMemoryUtil uint64) {
+	cpuTime, currMemoryUtil, err := l.utilizationScanner.Scan()
 	if err != nil {
 		level.Warn(l.logger).Log("msg", "failed to get CPU and memory stats", "err", err.Error())
 		// Disable any limiting, since we can't tell resource utilization
@@ -109,25 +116,30 @@ func (l *UtilizationBasedLimiter) compute(now time.Time) {
 		return
 	}
 
-	lastUpdate := l.lastUpdate
-	l.lastUpdate = now
-
-	lastCPUTime := l.lastCPUTime
-	l.lastCPUTime = cpuTime
-
-	if lastUpdate.IsZero() {
-		return
+	// Add the instant CPU utilization to the moving average. The instant CPU
+	// utilization can only be computed starting from the 2nd tick.
+	if prevUpdate, prevCPUTime := l.lastUpdate, l.lastCPUTime; !prevUpdate.IsZero() {
+		cpuUtil := (cpuTime - prevCPUTime) / now.Sub(prevUpdate).Seconds()
+		l.cpuMovingAvg.Add(int64(cpuUtil * 100))
+		l.cpuMovingAvg.Tick()
 	}
 
-	cpuUtil := (cpuTime - lastCPUTime) / now.Sub(lastUpdate).Seconds()
-	l.cpuMovingAvg.Add(int64(cpuUtil * 100))
-	l.cpuMovingAvg.Tick()
-	cpuA := float64(l.cpuMovingAvg.Rate()) / 100
+	l.lastUpdate = now
+	l.lastCPUTime = cpuTime
+
+	// The CPU utilization moving average requires a warmup period before getting
+	// stable results. In this implementation we use a warmup period equal to the
+	// sliding window. During the warmup, the reported CPU utilization will be 0.
+	if l.firstUpdate.IsZero() {
+		l.firstUpdate = now
+	} else if now.Add(-resourceUtilizationSlidingWindow + 1).After(l.firstUpdate) {
+		currCPUUtil = float64(l.cpuMovingAvg.Rate()) / 100
+	}
 
 	var reason string
-	if l.memoryLimit > 0 && memUtil >= l.memoryLimit {
+	if l.memoryLimit > 0 && currMemoryUtil >= l.memoryLimit {
 		reason = "memory"
-	} else if l.cpuLimit > 0 && cpuA >= l.cpuLimit {
+	} else if l.cpuLimit > 0 && currCPUUtil >= l.cpuLimit {
 		reason = "cpu"
 	}
 
@@ -140,14 +152,16 @@ func (l *UtilizationBasedLimiter) compute(now time.Time) {
 
 	if enable {
 		level.Info(l.logger).Log("msg", "enabling resource utilization based limiting",
-			"reason", reason, "memory_limit", formatMemoryLimit(l.memoryLimit), "memory_utilization", formatMemory(memUtil),
-			"cpu_limit", formatCPULimit(l.cpuLimit), "cpu_utilization", formatCPU(cpuA))
+			"reason", reason, "memory_limit", formatMemoryLimit(l.memoryLimit), "memory_utilization", formatMemory(currMemoryUtil),
+			"cpu_limit", formatCPULimit(l.cpuLimit), "cpu_utilization", formatCPU(currCPUUtil))
 	} else {
 		level.Info(l.logger).Log("msg", "disabling resource utilization based limiting",
-			"memory_limit", formatMemoryLimit(l.memoryLimit), "memory_utilization", formatMemory(memUtil),
-			"cpu_limit", formatCPULimit(l.cpuLimit), "cpu_utilization", formatCPU(cpuA))
+			"memory_limit", formatMemoryLimit(l.memoryLimit), "memory_utilization", formatMemory(currMemoryUtil),
+			"cpu_limit", formatCPULimit(l.cpuLimit), "cpu_utilization", formatCPU(currCPUUtil))
 	}
+
 	l.limitingReason.Store(reason)
+	return
 }
 
 func formatCPU(value float64) string {

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -141,7 +141,7 @@ func TestUtilizationBasedLimiter_CPUUtilizationSensitivity(t *testing.T) {
 			}(),
 			expectedMaxCPUUtilization: 1.49,
 		},
-		"10 seconds spike + 110 seconds idle (moving average warmups the first 60 seconds)": {
+		"10 seconds spike + 110 seconds idle (moving average warms up the first 60 seconds)": {
 			instantCPUValues: func() []float64 {
 				values := []float64{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
 				values = append(values, generateConstCPUUtilization(110, 0)...)


### PR DESCRIPTION
#### What this PR does
Yesterday I enabled the CPU-based limiting in a production cell and I noticed requests to be limited right after the ingester startup, even if the 1m CPU utilization average (as computed by `rate(container_cpu_usage_seconds_total[1m])`) was way below the limit (about the half).

After some investigation, I realised that the limit triggered right after the limiter was started. We start the limiter after we replay the TSDB WALs in the ingester, and right before the ingester is ready to accept samples. Looking at logs of ingesters where the limit triggered, they all show the same pattern:

```
ts=2023-06-30T18:07:17.632955811Z caller=ingester.go:2210 level=info msg="successfully opened existing TSDBs"
ts=2023-06-30T18:07:17.633186146Z caller=mimir.go:834 level=info msg="Application started"
ts=2023-06-30T18:07:19.633923839Z caller=utilization.go:149 level=info context="read path" msg="enabling resource utilization based limiting" reason=cpu memory_limit=21474836480 memory_utilization=5136072704 cpu_limit=8 cpu_utilization=8.61
ts=2023-06-30T18:07:22.634063682Z caller=utilization.go:153 level=info context="read path" msg="disabling resource utilization based limiting" memory_limit=21474836480 memory_utilization=5138870272 cpu_limit=8 cpu_utilization=7.892821998317039
```

While reading https://github.com/VividCortex/ewma#readme to learn more how the EWMA works, I reliased that to get more stable results you should have a warmup period (which is also implemented by VividCortex's `VariableEWMA`). The idea of the warmup period is that for the first N samples, you add samples to the EWMA but you don't consider the computed rate as valid.

In this PR I'm adding a warmup period to our `UtilizationBasedLimiter`. I've also added a test to show the CPU utilization "sensitivity" (I just assert on the max CPU utilization because that's what we care with regards to the limiting).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
