### PR TITLE
ulidtime: add -seconds flag and exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@
 ### Tools
 
 * [CHANGE] copyblocks: add support for S3 and the ability to copy between different object storage services. Due to this, the `-source-service` and `-destination-service` flags are now required and the `-service` flag has been removed. #5486
+* [ENHANCEMENT] ulidtime: add -seconds flag to print timestamps as Unix timestamps. #5621
+* [ENHANCEMENT] ulidtime: exit with status code 1 if some ULIDs can't be parsed. #5621
 * [BUGFIX] Stop tools from panicking when `-help` flag is passed. #5412
 * [BUGFIX] Remove github.com/golang/glog command line flags from tools. #5413
 

--- a/tools/ulidtime/main.go
+++ b/tools/ulidtime/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -12,17 +13,29 @@ import (
 )
 
 func main() {
-	if len(os.Args) == 1 {
+	seconds := flag.Bool("seconds", false, "Print timestamp as unix timestamp in seconds")
+	flag.Parse()
+
+	if len(flag.Args()) == 0 {
 		fmt.Println("Usage:", os.Args[0], "[ulid ...]")
+		os.Exit(1)
 		return
 	}
 
-	for _, v := range os.Args[1:] {
+	exit := 0
+	for _, v := range flag.Args() {
 		id, err := ulid.Parse(v)
 		if err != nil {
 			log.Printf("failed to parse %q: %v", v, err)
+			exit = 1
 		} else {
-			fmt.Println(id.String(), ulid.Time(id.Time()).UTC().Format(time.RFC3339Nano))
+			if *seconds {
+				fmt.Println(id.String(), ulid.Time(id.Time()).UTC().Unix())
+			} else {
+				fmt.Println(id.String(), ulid.Time(id.Time()).UTC().Format(time.RFC3339Nano))
+			}
 		}
 	}
+
+	os.Exit(exit)
 }


### PR DESCRIPTION
#### What this PR does

This PR modifies `ulidtime` tool to add `-seconds` flag to print timestamp from ULID as Unix timestamp. `ulidtime` now also exits with status code 1 if any ulid cannot be parsed.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
