### PR TITLE
ingester and distributor: don't log errors that cause OOMs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/spf13/afero v1.9.5
 	github.com/stretchr/testify v1.8.4
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
-	github.com/weaveworks/common v0.0.0-20230511094633-334485600903
+	github.com/weaveworks/common v0.0.0-20230714173453-d1f8877b91ce
 	go.uber.org/atomic v1.11.0
 	go.uber.org/goleak v1.2.1
 	golang.org/x/crypto v0.11.0
@@ -271,3 +271,6 @@ replace github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentraci
 
 // Replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite with a fork until https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/24288 is merged.
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite => github.com/charleskorn/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.0.0-20230717033559-beffb82bb827
+
+// Use a fork of weaveworks/common while we work out if there is a better design for https://github.com/weaveworks/common/pull/293
+replace github.com/weaveworks/common => github.com/weaveworks/common v0.0.0-20230714173453-d1f8877b91ce

--- a/go.sum
+++ b/go.sum
@@ -1264,8 +1264,8 @@ github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
-github.com/weaveworks/common v0.0.0-20230511094633-334485600903 h1:ph7R2CS/0o1gBzpzK/CioUKJVsXNVXfDGR8FZ9rMZIw=
-github.com/weaveworks/common v0.0.0-20230511094633-334485600903/go.mod h1:rgbeLfJUtEr+G74cwFPR1k/4N0kDeaeSv/qhUNE4hm8=
+github.com/weaveworks/common v0.0.0-20230714173453-d1f8877b91ce h1:8Gh0psRT42deLI53RVwLq2idJtRtDbdjhdX5LqnVznU=
+github.com/weaveworks/common v0.0.0-20230714173453-d1f8877b91ce/go.mod h1:rgbeLfJUtEr+G74cwFPR1k/4N0kDeaeSv/qhUNE4hm8=
 github.com/weaveworks/promrus v1.2.0 h1:jOLf6pe6/vss4qGHjXmGz4oDJQA+AOCqEL3FvvZGz7M=
 github.com/weaveworks/promrus v1.2.0/go.mod h1:SaE82+OJ91yqjrE1rsvBWVzNZKcHYFtMUyS1+Ogs/KA=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/instrument"
+	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/mtime"
 	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
@@ -1013,7 +1014,7 @@ func (d *Distributor) limitsMiddleware(next push.Func) push.Func {
 
 		il := d.getInstanceLimits()
 		if il.MaxInflightPushRequests > 0 && inflight > int64(il.MaxInflightPushRequests) {
-			return nil, errMaxInflightRequestsReached
+			return nil, middleware.DoNotLogError{Err: errMaxInflightRequestsReached}
 		}
 
 		if il.MaxIngestionRate > 0 {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -789,7 +789,7 @@ func TestDistributor_PushInstanceLimits(t *testing.T) {
 				if push.expectedError == nil {
 					assert.Nil(t, err)
 				} else {
-					assert.Equal(t, push.expectedError, err)
+					assert.ErrorIs(t, err, push.expectedError)
 				}
 
 				d.ingestionRate.Tick()
@@ -2714,7 +2714,7 @@ func TestInstanceLimitsBeforeHaDedupe(t *testing.T) {
 	// If we HA deduplication runs before instance limits check,
 	// then this would set replica for the cluster.
 	_, err := wrappedMockPush(ctx, push.NewParsedRequest(writeReqReplica1))
-	require.Equal(t, errMaxInflightRequestsReached, err)
+	require.ErrorIs(t, err, errMaxInflightRequestsReached)
 
 	// Simulate no other inflight request.
 	ds[0].inflightPushRequests.Dec()

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -47,6 +47,7 @@ import (
 	"github.com/prometheus/prometheus/util/zeropool"
 	"github.com/thanos-io/objstore"
 	"github.com/weaveworks/common/httpgrpc"
+	"github.com/weaveworks/common/middleware"
 	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
@@ -707,7 +708,7 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, pushReq *push.Request) (
 	defer pushReq.CleanUp()
 
 	if err := i.checkRunning(); err != nil {
-		return nil, err
+		return nil, middleware.DoNotLogError{Err: err}
 	}
 
 	// We will report *this* request in the error too.

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 
 	"github.com/pkg/errors"
+	"github.com/weaveworks/common/middleware"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/util/globalerror"
@@ -26,7 +27,7 @@ var (
 	errMaxIngestionRateReached    = errors.New(globalerror.IngesterMaxIngestionRate.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
 	errMaxTenantsReached          = errors.New(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
 	errMaxInMemorySeriesReached   = errors.New(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
-	errMaxInflightRequestsReached = errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxInflightRequestsReached = middleware.DoNotLogError{Err: errors.New(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))}
 )
 
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return

--- a/vendor/github.com/weaveworks/common/grpc/cancel.go
+++ b/vendor/github.com/weaveworks/common/grpc/cancel.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -9,7 +10,7 @@ import (
 
 // IsCanceled checks whether an error comes from an operation being canceled
 func IsCanceled(err error) bool {
-	if err == context.Canceled {
+	if errors.Is(err, context.Canceled) {
 		return true
 	}
 	s, ok := status.FromError(err)

--- a/vendor/github.com/weaveworks/common/middleware/grpc_logging.go
+++ b/vendor/github.com/weaveworks/common/middleware/grpc_logging.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"time"
 
 	"golang.org/x/net/context"
@@ -30,6 +31,9 @@ func (s GRPCServerLog) UnaryServerInterceptor(ctx context.Context, req interface
 	resp, err := handler(ctx, req)
 	if err == nil && s.DisableRequestSuccessLog {
 		return resp, nil
+	}
+	if errors.Is(err, DoNotLogError{}) {
+		return resp, err
 	}
 
 	entry := user.LogWith(ctx, s.Log).WithFields(logging.Fields{"method": info.FullMethod, "duration": time.Since(begin)})

--- a/vendor/github.com/weaveworks/common/middleware/logging.go
+++ b/vendor/github.com/weaveworks/common/middleware/logging.go
@@ -14,11 +14,12 @@ import (
 
 // Log middleware logs http requests
 type Log struct {
-	Log                   logging.Interface
-	LogRequestHeaders     bool // LogRequestHeaders true -> dump http headers at debug log level
-	LogRequestAtInfoLevel bool // LogRequestAtInfoLevel true -> log requests at info log level
-	SourceIPs             *SourceIPExtractor
-	HttpHeadersToExclude  map[string]bool
+	Log                      logging.Interface
+	DisableRequestSuccessLog bool
+	LogRequestHeaders        bool // LogRequestHeaders true -> dump http headers at debug log level
+	LogRequestAtInfoLevel    bool // LogRequestAtInfoLevel true -> log requests at info log level
+	SourceIPs                *SourceIPExtractor
+	HttpHeadersToExclude     map[string]bool
 }
 
 var defaultExcludedHeaders = map[string]bool{
@@ -44,6 +45,14 @@ func NewLogMiddleware(log logging.Interface, logRequestHeaders bool, logRequestA
 		HttpHeadersToExclude:  httpHeadersToExclude,
 	}
 }
+
+// This can be used with `errors.Is` to see if the error marked itself as not to be logged.
+// E.g. if the error is caused by overload, then we don't want to log it because that uses more resource.
+type DoNotLogError struct{ Err error }
+
+func (i DoNotLogError) Error() string        { return i.Err.Error() }
+func (i DoNotLogError) Unwrap() error        { return i.Err }
+func (i DoNotLogError) Is(target error) bool { _, ok := target.(DoNotLogError); return ok }
 
 // logWithRequest information from the request and context as fields.
 func (l Log) logWithRequest(r *http.Request) logging.Interface {
@@ -82,6 +91,9 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 		statusCode, writeErr := wrapped.getStatusCode(), wrapped.getWriteError()
 
 		if writeErr != nil {
+			if errors.Is(writeErr, DoNotLogError{}) {
+				return
+			}
 			if errors.Is(writeErr, context.Canceled) {
 				if l.LogRequestAtInfoLevel {
 					requestLog.Infof("%s %s %s, request cancelled: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
@@ -94,20 +106,27 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 
 			return
 		}
-		if 100 <= statusCode && statusCode < 500 || statusCode == http.StatusBadGateway || statusCode == http.StatusServiceUnavailable {
+
+		switch {
+		// success and shouldn't log successful requests.
+		case statusCode >= 200 && statusCode < 300 && l.DisableRequestSuccessLog:
+			return
+
+		case 100 <= statusCode && statusCode < 500 || statusCode == http.StatusBadGateway || statusCode == http.StatusServiceUnavailable:
 			if l.LogRequestAtInfoLevel {
 				requestLog.Infof("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
-			} else {
-				requestLog.Debugf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
-			}
-			if l.LogRequestHeaders && headers != nil {
-				if l.LogRequestAtInfoLevel {
+
+				if l.LogRequestHeaders && headers != nil {
 					requestLog.Infof("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
-				} else {
-					requestLog.Debugf("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
 				}
+				return
 			}
-		} else {
+
+			requestLog.Debugf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
+			if l.LogRequestHeaders && headers != nil {
+				requestLog.Debugf("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
+			}
+		default:
 			requestLog.Warnf("%s %s (%d) %s Response: %q ws: %v; %s",
 				r.Method, uri, statusCode, time.Since(begin), buf.Bytes(), IsWSHandshakeRequest(r), headers)
 		}

--- a/vendor/github.com/weaveworks/common/server/metrics.go
+++ b/vendor/github.com/weaveworks/common/server/metrics.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaveworks/common/instrument"
+	"github.com/weaveworks/common/middleware"
+	"time"
+)
+
+type Metrics struct {
+	TcpConnections      *prometheus.GaugeVec
+	TcpConnectionsLimit *prometheus.GaugeVec
+	RequestDuration     *prometheus.HistogramVec
+	ReceivedMessageSize *prometheus.HistogramVec
+	SentMessageSize     *prometheus.HistogramVec
+	InflightRequests    *prometheus.GaugeVec
+}
+
+func NewServerMetrics(cfg Config) *Metrics {
+	return &Metrics{
+		TcpConnections: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: cfg.MetricsNamespace,
+			Name:      "tcp_connections",
+			Help:      "Current number of accepted TCP connections.",
+		}, []string{"protocol"}),
+		TcpConnectionsLimit: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: cfg.MetricsNamespace,
+			Name:      "tcp_connections_limit",
+			Help:      "The max number of TCP connections that can be accepted (0 means no limit).",
+		}, []string{"protocol"}),
+		RequestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:                       cfg.MetricsNamespace,
+			Name:                            "request_duration_seconds",
+			Help:                            "Time (in seconds) spent serving HTTP requests.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     cfg.MetricsNativeHistogramFactor,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"method", "route", "status_code", "ws"}),
+		ReceivedMessageSize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: cfg.MetricsNamespace,
+			Name:      "request_message_bytes",
+			Help:      "Size (in bytes) of messages received in the request.",
+			Buckets:   middleware.BodySizeBuckets,
+		}, []string{"method", "route"}),
+		SentMessageSize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: cfg.MetricsNamespace,
+			Name:      "response_message_bytes",
+			Help:      "Size (in bytes) of messages sent in response.",
+			Buckets:   middleware.BodySizeBuckets,
+		}, []string{"method", "route"}),
+		InflightRequests: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: cfg.MetricsNamespace,
+			Name:      "inflight_requests",
+			Help:      "Current number of inflight requests.",
+		}, []string{"method", "route"}),
+	}
+}
+
+func (s *Metrics) MustRegister(registerer prometheus.Registerer) {
+	registerer.MustRegister(
+		s.TcpConnections,
+		s.TcpConnectionsLimit,
+		s.RequestDuration,
+		s.ReceivedMessageSize,
+		s.SentMessageSize,
+		s.InflightRequests,
+	)
+}

--- a/vendor/github.com/weaveworks/common/server/server.go
+++ b/vendor/github.com/weaveworks/common/server/server.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/weaveworks/common/httpgrpc"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
-	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/signals"
@@ -178,6 +177,14 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.LogRequestAtInfoLevel, "server.log-request-at-info-level-enabled", false, "Optionally log requests at info level instead of debug level. Applies to request headers as well if server.log-request-headers is enabled.")
 }
 
+func (cfg *Config) registererOrDefault() prometheus.Registerer {
+	// If user doesn't supply a Registerer/gatherer, use Prometheus' by default.
+	if cfg.Registerer != nil {
+		return cfg.Registerer
+	}
+	return prometheus.DefaultRegisterer
+}
+
 // Server wraps a HTTP and gRPC server, and some common initialization.
 //
 // Servers will be automatically instrumented for Prometheus metrics.
@@ -202,8 +209,20 @@ type Server struct {
 	Gatherer   prometheus.Gatherer
 }
 
-// New makes a new Server
+// New makes a new Server. It will panic if the metrics cannot be registered.
 func New(cfg Config) (*Server, error) {
+	metrics := NewServerMetrics(cfg)
+	metrics.MustRegister(cfg.registererOrDefault())
+	return newServer(cfg, metrics)
+}
+
+// NewWithMetrics makes a new Server using the provided Metrics. It will not attempt to register the metrics,
+// the user is responsible for doing so.
+func NewWithMetrics(cfg Config, metrics *Metrics) (*Server, error) {
+	return newServer(cfg, metrics)
+}
+
+func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	// If user doesn't supply a logging implementation, by default instantiate
 	// logrus.
 	log := cfg.Log
@@ -211,29 +230,10 @@ func New(cfg Config) (*Server, error) {
 		log = logging.NewLogrus(cfg.LogLevel)
 	}
 
-	// If user doesn't supply a registerer/gatherer, use Prometheus' by default.
-	reg := cfg.Registerer
-	if reg == nil {
-		reg = prometheus.DefaultRegisterer
-	}
 	gatherer := cfg.Gatherer
 	if gatherer == nil {
 		gatherer = prometheus.DefaultGatherer
 	}
-
-	tcpConnections := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: cfg.MetricsNamespace,
-		Name:      "tcp_connections",
-		Help:      "Current number of accepted TCP connections.",
-	}, []string{"protocol"})
-	reg.MustRegister(tcpConnections)
-
-	tcpConnectionsLimit := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: cfg.MetricsNamespace,
-		Name:      "tcp_connections_limit",
-		Help:      "The max number of TCP connections that can be accepted (0 means no limit).",
-	}, []string{"protocol"})
-	reg.MustRegister(tcpConnectionsLimit)
 
 	network := cfg.HTTPListenNetwork
 	if network == "" {
@@ -244,9 +244,9 @@ func New(cfg Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpListener = middleware.CountingListener(httpListener, tcpConnections.WithLabelValues("http"))
+	httpListener = middleware.CountingListener(httpListener, metrics.TcpConnections.WithLabelValues("http"))
 
-	tcpConnectionsLimit.WithLabelValues("http").Set(float64(cfg.HTTPConnLimit))
+	metrics.TcpConnectionsLimit.WithLabelValues("http").Set(float64(cfg.HTTPConnLimit))
 	if cfg.HTTPConnLimit > 0 {
 		httpListener = netutil.LimitListener(httpListener, cfg.HTTPConnLimit)
 	}
@@ -268,9 +268,9 @@ func New(cfg Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	grpcListener = middleware.CountingListener(grpcListener, tcpConnections.WithLabelValues("grpc"))
+	grpcListener = middleware.CountingListener(grpcListener, metrics.TcpConnections.WithLabelValues("grpc"))
 
-	tcpConnectionsLimit.WithLabelValues("grpc").Set(float64(cfg.GRPCConnLimit))
+	metrics.TcpConnectionsLimit.WithLabelValues("grpc").Set(float64(cfg.GRPCConnLimit))
 	if cfg.GRPCConnLimit > 0 {
 		grpcListener = netutil.LimitListener(grpcListener, cfg.GRPCConnLimit)
 	}
@@ -316,41 +316,6 @@ func New(cfg Config) (*Server, error) {
 		}
 	}
 
-	// Prometheus histograms for requests.
-	requestDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:                       cfg.MetricsNamespace,
-		Name:                            "request_duration_seconds",
-		Help:                            "Time (in seconds) spent serving HTTP requests.",
-		Buckets:                         instrument.DefBuckets,
-		NativeHistogramBucketFactor:     cfg.MetricsNativeHistogramFactor,
-		NativeHistogramMaxBucketNumber:  100,
-		NativeHistogramMinResetDuration: time.Hour,
-	}, []string{"method", "route", "status_code", "ws"})
-	reg.MustRegister(requestDuration)
-
-	receivedMessageSize := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: cfg.MetricsNamespace,
-		Name:      "request_message_bytes",
-		Help:      "Size (in bytes) of messages received in the request.",
-		Buckets:   middleware.BodySizeBuckets,
-	}, []string{"method", "route"})
-	reg.MustRegister(receivedMessageSize)
-
-	sentMessageSize := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: cfg.MetricsNamespace,
-		Name:      "response_message_bytes",
-		Help:      "Size (in bytes) of messages sent in response.",
-		Buckets:   middleware.BodySizeBuckets,
-	}, []string{"method", "route"})
-	reg.MustRegister(sentMessageSize)
-
-	inflightRequests := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: cfg.MetricsNamespace,
-		Name:      "inflight_requests",
-		Help:      "Current number of inflight requests.",
-	}, []string{"method", "route"})
-	reg.MustRegister(inflightRequests)
-
 	log.WithField("http", httpListener.Addr()).WithField("grpc", grpcListener.Addr()).Infof("server listening on addresses")
 
 	// Setup gRPC server
@@ -362,14 +327,14 @@ func New(cfg Config) (*Server, error) {
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
 		serverLog.UnaryServerInterceptor,
 		otgrpc.OpenTracingServerInterceptor(opentracing.GlobalTracer()),
-		middleware.UnaryServerInstrumentInterceptor(requestDuration),
+		middleware.UnaryServerInstrumentInterceptor(metrics.RequestDuration),
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
 
 	grpcStreamMiddleware := []grpc.StreamServerInterceptor{
 		serverLog.StreamServerInterceptor,
 		otgrpc.OpenTracingStreamServerInterceptor(opentracing.GlobalTracer()),
-		middleware.StreamServerInstrumentInterceptor(requestDuration),
+		middleware.StreamServerInstrumentInterceptor(metrics.RequestDuration),
 	}
 	grpcStreamMiddleware = append(grpcStreamMiddleware, cfg.GRPCStreamMiddleware...)
 
@@ -394,7 +359,11 @@ func New(cfg Config) (*Server, error) {
 		grpc.MaxRecvMsgSize(cfg.GPRCServerMaxRecvMsgSize),
 		grpc.MaxSendMsgSize(cfg.GRPCServerMaxSendMsgSize),
 		grpc.MaxConcurrentStreams(uint32(cfg.GPRCServerMaxConcurrentStreams)),
-		grpc.StatsHandler(middleware.NewStatsHandler(receivedMessageSize, sentMessageSize, inflightRequests)),
+		grpc.StatsHandler(middleware.NewStatsHandler(
+			metrics.ReceivedMessageSize,
+			metrics.SentMessageSize,
+			metrics.InflightRequests,
+		)),
 	}
 	grpcOptions = append(grpcOptions, cfg.GRPCOptions...)
 	if grpcTLSConfig != nil {
@@ -428,18 +397,21 @@ func New(cfg Config) (*Server, error) {
 		}
 	}
 
+	defaultLogMiddleware := middleware.NewLogMiddleware(log, cfg.LogRequestHeaders, cfg.LogRequestAtInfoLevel, sourceIPs, strings.Split(cfg.LogRequestExcludeHeadersList, ","))
+	defaultLogMiddleware.DisableRequestSuccessLog = cfg.DisableRequestSuccessLog
+
 	defaultHTTPMiddleware := []middleware.Interface{
 		middleware.Tracer{
 			RouteMatcher: router,
 			SourceIPs:    sourceIPs,
 		},
-		middleware.NewLogMiddleware(log, cfg.LogRequestHeaders, cfg.LogRequestAtInfoLevel, sourceIPs, strings.Split(cfg.LogRequestExcludeHeadersList, ",")),
+		defaultLogMiddleware,
 		middleware.Instrument{
 			RouteMatcher:     router,
-			Duration:         requestDuration,
-			RequestBodySize:  receivedMessageSize,
-			ResponseBodySize: sentMessageSize,
-			InflightRequests: inflightRequests,
+			Duration:         metrics.RequestDuration,
+			RequestBodySize:  metrics.ReceivedMessageSize,
+			ResponseBodySize: metrics.SentMessageSize,
+			InflightRequests: metrics.InflightRequests,
 		},
 	}
 	var httpMiddleware []middleware.Interface
@@ -477,7 +449,7 @@ func New(cfg Config) (*Server, error) {
 		GRPC:             grpcServer,
 		GRPCOnHTTPServer: grpcOnHttpServer,
 		Log:              log,
-		Registerer:       reg,
+		Registerer:       cfg.registererOrDefault(),
 		Gatherer:         gatherer,
 	}, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1024,7 +1024,7 @@ github.com/uber/jaeger-client-go/utils
 ## explicit
 github.com/uber/jaeger-lib/metrics
 github.com/uber/jaeger-lib/metrics/prometheus
-# github.com/weaveworks/common v0.0.0-20230511094633-334485600903
+# github.com/weaveworks/common v0.0.0-20230714173453-d1f8877b91ce => github.com/weaveworks/common v0.0.0-20230714173453-d1f8877b91ce
 ## explicit; go 1.14
 github.com/weaveworks/common/errors
 github.com/weaveworks/common/grpc
@@ -1486,3 +1486,4 @@ sigs.k8s.io/yaml
 # github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-20230303030534-7248a2f4c9cc
 # github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
 # github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite => github.com/charleskorn/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.0.0-20230717033559-beffb82bb827
+# github.com/weaveworks/common => github.com/weaveworks/common v0.0.0-20230714173453-d1f8877b91ce


### PR DESCRIPTION
#### What this PR does

Not-ready and over-max-inflight can be emitted when the server is overloaded, in which case we don't want to spend more resource logging the fact. The problem will be visible in metrics.

Temporarily using a branch from upstream weaveworks/common, to check Mimir still passes CI.

#### Which issue(s) this PR fixes or relates to

Fixes #397

#### Checklist

- [x] Tests updated
- NA Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
