### PR TITLE
mimirtool: order command in help text alphabetically

### DIFF
--- a/cmd/mimirtool/main.go
+++ b/cmd/mimirtool/main.go
@@ -40,6 +40,7 @@ func main() {
 	alertCommand.Register(app, envVars, prometheus.DefaultRegisterer)
 	alertmanagerCommand.Register(app, envVars)
 	analyzeCommand.Register(app, envVars)
+	backfillCommand.Register(app, envVars)
 	bucketValidateCommand.Register(app, envVars)
 	configCommand.Register(app, envVars)
 	loadgenCommand.Register(app, envVars, prometheus.DefaultRegisterer)
@@ -47,7 +48,6 @@ func main() {
 	pushGateway.Register(app, envVars)
 	remoteReadCommand.Register(app, envVars)
 	ruleCommand.Register(app, envVars, prometheus.DefaultRegisterer)
-	backfillCommand.Register(app, envVars)
 
 	app.Command("version", "Get the version of the mimirtool CLI").Action(func(k *kingpin.ParseContext) error {
 		fmt.Fprintln(os.Stdout, mimirversion.Print("Mimirtool"))


### PR DESCRIPTION
backfil was added at the end and the helm text looks like this

<details>
<summary>Details</summary>


```
mimirtool --help
usage: mimirtool [<flags>] <command> [<args> ...]

A command-line tool to manage Mimir and GEM.

Flags:
  --help                      Show context-sensitive help (also try --help-long and --help-man).
  --log.level="info"          set level of the logger
  --push-gateway.endpoint=PUSH-GATEWAY.ENDPOINT
                              url for the push-gateway to register metrics
  --push-gateway.job=PUSH-GATEWAY.JOB
                              job name to register metrics
  --push-gateway.interval=1m  interval to forward metrics to the push gateway

Commands:
  help [<command>...]
    Show help.

  acl generate-header --id=ID --rule=RULE
    Generate the header that needs to be passed to the datasource for setting ACLs.

  alerts verify [<flags>]
    Verifies whether or not alerts in an Alertmanager cluster are deduplicated; useful for verifying correct configuration when transferring from Prometheus to Grafana Mimir alert evaluation.

  alertmanager get --address=ADDRESS --id=ID [<flags>]
    Get the Alertmanager configuration that is currently in the Grafana Mimir Alertmanager.

  alertmanager delete --address=ADDRESS --id=ID
    Delete the Alertmanager configuration that is currently in the Grafana Mimir Alertmanager.

  alertmanager load --address=ADDRESS --id=ID <config> [<template-files>...]
    Load Alertmanager tenant configuration and template files into Grafana Mimir.

  alertmanager verify <config> [<template-files>...]
    Verify Alertmanager tenant configuration and template files.

  analyze prometheus --address=ADDRESS [<flags>]
    Take the metrics being used in Grafana and get the cardinality from a Prometheus.

  analyze grafana --address=ADDRESS [<flags>]
    Analyze and output the metrics used in Grafana Dashboards.

  analyze ruler --address=ADDRESS [<flags>]
    Analyze and extract the metrics that are used in Grafana Mimir rules

  analyze dashboard [<flags>] <files>...
    Analyze and output the metrics used in Grafana dashboard files

  analyze rule-file [<flags>] <files>...
    Analyze and output the metrics used in Prometheus rules files

  bucket-validation [<flags>]
    Validate that object store bucket works correctly.

  config convert [<flags>]
    Convert configuration parameters (YAML and CLI flags) from Cortex v1.10.0 and above to Grafana Mimir v2.0.0 (default), and from Grafana Metrics Enterprise v1.7.0 to v2.0.0 (via --gem flag).

  loadgen [<flags>]
    Simple load generator for Grafana Mimir.

  remote-read export --address=ADDRESS [<flags>]
    Export metrics remote read series into a local TSDB.

  remote-read dump --address=ADDRESS [<flags>]
    Dump remote read series.

  remote-read stats --address=ADDRESS [<flags>]
    Show statistic of remote read series.

  rules list --address=ADDRESS --id=ID [<flags>]
    List the rules currently in the Grafana Mimir ruler.

  rules print --address=ADDRESS --id=ID [<flags>]
    Print the rules currently in the Grafana Mimir ruler.

  rules get --address=ADDRESS --id=ID [<flags>] <namespace> <group>
    Retrieve a rulegroup from the ruler.

  rules delete --address=ADDRESS --id=ID [<flags>] <namespace> <group>
    Delete a rulegroup from the ruler.

  rules load --address=ADDRESS --id=ID [<flags>] <rule-files>...
    Load a set of rules to a designated Grafana Mimir endpoint.

  rules diff --address=ADDRESS --id=ID [<flags>] [<rule-files>...]
    Diff a set of rules to a designated Grafana Mimir endpoint.

  rules sync --address=ADDRESS --id=ID [<flags>] [<rule-files>...]
    Sync a set of rules to a designated Grafana Mimir endpoint.

  rules prepare [<flags>] [<rule-files>...]
    Modify a set of rules by including an specific label in aggregations.

  rules lint [<flags>] [<rule-files>...]
    Format a set of rule files. Keys are sorted alphabetically, with 4 spaces as indentantion, and PromQL expressions are formatted to a single line.

  rules check [<flags>] [<rule-files>...]
    Run various best practice checks against rules.

  rules delete-namespace --address=ADDRESS --id=ID [<flags>] <namespace>
    Delete a namespace from the ruler.

> backfill --address=ADDRESS --id=ID [<flags>] <block-dir>...
    Upload Prometheus TSDB blocks to Grafana Mimir compactor.

  version
    Get the version of the mimirtool CLI

```


</details>

after this change the help text is

<details><summary>Details</summary>

```
go run cmd/mimirtool/main.go --help
usage: mimirtool [<flags>] <command> [<args> ...]

A command-line tool to manage Mimir and GEM.

Flags:
  --help                      Show context-sensitive help (also try --help-long and --help-man).
  --log.level="info"          set level of the logger
  --push-gateway.endpoint=PUSH-GATEWAY.ENDPOINT
                              url for the push-gateway to register metrics
  --push-gateway.job=PUSH-GATEWAY.JOB
                              job name to register metrics
  --push-gateway.interval=1m  interval to forward metrics to the push gateway

Commands:
  help [<command>...]
    Show help.

  acl generate-header --id=ID --rule=RULE
    Generate the header that needs to be passed to the datasource for setting ACLs.

  alerts verify [<flags>]
    Verifies whether or not alerts in an Alertmanager cluster are deduplicated; useful for verifying correct configuration when transferring from Prometheus to Grafana Mimir alert
    evaluation.

  alertmanager get --address=ADDRESS --id=ID [<flags>]
    Get the Alertmanager configuration that is currently in the Grafana Mimir Alertmanager.

  alertmanager delete --address=ADDRESS --id=ID
    Delete the Alertmanager configuration that is currently in the Grafana Mimir Alertmanager.

  alertmanager load --address=ADDRESS --id=ID <config> [<template-files>...]
    Load Alertmanager tenant configuration and template files into Grafana Mimir.

  alertmanager verify <config> [<template-files>...]
    Verify Alertmanager tenant configuration and template files.

  analyze prometheus --address=ADDRESS [<flags>]
    Take the metrics being used in Grafana and get the cardinality from a Prometheus.

  analyze grafana --address=ADDRESS [<flags>]
    Analyze and output the metrics used in Grafana Dashboards.

  analyze ruler --address=ADDRESS [<flags>]
    Analyze and extract the metrics that are used in Grafana Mimir rules

  analyze dashboard [<flags>] <files>...
    Analyze and output the metrics used in Grafana dashboard files

  analyze rule-file [<flags>] <files>...
    Analyze and output the metrics used in Prometheus rules files

> backfill --address=ADDRESS --id=ID [<flags>] <block-dir>...
    Upload Prometheus TSDB blocks to Grafana Mimir compactor.

  bucket-validation [<flags>]
    Validate that object store bucket works correctly.

  config convert [<flags>]
    Convert configuration parameters (YAML and CLI flags) from Cortex v1.10.0 and above to Grafana Mimir v2.0.0 (default), and from Grafana Metrics Enterprise v1.7.0 to v2.0.0 (via
    --gem flag).

  loadgen [<flags>]
    Simple load generator for Grafana Mimir.

  remote-read export --address=ADDRESS [<flags>]
    Export metrics remote read series into a local TSDB.

  remote-read dump --address=ADDRESS [<flags>]
    Dump remote read series.

  remote-read stats --address=ADDRESS [<flags>]
    Show statistic of remote read series.

  rules list --address=ADDRESS --id=ID [<flags>]
    List the rules currently in the Grafana Mimir ruler.

  rules print --address=ADDRESS --id=ID [<flags>]
    Print the rules currently in the Grafana Mimir ruler.

  rules get --address=ADDRESS --id=ID [<flags>] <namespace> <group>
    Retrieve a rulegroup from the ruler.

  rules delete --address=ADDRESS --id=ID [<flags>] <namespace> <group>
    Delete a rulegroup from the ruler.

  rules load --address=ADDRESS --id=ID [<flags>] <rule-files>...
    Load a set of rules to a designated Grafana Mimir endpoint.

  rules diff --address=ADDRESS --id=ID [<flags>] [<rule-files>...]
    Diff a set of rules to a designated Grafana Mimir endpoint.

  rules sync --address=ADDRESS --id=ID [<flags>] [<rule-files>...]
    Sync a set of rules to a designated Grafana Mimir endpoint.

  rules prepare [<flags>] [<rule-files>...]
    Modify a set of rules by including an specific label in aggregations.

  rules lint [<flags>] [<rule-files>...]
    Format a set of rule files. Keys are sorted alphabetically, with 4 spaces as indentantion, and PromQL expressions are formatted to a single line.

  rules check [<flags>] [<rule-files>...]
    Run various best practice checks against rules.

  rules delete-namespace --address=ADDRESS --id=ID [<flags>] <namespace>
    Delete a namespace from the ruler.

  version
    Get the version of the mimirtool CLI
```

</details> 


```diff
*** /dev/fd/63	Tue Jul  4 17:23:02 2023
--- /dev/fd/62	Tue Jul  4 17:23:02 2023
*************** Commands:
*** 56,61 ****
--- 56,64 ----
    analyze rule-file [<flags>] <files>...
      Analyze and output the metrics used in Prometheus rules files

+   backfill --address=ADDRESS --id=ID [<flags>] <block-dir>...
+     Upload Prometheus TSDB blocks to Grafana Mimir compactor.
+
    bucket-validation [<flags>]
      Validate that object store bucket works correctly.

*************** Commands:
*** 110,118 ****
    rules delete-namespace --address=ADDRESS --id=ID [<flags>] <namespace>
      Delete a namespace from the ruler.

-   backfill --address=ADDRESS --id=ID [<flags>] <block-dir>...
-     Upload Prometheus TSDB blocks to Grafana Mimir compactor.
-
    version
      Get the version of the mimirtool CLI

--- 113,118 ----
```


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->
