### PR TITLE
Add query results cache support for label names and label values APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [FEATURE] Query-frontend: added experimental support to cache cardinality query responses. The cache will be used when `-query-frontend.cache-results` is enabled and `-query-frontend.results-cache-ttl-for-cardinality-query` set to a value greater than 0. The following metrics have been added to track the query results cache hit ratio per `request_type`: #5212 #5235
   * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality"}`
   * `cortex_frontend_query_result_cache_hits_total{request_type="query_range|cardinality"}`
+* [FEATURE] Query-frontend: added experimental support to cache label names and label values query responses. The cache will be used when `-query-frontend.cache-results` is enabled and `-query-frontend.results-cache-ttl-for-labels-query` set to a value greater than 0. #5426
 * [FEATURE] Added `-<prefix>.s3.list-objects-version` flag to configure the S3 list objects version.
 * [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392 #5394
   * `-ingester.read-path-cpu-utilization-limit`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,9 @@
 * [CHANGE] Querier: `-query-frontend.cache-unaligned-requests` has been moved from a global flag to a per-tenant override. #5312
 * [CHANGE] Ingester: removed `cortex_ingester_shipper_dir_syncs_total` and `cortex_ingester_shipper_dir_sync_failures_total` metrics. The former metric was not much useful, and the latter was never incremented. #5396
 * [FEATURE] Cardinality API: Add a new `count_method` parameter which enables counting active series #5136
-* [FEATURE] Query-frontend: added experimental support to cache cardinality query responses. The cache will be used when `-query-frontend.cache-results` is enabled and `-query-frontend.results-cache-ttl-for-cardinality-query` set to a value greater than 0. The following metrics have been added to track the query results cache hit ratio per `request_type`: #5212 #5235
-  * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality"}`
-  * `cortex_frontend_query_result_cache_hits_total{request_type="query_range|cardinality"}`
-* [FEATURE] Query-frontend: added experimental support to cache label names and label values query responses. The cache will be used when `-query-frontend.cache-results` is enabled and `-query-frontend.results-cache-ttl-for-labels-query` set to a value greater than 0. #5426
+* [FEATURE] Query-frontend: added experimental support to cache cardinality, label names and label values query responses. The cache will be used when `-query-frontend.cache-results` is enabled, and `-query-frontend.results-cache-ttl-for-cardinality-query` or `-query-frontend.results-cache-ttl-for-labels-query` set to a value greater than 0. The following metrics have been added to track the query results cache hit ratio per `request_type`: #5212 #5235 #5426
+  * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality|label_names_and_values"}`
+  * `cortex_frontend_query_result_cache_hits_total{request_type="query_range|cardinality|label_names_and_values"}`
 * [FEATURE] Added `-<prefix>.s3.list-objects-version` flag to configure the S3 list objects version.
 * [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392 #5394
   * `-ingester.read-path-cpu-utilization-limit`

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3216,6 +3216,17 @@
         },
         {
           "kind": "field",
+          "name": "results_cache_ttl_for_labels_query",
+          "required": false,
+          "desc": "Time to live duration for cached label names and label values query results. The value 0 disables the cache.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "query-frontend.results-cache-ttl-for-labels-query",
+          "fieldType": "duration",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "cache_unaligned_requests",
           "required": false,
           "desc": "Cache requests that are not step-aligned.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1735,6 +1735,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Time to live duration for cached query results. If query falls into out-of-order time window, -query-frontend.results-cache-ttl-for-out-of-order-time-window is used instead. (default 1w)
   -query-frontend.results-cache-ttl-for-cardinality-query duration
     	[experimental] Time to live duration for cached cardinality query results. The value 0 disables the cache.
+  -query-frontend.results-cache-ttl-for-labels-query duration
+    	[experimental] Time to live duration for cached label names and label values query results. The value 0 disables the cache.
   -query-frontend.results-cache-ttl-for-out-of-order-time-window duration
     	[experimental] Time to live duration for cached query results if query falls into out-of-order time window. This is lower than -query-frontend.results-cache-ttl so that incoming out-of-order samples are returned in the query results sooner. (default 10m)
   -query-frontend.results-cache.backend string

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -104,6 +104,7 @@ The following features are currently experimental:
   - Use of Redis cache backend (`-query-frontend.results-cache.backend=redis`)
   - Query expression size limit (`-query-frontend.max-query-expression-size-bytes`)
   - Cardinality query result caching (`-query-frontend.results-cache-ttl-for-cardinality-query`)
+  - Label names and values query result caching (`-query-frontend.results-cache-ttl-for-labels-query`)
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
 - Store-gateway

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2893,6 +2893,11 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -query-frontend.results-cache-ttl-for-cardinality-query
 [results_cache_ttl_for_cardinality_query: <duration> | default = 0s]
 
+# (experimental) Time to live duration for cached label names and label values
+# query results. The value 0 disables the cache.
+# CLI flag: -query-frontend.results-cache-ttl-for-labels-query
+[results_cache_ttl_for_labels_query: <duration> | default = 0s]
+
 # (advanced) Cache requests that are not step-aligned.
 # CLI flag: -query-frontend.cache-unaligned-requests
 [cache_unaligned_requests: <boolean> | default = false]

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/integration/e2emimir"
+	"github.com/grafana/mimir/pkg/util"
 )
 
 func TestGettingStartedWithGrafanaMimir(t *testing.T) {
@@ -92,11 +93,11 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService, s
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
 
-	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
+	labelValues, err := c.LabelValues("foo", util.PrometheusMinTime, util.PrometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(prometheusMinTime, prometheusMaxTime)
+	labelNames, err := c.LabelNames(util.PrometheusMinTime, util.PrometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/integration/e2emimir"
+	"github.com/grafana/mimir/pkg/util"
 )
 
 func TestOTLPIngestion(t *testing.T) {
@@ -57,11 +58,11 @@ func TestOTLPIngestion(t *testing.T) {
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
 
-	labelValues, err := c.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
+	labelValues, err := c.LabelValues("foo", util.PrometheusMinTime, util.PrometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(prometheusMinTime, prometheusMaxTime)
+	labelNames, err := c.LabelNames(util.PrometheusMinTime, util.PrometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 

--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/grafana/mimir/integration/e2emimir"
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/util"
 )
 
 func TestReadWriteModeQueryingIngester(t *testing.T) {
@@ -55,11 +56,11 @@ func runQueryingIngester(t *testing.T, client *e2emimir.Client, seriesName strin
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 
 	// Verify we can retrieve the labels we just pushed.
-	labelValues, err := client.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
+	labelValues, err := client.LabelValues("foo", util.PrometheusMinTime, util.PrometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := client.LabelNames(prometheusMinTime, prometheusMaxTime)
+	labelNames, err := client.LabelNames(util.PrometheusMinTime, util.PrometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }
@@ -108,11 +109,11 @@ func runQueryingStoreGateway(t *testing.T, client *e2emimir.Client, cluster read
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 
 	// Verify we can retrieve the labels we just pushed.
-	labelValues, err := client.LabelValues("foo", prometheusMinTime, prometheusMaxTime, nil)
+	labelValues, err := client.LabelValues("foo", util.PrometheusMinTime, util.PrometheusMaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := client.LabelNames(prometheusMinTime, prometheusMaxTime)
+	labelNames, err := client.LabelNames(util.PrometheusMinTime, util.PrometheusMaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }

--- a/integration/util.go
+++ b/integration/util.go
@@ -8,7 +8,6 @@ package integration
 
 import (
 	"bytes"
-	"math"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -41,14 +40,6 @@ var (
 	generateTestGaugeHistogram      = test.GenerateTestGaugeHistogram
 	generateTestGaugeFloatHistogram = test.GenerateTestGaugeFloatHistogram
 	generateTestSampleHistogram     = test.GenerateTestSampleHistogram
-
-	// These are the earliest and latest possible timestamps supported by the Prometheus API -
-	// the Prometheus API does not support omitting a time range from query requests,
-	// so we use these when we want to query over all time.
-	// These values are defined in github.com/prometheus/prometheus/web/api/v1/api.go but
-	// sadly not exported.
-	prometheusMinTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
-	prometheusMaxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
 )
 
 // generateSeriesFunc defines what kind of series (and expected vectors/matrices) to generate - float samples or native histograms

--- a/pkg/cardinality/request.go
+++ b/pkg/cardinality/request.go
@@ -23,9 +23,6 @@ const (
 )
 
 const (
-	RequestTypeLabelNames  = RequestType(iota)
-	RequestTypeLabelValues = RequestType(iota)
-
 	minLimit           = 0
 	maxLimit           = 500
 	defaultLimit       = 20
@@ -34,8 +31,6 @@ const (
 	stringParamSeparator = rune(0)
 	stringValueSeparator = rune(1)
 )
-
-type RequestType int
 
 type LabelNamesRequest struct {
 	Matchers []*labels.Matcher
@@ -60,10 +55,6 @@ func (r *LabelNamesRequest) String() string {
 	b.WriteString(strconv.Itoa(r.Limit))
 
 	return b.String()
-}
-
-func (r *LabelNamesRequest) RequestType() RequestType {
-	return RequestTypeLabelNames
 }
 
 // DecodeLabelNamesRequest decodes the input http.Request into a LabelNamesRequest.
@@ -130,10 +121,6 @@ func (r *LabelValuesRequest) String() string {
 	b.WriteString(strconv.Itoa(r.Limit))
 
 	return b.String()
-}
-
-func (r *LabelValuesRequest) RequestType() RequestType {
-	return RequestTypeLabelValues
 }
 
 // DecodeLabelValuesRequest decodes the input http.Request into a LabelValuesRequest.

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -63,27 +63,27 @@ func TestRequest(t *testing.T) {
 			},
 		},
 		{
-			url:         "api/v1/query_range?start=foo",
+			url:         "/api/v1/query_range?start=foo",
 			expectedErr: apierror.New(apierror.TypeBadData, "invalid parameter \"start\": cannot parse \"foo\" to a valid timestamp"),
 		},
 		{
-			url:         "api/v1/query_range?start=123&end=bar",
+			url:         "/api/v1/query_range?start=123&end=bar",
 			expectedErr: apierror.New(apierror.TypeBadData, "invalid parameter \"end\": cannot parse \"bar\" to a valid timestamp"),
 		},
 		{
-			url:         "api/v1/query_range?start=123&end=0",
+			url:         "/api/v1/query_range?start=123&end=0",
 			expectedErr: errEndBeforeStart,
 		},
 		{
-			url:         "api/v1/query_range?start=123&end=456&step=baz",
+			url:         "/api/v1/query_range?start=123&end=456&step=baz",
 			expectedErr: apierror.New(apierror.TypeBadData, "invalid parameter \"step\": cannot parse \"baz\" to a valid duration"),
 		},
 		{
-			url:         "api/v1/query_range?start=123&end=456&step=-1",
+			url:         "/api/v1/query_range?start=123&end=456&step=-1",
 			expectedErr: errNegativeStep,
 		},
 		{
-			url:         "api/v1/query_range?start=0&end=11001&step=1",
+			url:         "/api/v1/query_range?start=0&end=11001&step=1",
 			expectedErr: errStepTooSmall,
 		},
 	} {

--- a/pkg/frontend/querymiddleware/generic_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache_test.go
@@ -168,7 +168,10 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 					// Mock the limits.
 					limits := multiTenantMockLimits{
 						byTenant: map[string]mockLimits{
-							userID: {resultsCacheTTLForCardinalityQuery: testData.cacheTTL},
+							userID: {
+								resultsCacheTTLForCardinalityQuery: testData.cacheTTL,
+								resultsCacheTTLForLabelsQuery:      testData.cacheTTL,
+							},
 						},
 					}
 

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -24,7 +24,6 @@ const (
 	labelValuesQueryCachePrefix = "lv:"
 
 	stringParamSeparator = rune(0)
-	stringValueSeparator = rune(1)
 )
 
 func newLabelsQueryCacheRoundTripper(cache cache.Cache, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
@@ -120,18 +119,7 @@ func generateLabelsQueryRequestCacheKey(startTime, endTime int64, labelName stri
 
 	// Add matcher sets.
 	b.WriteRune(stringParamSeparator)
-	b.WriteString(fmt.Sprintf("%d", len(matcherSets)))
-
-	for _, set := range matcherSets {
-		b.WriteRune(stringParamSeparator)
-
-		for idx, matcher := range set {
-			if idx > 0 {
-				b.WriteRune(stringValueSeparator)
-			}
-			b.WriteString(matcher.String())
-		}
-	}
+	b.WriteString(util.MultiMatchersStringer(matcherSets).String())
 
 	return b.String()
 }

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/cache"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"golang.org/x/exp/slices"
+
+	"github.com/grafana/mimir/pkg/util"
+)
+
+const (
+	labelNamesQueryCachePrefix  = "ln:"
+	labelValuesQueryCachePrefix = "lv:"
+
+	stringParamSeparator = rune(0)
+	stringValueSeparator = rune(1)
+)
+
+var (
+	prometheusMinTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC().UnixMilli()
+	prometheusMaxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC().UnixMilli()
+)
+
+func newLabelsQueryCacheRoundTripper(cache cache.Cache, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
+	delegate := &labelsQueryCache{
+		limits: limits,
+	}
+
+	return newGenericQueryCacheRoundTripper(cache, delegate, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
+}
+
+type labelsQueryCache struct {
+	limits Limits
+}
+
+func (c *labelsQueryCache) getTTL(userID string) time.Duration {
+	return c.limits.ResultsCacheTTLForLabelsQuery(userID)
+}
+
+func (c *labelsQueryCache) parseRequest(req *http.Request) (*genericQueryRequest, error) {
+	if err := req.ParseForm(); err != nil {
+		return nil, err
+	}
+
+	var (
+		cacheKeyPrefix string
+		labelName      string
+	)
+
+	// Detect the request type
+	switch {
+	case strings.HasSuffix(req.URL.Path, labelNamesPathSuffix):
+		cacheKeyPrefix = labelNamesQueryCachePrefix
+	case labelValuesPathSuffix.MatchString(req.URL.Path):
+		cacheKeyPrefix = labelValuesQueryCachePrefix
+		labelName = labelValuesPathSuffix.FindStringSubmatch(req.URL.Path)[1]
+	default:
+		return nil, errors.New("unknown labels API endpoint")
+	}
+
+	// Both the label names and label values API endpoints support the same exact parameters (with the same defaults),
+	// so in this function there's no distinction between the two.
+	startTime, err := parseRequestTimeParam(req, "start", prometheusMinTime)
+	if err != nil {
+		return nil, err
+	}
+
+	endTime, err := parseRequestTimeParam(req, "end", prometheusMaxTime)
+	if err != nil {
+		return nil, err
+	}
+
+	matcherSets, err := parseRequestMatchersParam(req, "match[]")
+	if err != nil {
+		return nil, err
+	}
+
+	return &genericQueryRequest{
+		cacheKey:       generateLabelsQueryRequestCacheKey(startTime, endTime, labelName, matcherSets),
+		cacheKeyPrefix: cacheKeyPrefix,
+	}, nil
+}
+
+func generateLabelsQueryRequestCacheKey(startTime, endTime int64, labelName string, matcherSets [][]*labels.Matcher) string {
+	var (
+		twoHoursMillis = (2 * time.Hour).Milliseconds()
+		b              = strings.Builder{}
+	)
+
+	// Align start and end times to default block boundaries. The reason is that both TSDB (so the Mimir ingester)
+	// and Mimir store-gateway query the label names and values out of blocks overlapping within the start and end
+	// time. This means that for maximum granularity is the block.
+	if startTime != prometheusMinTime {
+		if reminder := startTime % twoHoursMillis; reminder != 0 {
+			startTime -= reminder
+		}
+	}
+	if endTime != prometheusMaxTime {
+		if reminder := endTime % twoHoursMillis; reminder != 0 {
+			endTime += twoHoursMillis - reminder
+		}
+	}
+
+	// Add start and end time.
+	b.WriteString(fmt.Sprintf("%d", startTime))
+	b.WriteRune(stringParamSeparator)
+	b.WriteString(fmt.Sprintf("%d", endTime))
+
+	// Add label name (if any).
+	if labelName != "" {
+		b.WriteRune(stringParamSeparator)
+		b.WriteString(labelName)
+	}
+
+	// Add matcher sets.
+	b.WriteRune(stringParamSeparator)
+	b.WriteString(fmt.Sprintf("%d", len(matcherSets)))
+
+	for _, set := range matcherSets {
+		b.WriteRune(stringParamSeparator)
+
+		for idx, matcher := range set {
+			if idx > 0 {
+				b.WriteRune(stringValueSeparator)
+			}
+			b.WriteString(matcher.String())
+		}
+	}
+
+	return b.String()
+}
+
+func parseRequestTimeParam(req *http.Request, paramName string, defaultValue int64) (int64, error) {
+	value := req.FormValue(paramName)
+	if value == "" {
+		return defaultValue, nil
+	}
+
+	parsed, err := util.ParseTime(value)
+	if err != nil {
+		return 0, errors.Wrapf(err, "invalid '%s' parameter", paramName)
+	}
+
+	return parsed, nil
+}
+
+func parseRequestMatchersParam(req *http.Request, paramName string) ([][]*labels.Matcher, error) {
+	matcherSets := make([][]*labels.Matcher, 0, len(req.Form[paramName]))
+
+	for _, value := range req.Form[paramName] {
+
+		matchers, err := parser.ParseMetricSelector(value)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid '%s' parameter", paramName)
+		}
+		matcherSets = append(matcherSets, matchers)
+	}
+
+	// Ensure stable sorting (improves query results cache hit ratio).
+	for _, set := range matcherSets {
+		slices.SortFunc(set, func(a, b *labels.Matcher) bool {
+			return compareLabelMatchers(a, b) < 0
+		})
+	}
+
+	slices.SortFunc(matcherSets, func(a, b []*labels.Matcher) bool {
+		idx := 0
+
+		for ; idx < len(a) && idx < len(b); idx++ {
+			if c := compareLabelMatchers(a[idx], b[idx]); c != 0 {
+				return c < 0
+			}
+		}
+
+		// All label matchers are equal so far. Check which one has fewer matchers.
+		return idx < len(b)
+	})
+
+	return matcherSets, nil
+}
+
+func compareLabelMatchers(a, b *labels.Matcher) int {
+	if a.Name != b.Name {
+		return strings.Compare(a.Name, b.Name)
+	}
+	if a.Type != b.Type {
+		return int(b.Type) - int(a.Type)
+	}
+	return strings.Compare(a.Value, b.Value)
+}

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabelsQueryCache_RoundTrip(t *testing.T) {
+	testGenericQueryCacheRoundTrip(t, newLabelsQueryCacheRoundTripper, "label_names_and_values", map[string]testGenericQueryCacheRequestType{
+		"label names request": {
+			url:            mustParseURL(t, `/prometheus/api/v1/labels?start=2023-07-05T01:00:00Z&end=2023-07-05T08:00:00Z&match[]={job="test_1"}&match[]={job!="test_2"}`),
+			cacheKey:       "user-1:1688515200000\x001688544000000\x002\x00job!=\"test_2\"\x00job=\"test_1\"",
+			hashedCacheKey: labelNamesQueryCachePrefix + cacheHashKey("user-1:1688515200000\x001688544000000\x002\x00job!=\"test_2\"\x00job=\"test_1\""),
+		},
+		"label values request": {
+			url:            mustParseURL(t, `/prometheus/api/v1/label/test/values?start=2023-07-05T01:00:00Z&end=2023-07-05T08:00:00Z&match[]={job="test_1"}&match[]={job!="test_2"}`),
+			cacheKey:       "user-1:1688515200000\x001688544000000\x00test\x002\x00job!=\"test_2\"\x00job=\"test_1\"",
+			hashedCacheKey: labelValuesQueryCachePrefix + cacheHashKey("user-1:1688515200000\x001688544000000\x00test\x002\x00job!=\"test_2\"\x00job=\"test_1\""),
+		},
+	})
+}
+
+func TestLabelsQueryCache_parseRequest(t *testing.T) {
+	const labelName = "test"
+
+	tests := map[string]struct {
+		params                           url.Values
+		expectedCacheKeyWithLabelName    string
+		expectedCacheKeyWithoutLabelName string
+	}{
+		"no parameters provided": {
+			expectedCacheKeyWithLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", prometheusMinTime),
+				fmt.Sprintf("%d", prometheusMaxTime),
+				labelName,
+				"0",
+			}, string(stringParamSeparator)),
+			expectedCacheKeyWithoutLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", prometheusMinTime),
+				fmt.Sprintf("%d", prometheusMaxTime),
+				"0",
+			}, string(stringParamSeparator)),
+		},
+		"only start parameter provided": {
+			params: url.Values{
+				"start": []string{"2023-07-05T01:00:00Z"},
+			},
+			expectedCacheKeyWithLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
+				fmt.Sprintf("%d", prometheusMaxTime),
+				labelName,
+				"0",
+			}, string(stringParamSeparator)),
+			expectedCacheKeyWithoutLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
+				fmt.Sprintf("%d", prometheusMaxTime),
+				"0",
+			}, string(stringParamSeparator)),
+		},
+		"only end parameter provided": {
+			params: url.Values{
+				"end": []string{"2023-07-05T07:00:00Z"},
+			},
+			expectedCacheKeyWithLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", prometheusMinTime),
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T08:00:00Z")),
+				labelName,
+				"0",
+			}, string(stringParamSeparator)),
+			expectedCacheKeyWithoutLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", prometheusMinTime),
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T08:00:00Z")),
+				"0",
+			}, string(stringParamSeparator)),
+		},
+		"only match[] parameter provided": {
+			params: url.Values{
+				"match[]": []string{`{second!="2",first="1"}`},
+			},
+			expectedCacheKeyWithLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", prometheusMinTime),
+				fmt.Sprintf("%d", prometheusMaxTime),
+				labelName,
+				"1",
+				strings.Join([]string{`first="1"`, `second!="2"`}, string(stringValueSeparator)),
+			}, string(stringParamSeparator)),
+			expectedCacheKeyWithoutLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", prometheusMinTime),
+				fmt.Sprintf("%d", prometheusMaxTime),
+				"1",
+				strings.Join([]string{`first="1"`, `second!="2"`}, string(stringValueSeparator)),
+			}, string(stringParamSeparator)),
+		},
+		"all parameters provided with mixed timestamp formats": {
+			params: url.Values{
+				"start":   []string{"2023-07-05T01:00:00Z"},
+				"end":     []string{fmt.Sprintf("%d", mustParseTime("2023-07-05T07:00:00Z")/1000)},
+				"match[]": []string{`{second!="2",first="1"}`, `{third="3"}`},
+			},
+			expectedCacheKeyWithLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T08:00:00Z")),
+				labelName,
+				"2",
+				strings.Join([]string{`first="1"`, `second!="2"`}, string(stringValueSeparator)),
+				`third="3"`,
+			}, string(stringParamSeparator)),
+			expectedCacheKeyWithoutLabelName: strings.Join([]string{
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T08:00:00Z")),
+				"2",
+				strings.Join([]string{`first="1"`, `second!="2"`}, string(stringValueSeparator)),
+				`third="3"`,
+			}, string(stringParamSeparator)),
+		},
+	}
+
+	requestTypes := map[string]struct {
+		requestPath                   string
+		expectedCacheKeyPrefix        string
+		expectedCacheKeyWithLabelName bool
+	}{
+		"label names API": {
+			requestPath:                   "/api/v1/labels",
+			expectedCacheKeyPrefix:        labelNamesQueryCachePrefix,
+			expectedCacheKeyWithLabelName: false,
+		},
+		"label values API": {
+			requestPath:                   fmt.Sprintf("/api/v1/label/%s/values", labelName),
+			expectedCacheKeyPrefix:        labelValuesQueryCachePrefix,
+			expectedCacheKeyWithLabelName: true,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			for requestTypeName, requestTypeData := range requestTypes {
+				t.Run(requestTypeName, func(t *testing.T) {
+					req, err := http.NewRequest("GET", "http://localhost"+requestTypeData.requestPath+"?"+testData.params.Encode(), nil)
+					require.NoError(t, err)
+
+					c := &labelsQueryCache{}
+					actual, err := c.parseRequest(req)
+					require.NoError(t, err)
+
+					assert.Equal(t, requestTypeData.expectedCacheKeyPrefix, actual.cacheKeyPrefix)
+
+					if requestTypeData.expectedCacheKeyWithLabelName {
+						assert.Equal(t, testData.expectedCacheKeyWithLabelName, actual.cacheKey)
+					} else {
+						assert.Equal(t, testData.expectedCacheKeyWithoutLabelName, actual.cacheKey)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestGenerateLabelsQueryRequestCacheKey(t *testing.T) {
+	tests := map[string]struct {
+		startTime        int64
+		endTime          int64
+		labelName        string
+		matcherSets      [][]*labels.Matcher
+		expectedCacheKey string
+	}{
+		"start and end time are aligned to 2h boundaries": {
+			startTime: mustParseTime("2023-07-05T00:00:00Z"),
+			endTime:   mustParseTime("2023-07-05T06:00:00Z"),
+			expectedCacheKey: strings.Join([]string{
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T06:00:00Z")),
+				"0",
+			}, string(stringParamSeparator)),
+		},
+		"start and end time are not aligned to 2h boundaries": {
+			startTime: mustParseTime("2023-07-05T01:23:00Z"),
+			endTime:   mustParseTime("2023-07-05T06:23:00Z"),
+			expectedCacheKey: strings.Join([]string{
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T08:00:00Z")),
+				"0",
+			}, string(stringParamSeparator)),
+		},
+		"start and end time match prometheus min/max time": {
+			startTime: prometheusMinTime,
+			endTime:   prometheusMaxTime,
+			expectedCacheKey: strings.Join([]string{
+				fmt.Sprintf("%d", prometheusMinTime),
+				fmt.Sprintf("%d", prometheusMaxTime),
+				"0",
+			}, string(stringParamSeparator)),
+		},
+		"single label matcher set": {
+			startTime: mustParseTime("2023-07-05T00:00:00Z"),
+			endTime:   mustParseTime("2023-07-05T06:00:00Z"),
+			matcherSets: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "first", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "2"),
+				},
+			},
+			expectedCacheKey: strings.Join([]string{
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T06:00:00Z")),
+				"1",
+				strings.Join([]string{`first="1"`, `second!="2"`}, string(stringValueSeparator)),
+			}, string(stringParamSeparator)),
+		},
+		"multiple label matcher sets": {
+			startTime: mustParseTime("2023-07-05T00:00:00Z"),
+			endTime:   mustParseTime("2023-07-05T06:00:00Z"),
+			matcherSets: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "first", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "2"),
+				}, {
+					labels.MustNewMatcher(labels.MatchNotEqual, "first", "0"),
+				},
+			},
+			expectedCacheKey: strings.Join([]string{
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T06:00:00Z")),
+				"2",
+				strings.Join([]string{`first="1"`, `second!="2"`}, string(stringValueSeparator)),
+				`first!="0"`,
+			}, string(stringParamSeparator)),
+		},
+		"multiple label matcher sets and label name": {
+			startTime: mustParseTime("2023-07-05T00:00:00Z"),
+			endTime:   mustParseTime("2023-07-05T06:00:00Z"),
+			labelName: "test",
+			matcherSets: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "first", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "2"),
+				}, {
+					labels.MustNewMatcher(labels.MatchNotEqual, "first", "0"),
+				},
+			},
+			expectedCacheKey: strings.Join([]string{
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
+				fmt.Sprintf("%d", mustParseTime("2023-07-05T06:00:00Z")),
+				"test",
+				"2",
+				strings.Join([]string{`first="1"`, `second!="2"`}, string(stringValueSeparator)),
+				`first!="0"`,
+			}, string(stringParamSeparator)),
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testData.expectedCacheKey, generateLabelsQueryRequestCacheKey(testData.startTime, testData.endTime, testData.labelName, testData.matcherSets))
+		})
+	}
+}
+
+func TestParseRequestMatchersParam(t *testing.T) {
+	const paramName = "match[]"
+
+	tests := map[string]struct {
+		input    url.Values
+		expected [][]*labels.Matcher
+	}{
+		"single label matcher set with unique label names": {
+			input: url.Values{
+				paramName: []string{`{second!="2",first="1"}`},
+			},
+			expected: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "first", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "2"),
+				},
+			},
+		},
+		"single label matcher set with duplicated label names": {
+			input: url.Values{
+				paramName: []string{`{second!="2",second!="1",first="1"}`},
+			},
+			expected: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "first", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "2"),
+				},
+			},
+		},
+		"multiple label matcher sets with the same number of matchers each": {
+			input: url.Values{
+				paramName: []string{`{second!="2",first="1"}`, `{first="1",second!="1"}`},
+			},
+			expected: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "first", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "1"),
+				}, {
+					labels.MustNewMatcher(labels.MatchEqual, "first", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "2"),
+				},
+			},
+		},
+		"multiple label matcher sets with a different number of matchers each": {
+			input: url.Values{
+				paramName: []string{`{second!="2",first="1"}`, `{first="1",second!="2",third="3"}`},
+			},
+			expected: [][]*labels.Matcher{
+				{
+					labels.MustNewMatcher(labels.MatchEqual, "first", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "2"),
+				}, {
+					labels.MustNewMatcher(labels.MatchEqual, "first", "1"),
+					labels.MustNewMatcher(labels.MatchNotEqual, "second", "2"),
+					labels.MustNewMatcher(labels.MatchEqual, "third", "3"),
+				},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			t.Run("GET request", func(t *testing.T) {
+				req, err := http.NewRequest("GET", "http://localhost?"+testData.input.Encode(), nil)
+				require.NoError(t, err)
+				require.NoError(t, req.ParseForm())
+
+				actual, err := parseRequestMatchersParam(req, paramName)
+				require.NoError(t, err)
+
+				assert.Equal(t, testData.expected, actual)
+			})
+
+			t.Run("POST request", func(t *testing.T) {
+				req, err := http.NewRequest("POST", "http://localhost/", strings.NewReader(testData.input.Encode()))
+				require.NoError(t, err)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				require.NoError(t, req.ParseForm())
+
+				actual, err := parseRequestMatchersParam(req, "match[]")
+				require.NoError(t, err)
+
+				assert.Equal(t, testData.expected, actual)
+			})
+		})
+	}
+}
+
+func mustParseTime(input string) int64 {
+	parsed, err := time.Parse(time.RFC3339, input)
+	if err != nil {
+		panic(err)
+	}
+	return parsed.UnixMilli()
+}

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/util"
 )
 
 func TestLabelsQueryCache_RoundTrip(t *testing.T) {
@@ -40,14 +42,14 @@ func TestLabelsQueryCache_parseRequest(t *testing.T) {
 	}{
 		"no parameters provided": {
 			expectedCacheKeyWithLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", prometheusMinTime),
-				fmt.Sprintf("%d", prometheusMaxTime),
+				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
+				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
 				labelName,
 				"0",
 			}, string(stringParamSeparator)),
 			expectedCacheKeyWithoutLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", prometheusMinTime),
-				fmt.Sprintf("%d", prometheusMaxTime),
+				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
+				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
 				"0",
 			}, string(stringParamSeparator)),
 		},
@@ -57,13 +59,13 @@ func TestLabelsQueryCache_parseRequest(t *testing.T) {
 			},
 			expectedCacheKeyWithLabelName: strings.Join([]string{
 				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
-				fmt.Sprintf("%d", prometheusMaxTime),
+				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
 				labelName,
 				"0",
 			}, string(stringParamSeparator)),
 			expectedCacheKeyWithoutLabelName: strings.Join([]string{
 				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
-				fmt.Sprintf("%d", prometheusMaxTime),
+				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
 				"0",
 			}, string(stringParamSeparator)),
 		},
@@ -72,13 +74,13 @@ func TestLabelsQueryCache_parseRequest(t *testing.T) {
 				"end": []string{"2023-07-05T07:00:00Z"},
 			},
 			expectedCacheKeyWithLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", prometheusMinTime),
+				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
 				fmt.Sprintf("%d", mustParseTime("2023-07-05T08:00:00Z")),
 				labelName,
 				"0",
 			}, string(stringParamSeparator)),
 			expectedCacheKeyWithoutLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", prometheusMinTime),
+				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
 				fmt.Sprintf("%d", mustParseTime("2023-07-05T08:00:00Z")),
 				"0",
 			}, string(stringParamSeparator)),
@@ -88,15 +90,15 @@ func TestLabelsQueryCache_parseRequest(t *testing.T) {
 				"match[]": []string{`{second!="2",first="1"}`},
 			},
 			expectedCacheKeyWithLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", prometheusMinTime),
-				fmt.Sprintf("%d", prometheusMaxTime),
+				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
+				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
 				labelName,
 				"1",
 				strings.Join([]string{`first="1"`, `second!="2"`}, string(stringValueSeparator)),
 			}, string(stringParamSeparator)),
 			expectedCacheKeyWithoutLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", prometheusMinTime),
-				fmt.Sprintf("%d", prometheusMaxTime),
+				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
+				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
 				"1",
 				strings.Join([]string{`first="1"`, `second!="2"`}, string(stringValueSeparator)),
 			}, string(stringParamSeparator)),
@@ -193,11 +195,11 @@ func TestGenerateLabelsQueryRequestCacheKey(t *testing.T) {
 			}, string(stringParamSeparator)),
 		},
 		"start and end time match prometheus min/max time": {
-			startTime: prometheusMinTime,
-			endTime:   prometheusMaxTime,
+			startTime: util.PrometheusMinTime.UnixMilli(),
+			endTime:   util.PrometheusMaxTime.UnixMilli(),
 			expectedCacheKey: strings.Join([]string{
-				fmt.Sprintf("%d", prometheusMinTime),
-				fmt.Sprintf("%d", prometheusMaxTime),
+				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
+				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
 				"0",
 			}, string(stringParamSeparator)),
 		},

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -89,6 +89,9 @@ type Limits interface {
 	// ResultsCacheTTLForCardinalityQuery returns TTL for cached results for cardinality queries.
 	ResultsCacheTTLForCardinalityQuery(userID string) time.Duration
 
+	// ResultsCacheTTLForLabelsQuery returns TTL for cached results for label names and values queries.
+	ResultsCacheTTLForLabelsQuery(userID string) time.Duration
+
 	// ResultsCacheForUnalignedQueryEnabled returns whether to cache results for queries that are not step-aligned
 	ResultsCacheForUnalignedQueryEnabled(userID string) bool
 }

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -419,6 +419,10 @@ func (m multiTenantMockLimits) ResultsCacheTTLForCardinalityQuery(userID string)
 	return m.byTenant[userID].resultsCacheTTLForCardinalityQuery
 }
 
+func (m multiTenantMockLimits) ResultsCacheTTLForLabelsQuery(userID string) time.Duration {
+	return m.byTenant[userID].resultsCacheTTLForLabelsQuery
+}
+
 func (m multiTenantMockLimits) ResultsCacheForUnalignedQueryEnabled(userID string) bool {
 	return m.byTenant[userID].resultsCacheForUnalignedQueryEnabled
 }
@@ -450,6 +454,7 @@ type mockLimits struct {
 	resultsCacheTTL                      time.Duration
 	resultsCacheOutOfOrderWindowTTL      time.Duration
 	resultsCacheTTLForCardinalityQuery   time.Duration
+	resultsCacheTTLForLabelsQuery        time.Duration
 	resultsCacheForUnalignedQueryEnabled bool
 }
 
@@ -519,6 +524,10 @@ func (m mockLimits) ResultsCacheTTLForCardinalityQuery(string) time.Duration {
 	return m.resultsCacheTTLForCardinalityQuery
 }
 
+func (m mockLimits) ResultsCacheTTLForLabelsQuery(string) time.Duration {
+	return m.resultsCacheTTLForLabelsQuery
+}
+
 func (m mockLimits) ResultsCacheForUnalignedQueryEnabled(string) bool {
 	return m.resultsCacheForUnalignedQueryEnabled
 }
@@ -562,7 +571,7 @@ func TestLimitedRoundTripper_MaxQueryParallelism(t *testing.T) {
 
 	codec := newTestPrometheusCodec()
 	r, err := codec.EncodeRequest(ctx, &PrometheusRangeQueryRequest{
-		Path:  "/query_range",
+		Path:  "/api/v1/query_range",
 		Start: time.Now().Add(time.Hour).Unix(),
 		End:   util.TimeToMillis(time.Now()),
 		Step:  int64(1 * time.Second * time.Millisecond),
@@ -606,7 +615,7 @@ func TestLimitedRoundTripper_MaxQueryParallelismLateScheduling(t *testing.T) {
 
 	codec := newTestPrometheusCodec()
 	r, err := codec.EncodeRequest(ctx, &PrometheusRangeQueryRequest{
-		Path:  "/query_range",
+		Path:  "/api/v1/query_range",
 		Start: time.Now().Add(time.Hour).Unix(),
 		End:   util.TimeToMillis(time.Now()),
 		Step:  int64(1 * time.Second * time.Millisecond),
@@ -647,7 +656,7 @@ func TestLimitedRoundTripper_OriginalRequestContextCancellation(t *testing.T) {
 
 	codec := newTestPrometheusCodec()
 	r, err := codec.EncodeRequest(reqCtx, &PrometheusRangeQueryRequest{
-		Path:  "/query_range",
+		Path:  "/api/v1/query_range",
 		Start: time.Now().Add(time.Hour).Unix(),
 		End:   util.TimeToMillis(time.Now()),
 		Step:  int64(1 * time.Second * time.Millisecond),

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -353,6 +353,45 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestIsLabelsQuery(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{
+			path:     "/api/v1/labels/unknown",
+			expected: false,
+		}, {
+			path:     "/api/v1/",
+			expected: false,
+		}, {
+			path:     "/api/v1/labels",
+			expected: true,
+		}, {
+			path:     "/prometheus/api/v1/labels",
+			expected: true,
+		}, {
+			path:     "/api/v1/label/test/values",
+			expected: true,
+		}, {
+			path:     "/prometheus/api/v1/label/test/values",
+			expected: true,
+		}, {
+			path:     "/prometheus/api/v1/label/test/values/unknown",
+			expected: false,
+		}, {
+			path:     "/prometheus/api/v1/label/test/unknown/values",
+			expected: false,
+		},
+	}
+
+	for _, testData := range tests {
+		t.Run(testData.path, func(t *testing.T) {
+			assert.Equal(t, testData.expected, isLabelsQuery(testData.path))
+		})
+	}
+}
+
 type singleHostRoundTripper struct {
 	host string
 	next http.RoundTripper

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -368,11 +368,17 @@ func TestIsLabelsQuery(t *testing.T) {
 			path:     "/api/v1/labels",
 			expected: true,
 		}, {
+			path:     "/labels",
+			expected: false,
+		}, {
 			path:     "/prometheus/api/v1/labels",
 			expected: true,
 		}, {
 			path:     "/api/v1/label/test/values",
 			expected: true,
+		}, {
+			path:     "/values",
+			expected: false,
 		}, {
 			path:     "/prometheus/api/v1/label/test/values",
 			expected: true,

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -16,6 +16,14 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 )
 
+var (
+	// PrometheusMinTime is earliest possible timestamp supported by the Prometheus API.
+	PrometheusMinTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
+
+	// PrometheusMaxTime is latest possible timestamp supported by the Prometheus API.
+	PrometheusMaxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
+)
+
 func TimeToMillis(t time.Time) int64 {
 	return t.Unix()*1000 + int64(t.Nanosecond())/int64(time.Millisecond)
 }

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -7,7 +7,6 @@ package util
 
 import (
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -36,14 +35,14 @@ func TestTimeFromMillis(t *testing.T) {
 	}
 }
 
-func TestTimeRoundTrip(t *testing.T) {
+func TestTimeRoundTripUsingPrometheusMinAndMaxTimestamps(t *testing.T) {
 	refTime, _ := time.Parse(time.Layout, time.Layout)
 	var testExpr = []struct {
 		input time.Time
 	}{
 		{input: refTime},
-		{input: time.Unix(math.MinInt64/1000+62135596801, 0).UTC()},         // minTime from Prometheus API
-		{input: time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()}, // maxTime from Prometheus API
+		{input: PrometheusMinTime},
+		{input: PrometheusMaxTime},
 	}
 
 	for i, c := range testExpr {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -126,6 +126,7 @@ type Limits struct {
 	ResultsCacheTTL                        model.Duration `yaml:"results_cache_ttl" json:"results_cache_ttl" category:"experimental"`
 	ResultsCacheTTLForOutOfOrderTimeWindow model.Duration `yaml:"results_cache_ttl_for_out_of_order_time_window" json:"results_cache_ttl_for_out_of_order_time_window" category:"experimental"`
 	ResultsCacheTTLForCardinalityQuery     model.Duration `yaml:"results_cache_ttl_for_cardinality_query" json:"results_cache_ttl_for_cardinality_query" category:"experimental"`
+	ResultsCacheTTLForLabelsQuery          model.Duration `yaml:"results_cache_ttl_for_labels_query" json:"results_cache_ttl_for_labels_query" category:"experimental"`
 	ResultsCacheForUnalignedQueryEnabled   bool           `yaml:"cache_unaligned_requests" json:"cache_unaligned_requests" category:"advanced"`
 	MaxQueryExpressionSizeBytes            int            `yaml:"max_query_expression_size_bytes" json:"max_query_expression_size_bytes" category:"experimental"`
 
@@ -262,6 +263,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	_ = l.ResultsCacheTTLForOutOfOrderTimeWindow.Set("10m")
 	f.Var(&l.ResultsCacheTTLForOutOfOrderTimeWindow, resultsCacheTTLForOutOfOrderWindowFlag, fmt.Sprintf("Time to live duration for cached query results if query falls into out-of-order time window. This is lower than -%s so that incoming out-of-order samples are returned in the query results sooner.", resultsCacheTTLFlag))
 	f.Var(&l.ResultsCacheTTLForCardinalityQuery, "query-frontend.results-cache-ttl-for-cardinality-query", "Time to live duration for cached cardinality query results. The value 0 disables the cache.")
+	f.Var(&l.ResultsCacheTTLForLabelsQuery, "query-frontend.results-cache-ttl-for-labels-query", "Time to live duration for cached label names and label values query results. The value 0 disables the cache.")
 	f.BoolVar(&l.ResultsCacheForUnalignedQueryEnabled, "query-frontend.cache-unaligned-requests", false, "Cache requests that are not step-aligned.")
 	f.IntVar(&l.MaxQueryExpressionSizeBytes, maxQueryExpressionSizeBytesFlag, 0, "Max size of the raw query, in bytes. 0 to not apply a limit to the size of the query.")
 
@@ -834,6 +836,10 @@ func (o *Overrides) ResultsCacheTTLForOutOfOrderTimeWindow(user string) time.Dur
 
 func (o *Overrides) ResultsCacheTTLForCardinalityQuery(user string) time.Duration {
 	return time.Duration(o.getOverridesForUser(user).ResultsCacheTTLForCardinalityQuery)
+}
+
+func (o *Overrides) ResultsCacheTTLForLabelsQuery(user string) time.Duration {
+	return time.Duration(o.getOverridesForUser(user).ResultsCacheTTLForLabelsQuery)
 }
 
 func (o *Overrides) ResultsCacheForUnalignedQueryEnabled(userID string) bool {


### PR DESCRIPTION
#### What this PR does
Similarly to https://github.com/grafana/mimir/pull/5212, in this PR I'm adding the support to cache label names and label values responses. See details at: https://github.com/grafana/mimir/issues/5395

Note to reviewers:
- I manually tested it and looks working as intended.
- I opted for a new configuration option to specify the labels query response cache TTL, instead of one in common with the cardinality API, because I think we can potentially cache a bit longer for cardinality APIs. Since these config options are still marked experimental (so we're not committing to them yet) I prefer to keep them separated while rolling out the feature.

#### Which issue(s) this PR fixes or relates to

Fixes #5395

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
