### PR TITLE
usage: skip structs marked as hidden in usage help output

### DIFF
--- a/cmd/mimir/main_test.go
+++ b/cmd/mimir/main_test.go
@@ -443,6 +443,10 @@ func TestFieldCategoryOverridesNotStale(t *testing.T) {
 
 	fs := flag.NewFlagSet("test", flag.PanicOnError)
 
+	// Add ignored flags.
+	flagext.IgnoredFlag(fs, configFileOption, "Configuration file to load.")
+	_ = fs.Bool(configExpandEnv, false, "Expands ${var} or $var in config according to the values of the environment variables.")
+
 	var (
 		cfg mimir.Config
 		mf  mainFlags

--- a/pkg/util/fieldcategory/overrides.go
+++ b/pkg/util/fieldcategory/overrides.go
@@ -68,6 +68,10 @@ var overrides = map[string]Category{
 	"server.path-prefix":                                Advanced,
 	"server.register-instrumentation":                   Advanced,
 	"server.log-request-at-info-level-enabled":          Advanced,
+
+	// main.go global flags
+	"config.file":       Basic,
+	"config.expand-env": Basic,
 }
 
 func AddOverrides(o map[string]Category) {

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -59,6 +59,9 @@ func Usage(printAll bool, configs ...interface{}) error {
 			case "deprecated":
 				fieldCat = fieldcategory.Deprecated
 			}
+		} else {
+			// The field is neither an override nor has been parsed, so we'll skip it.
+			return
 		}
 
 		if fieldCat != fieldcategory.Basic && !printAll {
@@ -149,7 +152,7 @@ func parseStructure(structure interface{}, fields map[uintptr]reflect.StructFiel
 		fields[fieldValue.Addr().Pointer()] = field
 
 		// Recurse if a struct
-		if field.Type.Kind() != reflect.Struct || ignoreStructType(field.Type) || !field.IsExported() {
+		if field.Type.Kind() != reflect.Struct || isFieldHidden(field) || ignoreStructType(field.Type) || !field.IsExported() {
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This is a follow-up PR for https://github.com/grafana/mimir/pull/5630

Here we are adapting usage rendering logic to completely skip structs that have been marked as hidden, instead of only fields. 

Additionally, two global flags have been added to the overrides map, as non parsed fields are now skipped.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
