### PR TITLE
exporter: do not check extra metrics against `enabledMetrics`

### DIFF
--- a/pkg/util/validation/exporter/exporter.go
+++ b/pkg/util/validation/exporter/exporter.go
@@ -255,9 +255,9 @@ func (oe *OverridesExporter) Collect(ch chan<- prometheus.Metric) {
 
 	// Add extra exported metrics
 	for _, em := range oe.extraMetrics {
-		if oe.enabledMetrics.IsAllowed(em.Name) {
-			exportedMetrics = append(exportedMetrics, em)
-		}
+		// Donwstream projects should be responsible for enabling/disabling their own metrics,
+		// so we don't check against enabledMetrics here.
+		exportedMetrics = append(exportedMetrics, em)
 	}
 
 	// default limits

--- a/pkg/util/validation/exporter/exporter_test.go
+++ b/pkg/util/validation/exporter/exporter_test.go
@@ -201,14 +201,17 @@ func TestOverridesExporter_withExtraMetrics(t *testing.T) {
 		},
 	}
 
-	config := Config{EnabledMetrics: append(defaultEnabledMetricNames, "custom_extra_limit"), ExtraMetrics: []ExportedMetric{
-		{
-			Name: "custom_extra_limit",
-			Get: func(_ *validation.Limits) float64 {
-				return 1234.0
+	config := Config{
+		EnabledMetrics: defaultEnabledMetricNames,
+		ExtraMetrics: []ExportedMetric{
+			{
+				Name: "custom_extra_limit",
+				Get: func(_ *validation.Limits) float64 {
+					return 1234.0
+				},
 			},
 		},
-	}}
+	}
 
 	exporter, err := NewOverridesExporter(config, &validation.Limits{
 		IngestionRate:                22,


### PR DESCRIPTION
Avoid checking extra metrics against `enabledMetrics` in `overrides-exporter` component. This should be a downstream project responsibility.