### PR TITLE
Documentation: Fix Azure Blob Storage configuration example

### DIFF
--- a/docs/sources/mimir/configure/configure-object-storage-backend.md
+++ b/docs/sources/mimir/configure/configure-object-storage-backend.md
@@ -108,7 +108,7 @@ common:
   storage:
     backend: azure
     azure:
-      account_key: "${SWIFT_ACCOUNT_KEY}" # This is a secret injected via an environment variable
+      account_key: "${AZURE_ACCOUNT_KEY}" # This is a secret injected via an environment variable
       account_name: mimir-prod
       endpoint_suffix: "blob.core.windows.net"
 


### PR DESCRIPTION
#### What this PR does
Fix a documentation example of Azure Blob Storage configuration. It currently refers to `SWIFT_ACCOUNT_KEY`, where the "SWIFT" prefix must surely be by mistake?

Please let me know in case the prefix should actually be intentional :)

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [x] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
