### PR TITLE
Reduce memory usage of ActiveSeriesTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * [ENHANCEMENT] Distributor: improve performance ingesting OTLP payloads. #5531 #5607 #5616
 * [ENHANCEMENT] Ingester: optimize label-values with matchers call when number of matched series is small. #5600
 * [ENHANCEMENT] Compactor: Delete bucket-index, markers and debug files if there are no blocks left in the bucket index. This cleanup must be enabled by using `-compactor.no-blocks-file-cleanup-enabled` option. #5648
+* [ENHANCEMENT] Ingester: reduce memory usage of ActiveSeriesTracker. #5665
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 * [ENHANCEMENT] Distributor: improve performance ingesting OTLP payloads. #5531 #5607 #5616
 * [ENHANCEMENT] Ingester: optimize label-values with matchers call when number of matched series is small. #5600
 * [ENHANCEMENT] Compactor: Delete bucket-index, markers and debug files if there are no blocks left in the bucket index. This cleanup must be enabled by using `-compactor.no-blocks-file-cleanup-enabled` option. #5648
-* [ENHANCEMENT] Ingester: reduce memory usage of ActiveSeriesTracker. #5665
+* [ENHANCEMENT] Ingester: reduce memory usage of active series tracker. #5665
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -409,9 +409,7 @@ func resizeAndClear(l int, prev []uint32) []uint32 {
 		if l == 0 {
 			return nil
 		}
-		// The allocation is bigger than the required capacity to save time in cases when the number of matchers are just slightly increasing.
-		// In cases where the default matchers are slightly changed in size it could save from lot of reallocations, while having low memory impact.
-		return make([]uint32, l, l*2)
+		return make([]uint32, l)
 	}
 
 	p := prev[:l]

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -60,12 +60,12 @@ type seriesStripe struct {
 
 	mu                                   sync.RWMutex
 	refs                                 map[storage.SeriesRef]seriesEntry
-	active                               int   // Number of active entries in this stripe. Only decreased during purge or clear.
-	activeMatching                       []int // Number of active entries in this stripe matching each matcher of the configured Matchers.
-	activeNativeHistograms               int   // Number of active entries (only native histograms) in this stripe. Only decreased during purge or clear.
-	activeMatchingNativeHistograms       []int // Number of active entries (only native histograms) in this stripe matching each matcher of the configured Matchers.
-	activeNativeHistogramBuckets         int   // Number of buckets in active native histogram entries in this stripe. Only decreased during purge or clear.
-	activeMatchingNativeHistogramBuckets []int // Number of buckets in active native histogram entries in this stripe matching each matcher of the configured Matchers.
+	active                               uint32   // Number of active entries in this stripe. Only decreased during purge or clear.
+	activeMatching                       []uint32 // Number of active entries in this stripe matching each matcher of the configured Matchers.
+	activeNativeHistograms               uint32   // Number of active entries (only native histograms) in this stripe. Only decreased during purge or clear.
+	activeMatchingNativeHistograms       []uint32 // Number of active entries (only native histograms) in this stripe matching each matcher of the configured Matchers.
+	activeNativeHistogramBuckets         uint32   // Number of buckets in active native histogram entries in this stripe. Only decreased during purge or clear.
+	activeMatchingNativeHistogramBuckets []uint32 // Number of buckets in active native histogram entries in this stripe matching each matcher of the configured Matchers.
 }
 
 // seriesEntry holds a timestamp for single series.
@@ -148,9 +148,9 @@ func (c *ActiveSeries) ContainsRef(ref storage.SeriesRef) bool {
 func (c *ActiveSeries) Active() (total, totalNativeHistograms, totalNativeHistogramBuckets int) {
 	for s := 0; s < numStripes; s++ {
 		all, histograms, buckets := c.stripes[s].getTotal()
-		total += all
-		totalNativeHistograms += histograms
-		totalNativeHistogramBuckets += buckets
+		total += int(all)
+		totalNativeHistograms += int(histograms)
+		totalNativeHistogramBuckets += int(buckets)
 	}
 	return
 }
@@ -165,14 +165,14 @@ func (c *ActiveSeries) ActiveWithMatchers() (total int, totalMatching []int, tot
 	c.matchersMutex.RLock()
 	defer c.matchersMutex.RUnlock()
 
-	totalMatching = resizeAndClear(len(c.matchers.MatcherNames()), nil)
-	totalMatchingNativeHistograms = resizeAndClear(len(c.matchers.MatcherNames()), nil)
-	totalMatchingNativeHistogramBuckets = resizeAndClear(len(c.matchers.MatcherNames()), nil)
+	totalMatching = make([]int, len(c.matchers.MatcherNames()))
+	totalMatchingNativeHistograms = make([]int, len(c.matchers.MatcherNames()))
+	totalMatchingNativeHistogramBuckets = make([]int, len(c.matchers.MatcherNames()))
 	for s := 0; s < numStripes; s++ {
 		all, histograms, buckets := c.stripes[s].getTotalAndUpdateMatching(totalMatching, totalMatchingNativeHistograms, totalMatchingNativeHistogramBuckets)
-		total += all
-		totalNativeHistograms += histograms
-		totalNativeHistogramBuckets += buckets
+		total += int(all)
+		totalNativeHistograms += int(histograms)
+		totalNativeHistogramBuckets += int(buckets)
 	}
 
 	return
@@ -189,7 +189,7 @@ func (s *seriesStripe) containsRef(ref storage.SeriesRef) bool {
 // getTotal will return the total active series in the stripe
 // and the total active series that are native histograms
 // and the total number of buckets in active native histogram series
-func (s *seriesStripe) getTotal() (int, int, int) {
+func (s *seriesStripe) getTotal() (uint32, uint32, uint32) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.active, s.activeNativeHistograms, s.activeNativeHistogramBuckets
@@ -198,19 +198,19 @@ func (s *seriesStripe) getTotal() (int, int, int) {
 // getTotalAndUpdateMatching will return the total active series in the stripe and also update the slice provided
 // with each matcher's total, and will also do the same for total active series that are native histograms
 // as well as the total number of buckets in active native histogram series
-func (s *seriesStripe) getTotalAndUpdateMatching(matching []int, matchingNativeHistograms []int, matchingNativeHistogramBuckets []int) (int, int, int) {
+func (s *seriesStripe) getTotalAndUpdateMatching(matching []int, matchingNativeHistograms []int, matchingNativeHistogramBuckets []int) (uint32, uint32, uint32) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	// len(matching) == len(s.activeMatching) by design, and it could be nil
 	for i, a := range s.activeMatching {
-		matching[i] += a
+		matching[i] += int(a)
 	}
 	for i, a := range s.activeMatchingNativeHistograms {
-		matchingNativeHistograms[i] += a
+		matchingNativeHistograms[i] += int(a)
 	}
 	for i, a := range s.activeMatchingNativeHistogramBuckets {
-		matchingNativeHistogramBuckets[i] += a
+		matchingNativeHistogramBuckets[i] += int(a)
 	}
 
 	return s.active, s.activeNativeHistograms, s.activeNativeHistogramBuckets
@@ -263,27 +263,27 @@ func (s *seriesStripe) findAndUpdateOrCreateEntryForSeries(ref storage.SeriesRef
 			if numNativeHistogramBuckets >= 0 && entry.numNativeHistogramBuckets >= 0 {
 				// change number of buckets but still a histogram
 				diff := numNativeHistogramBuckets - entry.numNativeHistogramBuckets
-				s.activeNativeHistogramBuckets += diff
+				s.activeNativeHistogramBuckets = uint32(int(s.activeNativeHistogramBuckets) + diff)
 				for i := 0; i < matchesLen; i++ {
-					s.activeMatchingNativeHistogramBuckets[matches.get(i)] += diff
+					s.activeMatchingNativeHistogramBuckets[matches.get(i)] = uint32(int(s.activeMatchingNativeHistogramBuckets[matches.get(i)]) + diff)
 				}
 			} else if numNativeHistogramBuckets >= 0 {
 				// change from float to histogram
 				s.activeNativeHistograms++
-				s.activeNativeHistogramBuckets += numNativeHistogramBuckets
+				s.activeNativeHistogramBuckets += uint32(numNativeHistogramBuckets)
 				for i := 0; i < matchesLen; i++ {
 					match := matches.get(i)
 					s.activeMatchingNativeHistograms[match]++
-					s.activeMatchingNativeHistogramBuckets[match] += numNativeHistogramBuckets
+					s.activeMatchingNativeHistogramBuckets[match] += uint32(numNativeHistogramBuckets)
 				}
 			} else {
 				// change from histogram to float
 				s.activeNativeHistograms--
-				s.activeNativeHistogramBuckets -= entry.numNativeHistogramBuckets
+				s.activeNativeHistogramBuckets -= uint32(entry.numNativeHistogramBuckets)
 				for i := 0; i < matchesLen; i++ {
 					match := matches.get(i)
 					s.activeMatchingNativeHistograms[match]--
-					s.activeMatchingNativeHistogramBuckets[match] -= entry.numNativeHistogramBuckets
+					s.activeMatchingNativeHistogramBuckets[match] -= uint32(entry.numNativeHistogramBuckets)
 				}
 			}
 			entry.numNativeHistogramBuckets = numNativeHistogramBuckets
@@ -298,14 +298,14 @@ func (s *seriesStripe) findAndUpdateOrCreateEntryForSeries(ref storage.SeriesRef
 	s.active++
 	if numNativeHistogramBuckets >= 0 {
 		s.activeNativeHistograms++
-		s.activeNativeHistogramBuckets += numNativeHistogramBuckets
+		s.activeNativeHistogramBuckets += uint32(numNativeHistogramBuckets)
 	}
 	for i := 0; i < matchesLen; i++ {
 		match := matches.get(i)
 		s.activeMatching[match]++
 		if numNativeHistogramBuckets >= 0 {
 			s.activeMatchingNativeHistograms[match]++
-			s.activeMatchingNativeHistogramBuckets[match] += numNativeHistogramBuckets
+			s.activeMatchingNativeHistogramBuckets[match] += uint32(numNativeHistogramBuckets)
 		}
 	}
 
@@ -381,7 +381,7 @@ func (s *seriesStripe) purge(keepUntil time.Time) {
 		s.active++
 		if entry.numNativeHistogramBuckets >= 0 {
 			s.activeNativeHistograms++
-			s.activeNativeHistogramBuckets += entry.numNativeHistogramBuckets
+			s.activeNativeHistogramBuckets += uint32(entry.numNativeHistogramBuckets)
 		}
 		ml := entry.matches.len()
 		for i := 0; i < ml; i++ {
@@ -389,7 +389,7 @@ func (s *seriesStripe) purge(keepUntil time.Time) {
 			s.activeMatching[match]++
 			if entry.numNativeHistogramBuckets >= 0 {
 				s.activeMatchingNativeHistograms[match]++
-				s.activeMatchingNativeHistogramBuckets[match] += entry.numNativeHistogramBuckets
+				s.activeMatchingNativeHistogramBuckets[match] += uint32(entry.numNativeHistogramBuckets)
 			}
 		}
 		if ts < oldest {
@@ -404,14 +404,14 @@ func (s *seriesStripe) purge(keepUntil time.Time) {
 	}
 }
 
-func resizeAndClear(l int, prev []int) []int {
+func resizeAndClear(l int, prev []uint32) []uint32 {
 	if cap(prev) < l {
 		if l == 0 {
 			return nil
 		}
 		// The allocation is bigger than the required capacity to save time in cases when the number of matchers are just slightly increasing.
 		// In cases where the default matchers are slightly changed in size it could save from lot of reallocations, while having low memory impact.
-		return make([]int, l, l*2)
+		return make([]uint32, l, l*2)
 	}
 
 	p := prev[:l]

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	numStripes = 512
+	numStripes = 128
 
 	EnabledFlag     = "ingester.active-series-metrics-enabled"
 	IdleTimeoutFlag = "ingester.active-series-metrics-idle-timeout"

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -31,11 +31,11 @@ func TestActiveSeries_UpdateSeries_NoMatchers(t *testing.T) {
 	assert.True(t, valid)
 	allActive, activeMatching, allActiveHistograms, activeMatchingHistograms, allActiveBuckets, activeMatchingBuckets := c.ActiveWithMatchers()
 	assert.Equal(t, 0, allActive)
-	assert.Nil(t, activeMatching)
+	assert.Empty(t, activeMatching)
 	assert.Equal(t, 0, allActiveHistograms)
-	assert.Nil(t, activeMatchingHistograms)
+	assert.Empty(t, activeMatchingHistograms)
 	assert.Equal(t, 0, allActiveBuckets)
-	assert.Nil(t, activeMatchingBuckets)
+	assert.Empty(t, activeMatchingBuckets)
 
 	c.UpdateSeries(ls1, ref1, time.Now(), -1)
 	valid = c.Purge(time.Now())
@@ -155,7 +155,7 @@ func TestActiveSeries_ContainsRef(t *testing.T) {
 			assert.True(t, valid)
 			allActive, activeMatching, _, _, _, _ := c.ActiveWithMatchers()
 			assert.Equal(t, exp, allActive)
-			assert.Nil(t, activeMatching)
+			assert.Empty(t, activeMatching)
 
 			for i := 0; i < len(series); i++ {
 				assert.Equal(t, i >= ttl, c.ContainsRef(refs[i]))
@@ -374,7 +374,7 @@ func TestActiveSeries_Purge_NoMatchers(t *testing.T) {
 			assert.True(t, valid)
 			allActive, activeMatching, _, _, _, _ := c.ActiveWithMatchers()
 			assert.Equal(t, exp, allActive)
-			assert.Nil(t, activeMatching)
+			assert.Empty(t, activeMatching)
 		})
 	}
 }
@@ -504,7 +504,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 	assert.True(t, valid)
 	allActive, activeMatching, _, _, _, _ = c.ActiveWithMatchers()
 	assert.Equal(t, 1, allActive)
-	assert.Equal(t, []int(nil), activeMatching)
+	assert.Empty(t, activeMatching)
 
 	asmWithMoreMatchers := NewMatchers(mustNewCustomTrackersConfigFromMap(t, map[string]string{
 		"a": `{a="3"}`,

--- a/pkg/ingester/activeseries/custom_trackers_config_test.go
+++ b/pkg/ingester/activeseries/custom_trackers_config_test.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func mustNewCustomTrackersConfigFromMap(t *testing.T, source map[string]string) CustomTrackersConfig {
+func mustNewCustomTrackersConfigFromMap(t require.TestingT, source map[string]string) CustomTrackersConfig {
 	m, err := NewCustomTrackersConfig(source)
 	require.NoError(t, err)
 	return m


### PR DESCRIPTION
#### What this PR does

Three changes:
* Store stripe counts as uint32 - a range of 4 billion ought to be enough, on one ingester.
* Smaller slice for match counts - we prefer to optimise for all the times when matchers are not increasing. On a multi-tenant system this will be the vast majority.
* Reduce stripes from 512 to 128 - this reduces memory for small tenants by 75%. Benchmarks show no difference in access speed.

And extend the benchmark to include matchers.

```
goos: linux
goarch: amd64
pkg: github.com/grafana/mimir/pkg/ingester/activeseries
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
                                                                 │   before.txt   │              after.txt              │
                                                                 │     sec/op     │    sec/op     vs base               │
ActiveSeriesTest_single_series/50-4                                  55.46n ±  2%   54.00n ±  6%        ~ (p=0.093 n=6)
ActiveSeriesTest_single_series/100-4                                 54.98n ±  1%   53.79n ± 10%        ~ (p=0.065 n=6)
ActiveSeriesTest_single_series/500-4                                 55.02n ±  3%   53.52n ±  6%        ~ (p=0.093 n=6)
ActiveSeries_UpdateSeries/rounds=0_series=0_matchers=0-4            112.57µ ± 38%   19.84µ ±  6%  -82.38% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=0_series=0_matchers=100-4         1052.40µ ± 12%   97.60µ ±  8%  -90.73% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=100000_matchers=0-4        42.45m ± 10%   41.85m ±  7%        ~ (p=0.818 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=100000_matchers=100-4      569.2m ± 12%   538.5m ±  2%        ~ (p=0.065 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=1000000_matchers=0-4       651.5m ± 10%   635.1m ±  5%        ~ (p=0.394 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=100000_matchers=0-4       144.4m ± 11%   137.0m ± 32%        ~ (p=0.485 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=1000000_matchers=0-4       2.125 ± 18%    2.032 ±  5%        ~ (p=0.132 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=100000_matchers=100-4     669.1m ± 19%   635.1m ±  2%   -5.08% (p=0.026 n=6)
ActiveSeries_Active_once-4                                           262.0µ ±  3%   217.9µ ±  4%  -16.84% (p=0.002 n=6)
ActiveSeries_Active_twice-4                                          280.2µ ±  8%   225.2µ ±  3%  -19.64% (p=0.002 n=6)

                                                                 │    before.txt    │               after.txt               │
                                                                 │       B/op       │     B/op      vs base                 │
ActiveSeriesTest_single_series/50-4                                   0.000 ±  0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ActiveSeriesTest_single_series/100-4                                  0.000 ±  0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ActiveSeriesTest_single_series/500-4                                  0.000 ±  0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
ActiveSeries_UpdateSeries/rounds=0_series=0_matchers=0-4           104.00Ki ±  0%     24.62Ki ± 0%  -76.32% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=0_series=0_matchers=100-4         2792.0Ki ±  0%     180.6Ki ± 0%  -93.53% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=100000_matchers=0-4       18.25Mi ±  0%     18.10Mi ± 0%   -0.81% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=100000_matchers=100-4     20.88Mi ±  0%     18.26Mi ± 0%  -12.53% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=1000000_matchers=0-4      272.7Mi ±  0%     272.5Mi ± 0%   -0.07% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=100000_matchers=0-4      18.25Mi ±  0%     18.10Mi ± 0%   -0.80% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=1000000_matchers=0-4     272.7Mi ±  0%     272.5Mi ± 0%   -0.07% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=100000_matchers=100-4    20.86Mi ±  0%     18.26Mi ± 0%  -12.48% (p=0.002 n=6)
ActiveSeries_Active_once-4                                           123.50 ± 10%       90.00 ± 8%  -27.13% (p=0.002 n=6)
ActiveSeries_Active_twice-4                                          128.50 ±  9%       92.00 ± 8%  -28.40% (p=0.002 n=6)

                                                                 │   before.txt   │               after.txt               │
                                                                 │   allocs/op    │  allocs/op    vs base                 │
ActiveSeriesTest_single_series/50-4                                 0.000 ±  0%      0.000 ±  0%        ~ (p=1.000 n=6) ¹
ActiveSeriesTest_single_series/100-4                                0.000 ±  0%      0.000 ±  0%        ~ (p=1.000 n=6) ¹
ActiveSeriesTest_single_series/500-4                                0.000 ±  0%      0.000 ±  0%        ~ (p=1.000 n=6) ¹
ActiveSeries_UpdateSeries/rounds=0_series=0_matchers=0-4            513.0 ±  0%      129.0 ±  0%  -74.85% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=0_series=0_matchers=100-4         2049.0 ±  0%      513.0 ±  0%  -74.96% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=100000_matchers=0-4      107.7k ±  0%     104.3k ±  0%   -3.14% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=100000_matchers=100-4    109.2k ±  0%     104.7k ±  0%   -4.15% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=1_series=1000000_matchers=0-4     1.035M ±  0%     1.037M ±  0%   +0.15% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=100000_matchers=0-4     107.7k ±  0%     104.3k ±  0%   -3.14% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=1000000_matchers=0-4    1.035M ±  0%     1.037M ±  0%   +0.15% (p=0.002 n=6)
ActiveSeries_UpdateSeries/rounds=10_series=100000_matchers=100-4   109.2k ±  0%     104.7k ±  0%   -4.12% (p=0.002 n=6)
ActiveSeries_Active_once-4                                          5.000 ± 20%      4.000 ± 25%  -20.00% (p=0.011 n=6)
ActiveSeries_Active_twice-4                                         6.000 ± 17%      5.000 ± 20%  -16.67% (p=0.013 n=6)
```

#### Checklist

- [x] Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated
