### PR TITLE
exporter: allow editing enabled metrics from downstream projects

### DIFF
--- a/pkg/util/validation/exporter/exporter.go
+++ b/pkg/util/validation/exporter/exporter.go
@@ -85,7 +85,8 @@ type Config struct {
 	EnabledMetrics flagext.StringSliceCSV `yaml:"enabled_metrics" category:"experimental"`
 
 	// This allows downstream projects to define their own metrics and expose them via the exporter.
-	ExtraMetrics []ExportedMetric `yaml:"-"`
+	ExtraMetrics        []ExportedMetric       `yaml:"-"`
+	EnabledExtraMetrics flagext.StringSliceCSV `yaml:"-"`
 }
 
 type ExportedMetric struct {
@@ -170,7 +171,7 @@ func NewOverridesExporter(
 		}
 	}
 
-	exporter.enabledMetrics = util.NewAllowedTenants(config.EnabledMetrics, nil)
+	exporter.enabledMetrics = util.NewAllowedTenants(append(config.EnabledMetrics, config.EnabledExtraMetrics...), nil)
 
 	exporter.Service = services.NewBasicService(exporter.starting, exporter.running, exporter.stopping)
 	return exporter, nil

--- a/pkg/util/validation/exporter/exporter_test.go
+++ b/pkg/util/validation/exporter/exporter_test.go
@@ -201,14 +201,18 @@ func TestOverridesExporter_withExtraMetrics(t *testing.T) {
 		},
 	}
 
-	config := Config{EnabledMetrics: append(defaultEnabledMetricNames, "custom_extra_limit"), ExtraMetrics: []ExportedMetric{
-		{
-			Name: "custom_extra_limit",
-			Get: func(_ *validation.Limits) float64 {
-				return 1234.0
+	config := Config{
+		EnabledMetrics: defaultEnabledMetricNames,
+		ExtraMetrics: []ExportedMetric{
+			{
+				Name: "custom_extra_limit",
+				Get: func(_ *validation.Limits) float64 {
+					return 1234.0
+				},
 			},
 		},
-	}}
+		EnabledExtraMetrics: []string{"custom_extra_limit"},
+	}
 
 	exporter, err := NewOverridesExporter(config, &validation.Limits{
 		IngestionRate:                22,


### PR DESCRIPTION
this is a follow-up PR for https://github.com/grafana/mimir/pull/5474

add extra field to allow enabling/disabling extra metrics from downstream projects. 