### PR TITLE
Update mimir-prometheus to commit c8f5ad1492

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
   * `-log.buffered`: Enable buffered logging
 * [ENHANCEMENT] Distributor: add more detailed information to traces generated while processing OTLP write requests. #5539
 * [ENHANCEMENT] Distributor: improve performance ingesting OTLP payloads. #5531
+* [ENHANCEMENT] Ingester: optimize label-values with matchers call when number of matched series is small. #5600
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/go.mod
+++ b/go.mod
@@ -246,7 +246,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230719142958-2a075ced6239
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230727094429-c8f5ad1492a4
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -876,8 +876,8 @@ github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9 h1:WB3bGH2f1UN6
 github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20230719142958-2a075ced6239 h1:R4du9uPB/duDgqoiIv0WF4VlgAEP7JHtfTqYrPcpAhw=
-github.com/grafana/mimir-prometheus v0.0.0-20230719142958-2a075ced6239/go.mod h1:qhOft1UVX3VcKg6gLl0K6LE03tncrpkY6nFTy+6P1P0=
+github.com/grafana/mimir-prometheus v0.0.0-20230727094429-c8f5ad1492a4 h1:jPjIPMlxkAAj6k0d6fsUj8rTGFwma6LsN4XUo9+sJsY=
+github.com/grafana/mimir-prometheus v0.0.0-20230727094429-c8f5ad1492a4/go.mod h1:qhOft1UVX3VcKg6gLl0K6LE03tncrpkY6nFTy+6P1P0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -886,7 +886,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230719142958-2a075ced6239
+# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230727094429-c8f5ad1492a4
 ## explicit; go 1.19
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1480,7 +1480,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230719142958-2a075ced6239
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230727094429-c8f5ad1492a4
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6


### PR DESCRIPTION
#### What this PR does
This PR updates `mimir-prometheus` to https://github.com/grafana/mimir-prometheus/commit/c8f5ad1492a4175b1b8f78da8489597f35fc0dd7, which brings optimization from https://github.com/grafana/mimir-prometheus/pull/518.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
