### PR TITLE
Add metrics for requests rejected due to per-instance limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 * [ENHANCEMENT] Ingester: Add two metrics tracking resource utilization calculated by utilization based limiter: #5496
   * `cortex_ingester_utilization_limiter_current_cpu_load`: The current exponential weighted moving average of the ingester's CPU load
   * `cortex_ingester_utilization_limiter_current_memory_usage_bytes`: The current ingester memory utilization
-* [ENHANCEMENT] Distributor Ingester: Add metrics to count the number of requests rejected for hitting per-instance limits, `cortex_distributor_instance_discarded_requests_total` and `cortex_ingester_instance_discarded_requests_total` respectively. #5551
+* [ENHANCEMENT] Distributor Ingester: Add metrics to count the number of requests rejected for hitting per-instance limits, `cortex_distributor_instance_rejected_requests_total` and `cortex_ingester_instance_rejected_requests_total` respectively. #5551
 * [ENHANCEMENT] Distributor: add support for ingesting exponential histograms that are over the native histogram scale limit of 8 in OpenTelemetry format by downscaling them. #5532
 * [ENHANCEMENT] General: buffered logging: #5506
   * `-log.buffered`: Enable buffered logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [ENHANCEMENT] Ingester: Add two metrics tracking resource utilization calculated by utilization based limiter: #5496
   * `cortex_ingester_utilization_limiter_current_cpu_load`: The current exponential weighted moving average of the ingester's CPU load
   * `cortex_ingester_utilization_limiter_current_memory_usage_bytes`: The current ingester memory utilization
+* [ENHANCEMENT] Distributor Ingester: Add metrics to count the number of requests rejected for hitting per-instance limits, `cortex_distributor_instance_discarded_requests_total` and `cortex_ingester_instance_discarded_requests_total` respectively. #5551
 * [ENHANCEMENT] Distributor: add support for ingesting exponential histograms that are over the native histogram scale limit of 8 in OpenTelemetry format by downscaling them. #5532
 * [ENHANCEMENT] General: buffered logging: #5506
   * `-log.buffered`: Enable buffered logging

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -119,6 +119,13 @@ const (
 	maxTSDBOpenWithoutConcurrency = 10
 )
 
+var (
+	reasonIngesterMaxIngestionRate        = globalerror.IngesterMaxIngestionRate.LabelValue()
+	reasonIngesterMaxTenants              = globalerror.IngesterMaxTenants.LabelValue()
+	reasonIngesterMaxInMemorySeries       = globalerror.IngesterMaxInMemorySeries.LabelValue()
+	reasonIngesterMaxInflightPushRequests = globalerror.IngesterMaxInflightPushRequests.LabelValue()
+)
+
 // BlocksUploader interface is used to have an easy way to mock it in tests.
 type BlocksUploader interface {
 	Sync(ctx context.Context) (uploaded int, err error)
@@ -718,7 +725,7 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, pushReq *push.Request) (
 	il := i.getInstanceLimits()
 	if il != nil && il.MaxInflightPushRequests > 0 {
 		if inflight > il.MaxInflightPushRequests {
-			i.metrics.discardedInstance.WithLabelValues(validation.ReasonIngesterMaxInflightPushRequests).Inc()
+			i.metrics.rejected.WithLabelValues(reasonIngesterMaxInflightPushRequests).Inc()
 			return nil, errMaxInflightRequestsReached
 		}
 	}
@@ -730,7 +737,7 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, pushReq *push.Request) (
 
 	if il != nil && il.MaxIngestionRate > 0 {
 		if rate := i.ingestionRate.Rate(); rate >= il.MaxIngestionRate {
-			i.metrics.discardedInstance.WithLabelValues(validation.ReasonIngesterMaxIngestionRate).Inc()
+			i.metrics.rejected.WithLabelValues(reasonIngesterMaxIngestionRate).Inc()
 			return nil, errMaxIngestionRateReached
 		}
 	}
@@ -2026,7 +2033,7 @@ func (i *Ingester) getOrCreateTSDB(userID string, force bool) (*userTSDB, error)
 	gl := i.getInstanceLimits()
 	if gl != nil && gl.MaxInMemoryTenants > 0 {
 		if users := int64(len(i.tsdbs)); users >= gl.MaxInMemoryTenants {
-			i.metrics.discardedInstance.WithLabelValues(validation.ReasonIngesterMaxTenants).Inc()
+			i.metrics.rejected.WithLabelValues(reasonIngesterMaxTenants).Inc()
 			return nil, errMaxTenantsReached
 		}
 	}
@@ -2061,7 +2068,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 		ingestedRuleSamples: util_math.NewEWMARate(0.2, i.cfg.RateUpdatePeriod),
 		instanceLimitsFn:    i.getInstanceLimits,
 		instanceSeriesCount: &i.seriesCount,
-		instanceErrors:      i.metrics.discardedInstance,
+		instanceErrors:      i.metrics.rejected,
 		blockMinRetention:   i.cfg.BlocksStorageConfig.TSDB.Retention,
 	}
 

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -60,7 +60,8 @@ type ingesterMetrics struct {
 	// Open all existing TSDBs metrics
 	openExistingTSDB prometheus.Counter
 
-	discarded *discardedMetrics
+	discarded         *discardedMetrics
+	discardedInstance *prometheus.CounterVec
 
 	// Discarded metadata
 	discardedMetadataPerUserMetadataLimit   *prometheus.CounterVec
@@ -310,6 +311,10 @@ func newIngesterMetrics(
 		}),
 
 		discarded: newDiscardedMetrics(r),
+		discardedInstance: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ingester_instance_discarded_requests_total",
+			Help: "Requests discarded for hitting per-instance limits",
+		}, []string{"reason"}),
 
 		discardedMetadataPerUserMetadataLimit:   validation.DiscardedMetadataCounter(r, perUserMetadataLimit),
 		discardedMetadataPerMetricMetadataLimit: validation.DiscardedMetadataCounter(r, perMetricMetadataLimit),

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
 	"github.com/grafana/mimir/pkg/util/extract"
 	util_math "github.com/grafana/mimir/pkg/util/math"
-	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 type tsdbState int
@@ -267,7 +266,7 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 	gl := u.instanceLimitsFn()
 	if gl != nil && gl.MaxInMemorySeries > 0 {
 		if series := u.instanceSeriesCount.Load(); series >= gl.MaxInMemorySeries {
-			u.instanceErrors.WithLabelValues(validation.ReasonIngesterMaxInMemorySeries).Inc()
+			u.instanceErrors.WithLabelValues(reasonIngesterMaxInMemorySeries).Inc()
 			return errMaxInMemorySeriesReached
 		}
 	}

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
@@ -22,6 +23,7 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
 	"github.com/grafana/mimir/pkg/util/extract"
 	util_math "github.com/grafana/mimir/pkg/util/math"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 type tsdbState int
@@ -88,6 +90,7 @@ type userTSDB struct {
 
 	instanceSeriesCount *atomic.Int64 // Shared across all userTSDB instances created by ingester.
 	instanceLimitsFn    func() *InstanceLimits
+	instanceErrors      *prometheus.CounterVec
 
 	stateMtx                                     sync.RWMutex
 	state                                        tsdbState
@@ -264,6 +267,7 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 	gl := u.instanceLimitsFn()
 	if gl != nil && gl.MaxInMemorySeries > 0 {
 		if series := u.instanceSeriesCount.Load(); series >= gl.MaxInMemorySeries {
+			u.instanceErrors.WithLabelValues(validation.ReasonIngesterMaxInMemorySeries).Inc()
 			return errMaxInMemorySeriesReached
 		}
 	}

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -96,6 +96,11 @@ func (id ID) MessageWithStrategyAndPerTenantLimitConfig(msg, strategy, flag stri
 		msg, errPrefix, id, strategy, plural, flagsList)
 }
 
+// LabelValue returns the error ID converted to a form suitable for use as a Prometheus label value.
+func (id ID) LabelValue() string {
+	return strings.ReplaceAll(string(id), "-", "_")
+}
+
 func buildFlagsList(flag string, addFlags ...string) (string, string) {
 	var sb strings.Builder
 	sb.WriteString("-")

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -6,7 +6,6 @@
 package validation
 
 import (
-	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -29,26 +28,26 @@ const (
 
 var (
 	// Discarded series / samples reasons.
-	reasonMissingMetricName         = metricReasonFromErrorID(globalerror.MissingMetricName)
-	reasonInvalidMetricName         = metricReasonFromErrorID(globalerror.InvalidMetricName)
-	reasonMaxLabelNamesPerSeries    = metricReasonFromErrorID(globalerror.MaxLabelNamesPerSeries)
-	reasonInvalidLabel              = metricReasonFromErrorID(globalerror.SeriesInvalidLabel)
-	reasonLabelNameTooLong          = metricReasonFromErrorID(globalerror.SeriesLabelNameTooLong)
-	reasonLabelValueTooLong         = metricReasonFromErrorID(globalerror.SeriesLabelValueTooLong)
-	reasonMaxNativeHistogramBuckets = metricReasonFromErrorID(globalerror.MaxNativeHistogramBuckets)
-	reasonDuplicateLabelNames       = metricReasonFromErrorID(globalerror.SeriesWithDuplicateLabelNames)
-	reasonTooFarInFuture            = metricReasonFromErrorID(globalerror.SampleTooFarInFuture)
+	reasonMissingMetricName         = globalerror.MissingMetricName.LabelValue()
+	reasonInvalidMetricName         = globalerror.InvalidMetricName.LabelValue()
+	reasonMaxLabelNamesPerSeries    = globalerror.MaxLabelNamesPerSeries.LabelValue()
+	reasonInvalidLabel              = globalerror.SeriesInvalidLabel.LabelValue()
+	reasonLabelNameTooLong          = globalerror.SeriesLabelNameTooLong.LabelValue()
+	reasonLabelValueTooLong         = globalerror.SeriesLabelValueTooLong.LabelValue()
+	reasonMaxNativeHistogramBuckets = globalerror.MaxNativeHistogramBuckets.LabelValue()
+	reasonDuplicateLabelNames       = globalerror.SeriesWithDuplicateLabelNames.LabelValue()
+	reasonTooFarInFuture            = globalerror.SampleTooFarInFuture.LabelValue()
 
 	// Discarded exemplars reasons.
-	reasonExemplarLabelsMissing    = metricReasonFromErrorID(globalerror.ExemplarLabelsMissing)
-	reasonExemplarLabelsTooLong    = metricReasonFromErrorID(globalerror.ExemplarLabelsTooLong)
-	reasonExemplarTimestampInvalid = metricReasonFromErrorID(globalerror.ExemplarTimestampInvalid)
+	reasonExemplarLabelsMissing    = globalerror.ExemplarLabelsMissing.LabelValue()
+	reasonExemplarLabelsTooLong    = globalerror.ExemplarLabelsTooLong.LabelValue()
+	reasonExemplarTimestampInvalid = globalerror.ExemplarTimestampInvalid.LabelValue()
 	reasonExemplarLabelsBlank      = "exemplar_labels_blank"
 	reasonExemplarTooOld           = "exemplar_too_old"
 
 	// Discarded metadata reasons.
-	reasonMetadataMetricNameTooLong = metricReasonFromErrorID(globalerror.MetricMetadataMetricNameTooLong)
-	reasonMetadataUnitTooLong       = metricReasonFromErrorID(globalerror.MetricMetadataUnitTooLong)
+	reasonMetadataMetricNameTooLong = globalerror.MetricMetadataMetricNameTooLong.LabelValue()
+	reasonMetadataUnitTooLong       = globalerror.MetricMetadataUnitTooLong.LabelValue()
 
 	// ReasonRateLimited is one of the values for the reason to discard samples.
 	// Declared here to avoid duplication in ingester and distributor.
@@ -56,20 +55,7 @@ var (
 
 	// ReasonTooManyHAClusters is one of the reasons for discarding samples.
 	ReasonTooManyHAClusters = "too_many_ha_clusters"
-
-	ReasonDistributorMaxIngestionRate             = metricReasonFromErrorID(globalerror.DistributorMaxIngestionRate)
-	ReasonDistributorMaxInflightPushRequests      = metricReasonFromErrorID(globalerror.DistributorMaxInflightPushRequests)
-	ReasonDistributorMaxInflightPushRequestsBytes = metricReasonFromErrorID(globalerror.DistributorMaxInflightPushRequestsBytes)
-
-	ReasonIngesterMaxIngestionRate        = metricReasonFromErrorID(globalerror.IngesterMaxIngestionRate)
-	ReasonIngesterMaxTenants              = metricReasonFromErrorID(globalerror.IngesterMaxTenants)
-	ReasonIngesterMaxInMemorySeries       = metricReasonFromErrorID(globalerror.IngesterMaxInMemorySeries)
-	ReasonIngesterMaxInflightPushRequests = metricReasonFromErrorID(globalerror.IngesterMaxInflightPushRequests)
 )
-
-func metricReasonFromErrorID(id globalerror.ID) string {
-	return strings.ReplaceAll(string(id), "-", "_")
-}
 
 // DiscardedRequestsCounter creates per-user counter vector for requests discarded for a given reason.
 func DiscardedRequestsCounter(reg prometheus.Registerer, reason string) *prometheus.CounterVec {

--- a/pkg/util/validation/validate.go
+++ b/pkg/util/validation/validate.go
@@ -56,6 +56,15 @@ var (
 
 	// ReasonTooManyHAClusters is one of the reasons for discarding samples.
 	ReasonTooManyHAClusters = "too_many_ha_clusters"
+
+	ReasonDistributorMaxIngestionRate             = metricReasonFromErrorID(globalerror.DistributorMaxIngestionRate)
+	ReasonDistributorMaxInflightPushRequests      = metricReasonFromErrorID(globalerror.DistributorMaxInflightPushRequests)
+	ReasonDistributorMaxInflightPushRequestsBytes = metricReasonFromErrorID(globalerror.DistributorMaxInflightPushRequestsBytes)
+
+	ReasonIngesterMaxIngestionRate        = metricReasonFromErrorID(globalerror.IngesterMaxIngestionRate)
+	ReasonIngesterMaxTenants              = metricReasonFromErrorID(globalerror.IngesterMaxTenants)
+	ReasonIngesterMaxInMemorySeries       = metricReasonFromErrorID(globalerror.IngesterMaxInMemorySeries)
+	ReasonIngesterMaxInflightPushRequests = metricReasonFromErrorID(globalerror.IngesterMaxInflightPushRequests)
 )
 
 func metricReasonFromErrorID(id globalerror.ID) string {


### PR DESCRIPTION
#### What this PR does

Add metrics to distributors and ingesters that are incremented when we reject requests due to hitting per-instance limits.

#### Which issue(s) this PR fixes or relates to

Related #5494 #397

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
