### PR TITLE
block: Use filepath.Join for local files

### DIFF
--- a/pkg/storage/tsdb/block/block.go
+++ b/pkg/storage/tsdb/block/block.go
@@ -48,7 +48,7 @@ func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id
 		return errors.Wrap(err, "create dir")
 	}
 
-	if err := objstore.DownloadFile(ctx, logger, bucket, path.Join(id.String(), MetaFilename), path.Join(dst, MetaFilename)); err != nil {
+	if err := objstore.DownloadFile(ctx, logger, bucket, path.Join(id.String(), MetaFilename), filepath.Join(dst, MetaFilename)); err != nil {
 		return err
 	}
 
@@ -63,7 +63,6 @@ func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id
 		// This can happen if block is empty. We cannot easily upload empty directory, so create one here.
 		return os.Mkdir(chunksDir, os.ModePerm)
 	}
-
 	if err != nil {
 		return errors.Wrapf(err, "stat %s", chunksDir)
 	}


### PR DESCRIPTION
#### What this PR does
Minor improvement: Use `filepath.Join` for the local path instead of `path.Join` when downloading a block file.

#### Which issue(s) this PR fixes or relates to 

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
