### PR TITLE
Chore: set Jaeger sampler to be probabilistic

### DIFF
--- a/integration/e2emimir/service.go
+++ b/integration/e2emimir/service.go
@@ -32,7 +32,7 @@ func NewMimirService(
 	// Add jaeger configuration with a 50% sampling rate so that we can trigger
 	// code paths that rely on a trace being sampled.
 	s.SetEnvVars(map[string]string{
-		"JAEGER_SAMPLER_TYPE":  "const",
+		"JAEGER_SAMPLER_TYPE":  "probabilistic",
 		"JAEGER_SAMPLER_PARAM": "0.5",
 	})
 	return s


### PR DESCRIPTION
Chore: set Jaeger sampler to be probabilistic

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
During the otel migration, I noticed the current e2e tracing is actually always sampled, see [code](https://github.com/jaegertracing/jaeger-client-go/blob/master/config/config.go#L371), reading the commands, we actually want to have 50% sampling rate in order to test both sampled/unsampled cases. 
#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
