### PR TITLE
UtilizationBasedLimiter: Document monotonic clock usage

### DIFF
--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -144,6 +144,9 @@ func (l *UtilizationBasedLimiter) compute(nowFn func() time.Time) (currCPUUtil f
 	// Add the instant CPU utilization to the moving average. The instant CPU
 	// utilization can only be computed starting from the 2nd tick.
 	if prevUpdate, prevCPUTime := l.lastUpdate, l.lastCPUTime; !prevUpdate.IsZero() {
+		// Provided that nowFn returns a Time with monotonic clock reading (like time.Now()), time.Sub is robust
+		// against wall clock changes, since it's based on the monotonic clock:
+		// https://pkg.go.dev/time#hdr-Monotonic_Clocks
 		cpuUtil := (cpuTime - prevCPUTime) / now.Sub(prevUpdate).Seconds()
 		l.cpuMovingAvg.Add(int64(cpuUtil * 100))
 		l.cpuMovingAvg.Tick()


### PR DESCRIPTION
#### What this PR does
In `pkg/util/limiter.UtilizationBasedLimiter`, note that CPU utilization calculation is based on the monotonic clock (robust against wall clock changes).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
