### PR TITLE
Dashboards: rename "Blocks currently loaded" to "Blocks currently owned" in the "Mimir / Queries" dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 * [ENHANCEMENT] Dashboards: add "rejected queries" panel to "queries" dashboard. #5429
 * [ENHANCEMENT] Dashboards: add native histogram active series and active buckets to "tenants" dashboard. #5543
 * [ENHANCEMENT] Dashboards: add panels to "Mimir / Writes" for requests rejected for per-instance limits. #5638
+* [ENHANCEMENT] Dashboards: rename "Blocks currently loaded" to "Blocks currently owned" in the "Mimir / Queries" dashboard. #5705
 * [BUGFIX] Alerts: fix `MimirIngesterRestarts` to fire only when the ingester container is restarted, excluding the cases the pod is rescheduled. #5397
 * [BUGFIX] Dashboards: fix "unhealthy pods" panel on "rollout progress" dashboard showing only a number rather than the name of the workload and the number of unhealthy pods if only one workload has unhealthy pods. #5113 #5200
 * [BUGFIX] Alerts: fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts. #5396

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -14716,6 +14716,7 @@ data:
                       "dashLength": 10,
                       "dashes": false,
                       "datasource": "$datasource",
+                      "description": "### Blocks currently owned\nThis panel shows the number of blocks owned by each store-gateway replica.\nFor each owned block, the store-gateway keeps its index-header on disk, and\neventually loaded in memory (if index-header lazy loading is disabled, or lazy loading\nis enabled and the index-header was loaded).\n\n",
                       "fill": 0,
                       "id": 29,
                       "legend": {
@@ -14752,7 +14753,7 @@ data:
                       "thresholds": [ ],
                       "timeFrom": null,
                       "timeShift": null,
-                      "title": "Blocks currently loaded",
+                      "title": "Blocks currently owned",
                       "tooltip": {
                          "shared": false,
                          "sort": 0,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -2343,6 +2343,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Blocks currently owned\nThis panel shows the number of blocks owned by each store-gateway replica.\nFor each owned block, the store-gateway keeps its index-header on disk, and\neventually loaded in memory (if index-header lazy loading is disabled, or lazy loading\nis enabled and the index-header was loaded).\n\n",
                   "fill": 0,
                   "id": 29,
                   "legend": {
@@ -2379,7 +2380,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Blocks currently loaded",
+                  "title": "Blocks currently owned",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -2343,6 +2343,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Blocks currently owned\nThis panel shows the number of blocks owned by each store-gateway replica.\nFor each owned block, the store-gateway keeps its index-header on disk, and\neventually loaded in memory (if index-header lazy loading is disabled, or lazy loading\nis enabled and the index-header was loaded).\n\n",
                   "fill": 0,
                   "id": 29,
                   "legend": {
@@ -2379,7 +2380,7 @@
                   "thresholds": [ ],
                   "timeFrom": null,
                   "timeShift": null,
-                  "title": "Blocks currently loaded",
+                  "title": "Blocks currently owned",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -303,9 +303,18 @@ local filename = 'mimir-queries.json';
     .addRow(
       $.row('')
       .addPanel(
-        $.panel('Blocks currently loaded') +
+        $.panel('Blocks currently owned') +
         $.queryPanel('cortex_bucket_store_blocks_loaded{component="store-gateway",%s}' % $.jobMatcher($._config.job_names.store_gateway), '{{%s}}' % $._config.per_instance_label) +
-        { fill: 0 }
+        { fill: 0 } +
+        $.panelDescription(
+          'Blocks currently owned',
+          |||
+            This panel shows the number of blocks owned by each store-gateway replica.
+            For each owned block, the store-gateway keeps its index-header on disk, and
+            eventually loaded in memory (if index-header lazy loading is disabled, or lazy loading
+            is enabled and the index-header was loaded).
+          |||
+        ),
       )
       .addPanel(
         $.panel('Blocks loaded / sec') +


### PR DESCRIPTION
#### What this PR does
While being on-call, I noticed that the "Blocks currently loaded" in the "Mimir / Queries" dashboard may be misleading, because by "loaded" you may think about "block index-header loaded". The panel actually shows the number of blocks owned by the store-gateway replica, and it's unrelated by the number of blocks whose index-header has been loaded.

In this PR I propose to rename the panel and add a panel description to clarify it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
