### PR TITLE
Improve runbook for MimirRequestErrors, Alertmanager section, for alertmanager distributor problems

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -286,6 +286,10 @@ How to **investigate**:
 - Looking at `Mimir / Alertmanager` dashboard you should see in which part of the stack the error originates
 - If some replicas are going OOM (`OOMKilled`): scale up or increase the memory
 - If the failing service is crashing / panicking: look for the stack trace in the logs and investigate from there
+- If the `route` label is `alertmanager`, check the logs for distributor errors containing `component=AlertmanagerDistributor`
+  - Check if instances are starved for resources using the `Mimir / Alertmanager resources` dashboard
+  - If the distributor errors are `context deadline exceeded` and the instances are not starved for resources, increase the distributor
+  timeout with `-alertmanager.alertmanager-client.remote-timeout=<timeout>`. The defaut is 2s if not specified.
 
 ### MimirIngesterUnhealthy
 


### PR DESCRIPTION
#### What this PR does

The alertmanager's distributor fans out tenant requests to the correct alertmanager. There is a specific state where this may be failing, but it's not immediately obvious from the alert.

Add a couple lines to the Alertmanager section of the `MimirRequestErrors` runbook which handle this case, and describe what to do.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
