### PR TITLE
Docs publish: allow triggering helm docs publish on chart version change

### DIFF
--- a/.github/workflows/publish-technical-documentation-release-helm-charts.yml
+++ b/.github/workflows/publish-technical-documentation-release-helm-charts.yml
@@ -8,6 +8,7 @@ on:
     - "mimir-distributed-release-[0-9]+.[0-9]+"
     paths:
     - "docs/sources/helm-charts/**"
+    - "operations/helm/charts/mimir-distributed/Chart.yaml"
 
   workflow_dispatch: # for manual testing
 


### PR DESCRIPTION
We released the Helm chart in #5492, but it did not even trigger docs update since path filter didn't match.
