### PR TITLE
Avoid racing with rule evaluation when comparing backends with query-tee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 ### Query-tee
 
 * [CHANGE] Proxy `Content-Type` response header from backend. Previously `Content-Type: text/plain; charset=utf-8` was returned on all requests. #5183
+* [CHANGE] Increase default value of `-proxy.compare-skip-recent-samples` to avoid racing with recording rule evaluation. #5561
 
 ### Documentation
 

--- a/docs/sources/mimir/manage/tools/query-tee.md
+++ b/docs/sources/mimir/manage/tools/query-tee.md
@@ -121,7 +121,7 @@ When the query results comparison is enabled, the query-tee compares the respons
 
 > **Note**: The default value of `-proxy.compare-skip-recent-samples` is 2 minutes. This means points within results with a timestamp within 2 minutes of the current time will not be compared.
 > This prevents false positives due to racing with ingestion, and, if the query selects the output of recording rules, rule evaluation.
-> 
+>
 > If either Mimir cluster is running with a non-default value of `-ruler.evaluation-delay-duration`, we recommend setting `-proxy.compare-skip-recent-samples` to 1 minute more than the
 > value of `-ruler.evaluation-delay-duration`.
 

--- a/docs/sources/mimir/manage/tools/query-tee.md
+++ b/docs/sources/mimir/manage/tools/query-tee.md
@@ -119,6 +119,12 @@ When the query results comparison is enabled, the query-tee compares the respons
 
 > **Note**: Floating point sample values are compared with a tolerance that can be configured via `-proxy.value-comparison-tolerance`. The configured tolerance prevents false positives due to differences in floating point values rounding introduced by the non-deterministic series ordering within the Prometheus PromQL engine.
 
+> **Note**: The default value of `-proxy.compare-skip-recent-samples` is 2 minutes. This means points within results with a timestamp within 2 minutes of the current time will not be compared.
+> This prevents false positives due to racing with ingestion, and, if the query selects the output of recording rules, rule evaluation.
+> 
+> If either Mimir cluster is running with a non-default value of `-ruler.evaluation-delay-duration`, we recommend setting `-proxy.compare-skip-recent-samples` to 1 minute more than the
+> value of `-ruler.evaluation-delay-duration`.
+
 ### Exported metrics
 
 The query-tee exposes the following Prometheus metrics at the `/metrics` endpoint listening on the port configured via the flag `-server.metrics-port`:

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -51,7 +51,7 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.CompareResponses, "proxy.compare-responses", false, "Compare responses between preferred and secondary endpoints for supported routes.")
 	f.Float64Var(&cfg.ValueComparisonTolerance, "proxy.value-comparison-tolerance", 0.000001, "The tolerance to apply when comparing floating point values in the responses. 0 to disable tolerance and require exact match (not recommended).")
 	f.BoolVar(&cfg.UseRelativeError, "proxy.compare-use-relative-error", false, "Use relative error tolerance when comparing floating point values.")
-	f.DurationVar(&cfg.SkipRecentSamples, "proxy.compare-skip-recent-samples", 60*time.Second, "The window from now to skip comparing samples. 0 to disable.")
+	f.DurationVar(&cfg.SkipRecentSamples, "proxy.compare-skip-recent-samples", 2*time.Minute, "The window from now to skip comparing samples. 0 to disable.")
 	f.BoolVar(&cfg.PassThroughNonRegisteredRoutes, "proxy.passthrough-non-registered-routes", false, "Passthrough requests for non-registered routes to preferred backend.")
 }
 


### PR DESCRIPTION
#### What this PR does

This PR adjusts the default value of `-proxy.compare-skip-recent-samples` for `query-tee` to avoid racing with rule evaluation, and updates the docs to include some explanation of this.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
