### PR TITLE
Update Mimir tutorial mount

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Run doc-validator tool (mimir)
         run: >
           doc-validator
+          '--skip-checks=^canonical-does-not-match-pretty-URL$'
           docs/sources/mimir
           /docs/mimir/latest
           | reviewdog

--- a/docs/sources/mimir/get-started/play-with-grafana-mimir/index.md
+++ b/docs/sources/mimir/get-started/play-with-grafana-mimir/index.md
@@ -1,11 +1,9 @@
 ---
-aliases:
-  - ../tutorials/play-with-grafana-mimir/
-  - ../tutorials/
 associated_technologies:
   - mimir
 author:
   - marco
+canonical: https://grafana.com/tutorials/play-with-grafana-mimir/
 description: Learn about Grafana Mimir, which provides distributed,
   horizontally scalable, and highly available long term storage for Prometheus.
 keywords:

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -6,3 +6,6 @@ export DOC_VALIDATOR_IMAGE := $(shell sed -n 's, *image: \(grafana/doc-validator
 
 # Use alternative image until make-docs 3.0.0 is rolled out.
 export DOCS_IMAGE := grafana/docs-base:dbd975af06
+
+# Skip some doc-validator checks.
+export DOC_VALIDATOR_SKIP_CHECKS := ^canonical-does-not-match-pretty-URL$


### PR DESCRIPTION
- Remove aliases. The Mimir tutorials pages were never published by the website as can be seen by the removed snippet in this patch. Considering that, these aliases are for the wrong location and are not needed since this file is still published at /tutorials/play-with-grafana-mimir.
- Update mount to use "next" version. This is a more accurate tutorial because the tutorials relies on code in the `main` branch of the source repository and that is published as "next" not "latest".
- Add canonical URL. Although "next" documentation is not indexed, this is still required for when this page is part of a release so that search engines know that the /tutorials/ page is the canonical website page.
