### PR TITLE
tools: Remove glog command line flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 ### Tools
 
 * [BUGFIX] Stop tools from panicking when `-help` flag is passed. #5412
+* [BUGFIX] Remove github.com/golang/glog command line flags from tools. #5413
 
 ## 2.9.0
 

--- a/tools/compaction-planner/main.go
+++ b/tools/compaction-planner/main.go
@@ -28,6 +28,9 @@ import (
 )
 
 func main() {
+	// Clean up all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	cfg := struct {
 		bucket      bucket.Config
 		userID      string

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -110,6 +110,9 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 }
 
 func main() {
+	// Clean up all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	cfg := config{}
 	cfg.RegisterFlags(flag.CommandLine)
 

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -130,6 +130,9 @@ func generateBlockMarkdown(blocks []*parse.ConfigBlock, blockName, fieldName str
 }
 
 func main() {
+	// Clean up all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	// Parse the generator flags.
 	flag.Parse()
 	if flag.NArg() != 1 {

--- a/tools/list-deduplicated-blocks/main.go
+++ b/tools/list-deduplicated-blocks/main.go
@@ -32,6 +32,9 @@ import (
 )
 
 func main() {
+	// Clean up all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	cfg := struct {
 		bucket           bucket.Config
 		userID           string

--- a/tools/listblocks/main.go
+++ b/tools/listblocks/main.go
@@ -44,6 +44,9 @@ type config struct {
 }
 
 func main() {
+	// Clean up all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	logger := gokitlog.NewNopLogger()
 	cfg := config{}
 	cfg.bucket.RegisterFlags(flag.CommandLine)

--- a/tools/tsdb-compact/main.go
+++ b/tools/tsdb-compact/main.go
@@ -17,6 +17,9 @@ import (
 )
 
 func main() {
+	// Clean up all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	var (
 		outputDir     string
 		shardCount    int

--- a/tools/tsdb-index-health/main.go
+++ b/tools/tsdb-index-health/main.go
@@ -16,6 +16,9 @@ import (
 var logger = log.NewLogfmtLogger(os.Stderr)
 
 func main() {
+	// Cleanup all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	verifyChunks := flag.Bool("check-chunks", false, "Verify chunks in segment files.")
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options...] <block-dir> [<block-dir> ...]:\n", os.Args[0])

--- a/tools/tsdb-index-toc/main.go
+++ b/tools/tsdb-index-toc/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"log"
+	"os"
 	"unsafe"
 
 	"github.com/prometheus/prometheus/tsdb/fileutil"
@@ -14,6 +15,9 @@ import (
 )
 
 func main() {
+	// Clean up all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	flag.Parse()
 
 	filepath := flag.Arg(0)

--- a/tools/tsdb-index/main.go
+++ b/tools/tsdb-index/main.go
@@ -21,6 +21,9 @@ import (
 var logger = log.NewLogfmtLogger(os.Stderr)
 
 func main() {
+	// Clean up all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	metricSelector := flag.String("select", "", "PromQL metric selector")
 	printChunks := flag.Bool("show-chunks", false, "Print chunk details")
 	flag.Parse()

--- a/tools/tsdb-symbols/main.go
+++ b/tools/tsdb-symbols/main.go
@@ -22,6 +22,9 @@ import (
 )
 
 func main() {
+	// Clean up all flags registered via init() methods of 3rd-party libraries.
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	shards := 0
 
 	flag.IntVar(&shards, "shard-count", 0, "number of shards")


### PR DESCRIPTION
#### What this PR does
The module github.com/golang/glog registers its own command line flags in the `init` function. As #4781 does for Mimir itself, drop glog command line flags from affected tools:

* tsdb-index-health
* tsdb-index-toc
* tsdb-compact
* doc-generator
* tsdb-index
* listblocks
* list-deduplicated-blocks
* tsdb-symbols
* copy-blocks
* compaction-planner

#### Which issue(s) this PR fixes or relates to


#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
