### PR TITLE
mimirtool: Adding datasource type metrics Template Variable analyzer

### DIFF
--- a/pkg/mimirtool/analyze/grafana.go
+++ b/pkg/mimirtool/analyze/grafana.go
@@ -112,10 +112,8 @@ func metricsFromTemplating(templating minisdk.Templating, metrics map[string]str
 		if templateVar.Datasource.LegacyName != "" {
 			var isPrometheusDS bool
 			for _, templateVarTemp := range templating.List {
-				if templateVarTemp.Name == strings.Replace(templateVar.Datasource.LegacyName, "$", "", 1) && templateVarTemp.Type == "datasource" {
-					if templateVarTemp.Type == "prometheus" {
-						isPrometheusDS = true
-					}
+				if templateVarTemp.Name == strings.Replace(templateVar.Datasource.LegacyName, "$", "", 1) && templateVarTemp.Type == "datasource" && templateVarTemp.Query == "prometheus" {
+					isPrometheusDS = true
 					break
 				}
 			}

--- a/pkg/mimirtool/analyze/grafana.go
+++ b/pkg/mimirtool/analyze/grafana.go
@@ -109,6 +109,25 @@ func metricsFromTemplating(templating minisdk.Templating, metrics map[string]str
 			continue
 		}
 
+		if templateVar.Datasource.LegacyName != "" {
+			var isPrometheusDS bool
+			for _, templateVarTemp := range templating.List {
+				if templateVarTemp.Name == strings.Replace(templateVar.Datasource.LegacyName, "$", "", 1) && templateVarTemp.Type == "datasource" {
+					if templateVarTemp.Type == "prometheus" {
+						isPrometheusDS = true
+					}
+					break
+				}
+			}
+			if !isPrometheusDS {
+				continue
+			}
+		}
+
+		if templateVar.Datasource.LegacyName == "" && templateVar.Datasource.Type != "prometheus" {
+			continue
+		}
+
 		query, err := getQueryFromTemplating(templateVar.Name, templateVar.Query)
 		if err != nil {
 			parseErrors = append(parseErrors, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This is fixing `metricsFromTemplating` function to list metrics only if the datasource type is `prometheus`.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
