### PR TITLE
Alertmanager: Support changing the default templates for all tenants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [ENHANCEMENT] Distributor: add more detailed information to traces generated while processing OTLP write requests. #5539
 * [ENHANCEMENT] Distributor: improve performance ingesting OTLP payloads. #5531 #5607
 * [ENHANCEMENT] Ingester: optimize label-values with matchers call when number of matched series is small. #5600
+* [ENHANCEMENT] Alertmanager: added experimental `-alertmanager.default-template` option to allow a default template file to be loaded for tenants. #5611
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -12399,6 +12399,17 @@
           "fieldFlag": "alertmanager.enable-state-cleanup",
           "fieldType": "boolean",
           "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
+          "name": "default_template",
+          "required": false,
+          "desc": "Optional filename of a template file which is loaded by default for all tenants, prior to their own templates being loaded.",
+          "fieldValue": null,
+          "fieldDefaultValue": "",
+          "fieldFlag": "alertmanager.default-template",
+          "fieldType": "string",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -153,6 +153,8 @@ Usage of ./cmd/mimir/mimir:
     	Filename of fallback config to use if none specified for instance.
   -alertmanager.configs.poll-interval duration
     	How frequently to poll Alertmanager configs. (default 15s)
+  -alertmanager.default-template string
+    	[experimental] Optional filename of a template file which is loaded by default for all tenants, prior to their own templates being loaded.
   -alertmanager.enable-api
     	Enable the alertmanager config API. (default true)
   -alertmanager.enable-state-cleanup

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2035,6 +2035,11 @@ alertmanager_client:
 # removed for any tenant that does not have a configuration.
 # CLI flag: -alertmanager.enable-state-cleanup
 [enable_state_cleanup: <boolean> | default = true]
+
+# (experimental) Optional filename of a template file which is loaded by default
+# for all tenants, prior to their own templates being loaded.
+# CLI flag: -alertmanager.default-template
+[default_template: <string> | default = ""]
 ```
 
 ### alertmanager_storage


### PR DESCRIPTION
This change adds a new configuration option `-alertmanager.default-template`
which allows the system operator to specify a template file to be parsed
prior to tenant template files. What this essentially provides is a simple
way for operators to alter the default templates (which we inherit from
upstream Alertmanger), without rebuilding Mimir.

Fixes #5460 