### PR TITLE
Fix MimirIngesterHasNotShippedBlocks alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 * [ENHANCEMENT] Querier: add `cortex_queries_rejected_total` metric that counts the number of queries rejected due to hitting a limit (eg. max series per query or max chunks per query). #5316
 * [ENHANCEMENT] Querier: add experimental `-querier.minimize-ingester-requests-hedging-delay` option to initiate requests to further ingesters when request minimisation is enabled and not all initial requests have completed. #5368
 * [ENHANCEMENT] Clarify docs for `-ingester.client.*` flags to make it clear that these are used by both queriers and distributors. #5375
-* [ENHANCEMENT] Ingester: added `cortex_ingester_shipper_last_successful_upload_time` metric tracking the last successful TSDB block uploaded to the bucket (unix timestamp in seconds). #5396
+* [ENHANCEMENT] Ingester: added `cortex_ingester_shipper_last_successful_upload_timestamp_seconds` metric tracking the last successful TSDB block uploaded to the bucket (unix timestamp in seconds). #5396
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [CHANGE] Querier: change the default value of the experimental `-querier.streaming-chunks-per-ingester-buffer-size` flag to 256. #5203
 * [CHANGE] Querier: only initiate query requests to ingesters in the `ACTIVE` state in the ring. #5342
 * [CHANGE] Querier: `-query-frontend.cache-unaligned-requests` has been moved from a global flag to a per-tenant override. #5312
+* [CHANGE] Ingester: removed `cortex_ingester_shipper_dir_syncs_total` and `cortex_ingester_shipper_dir_sync_failures_total` metrics. The former metric was not much useful, and the latter was never incremented. #5396
 * [FEATURE] Cardinality API: Add a new `count_method` parameter which enables counting active series #5136
 * [FEATURE] Query-frontend: added experimental support to cache cardinality query responses. The cache will be used when `-query-frontend.cache-results` is enabled and `-query-frontend.results-cache-ttl-for-cardinality-query` set to a value greater than 0. The following metrics have been added to track the query results cache hit ratio per `request_type`: #5212 #5235
   * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality"}`
@@ -41,6 +42,7 @@
 * [ENHANCEMENT] Querier: add `cortex_queries_rejected_total` metric that counts the number of queries rejected due to hitting a limit (eg. max series per query or max chunks per query). #5316
 * [ENHANCEMENT] Querier: add experimental `-querier.minimize-ingester-requests-hedging-delay` option to initiate requests to further ingesters when request minimisation is enabled and not all initial requests have completed. #5368
 * [ENHANCEMENT] Clarify docs for `-ingester.client.*` flags to make it clear that these are used by both queriers and distributors. #5375
+* [ENHANCEMENT] Ingester: added `cortex_ingester_shipper_last_successful_upload_time` metric tracking the last successful TSDB block uploaded to the bucket (unix timestamp in seconds). #5396
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377
@@ -54,6 +56,7 @@
 * [ENHANCEMENT] Dashboards: show container name first in "pods count per version" panel on "rollout progress" dashboard. #5113
 * [ENHANCEMENT] Dashboards: show time spend waiting for turn when lazy loading index headers in the "index-header lazy load gate latency" panel on the "queries" dashboard. #5313
 * [BUGFIX] Dashboards: fix "unhealthy pods" panel on "rollout progress" dashboard showing only a number rather than the name of the workload and the number of unhealthy pods if only one workload has unhealthy pods. #5113 #5200
+* [BUGFIX] Alerts: fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts. #5396
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -631,9 +631,9 @@ spec:
           }} has not shipped any block in the last 4 hours.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblocks
       expr: |
-        (min by(cluster, namespace, pod) (time() - cortex_ingester_shipper_last_successful_upload_time) > 60 * 60 * 4)
+        (min by(cluster, namespace, pod) (time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 60 * 60 * 4)
         and
-        (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_time) > 0)
+        (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
         and
         # Only if the ingester has ingested samples over the last 4h.
         (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
@@ -652,7 +652,7 @@ spec:
           }} has not shipped any block in the last 4 hours.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblockssincestart
       expr: |
-        (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_time) == 0)
+        (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
         and
         (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
       for: 4h

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -631,9 +631,9 @@ spec:
           }} has not shipped any block in the last 4 hours.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblocks
       expr: |
-        (min by(cluster, namespace, pod) (time() - thanos_shipper_last_successful_upload_time) > 60 * 60 * 4)
+        (min by(cluster, namespace, pod) (time() - cortex_ingester_shipper_last_successful_upload_time) > 60 * 60 * 4)
         and
-        (max by(cluster, namespace, pod) (thanos_shipper_last_successful_upload_time) > 0)
+        (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_time) > 0)
         and
         # Only if the ingester has ingested samples over the last 4h.
         (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
@@ -652,7 +652,7 @@ spec:
           }} has not shipped any block in the last 4 hours.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblockssincestart
       expr: |
-        (max by(cluster, namespace, pod) (thanos_shipper_last_successful_upload_time) == 0)
+        (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_time) == 0)
         and
         (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
       for: 4h

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -605,9 +605,9 @@ groups:
         }} has not shipped any block in the last 4 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblocks
     expr: |
-      (min by(cluster, namespace, instance) (time() - thanos_shipper_last_successful_upload_time) > 60 * 60 * 4)
+      (min by(cluster, namespace, instance) (time() - cortex_ingester_shipper_last_successful_upload_time) > 60 * 60 * 4)
       and
-      (max by(cluster, namespace, instance) (thanos_shipper_last_successful_upload_time) > 0)
+      (max by(cluster, namespace, instance) (cortex_ingester_shipper_last_successful_upload_time) > 0)
       and
       # Only if the ingester has ingested samples over the last 4h.
       (max by(cluster, namespace, instance) (max_over_time(cluster_namespace_instance:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
@@ -626,7 +626,7 @@ groups:
         }} has not shipped any block in the last 4 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblockssincestart
     expr: |
-      (max by(cluster, namespace, instance) (thanos_shipper_last_successful_upload_time) == 0)
+      (max by(cluster, namespace, instance) (cortex_ingester_shipper_last_successful_upload_time) == 0)
       and
       (max by(cluster, namespace, instance) (max_over_time(cluster_namespace_instance:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
     for: 4h

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -605,9 +605,9 @@ groups:
         }} has not shipped any block in the last 4 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblocks
     expr: |
-      (min by(cluster, namespace, instance) (time() - cortex_ingester_shipper_last_successful_upload_time) > 60 * 60 * 4)
+      (min by(cluster, namespace, instance) (time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 60 * 60 * 4)
       and
-      (max by(cluster, namespace, instance) (cortex_ingester_shipper_last_successful_upload_time) > 0)
+      (max by(cluster, namespace, instance) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
       and
       # Only if the ingester has ingested samples over the last 4h.
       (max by(cluster, namespace, instance) (max_over_time(cluster_namespace_instance:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
@@ -626,7 +626,7 @@ groups:
         }} has not shipped any block in the last 4 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblockssincestart
     expr: |
-      (max by(cluster, namespace, instance) (cortex_ingester_shipper_last_successful_upload_time) == 0)
+      (max by(cluster, namespace, instance) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
       and
       (max by(cluster, namespace, instance) (max_over_time(cluster_namespace_instance:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
     for: 4h

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -619,9 +619,9 @@ groups:
         }} has not shipped any block in the last 4 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblocks
     expr: |
-      (min by(cluster, namespace, pod) (time() - cortex_ingester_shipper_last_successful_upload_time) > 60 * 60 * 4)
+      (min by(cluster, namespace, pod) (time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 60 * 60 * 4)
       and
-      (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_time) > 0)
+      (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
       and
       # Only if the ingester has ingested samples over the last 4h.
       (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
@@ -640,7 +640,7 @@ groups:
         }} has not shipped any block in the last 4 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblockssincestart
     expr: |
-      (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_time) == 0)
+      (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
       and
       (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
     for: 4h

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -619,9 +619,9 @@ groups:
         }} has not shipped any block in the last 4 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblocks
     expr: |
-      (min by(cluster, namespace, pod) (time() - thanos_shipper_last_successful_upload_time) > 60 * 60 * 4)
+      (min by(cluster, namespace, pod) (time() - cortex_ingester_shipper_last_successful_upload_time) > 60 * 60 * 4)
       and
-      (max by(cluster, namespace, pod) (thanos_shipper_last_successful_upload_time) > 0)
+      (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_time) > 0)
       and
       # Only if the ingester has ingested samples over the last 4h.
       (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
@@ -640,7 +640,7 @@ groups:
         }} has not shipped any block in the last 4 hours.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblockssincestart
     expr: |
-      (max by(cluster, namespace, pod) (thanos_shipper_last_successful_upload_time) == 0)
+      (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_time) == 0)
       and
       (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
     for: 4h

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -9,9 +9,9 @@
           alert: $.alertName('IngesterHasNotShippedBlocks'),
           'for': '15m',
           expr: |||
-            (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (time() - cortex_ingester_shipper_last_successful_upload_time) > 60 * 60 * 4)
+            (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 60 * 60 * 4)
             and
-            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_shipper_last_successful_upload_time) > 0)
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
             and
             # Only if the ingester has ingested samples over the last 4h.
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
@@ -39,7 +39,7 @@
           alert: $.alertName('IngesterHasNotShippedBlocksSinceStart'),
           'for': '4h',
           expr: |||
-            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_shipper_last_successful_upload_time) == 0)
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
             and
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
           ||| % {

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -9,9 +9,9 @@
           alert: $.alertName('IngesterHasNotShippedBlocks'),
           'for': '15m',
           expr: |||
-            (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (time() - thanos_shipper_last_successful_upload_time) > 60 * 60 * 4)
+            (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (time() - cortex_ingester_shipper_last_successful_upload_time) > 60 * 60 * 4)
             and
-            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (thanos_shipper_last_successful_upload_time) > 0)
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_shipper_last_successful_upload_time) > 0)
             and
             # Only if the ingester has ingested samples over the last 4h.
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
@@ -39,7 +39,7 @@
           alert: $.alertName('IngesterHasNotShippedBlocksSinceStart'),
           'for': '4h',
           expr: |||
-            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (thanos_shipper_last_successful_upload_time) == 0)
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_shipper_last_successful_upload_time) == 0)
             and
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
           ||| % {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -229,6 +229,9 @@ type Ingester struct {
 	// Value used by shipper as external label.
 	shipperIngesterID string
 
+	// Metrics shared across all per-tenant shippers.
+	shipperMetrics *shipperMetrics
+
 	subservices  *services.Manager
 	activeGroups *util.ActiveGroupsCleanupService
 
@@ -289,6 +292,7 @@ func newIngester(cfg Config, limits *validation.Overrides, registerer prometheus
 		usersMetadata:       make(map[string]*userMetricsMetadata),
 		bucket:              bucketClient,
 		tsdbMetrics:         newTSDBMetrics(registerer, logger),
+		shipperMetrics:      newShipperMetrics(registerer),
 		forceCompactTrigger: make(chan requestWithUsersAndCallback),
 		shipTrigger:         make(chan requestWithUsersAndCallback),
 		seriesHashCache:     hashcache.NewSeriesHashCache(cfg.BlocksStorageConfig.TSDB.SeriesHashCacheMaxBytes),
@@ -2076,7 +2080,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 			userLogger,
 			i.limits,
 			userID,
-			tsdbPromReg,
+			i.shipperMetrics,
 			udir,
 			bucket.NewUserBucketClient(userID, i.bucket, i.limits),
 			block.ReceiveSource,

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -4211,10 +4211,10 @@ func TestIngester_flushing(t *testing.T) {
 					# TYPE cortex_ingester_shipper_uploads_total counter
 					cortex_ingester_shipper_uploads_total 0
 
-					# HELP cortex_ingester_shipper_last_successful_upload_time Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
-					# TYPE cortex_ingester_shipper_last_successful_upload_time gauge
-					cortex_ingester_shipper_last_successful_upload_time 0
-				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_time"))
+					# HELP cortex_ingester_shipper_last_successful_upload_timestamp_seconds Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
+					# TYPE cortex_ingester_shipper_last_successful_upload_timestamp_seconds gauge
+					cortex_ingester_shipper_last_successful_upload_timestamp_seconds 0
+				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_timestamp_seconds"))
 
 				// Shutdown ingester. This triggers flushing of the block.
 				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), i))
@@ -4248,10 +4248,10 @@ func TestIngester_flushing(t *testing.T) {
 					# TYPE cortex_ingester_shipper_uploads_total counter
 					cortex_ingester_shipper_uploads_total 0
 
-					# HELP cortex_ingester_shipper_last_successful_upload_time Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
-					# TYPE cortex_ingester_shipper_last_successful_upload_time gauge
-					cortex_ingester_shipper_last_successful_upload_time 0
-				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_time"))
+					# HELP cortex_ingester_shipper_last_successful_upload_timestamp_seconds Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
+					# TYPE cortex_ingester_shipper_last_successful_upload_timestamp_seconds gauge
+					cortex_ingester_shipper_last_successful_upload_timestamp_seconds 0
+				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_timestamp_seconds"))
 
 				response1 := httptest.NewRecorder()
 				i.PrepareShutdownHandler(response1, httptest.NewRequest("GET", "/ingester/prepare-shutdown", nil))
@@ -4322,10 +4322,10 @@ func TestIngester_flushing(t *testing.T) {
 					# TYPE cortex_ingester_shipper_uploads_total counter
 					cortex_ingester_shipper_uploads_total 0
 
-					# HELP cortex_ingester_shipper_last_successful_upload_time Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
-					# TYPE cortex_ingester_shipper_last_successful_upload_time gauge
-					cortex_ingester_shipper_last_successful_upload_time 0
-				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_time"))
+					# HELP cortex_ingester_shipper_last_successful_upload_timestamp_seconds Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
+					# TYPE cortex_ingester_shipper_last_successful_upload_timestamp_seconds gauge
+					cortex_ingester_shipper_last_successful_upload_timestamp_seconds 0
+				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_timestamp_seconds"))
 
 				i.ShutdownHandler(httptest.NewRecorder(), httptest.NewRequest("POST", "/ingester/shutdown", nil))
 
@@ -4354,10 +4354,10 @@ func TestIngester_flushing(t *testing.T) {
 					# TYPE cortex_ingester_shipper_uploads_total counter
 					cortex_ingester_shipper_uploads_total 0
 
-					# HELP cortex_ingester_shipper_last_successful_upload_time Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
-					# TYPE cortex_ingester_shipper_last_successful_upload_time gauge
-					cortex_ingester_shipper_last_successful_upload_time 0
-				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_time"))
+					# HELP cortex_ingester_shipper_last_successful_upload_timestamp_seconds Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
+					# TYPE cortex_ingester_shipper_last_successful_upload_timestamp_seconds gauge
+					cortex_ingester_shipper_last_successful_upload_timestamp_seconds 0
+				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_timestamp_seconds"))
 
 				// Using wait=true makes this a synchronous call.
 				i.FlushHandler(httptest.NewRecorder(), httptest.NewRequest("POST", "/ingester/flush?wait=true", nil))
@@ -4387,10 +4387,10 @@ func TestIngester_flushing(t *testing.T) {
 					# TYPE cortex_ingester_shipper_uploads_total counter
 					cortex_ingester_shipper_uploads_total 0
 
-					# HELP cortex_ingester_shipper_last_successful_upload_time Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
-					# TYPE cortex_ingester_shipper_last_successful_upload_time gauge
-					cortex_ingester_shipper_last_successful_upload_time 0
-				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_time"))
+					# HELP cortex_ingester_shipper_last_successful_upload_timestamp_seconds Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
+					# TYPE cortex_ingester_shipper_last_successful_upload_timestamp_seconds gauge
+					cortex_ingester_shipper_last_successful_upload_timestamp_seconds 0
+				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_timestamp_seconds"))
 
 				users := url.Values{}
 				users.Add(tenantParam, "unknown-user")
@@ -4405,10 +4405,10 @@ func TestIngester_flushing(t *testing.T) {
 					# TYPE cortex_ingester_shipper_uploads_total counter
 					cortex_ingester_shipper_uploads_total 0
 
-					# HELP cortex_ingester_shipper_last_successful_upload_time Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
-					# TYPE cortex_ingester_shipper_last_successful_upload_time gauge
-					cortex_ingester_shipper_last_successful_upload_time 0
-				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_time"))
+					# HELP cortex_ingester_shipper_last_successful_upload_timestamp_seconds Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
+					# TYPE cortex_ingester_shipper_last_successful_upload_timestamp_seconds gauge
+					cortex_ingester_shipper_last_successful_upload_timestamp_seconds 0
+				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_timestamp_seconds"))
 				verifyCompactedHead(t, i, false)
 
 				users = url.Values{}
@@ -4453,10 +4453,10 @@ func TestIngester_flushing(t *testing.T) {
 					# TYPE cortex_ingester_shipper_uploads_total counter
 					cortex_ingester_shipper_uploads_total 0
 
-					# HELP cortex_ingester_shipper_last_successful_upload_time Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
-					# TYPE cortex_ingester_shipper_last_successful_upload_time gauge
-					cortex_ingester_shipper_last_successful_upload_time 0
-				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_time"))
+					# HELP cortex_ingester_shipper_last_successful_upload_timestamp_seconds Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.
+					# TYPE cortex_ingester_shipper_last_successful_upload_timestamp_seconds gauge
+					cortex_ingester_shipper_last_successful_upload_timestamp_seconds 0
+				`), "cortex_ingester_shipper_uploads_total", "cortex_ingester_shipper_last_successful_upload_timestamp_seconds"))
 
 				i.FlushHandler(httptest.NewRecorder(), httptest.NewRequest("POST", "/ingester/flush?wait=true", nil))
 
@@ -7399,5 +7399,5 @@ func verifyShipperLastSuccessfulUploadTimeMetric(t *testing.T, reg *prometheus.R
 
 	metrics, err := dskit_metrics.NewMetricFamilyMapFromGatherer(reg)
 	require.NoError(t, err)
-	assert.InDelta(t, float64(expected), metrics.MaxGauges("cortex_ingester_shipper_last_successful_upload_time"), 5)
+	assert.InDelta(t, float64(expected), metrics.MaxGauges("cortex_ingester_shipper_last_successful_upload_timestamp_seconds"), 5)
 }

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -360,12 +360,6 @@ func (m *discardedMetrics) DeleteLabelValues(userID string, group string) {
 
 // TSDB metrics collector. Each tenant has its own registry, that TSDB code uses.
 type tsdbMetrics struct {
-	// Metrics aggregated from Thanos shipper.
-	dirSyncs        *prometheus.Desc // sum(thanos_shipper_dir_syncs_total)
-	dirSyncFailures *prometheus.Desc // sum(thanos_shipper_dir_sync_failures_total)
-	uploads         *prometheus.Desc // sum(thanos_shipper_uploads_total)
-	uploadFailures  *prometheus.Desc // sum(thanos_shipper_upload_failures_total)
-
 	// Metrics aggregated from TSDB.
 	tsdbCompactionsTotal              *prometheus.Desc
 	tsdbCompactionDuration            *prometheus.Desc
@@ -421,22 +415,6 @@ func newTSDBMetrics(r prometheus.Registerer, logger log.Logger) *tsdbMetrics {
 	m := &tsdbMetrics{
 		regs: dskit_metrics.NewTenantRegistries(logger),
 
-		dirSyncs: prometheus.NewDesc(
-			"cortex_ingester_shipper_dir_syncs_total",
-			"Total number of TSDB dir syncs",
-			nil, nil),
-		dirSyncFailures: prometheus.NewDesc(
-			"cortex_ingester_shipper_dir_sync_failures_total",
-			"Total number of failed TSDB dir syncs",
-			nil, nil),
-		uploads: prometheus.NewDesc(
-			"cortex_ingester_shipper_uploads_total",
-			"Total number of uploaded TSDB blocks",
-			nil, nil),
-		uploadFailures: prometheus.NewDesc(
-			"cortex_ingester_shipper_upload_failures_total",
-			"Total number of TSDB block upload failures",
-			nil, nil),
 		tsdbCompactionsTotal: prometheus.NewDesc(
 			"cortex_ingester_tsdb_compactions_total",
 			"Total number of TSDB compactions that were executed.",
@@ -614,11 +592,6 @@ func newTSDBMetrics(r prometheus.Registerer, logger log.Logger) *tsdbMetrics {
 }
 
 func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
-	out <- sm.dirSyncs
-	out <- sm.dirSyncFailures
-	out <- sm.uploads
-	out <- sm.uploadFailures
-
 	out <- sm.tsdbCompactionsTotal
 	out <- sm.tsdbCompactionDuration
 	out <- sm.tsdbFsyncDuration
@@ -666,12 +639,6 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 
 func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data := sm.regs.BuildMetricFamiliesPerTenant()
-
-	// OK, we have it all. Let's build results.
-	data.SendSumOfCounters(out, sm.dirSyncs, "thanos_shipper_dir_syncs_total")
-	data.SendSumOfCounters(out, sm.dirSyncFailures, "thanos_shipper_dir_sync_failures_total")
-	data.SendSumOfCounters(out, sm.uploads, "thanos_shipper_uploads_total")
-	data.SendSumOfCounters(out, sm.uploadFailures, "thanos_shipper_upload_failures_total")
 
 	data.SendSumOfCounters(out, sm.tsdbCompactionsTotal, "prometheus_tsdb_compactions_total")
 	data.SendSumOfHistograms(out, sm.tsdbCompactionDuration, "prometheus_tsdb_compaction_duration_seconds")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -26,26 +26,6 @@ func TestTSDBMetrics(t *testing.T) {
 	tsdbMetrics.setRegistryForUser("user3", populateTSDBMetrics(999))
 
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
-			# HELP cortex_ingester_shipper_dir_syncs_total Total number of TSDB dir syncs
-			# TYPE cortex_ingester_shipper_dir_syncs_total counter
-			# 12345 + 85787 + 999
-			cortex_ingester_shipper_dir_syncs_total 99131
-
-			# HELP cortex_ingester_shipper_dir_sync_failures_total Total number of failed TSDB dir syncs
-			# TYPE cortex_ingester_shipper_dir_sync_failures_total counter
-			# 2*(12345 + 85787 + 999)
-			cortex_ingester_shipper_dir_sync_failures_total 198262
-
-			# HELP cortex_ingester_shipper_uploads_total Total number of uploaded TSDB blocks
-			# TYPE cortex_ingester_shipper_uploads_total counter
-			# 3*(12345 + 85787 + 999)
-			cortex_ingester_shipper_uploads_total 297393
-
-			# HELP cortex_ingester_shipper_upload_failures_total Total number of TSDB block upload failures
-			# TYPE cortex_ingester_shipper_upload_failures_total counter
-			# 4*(12345 + 85787 + 999)
-			cortex_ingester_shipper_upload_failures_total 396524
-
 			# HELP cortex_ingester_tsdb_compactions_total Total number of TSDB compactions that were executed.
 			# TYPE cortex_ingester_tsdb_compactions_total counter
 			cortex_ingester_tsdb_compactions_total 693917
@@ -270,26 +250,6 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 	tsdbMetrics.removeRegistryForUser("user3")
 
 	err := testutil.GatherAndCompare(mainReg, bytes.NewBufferString(`
-			# HELP cortex_ingester_shipper_dir_syncs_total Total number of TSDB dir syncs
-			# TYPE cortex_ingester_shipper_dir_syncs_total counter
-			# 12345 + 85787 + 999
-			cortex_ingester_shipper_dir_syncs_total 99131
-
-			# HELP cortex_ingester_shipper_dir_sync_failures_total Total number of failed TSDB dir syncs
-			# TYPE cortex_ingester_shipper_dir_sync_failures_total counter
-			# 2*(12345 + 85787 + 999)
-			cortex_ingester_shipper_dir_sync_failures_total 198262
-
-			# HELP cortex_ingester_shipper_uploads_total Total number of uploaded TSDB blocks
-			# TYPE cortex_ingester_shipper_uploads_total counter
-			# 3*(12345 + 85787 + 999)
-			cortex_ingester_shipper_uploads_total 297393
-
-			# HELP cortex_ingester_shipper_upload_failures_total Total number of TSDB block upload failures
-			# TYPE cortex_ingester_shipper_upload_failures_total counter
-			# 4*(12345 + 85787 + 999)
-			cortex_ingester_shipper_upload_failures_total 396524
-
 			# HELP cortex_ingester_tsdb_compactions_total Total number of TSDB compactions that were executed.
 			# TYPE cortex_ingester_tsdb_compactions_total counter
 			cortex_ingester_tsdb_compactions_total 693917
@@ -495,31 +455,6 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 
 func populateTSDBMetrics(base float64) *prometheus.Registry {
 	r := prometheus.NewRegistry()
-
-	// Thanos shipper.
-	dirSyncs := promauto.With(r).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_shipper_dir_syncs_total",
-		Help: "Total number of dir syncs",
-	})
-	dirSyncs.Add(1 * base)
-
-	dirSyncFailures := promauto.With(r).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_shipper_dir_sync_failures_total",
-		Help: "Total number of failed dir syncs",
-	})
-	dirSyncFailures.Add(2 * base)
-
-	uploads := promauto.With(r).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_shipper_uploads_total",
-		Help: "Total number of uploaded blocks",
-	})
-	uploads.Add(3 * base)
-
-	uploadFailures := promauto.With(r).NewCounter(prometheus.CounterOpts{
-		Name: "thanos_shipper_upload_failures_total",
-		Help: "Total number of block upload failures",
-	})
-	uploadFailures.Add(4 * base)
 
 	// TSDB Head
 	headSeries := promauto.With(r).NewGauge(prometheus.GaugeOpts{

--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -48,7 +48,7 @@ func newShipperMetrics(reg prometheus.Registerer) *shipperMetrics {
 			Help: "Total number of TSDB block upload failures",
 		}),
 		lastSuccessfulUploadTime: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name: "cortex_ingester_shipper_last_successful_upload_time",
+			Name: "cortex_ingester_shipper_last_successful_upload_timestamp_seconds",
 			Help: "Unix timestamp (in seconds) of the last successful TSDB block uploaded to the object storage.",
 		}),
 	}

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -51,7 +51,7 @@ func TestShipper(t *testing.T) {
 	logger := log.NewLogfmtLogger(logs)
 	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
-	s := newShipper(logger, overrides, "", nil, blocksDir, bkt, block.TestSource)
+	s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource)
 
 	t.Run("no shipper file yet", func(t *testing.T) {
 		// No shipper file = nothing is reported as shipped.
@@ -193,7 +193,7 @@ func TestShipper_DeceivingUploadErrors(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stderr)
 	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
-	s := newShipper(logger, overrides, "", nil, blocksDir, bkt, block.TestSource)
+	s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource)
 
 	// Create and upload a block
 	id1 := ulid.MustNew(1, nil)
@@ -259,7 +259,7 @@ func TestIterBlockMetas(t *testing.T) {
 	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
 	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
-	shipper := newShipper(nil, overrides, "", nil, dir, nil, block.TestSource)
+	shipper := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, nil, block.TestSource)
 	metas, err := shipper.blockMetasFromOldest()
 	require.NoError(t, err)
 	require.Equal(t, sort.SliceIsSorted(metas, func(i, j int) bool {
@@ -273,7 +273,7 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 	inmemory := objstore.NewInMemBucket()
 	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
-	s := newShipper(nil, overrides, "", nil, dir, inmemory, block.TestSource)
+	s := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, inmemory, block.TestSource)
 
 	id := ulid.MustNew(1, nil)
 	blockDir := path.Join(dir, id.String())
@@ -417,7 +417,7 @@ func TestShipper_AddOOOLabel(t *testing.T) {
 			}
 			overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tenantLimits))
 			require.NoError(t, err)
-			s := newShipper(logger, overrides, "", nil, blocksDir, bkt, block.TestSource)
+			s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource)
 
 			createBlock(t, blocksDir, tc.meta.ULID, tc.meta)
 


### PR DESCRIPTION
#### What this PR does
Earlier today we've got an issue for which I was expecting `MimirIngesterHasNotShippedBlocks` to fire, but it didn't. Turns out the reason is that the metric `thanos_shipper_last_successful_upload_time` is not exported anymore (it's tracked in the code, but not mapped in `tsdbMetrics`). This PR fixes it.

User-facing changes:
- Introduced `cortex_ingester_shipper_last_successful_upload_timestamp_seconds`
- Removed `cortex_ingester_shipper_dir_syncs_total` because useless (never used in our mixing)
- Removed `cortex_ingester_shipper_dir_sync_failures_total` because it was never incremented (never used in our mixin)

Note to reviewers:
- The shipper `metrics` struct has been renamed to `shipperMetrics` and is now shared across all shipper instances. The metrics tracked are safe to be shared because they're either counters (safe) or `cortex_ingester_shipper_last_successful_upload_timestamp_seconds` (gauge) which when updated is always set to current time (so we effectively track the "last successful upload time").

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
