### PR TITLE
Upgrade to golang/glog v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@
 
 ### Tools
 
+* [BUGFIX] Stop tools from panicking when `-help` flag is passed. #5412
+
 ## 2.9.0
 
 ### Grafana Mimir

--- a/go.mod
+++ b/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
-	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/glog v1.1.1 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -737,8 +737,8 @@ github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
-github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
-github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
+github.com/golang/glog v1.1.1 h1:jxpi2eWoU84wbX9iIEyAeeoac3FLuifZpY9tcNUD9kw=
+github.com/golang/glog v1.1.1/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/vendor/github.com/golang/glog/glog_file.go
+++ b/vendor/github.com/golang/glog/glog_file.go
@@ -153,8 +153,6 @@ var sinks struct {
 }
 
 func init() {
-	sinks.stderr.w = os.Stderr
-
 	// Register stderr first: that way if we crash during file-writing at least
 	// the log will have gone somewhere.
 	logsink.TextSinks = append(logsink.TextSinks, &sinks.stderr, &sinks.file)
@@ -167,7 +165,7 @@ func init() {
 // if they meet certain conditions.
 type stderrSink struct {
 	mu sync.Mutex
-	w  io.Writer
+	w  io.Writer // if nil Emit uses os.Stderr directly
 }
 
 // Enabled implements logsink.Text.Enabled.  It returns true if any of the
@@ -182,8 +180,11 @@ func (s *stderrSink) Enabled(m *logsink.Meta) bool {
 func (s *stderrSink) Emit(m *logsink.Meta, data []byte) (n int, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	dn, err := s.w.Write(data)
+	w := s.w
+	if w == nil {
+		w = os.Stderr
+	}
+	dn, err := w.Write(data)
 	n += dn
 	return n, err
 }

--- a/vendor/github.com/golang/glog/glog_file_linux.go
+++ b/vendor/github.com/golang/glog/glog_file_linux.go
@@ -1,0 +1,39 @@
+// Go support for leveled logs, analogous to https://github.com/google/glog.
+//
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package glog
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+)
+
+// abortProcess attempts to kill the current process in a way that will dump the
+// currently-running goroutines someplace useful (like stderr).
+//
+// It does this by sending SIGABRT to the current thread.
+//
+// If successful, abortProcess does not return.
+func abortProcess() error {
+	runtime.LockOSThread()
+	if err := syscall.Tgkill(syscall.Getpid(), syscall.Gettid(), syscall.SIGABRT); err != nil {
+		return err
+	}
+	return errors.New("log: killed current thread with SIGABRT, but still running")
+}

--- a/vendor/github.com/golang/glog/glog_file_other.go
+++ b/vendor/github.com/golang/glog/glog_file_other.go
@@ -1,0 +1,30 @@
+// Go support for leveled logs, analogous to https://github.com/google/glog.
+//
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !(unix || windows)
+
+package glog
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// abortProcess returns an error on platforms that presumably don't support signals.
+func abortProcess() error {
+	return fmt.Errorf("not sending SIGABRT (%s/%s does not support signals), falling back", runtime.GOOS, runtime.GOARCH)
+
+}

--- a/vendor/github.com/golang/glog/glog_file_posix.go
+++ b/vendor/github.com/golang/glog/glog_file_posix.go
@@ -1,0 +1,53 @@
+// Go support for leveled logs, analogous to https://github.com/google/glog.
+//
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build (unix || windows) && !linux
+
+package glog
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+// abortProcess attempts to kill the current process in a way that will dump the
+// currently-running goroutines someplace useful (like stderr).
+//
+// It does this by sending SIGABRT to the current process. Unfortunately, the
+// signal may or may not be delivered to the current thread; in order to do that
+// portably, we would need to add a cgo dependency and call pthread_kill.
+//
+// If successful, abortProcess does not return.
+func abortProcess() error {
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return err
+	}
+	if err := p.Signal(syscall.SIGABRT); err != nil {
+		return err
+	}
+
+	// Sent the signal.  Now we wait for it to arrive and any SIGABRT handlers to
+	// run (and eventually terminate the process themselves).
+	//
+	// We could just "select{}" here, but there's an outside chance that would
+	// trigger the runtime's deadlock detector if there happen not to be any
+	// background goroutines running.  So we'll sleep a while first to give
+	// the signal some time.
+	time.Sleep(10 * time.Second)
+	select {}
+}

--- a/vendor/github.com/golang/glog/glog_flags.go
+++ b/vendor/github.com/golang/glog/glog_flags.go
@@ -133,6 +133,11 @@ func (l *Level) Set(value string) error {
 type vModuleFlag struct{ *verboseFlags }
 
 func (f vModuleFlag) String() string {
+	// Do not panic on the zero value.
+	// https://groups.google.com/g/golang-nuts/c/Atlr8uAjn6U/m/iId17Td5BQAJ.
+	if f.verboseFlags == nil {
+		return ""
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -192,9 +197,7 @@ func (f *verboseFlags) levelForPC(pc uintptr) Level {
 	file, _ := fn.FileLine(pc)
 	// The file is something like /a/b/c/d.go. We want just the d for
 	// regular matches, /a/b/c/d for full matches.
-	if strings.HasSuffix(file, ".go") {
-		file = file[:len(file)-3]
-	}
+	file = strings.TrimSuffix(file, ".go")
 	full := file
 	if slash := strings.LastIndex(file, "/"); slash >= 0 {
 		file = file[slash+1:]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -452,8 +452,8 @@ github.com/gogo/status
 # github.com/golang-jwt/jwt/v4 v4.5.0
 ## explicit; go 1.16
 github.com/golang-jwt/jwt/v4
-# github.com/golang/glog v1.1.0
-## explicit; go 1.18
+# github.com/golang/glog v1.1.1
+## explicit; go 1.19
 github.com/golang/glog
 github.com/golang/glog/internal/logsink
 github.com/golang/glog/internal/stackdump


### PR DESCRIPTION
#### What this PR does
Upgrade indirect dependency github.com/golang/glog from v1.1.0 to v1.1.1.

#### Which issue(s) this PR fixes or relates to
Most importantly the upgrade to v1.1.1 [stops](https://github.com/golang/glog/commit/9c9801e69114b582b12aa7010c75fe2105ae23b3) Mimir tools such as `copyblocks` and `compaction-planner` from panicking when you pass the `-help` flag:

```
$ ./tools/compaction-planner/compaction-planner -help
[...]
panic calling String method on zero glog.vModuleFlag for flag vmodule: runtime error: invalid memory address or nil pointer dereference
```

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
