### PR TITLE
Default to shared crosshair in dashboards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [CHANGE] Dashboards: show all workloads in selected namespace on "rollout progress" dashboard. #5113
 * [CHANGE] Dashboards: show the number of updated and ready pods for each workload in the "rollout progress" panel on the "rollout progress" dashboard. #5113
 * [CHANGE] Dashboards: removed "Query results cache misses" panel on the "Mimir / Queries" dashboard. #5423
+* [CHANGE] Dashboards: default to shared crosshair on all dashboards. #5489
 * [ENHANCEMENT] Dashboards: adjust layout of "rollout progress" dashboard panels so that the "rollout progress" panel doesn't require scrolling. #5113
 * [ENHANCEMENT] Dashboards: show container name first in "pods count per version" panel on "rollout progress" dashboard. #5113
 * [ENHANCEMENT] Dashboards: show time spend waiting for turn when lazy loading index headers in the "index-header lazy load gate latency" panel on the "queries" dashboard. #5313

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -28,7 +28,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -892,7 +892,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -3661,7 +3661,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -4632,7 +4632,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -6967,7 +6967,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -7297,7 +7297,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -8273,7 +8273,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -8555,7 +8555,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -9727,7 +9727,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -11073,7 +11073,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -12588,7 +12588,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -15862,7 +15862,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -18054,7 +18054,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -20782,7 +20782,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -25550,7 +25550,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -26590,7 +26590,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -27797,7 +27797,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -29263,7 +29263,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -31933,7 +31933,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -32312,7 +32312,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -32651,7 +32651,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -35331,7 +35331,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -36825,7 +36825,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -37997,7 +37997,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {
@@ -39410,7 +39410,7 @@ data:
           },
           "editable": true,
           "gnetId": null,
-          "graphTooltip": 0,
+          "graphTooltip": 1,
           "hideControls": false,
           "links": [
              {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-config.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-object-store.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overrides.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overrides.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-networking.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-networking.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-rollout-progress.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-scaling.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-scaling.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-top-tenants.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-networking.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-config.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overrides.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview-networking.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-scaling.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -12,7 +12,7 @@
       },
       "editable": true,
       "gnetId": null,
-      "graphTooltip": 0,
+      "graphTooltip": 1,
       "hideControls": false,
       "links": [
          {

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -13,7 +13,7 @@
     // 1: Shared crosshair, the crosshair will appear on all panels but the
     // tooltip will  appear only on the panel under the cursor
     // 2: Shared Tooltip, both crosshair and tooltip will appear on all panels
-    graph_tooltip: 0,
+    graph_tooltip: 1,
 
     // Tags for dashboards.
     tags: ['mimir'],


### PR DESCRIPTION
#### What this PR does

This PR changes the default configuration for dashboards in the mixin to use the shared crosshair by default.

While I realise this is a matter of personal taste, this seems like a reasonable default to me as it makes it much easier to compare data across panels on a single dashboard.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
