### PR TITLE
Jsonnet: fix compilation when index, chunks or metadata caches are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@
   * `autoscaling_alertmanager_cpu_target_utilization` (defaults to `1`)
 * [ENHANCEMENT] Gossip-ring: add appProtocol for istio compatibility. #5680
 * [ENHANCEMENT] Add _config.commonConfig to allow adding common configuration parameters for all Mimir components. #5703
+* [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled.jsonnet
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled.jsonnet
@@ -1,26 +1,6 @@
-local mimir = import 'mimir/mimir.libsonnet';
-
-mimir {
+// Based on test-read-write-deployment-mode-s3.jsonnet.
+(import 'test-read-write-deployment-mode-s3.jsonnet') {
   _config+:: {
-    namespace: 'default',
-    external_url: 'http://test',
-    aws_region: 'eu-west-1',
-
-    storage_backend: 's3',
-    blocks_storage_bucket_name: 'blocks-bucket',
-    bucket_index_enabled: true,
-    query_scheduler_enabled: true,
-
-    ruler_enabled: true,
-    ruler_storage_bucket_name: 'rules-bucket',
-
-    alertmanager_enabled: true,
-    alertmanager_storage_bucket_name: 'alerts-bucket',
-
-    deployment_mode: 'read-write',
-    multi_zone_ingester_enabled: true,
-    multi_zone_store_gateway_enabled: true,
-
     autoscaling_mimir_read_enabled: true,
     autoscaling_mimir_read_min_replicas: 2,
     autoscaling_mimir_read_max_replicas: 20,

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -1,0 +1,1414 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: mimir-backend-rollout
+  name: mimir-backend-rollout
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      rollout-group: mimir-backend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: mimir-read
+  name: mimir-read
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: mimir-read
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: mimir-write-rollout
+  name: mimir-write-rollout
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      rollout-group: mimir-write
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: rollout-operator
+  name: rollout-operator
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: rollout-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rollout-operator
+  namespace: default
+---
+apiVersion: v1
+data:
+  overrides.yaml: |
+    overrides: {}
+kind: ConfigMap
+metadata:
+  name: overrides
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rollout-operator-role
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - watch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rollout-operator-rolebinding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rollout-operator-role
+subjects:
+- kind: ServiceAccount
+  name: rollout-operator
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gossip-ring
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - appProtocol: tcp
+    name: gossip-ring
+    port: 7946
+    protocol: TCP
+    targetPort: 7946
+  selector:
+    gossip_ring_member: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-backend
+  name: mimir-backend
+  namespace: default
+spec:
+  ports:
+  - name: mimir-backend-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-backend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-backend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    rollout-group: mimir-backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-backend-zone-a
+  name: mimir-backend-zone-a
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: mimir-backend-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-backend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-backend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-backend-zone-a
+    rollout-group: mimir-backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-backend-zone-b
+  name: mimir-backend-zone-b
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: mimir-backend-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-backend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-backend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-backend-zone-b
+    rollout-group: mimir-backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-backend-zone-c
+  name: mimir-backend-zone-c
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: mimir-backend-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-backend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-backend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-backend-zone-c
+    rollout-group: mimir-backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-read
+  name: mimir-read
+  namespace: default
+spec:
+  ports:
+  - name: mimir-read-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-read-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-read-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-read
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-read
+  name: mimir-read-headless
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: mimir-read-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-read-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-read-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-read
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-write
+  name: mimir-write
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: mimir-write-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-write-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-write-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    rollout-group: mimir-write
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-write-zone-a
+  name: mimir-write-zone-a
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: mimir-write-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-write-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-write-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-write-zone-a
+    rollout-group: mimir-write
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-write-zone-b
+  name: mimir-write-zone-b
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: mimir-write-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-write-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-write-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-write-zone-b
+    rollout-group: mimir-write
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mimir-write-zone-c
+  name: mimir-write-zone-c
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: mimir-write-gossip-ring
+    port: 7946
+    targetPort: 7946
+  - name: mimir-write-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: mimir-write-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: mimir-write-zone-c
+    rollout-group: mimir-write
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mimir-read
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: mimir-read
+  strategy:
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: mimir-read
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -common.storage.backend=s3
+        - -common.storage.s3.endpoint=s3.dualstack.eu-west-1.amazonaws.com
+        - -distributor.health-check-ingesters=true
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=268435456
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
+        - -query-frontend.align-queries-with-step=false
+        - -query-frontend.max-total-query-length=12000h
+        - -query-frontend.query-sharding-target-series-per-shard=0
+        - -query-scheduler.max-used-instances=2
+        - -query-scheduler.ring.prefix=
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -target=read
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
+          value: "1024"
+        image: grafana/mimir:2.9.0
+        imagePullPolicy: IfNotPresent
+        name: mimir-read
+        ports:
+        - containerPort: 7946
+          name: gossip-ring
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: mimir-read
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rollout-operator
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: rollout-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: rollout-operator
+    spec:
+      containers:
+      - args:
+        - -kubernetes.namespace=default
+        image: grafana/rollout-operator:v0.6.0
+        imagePullPolicy: IfNotPresent
+        name: rollout-operator
+        ports:
+        - containerPort: 8001
+          name: http-metrics
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8001
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: "1"
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      serviceAccountName: rollout-operator
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "10"
+  labels:
+    rollout-group: mimir-backend
+  name: mimir-backend-zone-a
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mimir-backend-zone-a
+      rollout-group: mimir-backend
+  serviceName: mimir-backend-zone-a
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: mimir-backend-zone-a
+        rollout-group: mimir-backend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - mimir-backend
+              - key: name
+                operator: NotIn
+                values:
+                - mimir-backend-zone-a
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -alertmanager-storage.s3.bucket-name=alerts-bucket
+        - -alertmanager.sharding-ring.replication-factor=3
+        - -alertmanager.sharding-ring.store=memberlist
+        - -alertmanager.storage.path=/data/alertmanager
+        - -alertmanager.web.external-url=http://test/alertmanager
+        - -blocks-storage.bucket-store.index-header-lazy-loading-enabled=true
+        - -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout=60m
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -common.storage.backend=s3
+        - -common.storage.s3.endpoint=s3.dualstack.eu-west-1.amazonaws.com
+        - -compactor.block-ranges=2h,12h,24h
+        - -compactor.blocks-retention-period=0
+        - -compactor.cleanup-interval=15m
+        - -compactor.compaction-concurrency=1
+        - -compactor.compaction-interval=30m
+        - -compactor.compactor-tenant-shard-size=1
+        - -compactor.data-dir=/data/compactor
+        - -compactor.deletion-delay=2h
+        - -compactor.first-level-compaction-wait-period=25m
+        - -compactor.max-closing-blocks-concurrency=2
+        - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.ring.prefix=
+        - -compactor.ring.store=memberlist
+        - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.split-and-merge-shards=0
+        - -compactor.split-groups=1
+        - -compactor.symbols-flushers-concurrency=4
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -overrides-exporter.ring.enabled=true
+        - -overrides-exporter.ring.prefix=
+        - -overrides-exporter.ring.store=memberlist
+        - -overrides-exporter.ring.wait-stability-min-duration=1m
+        - -querier.max-partial-query-length=768h
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -query-scheduler.max-used-instances=2
+        - -query-scheduler.ring.prefix=
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -ruler-storage.s3.bucket-name=rules-bucket
+        - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
+        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rules-per-rule-group=20
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
+        - -ruler.ring.store=memberlist
+        - -ruler.rule-path=/rules
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.instance-availability-zone=zone-a
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -target=backend
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:2.9.0
+        imagePullPolicy: IfNotPresent
+        name: mimir-backend
+        ports:
+        - containerPort: 7946
+          name: gossip-ring
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: 1
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: mimir-backend-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mimir-backend-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: fast-dont-retain
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "10"
+  labels:
+    rollout-group: mimir-backend
+  name: mimir-backend-zone-b
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mimir-backend-zone-b
+      rollout-group: mimir-backend
+  serviceName: mimir-backend-zone-b
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: mimir-backend-zone-b
+        rollout-group: mimir-backend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - mimir-backend
+              - key: name
+                operator: NotIn
+                values:
+                - mimir-backend-zone-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -alertmanager-storage.s3.bucket-name=alerts-bucket
+        - -alertmanager.sharding-ring.replication-factor=3
+        - -alertmanager.sharding-ring.store=memberlist
+        - -alertmanager.storage.path=/data/alertmanager
+        - -alertmanager.web.external-url=http://test/alertmanager
+        - -blocks-storage.bucket-store.index-header-lazy-loading-enabled=true
+        - -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout=60m
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -common.storage.backend=s3
+        - -common.storage.s3.endpoint=s3.dualstack.eu-west-1.amazonaws.com
+        - -compactor.block-ranges=2h,12h,24h
+        - -compactor.blocks-retention-period=0
+        - -compactor.cleanup-interval=15m
+        - -compactor.compaction-concurrency=1
+        - -compactor.compaction-interval=30m
+        - -compactor.compactor-tenant-shard-size=1
+        - -compactor.data-dir=/data/compactor
+        - -compactor.deletion-delay=2h
+        - -compactor.first-level-compaction-wait-period=25m
+        - -compactor.max-closing-blocks-concurrency=2
+        - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.ring.prefix=
+        - -compactor.ring.store=memberlist
+        - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.split-and-merge-shards=0
+        - -compactor.split-groups=1
+        - -compactor.symbols-flushers-concurrency=4
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -overrides-exporter.ring.enabled=true
+        - -overrides-exporter.ring.prefix=
+        - -overrides-exporter.ring.store=memberlist
+        - -overrides-exporter.ring.wait-stability-min-duration=1m
+        - -querier.max-partial-query-length=768h
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -query-scheduler.max-used-instances=2
+        - -query-scheduler.ring.prefix=
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -ruler-storage.s3.bucket-name=rules-bucket
+        - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
+        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rules-per-rule-group=20
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
+        - -ruler.ring.store=memberlist
+        - -ruler.rule-path=/rules
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.instance-availability-zone=zone-b
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -target=backend
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:2.9.0
+        imagePullPolicy: IfNotPresent
+        name: mimir-backend
+        ports:
+        - containerPort: 7946
+          name: gossip-ring
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: 1
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: mimir-backend-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mimir-backend-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: fast-dont-retain
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "10"
+  labels:
+    rollout-group: mimir-backend
+  name: mimir-backend-zone-c
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mimir-backend-zone-c
+      rollout-group: mimir-backend
+  serviceName: mimir-backend-zone-c
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: mimir-backend-zone-c
+        rollout-group: mimir-backend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - mimir-backend
+              - key: name
+                operator: NotIn
+                values:
+                - mimir-backend-zone-c
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -alertmanager-storage.s3.bucket-name=alerts-bucket
+        - -alertmanager.sharding-ring.replication-factor=3
+        - -alertmanager.sharding-ring.store=memberlist
+        - -alertmanager.storage.path=/data/alertmanager
+        - -alertmanager.web.external-url=http://test/alertmanager
+        - -blocks-storage.bucket-store.index-header-lazy-loading-enabled=true
+        - -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout=60m
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -common.storage.backend=s3
+        - -common.storage.s3.endpoint=s3.dualstack.eu-west-1.amazonaws.com
+        - -compactor.block-ranges=2h,12h,24h
+        - -compactor.blocks-retention-period=0
+        - -compactor.cleanup-interval=15m
+        - -compactor.compaction-concurrency=1
+        - -compactor.compaction-interval=30m
+        - -compactor.compactor-tenant-shard-size=1
+        - -compactor.data-dir=/data/compactor
+        - -compactor.deletion-delay=2h
+        - -compactor.first-level-compaction-wait-period=25m
+        - -compactor.max-closing-blocks-concurrency=2
+        - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.ring.prefix=
+        - -compactor.ring.store=memberlist
+        - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.split-and-merge-shards=0
+        - -compactor.split-groups=1
+        - -compactor.symbols-flushers-concurrency=4
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -overrides-exporter.ring.enabled=true
+        - -overrides-exporter.ring.prefix=
+        - -overrides-exporter.ring.store=memberlist
+        - -overrides-exporter.ring.wait-stability-min-duration=1m
+        - -querier.max-partial-query-length=768h
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -query-scheduler.max-used-instances=2
+        - -query-scheduler.ring.prefix=
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -ruler-storage.s3.bucket-name=rules-bucket
+        - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
+        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rules-per-rule-group=20
+        - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
+        - -ruler.ring.store=memberlist
+        - -ruler.rule-path=/rules
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.instance-availability-zone=zone-c
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -target=backend
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:2.9.0
+        imagePullPolicy: IfNotPresent
+        name: mimir-backend
+        ports:
+        - containerPort: 7946
+          name: gossip-ring
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: 1
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: mimir-backend-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mimir-backend-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: fast-dont-retain
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "25"
+  labels:
+    rollout-group: mimir-write
+  name: mimir-write-zone-a
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mimir-write-zone-a
+      rollout-group: mimir-write
+  serviceName: mimir-write-zone-a
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: mimir-write-zone-a
+        rollout-group: mimir-write
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - mimir-write
+              - key: name
+                operator: NotIn
+                values:
+                - mimir-write-zone-a
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.wal-replay-concurrency=3
+        - -common.storage.backend=s3
+        - -common.storage.s3.endpoint=s3.dualstack.eu-west-1.amazonaws.com
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.etcd.endpoints=etcd-client.default.svc.cluster.local.:2379
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=etcd
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.ring.prefix=
+        - -distributor.ring.store=memberlist
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.instance-availability-zone=zone-a
+        - -ingester.ring.num-tokens=512
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.tokens-file-path=/data/tokens
+        - -ingester.ring.unregister-on-shutdown=true
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=10000
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=write
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:2.9.0
+        imagePullPolicy: IfNotPresent
+        name: mimir-write
+        ports:
+        - containerPort: 7946
+          name: gossip-ring
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: mimir-write-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mimir-write-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "25"
+  labels:
+    rollout-group: mimir-write
+  name: mimir-write-zone-b
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mimir-write-zone-b
+      rollout-group: mimir-write
+  serviceName: mimir-write-zone-b
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: mimir-write-zone-b
+        rollout-group: mimir-write
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - mimir-write
+              - key: name
+                operator: NotIn
+                values:
+                - mimir-write-zone-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.wal-replay-concurrency=3
+        - -common.storage.backend=s3
+        - -common.storage.s3.endpoint=s3.dualstack.eu-west-1.amazonaws.com
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.etcd.endpoints=etcd-client.default.svc.cluster.local.:2379
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=etcd
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.ring.prefix=
+        - -distributor.ring.store=memberlist
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.instance-availability-zone=zone-b
+        - -ingester.ring.num-tokens=512
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.tokens-file-path=/data/tokens
+        - -ingester.ring.unregister-on-shutdown=true
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=10000
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=write
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:2.9.0
+        imagePullPolicy: IfNotPresent
+        name: mimir-write
+        ports:
+        - containerPort: 7946
+          name: gossip-ring
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: mimir-write-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mimir-write-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "25"
+  labels:
+    rollout-group: mimir-write
+  name: mimir-write-zone-c
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mimir-write-zone-c
+      rollout-group: mimir-write
+  serviceName: mimir-write-zone-c
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: mimir-write-zone-c
+        rollout-group: mimir-write
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - mimir-write
+              - key: name
+                operator: NotIn
+                values:
+                - mimir-write-zone-c
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.wal-replay-concurrency=3
+        - -common.storage.backend=s3
+        - -common.storage.s3.endpoint=s3.dualstack.eu-west-1.amazonaws.com
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.etcd.endpoints=etcd-client.default.svc.cluster.local.:2379
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=etcd
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.ring.prefix=
+        - -distributor.ring.store=memberlist
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.instance-availability-zone=zone-c
+        - -ingester.ring.num-tokens=512
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.tokens-file-path=/data/tokens
+        - -ingester.ring.unregister-on-shutdown=true
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=10000
+        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=write
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:2.9.0
+        imagePullPolicy: IfNotPresent
+        name: mimir-write
+        ports:
+        - containerPort: 7946
+          name: gossip-ring
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: mimir-write-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mimir-write-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: etcd.database.coreos.com/v1beta2
+kind: EtcdCluster
+metadata:
+  annotations:
+    etcd.database.coreos.com/scope: clusterwide
+  name: etcd
+  namespace: default
+spec:
+  pod:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              etcd_cluster: etcd
+          topologyKey: kubernetes.io/hostname
+    annotations:
+      prometheus.io/port: "2379"
+      prometheus.io/scrape: "true"
+    etcdEnv:
+    - name: ETCD_AUTO_COMPACTION_RETENTION
+      value: 1h
+    labels:
+      name: etcd
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+  size: 3
+  version: 3.3.13

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled.jsonnet
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled.jsonnet
@@ -1,0 +1,9 @@
+// Based on test-read-write-deployment-mode-s3.jsonnet.
+(import 'test-read-write-deployment-mode-s3.jsonnet') {
+  _config+:: {
+    cache_frontend_enabled: false,
+    cache_index_queries_enabled: false,
+    cache_chunks_enabled: false,
+    cache_metadata_enabled: false,
+  },
+}

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -610,44 +610,60 @@
       // First we will check if index, chunks and metadata cache backend config is equal to Redis
       // then we will enable flag for Redis cache. Otherwise, we assume the cache is Memcached.
       if $._config.cache_index_queries_backend == 'redis' && $._config.cache_chunks_backend == 'redis' && $._config.cache_metadata_backend == 'redis' then
-        {
-          // We use the similar config like memcached in the following else branch for memcached configuration.
-          // the small difference is in redis we set "get" concurrency to connection-poll-size instead of max-idle-connections.
-          'blocks-storage.bucket-store.index-cache.redis.max-get-multi-concurrency': 100,
-          'blocks-storage.bucket-store.chunks-cache.redis.max-get-multi-concurrency': 100,
-          'blocks-storage.bucket-store.metadata-cache.redis.max-get-multi-concurrency': 100,
-          'blocks-storage.bucket-store.index-cache.redis.connection-pool-size':
-            $.store_gateway_args['blocks-storage.bucket-store.index-cache.redis.max-get-multi-concurrency'] +
-            $.store_gateway_args['blocks-storage.bucket-store.index-cache.redis.max-async-concurrency'],
-          'blocks-storage.bucket-store.chunks-cache.redis.connection-pool-size':
-            $.store_gateway_args['blocks-storage.bucket-store.chunks-cache.redis.max-get-multi-concurrency'] +
-            $.store_gateway_args['blocks-storage.bucket-store.chunks-cache.redis.max-async-concurrency'],
-          'blocks-storage.bucket-store.metadata-cache.redis.connection-pool-size':
-            $.store_gateway_args['blocks-storage.bucket-store.metadata-cache.redis.max-get-multi-concurrency'] +
-            $.store_gateway_args['blocks-storage.bucket-store.metadata-cache.redis.max-async-concurrency'],
-        }
+        // We use the similar config like memcached in the following else branch for memcached configuration.
+        // the small difference is in redis we set "get" concurrency to connection-poll-size instead of max-idle-connections.
+        (
+          if !$._config.cache_index_queries_enabled then {} else {
+            'blocks-storage.bucket-store.index-cache.redis.max-get-multi-concurrency': 100,
+            'blocks-storage.bucket-store.index-cache.redis.connection-pool-size':
+              $.store_gateway_args['blocks-storage.bucket-store.index-cache.redis.max-get-multi-concurrency'] +
+              $.store_gateway_args['blocks-storage.bucket-store.index-cache.redis.max-async-concurrency'],
+          }
+        ) + (
+          if !$._config.cache_chunks_enabled then {} else {
+            'blocks-storage.bucket-store.chunks-cache.redis.max-get-multi-concurrency': 100,
+            'blocks-storage.bucket-store.chunks-cache.redis.connection-pool-size':
+              $.store_gateway_args['blocks-storage.bucket-store.chunks-cache.redis.max-get-multi-concurrency'] +
+              $.store_gateway_args['blocks-storage.bucket-store.chunks-cache.redis.max-async-concurrency'],
+          }
+        ) + (
+          if !$._config.cache_metadata_enabled then {} else {
+            'blocks-storage.bucket-store.metadata-cache.redis.max-get-multi-concurrency': 100,
+            'blocks-storage.bucket-store.metadata-cache.redis.connection-pool-size':
+              $.store_gateway_args['blocks-storage.bucket-store.metadata-cache.redis.max-get-multi-concurrency'] +
+              $.store_gateway_args['blocks-storage.bucket-store.metadata-cache.redis.max-async-concurrency'],
+          }
+        )
       else
-        {
-          // We should keep a number of idle connections equal to the max "get" concurrency,
-          // in order to avoid re-opening connections continuously (this would be slower
-          // and fill up the conntrack table too).
-          //
-          // The downside of this approach is that we'll end up with an higher number of
-          // active connections to memcached, so we have to make sure connections limit
-          // set in memcached is high enough.
-          'blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency': 100,
-          'blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency': 100,
-          'blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency': 100,
-          'blocks-storage.bucket-store.index-cache.memcached.max-idle-connections':
-            $.store_gateway_args['blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency'] +
-            $.store_gateway_args['blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency'],
-          'blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections':
-            $.store_gateway_args['blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency'] +
-            $.store_gateway_args['blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency'],
-          'blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections':
-            $.store_gateway_args['blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency'] +
-            $.store_gateway_args['blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency'],
-        }
+        // We should keep a number of idle connections equal to the max "get" concurrency,
+        // in order to avoid re-opening connections continuously (this would be slower
+        // and fill up the conntrack table too).
+        //
+        // The downside of this approach is that we'll end up with an higher number of
+        // active connections to memcached, so we have to make sure connections limit
+        // set in memcached is high enough.
+        (
+          if !$._config.cache_index_queries_enabled then {} else {
+            'blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency': 100,
+            'blocks-storage.bucket-store.index-cache.memcached.max-idle-connections':
+              $.store_gateway_args['blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency'] +
+              $.store_gateway_args['blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency'],
+          }
+        ) + (
+          if !$._config.cache_chunks_enabled then {} else {
+            'blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency': 100,
+            'blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections':
+              $.store_gateway_args['blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency'] +
+              $.store_gateway_args['blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency'],
+          }
+        ) + (
+          if !$._config.cache_metadata_enabled then {} else {
+            'blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency': 100,
+            'blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections':
+              $.store_gateway_args['blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency'] +
+              $.store_gateway_args['blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency'],
+          }
+        )
     ),
 
   blocks_chunks_caching_config::


### PR DESCRIPTION
#### What this PR does
As reported in #5683, the jsonnet compilation is broken when index, chunks or metadata caches are disabled because of some missing CLI flags in `$.store_gateway_args` which we reference when building `$._config.blocks_chunks_concurrency_connection_config`. This PR fixes it adding conditionals.

I've also added a jsonnet test. The comparison between `operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml` and `operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml` is [here](https://gist.github.com/pracucci/799fe2040e73a955d31b168f5109e840).

#### Which issue(s) this PR fixes or relates to

Fixes #5683

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
