### PR TITLE
native histograms: update tenants panel with tracking information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * [ENHANCEMENT] Dashboards: show time spend waiting for turn when lazy loading index headers in the "index-header lazy load gate latency" panel on the "queries" dashboard. #5313
 * [ENHANCEMENT] Dashboards: split query results cache hit ratio by request type in "Query results cache hit ratio" panel on the "Mimir / Queries" dashboard. #5423
 * [ENHANCEMENT] Dashboards: add "rejected queries" panel to "queries" dashboard. #5429
+* [ENHANCEMENT] Dashboards: add native histogram active series and active buckets to "tenants" dashboard. #5543
 * [BUGFIX] Alerts: fix `MimirIngesterRestarts` to fire only when the ingester container is restarted, excluding the cases the pod is rescheduled. #5397
 * [BUGFIX] Dashboards: fix "unhealthy pods" panel on "rollout progress" dashboard showing only a number rather than the name of the workload and the number of unhealthy pods if only one workload has unhealthy pods. #5113 #5200
 * [BUGFIX] Alerts: fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts. #5396

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -32188,7 +32188,7 @@ data:
                       "dashLength": 10,
                       "dashes": false,
                       "datasource": "$datasource",
-                      "description": "### Series\nNumber of active and in-memory series per user, and active series matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
+                      "description": "### All series\nNumber of active and in-memory series per user, and active series matching custom trackers (in parenthesis).\nNote that these counts include all series regardless of the type of data (counter, gauge, native histogram, etc.).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
                       "fill": 1,
                       "id": 2,
                       "legend": {
@@ -32216,7 +32216,7 @@ data:
                          }
                       ],
                       "spaceLength": 10,
-                      "span": 3,
+                      "span": 4,
                       "stack": false,
                       "steppedLine": false,
                       "targets": [
@@ -32252,7 +32252,7 @@ data:
                       "thresholds": [ ],
                       "timeFrom": null,
                       "timeShift": null,
-                      "title": "Series",
+                      "title": "All series",
                       "tooltip": {
                          "shared": false,
                          "sort": 0,
@@ -32291,9 +32291,199 @@ data:
                       "dashLength": 10,
                       "dashes": false,
                       "datasource": "$datasource",
-                      "description": "### Series with exemplars\nNumber of series with exemplars currently in storage.\n\n",
+                      "description": "### Native histogram series\nNumber of active native histogram series per user, and active native histogram series matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
                       "fill": 1,
                       "id": 3,
+                      "legend": {
+                         "avg": false,
+                         "current": false,
+                         "max": false,
+                         "min": false,
+                         "show": true,
+                         "total": false,
+                         "values": false
+                      },
+                      "lines": true,
+                      "linewidth": 1,
+                      "links": [ ],
+                      "nullPointMode": "null as zero",
+                      "percentage": false,
+                      "pointradius": 5,
+                      "points": false,
+                      "renderer": "flot",
+                      "seriesOverrides": [
+                         {
+                            "alias": "limit",
+                            "dashes": true,
+                            "fill": 0
+                         }
+                      ],
+                      "spaceLength": 10,
+                      "span": 4,
+                      "stack": false,
+                      "steppedLine": false,
+                      "targets": [
+                         {
+                            "expr": "sum(\n  cortex_ingester_active_native_histogram_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n)\n",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "active",
+                            "legendLink": null
+                         },
+                         {
+                            "expr": "sum by (name) (\n  cortex_ingester_active_native_histogram_series_custom_tracker{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n) > 0\n",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "active ({{ name }})",
+                            "legendLink": null
+                         }
+                      ],
+                      "thresholds": [ ],
+                      "timeFrom": null,
+                      "timeShift": null,
+                      "title": "Native histogram series",
+                      "tooltip": {
+                         "shared": false,
+                         "sort": 0,
+                         "value_type": "individual"
+                      },
+                      "type": "graph",
+                      "xaxis": {
+                         "buckets": null,
+                         "mode": "time",
+                         "name": null,
+                         "show": true,
+                         "values": [ ]
+                      },
+                      "yaxes": [
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                         },
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                         }
+                      ]
+                   },
+                   {
+                      "aliasColors": { },
+                      "bars": false,
+                      "dashLength": 10,
+                      "dashes": false,
+                      "datasource": "$datasource",
+                      "description": "### Total number of buckets used by native histogram series\nTotal number of buckets in active native histogram series per user, and total active native histogram buckets matching custom trackers (in parenthesis).\n\n",
+                      "fill": 1,
+                      "id": 4,
+                      "legend": {
+                         "avg": false,
+                         "current": false,
+                         "max": false,
+                         "min": false,
+                         "show": true,
+                         "total": false,
+                         "values": false
+                      },
+                      "lines": true,
+                      "linewidth": 1,
+                      "links": [ ],
+                      "nullPointMode": "null as zero",
+                      "percentage": false,
+                      "pointradius": 5,
+                      "points": false,
+                      "renderer": "flot",
+                      "seriesOverrides": [
+                         {
+                            "alias": "limit",
+                            "dashes": true,
+                            "fill": 0
+                         }
+                      ],
+                      "spaceLength": 10,
+                      "span": 4,
+                      "stack": false,
+                      "steppedLine": false,
+                      "targets": [
+                         {
+                            "expr": "sum(\n  cortex_ingester_active_native_histogram_buckets{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n)\n",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "active",
+                            "legendLink": null
+                         },
+                         {
+                            "expr": "sum by (name) (\n  cortex_ingester_active_native_histogram_buckets_custom_tracker{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n) > 0\n",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "active ({{ name }})",
+                            "legendLink": null
+                         }
+                      ],
+                      "thresholds": [ ],
+                      "timeFrom": null,
+                      "timeShift": null,
+                      "title": "Total number of buckets used by native histogram series",
+                      "tooltip": {
+                         "shared": false,
+                         "sort": 0,
+                         "value_type": "individual"
+                      },
+                      "type": "graph",
+                      "xaxis": {
+                         "buckets": null,
+                         "mode": "time",
+                         "name": null,
+                         "show": true,
+                         "values": [ ]
+                      },
+                      "yaxes": [
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                         },
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                         }
+                      ]
+                   }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "Active series and native histograms",
+                "titleSize": "h6"
+             },
+             {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                   {
+                      "aliasColors": { },
+                      "bars": false,
+                      "dashLength": 10,
+                      "dashes": false,
+                      "datasource": "$datasource",
+                      "description": "### Series with exemplars\nNumber of series with exemplars currently in storage.\n\n",
+                      "fill": 1,
+                      "id": 5,
                       "legend": {
                          "show": false
                       },
@@ -32307,7 +32497,7 @@ data:
                       "renderer": "flot",
                       "seriesOverrides": [ ],
                       "spaceLength": 10,
-                      "span": 3,
+                      "span": 4,
                       "stack": false,
                       "steppedLine": false,
                       "targets": [
@@ -32363,7 +32553,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Newest seen sample age\nThe age of the newest received sample seen in the distributors.\n\n",
                       "fill": 1,
-                      "id": 4,
+                      "id": 6,
                       "legend": {
                          "show": false
                       },
@@ -32377,7 +32567,7 @@ data:
                       "renderer": "flot",
                       "seriesOverrides": [ ],
                       "spaceLength": 10,
-                      "span": 3,
+                      "span": 4,
                       "stack": false,
                       "steppedLine": false,
                       "targets": [
@@ -32433,7 +32623,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Oldest exemplar age\nThe age of the oldest exemplar stored in circular storage.\nUseful to check for what time range the current exemplar buffer limit allows.\nThis usually means the max age for all exemplars for a typical setup.\nThis is not true though if one of the series timestamp is in future compared to rest series.\n\n",
                       "fill": 1,
-                      "id": 5,
+                      "id": 7,
                       "legend": {
                          "show": false
                       },
@@ -32447,7 +32637,7 @@ data:
                       "renderer": "flot",
                       "seriesOverrides": [ ],
                       "spaceLength": 10,
-                      "span": 3,
+                      "span": 4,
                       "stack": false,
                       "steppedLine": false,
                       "targets": [
@@ -32500,7 +32690,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Series and exemplars",
+                "title": "Samples and exemplars",
                 "titleSize": "h6"
              },
              {
@@ -32515,7 +32705,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor requests incoming rate\nThe rate of requests that have come in to the distributor, including rejected requests.\n\n",
                       "fill": 1,
-                      "id": 6,
+                      "id": 8,
                       "legend": {
                          "show": false
                       },
@@ -32585,7 +32775,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor requests received (accepted) rate\nThe rate of received requests, excluding rejected requests.\n\n",
                       "fill": 1,
-                      "id": 7,
+                      "id": 9,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32674,7 +32864,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor discarded requests rate\nThe rate of each request's discarding reason.\n\n",
                       "fill": 1,
-                      "id": 8,
+                      "id": 10,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32762,7 +32952,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor samples incoming rate\nThe rate of samples that have come in to the distributor, including rejected or deduped exemplars.\n\n",
                       "fill": 1,
-                      "id": 9,
+                      "id": 11,
                       "legend": {
                          "show": false
                       },
@@ -32832,7 +33022,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor samples received (accepted) rate\nThe rate of received samples, excluding rejected and deduped samples.\n\n",
                       "fill": 1,
-                      "id": 10,
+                      "id": 12,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32921,7 +33111,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor deduplicated/non-HA\nThe rate of deduplicated samples and the rate of received samples for a user that has HA tracking turned on, but the sample didn't contain both HA labels.\n\n",
                       "fill": 1,
-                      "id": 11,
+                      "id": 13,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -33004,7 +33194,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor and ingester discarded samples rate\nThe rate of each sample's discarding reason.\n\n",
                       "fill": 1,
-                      "id": 12,
+                      "id": 14,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -33099,7 +33289,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor exemplars incoming rate\nThe rate of exemplars that have come in to the distributor, including rejected or deduped exemplars.\n\n",
                       "fill": 1,
-                      "id": 13,
+                      "id": 15,
                       "legend": {
                          "show": false
                       },
@@ -33169,7 +33359,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor exemplars received (accepted) rate\nThe rate of received exemplars, excluding rejected and deduped exemplars.\nThis number can be sensibly lower than incoming rate because we dedupe the HA sent exemplars, and then reject based on time.\nSee discarded rate for reasons why exemplars are being discarded.\n\n",
                       "fill": 1,
-                      "id": 14,
+                      "id": 16,
                       "legend": {
                          "show": false
                       },
@@ -33239,7 +33429,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Distributor discarded exemplars rate\nThe rate of each exmplars' discarding reason.\n\n",
                       "fill": 1,
-                      "id": 15,
+                      "id": 17,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -33315,7 +33505,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\n\n",
                       "fill": 1,
-                      "id": 16,
+                      "id": 18,
                       "legend": {
                          "show": false
                       },
@@ -33397,7 +33587,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Symbol table size for loaded blocks\nSize of symbol table in memory for loaded blocks, averaged by ingester.\n\n",
                       "fill": 1,
-                      "id": 17,
+                      "id": 19,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -33473,7 +33663,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Space used by local blocks\nThe number of bytes that are currently used for local storage by all blocks.\n\n",
                       "fill": 1,
-                      "id": 18,
+                      "id": 20,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -33561,7 +33751,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Number of groups\nTotal number of rule groups for a tenant.\n\n",
                       "fill": 1,
-                      "id": 19,
+                      "id": 21,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -33650,7 +33840,7 @@ data:
                       "datasource": "$datasource",
                       "description": "### Number of rules\nTotal number of rules for a tenant.\n\n",
                       "fill": 1,
-                      "id": 20,
+                      "id": 22,
                       "legend": {
                          "show": false
                       },
@@ -33719,7 +33909,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 21,
+                      "id": 23,
                       "legend": {
                          "show": false
                       },
@@ -33788,7 +33978,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 22,
+                      "id": 24,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -33875,7 +34065,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 23,
+                      "id": 25,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -33990,7 +34180,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 24,
+                      "id": 26,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -34117,7 +34307,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 25,
+                      "id": 27,
                       "legend": {
                          "show": false
                       },
@@ -34188,7 +34378,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 26,
+                      "id": 28,
                       "legend": {
                          "show": false
                       },
@@ -34269,7 +34459,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 27,
+                      "id": 29,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -34344,7 +34534,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 28,
+                      "id": 30,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -34431,7 +34621,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 29,
+                      "id": 31,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -34506,7 +34696,7 @@ data:
                       "dashes": false,
                       "datasource": "$datasource",
                       "fill": 1,
-                      "id": 30,
+                      "id": 32,
                       "legend": {
                          "avg": false,
                          "current": false,

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -32416,14 +32416,14 @@ data:
                             "expr": "sum(\n  cortex_ingester_active_native_histogram_buckets{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n)\n",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "active",
+                            "legendFormat": "buckets",
                             "legendLink": null
                          },
                          {
                             "expr": "sum by (name) (\n  cortex_ingester_active_native_histogram_buckets_custom_tracker{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n) > 0\n",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "active ({{ name }})",
+                            "legendFormat": "buckets ({{ name }})",
                             "legendLink": null
                          }
                       ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -291,14 +291,14 @@
                         "expr": "sum(\n  cortex_ingester_active_native_histogram_buckets{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "active",
+                        "legendFormat": "buckets",
                         "legendLink": null
                      },
                      {
                         "expr": "sum by (name) (\n  cortex_ingester_active_native_histogram_buckets_custom_tracker{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n) > 0\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "active ({{ name }})",
+                        "legendFormat": "buckets ({{ name }})",
                         "legendLink": null
                      }
                   ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -255,7 +255,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Native histogram buckets\nNumber of active native histogram buckets per user, and active native histogram buckets matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
+                  "description": "### Total number of buckets used by native histogram series\nTotal number of buckets in active native histogram series per user, and total active native histogram buckets matching custom trackers (in parenthesis).\n\n",
                   "fill": 1,
                   "id": 4,
                   "legend": {
@@ -305,7 +305,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Native histogram buckets",
+                  "title": "Total number of buckets used by native histogram series",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -63,7 +63,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Series\nNumber of active and in-memory series per user, and active series matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
+                  "description": "### All series\nNumber of active and in-memory series per user, and active series matching custom trackers (in parenthesis).\nNote that these counts include all series regardless of the type of data (counter, gauge, native histogram, etc.).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
                   "fill": 1,
                   "id": 2,
                   "legend": {
@@ -91,7 +91,7 @@
                      }
                   ],
                   "spaceLength": 10,
-                  "span": 3,
+                  "span": 4,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -127,7 +127,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series",
+                  "title": "All series",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -166,9 +166,199 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Series with exemplars\nNumber of series with exemplars currently in storage.\n\n",
+                  "description": "### Native histogram series\nNumber of active native histogram series per user, and active native histogram series matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
                   "fill": 1,
                   "id": 3,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [
+                     {
+                        "alias": "limit",
+                        "dashes": true,
+                        "fill": 0
+                     }
+                  ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  cortex_ingester_active_native_histogram_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n)\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "active",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum by (name) (\n  cortex_ingester_active_native_histogram_series_custom_tracker{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n) > 0\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "active ({{ name }})",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Native histogram series",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Native histogram buckets\nNumber of active native histogram buckets per user, and active native histogram buckets matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
+                  "fill": 1,
+                  "id": 4,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [
+                     {
+                        "alias": "limit",
+                        "dashes": true,
+                        "fill": 0
+                     }
+                  ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  cortex_ingester_active_native_histogram_buckets{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n)\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "active",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum by (name) (\n  cortex_ingester_active_native_histogram_buckets_custom_tracker{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n) > 0\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "active ({{ name }})",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Native histogram buckets",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Active series and native histograms",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Series with exemplars\nNumber of series with exemplars currently in storage.\n\n",
+                  "fill": 1,
+                  "id": 5,
                   "legend": {
                      "show": false
                   },
@@ -182,7 +372,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 3,
+                  "span": 4,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -238,7 +428,7 @@
                   "datasource": "$datasource",
                   "description": "### Newest seen sample age\nThe age of the newest received sample seen in the distributors.\n\n",
                   "fill": 1,
-                  "id": 4,
+                  "id": 6,
                   "legend": {
                      "show": false
                   },
@@ -252,7 +442,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 3,
+                  "span": 4,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -308,7 +498,7 @@
                   "datasource": "$datasource",
                   "description": "### Oldest exemplar age\nThe age of the oldest exemplar stored in circular storage.\nUseful to check for what time range the current exemplar buffer limit allows.\nThis usually means the max age for all exemplars for a typical setup.\nThis is not true though if one of the series timestamp is in future compared to rest series.\n\n",
                   "fill": 1,
-                  "id": 5,
+                  "id": 7,
                   "legend": {
                      "show": false
                   },
@@ -322,7 +512,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 3,
+                  "span": 4,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -375,7 +565,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Series and exemplars",
+            "title": "Samples and exemplars",
             "titleSize": "h6"
          },
          {
@@ -390,7 +580,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor requests incoming rate\nThe rate of requests that have come in to the distributor, including rejected requests.\n\n",
                   "fill": 1,
-                  "id": 6,
+                  "id": 8,
                   "legend": {
                      "show": false
                   },
@@ -460,7 +650,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor requests received (accepted) rate\nThe rate of received requests, excluding rejected requests.\n\n",
                   "fill": 1,
-                  "id": 7,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -549,7 +739,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor discarded requests rate\nThe rate of each request's discarding reason.\n\n",
                   "fill": 1,
-                  "id": 8,
+                  "id": 10,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -637,7 +827,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor samples incoming rate\nThe rate of samples that have come in to the distributor, including rejected or deduped exemplars.\n\n",
                   "fill": 1,
-                  "id": 9,
+                  "id": 11,
                   "legend": {
                      "show": false
                   },
@@ -707,7 +897,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor samples received (accepted) rate\nThe rate of received samples, excluding rejected and deduped samples.\n\n",
                   "fill": 1,
-                  "id": 10,
+                  "id": 12,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -796,7 +986,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor deduplicated/non-HA\nThe rate of deduplicated samples and the rate of received samples for a user that has HA tracking turned on, but the sample didn't contain both HA labels.\n\n",
                   "fill": 1,
-                  "id": 11,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -879,7 +1069,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor and ingester discarded samples rate\nThe rate of each sample's discarding reason.\n\n",
                   "fill": 1,
-                  "id": 12,
+                  "id": 14,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -974,7 +1164,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor exemplars incoming rate\nThe rate of exemplars that have come in to the distributor, including rejected or deduped exemplars.\n\n",
                   "fill": 1,
-                  "id": 13,
+                  "id": 15,
                   "legend": {
                      "show": false
                   },
@@ -1044,7 +1234,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor exemplars received (accepted) rate\nThe rate of received exemplars, excluding rejected and deduped exemplars.\nThis number can be sensibly lower than incoming rate because we dedupe the HA sent exemplars, and then reject based on time.\nSee discarded rate for reasons why exemplars are being discarded.\n\n",
                   "fill": 1,
-                  "id": 14,
+                  "id": 16,
                   "legend": {
                      "show": false
                   },
@@ -1114,7 +1304,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor discarded exemplars rate\nThe rate of each exmplars' discarding reason.\n\n",
                   "fill": 1,
-                  "id": 15,
+                  "id": 17,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1190,7 +1380,7 @@
                   "datasource": "$datasource",
                   "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\n\n",
                   "fill": 1,
-                  "id": 16,
+                  "id": 18,
                   "legend": {
                      "show": false
                   },
@@ -1272,7 +1462,7 @@
                   "datasource": "$datasource",
                   "description": "### Symbol table size for loaded blocks\nSize of symbol table in memory for loaded blocks, averaged by ingester.\n\n",
                   "fill": 1,
-                  "id": 17,
+                  "id": 19,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1348,7 +1538,7 @@
                   "datasource": "$datasource",
                   "description": "### Space used by local blocks\nThe number of bytes that are currently used for local storage by all blocks.\n\n",
                   "fill": 1,
-                  "id": 18,
+                  "id": 20,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1436,7 +1626,7 @@
                   "datasource": "$datasource",
                   "description": "### Number of groups\nTotal number of rule groups for a tenant.\n\n",
                   "fill": 1,
-                  "id": 19,
+                  "id": 21,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1525,7 +1715,7 @@
                   "datasource": "$datasource",
                   "description": "### Number of rules\nTotal number of rules for a tenant.\n\n",
                   "fill": 1,
-                  "id": 20,
+                  "id": 22,
                   "legend": {
                      "show": false
                   },
@@ -1594,7 +1784,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 21,
+                  "id": 23,
                   "legend": {
                      "show": false
                   },
@@ -1663,7 +1853,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 22,
+                  "id": 24,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1750,7 +1940,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 23,
+                  "id": 25,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1865,7 +2055,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 24,
+                  "id": 26,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1992,7 +2182,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 25,
+                  "id": 27,
                   "legend": {
                      "show": false
                   },
@@ -2063,7 +2253,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 26,
+                  "id": 28,
                   "legend": {
                      "show": false
                   },
@@ -2144,7 +2334,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 27,
+                  "id": 29,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2219,7 +2409,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 28,
+                  "id": 30,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2306,7 +2496,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 29,
+                  "id": 31,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2381,7 +2571,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 30,
+                  "id": 32,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -291,14 +291,14 @@
                         "expr": "sum(\n  cortex_ingester_active_native_histogram_buckets{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n)\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "active",
+                        "legendFormat": "buckets",
                         "legendLink": null
                      },
                      {
                         "expr": "sum by (name) (\n  cortex_ingester_active_native_histogram_buckets_custom_tracker{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n) > 0\n",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "active ({{ name }})",
+                        "legendFormat": "buckets ({{ name }})",
                         "legendLink": null
                      }
                   ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -255,7 +255,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Native histogram buckets\nNumber of active native histogram buckets per user, and active native histogram buckets matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
+                  "description": "### Total number of buckets used by native histogram series\nTotal number of buckets in active native histogram series per user, and total active native histogram buckets matching custom trackers (in parenthesis).\n\n",
                   "fill": 1,
                   "id": 4,
                   "legend": {
@@ -305,7 +305,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Native histogram buckets",
+                  "title": "Total number of buckets used by native histogram series",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -63,7 +63,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Series\nNumber of active and in-memory series per user, and active series matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
+                  "description": "### All series\nNumber of active and in-memory series per user, and active series matching custom trackers (in parenthesis).\nNote that these counts include all series regardless of the type of data (counter, gauge, native histogram, etc.).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
                   "fill": 1,
                   "id": 2,
                   "legend": {
@@ -91,7 +91,7 @@
                      }
                   ],
                   "spaceLength": 10,
-                  "span": 3,
+                  "span": 4,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -127,7 +127,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Series",
+                  "title": "All series",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -166,9 +166,199 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Series with exemplars\nNumber of series with exemplars currently in storage.\n\n",
+                  "description": "### Native histogram series\nNumber of active native histogram series per user, and active native histogram series matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
                   "fill": 1,
                   "id": 3,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [
+                     {
+                        "alias": "limit",
+                        "dashes": true,
+                        "fill": 0
+                     }
+                  ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  cortex_ingester_active_native_histogram_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n)\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "active",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum by (name) (\n  cortex_ingester_active_native_histogram_series_custom_tracker{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n) > 0\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "active ({{ name }})",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Native histogram series",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Native histogram buckets\nNumber of active native histogram buckets per user, and active native histogram buckets matching custom trackers (in parenthesis).\nNote that active series matching custom trackers are included in the total active series count.\n\n",
+                  "fill": 1,
+                  "id": 4,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [
+                     {
+                        "alias": "limit",
+                        "dashes": true,
+                        "fill": 0
+                     }
+                  ],
+                  "spaceLength": 10,
+                  "span": 4,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum(\n  cortex_ingester_active_native_histogram_buckets{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n)\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "active",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum by (name) (\n  cortex_ingester_active_native_histogram_buckets_custom_tracker{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n  / on(cluster, namespace) group_left\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor|cortex|mimir|mimir-write.*))\"})\n) > 0\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "active ({{ name }})",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Native histogram buckets",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Active series and native histograms",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Series with exemplars\nNumber of series with exemplars currently in storage.\n\n",
+                  "fill": 1,
+                  "id": 5,
                   "legend": {
                      "show": false
                   },
@@ -182,7 +372,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 3,
+                  "span": 4,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -238,7 +428,7 @@
                   "datasource": "$datasource",
                   "description": "### Newest seen sample age\nThe age of the newest received sample seen in the distributors.\n\n",
                   "fill": 1,
-                  "id": 4,
+                  "id": 6,
                   "legend": {
                      "show": false
                   },
@@ -252,7 +442,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 3,
+                  "span": 4,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -308,7 +498,7 @@
                   "datasource": "$datasource",
                   "description": "### Oldest exemplar age\nThe age of the oldest exemplar stored in circular storage.\nUseful to check for what time range the current exemplar buffer limit allows.\nThis usually means the max age for all exemplars for a typical setup.\nThis is not true though if one of the series timestamp is in future compared to rest series.\n\n",
                   "fill": 1,
-                  "id": 5,
+                  "id": 7,
                   "legend": {
                      "show": false
                   },
@@ -322,7 +512,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 3,
+                  "span": 4,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -375,7 +565,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Series and exemplars",
+            "title": "Samples and exemplars",
             "titleSize": "h6"
          },
          {
@@ -390,7 +580,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor requests incoming rate\nThe rate of requests that have come in to the distributor, including rejected requests.\n\n",
                   "fill": 1,
-                  "id": 6,
+                  "id": 8,
                   "legend": {
                      "show": false
                   },
@@ -460,7 +650,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor requests received (accepted) rate\nThe rate of received requests, excluding rejected requests.\n\n",
                   "fill": 1,
-                  "id": 7,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -549,7 +739,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor discarded requests rate\nThe rate of each request's discarding reason.\n\n",
                   "fill": 1,
-                  "id": 8,
+                  "id": 10,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -637,7 +827,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor samples incoming rate\nThe rate of samples that have come in to the distributor, including rejected or deduped exemplars.\n\n",
                   "fill": 1,
-                  "id": 9,
+                  "id": 11,
                   "legend": {
                      "show": false
                   },
@@ -707,7 +897,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor samples received (accepted) rate\nThe rate of received samples, excluding rejected and deduped samples.\n\n",
                   "fill": 1,
-                  "id": 10,
+                  "id": 12,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -796,7 +986,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor deduplicated/non-HA\nThe rate of deduplicated samples and the rate of received samples for a user that has HA tracking turned on, but the sample didn't contain both HA labels.\n\n",
                   "fill": 1,
-                  "id": 11,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -879,7 +1069,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor and ingester discarded samples rate\nThe rate of each sample's discarding reason.\n\n",
                   "fill": 1,
-                  "id": 12,
+                  "id": 14,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -974,7 +1164,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor exemplars incoming rate\nThe rate of exemplars that have come in to the distributor, including rejected or deduped exemplars.\n\n",
                   "fill": 1,
-                  "id": 13,
+                  "id": 15,
                   "legend": {
                      "show": false
                   },
@@ -1044,7 +1234,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor exemplars received (accepted) rate\nThe rate of received exemplars, excluding rejected and deduped exemplars.\nThis number can be sensibly lower than incoming rate because we dedupe the HA sent exemplars, and then reject based on time.\nSee discarded rate for reasons why exemplars are being discarded.\n\n",
                   "fill": 1,
-                  "id": 14,
+                  "id": 16,
                   "legend": {
                      "show": false
                   },
@@ -1114,7 +1304,7 @@
                   "datasource": "$datasource",
                   "description": "### Distributor discarded exemplars rate\nThe rate of each exmplars' discarding reason.\n\n",
                   "fill": 1,
-                  "id": 15,
+                  "id": 17,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1190,7 +1380,7 @@
                   "datasource": "$datasource",
                   "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\n\n",
                   "fill": 1,
-                  "id": 16,
+                  "id": 18,
                   "legend": {
                      "show": false
                   },
@@ -1272,7 +1462,7 @@
                   "datasource": "$datasource",
                   "description": "### Symbol table size for loaded blocks\nSize of symbol table in memory for loaded blocks, averaged by ingester.\n\n",
                   "fill": 1,
-                  "id": 17,
+                  "id": 19,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1348,7 +1538,7 @@
                   "datasource": "$datasource",
                   "description": "### Space used by local blocks\nThe number of bytes that are currently used for local storage by all blocks.\n\n",
                   "fill": 1,
-                  "id": 18,
+                  "id": 20,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1436,7 +1626,7 @@
                   "datasource": "$datasource",
                   "description": "### Number of groups\nTotal number of rule groups for a tenant.\n\n",
                   "fill": 1,
-                  "id": 19,
+                  "id": 21,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1525,7 +1715,7 @@
                   "datasource": "$datasource",
                   "description": "### Number of rules\nTotal number of rules for a tenant.\n\n",
                   "fill": 1,
-                  "id": 20,
+                  "id": 22,
                   "legend": {
                      "show": false
                   },
@@ -1594,7 +1784,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 21,
+                  "id": 23,
                   "legend": {
                      "show": false
                   },
@@ -1663,7 +1853,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 22,
+                  "id": 24,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1750,7 +1940,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 23,
+                  "id": 25,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1865,7 +2055,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 24,
+                  "id": 26,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1992,7 +2182,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 25,
+                  "id": 27,
                   "legend": {
                      "show": false
                   },
@@ -2063,7 +2253,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 26,
+                  "id": 28,
                   "legend": {
                      "show": false
                   },
@@ -2144,7 +2334,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 27,
+                  "id": 29,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2219,7 +2409,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 28,
+                  "id": 30,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2306,7 +2496,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 29,
+                  "id": 31,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -2381,7 +2571,7 @@
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 1,
-                  "id": 30,
+                  "id": 32,
                   "legend": {
                      "avg": false,
                      "current": false,

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -139,7 +139,7 @@ local filename = 'mimir-tenants.json';
         ),
       )
       .addPanel(
-        local title = 'Native histogram buckets';
+        local title = 'Total number of buckets used by native histogram series';
         $.panel(title) +
         $.queryPanel(
           [
@@ -175,8 +175,7 @@ local filename = 'mimir-tenants.json';
         $.panelDescription(
           title,
           |||
-            Number of active native histogram buckets per user, and active native histogram buckets matching custom trackers (in parenthesis).
-            Note that active series matching custom trackers are included in the total active series count.
+            Total number of buckets in active native histogram series per user, and total active native histogram buckets matching custom trackers (in parenthesis).
           |||
         ),
       )

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -35,9 +35,9 @@ local filename = 'mimir-tenants.json';
     )
 
     .addRow(
-      $.row('Series and exemplars')
+      $.row('Active series and native histograms')
       .addPanel(
-        local title = 'Series';
+        local title = 'All series';
         $.panel(title) +
         $.queryPanel(
           [
@@ -91,10 +91,99 @@ local filename = 'mimir-tenants.json';
           title,
           |||
             Number of active and in-memory series per user, and active series matching custom trackers (in parenthesis).
+            Note that these counts include all series regardless of the type of data (counter, gauge, native histogram, etc.).
             Note that active series matching custom trackers are included in the total active series count.
           |||
         ),
       )
+      .addPanel(
+        local title = 'Native histogram series';
+        $.panel(title) +
+        $.queryPanel(
+          [
+            |||
+              sum(
+                cortex_ingester_active_native_histogram_series{%(ingester)s, user="$user"}
+                / on(%(group_by_cluster)s) group_left
+                max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
+              )
+            ||| % {
+              ingester: $.jobMatcher($._config.job_names.ingester),
+              distributor: $.jobMatcher($._config.job_names.distributor),
+              group_by_cluster: $._config.group_by_cluster,
+            },
+            |||
+              sum by (name) (
+                cortex_ingester_active_native_histogram_series_custom_tracker{%(ingester)s, user="$user"}
+                / on(%(group_by_cluster)s) group_left
+                max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
+              ) > 0
+            ||| % {
+              ingester: $.jobMatcher($._config.job_names.ingester),
+              distributor: $.jobMatcher($._config.job_names.distributor),
+              group_by_cluster: $._config.group_by_cluster,
+            },
+          ],
+          [
+            'active',
+            'active ({{ name }})',
+          ],
+        ) +
+        { seriesOverrides: [limit_style] } +
+        $.panelDescription(
+          title,
+          |||
+            Number of active native histogram series per user, and active native histogram series matching custom trackers (in parenthesis).
+            Note that active series matching custom trackers are included in the total active series count.
+          |||
+        ),
+      )
+      .addPanel(
+        local title = 'Native histogram buckets';
+        $.panel(title) +
+        $.queryPanel(
+          [
+            |||
+              sum(
+                cortex_ingester_active_native_histogram_buckets{%(ingester)s, user="$user"}
+                / on(%(group_by_cluster)s) group_left
+                max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
+              )
+            ||| % {
+              ingester: $.jobMatcher($._config.job_names.ingester),
+              distributor: $.jobMatcher($._config.job_names.distributor),
+              group_by_cluster: $._config.group_by_cluster,
+            },
+            |||
+              sum by (name) (
+                cortex_ingester_active_native_histogram_buckets_custom_tracker{%(ingester)s, user="$user"}
+                / on(%(group_by_cluster)s) group_left
+                max by (%(group_by_cluster)s) (cortex_distributor_replication_factor{%(distributor)s})
+              ) > 0
+            ||| % {
+              ingester: $.jobMatcher($._config.job_names.ingester),
+              distributor: $.jobMatcher($._config.job_names.distributor),
+              group_by_cluster: $._config.group_by_cluster,
+            },
+          ],
+          [
+            'active',
+            'active ({{ name }})',
+          ],
+        ) +
+        { seriesOverrides: [limit_style] } +
+        $.panelDescription(
+          title,
+          |||
+            Number of active native histogram buckets per user, and active native histogram buckets matching custom trackers (in parenthesis).
+            Note that active series matching custom trackers are included in the total active series count.
+          |||
+        ),
+      )
+    )
+
+    .addRow(
+      $.row('Samples and exemplars')
       .addPanel(
         local title = 'Series with exemplars';
         $.panel(title) +

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -167,8 +167,8 @@ local filename = 'mimir-tenants.json';
             },
           ],
           [
-            'active',
-            'active ({{ name }})',
+            'buckets',
+            'buckets ({{ name }})',
           ],
         ) +
         { seriesOverrides: [limit_style] } +


### PR DESCRIPTION
#### What this PR does

Adds two new panels to the Tenants dashboard to have information about the tracked native histograms series and
buckets.

Proposal is to split the current top row: keep the series panel and move exemplars/samples to their own row.
Add native histogram tracking to the top row:
![image](https://github.com/grafana/mimir/assets/13435893/81a72830-f47f-4713-ba99-32bd5cb8b65f)


#### Which issue(s) this PR fixes or relates to

Fixes #5542 

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
