### PR TITLE
Docs: Remove hard-to-maintain file with single link

### DIFF
--- a/tutorials
+++ b/tutorials
@@ -1,1 +1,0 @@
-Content moved to docs/sources/mimir/tutorials/


### PR DESCRIPTION
#### What this PR does

This PR removes `tutorials` file, which was preserved as symlink #1564 and later changed to file #2007, because old version of  [play with Grafana Mimir tutorial](https://grafana.com/tutorials/play-with-grafana-mimir/) referred to it. But that's not the case for some time.