### PR TITLE
Docs: mention query results cache for label names and values API

### DIFF
--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -485,6 +485,10 @@ For more information, refer to Prometheus [get label names](https://prometheus.i
 
 Requires [authentication](#authentication).
 
+#### Caching
+
+The query-frontend can return a stale response fetched from the query results cache if `-query-frontend.cache-results` is enabled and `-query-frontend.results-cache-ttl-for-labels-query` set to a value greater than `0`.
+
 ### Get label values
 
 ```
@@ -494,6 +498,10 @@ GET <prometheus-http-prefix>/api/v1/label/{name}/values
 For more information, refer to Prometheus [get label values](https://prometheus.io/docs/prometheus/latest/querying/api/#querying-label-values).
 
 Requires [authentication](#authentication).
+
+#### Caching
+
+The query-frontend can return a stale response fetched from the query results cache if `-query-frontend.cache-results` is enabled and `-query-frontend.results-cache-ttl-for-labels-query` set to a value greater than `0`.
 
 ### Get metric metadata
 


### PR DESCRIPTION
#### What this PR does
Similarly to what we did in #5232, in this PR I'm mentioning that the response for label names and values API could be picked up from the cache.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
