### PR TITLE
usage: do not render `doc:"hidden"` fields in help usage output

### DIFF
--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -725,8 +725,6 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Maximum number of entries in the cache for postings for matchers in each compacted block when TTL is greater than 0. (default 100)
   -blocks-storage.tsdb.block-postings-for-matchers-cache-ttl duration
     	[experimental] How long to cache postings for matchers in each compacted block queried from the ingester. 0 disables the cache and just deduplicates the in-flight calls. (default 10s)
-  -blocks-storage.tsdb.block-ranges-period comma-separated-list-of-durations
-    	[experimental] TSDB blocks range period. (default 2h0m0s)
   -blocks-storage.tsdb.close-idle-tsdb-timeout duration
     	If TSDB has not received any data for this duration, and all blocks from TSDB have been shipped, TSDB is closed and deleted from local disk. If set to positive value, this value should be equal or higher than -querier.query-ingesters-within flag to make sure that TSDB is not closed prematurely, which could cause partial query results. 0 or negative value disables closing of idle TSDB. (default 13h0m0s)
   -blocks-storage.tsdb.dir string

--- a/pkg/util/fieldcategory/overrides.go
+++ b/pkg/util/fieldcategory/overrides.go
@@ -15,6 +15,8 @@ const (
 	Experimental
 	// Deprecated is the deprecated field category.
 	Deprecated
+	// Hidden is the hidden field category.
+	Hidden
 )
 
 func (c Category) String() string {
@@ -27,6 +29,8 @@ func (c Category) String() string {
 		return "experimental"
 	case Deprecated:
 		return "deprecated"
+	case Hidden:
+		return "hidden"
 	default:
 		panic(fmt.Sprintf("Unknown field category: %d", c))
 	}

--- a/pkg/util/fieldcategory/overrides.go
+++ b/pkg/util/fieldcategory/overrides.go
@@ -15,8 +15,6 @@ const (
 	Experimental
 	// Deprecated is the deprecated field category.
 	Deprecated
-	// Hidden is the hidden field category.
-	Hidden
 )
 
 func (c Category) String() string {
@@ -29,8 +27,6 @@ func (c Category) String() string {
 		return "experimental"
 	case Deprecated:
 		return "deprecated"
-	case Hidden:
-		return "hidden"
 	default:
 		panic(fmt.Sprintf("Unknown field category: %d", c))
 	}

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -32,36 +32,35 @@ func Usage(printAll bool, configs ...interface{}) error {
 		v := reflect.ValueOf(fl.Value)
 		fieldCat := fieldcategory.Basic
 		var field reflect.StructField
+		var hasField bool
 
 		// Do not print usage for deprecated flags.
 		if fl.Value.String() == "deprecated" {
 			return
 		}
-
-		if override, ok := fieldcategory.GetOverride(fl.Name); ok {
-			fieldCat = override
-		} else if v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Ptr {
 			ptr := v.Pointer()
-			field, ok = fields[ptr]
-			if ok {
-				catStr := field.Tag.Get("category")
-				switch catStr {
-				case "advanced":
-					fieldCat = fieldcategory.Advanced
-				case "experimental":
-					fieldCat = fieldcategory.Experimental
-				case "deprecated":
-					fieldCat = fieldcategory.Deprecated
-				case "hidden":
-					fieldCat = fieldcategory.Hidden
-				}
+			field, hasField = fields[ptr]
+			if hasField && isFieldHidden(field) {
+				// Don't print help for this flag since it's hidden
+				return
 			}
 		}
 
-		if fieldCat == fieldcategory.Hidden {
-			// Don't print help for this flag since it's hidden
-			return
+		if override, ok := fieldcategory.GetOverride(fl.Name); ok {
+			fieldCat = override
+		} else if hasField {
+			catStr := field.Tag.Get("category")
+			switch catStr {
+			case "advanced":
+				fieldCat = fieldcategory.Advanced
+			case "experimental":
+				fieldCat = fieldcategory.Experimental
+			case "deprecated":
+				fieldCat = fieldcategory.Deprecated
+			}
 		}
+
 		if fieldCat != fieldcategory.Basic && !printAll {
 			// Don't print help for this flag since we're supposed to print only basic flags
 			return
@@ -227,6 +226,16 @@ func getFlagName(fl *flag.Flag) string {
 	}
 
 	return "value"
+}
+
+func isFieldHidden(f reflect.StructField) bool {
+	return getDocTagFlag(f, "hidden")
+}
+
+func getDocTagFlag(f reflect.StructField, name string) bool {
+	cfg := parseDocTag(f)
+	_, ok := cfg[name]
+	return ok
 }
 
 func getFlagDefault(fl *flag.Flag, field reflect.StructField) string {

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -52,10 +52,16 @@ func Usage(printAll bool, configs ...interface{}) error {
 					fieldCat = fieldcategory.Experimental
 				case "deprecated":
 					fieldCat = fieldcategory.Deprecated
+				case "hidden":
+					fieldCat = fieldcategory.Hidden
 				}
 			}
 		}
 
+		if fieldCat == fieldcategory.Hidden {
+			// Don't print help for this flag since it's hidden
+			return
+		}
 		if fieldCat != fieldcategory.Basic && !printAll {
 			// Don't print help for this flag since we're supposed to print only basic flags
 			return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR changes the logic of the usage output to omit all fields that have been marked with the doc:"hidden" struct tag.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
