### PR TITLE
Jsonnet: do not inherit querier's GOMAXPROCS in mimir-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@
 * [ENHANCEMENT] Distributor: allow adjustment of the targeted CPU usage as a percentage of requested CPU. This can be adjusted with `_config.autoscaling_distributor_cpu_target_utilization`. #5525
 * [ENHANCEMENT] Ruler: add configuration option `_config.ruler_remote_evaluation_max_query_response_size_bytes` to easily set the maximum query response size allowed (in bytes). #5592
 * [ENHANCEMENT] Distributor: dynamically set `GOMAXPROCS` based on the CPU request. This should reduce distributor CPU utilization, assuming the CPU request is set to a value close to the actual utilization. #5588
-* [ENHANCEMENT] Querier: dynamically set `GOMAXPROCS` based on the CPU request. This should reduce noisy neighbour issues created by the querier, whose CPU utilization could eventually saturate the Kubernetes node if unbounded. #5646
+* [ENHANCEMENT] Querier: dynamically set `GOMAXPROCS` based on the CPU request. This should reduce noisy neighbour issues created by the querier, whose CPU utilization could eventually saturate the Kubernetes node if unbounded. #5646 #5658
 * [ENHANCEMENT] Allow to remove an entry from the configured environment variable for a given component, setting the environment value to `null` in the `*_env_map` objects (e.g. `store_gateway_env_map+:: { 'field': null}`). #5599
 * [ENHANCEMENT] Allow overriding the default number of replicas for `etcd`.
 

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1085,8 +1085,6 @@ spec:
         - -target=read
         - -usage-stats.installation-mode=jsonnet
         env:
-        - name: GOMAXPROCS
-          value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
         image: grafana/mimir:2.9.0

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -553,8 +553,6 @@ spec:
         - -target=read
         - -usage-stats.installation-mode=jsonnet
         env:
-        - name: GOMAXPROCS
-          value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
         image: grafana/mimir:2.9.0

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -554,8 +554,6 @@ spec:
         - -target=read
         - -usage-stats.installation-mode=jsonnet
         env:
-        - name: GOMAXPROCS
-          value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1024"
         image: grafana/mimir:2.9.0

--- a/operations/mimir/read-write-deployment/read.libsonnet
+++ b/operations/mimir/read-write-deployment/read.libsonnet
@@ -32,7 +32,10 @@
       ), byContainerPort
     ),
 
-  mimir_read_env_map:: $.querier_env_map,
+  mimir_read_env_map:: $.querier_env_map {
+    // Do not inherit GOMAXPROCS from querier because mimir-read runs more components.
+    GOMAXPROCS: null,
+  },
 
   mimir_read_container:: if !$._config.is_read_write_deployment_mode then null else
     container.new('mimir-read', $._images.mimir_read) +


### PR DESCRIPTION
#### What this PR does
A small follow up on https://github.com/grafana/mimir/pull/5646, to not inherit GOMAXPROCS in mimir-read too.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
