### PR TITLE
Jsonnet: allow to remove an entry from the configured environment variable for a given component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@
 * [ENHANCEMENT] Distributor: allow adjustment of the targeted CPU usage as a percentage of requested CPU. This can be adjusted with `_config.autoscaling_distributor_cpu_target_utilization`. #5525
 * [ENHANCEMENT] Ruler: add configuration option `_config.ruler_remote_evaluation_max_query_response_size_bytes` to easily set the maximum query response size allowed (in bytes). #5592
 * [ENHANCEMENT] Distributor: dynamically set `GOMAXPROCS` based on the CPU request. This should reduce distributor CPU utilization, assuming the CPU request is set to a value close to the actual utilization. #5588
-* [ENHANCEMENT] Allow to remove an entry from the configured environment variable for a given component, setting the environment value to `null` in the `*_env_map` objects (e.g. `store_gateway_env_var+:: { 'field': null}`). #5599
+* [ENHANCEMENT] Allow to remove an entry from the configured environment variable for a given component, setting the environment value to `null` in the `*_env_map` objects (e.g. `store_gateway_env_map+:: { 'field': null}`). #5599
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 * [ENHANCEMENT] Distributor: allow adjustment of the targeted CPU usage as a percentage of requested CPU. This can be adjusted with `_config.autoscaling_distributor_cpu_target_utilization`. #5525
 * [ENHANCEMENT] Ruler: add configuration option `_config.ruler_remote_evaluation_max_query_response_size_bytes` to easily set the maximum query response size allowed (in bytes). #5592
 * [ENHANCEMENT] Distributor: dynamically set `GOMAXPROCS` based on the CPU request. This should reduce distributor CPU utilization, assuming the CPU request is set to a value close to the actual utilization. #5588
+* [ENHANCEMENT] Allow to remove an entry from the configured environment variable for a given component, setting the environment value to `null` in the `*_env_map` objects (e.g. `store_gateway_env_var+:: { 'field': null}`). #5599
 
 ### Mimirtool
 

--- a/operations/mimir/alertmanager.libsonnet
+++ b/operations/mimir/alertmanager.libsonnet
@@ -56,7 +56,7 @@
     if $._config.alertmanager_enabled then
       container.new('alertmanager', $._images.alertmanager) +
       container.withPorts($.alertmanager_ports) +
-      (if std.length($.alertmanager_env_map) > 0 then container.withEnvMap($.alertmanager_env_map) else {}) +
+      (if std.length($.alertmanager_env_map) > 0 then container.withEnvMap(std.prune($.alertmanager_env_map)) else {}) +
       container.withEnvMixin([container.envType.fromFieldPath('POD_IP', 'status.podIP')]) +
       container.withArgsMixin(
         $.util.mapToFlags($.alertmanager_args)

--- a/operations/mimir/compactor.libsonnet
+++ b/operations/mimir/compactor.libsonnet
@@ -88,7 +88,7 @@
     container.withPorts($.compactor_ports) +
     container.withArgsMixin($.util.mapToFlags($.compactor_args)) +
     container.withVolumeMountsMixin([volumeMount.new('compactor-data', '/data')]) +
-    (if std.length($.compactor_env_map) > 0 then container.withEnvMap($.compactor_env_map) else {}) +
+    (if std.length($.compactor_env_map) > 0 then container.withEnvMap(std.prune($.compactor_env_map)) else {}) +
     // Do not limit compactor CPU and request enough cores to honor configured max concurrency.
     $.util.resourcesRequests($._config.compactor_max_concurrency, '6Gi') +
     $.util.resourcesLimits(null, '6Gi') +

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -48,7 +48,7 @@
     container.new('distributor', $._images.distributor) +
     container.withPorts($.distributor_ports) +
     container.withArgsMixin($.util.mapToFlags($.distributor_args)) +
-    (if std.length($.distributor_env_map) > 0 then container.withEnvMap($.distributor_env_map) else {}) +
+    (if std.length($.distributor_env_map) > 0 then container.withEnvMap(std.prune($.distributor_env_map)) else {}) +
     $.util.resourcesRequests('2', '2Gi') +
     $.util.resourcesLimits(null, '4Gi') +
     $.util.readinessProbe +

--- a/operations/mimir/flusher-job-blocks.libsonnet
+++ b/operations/mimir/flusher-job-blocks.libsonnet
@@ -23,7 +23,7 @@
       target: 'flusher',
       'blocks-storage.tsdb.retention-period': '10000h',  // don't delete old blocks too soon.
     })) +
-    (if std.length($.flusher_env_map) > 0 then container.withEnvMap($.flusher_env_map) else {}) +
+    (if std.length($.flusher_env_map) > 0 then container.withEnvMap(std.prune($.flusher_env_map)) else {}) +
     $.util.resourcesRequests('4', '15Gi') +
     $.util.resourcesLimits(null, '25Gi') +
     $.util.readinessProbe +

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -80,7 +80,7 @@
     (if with_anti_affinity then $.util.antiAffinity else {}),
 
   ingester_statefulset: if !$._config.is_microservices_deployment_mode then null else
-    self.newIngesterStatefulSet('ingester', $.ingester_container + (if std.length($.ingester_env_map) > 0 then container.withEnvMap($.ingester_env_map) else {}), !$._config.ingester_allow_multiple_replicas_on_same_node),
+    self.newIngesterStatefulSet('ingester', $.ingester_container + (if std.length($.ingester_env_map) > 0 then container.withEnvMap(std.prune($.ingester_env_map)) else {}), !$._config.ingester_allow_multiple_replicas_on_same_node),
 
   ingester_service: if !$._config.is_microservices_deployment_mode then null else
     $.util.serviceFor($.ingester_statefulset, $._config.service_ignored_labels),

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -88,7 +88,7 @@
         'ingester.ring.instance-availability-zone': 'zone-%s' % zone,
       },
     )) +
-    (if std.length(envmap) > 0 then container.withEnvMap(envmap) else {}),
+    (if std.length(envmap) > 0 then container.withEnvMap(std.prune(envmap)) else {}),
 
   newIngesterZoneStatefulSet(zone, container)::
     local name = 'ingester-zone-%s' % zone;
@@ -216,7 +216,7 @@
         'store-gateway.sharding-ring.prefix': 'multi-zone/',
       }
     )) +
-    (if std.length(envmap) > 0 then container.withEnvMap(envmap) else {}),
+    (if std.length(envmap) > 0 then container.withEnvMap(std.prune(envmap)) else {}),
 
   newStoreGatewayZoneStatefulSet(zone, container)::
     local name = 'store-gateway-zone-%s' % zone;

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -44,7 +44,7 @@
       $.overrides_exporter_port,
     ]) +
     container.withArgsMixin($.util.mapToFlags($.overrides_exporter_args)) +
-    (if std.length($.overrides_exporter_container_env_map) > 0 then container.withEnvMap($.overrides_exporter_container_env_map) else {}) +
+    (if std.length($.overrides_exporter_container_env_map) > 0 then container.withEnvMap(std.prune($.overrides_exporter_container_env_map)) else {}) +
     $.util.resourcesRequests('0.5', '0.5Gi') +
     $.util.readinessProbe +
     container.mixin.readinessProbe.httpGet.withPort($.overrides_exporter_port.name),

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -36,7 +36,7 @@
     container.withArgsMixin($.util.mapToFlags(args)) +
     $.jaeger_mixin +
     $.util.readinessProbe +
-    (if std.length(envmap) > 0 then container.withEnvMap(envmap) else {}) +
+    (if std.length(envmap) > 0 then container.withEnvMap(std.prune(envmap)) else {}) +
     $.util.resourcesRequests('1', '12Gi') +
     $.util.resourcesLimits(null, '24Gi'),
 

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -23,7 +23,7 @@
     container.new(name, $._images.query_frontend) +
     container.withPorts($.query_frontend_ports) +
     container.withArgsMixin($.util.mapToFlags(args)) +
-    (if std.length(envmap) > 0 then container.withEnvMap(envmap) else {}) +
+    (if std.length(envmap) > 0 then container.withEnvMap(std.prune(envmap)) else {}) +
     $.jaeger_mixin +
     $.util.readinessProbe +
     $.util.resourcesRequests('2', '600Mi') +

--- a/operations/mimir/query-scheduler.libsonnet
+++ b/operations/mimir/query-scheduler.libsonnet
@@ -24,7 +24,7 @@
     container.new(name, $._images.query_scheduler) +
     container.withPorts($.query_scheduler_ports) +
     container.withArgsMixin($.util.mapToFlags(args)) +
-    (if std.length(envmap) > 0 then container.withEnvMap(envmap) else {}) +
+    (if std.length(envmap) > 0 then container.withEnvMap(std.prune(envmap)) else {}) +
     $.jaeger_mixin +
     $.util.readinessProbe +
     $.util.resourcesRequests('2', '1Gi') +

--- a/operations/mimir/read-write-deployment/read.libsonnet
+++ b/operations/mimir/read-write-deployment/read.libsonnet
@@ -40,7 +40,7 @@
     container.withArgsMixin($.util.mapToFlags($.mimir_read_args)) +
     $.jaeger_mixin +
     $.util.readinessProbe +
-    (if std.length($.mimir_read_env_map) > 0 then container.withEnvMap($.mimir_read_env_map) else {}) +
+    (if std.length($.mimir_read_env_map) > 0 then container.withEnvMap(std.prune($.mimir_read_env_map)) else {}) +
     $.util.resourcesRequests('1', '12Gi') +
     $.util.resourcesLimits(null, '24Gi'),
 

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -38,7 +38,7 @@
       container.new('ruler', $._images.ruler) +
       container.withPorts($.util.defaultPorts) +
       container.withArgsMixin($.util.mapToFlags($.ruler_args)) +
-      (if std.length($.ruler_env_map) > 0 then container.withEnvMap($.ruler_env_map) else {}) +
+      (if std.length($.ruler_env_map) > 0 then container.withEnvMap(std.prune($.ruler_env_map)) else {}) +
       $.util.resourcesRequests('1', '6Gi') +
       $.util.resourcesLimits('16', '16Gi') +
       $.util.readinessProbe +

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -80,7 +80,7 @@
 
   store_gateway_statefulset: if !$._config.is_microservices_deployment_mode then null else
     self.newStoreGatewayStatefulSet('store-gateway',
-                                    $.store_gateway_container + (if std.length($.store_gateway_env_map) > 0 then container.withEnvMap($.store_gateway_env_map) else {}),
+                                    $.store_gateway_container + (if std.length($.store_gateway_env_map) > 0 then container.withEnvMap(std.prune($.store_gateway_env_map)) else {}),
                                     !$._config.store_gateway_allow_multiple_replicas_on_same_node),
 
   store_gateway_service: if !$._config.is_microservices_deployment_mode then null else


### PR DESCRIPTION
#### What this PR does
I have an use case to remove an env var from `distributor_env_map` but it's not easy to do because we don't prune it. This PR should make it trivial.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
