### PR TITLE
Chore: use upstream Prometheus API v1 MinTime and MaxTime

### DIFF
--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/integration/e2emimir"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 func TestGettingStartedWithGrafanaMimir(t *testing.T) {
@@ -93,11 +93,11 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService, s
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
 
-	labelValues, err := c.LabelValues("foo", util.PrometheusMinTime, util.PrometheusMaxTime, nil)
+	labelValues, err := c.LabelValues("foo", v1.MinTime, v1.MaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(util.PrometheusMinTime, util.PrometheusMaxTime)
+	labelNames, err := c.LabelNames(v1.MinTime, v1.MaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -11,11 +11,11 @@ import (
 	e2edb "github.com/grafana/e2e/db"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/integration/e2emimir"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 func TestOTLPIngestion(t *testing.T) {
@@ -58,11 +58,11 @@ func TestOTLPIngestion(t *testing.T) {
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
 
-	labelValues, err := c.LabelValues("foo", util.PrometheusMinTime, util.PrometheusMaxTime, nil)
+	labelValues, err := c.LabelValues("foo", v1.MinTime, v1.MaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(util.PrometheusMinTime, util.PrometheusMaxTime)
+	labelNames, err := c.LabelNames(v1.MinTime, v1.MaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 

--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage/remote"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/integration/e2emimir"
 	"github.com/grafana/mimir/pkg/mimirpb"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 func TestReadWriteModeQueryingIngester(t *testing.T) {
@@ -56,11 +56,11 @@ func runQueryingIngester(t *testing.T, client *e2emimir.Client, seriesName strin
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 
 	// Verify we can retrieve the labels we just pushed.
-	labelValues, err := client.LabelValues("foo", util.PrometheusMinTime, util.PrometheusMaxTime, nil)
+	labelValues, err := client.LabelValues("foo", v1.MinTime, v1.MaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := client.LabelNames(util.PrometheusMinTime, util.PrometheusMaxTime)
+	labelNames, err := client.LabelNames(v1.MinTime, v1.MaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }
@@ -109,11 +109,11 @@ func runQueryingStoreGateway(t *testing.T, client *e2emimir.Client, cluster read
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
 
 	// Verify we can retrieve the labels we just pushed.
-	labelValues, err := client.LabelValues("foo", util.PrometheusMinTime, util.PrometheusMaxTime, nil)
+	labelValues, err := client.LabelValues("foo", v1.MinTime, v1.MaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := client.LabelNames(util.PrometheusMinTime, util.PrometheusMaxTime)
+	labelNames, err := client.LabelNames(v1.MinTime, v1.MaxTime)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"golang.org/x/exp/slices"
 
 	"github.com/grafana/mimir/pkg/util"
@@ -62,12 +63,12 @@ func (c *labelsQueryCache) parseRequest(path string, values url.Values) (*generi
 
 	// Both the label names and label values API endpoints support the same exact parameters (with the same defaults),
 	// so in this function there's no distinction between the two.
-	startTime, err := parseRequestTimeParam(values, "start", util.PrometheusMinTime.UnixMilli())
+	startTime, err := parseRequestTimeParam(values, "start", v1.MinTime.UnixMilli())
 	if err != nil {
 		return nil, err
 	}
 
-	endTime, err := parseRequestTimeParam(values, "end", util.PrometheusMaxTime.UnixMilli())
+	endTime, err := parseRequestTimeParam(values, "end", v1.MaxTime.UnixMilli())
 	if err != nil {
 		return nil, err
 	}
@@ -92,12 +93,12 @@ func generateLabelsQueryRequestCacheKey(startTime, endTime int64, labelName stri
 	// Align start and end times to default block boundaries. The reason is that both TSDB (so the Mimir ingester)
 	// and Mimir store-gateway query the label names and values out of blocks overlapping within the start and end
 	// time. This means that for maximum granularity is the block.
-	if startTime != util.PrometheusMinTime.UnixMilli() {
+	if startTime != v1.MinTime.UnixMilli() {
 		if reminder := startTime % twoHoursMillis; reminder != 0 {
 			startTime -= reminder
 		}
 	}
-	if endTime != util.PrometheusMaxTime.UnixMilli() {
+	if endTime != v1.MaxTime.UnixMilli() {
 		if reminder := endTime % twoHoursMillis; reminder != 0 {
 			endTime += twoHoursMillis - reminder
 		}

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -11,10 +11,9 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/mimir/pkg/util"
 )
 
 func TestLabelsQueryCache_RoundTrip(t *testing.T) {
@@ -44,14 +43,14 @@ func TestLabelsQueryCache_parseRequest(t *testing.T) {
 	}{
 		"no parameters provided": {
 			expectedCacheKeyWithLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
-				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MinTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MaxTime.UnixMilli()),
 				labelName,
 				"",
 			}, string(stringParamSeparator)),
 			expectedCacheKeyWithoutLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
-				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MinTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MaxTime.UnixMilli()),
 				"",
 			}, string(stringParamSeparator)),
 		},
@@ -61,13 +60,13 @@ func TestLabelsQueryCache_parseRequest(t *testing.T) {
 			},
 			expectedCacheKeyWithLabelName: strings.Join([]string{
 				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
-				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MaxTime.UnixMilli()),
 				labelName,
 				"",
 			}, string(stringParamSeparator)),
 			expectedCacheKeyWithoutLabelName: strings.Join([]string{
 				fmt.Sprintf("%d", mustParseTime("2023-07-05T00:00:00Z")),
-				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MaxTime.UnixMilli()),
 				"",
 			}, string(stringParamSeparator)),
 		},
@@ -76,13 +75,13 @@ func TestLabelsQueryCache_parseRequest(t *testing.T) {
 				"end": []string{"2023-07-05T07:00:00Z"},
 			},
 			expectedCacheKeyWithLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MinTime.UnixMilli()),
 				fmt.Sprintf("%d", mustParseTime("2023-07-05T08:00:00Z")),
 				labelName,
 				"",
 			}, string(stringParamSeparator)),
 			expectedCacheKeyWithoutLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MinTime.UnixMilli()),
 				fmt.Sprintf("%d", mustParseTime("2023-07-05T08:00:00Z")),
 				"",
 			}, string(stringParamSeparator)),
@@ -92,14 +91,14 @@ func TestLabelsQueryCache_parseRequest(t *testing.T) {
 				"match[]": []string{`{second!="2",first="1"}`},
 			},
 			expectedCacheKeyWithLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
-				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MinTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MaxTime.UnixMilli()),
 				labelName,
 				`{first="1",second!="2"}`,
 			}, string(stringParamSeparator)),
 			expectedCacheKeyWithoutLabelName: strings.Join([]string{
-				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
-				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MinTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MaxTime.UnixMilli()),
 				`{first="1",second!="2"}`,
 			}, string(stringParamSeparator)),
 		},
@@ -188,11 +187,11 @@ func TestGenerateLabelsQueryRequestCacheKey(t *testing.T) {
 			}, string(stringParamSeparator)),
 		},
 		"start and end time match prometheus min/max time": {
-			startTime: util.PrometheusMinTime.UnixMilli(),
-			endTime:   util.PrometheusMaxTime.UnixMilli(),
+			startTime: v1.MinTime.UnixMilli(),
+			endTime:   v1.MaxTime.UnixMilli(),
 			expectedCacheKey: strings.Join([]string{
-				fmt.Sprintf("%d", util.PrometheusMinTime.UnixMilli()),
-				fmt.Sprintf("%d", util.PrometheusMaxTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MinTime.UnixMilli()),
+				fmt.Sprintf("%d", v1.MaxTime.UnixMilli()),
 				"",
 			}, string(stringParamSeparator)),
 		},

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -16,14 +16,6 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 )
 
-var (
-	// PrometheusMinTime is earliest possible timestamp supported by the Prometheus API.
-	PrometheusMinTime = time.Unix(math.MinInt64/1000+62135596801, 0).UTC()
-
-	// PrometheusMaxTime is latest possible timestamp supported by the Prometheus API.
-	PrometheusMaxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999).UTC()
-)
-
 func TimeToMillis(t time.Time) int64 {
 	return t.Unix()*1000 + int64(t.Nanosecond())/int64(time.Millisecond)
 }

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,8 +42,8 @@ func TestTimeRoundTripUsingPrometheusMinAndMaxTimestamps(t *testing.T) {
 		input time.Time
 	}{
 		{input: refTime},
-		{input: PrometheusMinTime},
-		{input: PrometheusMaxTime},
+		{input: v1.MinTime},
+		{input: v1.MaxTime},
 	}
 
 	for i, c := range testExpr {


### PR DESCRIPTION
#### What this PR does
The PR https://github.com/prometheus/prometheus/pull/12535 has been merged and vendored in https://github.com/grafana/mimir/pull/5549. We can now use upstream `MinTime` and `MaxTime`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
