### PR TITLE
copyblocks: add support for S3-compatible buckets and object storage migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 
 ### Tools
 
-* [CHANGE] copyblocks: add support for S3, as well as the ability to copy between the same or different object storage services. Due to this, the `-source-service` and `-destination-service` flags are now required and the `-service` flag has been removed. #5486
+* [CHANGE] copyblocks: add support for S3 and the ability to copy between different object storage services. Due to this, the `-source-service` and `-destination-service` flags are now required and the `-service` flag has been removed. #5486
 * [BUGFIX] Stop tools from panicking when `-help` flag is passed. #5412
 * [BUGFIX] Remove github.com/golang/glog command line flags from tools. #5413
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 
 ### Tools
 
+* [CHANGE] copyblocks: support for S3 was added as well as the ability to client-side copy between the same or different object storage services. Due to this, the tool now requires `-source-service` and `-destination-service` instead of `-service`. #5486
 * [BUGFIX] Stop tools from panicking when `-help` flag is passed. #5412
 * [BUGFIX] Remove github.com/golang/glog command line flags from tools. #5413
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 
 ### Tools
 
-* [CHANGE] copyblocks: support for S3 was added as well as the ability to client-side copy between the same or different object storage services. Due to this, the tool now requires `-source-service` and `-destination-service` instead of `-service`. #5486
+* [CHANGE] copyblocks: add support for S3, as well as the ability to copy between the same or different object storage services. Due to this, the `-source-service` and `-destination-service` flags are now required and the `-service` flag has been removed. #5486
 * [BUGFIX] Stop tools from panicking when `-help` flag is passed. #5412
 * [BUGFIX] Remove github.com/golang/glog command line flags from tools. #5413
 

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -1,7 +1,8 @@
 # Copyblocks
 
-This program can copy Mimir blocks server-side between two buckets on the same object storage service provider.
-The currently supported services are Google Cloud Storage (GCS) and Azure Blob Storage (ABS).
+This program can copy Mimir blocks between two buckets. By default the copy will be performed server-side if both buckets are on the same object storage service provider. If the buckets are on different object storage providers, or if `--client-side-copy` is passed, then the copy will be performed client side.
+
+The currently supported services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS).
 
 ## Features
 
@@ -16,24 +17,67 @@ The currently supported services are Google Cloud Storage (GCS) and Azure Blob S
 
 ```bash
 ./copyblocks \
-  --service gcs \
+  --source-service gcs \
+  --destination-service gcs \
   --copy-period 24h \
+  --min-block-duration 23h \
   --source-bucket <source bucket name> \
-  --destination-bucket <destination bucket name> \
-  --min-block-duration 23h
+  --destination-bucket <destination bucket name>
 ```
 
 ### Example for Azure Blob Storage
 
 ```bash
 ./copyblocks \
-  --service abs \
+  --source-service abs \
+  --destination-service abs \
   --copy-period 24h \
+  --min-block-duration 23h \
   --source-bucket https://<source account name>.blob.core.windows.net/<source bucket name> \
   --azure-source-account-name <source account name> \
   --azure-source-account-key <source account key> \
   --destination-bucket https://<destination account name>.blob.core.windows.net/<destination bucket name> \
   --azure-destination-account-name <destination account name> \
-  --azure-destination-account-key <destination account key> \
-  --min-block-duration 23h
+  --azure-destination-account-key <destination account key>
+```
+
+### Example for Amazon Simple Storage Service
+
+The destination credentials are used to intiate the server-side copy which may require setting up additional permissions for the copy to have access the source bucket. Consider passing `--client-side-copy` if you would rather avoid that.
+
+```bash
+./copyblocks \
+  --source-service s3 \
+  --destination-service s3 \
+  --copy-period 24h \
+  --min-block-duration 23h \
+  --source-bucket <source bucket name> \
+  --s3-source-access-key <source access key> \
+  --s3-source-secret-key <source secret key> \
+  --s3-source-endpoint <source endpoint> \
+  --destination-bucket <destination bucket name> \
+  --s3-destination-access-key <destination access key> \
+  --s3-destination-secret-key <destination secret key> \
+  --s3-destination-endpoint <destination endpoint>
+```
+
+### Example for copying between different providers
+
+Combine the relavant source and destination configuration options using the above examples as a guide.
+
+For instance, to copy from S3 to ABS:
+
+```bash
+./copyblocks \
+  --source-service s3 \
+  --destination-service abs \
+  --copy-period 24h \
+  --min-block-duration 23h \
+  --source-bucket <source bucket name> \
+  --s3-source-access-key <source access key> \
+  --s3-source-secret-key <source secret key> \
+  --s3-source-endpoint <source endpoint> \
+  --destination-bucket https://<destination account name>.blob.core.windows.net/<destination bucket name> \
+  --azure-destination-account-name <destination account name> \
+  --azure-destination-account-key <destination account key>
 ```

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -1,6 +1,8 @@
 # Copyblocks
 
-This program can copy Mimir blocks between two buckets. By default the copy will be performed server-side if both buckets are on the same object storage service provider. If the buckets are on different object storage providers, or if `--client-side-copy` is passed, then the copy will be performed client side.
+This program can copy Mimir blocks between two buckets.
+
+By default, the copy will be attempted server-side if both buckets are on the same object storage service. If the buckets are on different object storage services, or if `--client-side-copy` is passed, then the copy will be performed client side.
 
 The currently supported services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS).
 
@@ -43,7 +45,8 @@ The currently supported services are Amazon Simple Storage Service (S3 and S3-co
 
 ### Example for Amazon Simple Storage Service
 
-The destination credentials are used to intiate the server-side copy which may require setting up additional permissions for the copy to have access the source bucket. Consider passing `--client-side-copy` if you would rather avoid that.
+The destination is called to intiate the server-side copy which may require setting up additional permissions for the copy to have access the source bucket.
+Consider passing `--client-side-copy` to avoid having to deal with that.
 
 ```bash
 ./copyblocks \
@@ -64,7 +67,6 @@ The destination credentials are used to intiate the server-side copy which may r
 ### Example for copying between different providers
 
 Combine the relavant source and destination configuration options using the above examples as a guide.
-
 For instance, to copy from S3 to ABS:
 
 ```bash

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -2,7 +2,7 @@
 
 This program can copy Mimir blocks between two buckets.
 
-By default, the copy will be attempted server-side if both buckets are on the same object storage service. If the buckets are on different object storage services, or if `--client-side-copy` is passed, then the copy will be performed client side.
+By default, the copy will be attempted server-side if both the source and destination specify the same object storage service. If the buckets are on different object storage services, or if `--client-side-copy` is passed, then the copy will be performed client side.
 
 The currently supported services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS).
 

--- a/tools/copyblocks/abs.go
+++ b/tools/copyblocks/abs.go
@@ -51,16 +51,16 @@ type azureClientConfig struct {
 }
 
 func (c *azureClientConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
-	f.StringVar(&c.accountName, prefix+"account-name", "", "Account name for the azure bucket.")
-	f.StringVar(&c.accountKey, prefix+"account-key", "", "Account key for the azure bucket.")
+	f.StringVar(&c.accountName, prefix+"account-name", "", "Account name for the Azure bucket.")
+	f.StringVar(&c.accountKey, prefix+"account-key", "", "Account key for the Azure bucket.")
 }
 
 func (c *azureClientConfig) validate(prefix string) error {
 	if c.accountName == "" {
-		return fmt.Errorf("the azure bucket's account name (%s) is required", prefix+"account-name")
+		return fmt.Errorf("the Azure bucket's account name (%s) is required", prefix+"account-name")
 	}
 	if c.accountKey == "" {
-		return fmt.Errorf("the azure bucket's account key (%s) is required", prefix+"account-key")
+		return fmt.Errorf("the Azure bucket's account key (%s) is required", prefix+"account-key")
 	}
 	return nil
 }
@@ -79,15 +79,15 @@ func newAzureBucketClient(cfg azureClientConfig, containerURL string, backoffCfg
 	}
 	containerName := urlParts.ContainerName
 	if containerName == "" {
-		return nil, errors.New("container name missing from azure bucket URL")
+		return nil, errors.New("container name missing from Azure bucket URL")
 	}
 	serviceURL, found := strings.CutSuffix(containerURL, containerName)
 	if !found {
-		return nil, errors.New("malformed or unexpected azure bucket URL")
+		return nil, errors.New("malformed or unexpected Azure bucket URL")
 	}
 	keyCred, err := azblob.NewSharedKeyCredential(cfg.accountName, cfg.accountKey)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get azure shared key credential")
+		return nil, errors.Wrapf(err, "failed to get Azure shared key credential")
 	}
 	client, err := azblob.NewClientWithSharedKeyCredential(serviceURL, keyCred, nil)
 	if err != nil {
@@ -118,7 +118,7 @@ func (bkt *azureBucket) ServerSideCopy(ctx context.Context, objectName string, d
 	sourceClient := bkt.containerClient.NewBlobClient(objectName)
 	d, ok := dstBucket.(*azureBucket)
 	if !ok {
-		return errors.New("destination bucket wasn't a blob storage bucket")
+		return errors.New("destination bucket wasn't an Azure bucket")
 	}
 	dstClient := d.containerClient.NewBlobClient(objectName)
 
@@ -197,17 +197,17 @@ func (bkt *azureBucket) ClientSideCopy(ctx context.Context, objectName string, d
 	sourceClient := bkt.containerClient.NewBlobClient(objectName)
 	response, err := sourceClient.DownloadStream(ctx, nil)
 	if err != nil {
-		return errors.Wrap(err, "failed while getting source object from azure")
+		return errors.Wrap(err, "failed while getting source object from Azure")
 	}
 	if response.ContentLength == nil {
-		return errors.New("source object from azure did not contain a content length")
+		return errors.New("source object from Azure did not contain a content length")
 	}
 	body := response.DownloadResponse.Body
 	if err := dstBucket.Upload(ctx, objectName, body, *response.ContentLength); err != nil {
 		_ = body.Close()
-		return errors.New("failed uploading source object from azure to destination")
+		return errors.New("failed uploading source object from Azure to destination")
 	}
-	return errors.Wrap(body.Close(), "failed closing azure source object reader")
+	return errors.Wrap(body.Close(), "failed closing Azure source object reader")
 }
 
 func (bkt *azureBucket) ListPrefix(ctx context.Context, prefix string, recursive bool) ([]string, error) {

--- a/tools/copyblocks/gcs.go
+++ b/tools/copyblocks/gcs.go
@@ -36,7 +36,7 @@ func (bkt *gcsBucket) Get(ctx context.Context, objectName string) (io.ReadCloser
 func (bkt *gcsBucket) ServerSideCopy(ctx context.Context, objectName string, dstBucket bucket) error {
 	d, ok := dstBucket.(*gcsBucket)
 	if !ok {
-		return errors.New("destination bucket wasn't a gcs bucket")
+		return errors.New("destination bucket wasn't a GCS bucket")
 	}
 	srcObj := bkt.Object(objectName)
 	dstObject := d.BucketHandle.Object(objectName)
@@ -49,13 +49,13 @@ func (bkt *gcsBucket) ClientSideCopy(ctx context.Context, objectName string, dst
 	srcObj := bkt.Object(objectName)
 	reader, err := srcObj.NewReader(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get gcs source object reader")
+		return errors.Wrap(err, "failed to get GCS source object reader")
 	}
 	if err := dstBucket.Upload(ctx, objectName, reader, reader.Attrs.Size); err != nil {
 		_ = reader.Close()
-		return errors.Wrap(err, "failed to upload gcs source object to destination")
+		return errors.Wrap(err, "failed to upload GCS source object to destination")
 	}
-	return errors.Wrap(reader.Close(), "failed closing gcs source object reader")
+	return errors.Wrap(reader.Close(), "failed closing GCS source object reader")
 }
 
 func (bkt *gcsBucket) ListPrefix(ctx context.Context, prefix string, recursive bool) ([]string, error) {

--- a/tools/copyblocks/gcs.go
+++ b/tools/copyblocks/gcs.go
@@ -33,7 +33,7 @@ func (bkt *gcsBucket) Get(ctx context.Context, objectName string) (io.ReadCloser
 	return r, nil
 }
 
-func (bkt *gcsBucket) Copy(ctx context.Context, objectName string, dstBucket bucket) error {
+func (bkt *gcsBucket) ServerSideCopy(ctx context.Context, objectName string, dstBucket bucket) error {
 	d, ok := dstBucket.(*gcsBucket)
 	if !ok {
 		return errors.New("destination bucket wasn't a gcs bucket")
@@ -43,6 +43,19 @@ func (bkt *gcsBucket) Copy(ctx context.Context, objectName string, dstBucket buc
 	copier := dstObject.CopierFrom(srcObj)
 	_, err := copier.Run(ctx)
 	return err
+}
+
+func (bkt *gcsBucket) ClientSideCopy(ctx context.Context, objectName string, dstBucket bucket) error {
+	srcObj := bkt.Object(objectName)
+	reader, err := srcObj.NewReader(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get gcs source object reader")
+	}
+	if err := dstBucket.Upload(ctx, objectName, reader, reader.Attrs.Size); err != nil {
+		_ = reader.Close()
+		return errors.Wrap(err, "failed to upload gcs source object to destination")
+	}
+	return errors.Wrap(reader.Close(), "failed closing gcs source object reader")
 }
 
 func (bkt *gcsBucket) ListPrefix(ctx context.Context, prefix string, recursive bool) ([]string, error) {
@@ -90,9 +103,19 @@ func (bkt *gcsBucket) ListPrefix(ctx context.Context, prefix string, recursive b
 	return result, nil
 }
 
-func (bkt *gcsBucket) UploadMarkerFile(ctx context.Context, objectName string) error {
+func (bkt *gcsBucket) Upload(ctx context.Context, objectName string, reader io.Reader, contentLength int64) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	obj := bkt.Object(objectName)
 	w := obj.NewWriter(ctx)
+	n, err := io.Copy(w, reader)
+	if err != nil {
+		return errors.Wrap(err, "failed during copy stage of GCS upload")
+	}
+	if n != contentLength {
+		return errors.Wrapf(err, "unexpected content length from copy: expected=%d, actual=%d", contentLength, n)
+	}
 	return w.Close()
 }
 

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -86,7 +86,7 @@ func (c *config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&c.copyPeriod, "copy-period", 0, "How often to repeat the copy. If set to 0, copy is done once, and the program stops. Otherwise, the program keeps running and copying blocks until it is terminated.")
 	f.Var(&c.enabledUsers, "enabled-users", "If not empty, only blocks for these users are copied.")
 	f.Var(&c.disabledUsers, "disabled-users", "If not empty, blocks for these users are not copied.")
-	f.BoolVar(&c.dryRun, "dry-run", false, "Don't perform copy; only log what would happen.")
+	f.BoolVar(&c.dryRun, "dry-run", false, "Don't perform any copy; only log what would happen.")
 	f.BoolVar(&c.clientSideCopy, "client-side-copy", false, "Use client side copying. This option is only respected if copying between two buckets of the same service. Client side copying is always used when copying between different services.")
 	f.StringVar(&c.httpListen, "http-listen-address", ":8080", "HTTP listen address.")
 	c.azureConfig.RegisterFlags(f)
@@ -169,11 +169,17 @@ func main() {
 }
 
 func initializeBuckets(ctx context.Context, cfg config) (sourceBucket bucket, destBucket bucket, err error) {
-	if cfg.sourceService == "" || cfg.destinationService == "" {
-		return nil, nil, errors.New("--source-service or --destination-service is missing")
+	if cfg.sourceService == "" {
+		return nil, nil, errors.New("--source-service is missing")
 	}
-	if cfg.sourceBucket == "" || cfg.destBucket == "" {
-		return nil, nil, errors.New("--source-bucket or --destination-bucket is missing")
+	if cfg.destinationService == "" {
+		return nil, nil, errors.New("--destination-service is missing")
+	}
+	if cfg.sourceBucket == "" {
+		return nil, nil, errors.New("--source-bucket is missing")
+	}
+	if cfg.destBucket == "" {
+		return nil, nil, errors.New("--destination-bucket is missing")
 	}
 	if cfg.sourceBucket == cfg.destBucket {
 		return nil, nil, errors.New("--source-bucket and --destination-bucket can not be the same")

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -74,7 +74,7 @@ type config struct {
 
 func (c *config) RegisterFlags(f *flag.FlagSet) {
 	acceptedServices := fmt.Sprintf(" Accepted values: %s, %s or %s.", serviceABS, serviceGCS, serviceS3)
-	f.StringVar(&c.sourceService, "source-service", "", "Service that the source buckets is on."+acceptedServices)
+	f.StringVar(&c.sourceService, "source-service", "", "Service that the source bucket is on."+acceptedServices)
 	f.StringVar(&c.destinationService, "destination-service", "", "Service that the destination bucket is on."+acceptedServices)
 	f.StringVar(&c.sourceBucket, "source-bucket", "", "Source bucket with blocks.")
 	f.StringVar(&c.destBucket, "destination-bucket", "", "Destination bucket with blocks.")
@@ -87,7 +87,7 @@ func (c *config) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&c.enabledUsers, "enabled-users", "If not empty, only blocks for these users are copied.")
 	f.Var(&c.disabledUsers, "disabled-users", "If not empty, blocks for these users are not copied.")
 	f.BoolVar(&c.dryRun, "dry-run", false, "Don't perform copy; only log what would happen.")
-	f.BoolVar(&c.clientSideCopy, "client-side-copy", false, "Use client side copying. This option is only respected if copying between two buckets of the same service, otherwise it is assumed to be true.")
+	f.BoolVar(&c.clientSideCopy, "client-side-copy", false, "Use client side copying. This option is only respected if copying between two buckets of the same service. Client side copying is always used when copying between different services.")
 	f.StringVar(&c.httpListen, "http-listen-address", ":8080", "HTTP listen address.")
 	c.azureConfig.RegisterFlags(f)
 	c.s3Config.RegisterFlags(f)

--- a/tools/copyblocks/s3.go
+++ b/tools/copyblocks/s3.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io"
+	"strings"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/pkg/errors"
+)
+
+type s3Config struct {
+	source      s3ClientConfig
+	destination s3ClientConfig
+}
+
+func (c *s3Config) RegisterFlags(f *flag.FlagSet) {
+	c.source.RegisterFlags("s3-source-", f)
+	c.destination.RegisterFlags("s3-destination-", f)
+}
+
+func (c *s3Config) validate(source, destination string) error {
+	if source == serviceS3 {
+		if err := c.source.validate("s3-source-"); err != nil {
+			return err
+		}
+	}
+	if destination == serviceS3 {
+		return c.destination.validate("s3-destination-")
+	}
+	return nil
+}
+
+type s3ClientConfig struct {
+	endpoint  string
+	accessKey string
+	secretKey string
+	secure    bool
+}
+
+func (c *s3ClientConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
+	f.StringVar(&c.endpoint, prefix+"endpoint", "", "The endpoint to contact when accessing the bucket.")
+	f.StringVar(&c.accessKey, prefix+"access-key", "", "The access key used in AWSV4 Authorization.")
+	f.StringVar(&c.secretKey, prefix+"secret-key", "", "The secret key used in AWSV4 Authorization.")
+	f.BoolVar(&c.secure, prefix+"secure", true, "The default value true corresponds to using https, otherwise uses http.")
+}
+
+func (c *s3ClientConfig) validate(prefix string) error {
+	if c.endpoint == "" {
+		return errors.New(prefix + "endpoint is missing")
+	}
+	if c.accessKey == "" {
+		return errors.New(prefix + "access-key is missing")
+	}
+	if c.secretKey == "" {
+		return errors.New(prefix + "secret-key is missing")
+	}
+	return nil
+}
+
+type s3Bucket struct {
+	*minio.Client
+	bucketName string
+}
+
+func newS3Client(cfg s3ClientConfig, bucketName string) (bucket, error) {
+	client, err := minio.New(cfg.endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(cfg.accessKey, cfg.secretKey, ""),
+		Secure: cfg.secure,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &s3Bucket{
+		Client:     client,
+		bucketName: bucketName,
+	}, nil
+}
+
+func (bkt *s3Bucket) Get(ctx context.Context, objectName string) (io.ReadCloser, error) {
+	obj, err := bkt.GetObject(ctx, bkt.bucketName, objectName, minio.GetObjectOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (bkt *s3Bucket) ServerSideCopy(ctx context.Context, objectName string, dstBucket bucket) error {
+	d, ok := dstBucket.(*s3Bucket)
+	if !ok {
+		return errors.New("destination bucket wasn't an s3 bucket")
+	}
+	_, err := d.CopyObject(ctx,
+		minio.CopyDestOptions{
+			Bucket: d.bucketName,
+			Object: objectName,
+		},
+		minio.CopySrcOptions{
+			Bucket: bkt.bucketName,
+			Object: objectName,
+		},
+	)
+	return err
+}
+
+func (bkt *s3Bucket) ClientSideCopy(ctx context.Context, objectName string, dstBucket bucket) error {
+	obj, err := bkt.GetObject(ctx, bkt.bucketName, objectName, minio.GetObjectOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to get source object from s3")
+	}
+	objInfo, err := obj.Stat()
+	if err != nil {
+		return errors.Wrap(err, "failed to get source object information from s3")
+	}
+	if err := dstBucket.Upload(ctx, objectName, obj, objInfo.Size); err != nil {
+		_ = obj.Close()
+		return errors.Wrap(err, "failed to upload source object from s3 to destination")
+	}
+	return errors.Wrap(obj.Close(), "failed to close source object reader from s3")
+}
+
+func (bkt *s3Bucket) ListPrefix(ctx context.Context, prefix string, recursive bool) ([]string, error) {
+	if prefix != "" && !strings.HasSuffix(prefix, delim) {
+		prefix = prefix + delim
+	}
+	options := minio.ListObjectsOptions{
+		Prefix:    prefix,
+		Recursive: recursive,
+	}
+	result := make([]string, 0, 10)
+	objects := bkt.ListObjects(ctx, bkt.bucketName, options)
+	for obj := range objects {
+		if obj.Err != nil {
+			return nil, obj.Err
+		}
+		result = append(result, obj.Key)
+	}
+	return result, ctx.Err()
+}
+
+func (bkt *s3Bucket) Upload(ctx context.Context, objectName string, reader io.Reader, contentLength int64) error {
+	_, err := bkt.PutObject(ctx, bkt.bucketName, objectName, reader, contentLength, minio.PutObjectOptions{})
+	return err
+}
+
+func (bkt *s3Bucket) Name() string {
+	return bkt.bucketName
+}

--- a/tools/copyblocks/s3.go
+++ b/tools/copyblocks/s3.go
@@ -46,7 +46,7 @@ func (c *s3ClientConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.endpoint, prefix+"endpoint", "", "The endpoint to contact when accessing the bucket.")
 	f.StringVar(&c.accessKey, prefix+"access-key", "", "The access key used in AWSV4 Authorization.")
 	f.StringVar(&c.secretKey, prefix+"secret-key", "", "The secret key used in AWSV4 Authorization.")
-	f.BoolVar(&c.secure, prefix+"secure", true, "The default value true corresponds to using https, otherwise uses http.")
+	f.BoolVar(&c.secure, prefix+"secure", true, "If true (default), use HTTPS when connecting to the bucket. If false, insecure HTTP is used.")
 }
 
 func (c *s3ClientConfig) validate(prefix string) error {

--- a/tools/copyblocks/s3.go
+++ b/tools/copyblocks/s3.go
@@ -137,7 +137,13 @@ func (bkt *s3Bucket) ListPrefix(ctx context.Context, prefix string, recursive bo
 		if obj.Err != nil {
 			return nil, obj.Err
 		}
-		result = append(result, obj.Key)
+		key := obj.Key
+		if strings.HasPrefix(key, prefix) {
+			key = strings.TrimPrefix(key, prefix)
+		} else {
+			return nil, errors.Errorf("listPrefix: path has invalid prefix: %v, expected prefix: %v", key, prefix)
+		}
+		result = append(result, key)
 	}
 	return result, ctx.Err()
 }

--- a/tools/copyblocks/s3.go
+++ b/tools/copyblocks/s3.go
@@ -44,8 +44,8 @@ type s3ClientConfig struct {
 
 func (c *s3ClientConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.endpoint, prefix+"endpoint", "", "The endpoint to contact when accessing the bucket.")
-	f.StringVar(&c.accessKey, prefix+"access-key", "", "The access key used in AWSV4 Authorization.")
-	f.StringVar(&c.secretKey, prefix+"secret-key", "", "The secret key used in AWSV4 Authorization.")
+	f.StringVar(&c.accessKey, prefix+"access-key", "", "The access key used in AWS Signature Version 4 authentication.")
+	f.StringVar(&c.secretKey, prefix+"secret-key", "", "The secret key used in AWS Signature Version 4 authentication.")
 	f.BoolVar(&c.secure, prefix+"secure", true, "If true (default), use HTTPS when connecting to the bucket. If false, insecure HTTP is used.")
 }
 
@@ -92,7 +92,7 @@ func (bkt *s3Bucket) Get(ctx context.Context, objectName string) (io.ReadCloser,
 func (bkt *s3Bucket) ServerSideCopy(ctx context.Context, objectName string, dstBucket bucket) error {
 	d, ok := dstBucket.(*s3Bucket)
 	if !ok {
-		return errors.New("destination bucket wasn't an s3 bucket")
+		return errors.New("destination bucket wasn't an S3 bucket")
 	}
 	_, err := d.CopyObject(ctx,
 		minio.CopyDestOptions{
@@ -110,17 +110,17 @@ func (bkt *s3Bucket) ServerSideCopy(ctx context.Context, objectName string, dstB
 func (bkt *s3Bucket) ClientSideCopy(ctx context.Context, objectName string, dstBucket bucket) error {
 	obj, err := bkt.GetObject(ctx, bkt.bucketName, objectName, minio.GetObjectOptions{})
 	if err != nil {
-		return errors.Wrap(err, "failed to get source object from s3")
+		return errors.Wrap(err, "failed to get source object from S3")
 	}
 	objInfo, err := obj.Stat()
 	if err != nil {
-		return errors.Wrap(err, "failed to get source object information from s3")
+		return errors.Wrap(err, "failed to get source object information from S3")
 	}
 	if err := dstBucket.Upload(ctx, objectName, obj, objInfo.Size); err != nil {
 		_ = obj.Close()
-		return errors.Wrap(err, "failed to upload source object from s3 to destination")
+		return errors.Wrap(err, "failed to upload source object from S3 to destination")
 	}
-	return errors.Wrap(obj.Close(), "failed to close source object reader from s3")
+	return errors.Wrap(obj.Close(), "failed to close source object reader from S3")
 }
 
 func (bkt *s3Bucket) ListPrefix(ctx context.Context, prefix string, recursive bool) ([]string, error) {


### PR DESCRIPTION
#### What this PR does

copyblocks currently supports `GCS->GCS` and `ABS->ABS` server-side copies. This change adds:

- `S3->S3` server-side copy support
- client-side copy support for copies to be performed across services (source GET chained to destination PUT)
- the ability to toggle between server-side copies and client-side copies if both buckets are on the same service 

so the new support looks like `{ABS, GCS, S3} -> {ABS, GCS, S3}`.

Notably `--service` was replaced with `--source-service` and `--destination-service`, since the services may not be the same.

~I have not finished testing these changes against real buckets yet, so I'm opening this as a draft.~

Tests Performed:

- [x] S3->GCS
- [x] GCS->S3
- [x] S3->ABS
- [x] ABS->S3
- [x] S3->S3 (client-side)
- [x] S3->S3 (server-side, tested locally with minio due to permissions)

The goal of this testing was line coverage by having each service be both a source and a destination in client-side copies and to exercise that the S3 client expects to be passed a correct content length during `Upload`.

#### Which issue(s) this PR fixes or relates to

Fixes: N/A

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
