### PR TITLE
Allocate ballast in smaller blocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377
 * [BUGFIX] Querier: Pass on HTTP 503 query response code. #5364
 * [BUGFIX] Store-gateway: Fix issue where stopping a store-gateway could cause all store-gateways to unload all blocks. #5464
+* [BUGFIX] Allocate ballast in smaller blocks to avoid problem when entire ballast was kept in memory working set. #5565 
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377
 * [BUGFIX] Querier: Pass on HTTP 503 query response code. #5364
 * [BUGFIX] Store-gateway: Fix issue where stopping a store-gateway could cause all store-gateways to unload all blocks. #5464
-* [BUGFIX] Allocate ballast in smaller blocks to avoid problem when entire ballast was kept in memory working set. #5565 
+* [BUGFIX] Allocate ballast in smaller blocks to avoid problem when entire ballast was kept in memory working set. #5565
 
 ### Mixin
 

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/mimir"
+	"github.com/grafana/mimir/pkg/util"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/usage"
 	"github.com/grafana/mimir/pkg/util/version"
@@ -168,8 +169,7 @@ func main() {
 
 	util_log.InitLogger(&cfg.Server, mainFlags.useBufferedLogger, !mainFlags.useBufferedLogger)
 
-	// Allocate a block of memory to alter GC behaviour. See https://github.com/golang/go/issues/23044
-	ballast := make([]byte, mainFlags.ballastBytes)
+	var ballast = util.AllocateBallast(mainFlags.ballastBytes)
 
 	// In testing mode skip JAEGER setup to avoid panic due to
 	// "duplicate metrics collector registration attempted"

--- a/pkg/util/ballast.go
+++ b/pkg/util/ballast.go
@@ -1,0 +1,23 @@
+package util
+
+// AllocateBallast allocates ballast of given size. to alter GC behaviour. See https://github.com/golang/go/issues/23044
+// Instead of allocating one big slice, we allocate many small ones to avoid keeping too much data in memory when Go runtime
+// decides that it needs to zero the slice.
+func AllocateBallast(ballastSize int) interface{} {
+	if ballastSize <= 0 {
+		return nil
+	}
+
+	const ballastSliceSize = 2 * 1024 * 1024
+
+	result := make([][]byte, 0, (ballastSize/ballastSliceSize)+1) // +1 just in case that ballast is not divisible by ballastSliceSize.
+	for ballastSize > 0 {
+		sz := ballastSliceSize
+		if ballastSize < ballastSliceSize {
+			sz = ballastSliceSize
+		}
+		result = append(result, make([]byte, sz))
+		ballastSize -= sz
+	}
+	return result
+}

--- a/pkg/util/ballast.go
+++ b/pkg/util/ballast.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 package util
 
 // AllocateBallast allocates ballast of given size, to alter GC behaviour. See https://github.com/golang/go/issues/23044

--- a/pkg/util/ballast.go
+++ b/pkg/util/ballast.go
@@ -1,6 +1,6 @@
 package util
 
-// AllocateBallast allocates ballast of given size. to alter GC behaviour. See https://github.com/golang/go/issues/23044
+// AllocateBallast allocates ballast of given size, to alter GC behaviour. See https://github.com/golang/go/issues/23044
 // Instead of allocating one big slice, we allocate many small ones to avoid keeping too much data in memory when Go runtime
 // decides that it needs to zero the slice.
 // Returned value should not be used.

--- a/pkg/util/ballast.go
+++ b/pkg/util/ballast.go
@@ -3,7 +3,8 @@ package util
 // AllocateBallast allocates ballast of given size. to alter GC behaviour. See https://github.com/golang/go/issues/23044
 // Instead of allocating one big slice, we allocate many small ones to avoid keeping too much data in memory when Go runtime
 // decides that it needs to zero the slice.
-func AllocateBallast(ballastSize int) interface{} {
+// Returned value should not be used.
+func AllocateBallast(ballastSize int) any {
 	if ballastSize <= 0 {
 		return nil
 	}
@@ -14,7 +15,7 @@ func AllocateBallast(ballastSize int) interface{} {
 	for ballastSize > 0 {
 		sz := ballastSliceSize
 		if ballastSize < ballastSliceSize {
-			sz = ballastSliceSize
+			sz = ballastSize
 		}
 		result = append(result, make([]byte, sz))
 		ballastSize -= sz

--- a/pkg/util/ballast_test.go
+++ b/pkg/util/ballast_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestAllocateBallast(t *testing.T) {
-	for i := 0; i < 20; i++ {
+	require.Nil(t, AllocateBallast(0))
+
+	for i := 1; i < 20; i++ {
 		size := i * 1024 * 1024
 
 		b := AllocateBallast(size).([][]byte)

--- a/pkg/util/ballast_test.go
+++ b/pkg/util/ballast_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
 package util
 
 import (

--- a/pkg/util/ballast_test.go
+++ b/pkg/util/ballast_test.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllocateBallast(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		size := i * 1024 * 1024
+
+		b := AllocateBallast(size).([][]byte)
+
+		totalSize := 0
+		for _, bs := range b {
+			totalSize += len(bs)
+		}
+		require.Equal(t, size, totalSize)
+	}
+}


### PR DESCRIPTION
#### What this PR does

This PR changes ballast allocation to use smaller blocks instead of one large byte slice. Using single large byte slice can sometimes lead to ballast being contributing to the working set of component.

This PR implements "trivial solution" mentioned in https://github.com/grafana/mimir/issues/5564.

(Moved ballast allocation to exported function so that we can reuse it from Grafana Enterprise Metrics too.)

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/5564

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
