### PR TITLE
Helm/jsonnet: remove ballast from distributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 * [CHANGE] Removed `_config.querier.concurrency` configuration option and replaced it with `_config.querier_max_concurrency` and `_config.ruler_querier_max_concurrency` to allow to easily fine tune it for different querier deployments. #5322
 * [CHANGE] Change `_config.multi_zone_ingester_max_unavailable` to 50. #5327
+* [CHANGE] Distributor: remove ballast, slow down GC using GOMEMLIMIT and GOGC. #5421
 * [FEATURE] Alertmanager: Add horizontal pod autoscaler config, that can be enabled using `autoscaling_alertmanager_enabled: true`. #5194 #5249
 * [ENHANCEMENT] Enable the `track_sizes` feature for Memcached pods to help determine cache efficiency. #5209
 * [ENHANCEMENT] Add per-container map for environment variables. #5181

--- a/operations/compare-helm-with-jsonnet/helm/00-base/values.yaml
+++ b/operations/compare-helm-with-jsonnet/helm/00-base/values.yaml
@@ -25,3 +25,10 @@ ingester:
 store_gateway:
   zoneAwareReplication:
     enabled: false
+
+# Used to compute GOMEMLIMIT and GOMAXPROCS. These request values are used in Jsonnet.
+distributor:
+  resources:
+    requests:
+      cpu: 2
+      memory: 2Gi

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [CHANGE] Changed max unavailable ingesters and store-gateways in a zone to 50. #5327
+* [CHANGE] Distributor: slow down GC using GOMEMLIMIT and GOGC. #5421
 * [ENHANCEMENT] Ruler: configure the ruler storage cache when the metadata cache is enabled. #5326 #5334
 * [ENHANCEMENT] Helm: support metricRelabelings in the monitoring serviceMonitor resources. #5340
 

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -97,6 +97,19 @@ spec:
             {{- with .Values.distributor.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            - name: "GOGC"
+              value: "1000"
+            {{- $cpu_request := dig "requests" "cpu" nil .Values.distributor.resources }}
+            {{- if $cpu_request }}
+              {{- $cpu_request_doubled := include "mimir.parseCPU" (dict "value" $cpu_request) | float64 | mulf 2 | ceil }}
+            - name: "GOMAXPROCS"
+              value: {{ $cpu_request_doubled | toString | toYaml }}
+            {{- end }}
+            {{- $mem_request := dig "requests" "memory" nil .Values.distributor.resources }}
+            {{- if $mem_request }}
+            - name: "GOMEMLIMIT"
+              value: {{include "mimir.siToBytes" (dict "value" $mem_request) | toString | toYaml }}
+            {{- end }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -90,6 +90,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -88,6 +88,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -90,6 +90,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -90,6 +90,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "4"
+            - name: "GOMEMLIMIT"
+              value: "4294967296"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -88,6 +88,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -87,6 +87,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -88,6 +88,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -90,6 +90,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "4"
+            - name: "GOMEMLIMIT"
+              value: "4294967296"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -91,6 +91,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -90,6 +90,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -87,6 +87,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -90,6 +90,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -88,6 +88,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -88,6 +88,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -88,6 +88,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -90,6 +90,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -89,6 +89,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -95,6 +95,12 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
+            - name: "GOGC"
+              value: "1000"
+            - name: "GOMAXPROCS"
+              value: "1"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
           envFrom:
       nodeSelector:
         {}

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -460,7 +460,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -472,6 +471,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "3435973836"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -757,7 +757,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=consul
-        - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
@@ -767,6 +766,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -909,7 +909,6 @@ spec:
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=consul
         - -ingester.ring.zone-awareness-enabled=true
-        - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
@@ -919,6 +918,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -739,7 +739,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=consul
-        - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
@@ -749,6 +748,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -330,7 +330,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -342,6 +341,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -806,7 +806,6 @@ spec:
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -818,6 +817,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -384,7 +384,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -396,6 +395,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -395,6 +394,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -391,7 +391,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml,/etc/another-config/runtimeconfig.yaml
@@ -403,6 +402,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -410,7 +410,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -422,6 +421,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -395,6 +394,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.cluster-label-verification-disabled=true
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
@@ -396,6 +395,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.cluster-label=my-cluster-label
         - -memberlist.cluster-label-verification-disabled=true
@@ -397,6 +396,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.cluster-label=my-cluster-label
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
@@ -396,6 +395,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -757,7 +757,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=consul
-        - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
@@ -767,6 +766,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -798,7 +798,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=multi
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -810,6 +809,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -798,7 +798,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=multi
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -810,6 +809,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -798,7 +798,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=multi
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -810,6 +809,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -798,7 +798,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=multi
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -810,6 +809,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -386,7 +386,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -398,6 +397,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -395,6 +394,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -395,6 +394,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -547,7 +547,6 @@ spec:
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -559,6 +558,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -615,7 +615,6 @@ spec:
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -627,6 +626,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -757,7 +757,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=consul
-        - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=2m
         - -server.grpc.keepalive.max-connection-age-grace=5m
@@ -767,6 +766,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -479,7 +479,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -491,6 +490,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -392,7 +392,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -404,6 +403,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -389,7 +389,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -401,6 +400,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -395,6 +394,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -461,7 +461,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -473,6 +472,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -461,7 +461,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -473,6 +472,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -384,7 +384,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -396,6 +395,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -384,7 +384,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -396,6 +395,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -395,6 +394,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -395,6 +394,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
@@ -307,7 +307,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -319,6 +318,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -383,7 +383,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -395,6 +394,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -312,7 +312,6 @@ spec:
         - -ingester.ring.prefix=
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
-        - -mem-ballast-size-bytes=1073741824
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -324,6 +323,13 @@ spec:
         - -server.http-listen-port=8080
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "4"
+        - name: GOMEMLIMIT
+          value: "2147483648"
         image: grafana/mimir:2.9.0
         imagePullPolicy: IfNotPresent
         name: distributor


### PR DESCRIPTION
#### What this PR does

This PR modifies distributor configuration to remove ballast (in Jsonnet), and use GOMEMLIMIT and GOGC settings to slow down GC. At the same time we set GOMAXPROCS to avoid using too many cores when memory reaches GOMEMLIMIT (by default Go runtime can use up to 50% of cores in the node to run GC).

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
