### PR TITLE
storegateway: Detect OOM During Eagerly Loading Index Header

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -49,6 +49,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	"github.com/grafana/mimir/pkg/util/atomicfs"
 	"github.com/grafana/mimir/pkg/util/shutdownmarker"
 
 	"github.com/grafana/dskit/tenant"
@@ -409,7 +410,7 @@ func (i *Ingester) starting(ctx context.Context) error {
 	}
 
 	shutdownMarkerPath := shutdownmarker.GetPath(i.cfg.BlocksStorageConfig.TSDB.Dir)
-	shutdownMarkerFound, err := shutdownmarker.Exists(shutdownMarkerPath)
+	shutdownMarkerFound, err := atomicfs.Exists(shutdownMarkerPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to check ingester shutdown marker")
 	}
@@ -2679,7 +2680,7 @@ func (i *Ingester) PrepareShutdownHandler(w http.ResponseWriter, r *http.Request
 	shutdownMarkerPath := shutdownmarker.GetPath(i.cfg.BlocksStorageConfig.TSDB.Dir)
 	switch r.Method {
 	case http.MethodGet:
-		exists, err := shutdownmarker.Exists(shutdownMarkerPath)
+		exists, err := atomicfs.Exists(shutdownMarkerPath)
 		if err != nil {
 			level.Error(i.logger).Log("msg", "unable to check for prepare-shutdown marker file", "path", shutdownMarkerPath, "err", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/storegateway/gateway_prepare_shutdown_http.go
+++ b/pkg/storegateway/gateway_prepare_shutdown_http.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/grafana/mimir/pkg/util"
+	"github.com/grafana/mimir/pkg/util/atomicfs"
 	"github.com/grafana/mimir/pkg/util/shutdownmarker"
 )
 
@@ -34,7 +35,7 @@ func (g *StoreGateway) PrepareShutdownHandler(w http.ResponseWriter, req *http.R
 	shutdownMarkerPath := shutdownmarker.GetPath(g.storageCfg.BucketStore.SyncDir)
 	switch req.Method {
 	case http.MethodGet:
-		exists, err := shutdownmarker.Exists(shutdownMarkerPath)
+		exists, err := atomicfs.Exists(shutdownMarkerPath)
 		if err != nil {
 			level.Error(g.logger).Log("msg", "unable to check for prepare-shutdown marker file", "path", shutdownMarkerPath, "err", err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -90,7 +91,7 @@ func (g *StoreGateway) unsetPrepareShutdown() {
 // previous attempt to shut down.
 func (g *StoreGateway) setPrepareShutdownFromShutdownMarker() error {
 	shutdownMarkerPath := shutdownmarker.GetPath(g.storageCfg.BucketStore.SyncDir)
-	shutdownMarkerFound, err := shutdownmarker.Exists(shutdownMarkerPath)
+	shutdownMarkerFound, err := atomicfs.Exists(shutdownMarkerPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to check store-gateway shutdown marker")
 	}

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -228,12 +228,12 @@ func (p *ReaderPool) tryEagerLoadIndexHeadersSnapshot(lazyBinaryReader *LazyBina
 	defer os.Remove(oomMarkerPath)
 
 	if !eagerLoadOOMMarkerExists {
-		atomicfs.CreateFile(oomMarkerPath, strings.NewReader(time.Now().UTC().Format(time.RFC3339)))
-		lazyBinaryReader.EagerLoad()
-		oomMarkerRemoveErr := os.Remove(oomMarkerPath)
-		if oomMarkerRemoveErr != nil {
-			level.Warn(p.logger).Log("msg", "removing eager-load oom marker file failed", "file", oomMarkerPath, "err", oomMarkerRemoveErr)
+		err := atomicfs.CreateFile(oomMarkerPath, strings.NewReader(time.Now().UTC().Format(time.RFC3339)))
+		if err != nil {
+			level.Warn(p.logger).Log("msg", "creating eager-load-oom-marker file failed", "file", oomMarkerPath, "err", err)
+			return
 		}
+		lazyBinaryReader.EagerLoad()
 	} else {
 		level.Warn(p.logger).Log("msg", "eager-load-oom-marker file presents; skipping eager loading and removing lazy-loaded blockID", "file", oomMarkerPath, "err", err)
 		delete(p.lazyLoadedHeadersSnapshot.IndexHeaderLastUsedTime, blockID)

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -223,6 +223,8 @@ func (p *ReaderPool) tryEagerLoadIndexHeadersSnapshot(lazyBinaryReader *LazyBina
 		level.Warn(p.logger).Log("msg", "checking eager-load-oom-marker file failed", "file", oomMarkerPath, "err", err)
 		return
 	}
+	// we will remove the marker either when marker doesn't exist (which later will be created) and also when it is already
+	// exist (when the process was previosly failed to complete eager loading).
 	defer os.Remove(oomMarkerPath)
 
 	if !eagerLoadOOMMarkerExists {

--- a/pkg/util/atomicfs/fsync.go
+++ b/pkg/util/atomicfs/fsync.go
@@ -63,7 +63,6 @@ func CreateFileAndMove(tmpPath, finalPath string, data io.Reader) error {
 }
 
 // Exists returns true if a file existed in the path p.
-// TODO: move shutdown marker usage to use this instead
 func Exists(p string) (bool, error) {
 	s, err := os.Stat(p)
 	if err != nil && os.IsNotExist(err) {

--- a/pkg/util/atomicfs/fsync.go
+++ b/pkg/util/atomicfs/fsync.go
@@ -61,3 +61,18 @@ func CreateFileAndMove(tmpPath, finalPath string, data io.Reader) error {
 	// we rely on the atomicity of this on Unix systems for this method to behave correctly
 	return os.Rename(tmpPath, finalPath)
 }
+
+// Exists returns true if a file existed in the path p.
+// TODO: move shutdown marker usage to use this instead
+func Exists(p string) (bool, error) {
+	s, err := os.Stat(p)
+	if err != nil && os.IsNotExist(err) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return s.Mode().IsRegular(), nil
+}

--- a/pkg/util/shutdownmarker/shutdown_marker.go
+++ b/pkg/util/shutdownmarker/shutdown_marker.go
@@ -40,20 +40,6 @@ func Remove(p string) error {
 	return merr.Err()
 }
 
-// Exists returns true if the shutdown marker file exists on the given path, false otherwise
-func Exists(p string) (bool, error) {
-	s, err := os.Stat(p)
-	if err != nil && os.IsNotExist(err) {
-		return false, nil
-	}
-
-	if err != nil {
-		return false, err
-	}
-
-	return s.Mode().IsRegular(), nil
-}
-
 // GetPath returns the absolute path of the shutdown marker file
 func GetPath(dirPath string) string {
 	return path.Join(dirPath, shutdownMarkerFilename)

--- a/pkg/util/shutdownmarker/shutdown_marker_test.go
+++ b/pkg/util/shutdownmarker/shutdown_marker_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/util/atomicfs"
 )
 
 func TestShutdownMarker_GetPath(t *testing.T) {
@@ -18,14 +20,14 @@ func TestShutdownMarker_GetPath(t *testing.T) {
 func TestShutdownMarker_Create(t *testing.T) {
 	dir := t.TempDir()
 	shutdownMarkerPath := GetPath(dir)
-	exists, err := Exists(shutdownMarkerPath)
+	exists, err := atomicfs.Exists(shutdownMarkerPath)
 	require.NoError(t, err)
 	require.False(t, exists)
 
 	err = Create(shutdownMarkerPath)
 	require.NoError(t, err)
 
-	exists, err = Exists(shutdownMarkerPath)
+	exists, err = atomicfs.Exists(shutdownMarkerPath)
 	require.NoError(t, err)
 	require.True(t, exists)
 }
@@ -33,17 +35,17 @@ func TestShutdownMarker_Create(t *testing.T) {
 func TestShutdownMarker_Remove(t *testing.T) {
 	dir := t.TempDir()
 	shutdownMarkerPath := GetPath(dir)
-	exists, err := Exists(shutdownMarkerPath)
+	exists, err := atomicfs.Exists(shutdownMarkerPath)
 	require.NoError(t, err)
 	require.False(t, exists)
 
 	require.Nil(t, Create(shutdownMarkerPath))
-	exists, err = Exists(shutdownMarkerPath)
+	exists, err = atomicfs.Exists(shutdownMarkerPath)
 	require.NoError(t, err)
 	require.True(t, exists)
 
 	require.Nil(t, Remove(shutdownMarkerPath))
-	exists, err = Exists(shutdownMarkerPath)
+	exists, err = atomicfs.Exists(shutdownMarkerPath)
 	require.NoError(t, err)
 	require.False(t, exists)
 }


### PR DESCRIPTION
**Note:** This PR is purposely targeting `lamida/sg-eager-load-headers` (#5596) for easier diffs, later the target will be changed to `lamida/sg-lazy-load` branch once #5596 is merged. Eventually, all lazy loading PRs will be merged to `main` branch in #5606.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

[Detect OOM](https://github.com/grafana/mimir/issues/4762#issuecomment-1512854593) in store gateway during eagerly loading lazy loaded index headers in startup. We are writing a marker file when store gateway starting to do eager loading and removing the marker once eager loading runs successfully. If there is a marker file at the beginning of eager loading, that could indicate previous eager loading failed, probably by OOM, and we skip eager loading the index header for such cases.

As part of this PR, I also moved `Exists` method from `shutdownmarker` package to `atomicfs` package because the later package seems more appropriate for the general use of the method.

#### Which issue(s) this PR fixes or relates to

Fixes #4762

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
