### PR TITLE
Remove use of `--relative-to` argument to `realpath`, so that `make build-mixin` works on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ build-mixin: check-mixin-jb
 		./tools/check-rules.sh "$(MIXIN_OUT_PATH)$$suffix/rules.yaml" 20 ; \
 		cd "$(MIXIN_OUT_PATH)$$suffix/.." && zip -q -r "mimir-mixin$$suffix.zip" $$(basename "$(MIXIN_OUT_PATH)$$suffix"); \
 		cd -; \
-		echo "The mixin has been compiled to $(MIXIN_OUT_PATH)$$suffix and archived to $$(realpath --relative-to=$$(pwd) $(MIXIN_OUT_PATH)$$suffix/../mimir-mixin$$suffix.zip)"; \
+		echo "The mixin has been compiled to $(MIXIN_OUT_PATH)$$suffix and archived to $$(realpath $(MIXIN_OUT_PATH)$$suffix/../mimir-mixin$$suffix.zip)"; \
 	done
 
 check-mixin-tests: ## Test the mixin files.


### PR DESCRIPTION
#### What this PR does

Running `make BUILD_IN_CONTAINER=false build-mixin` on macOS complains about `--relative-to`:

```
~/Repositories/Grafana/mimir
realpath: illegal option -- -
usage: realpath [-q] [path ...]
The mixin has been compiled to operations/mimir-mixin-compiled and archived to
~/Repositories/Grafana/mimir
realpath: illegal option -- -
usage: realpath [-q] [path ...]
The mixin has been compiled to operations/mimir-mixin-compiled-baremetal and archived to
```

This PR removes the use of `--relative-to`, as it doesn't seem necessary and allows engineers to run `build-mixin` on a macOS machine without using Docker.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
