### PR TITLE
Fix cardinality and label names/values requests handling on POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [CHANGE] Querier: `-query-frontend.cache-unaligned-requests` has been moved from a global flag to a per-tenant override. #5312
 * [CHANGE] Ingester: removed `cortex_ingester_shipper_dir_syncs_total` and `cortex_ingester_shipper_dir_sync_failures_total` metrics. The former metric was not much useful, and the latter was never incremented. #5396
 * [FEATURE] Cardinality API: Add a new `count_method` parameter which enables counting active series #5136
-* [FEATURE] Query-frontend: added experimental support to cache cardinality, label names and label values query responses. The cache will be used when `-query-frontend.cache-results` is enabled, and `-query-frontend.results-cache-ttl-for-cardinality-query` or `-query-frontend.results-cache-ttl-for-labels-query` set to a value greater than 0. The following metrics have been added to track the query results cache hit ratio per `request_type`: #5212 #5235 #5426
+* [FEATURE] Query-frontend: added experimental support to cache cardinality, label names and label values query responses. The cache will be used when `-query-frontend.cache-results` is enabled, and `-query-frontend.results-cache-ttl-for-cardinality-query` or `-query-frontend.results-cache-ttl-for-labels-query` set to a value greater than 0. The following metrics have been added to track the query results cache hit ratio per `request_type`: #5212 #5235 #5426 #5524
   * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality|label_names_and_values"}`
   * `cortex_frontend_query_result_cache_hits_total{request_type="query_range|cardinality|label_names_and_values"}`
 * [FEATURE] Added `-<prefix>.s3.list-objects-version` flag to configure the S3 list objects version.

--- a/pkg/cardinality/request_test.go
+++ b/pkg/cardinality/request_test.go
@@ -19,7 +19,7 @@ func TestDecodeLabelNamesRequest(t *testing.T) {
 		params = url.Values{
 			"selector": []string{`{second!="2",first="1"}`},
 			"limit":    []string{"100"},
-		}.Encode()
+		}
 
 		expected = &LabelNamesRequest{
 			Matchers: []*labels.Matcher{
@@ -30,8 +30,8 @@ func TestDecodeLabelNamesRequest(t *testing.T) {
 		}
 	)
 
-	t.Run("GET request", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "http://localhost?"+params, nil)
+	t.Run("DecodeLabelNamesRequest() with GET request", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://localhost?"+params.Encode(), nil)
 		require.NoError(t, err)
 
 		actual, err := DecodeLabelNamesRequest(req)
@@ -40,12 +40,19 @@ func TestDecodeLabelNamesRequest(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("POST request", func(t *testing.T) {
-		req, err := http.NewRequest("POST", "http://localhost/", strings.NewReader(params))
+	t.Run("DecodeLabelNamesRequest() with POST request", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "http://localhost/", strings.NewReader(params.Encode()))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		actual, err := DecodeLabelNamesRequest(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("DecodeLabelNamesRequestFromValues()", func(t *testing.T) {
+		actual, err := DecodeLabelNamesRequestFromValues(params)
 		require.NoError(t, err)
 
 		assert.Equal(t, expected, actual)
@@ -71,7 +78,7 @@ func TestDecodeLabelValuesRequest(t *testing.T) {
 			"label_names[]": []string{"metric_2", "metric_1"},
 			"count_method":  []string{"active"},
 			"limit":         []string{"100"},
-		}.Encode()
+		}
 
 		expected = &LabelValuesRequest{
 			LabelNames: []model.LabelName{"metric_1", "metric_2"},
@@ -84,9 +91,8 @@ func TestDecodeLabelValuesRequest(t *testing.T) {
 		}
 	)
 
-	t.Run("GET request", func(t *testing.T) {
-
-		req, err := http.NewRequest("GET", "http://localhost?"+params, nil)
+	t.Run("DecodeLabelValuesRequest() GET request", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://localhost?"+params.Encode(), nil)
 		require.NoError(t, err)
 
 		actual, err := DecodeLabelValuesRequest(req)
@@ -95,12 +101,19 @@ func TestDecodeLabelValuesRequest(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("POST request", func(t *testing.T) {
-		req, err := http.NewRequest("POST", "http://localhost/", strings.NewReader(params))
+	t.Run("DecodeLabelValuesRequest() POST request", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "http://localhost/", strings.NewReader(params.Encode()))
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		actual, err := DecodeLabelValuesRequest(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("DecodeLabelValuesRequestFromValues() GET request", func(t *testing.T) {
+		actual, err := DecodeLabelValuesRequestFromValues(params)
 		require.NoError(t, err)
 
 		assert.Equal(t, expected, actual)

--- a/pkg/frontend/querymiddleware/cardinality_query_cache.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache.go
@@ -5,6 +5,7 @@ package querymiddleware
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -36,10 +37,10 @@ func (c *cardinalityQueryCache) getTTL(userID string) time.Duration {
 	return c.limits.ResultsCacheTTLForCardinalityQuery(userID)
 }
 
-func (c *cardinalityQueryCache) parseRequest(req *http.Request) (*genericQueryRequest, error) {
+func (c *cardinalityQueryCache) parseRequest(path string, values url.Values) (*genericQueryRequest, error) {
 	switch {
-	case strings.HasSuffix(req.URL.Path, cardinalityLabelNamesPathSuffix):
-		parsed, err := cardinality.DecodeLabelNamesRequest(req)
+	case strings.HasSuffix(path, cardinalityLabelNamesPathSuffix):
+		parsed, err := cardinality.DecodeLabelNamesRequestFromValues(values)
 		if err != nil {
 			return nil, err
 		}
@@ -48,8 +49,8 @@ func (c *cardinalityQueryCache) parseRequest(req *http.Request) (*genericQueryRe
 			cacheKey:       parsed.String(),
 			cacheKeyPrefix: cardinalityLabelNamesQueryCachePrefix,
 		}, nil
-	case strings.HasSuffix(req.URL.Path, cardinalityLabelValuesPathSuffix):
-		parsed, err := cardinality.DecodeLabelValuesRequest(req)
+	case strings.HasSuffix(path, cardinalityLabelValuesPathSuffix):
+		parsed, err := cardinality.DecodeLabelValuesRequestFromValues(values)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
@@ -107,12 +107,14 @@ func TestCardinalityQueryCache_RoundTrip_WithTenantFederation(t *testing.T) {
 func TestCardinalityQueryCache_RoundTrip(t *testing.T) {
 	testGenericQueryCacheRoundTrip(t, newCardinalityQueryCacheRoundTripper, "cardinality", map[string]testGenericQueryCacheRequestType{
 		"label names request": {
-			url:            mustParseURL(t, `/prometheus/api/v1/cardinality/label_names?selector={job="test"}&limit=100`),
+			reqPath:        "/prometheus/api/v1/cardinality/label_names",
+			reqData:        url.Values{"selector": []string{`{job="test"}`}, "limit": []string{"100"}},
 			cacheKey:       "user-1:job=\"test\"\x00100",
 			hashedCacheKey: cardinalityLabelNamesQueryCachePrefix + cacheHashKey("user-1:job=\"test\"\x00100"),
 		},
 		"label values request": {
-			url:            mustParseURL(t, `/prometheus/api/v1/cardinality/label_values?selector={job="test"}&label_names[]=metric_1&label_names[]=metric_2&limit=100`),
+			reqPath:        "/prometheus/api/v1/cardinality/label_values",
+			reqData:        url.Values{"selector": []string{`{job="test"}`}, "label_names[]": []string{"metric_1", "metric_2"}, "limit": []string{"100"}},
 			cacheKey:       "user-1:metric_1\x01metric_2\x00job=\"test\"\x00inmemory\x00100",
 			hashedCacheKey: cardinalityLabelValuesQueryCachePrefix + cacheHashKey("user-1:metric_1\x01metric_2\x00job=\"test\"\x00inmemory\x00100"),
 		},

--- a/pkg/frontend/querymiddleware/generic_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache_test.go
@@ -26,7 +26,8 @@ import (
 type newGenericQueryCacheFunc func(cache cache.Cache, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper
 
 type testGenericQueryCacheRequestType struct {
-	url            *url.URL
+	reqPath        string
+	reqData        url.Values
 	cacheKey       string
 	hashedCacheKey string
 }
@@ -164,81 +165,114 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			for reqName, reqData := range requestTypes {
-				t.Run(reqName, func(t *testing.T) {
-					// Mock the limits.
-					limits := multiTenantMockLimits{
-						byTenant: map[string]mockLimits{
-							userID: {
-								resultsCacheTTLForCardinalityQuery: testData.cacheTTL,
-								resultsCacheTTLForLabelsQuery:      testData.cacheTTL,
+				for _, reqMethod := range []string{ /*http.MethodGet ,*/ http.MethodPost} {
+					t.Run(fmt.Sprintf("%s (%s)", reqName, reqMethod), func(t *testing.T) {
+						// Mock the limits.
+						limits := multiTenantMockLimits{
+							byTenant: map[string]mockLimits{
+								userID: {
+									resultsCacheTTLForCardinalityQuery: testData.cacheTTL,
+									resultsCacheTTLForLabelsQuery:      testData.cacheTTL,
+								},
 							},
-						},
-					}
-
-					// Mock the downstream.
-					downstreamCalled := false
-					downstream := RoundTripFunc(func(request *http.Request) (*http.Response, error) {
-						downstreamCalled = true
-						return testData.downstreamRes(), testData.downstreamErr
-					})
-
-					// Create the request.
-					req := &http.Request{URL: reqData.url, Header: testData.reqHeader}
-					req = req.WithContext(user.InjectOrgID(context.Background(), userID))
-
-					// Init the cache.
-					cacheBackend := cache.NewInstrumentedMockCache()
-					if testData.init != nil {
-						testData.init(t, cacheBackend, reqData.cacheKey, reqData.hashedCacheKey)
-					}
-					initialStoreCallsCount := cacheBackend.CountStoreCalls()
-
-					reg := prometheus.NewPedanticRegistry()
-					rt := newRoundTripper(cacheBackend, limits, downstream, testutil.NewLogger(t), reg)
-					res, err := rt.RoundTrip(req)
-					require.NoError(t, err)
-
-					// Assert on the downstream.
-					assert.Equal(t, testData.expectedDownstreamCalled, downstreamCalled)
-
-					// Assert on the response received.
-					assert.Equal(t, testData.expectedStatusCode, res.StatusCode)
-					assert.Equal(t, testData.expectedHeader, res.Header)
-
-					actualBody, err := io.ReadAll(res.Body)
-					require.NoError(t, err)
-					assert.Equal(t, testData.expectedBody, actualBody)
-
-					// Assert on the state of the cache.
-					if testData.expectedStoredToCache {
-						assert.Equal(t, initialStoreCallsCount+1, cacheBackend.CountStoreCalls())
-
-						items := cacheBackend.GetItems()
-						require.Len(t, items, 1)
-						require.NotZero(t, items[reqData.hashedCacheKey])
-
-						cached := CachedHTTPResponse{}
-						require.NoError(t, cached.Unmarshal(items[reqData.hashedCacheKey].Data))
-						assert.Equal(t, testData.expectedStatusCode, int(cached.StatusCode))
-						assert.Equal(t, testData.expectedHeader, DecodeCachedHTTPResponse(&cached).Header)
-						assert.Equal(t, testData.expectedBody, cached.Body)
-						assert.Equal(t, reqData.cacheKey, cached.CacheKey)
-						assert.WithinDuration(t, time.Now().Add(testData.cacheTTL), items[reqData.hashedCacheKey].ExpiresAt, 5*time.Second)
-					} else {
-						assert.Equal(t, initialStoreCallsCount, cacheBackend.CountStoreCalls())
-					}
-
-					// Assert on metrics.
-					expectedRequestsCount := 0
-					expectedHitsCount := 0
-					if testData.expectedLookupFromCache {
-						expectedRequestsCount = 1
-						if !testData.expectedDownstreamCalled {
-							expectedHitsCount = 1
 						}
-					}
 
-					assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+						var (
+							req                 *http.Request
+							downstreamCalled    = false
+							downstreamReqParams url.Values
+							err                 error
+						)
+
+						// Mock the downstream and capture the request.
+						downstream := RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+							downstreamCalled = true
+
+							// Parse the request body.
+							require.NoError(t, req.ParseForm())
+							downstreamReqParams = req.Form
+
+							return testData.downstreamRes(), testData.downstreamErr
+						})
+
+						// Create the request.
+						switch reqMethod {
+						case http.MethodGet:
+							req, err = http.NewRequest(reqMethod, reqData.reqPath+"?"+reqData.reqData.Encode(), nil)
+							require.NoError(t, err)
+						case http.MethodPost:
+							req, err = http.NewRequest(reqMethod, reqData.reqPath, strings.NewReader(reqData.reqData.Encode()))
+							req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+							require.NoError(t, err)
+						default:
+							t.Fatalf("unsupported HTTP method %q", reqMethod)
+						}
+
+						for name, values := range testData.reqHeader {
+							for _, value := range values {
+								req.Header.Set(name, value)
+							}
+						}
+
+						// Inject the tenant ID in the request.
+						req = req.WithContext(user.InjectOrgID(context.Background(), userID))
+
+						// Init the cache.
+						cacheBackend := cache.NewInstrumentedMockCache()
+						if testData.init != nil {
+							testData.init(t, cacheBackend, reqData.cacheKey, reqData.hashedCacheKey)
+						}
+						initialStoreCallsCount := cacheBackend.CountStoreCalls()
+
+						reg := prometheus.NewPedanticRegistry()
+						rt := newRoundTripper(cacheBackend, limits, downstream, testutil.NewLogger(t), reg)
+						res, err := rt.RoundTrip(req)
+						require.NoError(t, err)
+
+						// Assert on the downstream.
+						assert.Equal(t, testData.expectedDownstreamCalled, downstreamCalled)
+						if testData.expectedDownstreamCalled {
+							assert.Equal(t, reqData.reqData, downstreamReqParams)
+						}
+
+						// Assert on the response received.
+						assert.Equal(t, testData.expectedStatusCode, res.StatusCode)
+						assert.Equal(t, testData.expectedHeader, res.Header)
+
+						actualBody, err := io.ReadAll(res.Body)
+						require.NoError(t, err)
+						assert.Equal(t, testData.expectedBody, actualBody)
+
+						// Assert on the state of the cache.
+						if testData.expectedStoredToCache {
+							assert.Equal(t, initialStoreCallsCount+1, cacheBackend.CountStoreCalls())
+
+							items := cacheBackend.GetItems()
+							require.Len(t, items, 1)
+							require.NotZero(t, items[reqData.hashedCacheKey])
+
+							cached := CachedHTTPResponse{}
+							require.NoError(t, cached.Unmarshal(items[reqData.hashedCacheKey].Data))
+							assert.Equal(t, testData.expectedStatusCode, int(cached.StatusCode))
+							assert.Equal(t, testData.expectedHeader, DecodeCachedHTTPResponse(&cached).Header)
+							assert.Equal(t, testData.expectedBody, cached.Body)
+							assert.Equal(t, reqData.cacheKey, cached.CacheKey)
+							assert.WithinDuration(t, time.Now().Add(testData.cacheTTL), items[reqData.hashedCacheKey].ExpiresAt, 5*time.Second)
+						} else {
+							assert.Equal(t, initialStoreCallsCount, cacheBackend.CountStoreCalls())
+						}
+
+						// Assert on metrics.
+						expectedRequestsCount := 0
+						expectedHitsCount := 0
+						if testData.expectedLookupFromCache {
+							expectedRequestsCount = 1
+							if !testData.expectedDownstreamCalled {
+								expectedHitsCount = 1
+							}
+						}
+
+						assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
                         # HELP cortex_frontend_query_result_cache_requests_total Total number of requests (or partial requests) looked up in the results cache.
                         # TYPE cortex_frontend_query_result_cache_requests_total counter
                         cortex_frontend_query_result_cache_requests_total{request_type="%s"} %d
@@ -247,10 +281,11 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
                         # TYPE cortex_frontend_query_result_cache_hits_total counter
                         cortex_frontend_query_result_cache_hits_total{request_type="%s"} %d
 					`, requestTypeLabelValue, expectedRequestsCount, requestTypeLabelValue, expectedHitsCount)),
-						"cortex_frontend_query_result_cache_requests_total",
-						"cortex_frontend_query_result_cache_hits_total",
-					))
-				})
+							"cortex_frontend_query_result_cache_requests_total",
+							"cortex_frontend_query_result_cache_hits_total",
+						))
+					})
+				}
 			}
 		})
 	}

--- a/pkg/frontend/querymiddleware/generic_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache_test.go
@@ -165,7 +165,7 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			for reqName, reqData := range requestTypes {
-				for _, reqMethod := range []string{ /*http.MethodGet ,*/ http.MethodPost} {
+				for _, reqMethod := range []string{http.MethodGet, http.MethodPost} {
 					t.Run(fmt.Sprintf("%s (%s)", reqName, reqMethod), func(t *testing.T) {
 						// Mock the limits.
 						limits := multiTenantMockLimits{

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -365,11 +365,3 @@ func httpRequestActivity(request *http.Request, requestParams url.Values) string
 	// This doesn't have to be pretty, just useful for debugging, so prioritize efficiency.
 	return strings.Join([]string{tenantID, request.Method, request.URL.Path, params}, " ")
 }
-
-func copyValues(src url.Values) url.Values {
-	dst := make(url.Values, len(src))
-	for k, vs := range src {
-		dst[k] = append([]string(nil), vs...)
-	}
-	return dst
-}

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -6,7 +6,6 @@
 package transport
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -176,28 +175,14 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r = r.WithContext(ctx)
 	}
 
+	// Ensure to close the request body reader.
 	defer func() { _ = r.Body.Close() }()
 
-	// Store the body contents, so we can read it multiple times.
-	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize))
+	params, err := util.ParseRequestFormWithoutConsumingBody(r)
 	if err != nil {
-		writeError(w, err)
-		return
-	}
-	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-
-	// Parse the form, as it's needed to build the activity for the activity-tracker.
-	if err := r.ParseForm(); err != nil {
 		writeError(w, apierror.New(apierror.TypeBadData, err.Error()))
 		return
 	}
-
-	// Store a copy of the params and restore the request state.
-	// Restore the body, so it can be read again if it's used to forward the request through a roundtripper.
-	// Restore the Form and PostForm, to avoid subtle bugs in middlewares, as they were set by ParseForm.
-	params := copyValues(r.Form)
-	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-	r.Form, r.PostForm = nil, nil
 
 	activityIndex := f.at.Insert(func() string { return httpRequestActivity(r, params) })
 	defer f.at.Delete(activityIndex)

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -178,6 +178,9 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Ensure to close the request body reader.
 	defer func() { _ = r.Body.Close() }()
 
+	// Limit the read body size.
+	r.Body = http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize)
+
 	params, err := util.ParseRequestFormWithoutConsumingBody(r)
 	if err != nil {
 		writeError(w, apierror.New(apierror.TypeBadData, err.Error()))


### PR DESCRIPTION
#### What this PR does
We found a bug introduced in #5212 and #5426 which caused POST requests returning wrong results. The problem is that, when the cardinality and/or label names/values result cache is enabled, the caching middleware consumes the `http.Request` `Body` and so the body will be empty when later read to forward it to the query-scheduler or querier.

In this PR I propose a fix. The fix consists in consuming the Body and then replacing it with the original content. It's not a new approach, in fact we were already doing it in `Handler.ServeHTTP()` so I've re-used that code, moving it to a common utility function.

Note to reviewers:
- The modified integration and unit tests fail with the previous buggy version

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
