### PR TITLE
Simplify locking in LazyBinaryReader.

### DIFF
--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -224,7 +224,8 @@ func (r *LazyBinaryReader) EagerLoad() {
 }
 
 // getOrLoadReader ensures the underlying binary index-header reader has been successfully loaded.
-// Returns the reader, and an error on failure. Must be called without lock.
+// Returns the reader, wait group that should be used to signal that usage of reader is finished, and an error on failure.
+// Must be called without lock.
 func (r *LazyBinaryReader) getOrLoadReader() (Reader, *sync.WaitGroup, error) {
 	r.readerMx.RLock()
 	defer r.readerMx.RUnlock()

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -78,12 +78,11 @@ type LazyBinaryReader struct {
 	lazyLoadingGate gate.Gate
 	ctx             context.Context
 
+	readerMx      sync.RWMutex
+	reader        Reader
+	readerErr     error
+	readerInUse   sync.WaitGroup // Only increased when readerMx is held.
 	readerFactory func() (Reader, error)
-
-	readerMx    sync.RWMutex
-	reader      Reader
-	readerErr   error
-	readerInUse sync.WaitGroup // Only increased when readerMx is held.
 
 	// Keep track of the last time it was used.
 	usedAt *atomic.Int64

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -78,10 +78,12 @@ type LazyBinaryReader struct {
 	lazyLoadingGate gate.Gate
 	ctx             context.Context
 
-	readerMx      sync.RWMutex
-	reader        Reader
-	readerErr     error
 	readerFactory func() (Reader, error)
+
+	readerMx    sync.RWMutex
+	reader      Reader
+	readerErr   error
+	readerInUse sync.WaitGroup // Only increased when readerMx is held.
 
 	// Keep track of the last time it was used.
 	usedAt *atomic.Int64
@@ -148,121 +150,119 @@ func (r *LazyBinaryReader) Close() error {
 
 // IndexVersion implements Reader.
 func (r *LazyBinaryReader) IndexVersion() (int, error) {
-	r.readerMx.RLock()
-	defer r.readerMx.RUnlock()
-
-	if err := r.load(); err != nil {
+	reader, wg, err := r.getOrLoadReader()
+	if err != nil {
 		return 0, err
 	}
+	defer wg.Done()
 
-	r.usedAt.Store(time.Now().UnixNano())
-	return r.reader.IndexVersion()
+	return reader.IndexVersion()
 }
 
 // PostingsOffset implements Reader.
 func (r *LazyBinaryReader) PostingsOffset(name, value string) (index.Range, error) {
-	r.readerMx.RLock()
-	defer r.readerMx.RUnlock()
-
-	if err := r.load(); err != nil {
+	reader, wg, err := r.getOrLoadReader()
+	if err != nil {
 		return index.Range{}, err
 	}
+	defer wg.Done()
 
-	r.usedAt.Store(time.Now().UnixNano())
-	return r.reader.PostingsOffset(name, value)
+	return reader.PostingsOffset(name, value)
 }
 
 // LookupSymbol implements Reader.
 func (r *LazyBinaryReader) LookupSymbol(o uint32) (string, error) {
-	r.readerMx.RLock()
-	defer r.readerMx.RUnlock()
-
-	if err := r.load(); err != nil {
+	reader, wg, err := r.getOrLoadReader()
+	if err != nil {
 		return "", err
 	}
+	defer wg.Done()
 
-	r.usedAt.Store(time.Now().UnixNano())
-	return r.reader.LookupSymbol(o)
+	return reader.LookupSymbol(o)
 }
 
 // SymbolsReader implements Reader.
 func (r *LazyBinaryReader) SymbolsReader() (streamindex.SymbolsReader, error) {
-	r.readerMx.RLock()
-	defer r.readerMx.RUnlock()
-
-	if err := r.load(); err != nil {
+	reader, wg, err := r.getOrLoadReader()
+	if err != nil {
 		return nil, err
 	}
+	defer wg.Done()
 
-	r.usedAt.Store(time.Now().UnixNano())
-	return r.reader.SymbolsReader()
+	return reader.SymbolsReader()
 }
 
 // LabelValuesOffsets implements Reader.
 func (r *LazyBinaryReader) LabelValuesOffsets(name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error) {
-	r.readerMx.RLock()
-	defer r.readerMx.RUnlock()
-
-	if err := r.load(); err != nil {
+	reader, wg, err := r.getOrLoadReader()
+	if err != nil {
 		return nil, err
 	}
+	defer wg.Done()
 
-	r.usedAt.Store(time.Now().UnixNano())
-	return r.reader.LabelValuesOffsets(name, prefix, filter)
+	return reader.LabelValuesOffsets(name, prefix, filter)
 }
 
 // LabelNames implements Reader.
 func (r *LazyBinaryReader) LabelNames() ([]string, error) {
-	r.readerMx.RLock()
-	defer r.readerMx.RUnlock()
-
-	if err := r.load(); err != nil {
+	reader, wg, err := r.getOrLoadReader()
+	if err != nil {
 		return nil, err
 	}
+	defer wg.Done()
 
-	r.usedAt.Store(time.Now().UnixNano())
-	return r.reader.LabelNames()
+	return reader.LabelNames()
 }
 
 // EagerLoad attempts to eagerly load this index header.
 func (r *LazyBinaryReader) EagerLoad() {
-	r.readerMx.RLock()
-	defer r.readerMx.RUnlock()
-
-	if err := r.load(); err != nil {
+	_, wg, err := r.getOrLoadReader()
+	if err != nil {
 		level.Warn(r.logger).Log("msg", "eager loading of lazy loaded index-header failed; skipping", "err", err)
 		return
 	}
-
-	r.usedAt.Store(time.Now().UnixNano())
+	wg.Done()
 }
 
-// load ensures the underlying binary index-header reader has been successfully loaded. Returns
-// an error on failure. This function MUST be called with the read lock already acquired.
-func (r *LazyBinaryReader) load() error {
+// getOrLoadReader ensures the underlying binary index-header reader has been successfully loaded.
+// Returns the reader, and an error on failure. Must be called without lock.
+func (r *LazyBinaryReader) getOrLoadReader() (result Reader, _ *sync.WaitGroup, _ error) {
+	r.readerMx.RLock()
+	defer func() {
+		if result != nil {
+			r.usedAt.Store(time.Now().UnixNano())
+			r.readerInUse.Add(1)
+		}
+		r.readerMx.RUnlock()
+	}()
+
 	// Nothing to do if we already tried loading it.
 	if r.reader != nil {
-		return nil
+		return r.reader, &r.readerInUse, nil
 	}
 	if r.readerErr != nil {
-		return r.readerErr
+		return nil, nil, r.readerErr
 	}
 
-	// Release the read lock, so that load1 can take write lock. Take the read lock again once done.
+	// Release the read lock, so that loadReader can take write lock. Take the read lock again once done.
 	r.readerMx.RUnlock()
-	err := r.load1()
+	err := r.loadReader()
+	// Re-acquire read lock.
 	r.readerMx.RLock()
 
+	if err != nil {
+		return nil, nil, err
+	}
 	// Between the write lock release and the subsequent read lock, the unload() may have run,
 	// so we make sure to catch this edge case.
-	if err == nil && r.reader == nil {
-		err = errUnloadedWhileLoading
+	if r.reader == nil {
+		return nil, nil, errUnloadedWhileLoading
 	}
-	return err
+	return r.reader, &r.readerInUse, nil
 }
 
-// load1 is called from load, after releasing the read lock. load1 will acquire write lock instead.
-func (r *LazyBinaryReader) load1() error {
+// loadReader is called from getOrLoadReader, without any locks.
+func (r *LazyBinaryReader) loadReader() error {
 	// lazyLoadingGate implementation: blocks load if too many are happening at once.
 	// It's important to get permit from the Gate when NOT holding the read-lock, otherwise we risk that multiple goroutines
 	// that enter `load()` will deadlock themselves. (If Start() allows one goroutine to continue, but blocks another one,
@@ -309,6 +309,8 @@ func (r *LazyBinaryReader) load1() error {
 func (r *LazyBinaryReader) unloadIfIdleSince(ts int64) error {
 	r.readerMx.Lock()
 	defer r.readerMx.Unlock()
+
+	r.readerInUse.Wait()
 
 	// Nothing to do if already unloaded.
 	if r.reader == nil {

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -209,7 +209,7 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 					return
 				default:
 					_, err := r.PostingsOffset("a", "1")
-					require.True(t, err == nil || errors.Is(err, errUnloadedWhileLoading))
+					require.True(t, err == nil || errors.Is(err, errUnloadedWhileLoading), "unexpected error: %s", err)
 				}
 			}
 		}()


### PR DESCRIPTION
#### What this PR does

This PR modifies `LazyBinaryReader` in following ways:
- it renames `load` to `getOrLoadReader`. This method no longer requires read-lock, and returns either reader + "inuse" waigGroup, or error. WaitGroup must be used to indicate when operation has finished. `getOrLoadReader` also updates `r.usedAt`.
- previous `load1` method from https://github.com/grafana/mimir/pull/5605 was renamed to `loadReader`.
- `unloadIfIdleSince` now checks for `r.readerInUse` wait group

Idea of this PR was to concentrate use of `r.readerMx` lock in `getOrLoadReader`, and remove locking from individual `Reader` methods.

This was proposed in https://github.com/grafana/mimir/pull/5605#discussion_r1276721796

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
