### PR TITLE
Fix MimirIngesterRestarts to fire only when the ingester container is restarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [ENHANCEMENT] Dashboards: adjust layout of "rollout progress" dashboard panels so that the "rollout progress" panel doesn't require scrolling. #5113
 * [ENHANCEMENT] Dashboards: show container name first in "pods count per version" panel on "rollout progress" dashboard. #5113
 * [ENHANCEMENT] Dashboards: show time spend waiting for turn when lazy loading index headers in the "index-header lazy load gate latency" panel on the "queries" dashboard. #5313
+* [BUGFIX] Alerts: fix `MimirIngesterRestarts` to fire only when the ingester container is restarted, excluding the cases the pod is rescheduled. #5397
 * [BUGFIX] Dashboards: fix "unhealthy pods" panel on "rollout progress" dashboard showing only a number rather than the name of the workload and the number of unhealthy pods if only one workload has unhealthy pods. #5113 #5200
 
 ### Jsonnet

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -125,11 +125,20 @@ spec:
         severity: warning
     - alert: MimirIngesterRestarts
       annotations:
-        message: '{{ $labels.job }}/{{ $labels.pod }} has restarted {{ printf "%.2f"
-          $value }} times in the last 30 mins.'
+        message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+          }} has restarted {{ printf "%.2f" $value }} times in the last 30 mins.
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterrestarts
       expr: |
-        changes(process_start_time_seconds{job=~".*/(ingester.*|cortex|mimir|mimir-write.*)"}[30m]) >= 2
+        (
+          sum by(cluster, namespace, pod) (
+            increase(kube_pod_container_status_restarts_total{container=~"(ingester|mimir-write)"}[30m])
+          )
+          >= 2
+        )
+        and
+        (
+          count by(cluster, namespace, pod) (cortex_build_info) > 0
+        )
       labels:
         severity: warning
     - alert: MimirKVStoreFailure

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -113,11 +113,20 @@ groups:
       severity: warning
   - alert: MimirIngesterRestarts
     annotations:
-      message: '{{ $labels.job }}/{{ $labels.instance }} has restarted {{ printf "%.2f"
-        $value }} times in the last 30 mins.'
+      message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} has restarted {{ printf "%.2f" $value }} times in the last 30 mins.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterrestarts
     expr: |
-      changes(process_start_time_seconds{job=~".*/(ingester.*|cortex|mimir|mimir-write.*)"}[30m]) >= 2
+      (
+        sum by(cluster, namespace, instance) (
+          increase(kube_pod_container_status_restarts_total{container=~"(ingester|mimir-write)"}[30m])
+        )
+        >= 2
+      )
+      and
+      (
+        count by(cluster, namespace, instance) (cortex_build_info) > 0
+      )
     labels:
       severity: warning
   - alert: MimirKVStoreFailure

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -113,11 +113,20 @@ groups:
       severity: warning
   - alert: MimirIngesterRestarts
     annotations:
-      message: '{{ $labels.job }}/{{ $labels.pod }} has restarted {{ printf "%.2f"
-        $value }} times in the last 30 mins.'
+      message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} has restarted {{ printf "%.2f" $value }} times in the last 30 mins.
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterrestarts
     expr: |
-      changes(process_start_time_seconds{job=~".*/(ingester.*|cortex|mimir|mimir-write.*)"}[30m]) >= 2
+      (
+        sum by(cluster, namespace, pod) (
+          increase(kube_pod_container_status_restarts_total{container=~"(ingester|mimir-write)"}[30m])
+        )
+        >= 2
+      )
+      and
+      (
+        count by(cluster, namespace, pod) (cortex_build_info) > 0
+      )
     labels:
       severity: warning
   - alert: MimirKVStoreFailure


### PR DESCRIPTION
#### What this PR does
Today I was on-call and I noticed the alert `MimirIngesterRestarts` triggers more frequently than I expected. Turns out using `process_start_time_seconds` is not a good strategy because it will count re-schedulings and rolling updates. Instead, if we use `kube_pod_container_status_restarts_total` we also count container restarts, like OOMKilled or panics. This PR changes it.

I did a back test of the alert over the last 7d. The **old alert** query returned results these many times:
<img width="841" alt="Screenshot 2023-07-01 at 19 29 23" src="https://github.com/grafana/mimir/assets/1701904/fe1909e9-db12-45df-b3c6-6a231de95ac0">

The **new alert** would have returned results only 1 case, which is legit because there were ingesters OOMKilled:
<img width="848" alt="Screenshot 2023-07-01 at 19 29 28" src="https://github.com/grafana/mimir/assets/1701904/d96fbcdd-a19d-4973-9a74-bc94cfed9a77">


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
