### PR TITLE
Jsonnet: fix ruler-querier autoscaling target utilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,11 +111,10 @@
 * [ENHANCEMENT] Allow to remove an entry from the configured environment variable for a given component, setting the environment value to `null` in the `*_env_map` objects (e.g. `store_gateway_env_map+:: { 'field': null}`). #5599
 * [ENHANCEMENT] Allow overriding the default number of replicas for `etcd`.
 * [ENHANCEMENT] Memcached: reduce memory request for results, chunks and metadata caches. The requested memory is 5% greater than the configured memcached max cache size. #5661
-* [ENHANCEMENT] Autoscaling: Add the following configuration options to fine tune autoscaler target utilization: #5679
+* [ENHANCEMENT] Autoscaling: Add the following configuration options to fine tune autoscaler target utilization: #5679 #5682
   * `autoscaling_querier_target_utilization` (defaults to `0.75`)
   * `autoscaling_mimir_read_target_utilization` (defaults to `0.75`)
   * `autoscaling_ruler_querier_cpu_target_utilization` (defaults to `1`)
-  * `autoscaling_ruler_querier_memory_target_utilization` (defaults to `1`)
   * `autoscaling_distributor_memory_target_utilization` (defaults to `1`)
   * `autoscaling_ruler_cpu_target_utilization` (defaults to `1`)
   * `autoscaling_query_frontend_cpu_target_utilization` (defaults to `1`)


### PR DESCRIPTION
#### What this PR does
As spotted by @jhesketh [here](https://github.com/grafana/mimir/pull/5679#discussion_r1284452521) (thanks!) I did two mistakes in https://github.com/grafana/mimir/pull/5679, which I'm fixing in this PR:
- ruler-querier has no memory-based autoscaling
- `autoscaling_ruler_querier_cpu_target_utilization` was not applied

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
