### PR TITLE
Ingester: Add resource utilization metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 * [ENHANCEMENT] Ingester: added `cortex_ingester_shipper_last_successful_upload_timestamp_seconds` metric tracking the last successful TSDB block uploaded to the bucket (unix timestamp in seconds). #5396
 * [ENHANCEMENT] Ingester: Add two metrics tracking resource utilization calculated by utilization based limiter: #5496
   * `cortex_ingester_utilization_limiter_current_cpu_load`: The current exponential weighted moving average of the ingester's CPU load
-  * `cortex_ingester_utilization_limiter_current_memory_utilization`: The current ingester memory utilization
+  * `cortex_ingester_utilization_limiter_current_memory_usage_bytes`: The current ingester memory utilization
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
 * [ENHANCEMENT] Clarify docs for `-ingester.client.*` flags to make it clear that these are used by both queriers and distributors. #5375
 * [ENHANCEMENT] Querier: enforce `max-chunks-per-query` limit earlier in query processing when streaming chunks from ingesters to queriers to avoid unnecessarily consuming resources for queries that will be aborted. #5369 #5447
 * [ENHANCEMENT] Ingester: added `cortex_ingester_shipper_last_successful_upload_timestamp_seconds` metric tracking the last successful TSDB block uploaded to the bucket (unix timestamp in seconds). #5396
+* [ENHANCEMENT] Ingester: Add two metrics tracking resource utilization calculated by utilization based limiter: #5496
+  * `cortex_ingester_utilization_limiter_current_cpu_load`: The current exponential weighted moving average of the ingester's CPU load
+  * `cortex_ingester_utilization_limiter_current_memory_utilization`: The current ingester memory utilization
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -92,7 +92,7 @@ func NewUtilizationBasedLimiter(cpuLimit float64, memoryLimit uint64, logger log
 			return l.currCPUUtil.Load()
 		})
 		promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-			Name: "utilization_limiter_current_memory_utilization",
+			Name: "utilization_limiter_current_memory_usage_bytes",
 			Help: "Current memory utilization calculated by utilization based limiter.",
 		}, func() float64 {
 			return float64(l.currMemoryUtil.Load())

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -93,7 +93,7 @@ func NewUtilizationBasedLimiter(cpuLimit float64, memoryLimit uint64, logger log
 		})
 		promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 			Name: "utilization_limiter_current_memory_usage_bytes",
-			Help: "Current memory utilization calculated by utilization based limiter.",
+			Help: "Current memory usage calculated by utilization based limiter.",
 		}, func() float64 {
 			return float64(l.currMemoryUtil.Load())
 		})

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -62,7 +62,7 @@ func TestUtilizationBasedLimiter(t *testing.T) {
                                 # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
                                 # TYPE utilization_limiter_current_cpu_load gauge
             	           	utilization_limiter_current_cpu_load 0.10803555562923002
-            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory utilization calculated by utilization based limiter.
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory usage calculated by utilization based limiter.
             	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
             	           	utilization_limiter_current_memory_usage_bytes 0
 	`)))
@@ -87,7 +87,7 @@ func TestUtilizationBasedLimiter(t *testing.T) {
                                 # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
             	           	# TYPE utilization_limiter_current_cpu_load gauge
             	           	utilization_limiter_current_cpu_load  0.12581711205891943
-            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory utilization calculated by utilization based limiter.
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory usage calculated by utilization based limiter.
             	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
             	           	utilization_limiter_current_memory_usage_bytes 0
 		`)))
@@ -112,7 +112,7 @@ func TestUtilizationBasedLimiter(t *testing.T) {
                                 # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
             	           	# TYPE utilization_limiter_current_cpu_load gauge
             	           	utilization_limiter_current_cpu_load 0
-            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory utilization calculated by utilization based limiter.
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory usage calculated by utilization based limiter.
             	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
             	           	utilization_limiter_current_memory_usage_bytes 1.073741823e+09
 		`)))
@@ -133,7 +133,7 @@ func TestUtilizationBasedLimiter(t *testing.T) {
                                 # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
             	           	# TYPE utilization_limiter_current_cpu_load gauge
             	           	utilization_limiter_current_cpu_load 0
-            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory utilization calculated by utilization based limiter.
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory usage calculated by utilization based limiter.
             	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
             	           	utilization_limiter_current_memory_usage_bytes 1.073741824e+09
 		`)))

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +18,7 @@ func TestUtilizationBasedLimiter(t *testing.T) {
 
 	setup := func(t *testing.T, cpuLimit float64, memoryLimit uint64) (*UtilizationBasedLimiter, *fakeUtilizationScanner) {
 		fakeScanner := &fakeUtilizationScanner{}
-		lim := NewUtilizationBasedLimiter(cpuLimit, memoryLimit, log.NewNopLogger())
+		lim := NewUtilizationBasedLimiter(cpuLimit, memoryLimit, log.NewNopLogger(), prometheus.NewPedanticRegistry())
 		lim.utilizationScanner = fakeScanner
 		require.Empty(t, lim.LimitingReason(), "Limiting should initially be disabled")
 
@@ -190,7 +191,7 @@ func TestUtilizationBasedLimiter_CPUUtilizationSensitivity(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			scanner := &preRecordedUtilizationScanner{instantCPUValues: testData.instantCPUValues}
 
-			lim := NewUtilizationBasedLimiter(1, 0, log.NewNopLogger())
+			lim := NewUtilizationBasedLimiter(1, 0, log.NewNopLogger(), prometheus.NewPedanticRegistry())
 			lim.utilizationScanner = scanner
 
 			minCPUUtilization := float64(math.MaxInt64)

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -3,12 +3,14 @@
 package limiter
 
 import (
+	"bytes"
 	"math"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,19 +18,21 @@ import (
 func TestUtilizationBasedLimiter(t *testing.T) {
 	const gigabyte = 1024 * 1024 * 1024
 
-	setup := func(t *testing.T, cpuLimit float64, memoryLimit uint64) (*UtilizationBasedLimiter, *fakeUtilizationScanner) {
+	setup := func(t *testing.T, cpuLimit float64, memoryLimit uint64) (*UtilizationBasedLimiter,
+		*fakeUtilizationScanner, prometheus.Gatherer) {
 		fakeScanner := &fakeUtilizationScanner{}
-		lim := NewUtilizationBasedLimiter(cpuLimit, memoryLimit, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+		reg := prometheus.NewPedanticRegistry()
+		lim := NewUtilizationBasedLimiter(cpuLimit, memoryLimit, log.NewNopLogger(), reg)
 		lim.utilizationScanner = fakeScanner
 		require.Empty(t, lim.LimitingReason(), "Limiting should initially be disabled")
 
-		return lim, fakeScanner
+		return lim, fakeScanner, reg
 	}
 
 	tim := time.Now()
 
 	t.Run("CPU based limiting should be enabled if set to a value greater than 0", func(t *testing.T) {
-		lim, _ := setup(t, 0.11, gigabyte)
+		lim, _, reg := setup(t, 0.11, gigabyte)
 
 		// Warmup the CPU utilization.
 		for i := 0; i < int(resourceUtilizationSlidingWindow.Seconds()); i++ {
@@ -53,20 +57,44 @@ func TestUtilizationBasedLimiter(t *testing.T) {
 			tim = tim.Add(time.Second)
 		}
 		require.Empty(t, lim.LimitingReason(), "Limiting should be disabled again")
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+                                # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
+                                # TYPE utilization_limiter_current_cpu_load gauge
+            	           	utilization_limiter_current_cpu_load 0.10803555562923002
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory utilization calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
+            	           	utilization_limiter_current_memory_usage_bytes 0
+	`)))
 	})
 
 	t.Run("CPU based limiting should be disabled if set to 0", func(t *testing.T) {
-		lim, _ := setup(t, 0, gigabyte)
+		lim, _, reg := setup(t, 0, gigabyte)
+
+		// Warmup the CPU utilization.
+		for i := 0; i < int(resourceUtilizationSlidingWindow.Seconds()); i++ {
+			lim.compute(tim)
+			tim = tim.Add(time.Second)
+		}
 
 		for i := 0; i < 60; i++ {
 			lim.compute(tim)
 			tim = tim.Add(time.Second)
 			require.Empty(t, lim.LimitingReason(), "Limiting should be disabled")
 		}
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+                                # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_cpu_load gauge
+            	           	utilization_limiter_current_cpu_load  0.12581711205891943
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory utilization calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
+            	           	utilization_limiter_current_memory_usage_bytes 0
+		`)))
 	})
 
 	t.Run("memory based limiting should be enabled if set to a value greater than 0", func(t *testing.T) {
-		lim, fakeScanner := setup(t, 0.11, gigabyte)
+		lim, fakeScanner, reg := setup(t, 0.11, gigabyte)
 
 		// Compute the utilization a first time to warm up the limiter.
 		lim.compute(tim)
@@ -79,10 +107,19 @@ func TestUtilizationBasedLimiter(t *testing.T) {
 		fakeScanner.memoryUtilization = gigabyte - 1
 		lim.compute(tim)
 		require.Empty(t, lim.LimitingReason(), "Limiting should be disabled again")
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+                                # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_cpu_load gauge
+            	           	utilization_limiter_current_cpu_load 0
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory utilization calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
+            	           	utilization_limiter_current_memory_usage_bytes 1.073741823e+09
+		`)))
 	})
 
 	t.Run("memory based limiting should be disabled if set to 0", func(t *testing.T) {
-		lim, fakeScanner := setup(t, 0.11, 0)
+		lim, fakeScanner, reg := setup(t, 0.11, 0)
 
 		// Compute the utilization a first time to warm up the limiter.
 		lim.compute(tim)
@@ -91,6 +128,15 @@ func TestUtilizationBasedLimiter(t *testing.T) {
 		lim.compute(tim)
 		tim = tim.Add(time.Second)
 		require.Empty(t, lim.LimitingReason(), "Limiting should be disabled")
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+                                # HELP utilization_limiter_current_cpu_load Current average CPU load calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_cpu_load gauge
+            	           	utilization_limiter_current_cpu_load 0
+            	           	# HELP utilization_limiter_current_memory_usage_bytes Current memory utilization calculated by utilization based limiter.
+            	           	# TYPE utilization_limiter_current_memory_usage_bytes gauge
+            	           	utilization_limiter_current_memory_usage_bytes 1.073741824e+09
+		`)))
 	})
 }
 


### PR DESCRIPTION
#### What this PR does
Add two ingester metrics tracking resource utilization calculated by utilization based limiter:
  * `cortex_ingester_utilization_limiter_current_cpu_load`: The current exponential weighted moving average of the ingester's CPU load
  * `cortex_ingester_utilization_limiter_current_memory_usage_bytes`: The current ingester memory utilization

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
