### PR TITLE
add aws command to clean up thanos labels

### DIFF
--- a/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
+++ b/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
@@ -97,7 +97,7 @@ This may cause that incorrect results are returned for the query.
    For Amazon S3, use the `aws` tool:
 
    ```bash
-   aws s3 cp -r s3://<THANOS-BUCKET> s3://<INTERMEDIATE-MIMIR-BUCKET>/
+   aws s3 cp --recursive s3://<THANOS-BUCKET> s3://<INTERMEDIATE-MIMIR-BUCKET>/
    ```
 
    For Google Cloud Storage (GCS), use the `gsutil` tool:
@@ -347,7 +347,7 @@ This may cause that incorrect results are returned for the query.
    For Amazon S3, use the `aws` tool:
 
    ```bash
-   aws s3 cp -r s3://<INTERMEDIATE-MIMIR-BUCKET> s3://<MIMIR-GCS-BUCKET>/<TENANT>/
+   aws s3 cp --recursive s3://<INTERMEDIATE-MIMIR-BUCKET> s3://<MIMIR-AWS-BUCKET>/<TENANT>/
    ```
 
    For Google Cloud Storage (GCS), use the gsutil tool:

--- a/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
+++ b/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
@@ -293,12 +293,12 @@ This may cause that incorrect results are returned for the query.
 
    ```bash
    #!/bin/bash
-   
+
    BUCKET="XXX"
 
    echo "Fetching list of meta.json files (this can take a while if there are many blocks)"
    aws s3 ls $BUCKET --recursive | awk '{print $4}' | grep meta.json | grep -v meta.json.orig > meta-files.txt
-    
+
    echo "Processing meta.json files"
    for FILE in $(cat meta-files.txt); do
       echo "Removing Thanos labels from $FILE"
@@ -315,7 +315,8 @@ This may cause that incorrect results are returned for the query.
       fi
    done
    ```
-    For Google Cloud Storage (GCS), use the gsutil tool:
+
+   For Google Cloud Storage (GCS), use the gsutil tool:
 
    ```bash
    #!/bin/bash

--- a/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
+++ b/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
@@ -297,7 +297,7 @@ This may cause that incorrect results are returned for the query.
    BUCKET="XXX"
 
    echo "Fetching list of meta.json files (this can take a while if there are many blocks)"
-   aws s3 ls $BUCKET --recursive | awk '{print $4}' | grep meta.json > meta-files.txt
+   aws s3 ls $BUCKET --recursive | awk '{print $4}' | grep meta.json | grep -v meta.json.orig > meta-files.txt
     
    echo "Processing meta.json files"
    for FILE in $(cat meta-files.txt); do


### PR DESCRIPTION
#### What this PR does

Adds command to run for aws as the current script is only valid for gcs.

#### Checklist

- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
