### PR TITLE
Jsonnet: allow to fine tune target utilization for autoscaled components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@
 * [ENHANCEMENT] Allow to remove an entry from the configured environment variable for a given component, setting the environment value to `null` in the `*_env_map` objects (e.g. `store_gateway_env_map+:: { 'field': null}`). #5599
 * [ENHANCEMENT] Allow overriding the default number of replicas for `etcd`.
 * [ENHANCEMENT] Memcached: reduce memory request for results, chunks and metadata caches. The requested memory is 5% greater than the configured memcached max cache size. #5661
+* [ENHANCEMENT] Autoscaling: Add the following configuration options to fine tune autoscaler target utilization: #5679
+  * `autoscaling_querier_target_utilization` (defaults to `0.75`)
+  * `autoscaling_mimir_read_target_utilization` (defaults to `0.75`)
+  * `autoscaling_ruler_querier_cpu_target_utilization` (defaults to `1`)
+  * `autoscaling_ruler_querier_memory_target_utilization` (defaults to `1`)
+  * `autoscaling_distributor_memory_target_utilization` (defaults to `1`)
+  * `autoscaling_ruler_cpu_target_utilization` (defaults to `1`)
+  * `autoscaling_query_frontend_cpu_target_utilization` (defaults to `1`)
+  * `autoscaling_ruler_query_frontend_cpu_target_utilization` (defaults to `1`)
+  * `autoscaling_alertmanager_cpu_target_utilization` (defaults to `1`)
 
 ### Mimirtool
 

--- a/operations/mimir/read-write-deployment/autoscaling.libsonnet
+++ b/operations/mimir/read-write-deployment/autoscaling.libsonnet
@@ -3,6 +3,7 @@
     autoscaling_mimir_read_enabled: false,
     autoscaling_mimir_read_min_replicas: error 'you must set autoscaling_mimir_read_min_replicas in the _config',
     autoscaling_mimir_read_max_replicas: error 'you must set autoscaling_mimir_read_max_replicas in the _config',
+    autoscaling_mimir_read_target_utilization: $._config.autoscaling_querier_target_utilization,
   },
 
   //
@@ -19,6 +20,7 @@
       querier_max_concurrent=$.querier_args['querier.max-concurrent'],
       min_replicas=$._config.autoscaling_mimir_read_min_replicas,
       max_replicas=$._config.autoscaling_mimir_read_max_replicas,
+      target_utilization=$._config.autoscaling_mimir_read_target_utilization,
     ),
 
   mimir_read_deployment: if !$._config.is_read_write_deployment_mode then null else (


### PR DESCRIPTION
#### What this PR does
In Jsonnet, we currently allow to set the target utilization for some, but not all metrics used by HPA. In this PR I'm making the config consistent and add config options to fine tune it for every autoscaled component.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
