### PR TITLE
Do not merge: Ingester: Add alternate CPU load EWMA calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 
 require (
 	cloud.google.com/go/storage v1.31.0
+	github.com/VividCortex/ewma v1.2.0
 	github.com/alecthomas/chroma v0.10.0
 	github.com/aws/aws-sdk-go v1.44.298
 	github.com/dennwc/varint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -428,6 +428,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/OneOfOne/xxhash v1.2.6 h1:U68crOE3y3MPttCMQGywZOLrTeF5HHJ3/vDBCJn9/bA=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
+github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -257,9 +257,6 @@ type Ingester struct {
 	ingestionRate        *util_math.EwmaRate
 	inflightPushRequests atomic.Int64
 
-	currCPUUtil    *atomic.Float64
-	altCurrCPUUtil *atomic.Float64
-
 	// Anonymous usage statistics tracked by ingester.
 	memorySeriesStats                  *expvar.Int
 	memoryTenantsStats                 *expvar.Int
@@ -286,12 +283,6 @@ func newIngester(cfg Config, limits *validation.Overrides, registerer prometheus
 	usagestats.GetInt(replicationFactorStatsName).Set(int64(cfg.IngesterRing.ReplicationFactor))
 	usagestats.GetString(ringStoreStatsName).Set(cfg.IngesterRing.KVStore.Store)
 
-	var currCPUUtil *atomic.Float64
-	var altCurrCPUUtil *atomic.Float64
-	if cfg.ReadPathCPUUtilizationLimit > 0 || cfg.ReadPathMemoryUtilizationLimit > 0 {
-		currCPUUtil = &atomic.Float64{}
-		altCurrCPUUtil = &atomic.Float64{}
-	}
 	return &Ingester{
 		cfg:    cfg,
 		limits: limits,
@@ -313,9 +304,6 @@ func newIngester(cfg Config, limits *validation.Overrides, registerer prometheus
 		tenantsWithOutOfOrderEnabledStat:   usagestats.GetAndResetInt(tenantsWithOutOfOrderEnabledStatName),
 		minOutOfOrderTimeWindowSecondsStat: usagestats.GetAndResetInt(minOutOfOrderTimeWindowSecondsStatName),
 		maxOutOfOrderTimeWindowSecondsStat: usagestats.GetAndResetInt(maxOutOfOrderTimeWindowSecondsStatName),
-
-		currCPUUtil:    currCPUUtil,
-		altCurrCPUUtil: altCurrCPUUtil,
 	}, nil
 }
 
@@ -326,8 +314,7 @@ func New(cfg Config, limits *validation.Overrides, activeGroupsCleanupService *u
 		return nil, err
 	}
 	i.ingestionRate = util_math.NewEWMARate(0.2, instanceIngestionRateTickInterval)
-	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetrics.Enabled, i.getInstanceLimits, i.ingestionRate, &i.inflightPushRequests,
-		i.currCPUUtil, i.altCurrCPUUtil)
+	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetrics.Enabled, i.getInstanceLimits, i.ingestionRate, &i.inflightPushRequests)
 	i.activeGroups = activeGroupsCleanupService
 
 	if registerer != nil {
@@ -351,6 +338,12 @@ func New(cfg Config, limits *validation.Overrides, activeGroupsCleanupService *u
 		cfg.IngesterRing.ReplicationFactor,
 		cfg.IngesterRing.ZoneAwarenessEnabled)
 
+	if cfg.ReadPathCPUUtilizationLimit > 0 || cfg.ReadPathMemoryUtilizationLimit > 0 {
+		i.utilizationBasedLimiter = limiter.NewUtilizationBasedLimiter(cfg.ReadPathCPUUtilizationLimit,
+			cfg.ReadPathMemoryUtilizationLimit, log.WithPrefix(logger, "context", "read path"),
+			prometheus.WrapRegistererWithPrefix("cortex_ingester_", registerer))
+	}
+
 	i.shipperIngesterID = i.lifecycler.ID
 
 	// Apply positive jitter only to ensure that the minimum timeout is adhered to.
@@ -369,8 +362,7 @@ func NewForFlusher(cfg Config, limits *validation.Overrides, registerer promethe
 	if err != nil {
 		return nil, err
 	}
-	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil, &i.inflightPushRequests,
-		i.currCPUUtil, i.altCurrCPUUtil)
+	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil, &i.inflightPushRequests)
 
 	i.shipperIngesterID = "flusher"
 
@@ -428,10 +420,7 @@ func (i *Ingester) starting(ctx context.Context) error {
 		servs = append(servs, closeIdleService)
 	}
 
-	if i.cfg.ReadPathCPUUtilizationLimit > 0 || i.cfg.ReadPathMemoryUtilizationLimit > 0 {
-		i.utilizationBasedLimiter = limiter.NewUtilizationBasedLimiter(i.cfg.ReadPathCPUUtilizationLimit,
-			i.cfg.ReadPathMemoryUtilizationLimit, i.currCPUUtil, i.altCurrCPUUtil,
-			log.WithPrefix(i.logger, "context", "read path"))
+	if i.utilizationBasedLimiter != nil {
 		servs = append(servs, i.utilizationBasedLimiter)
 	}
 

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -49,8 +49,6 @@ type ingesterMetrics struct {
 	ingestionRate           prometheus.GaugeFunc
 	maxInflightPushRequests prometheus.GaugeFunc
 	inflightRequests        prometheus.GaugeFunc
-	currentCPULoad          prometheus.GaugeFunc
-	altCurrentCPULoad       prometheus.GaugeFunc
 
 	// Head compactions metrics.
 	compactionsTriggered   prometheus.Counter
@@ -81,8 +79,6 @@ func newIngesterMetrics(
 	instanceLimitsFn func() *InstanceLimits,
 	ingestionRate *util_math.EwmaRate,
 	inflightRequests *atomic.Int64,
-	currCPUUtil *atomic.Float64,
-	altCurrCPUUtil *atomic.Float64,
 ) *ingesterMetrics {
 	const (
 		instanceLimits     = "cortex_ingester_instance_limits"
@@ -240,27 +236,6 @@ func newIngesterMetrics(
 		}, func() float64 {
 			if inflightRequests != nil {
 				return float64(inflightRequests.Load())
-			}
-			return 0
-		}),
-
-		currentCPULoad: promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
-			Name:        "cortex_ingester_utilization_limiter_current_cpu_load",
-			Help:        "Current average CPU load calculated by utilization based limiter.",
-			ConstLabels: map[string]string{"method": "built-in"},
-		}, func() float64 {
-			if currCPUUtil != nil {
-				return currCPUUtil.Load()
-			}
-			return 0
-		}),
-		altCurrentCPULoad: promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
-			Name:        "cortex_ingester_utilization_limiter_current_cpu_load",
-			Help:        "Current average CPU load calculated by utilization based limiter.",
-			ConstLabels: map[string]string{"method": "alternate"},
-		}, func() float64 {
-			if altCurrCPUUtil != nil {
-				return altCurrCPUUtil.Load()
 			}
 			return 0
 		}),

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -49,6 +49,8 @@ type ingesterMetrics struct {
 	ingestionRate           prometheus.GaugeFunc
 	maxInflightPushRequests prometheus.GaugeFunc
 	inflightRequests        prometheus.GaugeFunc
+	currentCPULoad          prometheus.GaugeFunc
+	altCurrentCPULoad       prometheus.GaugeFunc
 
 	// Head compactions metrics.
 	compactionsTriggered   prometheus.Counter
@@ -79,6 +81,8 @@ func newIngesterMetrics(
 	instanceLimitsFn func() *InstanceLimits,
 	ingestionRate *util_math.EwmaRate,
 	inflightRequests *atomic.Int64,
+	currCPUUtil *atomic.Float64,
+	altCurrCPUUtil *atomic.Float64,
 ) *ingesterMetrics {
 	const (
 		instanceLimits     = "cortex_ingester_instance_limits"
@@ -236,6 +240,27 @@ func newIngesterMetrics(
 		}, func() float64 {
 			if inflightRequests != nil {
 				return float64(inflightRequests.Load())
+			}
+			return 0
+		}),
+
+		currentCPULoad: promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
+			Name:        "cortex_ingester_utilization_limiter_current_cpu_load",
+			Help:        "Current average CPU load calculated by utilization based limiter.",
+			ConstLabels: map[string]string{"method": "built-in"},
+		}, func() float64 {
+			if currCPUUtil != nil {
+				return currCPUUtil.Load()
+			}
+			return 0
+		}),
+		altCurrentCPULoad: promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
+			Name:        "cortex_ingester_utilization_limiter_current_cpu_load",
+			Help:        "Current average CPU load calculated by utilization based limiter.",
+			ConstLabels: map[string]string{"method": "alternate"},
+		}, func() float64 {
+			if altCurrCPUUtil != nil {
+				return altCurrCPUUtil.Load()
 			}
 			return 0
 		}),

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -133,7 +133,7 @@ func (l *UtilizationBasedLimiter) update(_ context.Context) error {
 
 // compute and return the current CPU and memory utilization.
 // This function must be called at a regular interval (resourceUtilizationUpdateInterval) to get a predictable behaviour.
-func (l *UtilizationBasedLimiter) compute(now time.Time) (currCPUUtil float64, currMemoryUtil uint64) {
+func (l *UtilizationBasedLimiter) compute(now time.Time) (currCPUUtil float64, currMemoryUtil uint64, altCPUUtil float64) {
 	cpuTime, currMemoryUtil, err := l.utilizationScanner.Scan()
 	if err != nil {
 		level.Warn(l.logger).Log("msg", "failed to get CPU and memory stats", "err", err.Error())
@@ -154,7 +154,7 @@ func (l *UtilizationBasedLimiter) compute(now time.Time) (currCPUUtil float64, c
 	l.lastUpdate = now
 	l.lastCPUTime = cpuTime
 
-	altCPUUtil := l.altCPUMovingAvg.Value()
+	altCPUUtil = l.altCPUMovingAvg.Value()
 	l.altCurrCPUUtil.Store(altCPUUtil)
 
 	// The CPU utilization moving average requires a warmup period before getting

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +18,7 @@ func TestUtilizationBasedLimiter(t *testing.T) {
 
 	setup := func(t *testing.T, cpuLimit float64, memoryLimit uint64) (*UtilizationBasedLimiter, *fakeUtilizationScanner) {
 		fakeScanner := &fakeUtilizationScanner{}
-		lim := NewUtilizationBasedLimiter(cpuLimit, memoryLimit, log.NewNopLogger())
+		lim := NewUtilizationBasedLimiter(cpuLimit, memoryLimit, log.NewNopLogger(), prometheus.NewPedanticRegistry())
 		lim.utilizationScanner = fakeScanner
 		require.Empty(t, lim.LimitingReason(), "Limiting should initially be disabled")
 
@@ -190,7 +191,7 @@ func TestUtilizationBasedLimiter_CPUUtilizationSensitivity(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			scanner := &preRecordedUtilizationScanner{instantCPUValues: testData.instantCPUValues}
 
-			lim := NewUtilizationBasedLimiter(1, 0, log.NewNopLogger())
+			lim := NewUtilizationBasedLimiter(1, 0, log.NewNopLogger(), prometheus.NewPedanticRegistry())
 			lim.utilizationScanner = scanner
 
 			minCPUUtilization := float64(math.MaxInt64)

--- a/vendor/github.com/VividCortex/ewma/.gitignore
+++ b/vendor/github.com/VividCortex/ewma/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.*.sw?
+/coverage.txt

--- a/vendor/github.com/VividCortex/ewma/.whitesource
+++ b/vendor/github.com/VividCortex/ewma/.whitesource
@@ -1,0 +1,3 @@
+{
+  "settingsInheritedFrom": "VividCortex/whitesource-config@master"
+}

--- a/vendor/github.com/VividCortex/ewma/LICENSE
+++ b/vendor/github.com/VividCortex/ewma/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2013 VividCortex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/VividCortex/ewma/README.md
+++ b/vendor/github.com/VividCortex/ewma/README.md
@@ -1,0 +1,145 @@
+# EWMA
+
+[![GoDoc](https://godoc.org/github.com/VividCortex/ewma?status.svg)](https://godoc.org/github.com/VividCortex/ewma)
+![build](https://github.com/VividCortex/ewma/workflows/build/badge.svg)
+[![codecov](https://codecov.io/gh/VividCortex/ewma/branch/master/graph/badge.svg)](https://codecov.io/gh/VividCortex/ewma)
+
+This repo provides Exponentially Weighted Moving Average algorithms, or EWMAs for short, [based on our
+Quantifying Abnormal Behavior talk](https://vividcortex.com/blog/2013/07/23/a-fast-go-library-for-exponential-moving-averages/).
+
+### Exponentially Weighted Moving Average
+
+An exponentially weighted moving average is a way to continuously compute a type of
+average for a series of numbers, as the numbers arrive. After a value in the series is
+added to the average, its weight in the average decreases exponentially over time. This
+biases the average towards more recent data. EWMAs are useful for several reasons, chiefly
+their inexpensive computational and memory cost, as well as the fact that they represent
+the recent central tendency of the series of values.
+
+The EWMA algorithm requires a decay factor, alpha. The larger the alpha, the more the average
+is biased towards recent history. The alpha must be between 0 and 1, and is typically
+a fairly small number, such as 0.04. We will discuss the choice of alpha later.
+
+The algorithm works thus, in pseudocode:
+
+1. Multiply the next number in the series by alpha.
+2. Multiply the current value of the average by 1 minus alpha.
+3. Add the result of steps 1 and 2, and store it as the new current value of the average.
+4. Repeat for each number in the series.
+
+There are special-case behaviors for how to initialize the current value, and these vary
+between implementations. One approach is to start with the first value in the series;
+another is to average the first 10 or so values in the series using an arithmetic average,
+and then begin the incremental updating of the average. Each method has pros and cons.
+
+It may help to look at it pictorially. Suppose the series has five numbers, and we choose
+alpha to be 0.50 for simplicity. Here's the series, with numbers in the neighborhood of 300.
+
+![Data Series](https://user-images.githubusercontent.com/279875/28242350-463289a2-6977-11e7-88ca-fd778ccef1f0.png)
+
+Now let's take the moving average of those numbers. First we set the average to the value
+of the first number.
+
+![EWMA Step 1](https://user-images.githubusercontent.com/279875/28242353-464c96bc-6977-11e7-9981-dc4e0789c7ba.png)
+
+Next we multiply the next number by alpha, multiply the current value by 1-alpha, and add
+them to generate a new value.
+
+![EWMA Step 2](https://user-images.githubusercontent.com/279875/28242351-464abefa-6977-11e7-95d0-43900f29bef2.png)
+
+This continues until we are done.
+
+![EWMA Step N](https://user-images.githubusercontent.com/279875/28242352-464c58f0-6977-11e7-8cd0-e01e4efaac7f.png)
+
+Notice how each of the values in the series decays by half each time a new value
+is added, and the top of the bars in the lower portion of the image represents the
+size of the moving average. It is a smoothed, or low-pass, average of the original
+series.
+
+For further reading, see [Exponentially weighted moving average](http://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average) on wikipedia.
+
+### Choosing Alpha
+
+Consider a fixed-size sliding-window moving average (not an exponentially weighted moving average)
+that averages over the previous N samples. What is the average age of each sample? It is N/2.
+
+Now suppose that you wish to construct a EWMA whose samples have the same average age. The formula
+to compute the alpha required for this is: alpha = 2/(N+1). Proof is in the book
+"Production and Operations Analysis" by Steven Nahmias.
+
+So, for example, if you have a time-series with samples once per second, and you want to get the
+moving average over the previous minute, you should use an alpha of .032786885. This, by the way,
+is the constant alpha used for this repository's SimpleEWMA.
+
+### Implementations
+
+This repository contains two implementations of the EWMA algorithm, with different properties.
+
+The implementations all conform to the MovingAverage interface, and the constructor returns
+that type.
+
+Current implementations assume an implicit time interval of 1.0 between every sample added.
+That is, the passage of time is treated as though it's the same as the arrival of samples.
+If you need time-based decay when samples are not arriving precisely at set intervals, then
+this package will not support your needs at present.
+
+#### SimpleEWMA
+
+A SimpleEWMA is designed for low CPU and memory consumption. It **will** have different behavior than the VariableEWMA
+for multiple reasons. It has no warm-up period and it uses a constant
+decay.  These properties let it use less memory.  It will also behave
+differently when it's equal to zero, which is assumed to mean
+uninitialized, so if a value is likely to actually become zero over time,
+then any non-zero value will cause a sharp jump instead of a small change.
+
+#### VariableEWMA
+
+Unlike SimpleEWMA, this supports a custom age which must be stored, and thus uses more memory.
+It also has a "warmup" time when you start adding values to it. It will report a value of 0.0
+until you have added the required number of samples to it. It uses some memory to store the
+number of samples added to it. As a result it uses a little over twice the memory of SimpleEWMA.
+
+## Usage
+
+### API Documentation
+
+View the GoDoc generated documentation [here](http://godoc.org/github.com/VividCortex/ewma).
+
+```go
+package main
+
+import "github.com/VividCortex/ewma"
+
+func main() {
+	samples := [100]float64{
+		4599, 5711, 4746, 4621, 5037, 4218, 4925, 4281, 5207, 5203, 5594, 5149,
+	}
+
+	e := ewma.NewMovingAverage()  //=> Returns a SimpleEWMA if called without params
+	a := ewma.NewMovingAverage(5) //=> returns a VariableEWMA with a decay of 2 / (5 + 1)
+
+	for _, f := range samples {
+		e.Add(f)
+		a.Add(f)
+	}
+
+	e.Value() //=> 13.577404704631077
+	a.Value() //=> 1.5806140565521463e-12
+}
+```
+
+## Contributing
+
+We only accept pull requests for minor fixes or improvements. This includes:
+
+* Small bug fixes
+* Typos
+* Documentation or comments
+
+Please open issues to discuss new features. Pull requests for new features will be rejected,
+so we recommend forking the repository and making changes in your fork for your use case.
+
+## License
+
+This repository is Copyright (c) 2013 VividCortex, Inc. All rights reserved.
+It is licensed under the MIT license. Please see the LICENSE file for applicable license terms.

--- a/vendor/github.com/VividCortex/ewma/codecov.yml
+++ b/vendor/github.com/VividCortex/ewma/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 15%
+    patch: off

--- a/vendor/github.com/VividCortex/ewma/ewma.go
+++ b/vendor/github.com/VividCortex/ewma/ewma.go
@@ -1,0 +1,126 @@
+// Package ewma implements exponentially weighted moving averages.
+package ewma
+
+// Copyright (c) 2013 VividCortex, Inc. All rights reserved.
+// Please see the LICENSE file for applicable license terms.
+
+const (
+	// By default, we average over a one-minute period, which means the average
+	// age of the metrics in the period is 30 seconds.
+	AVG_METRIC_AGE float64 = 30.0
+
+	// The formula for computing the decay factor from the average age comes
+	// from "Production and Operations Analysis" by Steven Nahmias.
+	DECAY float64 = 2 / (float64(AVG_METRIC_AGE) + 1)
+
+	// For best results, the moving average should not be initialized to the
+	// samples it sees immediately. The book "Production and Operations
+	// Analysis" by Steven Nahmias suggests initializing the moving average to
+	// the mean of the first 10 samples. Until the VariableEwma has seen this
+	// many samples, it is not "ready" to be queried for the value of the
+	// moving average. This adds some memory cost.
+	WARMUP_SAMPLES uint8 = 10
+)
+
+// MovingAverage is the interface that computes a moving average over a time-
+// series stream of numbers. The average may be over a window or exponentially
+// decaying.
+type MovingAverage interface {
+	Add(float64)
+	Value() float64
+	Set(float64)
+}
+
+// NewMovingAverage constructs a MovingAverage that computes an average with the
+// desired characteristics in the moving window or exponential decay. If no
+// age is given, it constructs a default exponentially weighted implementation
+// that consumes minimal memory. The age is related to the decay factor alpha
+// by the formula given for the DECAY constant. It signifies the average age
+// of the samples as time goes to infinity.
+func NewMovingAverage(age ...float64) MovingAverage {
+	if len(age) == 0 || age[0] == AVG_METRIC_AGE {
+		return new(SimpleEWMA)
+	}
+	return &VariableEWMA{
+		decay: 2 / (age[0] + 1),
+	}
+}
+
+// A SimpleEWMA represents the exponentially weighted moving average of a
+// series of numbers. It WILL have different behavior than the VariableEWMA
+// for multiple reasons. It has no warm-up period and it uses a constant
+// decay.  These properties let it use less memory.  It will also behave
+// differently when it's equal to zero, which is assumed to mean
+// uninitialized, so if a value is likely to actually become zero over time,
+// then any non-zero value will cause a sharp jump instead of a small change.
+// However, note that this takes a long time, and the value may just
+// decays to a stable value that's close to zero, but which won't be mistaken
+// for uninitialized. See http://play.golang.org/p/litxBDr_RC for example.
+type SimpleEWMA struct {
+	// The current value of the average. After adding with Add(), this is
+	// updated to reflect the average of all values seen thus far.
+	value float64
+}
+
+// Add adds a value to the series and updates the moving average.
+func (e *SimpleEWMA) Add(value float64) {
+	if e.value == 0 { // this is a proxy for "uninitialized"
+		e.value = value
+	} else {
+		e.value = (value * DECAY) + (e.value * (1 - DECAY))
+	}
+}
+
+// Value returns the current value of the moving average.
+func (e *SimpleEWMA) Value() float64 {
+	return e.value
+}
+
+// Set sets the EWMA's value.
+func (e *SimpleEWMA) Set(value float64) {
+	e.value = value
+}
+
+// VariableEWMA represents the exponentially weighted moving average of a series of
+// numbers. Unlike SimpleEWMA, it supports a custom age, and thus uses more memory.
+type VariableEWMA struct {
+	// The multiplier factor by which the previous samples decay.
+	decay float64
+	// The current value of the average.
+	value float64
+	// The number of samples added to this instance.
+	count uint8
+}
+
+// Add adds a value to the series and updates the moving average.
+func (e *VariableEWMA) Add(value float64) {
+	switch {
+	case e.count < WARMUP_SAMPLES:
+		e.count++
+		e.value += value
+	case e.count == WARMUP_SAMPLES:
+		e.count++
+		e.value = e.value / float64(WARMUP_SAMPLES)
+		e.value = (value * e.decay) + (e.value * (1 - e.decay))
+	default:
+		e.value = (value * e.decay) + (e.value * (1 - e.decay))
+	}
+}
+
+// Value returns the current value of the average, or 0.0 if the series hasn't
+// warmed up yet.
+func (e *VariableEWMA) Value() float64 {
+	if e.count <= WARMUP_SAMPLES {
+		return 0.0
+	}
+
+	return e.value
+}
+
+// Set sets the EWMA's value.
+func (e *VariableEWMA) Set(value float64) {
+	e.value = value
+	if e.count <= WARMUP_SAMPLES {
+		e.count = WARMUP_SAMPLES + 1
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,6 +95,9 @@ github.com/AzureAD/microsoft-authentication-library-for-go/apps/public
 github.com/DmitriyVTitov/size
 # github.com/HdrHistogram/hdrhistogram-go v1.1.2
 ## explicit; go 1.14
+# github.com/VividCortex/ewma v1.2.0
+## explicit; go 1.12
+github.com/VividCortex/ewma
 # github.com/alecthomas/chroma v0.10.0
 ## explicit; go 1.13
 github.com/alecthomas/chroma


### PR DESCRIPTION
#### What this PR does
Experimentally add parallel CPU load exponential weighted moving average calculation to the ingester, in order to see how it behaves versus our current one. Also add metrics exposing the average CPU load calculations (normal and alternate). Discussed with @pracucci in chat (who suggested exposing metrics for easier observation).

**I don't plan to merge this PR**, instead I want to test this change in our cloud.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
