### PR TITLE
Ingester: Support logging of samples EWMA CPU load is based on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@
   * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality|label_names_and_values"}`
   * `cortex_frontend_query_result_cache_hits_total{request_type="query_range|cardinality|label_names_and_values"}`
 * [FEATURE] Added `-<prefix>.s3.list-objects-version` flag to configure the S3 list objects version.
-* [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392 #5394 #5526
+* [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392 #5394 #5526 #5508
   * `-ingester.read-path-cpu-utilization-limit`
   * `-ingester.read-path-memory-utilization-limit`
+  * `-ingester.log-utilization-based-limiter-cpu-samples`
 * [FEATURE] Ruler: Support filtering results from rule status endpoint by `file`, `rule_group` and `rule_name`. #5291
 * [FEATURE] Ingester: add experimental support for creating tokens by using spread minimizing strategy. This can be enabled with `-ingester.ring.token-generation-strategy: spread-minimizing` and `-ingester.ring.spread-minimizing-zones: <all available zones>`. In that case `-ingester.ring.tokens-file-path` must be empty. #5308 #5324
 * [FEATURE] Ingester: add experimental support to compact the TSDB Head when the number of in-memory series is equal or greater than `-blocks-storage.tsdb.early-head-compaction-min-in-memory-series`, and the ingester estimates that the per-tenant TSDB Head compaction will reduce in-memory series by at least `-blocks-storage.tsdb.early-head-compaction-min-estimated-series-reduction-percentage`. #5371

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2729,6 +2729,17 @@
           "fieldFlag": "ingester.read-path-memory-utilization-limit",
           "fieldType": "int",
           "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "log_utilization_based_limiter_cpu_samples",
+          "required": false,
+          "desc": "Enable logging of utilization based limiter CPU samples.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "ingester.log-utilization-based-limiter-cpu-samples",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1247,6 +1247,8 @@ Usage of ./cmd/mimir/mimir:
     	Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.
   -ingester.instance-limits.max-tenants int
     	Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.
+  -ingester.log-utilization-based-limiter-cpu-samples
+    	[experimental] Enable logging of utilization based limiter CPU samples.
   -ingester.max-global-exemplars-per-user int
     	[experimental] The maximum number of exemplars in memory, across the cluster. 0 to disable exemplars ingestion.
   -ingester.max-global-metadata-per-metric int

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -988,6 +988,10 @@ instance_limits:
 # request limiting. Use 0 to disable it.
 # CLI flag: -ingester.read-path-memory-utilization-limit
 [read_path_memory_utilization_limit: <int> | default = 0]
+
+# (experimental) Enable logging of utilization based limiter CPU samples.
+# CLI flag: -ingester.log-utilization-based-limiter-cpu-samples
+[log_utilization_based_limiter_cpu_samples: <boolean> | default = false]
 ```
 
 ### querier

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -160,8 +160,9 @@ type Config struct {
 
 	IgnoreSeriesLimitForMetricNames string `yaml:"ignore_series_limit_for_metric_names" category:"advanced"`
 
-	ReadPathCPUUtilizationLimit    float64 `yaml:"read_path_cpu_utilization_limit" category:"experimental"`
-	ReadPathMemoryUtilizationLimit uint64  `yaml:"read_path_memory_utilization_limit" category:"experimental"`
+	ReadPathCPUUtilizationLimit          float64 `yaml:"read_path_cpu_utilization_limit" category:"experimental"`
+	ReadPathMemoryUtilizationLimit       uint64  `yaml:"read_path_memory_utilization_limit" category:"experimental"`
+	LogUtilizationBasedLimiterCPUSamples bool    `yaml:"log_utilization_based_limiter_cpu_samples" category:"experimental"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -177,6 +178,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.IgnoreSeriesLimitForMetricNames, "ingester.ignore-series-limit-for-metric-names", "", "Comma-separated list of metric names, for which the -ingester.max-global-series-per-metric limit will be ignored. Does not affect the -ingester.max-global-series-per-user limit.")
 	f.Float64Var(&cfg.ReadPathCPUUtilizationLimit, "ingester.read-path-cpu-utilization-limit", 0, "CPU utilization limit, as CPU cores, for CPU/memory utilization based read request limiting. Use 0 to disable it.")
 	f.Uint64Var(&cfg.ReadPathMemoryUtilizationLimit, "ingester.read-path-memory-utilization-limit", 0, "Memory limit, in bytes, for CPU/memory utilization based read request limiting. Use 0 to disable it.")
+	f.BoolVar(&cfg.LogUtilizationBasedLimiterCPUSamples, "ingester.log-utilization-based-limiter-cpu-samples", false, "Enable logging of utilization based limiter CPU samples.")
 }
 
 func (cfg *Config) Validate() error {
@@ -339,7 +341,8 @@ func New(cfg Config, limits *validation.Overrides, activeGroupsCleanupService *u
 
 	if cfg.ReadPathCPUUtilizationLimit > 0 || cfg.ReadPathMemoryUtilizationLimit > 0 {
 		i.utilizationBasedLimiter = limiter.NewUtilizationBasedLimiter(cfg.ReadPathCPUUtilizationLimit,
-			cfg.ReadPathMemoryUtilizationLimit, log.WithPrefix(logger, "context", "read path"),
+			cfg.ReadPathMemoryUtilizationLimit, cfg.LogUtilizationBasedLimiterCPUSamples,
+			log.WithPrefix(logger, "context", "read path"),
 			prometheus.WrapRegistererWithPrefix("cortex_ingester_", registerer))
 	}
 

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -4,7 +4,9 @@ package limiter
 
 import (
 	"bytes"
+	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -179,7 +181,12 @@ func TestUtilizationBasedLimiter(t *testing.T) {
 			ts = ts.Add(time.Second)
 		}
 
-		assert.Equal(t, instValues[2:62], lim.cpuSamples)
+		var sampleStrs []string
+		for i := 2; i < 62; i++ {
+			sampleStrs = append(sampleStrs, fmt.Sprintf("%.2f", instValues[i]))
+		}
+		exp := strings.Join(sampleStrs, ",")
+		assert.Equal(t, exp, lim.cpuSamples.String())
 	})
 }
 

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -35,44 +35,23 @@ func TestUtilizationBasedLimiter(t *testing.T) {
 	}
 
 	t.Run("CPU based limiting should be enabled if set to a value greater than 0", func(t *testing.T) {
-		lim, scanner, reg := setup(t, 0.11, gigabyte, true)
-
-		var prevTotalTime float64
-		samples := make([]float64, 60)
+		lim, _, reg := setup(t, 0.11, gigabyte, true)
 
 		// Warmup the CPU utilization.
 		for i := 0; i < int(resourceUtilizationSlidingWindow.Seconds()); i++ {
 			lim.compute(nowFn)
 			tim = tim.Add(time.Second)
-			for i := 1; i < len(samples); i++ {
-				samples[i-1] = samples[i]
-			}
-			s := scanner.totalTime - prevTotalTime
-			samples[len(samples)-1] = s
-			prevTotalTime = scanner.totalTime
 		}
 
 		// The fake utilization scanner linearly increases CPU usage for a minute
 		for i := 0; i < 59; i++ {
 			lim.compute(nowFn)
-			for i := 1; i < len(samples); i++ {
-				samples[i-1] = samples[i]
-			}
-			s := scanner.totalTime - prevTotalTime
-			samples[len(samples)-1] = s
-			prevTotalTime = scanner.totalTime
 			tim = tim.Add(time.Second)
 			require.Empty(t, lim.LimitingReason(), "Limiting should be disabled")
 		}
 		lim.compute(nowFn)
-		for i := 1; i < len(samples); i++ {
-			samples[i-1] = samples[i]
-		}
-		s := scanner.totalTime - prevTotalTime
-		samples[len(samples)-1] = s
 		tim = tim.Add(time.Second)
 		require.Equal(t, "cpu", lim.LimitingReason(), "Limiting should be enabled due to CPU")
-		require.Equal(t, samples, lim.cpuSamples)
 
 		// The fake utilization scanner drops CPU usage again after a minute, so we expect
 		// limiting to be disabled shortly.
@@ -182,6 +161,25 @@ func TestUtilizationBasedLimiter(t *testing.T) {
 		tim = tim.Add(time.Second)
 		require.Equal(t, "cpu", lim.LimitingReason(), "Limiting should be enabled due to CPU")
 		require.Nil(t, lim.cpuSamples)
+	})
+
+	t.Run("the limiter should collect the last 60 CPU samples", func(t *testing.T) {
+		var instValues []float64
+		for i := 1; i <= 62; i++ {
+			instValues = append(instValues, float64(i))
+		}
+		scanner := &preRecordedUtilizationScanner{instantCPUValues: instValues}
+		lim := NewUtilizationBasedLimiter(1, 0, true, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+		lim.utilizationScanner = scanner
+
+		for i, ts := 0, time.Now(); i < len(instValues); i++ {
+			lim.compute(func() time.Time {
+				return ts
+			})
+			ts = ts.Add(time.Second)
+		}
+
+		assert.Equal(t, instValues[2:62], lim.cpuSamples)
 	})
 }
 


### PR DESCRIPTION
#### What this PR does
To help debugging, support logging of samples EWMA CPU load is based on when enabling read path limiting. I'm making this logging configurable, behind an experimental flag.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
