### PR TITLE
Fix WAL compression regression introduced in #5549

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2083,7 +2083,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 		StripeSize:                         i.cfg.BlocksStorageConfig.TSDB.StripeSize,
 		HeadChunksWriteBufferSize:          i.cfg.BlocksStorageConfig.TSDB.HeadChunksWriteBufferSize,
 		HeadChunksEndTimeVariance:          i.cfg.BlocksStorageConfig.TSDB.HeadChunksEndTimeVariance,
-		WALCompression:                     i.cfg.BlocksStorageConfig.TSDB.WALCompressionType,
+		WALCompression:                     i.cfg.BlocksStorageConfig.TSDB.WALCompressionType(),
 		WALSegmentSize:                     i.cfg.BlocksStorageConfig.TSDB.WALSegmentSizeBytes,
 		WALReplayConcurrency:               walReplayConcurrency,
 		SeriesLifecycleCallback:            userDB,

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -190,25 +190,24 @@ func (cfg *BlocksStorageConfig) Validate(activeSeriesCfg activeseries.Config, lo
 //
 //nolint:revive
 type TSDBConfig struct {
-	Dir                       string               `yaml:"dir"`
-	BlockRanges               DurationList         `yaml:"block_ranges_period" category:"experimental" doc:"hidden"`
-	Retention                 time.Duration        `yaml:"retention_period"`
-	ShipInterval              time.Duration        `yaml:"ship_interval" category:"advanced"`
-	ShipConcurrency           int                  `yaml:"ship_concurrency" category:"advanced"`
-	HeadCompactionInterval    time.Duration        `yaml:"head_compaction_interval" category:"advanced"`
-	HeadCompactionConcurrency int                  `yaml:"head_compaction_concurrency" category:"advanced"`
-	HeadCompactionIdleTimeout time.Duration        `yaml:"head_compaction_idle_timeout" category:"advanced"`
-	HeadChunksWriteBufferSize int                  `yaml:"head_chunks_write_buffer_size_bytes" category:"advanced"`
-	HeadChunksEndTimeVariance float64              `yaml:"head_chunks_end_time_variance" category:"experimental"`
-	StripeSize                int                  `yaml:"stripe_size" category:"advanced"`
-	WALCompressionEnabled     bool                 `yaml:"wal_compression_enabled" category:"advanced"`
-	WALCompressionType        wlog.CompressionType `yaml:"-"`
-	WALSegmentSizeBytes       int                  `yaml:"wal_segment_size_bytes" category:"advanced"`
-	WALReplayConcurrency      int                  `yaml:"wal_replay_concurrency" category:"advanced"`
-	FlushBlocksOnShutdown     bool                 `yaml:"flush_blocks_on_shutdown" category:"advanced"`
-	CloseIdleTSDBTimeout      time.Duration        `yaml:"close_idle_tsdb_timeout" category:"advanced"`
-	MemorySnapshotOnShutdown  bool                 `yaml:"memory_snapshot_on_shutdown" category:"experimental"`
-	HeadChunksWriteQueueSize  int                  `yaml:"head_chunks_write_queue_size" category:"advanced"`
+	Dir                       string        `yaml:"dir"`
+	BlockRanges               DurationList  `yaml:"block_ranges_period" category:"experimental" doc:"hidden"`
+	Retention                 time.Duration `yaml:"retention_period"`
+	ShipInterval              time.Duration `yaml:"ship_interval" category:"advanced"`
+	ShipConcurrency           int           `yaml:"ship_concurrency" category:"advanced"`
+	HeadCompactionInterval    time.Duration `yaml:"head_compaction_interval" category:"advanced"`
+	HeadCompactionConcurrency int           `yaml:"head_compaction_concurrency" category:"advanced"`
+	HeadCompactionIdleTimeout time.Duration `yaml:"head_compaction_idle_timeout" category:"advanced"`
+	HeadChunksWriteBufferSize int           `yaml:"head_chunks_write_buffer_size_bytes" category:"advanced"`
+	HeadChunksEndTimeVariance float64       `yaml:"head_chunks_end_time_variance" category:"experimental"`
+	StripeSize                int           `yaml:"stripe_size" category:"advanced"`
+	WALCompressionEnabled     bool          `yaml:"wal_compression_enabled" category:"advanced"`
+	WALSegmentSizeBytes       int           `yaml:"wal_segment_size_bytes" category:"advanced"`
+	WALReplayConcurrency      int           `yaml:"wal_replay_concurrency" category:"advanced"`
+	FlushBlocksOnShutdown     bool          `yaml:"flush_blocks_on_shutdown" category:"advanced"`
+	CloseIdleTSDBTimeout      time.Duration `yaml:"close_idle_tsdb_timeout" category:"advanced"`
+	MemorySnapshotOnShutdown  bool          `yaml:"memory_snapshot_on_shutdown" category:"experimental"`
+	HeadChunksWriteQueueSize  int           `yaml:"head_chunks_write_queue_size" category:"advanced"`
 
 	// Series hash cache.
 	SeriesHashCacheMaxBytes uint64 `yaml:"series_hash_cache_max_size_bytes" category:"advanced"`
@@ -293,12 +292,6 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.EarlyHeadCompactionMinEstimatedSeriesReductionPercentage, "blocks-storage.tsdb.early-head-compaction-min-estimated-series-reduction-percentage", 10, "When the early compaction is enabled, the early compaction is triggered only if the estimated series reduction is at least the configured percentage (0-100).")
 
 	cfg.HeadCompactionIntervalJitterEnabled = true
-
-	if cfg.WALCompressionEnabled {
-		cfg.WALCompressionType = wlog.CompressionSnappy
-	} else {
-		cfg.WALCompressionType = wlog.CompressionNone
-	}
 }
 
 // Validate the config.
@@ -351,6 +344,14 @@ func (cfg *TSDBConfig) Validate(activeSeriesCfg activeseries.Config, logger log.
 	}
 
 	return nil
+}
+
+func (cfg *TSDBConfig) WALCompressionType() wlog.CompressionType {
+	if cfg.WALCompressionEnabled {
+		return wlog.CompressionSnappy
+	}
+
+	return wlog.CompressionNone
 }
 
 // BlocksDir returns the directory path where TSDB blocks and wal should be


### PR DESCRIPTION
#### What this PR does
I was doing a post-merge review of #5549 and I've found a bug: if we set the WALCompressionType in `RegisterFlags()` it will just be set to the default value, and not to the value set by the user. This PR fixes it. /cc @zenador @charleskorn 

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
