### PR TITLE
Docs: Change Tutorial directory for Get started, fix for #5350

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
 
 ### Documentation
 
+* [CHANGE] Docs: Change Docker Compose directory for Get started, fix for #5350
+
 ### Tools
 
 * [BUGFIX] Stop tools from panicking when `-help` flag is passed. #5412

--- a/docs/sources/mimir/get-started/play-with-grafana-mimir/index.md
+++ b/docs/sources/mimir/get-started/play-with-grafana-mimir/index.md
@@ -51,10 +51,10 @@ In this tutorial, you'll:
    ```
 1. Navigate to the tutorial directory:
    ```bash
-   cd docs/sources/mimir/tutorials/play-with-grafana-mimir/
+   cd docs/sources/mimir/get-started/play-with-grafana-mimir/
    ```
 
-**Note**: the instructions in this tutorial assume that your working directory is `docs/sources/mimir/tutorials/play-with-grafana-mimir/`.
+**Note**: the instructions in this tutorial assume that your working directory is `docs/sources/mimir/get-started/play-with-grafana-mimir/`.
 
 ## Start Grafana Mimir and dependencies
 


### PR DESCRIPTION
#### What this PR does
This PR Changes the `_index.md` in `play-with-grafana` for correct tutorial directory. 

#### Which issue(s) this PR fixes or relates to
This PR Fixes tutorial directory prior to #5350 

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
