### PR TITLE
overrides-exporter: add extra metrics support

### DIFF
--- a/pkg/util/validation/exporter/exporter_test.go
+++ b/pkg/util/validation/exporter/exporter_test.go
@@ -185,6 +185,83 @@ cortex_limits_defaults{limit_name="alertmanager_max_alerts_size_bytes"} 53
 	assert.NoError(t, err)
 }
 
+func TestOverridesExporter_withExtraMetrics(t *testing.T) {
+	tenantLimits := map[string]*validation.Limits{
+		"tenant-a": {
+			IngestionRate:                10,
+			IngestionBurstSize:           11,
+			MaxGlobalSeriesPerUser:       12,
+			MaxGlobalSeriesPerMetric:     13,
+			MaxGlobalExemplarsPerUser:    14,
+			MaxChunksPerQuery:            15,
+			MaxFetchedSeriesPerQuery:     16,
+			MaxFetchedChunkBytesPerQuery: 17,
+			RulerMaxRulesPerRuleGroup:    19,
+			RulerMaxRuleGroupsPerTenant:  20,
+		},
+	}
+
+	config := Config{EnabledMetrics: append(defaultEnabledMetricNames, "custom_extra_limit"), ExtraMetrics: []ExportedMetric{
+		{
+			Name: "custom_extra_limit",
+			Get: func(_ *validation.Limits) float64 {
+				return 1234.0
+			},
+		},
+	}}
+
+	exporter, err := NewOverridesExporter(config, &validation.Limits{
+		IngestionRate:                22,
+		IngestionBurstSize:           23,
+		MaxGlobalSeriesPerUser:       24,
+		MaxGlobalSeriesPerMetric:     25,
+		MaxGlobalExemplarsPerUser:    26,
+		MaxChunksPerQuery:            27,
+		MaxFetchedSeriesPerQuery:     28,
+		MaxFetchedChunkBytesPerQuery: 29,
+		RulerMaxRulesPerRuleGroup:    31,
+		RulerMaxRuleGroupsPerTenant:  32,
+	}, validation.NewMockTenantLimits(tenantLimits), log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	limitsMetrics := `
+# HELP cortex_limits_overrides Resource limit overrides applied to tenants
+# TYPE cortex_limits_overrides gauge
+cortex_limits_overrides{limit_name="custom_extra_limit",user="tenant-a"} 1234
+cortex_limits_overrides{limit_name="ingestion_rate",user="tenant-a"} 10
+cortex_limits_overrides{limit_name="ingestion_burst_size",user="tenant-a"} 11
+cortex_limits_overrides{limit_name="max_global_series_per_user",user="tenant-a"} 12
+cortex_limits_overrides{limit_name="max_global_series_per_metric",user="tenant-a"} 13
+cortex_limits_overrides{limit_name="max_global_exemplars_per_user",user="tenant-a"} 14
+cortex_limits_overrides{limit_name="max_fetched_chunks_per_query",user="tenant-a"} 15
+cortex_limits_overrides{limit_name="max_fetched_series_per_query",user="tenant-a"} 16
+cortex_limits_overrides{limit_name="max_fetched_chunk_bytes_per_query",user="tenant-a"} 17
+cortex_limits_overrides{limit_name="ruler_max_rules_per_rule_group",user="tenant-a"} 19
+cortex_limits_overrides{limit_name="ruler_max_rule_groups_per_tenant",user="tenant-a"} 20
+`
+
+	// Make sure each override matches the values from the supplied `Limit`
+	err = testutil.CollectAndCompare(exporter, bytes.NewBufferString(limitsMetrics), "cortex_limits_overrides")
+	assert.NoError(t, err)
+
+	limitsMetrics = `
+# HELP cortex_limits_defaults Resource limit defaults for tenants without overrides
+# TYPE cortex_limits_defaults gauge
+cortex_limits_defaults{limit_name="custom_extra_limit"} 1234
+cortex_limits_defaults{limit_name="ingestion_rate"} 22
+cortex_limits_defaults{limit_name="ingestion_burst_size"} 23
+cortex_limits_defaults{limit_name="max_global_series_per_user"} 24
+cortex_limits_defaults{limit_name="max_global_series_per_metric"} 25
+cortex_limits_defaults{limit_name="max_global_exemplars_per_user"} 26
+cortex_limits_defaults{limit_name="max_fetched_chunks_per_query"} 27
+cortex_limits_defaults{limit_name="max_fetched_series_per_query"} 28
+cortex_limits_defaults{limit_name="max_fetched_chunk_bytes_per_query"} 29
+cortex_limits_defaults{limit_name="ruler_max_rules_per_rule_group"} 31
+cortex_limits_defaults{limit_name="ruler_max_rule_groups_per_tenant"} 32
+`
+	err = testutil.CollectAndCompare(exporter, bytes.NewBufferString(limitsMetrics), "cortex_limits_defaults")
+	assert.NoError(t, err)
+}
+
 func TestOverridesExporter_withRing(t *testing.T) {
 	tenantLimits := map[string]*validation.Limits{
 		"tenant-a": {},


### PR DESCRIPTION
Since the `Limits` type now supports extensions (see PR https://github.com/grafana/mimir/pull/4397), downstream projects can take advantage of this functionality to add their own limits by extending the current runtime config, however , such limits are not exposed by the `override-exporter` component.

This PR adds the ability to add extra metrics to the exporter so that downstream projects can also export these limits/defaults wherever required.