### PR TITLE
Skip two consecutive CPU utilization updates in the UtilizationBasedLimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality|label_names_and_values"}`
   * `cortex_frontend_query_result_cache_hits_total{request_type="query_range|cardinality|label_names_and_values"}`
 * [FEATURE] Added `-<prefix>.s3.list-objects-version` flag to configure the S3 list objects version.
-* [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392 #5394 #5526 #5508
+* [FEATURE] Ingester: Add optional CPU/memory utilization based read request limiting, considered experimental. Disabled by default, enable by configuring limits via both of the following flags: #5012 #5392 #5394 #5526 #5508 #5704
   * `-ingester.read-path-cpu-utilization-limit`
   * `-ingester.read-path-memory-utilization-limit`
   * `-ingester.log-utilization-based-limiter-cpu-samples`

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -159,7 +159,7 @@ func (l *UtilizationBasedLimiter) compute(nowFn func() time.Time) (currCPUUtil f
 		timeSincePrevUpdate := now.Sub(prevUpdate)
 
 		// We expect the CPU utilization to be updated at a regular interval (resourceUtilizationUpdateInterval).
-		// Under some edge conditions (e.g. overloaded process / node) the time.Ticker, used to periodically call
+		// Under some edge conditions (e.g. overloaded process / node), the time.Ticker used to periodically call
 		// the UtilizationBasedLimiter.compute() function, may call compute() two times consecutively (or with a very
 		// short delay). We detect these cases and skip the update (it will be updated during the next regular tick).
 		if timeSincePrevUpdate > resourceUtilizationUpdateInterval/2 {

--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -336,9 +336,7 @@ func TestUtilizationBasedLimiter_ShouldNotUpdateCPUIfElapsedVeryShortTimeSincePr
 		assert.InDelta(t, float64(expected), lim.lastCPUTime, 0.0001)
 	}
 
-	// Track the CPU utilization two consecutive times, at a very short interval.
-	assert.InDelta(t, float64(5), lim.lastCPUTime, 0.0001)
-
+	// Track the CPU utilization few consecutive times, at a very short interval.
 	for i := 0; i < 5; i++ {
 		now = now.Add(resourceUtilizationUpdateInterval / 10)
 		lim.compute(nowFn)


### PR DESCRIPTION
#### What this PR does
We're still testing the CPU limit in the `UtilizationBasedLimiter` and we observe a weird behaviour. Sometimes, the limiter tracks a CPU utilization which is absurdly high (e.g. 108946 sec cores on a 32 cores machine). We haven't found the root cause, but I have a theory. In this PR I'm proposing a fix for that theory.

##### Theory

The `UtilizationBasedLimiter.compute()` is called by a `time.Ticker`. We know that a `time.Ticker` may call the function two consecutive times under some edge conditions. For example, look at [this example](https://go.dev/play/p/B1wmVKqjvpF). It prints:

```
2009-11-10 23:00:01 +0000 UTC m=+1.000000001
2009-11-10 23:00:02.99 +0000 UTC m=+2.990000001
2009-11-10 23:00:03 +0000 UTC m=+3.000000001
2009-11-10 23:00:04.99 +0000 UTC m=+4.990000001
```

Given ☝️ , a theory I have is that when ☝️ happens the computed `timeSincePrevUpdate` may be a very small number and so the divider in the following operation may be a very small number:

```
cpuUtil := (cpuTime - prevCPUTime) / timeSincePrevUpdate.Seconds()
```

When the divider is a very small number (e.g. 1 microsecond = 0.000001) it will amplify the value computed by `cpuTime - prevCPUTime`. We (myself included) expect `cpuTime - prevCPUTime` to be consistent with the elapsed time, so if the divider is a very small number then also `cpuTime - prevCPUTime` should be a very small number, but in practice we read from `/proc` and get the `time.Now()` at different times (the two operations are not atomic), so there's always a small drift between the two.

When the divider is 1 second, we don't notice this difference, but when the divider is a very small number because `compute()` was called two times consecutively, then the "small drift" will be amplified by factors, potentially leading to bogus CPU utilization computation.

This is just a theory, but I think what I'm proposing in this PR is a safe change to do anyway.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
