### PR TITLE
compactor: fix BenchmarkDeduplicateFilter_Filter

### DIFF
--- a/pkg/compactor/shard_aware_deduplicate_filter_test.go
+++ b/pkg/compactor/shard_aware_deduplicate_filter_test.go
@@ -395,13 +395,13 @@ func BenchmarkDeduplicateFilter_Filter(b *testing.B) {
 	var (
 		reg   prometheus.Registerer
 		count uint64
-		cases []map[ulid.ULID]*block.Meta
 	)
 
 	dedupFilter := NewShardAwareDeduplicateFilter()
 	synced := extprom.NewTxGaugeVec(reg, prometheus.GaugeOpts{}, []string{"state"})
 
 	for blocksNum := 10; blocksNum <= 10000; blocksNum *= 10 {
+		var cases []map[ulid.ULID]*block.Meta
 		// blocksNum number of blocks with all of them unique ULID and unique 100 sources.
 		cases = append(cases, make(map[ulid.ULID]*block.Meta, blocksNum))
 		for i := 0; i < blocksNum; i++ {


### PR DESCRIPTION
#### What this PR does

I noticed the benchmark results had an odd pattern:
```
BenchmarkDeduplicateFilter_Filter/Block-10/#00-8           36559             31444 ns/op           30191 B/op         84 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10/#01-8           12578             94630 ns/op           90644 B/op        253 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#00-8           1842            636375 ns/op          339749 B/op        831 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#01-8            534           1945411 ns/op         1020392 B/op       2494 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#02-8        3433188               351.4 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#03-8        3371540               349.4 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#00-8            28          38626635 ns/op         3510385 B/op       8527 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#01-8             8         126104427 ns/op        11433707 B/op      27722 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#02-8       3393375               349.2 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#03-8       3419830               351.9 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#04-8       3437992               349.3 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#05-8       3428716               350.4 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#00-8            1        9314033250 ns/op        67561168 B/op     164274 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#01-8            1        29501690542 ns/op       202588040 B/op    491671 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#02-8      3368296               351.9 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#03-8      3419041               350.0 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#04-8      3437418               349.9 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#05-8      3437319               348.4 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#06-8      3431043               349.1 ns/op             0 B/op          0 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#07-8      3381399               349.4 ns/op             0 B/op          0 allocs/op
```

The variable `cases` was appended to each time round, but only `0` and `1` were populated with any data.
I decided what was meant was just to have those two cases, so create a new `cases` for each number of blocks:

```
BenchmarkDeduplicateFilter_Filter/Block-10/#00-8           37465             31362 ns/op           30191 B/op         84 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10/#01-8           12716             93928 ns/op           90641 B/op        253 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#00-8           2148            538596 ns/op          302268 B/op        756 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-100/#01-8            729           1621291 ns/op          907473 B/op       2269 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#00-8            37          31086280 ns/op         3148539 B/op       7596 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-1000/#01-8            12          98316889 ns/op         9964838 B/op      24056 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#00-8            1        7379130333 ns/op        61041664 B/op     147549 allocs/op
BenchmarkDeduplicateFilter_Filter/Block-10000/#01-8            1        21718622500 ns/op       183079976 B/op    442289 allocs/op
```

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated
