### PR TITLE
math: Add NewEWMARateFromWindow for deriving alpha from window size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality|label_names_and_values"}`
   * `cortex_frontend_query_result_cache_hits_total{request_type="query_range|cardinality|label_names_and_values"}`
 * [FEATURE] Added `-<prefix>.s3.list-objects-version` flag to configure the S3 list objects version.
-* [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392 #5394
+* [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392 #5394 #5502
   * `-ingester.read-path-cpu-utilization-limit`
   * `-ingester.read-path-memory-utilization-limit`
 * [FEATURE] Ruler: Support filtering results from rule status endpoint by `file`, `rule_group` and `rule_name`. #5291

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -68,15 +68,13 @@ type UtilizationBasedLimiter struct {
 
 // NewUtilizationBasedLimiter returns a UtilizationBasedLimiter configured with cpuLimit and memoryLimit.
 func NewUtilizationBasedLimiter(cpuLimit float64, memoryLimit uint64, logger log.Logger) *UtilizationBasedLimiter {
-	// Calculate alpha for a minute long window
-	// https://github.com/VividCortex/ewma#choosing-alpha
-	alpha := 2 / (resourceUtilizationSlidingWindow.Seconds()/resourceUtilizationUpdateInterval.Seconds() + 1)
 	l := &UtilizationBasedLimiter{
 		logger:      logger,
 		cpuLimit:    cpuLimit,
 		memoryLimit: memoryLimit,
 		// Use a minute long window, each sample being a second apart
-		cpuMovingAvg: math.NewEWMARate(alpha, resourceUtilizationUpdateInterval),
+		cpuMovingAvg: math.NewEWMARateFromWindow(int(resourceUtilizationSlidingWindow.Seconds()),
+			resourceUtilizationUpdateInterval),
 	}
 	l.Service = services.NewTimerService(resourceUtilizationUpdateInterval, l.starting, l.update, nil)
 	return l

--- a/pkg/util/math/rate.go
+++ b/pkg/util/math/rate.go
@@ -31,6 +31,16 @@ func NewEWMARate(alpha float64, interval time.Duration) *EwmaRate {
 	}
 }
 
+// NewEWMARateFromWindow returns an EwmaRate with alpha computed from window size and for provided interval.
+func NewEWMARateFromWindow(window int, interval time.Duration) *EwmaRate {
+	// https://github.com/VividCortex/ewma#choosing-alpha
+	alpha := float64(2) / float64(window+1)
+	return &EwmaRate{
+		alpha:    alpha,
+		interval: interval,
+	}
+}
+
 // Rate returns the per-second rate.
 func (r *EwmaRate) Rate() float64 {
 	r.mutex.RLock()

--- a/pkg/util/math/rate_test.go
+++ b/pkg/util/math/rate_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,4 +50,32 @@ func TestRate(t *testing.T) {
 		r.Tick()
 		require.InDelta(t, tick.want, r.Rate(), 0.0000000001, "unexpected rate")
 	}
+}
+
+func TestNewEWMARateFromWindow(t *testing.T) {
+	var samples = [100]float64{
+		4599, 5711, 4746, 4621, 5037, 4218, 4925, 4281, 5207, 5203, 5594, 5149,
+		4948, 4994, 6056, 4417, 4973, 4714, 4964, 5280, 5074, 4913, 4119, 4522,
+		4631, 4341, 4909, 4750, 4663, 5167, 3683, 4964, 5151, 4892, 4171, 5097,
+		3546, 4144, 4551, 6557, 4234, 5026, 5220, 4144, 5547, 4747, 4732, 5327,
+		5442, 4176, 4907, 3570, 4684, 4161, 5206, 4952, 4317, 4819, 4668, 4603,
+		4885, 4645, 4401, 4362, 5035, 3954, 4738, 4545, 5433, 6326, 5927, 4983,
+		5364, 4598, 5071, 5231, 5250, 4621, 4269, 3953, 3308, 3623, 5264, 5322,
+		5395, 4753, 4936, 5315, 5243, 5060, 4989, 4921, 4480, 3426, 3687, 4220,
+		3197, 5139, 6101, 5279,
+	}
+
+	const window = 60
+	e := NewEWMARateFromWindow(window, time.Second)
+	// Warm up the ewma
+	for i := 0; i < window; i++ {
+		e.Tick()
+	}
+	for _, f := range samples {
+		e.Add(int64(f * 100))
+		e.Tick()
+	}
+
+	const exp = 4584.616105524594
+	assert.InDelta(t, exp, e.Rate()/100, 0.00000001)
 }


### PR DESCRIPTION
#### What this PR does
Add `math.NewEWMARateFromWindow` for deriving correct alpha from window size, and use it from `limiter.NewUtilizationBasedLimiter`.

#### Which issue(s) this PR fixes or relates to

I realized that we're using the wrong formula for deriving the EWMA alpha in [`limiter.NewUtilizationBasedLimiter`](https://github.com/grafana/mimir/blob/f86040d/pkg/util/limiter/utilization.go#L73). The formula should be `2/(N+1)`.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
