### PR TITLE
Fixing the HPA queries suffering the PromQL lookback period

### DIFF
--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1927,14 +1927,27 @@ spec:
   triggers:
   - metadata:
       metricName: cortex_alertmanager_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="alertmanager",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1780"
     type: prometheus
   - metadata:
       metricName: cortex_alertmanager_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="alertmanager",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="alertmanager",namespace="default"})
+            and
+            max by (pod) (up{container="alertmanager",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "9556302233"
     type: prometheus
@@ -1961,14 +1974,27 @@ spec:
   triggers:
   - metadata:
       metricName: cortex_distributor_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="distributor",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1780"
     type: prometheus
   - metadata:
       metricName: cortex_distributor_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="distributor",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
+            and
+            max by (pod) (up{container="distributor",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "3058016714"
     type: prometheus
@@ -2022,14 +2048,27 @@ spec:
   triggers:
   - metadata:
       metricName: query_frontend_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="query-frontend",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1780"
     type: prometheus
   - metadata:
       metricName: query_frontend_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="query-frontend",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="query-frontend",namespace="default"})
+            and
+            max by (pod) (up{container="query-frontend",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "559939584"
     type: prometheus
@@ -2056,14 +2095,27 @@ spec:
   triggers:
   - metadata:
       metricName: ruler_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="ruler",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "890"
     type: prometheus
   - metadata:
       metricName: ruler_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="ruler",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
+            and
+            max by (pod) (up{container="ruler",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "5733781340"
     type: prometheus
@@ -2090,8 +2142,14 @@ spec:
   triggers:
   - metadata:
       metricName: cortex_ruler_querier_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "178"
     type: prometheus
@@ -2118,14 +2176,27 @@ spec:
   triggers:
   - metadata:
       metricName: ruler_query_frontend_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1780"
     type: prometheus
   - metadata:
       metricName: ruler_query_frontend_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
+            and
+            max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "559939584"
     type: prometheus

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1927,14 +1927,27 @@ spec:
   triggers:
   - metadata:
       metricName: cortex_alertmanager_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="alertmanager",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2000"
     type: prometheus
   - metadata:
       metricName: cortex_alertmanager_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="alertmanager",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="alertmanager",namespace="default"})
+            and
+            max by (pod) (up{container="alertmanager",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "10737418240"
     type: prometheus
@@ -1961,14 +1974,27 @@ spec:
   triggers:
   - metadata:
       metricName: cortex_distributor_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="distributor",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2000"
     type: prometheus
   - metadata:
       metricName: cortex_distributor_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="distributor",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
+            and
+            max by (pod) (up{container="distributor",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "3435973836"
     type: prometheus
@@ -2022,14 +2048,27 @@ spec:
   triggers:
   - metadata:
       metricName: query_frontend_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="query-frontend",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2000"
     type: prometheus
   - metadata:
       metricName: query_frontend_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="query-frontend",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="query-frontend",namespace="default"})
+            and
+            max by (pod) (up{container="query-frontend",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"
     type: prometheus
@@ -2056,14 +2095,27 @@ spec:
   triggers:
   - metadata:
       metricName: ruler_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="ruler",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1000"
     type: prometheus
   - metadata:
       metricName: ruler_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="ruler",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
+            and
+            max by (pod) (up{container="ruler",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6442450944"
     type: prometheus
@@ -2090,8 +2142,14 @@ spec:
   triggers:
   - metadata:
       metricName: cortex_ruler_querier_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "200"
     type: prometheus
@@ -2118,14 +2176,27 @@ spec:
   triggers:
   - metadata:
       metricName: ruler_query_frontend_cpu_hpa_default
-      query: max_over_time(sum(rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))[15m:])
-        * 1000
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2000"
     type: prometheus
   - metadata:
       metricName: ruler_query_frontend_memory_hpa_default
-      query: max_over_time(sum(container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})[15m:])
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
+            and
+            max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"
     type: prometheus

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -173,7 +173,7 @@
 
   // To scale out relatively quickly, but scale in slower, we look at the average CPU utilization
   // per replica over 5m (rolling window) and then we pick the highest value over the last 15m.
-  // We multiply by 1000 to get the result in millicores. This is due to KEDA only working with ints.
+  // We multiply by 1000 to get the result in millicores. This is due to HPA only working with ints.
   // The "up" metrics correctly handles the stale marker when the pod is terminated, while it’s not the
   // case for the cAdvisor metrics. By intersecting these 2 metrics, we only look the CPU utilization
   // of containers there are running at any given time, without suffering the PromQL lookback period.
@@ -181,9 +181,9 @@
   local cpuHPAQuery = |||
     max_over_time(
       sum(
-        sum by (pod) (rate(container_cpu_usage_seconds_total{container="%s",namespace="%s"}[5m]))
+        sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"}[5m]))
         and
-        max by (pod) (up{container="%s",namespace="%s"}) > 0
+        max by (pod) (up{container="%(container)s",namespace="%(namespace)s"}) > 0
       )[15m:]
     ) * 1000
   |||,
@@ -196,9 +196,9 @@
   local memoryHPAQuery = |||
     max_over_time(
       sum(
-        sum by (pod) (container_memory_working_set_bytes{container="%s",namespace="%s"})
+        sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"})
         and
-        max by (pod) (up{container="%s",namespace="%s"}) > 0
+        max by (pod) (up{container="%(container)s",namespace="%(namespace)s"}) > 0
       )[15m:]
     )
   |||,
@@ -211,12 +211,10 @@
         {
           metric_name: '%s_cpu_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-          query: cpuHPAQuery % [
-            name,
-            $._config.namespace,
-            name,
-            $._config.namespace,
-          ],
+          query: cpuHPAQuery % {
+            container: name,
+            namespace: $._config.namespace,
+          },
 
           // Threshold is expected to be a string
           threshold: std.toString(std.floor(cpuToMilliCPUInt(cpu_requests) * cpu_target_utilization)),
@@ -224,12 +222,10 @@
         {
           metric_name: '%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-          query: memoryHPAQuery % [
-            name,
-            $._config.namespace,
-            name,
-            $._config.namespace,
-          ],
+          query: memoryHPAQuery % {
+            container: name,
+            namespace: $._config.namespace,
+          },
 
           // Threshold is expected to be a string
           threshold: std.toString(std.floor($.util.siToBytes(memory_requests) * memory_target_utilization)),
@@ -325,7 +321,7 @@
         metric_name: 'cortex_%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
         // Due to the more predicatable nature of the ruler-querier workload we can scale on CPU usage.
-        query: metricWithWeight(cpuHPAQuery % [name, $._config.namespace, name, $._config.namespace], weight),
+        query: metricWithWeight(cpuHPAQuery % { container: name, namespace: $._config.namespace }, weight),
 
         // threshold is expected to be a string.
         threshold: std.toString(std.floor(cpuToMilliCPUInt(querier_cpu_requests) * cpu_target_utilization)),
@@ -377,12 +373,10 @@
       {
         metric_name: 'cortex_%s_cpu_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-        query: cpuHPAQuery % [
-          name,
-          $._config.namespace,
-          name,
-          $._config.namespace,
-        ],
+        query: cpuHPAQuery % {
+          container: name,
+          namespace: $._config.namespace,
+        },
 
         // threshold is expected to be a string.
         threshold: std.toString(std.floor(cpuToMilliCPUInt(distributor_cpu_requests) * cpu_target_utilization)),
@@ -390,12 +384,10 @@
       {
         metric_name: 'cortex_%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-        query: memoryHPAQuery % [
-          name,
-          $._config.namespace,
-          name,
-          $._config.namespace,
-        ],
+        query: memoryHPAQuery % {
+          container: name,
+          namespace: $._config.namespace,
+        },
 
         // threshold is expected to be a string
         threshold: std.toString(std.floor($.util.siToBytes(distributor_memory_requests) * memory_target_utilization)),
@@ -434,12 +426,10 @@
         {
           metric_name: '%s_cpu_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-          query: cpuHPAQuery % [
-            name,
-            $._config.namespace,
-            name,
-            $._config.namespace,
-          ],
+          query: cpuHPAQuery % {
+            container: name,
+            namespace: $._config.namespace,
+          },
 
           // Threshold is expected to be a string
           threshold: std.toString(std.floor(cpuToMilliCPUInt($.ruler_container.resources.requests.cpu) * $._config.autoscaling_ruler_cpu_target_utilization)),
@@ -447,12 +437,10 @@
         {
           metric_name: '%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-          query: memoryHPAQuery % [
-            name,
-            $._config.namespace,
-            name,
-            $._config.namespace,
-          ],
+          query: memoryHPAQuery % {
+            container: name,
+            namespace: $._config.namespace,
+          },
 
           // Threshold is expected to be a string
           threshold: std.toString(std.floor($.util.siToBytes($.ruler_container.resources.requests.memory) * $._config.autoscaling_ruler_memory_target_utilization)),
@@ -484,12 +472,10 @@
       {
         metric_name: 'cortex_%s_cpu_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-        query: cpuHPAQuery % [
-          name,
-          $._config.namespace,
-          name,
-          $._config.namespace,
-        ],
+        query: cpuHPAQuery % {
+          container: name,
+          namespace: $._config.namespace,
+        },
 
         // Threshold is expected to be a string.
         // Since alertmanager is very memory-intensive as opposed to cpu-intensive, we don't bother
@@ -499,12 +485,10 @@
       {
         metric_name: 'cortex_%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-        query: memoryHPAQuery % [
-          name,
-          $._config.namespace,
-          name,
-          $._config.namespace,
-        ],
+        query: memoryHPAQuery % {
+          container: name,
+          namespace: $._config.namespace,
+        },
 
         // Threshold is expected to be a string.
         threshold: std.toString(std.floor($.util.siToBytes(alertmanager_memory_requests) * memory_target_utilization)),


### PR DESCRIPTION
#### What this PR does
CPU and memory HPA queries of some components (e.g., distributors, alert manager,  ruler, query frontend) take in account resources utilization of terminated pods as well (because of the 5m stale period). As a consequence, from HPA perspective it looks like the resource utilization doubled, hence HPA wants to scale up 2 times.

This PR fixes the problem by intersecting the resource utilization with the `up` metrics, in such a way that only the resource utilization of pods that are up and running is considered.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
