### PR TITLE
validate against out of order label sets in distributor

### DIFF
--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -19,6 +19,7 @@ const (
 	MaxLabelNamesPerSeries        ID = "max-label-names-per-series"
 	MaxNativeHistogramBuckets     ID = "max-native-histogram-buckets"
 	SeriesInvalidLabel            ID = "label-invalid"
+	SeriesWithUnsortedLabels      ID = "labels-not-sorted"
 	SeriesLabelNameTooLong        ID = "label-name-too-long"
 	SeriesLabelValueTooLong       ID = "label-value-too-long"
 	SeriesWithDuplicateLabelNames ID = "duplicate-label-names"

--- a/pkg/util/validation/errors.go
+++ b/pkg/util/validation/errors.go
@@ -76,6 +76,16 @@ func newInvalidLabelError(series []mimirpb.LabelAdapter, labelName string) Valid
 	}
 }
 
+var unsortedLabelsMsgFormat = globalerror.SeriesWithUnsortedLabels.Message(
+	"received a series with unsorted labelsseries: '%.200s'")
+
+func newUnsortedLabelsError(series []mimirpb.LabelAdapter) ValidationError {
+	return genericValidationError{
+		message: unsortedLabelsMsgFormat,
+		series:  series,
+	}
+}
+
 var duplicateLabelMsgFormat = globalerror.SeriesWithDuplicateLabelNames.Message(
 	"received a series with duplicate label name, label: '%.200s' series: '%.200s'")
 


### PR DESCRIPTION
We have seen a real world case where a client produce out of order label sets, these passed through the distributor's validation middleware successfully. Furthermore, the fact that the label sets were out of order also broke the distributor's validation for duplicated labels because it relies on the labels being sorted, resulting in duplicate samples being ingested.

To prevent this we should validate that label sets are sorted, which will also guarantee that unsorted label sets with duplicate labels will not be ingested.