### PR TITLE
fix[mimirtool]: order samples when performing export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Jsonnet
 
 ### Mimirtool
+* [BUGFIX] Fix out of bounds error on export with large timespans and/or series count. #5700
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/backfill/backfill.go
+++ b/pkg/mimirtool/backfill/backfill.go
@@ -90,7 +90,7 @@ func CreateBlocks(input IteratorCreator, mint, maxt int64, maxSamplesInAppender 
 
 	var wroteHeader bool
 
-	for t := mint; t <= maxt; t = t + blockDuration {
+	for t := mint; t <= maxt; t = t + blockDuration/2 {
 		err := func() error {
 			w, err := tsdb.NewBlockWriter(log.NewNopLogger(), outputDir, blockDuration)
 			if err != nil {
@@ -106,7 +106,7 @@ func CreateBlocks(input IteratorCreator, mint, maxt int64, maxSamplesInAppender 
 			ctx := context.Background()
 			app := w.Appender(ctx)
 			i := input()
-			tsUpper := t + blockDuration
+			tsUpper := t + blockDuration/2
 			samplesCount := 0
 			for {
 				err := i.Next()

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -416,8 +416,7 @@ func (c *RemoteReadCommand) export(_ *kingpin.ParseContext) error {
 	if err != nil {
 		return err
 	}
-
-	iterator := func() backfill.Iterator {
+	iteratorCreator := func() backfill.Iterator {
 		return newTimeSeriesIterator(timeseries)
 	}
 
@@ -434,7 +433,7 @@ func (c *RemoteReadCommand) export(_ *kingpin.ParseContext) error {
 	defer pipeR.Close()
 
 	log.Infof("Store TSDB blocks in '%s'", c.tsdbPath)
-	if err := backfill.CreateBlocks(iterator, int64(mint), int64(maxt), 1000, c.tsdbPath, true, pipeW); err != nil {
+	if err := backfill.CreateBlocks(iteratorCreator, int64(mint), int64(maxt), 1000, c.tsdbPath, true, pipeW); err != nil {
 		return err
 	}
 

--- a/pkg/mimirtool/commands/remote_read_test.go
+++ b/pkg/mimirtool/commands/remote_read_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/mimir/pkg/mimirtool/backfill"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/mimir/pkg/mimirtool/backfill"
 )
 
 func TestTimeSeriesIterator(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

When iterating over the samples returned by the remote read endpoint, the samples are grouped by series, e.g.:

```
{__name__="agent_build_info"} 1 1691474422539
{__name__="agent_build_info"} 1 1691474542539
{__name__="agent_build_info"} 1 1691474602539
{__name__="up"} 1 1691474422539
{__name__="up"} 1 1691474542539
{__name__="up"} 1 1691474602539
```

As long as all samples fall into the same block timespan (default is 2h and not configurable), this does not cause any issues. The same is the case if all series start at the same timestamp.

However if a block gets committed, the new minimum timestamp gets set to the lowest timestamp of the ingested samples up to now. If a series with an earlier starting timestamp exists in the remote_read response, this causes mimirtool to crash with an out of order error.

This PR fixes this by using a heap based iterator to iterate over the samples based on the timestamp value.


#### Checklist

- [x] Tests updated
- [x] ~Documentation added~
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
