### PR TITLE
querier: handle frontend connection errors when notifying query result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 * [BUGFIX] Querier: Pass on HTTP 503 query response code. #5364
 * [BUGFIX] Store-gateway: Fix issue where stopping a store-gateway could cause all store-gateways to unload all blocks. #5464
 * [BUGFIX] Allocate ballast in smaller blocks to avoid problem when entire ballast was kept in memory working set. #5565
-* [BUGFIX] Querier: Retry frontend result notification when closed connection is detected. #5591
+* [BUGFIX] Querier: Retry frontend result notification when an error is returned. #5591
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 * [BUGFIX] Querier: Pass on HTTP 503 query response code. #5364
 * [BUGFIX] Store-gateway: Fix issue where stopping a store-gateway could cause all store-gateways to unload all blocks. #5464
 * [BUGFIX] Allocate ballast in smaller blocks to avoid problem when entire ballast was kept in memory working set. #5565
-* [BUGFIX] Querier: Retry frontend result notification when closed connection is detected.
+* [BUGFIX] Querier: Retry frontend result notification when closed connection is detected. #5591
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [BUGFIX] Querier: Pass on HTTP 503 query response code. #5364
 * [BUGFIX] Store-gateway: Fix issue where stopping a store-gateway could cause all store-gateways to unload all blocks. #5464
 * [BUGFIX] Allocate ballast in smaller blocks to avoid problem when entire ballast was kept in memory working set. #5565
+* [BUGFIX] Querier: Retry frontend result notification when closed connection is detected.
 
 ### Mixin
 

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -227,7 +227,9 @@ retry:
 			Stats:        stats,
 		})
 		// If the used connection returned and error, remove it from the pool and retry.
-		if err != nil && retries <= maxNotifyFrontendRetries {
+		if err != nil && retries < maxNotifyFrontendRetries {
+			level.Warn(logger).Log("msg", "retrying to notify frontend about finished query", "err", err, "frontend", frontendAddress)
+
 			sp.frontendPool.RemoveClientFor(frontendAddress)
 			retries++
 

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -226,8 +226,8 @@ retry:
 			HttpResponse: response,
 			Stats:        stats,
 		})
-		// If the used connection is closed, remove it from the pool and retry.
-		if isClosedConnError(err) && retries <= maxNotifyFrontendRetries {
+		// If the used connection returned and error, remove it from the pool and retry.
+		if err != nil && retries <= maxNotifyFrontendRetries {
 			sp.frontendPool.RemoveClientFor(frontendAddress)
 			retries++
 
@@ -270,14 +270,4 @@ type frontendClient struct {
 
 func (fc *frontendClient) Close() error {
 	return fc.conn.Close()
-}
-
-// isClosedConnError reports whether err is an error from use of a closed
-// network connection.
-func isClosedConnError(err error) bool {
-	if err == nil {
-		return false
-	}
-	// It is not exported in a more reasonable way. See https://github.com/golang/go/issues/4373.
-	return strings.Contains(err.Error(), "use of closed network connection")
 }


### PR DESCRIPTION
This PR changes querier scheduler processor to handle closed connections when notifying query result to the frontend. 

As it is now, it is possible for the querier to use a closed connection before the pool detects and removes it internally, causing the affected query/shard to timeout. 

escalation ref: https://github.com/grafana/support-escalations/issues/6496