### PR TITLE
limits: export method to register extension defaults

### DIFF
--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -286,8 +286,6 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.AlertmanagerMaxDispatcherAggregationGroups, "alertmanager.max-dispatcher-aggregation-groups", 0, "Maximum number of aggregation groups in Alertmanager's dispatcher that a tenant can have. Each active aggregation group uses single goroutine. When the limit is reached, dispatcher will not dispatch alerts that belong to additional aggregation groups, but existing groups will keep working properly. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxAlertsCount, "alertmanager.max-alerts-count", 0, "Maximum number of alerts that a single tenant can have. Inserting more alerts will fail with a log message and metric increment. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxAlertsSizeBytes, "alertmanager.max-alerts-size-bytes", 0, "Maximum total size of alerts that a single tenant can have, alert size is the sum of the bytes of its labels, annotations and generatorURL. Inserting more alerts will fail with a log message and metric increment. 0 = no limit.")
-
-	l.setExtensionsDefaults()
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -327,7 +325,11 @@ func (l *Limits) unmarshal(decode func(any) error) error {
 	return l.validate()
 }
 
-func (l *Limits) setExtensionsDefaults() {
+// RegisterExtensionsDefaults registers the default values for extensions into l.
+// This is especially handy for those downstream projects that wish to have control
+// over the exact moment in which the registration happens (e.g. during service
+// dependency initialization).
+func (l *Limits) RegisterExtensionsDefaults() {
 	_, getExtensions := newLimitsWithExtensions((*plainLimits)(l))
 	l.extensions = getExtensions()
 }

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -7,7 +7,6 @@ package validation
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"reflect"
 	"strings"
@@ -722,10 +721,10 @@ func TestExtensions(t *testing.T) {
 		require.Equal(t, stringExtension("default string extension value"), getExtensionString(&limits))
 	})
 
-	t.Run("default value from registered flags", func(t *testing.T) {
+	t.Run("default value after registering extension defaults", func(t *testing.T) {
 		var limits Limits
 
-		limits.RegisterFlags(&flag.FlagSet{})
+		limits.RegisterExtensionsDefaults()
 
 		require.Equal(t, structExtension{Foo: 42}, getExtensionStruct(&limits))
 		require.Equal(t, stringExtension("default string extension value"), getExtensionString(&limits))


### PR DESCRIPTION
In the current scenario, if the `validation.Limits` type is configured through the command line instead of being unmarshalled from YAML, the `setExtensionsDefaults` method is called to read and load the default values for the limits extensions. However, there is a possible scenario where these defaults might not have been loaded yet (for instance, when the default configuration is configured through a service dependency).

This PR stops calling the `setExtensionsDefaults` from the `RegisterFlags` method, and instead makes it publicly available, so that downstream projects can determine the exact moment when the registration of these defaults should take place.