### PR TITLE
Added index-header estimate to tsdb-index-toc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
 * [CHANGE] copyblocks: add support for S3 and the ability to copy between different object storage services. Due to this, the `-source-service` and `-destination-service` flags are now required and the `-service` flag has been removed. #5486
 * [ENHANCEMENT] ulidtime: add -seconds flag to print timestamps as Unix timestamps. #5621
 * [ENHANCEMENT] ulidtime: exit with status code 1 if some ULIDs can't be parsed. #5621
+* [ENHANCEMENT] tsdb-index-toc: added index-header size estimates. #5652
 * [BUGFIX] Stop tools from panicking when `-help` flag is passed. #5412
 * [BUGFIX] Remove github.com/golang/glog command line flags from tools. #5413
 

--- a/tools/tsdb-index-toc/main.go
+++ b/tools/tsdb-index-toc/main.go
@@ -31,6 +31,12 @@ func main() {
 
 	filepath := args[0]
 
+	finfo, err := os.Stat(filepath)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	indexSize := finfo.Size()
+
 	f, err := fileutil.OpenMmapFile(filepath)
 	if err != nil {
 		log.Fatalf(err.Error())
@@ -42,21 +48,28 @@ func main() {
 	}
 
 	// See https://github.com/prometheus/prometheus/blob/main/tsdb/docs/format/index.md on the index format.
-	fmt.Println("Symbols table size:   ", toc.Series-toc.Symbols)
-	fmt.Println("Series size:          ", toc.LabelIndices-toc.Series)
-	fmt.Println("Label indices:        ", toc.Postings-toc.LabelIndices)
-	fmt.Println("Postings:             ", toc.LabelIndicesTable-toc.Postings)
-	fmt.Println("Label offset table:   ", toc.PostingsTable-toc.LabelIndicesTable)
+	fmt.Println("Index size:             ", indexSize)
+	fmt.Println("Symbols table size:     ", toc.Series-toc.Symbols)
+	fmt.Println("Series size:            ", toc.LabelIndices-toc.Series)
+	fmt.Println("Label indices:          ", toc.Postings-toc.LabelIndices)
+	fmt.Println("Postings:               ", toc.LabelIndicesTable-toc.Postings)
+	fmt.Println("Label offset table:     ", toc.PostingsTable-toc.LabelIndicesTable)
 
 	// Requires the full index to be correct.
 	if uint64(len(f.Bytes())) > toc.PostingsTable {
 		// TOC is a simple struct so unsafe.Sizeof() works correctly.
 		tocLength := uint64(unsafe.Sizeof(index.TOC{})) + crc32.Size
-
-		fmt.Println("Postings offset table:", uint64(len(f.Bytes()))-toc.PostingsTable-tocLength)
+		postingsTbl := uint64(len(f.Bytes())) - toc.PostingsTable - tocLength
+		indexHdr := toc.Series - toc.Symbols + postingsTbl + 34
+		fmt.Println("Postings offset table:  ", postingsTbl)
+		fmt.Println("Index-header size (est):", indexHdr)
+		fmt.Printf("Index-header %% (est):    %.3f\n", 100.0*float64(indexHdr)/float64(indexSize))
 	} else {
-		fmt.Println("Postings offset table: N/A")
+		fmt.Println("Postings offset table:   N/A")
+		fmt.Println("Index-header size (est): N/A")
+		fmt.Println("Index-header % (est):    N/A")
 	}
+
 }
 
 type realByteSlice []byte


### PR DESCRIPTION
#### What this PR does

This PR adds an estimate of the index-header size to the calculations performed by `tsdb-index-toc`. This assumes an index-header layout as described in the [Mimir documentation](https://grafana.com/docs/mimir/latest/references/architecture/binary-index-header/), and is labeled as an estimate. In addition it reports the total index size, and the index-header estimate as a % of the total index size. An example of the new output is below:
```bash
./tsdb-index-toc 01G6VNZB43M2M3Z4MVCA6T69PP/index
Index size:              63387634
Symbols table size:      356971
Series size:             51763202
Label indices:           36482
Postings:                10749856
Label offset table:      3953
Postings offset table:   477113
Index-header size (est): 834118
Index-header % (est):    1.316
```

#### Which issue(s) this PR fixes or relates to

The index-header estimates are useful for capacity planning and debugging purposes. Over time we have developed rules of thumb for the index-header size compared to the index size (~2%), but this gives an accurate estimate based on a particular index.

Using this tool on a sample of existing data can be useful in determining the size of persistent volumes (or other storage) needed to store the index-headers in Mimir store-gateways.

#### Checklist

- [N/A] Tests updated
- [N/A] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
