### PR TITLE
Enforce -validation.create-grace-period in the ingester too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [CHANGE] Ingester: Do not log errors related to hitting per-instance limits to reduce resource usage when ingesters are under pressure. #5585
 * [CHANGE] gRPC clients: use default connect timeout of 5s, and therefore enable default connect backoff max delay of 5s. #5562
 * [CHANGE] The `-shutdown-delay` flag is no longer experimental. #5701
+* [CHANGE] The `-validation.create-grace-period` is now enforced in the ingester too, other than distributor and query-frontend. If you've configured `-validation.create-grace-period` then make sure the configuration is applied to ingesters too. #5712
 * [FEATURE] Cardinality API: Add a new `count_method` parameter which enables counting active series #5136
 * [FEATURE] Query-frontend: added experimental support to cache cardinality, label names and label values query responses. The cache will be used when `-query-frontend.cache-results` is enabled, and `-query-frontend.results-cache-ttl-for-cardinality-query` or `-query-frontend.results-cache-ttl-for-labels-query` set to a value greater than 0. The following metrics have been added to track the query results cache hit ratio per `request_type`: #5212 #5235 #5426 #5524
   * `cortex_frontend_query_result_cache_requests_total{request_type="query_range|cardinality|label_names_and_values"}`

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2982,7 +2982,7 @@
           "kind": "field",
           "name": "creation_grace_period",
           "required": false,
-          "desc": "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -validation.create-grace-period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future).",
+          "desc": "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + grace_period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future).",
           "fieldValue": null,
           "fieldDefaultValue": 600000000000,
           "fieldFlag": "validation.create-grace-period",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2982,7 +2982,7 @@
           "kind": "field",
           "name": "creation_grace_period",
           "required": false,
-          "desc": "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -validation.create-grace-period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future). 0 to disable.",
+          "desc": "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -validation.create-grace-period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future).",
           "fieldValue": null,
           "fieldDefaultValue": 600000000000,
           "fieldFlag": "validation.create-grace-period",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2982,7 +2982,7 @@
           "kind": "field",
           "name": "creation_grace_period",
           "required": false,
-          "desc": "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample with timestamp `t` will be rejected if `t \u003e (now + validation.create-grace-period)`. Also used by query-frontend to avoid querying too far into the future. 0 to disable.",
+          "desc": "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -validation.create-grace-period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future). 0 to disable.",
           "fieldValue": null,
           "fieldDefaultValue": 600000000000,
           "fieldFlag": "validation.create-grace-period",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2584,7 +2584,7 @@ Usage of ./cmd/mimir/mimir:
   -usage-stats.installation-mode string
     	Installation mode. Supported values: custom, helm, jsonnet. (default "custom")
   -validation.create-grace-period duration
-    	Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample with timestamp `t` will be rejected if `t > (now + validation.create-grace-period)`. Also used by query-frontend to avoid querying too far into the future. 0 to disable. (default 10m)
+    	Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -validation.create-grace-period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future). 0 to disable. (default 10m)
   -validation.enforce-metadata-metric-name
     	Enforce every metadata has a metric name. (default true)
   -validation.max-label-names-per-series int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2584,7 +2584,7 @@ Usage of ./cmd/mimir/mimir:
   -usage-stats.installation-mode string
     	Installation mode. Supported values: custom, helm, jsonnet. (default "custom")
   -validation.create-grace-period duration
-    	Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -validation.create-grace-period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future). (default 10m)
+    	Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + grace_period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future). (default 10m)
   -validation.enforce-metadata-metric-name
     	Enforce every metadata has a metric name. (default true)
   -validation.max-label-names-per-series int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2584,7 +2584,7 @@ Usage of ./cmd/mimir/mimir:
   -usage-stats.installation-mode string
     	Installation mode. Supported values: custom, helm, jsonnet. (default "custom")
   -validation.create-grace-period duration
-    	Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -validation.create-grace-period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future). 0 to disable. (default 10m)
+    	Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -validation.create-grace-period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future). (default 10m)
   -validation.enforce-metadata-metric-name
     	Enforce every metadata has a metric name. (default true)
   -validation.max-label-names-per-series int

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1253,7 +1253,15 @@ This non-critical error occurs when Mimir receives a write request that contains
 Mimir accepts timestamps that are slightly in the future, due to skewed clocks for example. It rejects timestamps that are too far in the future, based on the definition that you can set via the `-validation.create-grace-period` option.
 On a per-tenant basis, you can fine tune the tolerance by configuring the `-validation.max-length-label-value` option.
 
-> **Note:** Series with invalid samples are skipped during the ingestion, and series within the same request are ingested.
+> **Note:** Series with invalid samples are skipped during the ingestion, and valid samples within the same request are ingested.
+
+### err-mimir-exemplar-too-far-in-future
+
+This non-critical error occurs when Mimir receives a write request that contains an exemplar whose timestamp is in the future compared to the current "real world" time.
+Mimir accepts timestamps that are slightly in the future, due to skewed clocks for example. It rejects timestamps that are too far in the future, based on the definition that you can set via the `-validation.create-grace-period` option.
+On a per-tenant basis, you can fine tune the tolerance by configuring the `-validation.max-length-label-value` option.
+
+> **Note:** Series with invalid exemplars are skipped during the ingestion, and valid exemplars within the same request are ingested.
 
 ### err-mimir-exemplar-labels-missing
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1253,7 +1253,7 @@ This non-critical error occurs when Mimir receives a write request that contains
 Mimir accepts timestamps that are slightly in the future, due to skewed clocks for example. It rejects timestamps that are too far in the future, based on the definition that you can set via the `-validation.create-grace-period` option.
 On a per-tenant basis, you can fine tune the tolerance by configuring the `-validation.max-length-label-value` option.
 
-> **Note:** Series with invalid samples are skipped during the ingestion, and valid samples within the same request are ingested.
+> **Note:** Only series with invalid samples are skipped during the ingestion. Valid samples within the same request are still ingested.
 
 ### err-mimir-exemplar-too-far-in-future
 
@@ -1261,7 +1261,7 @@ This non-critical error occurs when Mimir receives a write request that contains
 Mimir accepts timestamps that are slightly in the future, due to skewed clocks for example. It rejects timestamps that are too far in the future, based on the definition that you can set via the `-validation.create-grace-period` option.
 On a per-tenant basis, you can fine tune the tolerance by configuring the `-validation.max-length-label-value` option.
 
-> **Note:** Series with invalid exemplars are skipped during the ingestion, and valid exemplars within the same request are ingested.
+> **Note:** Only series with invalid samples are skipped during the ingestion. Valid samples within the same request are still ingested.
 
 ### err-mimir-exemplar-labels-missing
 

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2729,9 +2729,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 [max_native_histogram_buckets: <int> | default = 0]
 
 # (advanced) Controls how far into the future incoming samples are accepted
-# compared to the wall clock. Any sample with timestamp `t` will be rejected if
-# `t > (now + validation.create-grace-period)`. Also used by query-frontend to
-# avoid querying too far into the future. 0 to disable.
+# compared to the wall clock. Any sample will be rejected if its timestamp is
+# greater than '(now + -validation.create-grace-period)'. This configuration is
+# enforced in the distributor, ingester and query-frontend (to avoid querying
+# too far into the future). 0 to disable.
 # CLI flag: -validation.create-grace-period
 [creation_grace_period: <duration> | default = 10m]
 

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2732,7 +2732,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 # compared to the wall clock. Any sample will be rejected if its timestamp is
 # greater than '(now + -validation.create-grace-period)'. This configuration is
 # enforced in the distributor, ingester and query-frontend (to avoid querying
-# too far into the future). 0 to disable.
+# too far into the future).
 # CLI flag: -validation.create-grace-period
 [creation_grace_period: <duration> | default = 10m]
 

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2730,9 +2730,9 @@ The `limits` block configures default and per-tenant limits imposed by component
 
 # (advanced) Controls how far into the future incoming samples are accepted
 # compared to the wall clock. Any sample will be rejected if its timestamp is
-# greater than '(now + -validation.create-grace-period)'. This configuration is
-# enforced in the distributor, ingester and query-frontend (to avoid querying
-# too far into the future).
+# greater than '(now + grace_period)'. This configuration is enforced in the
+# distributor, ingester and query-frontend (to avoid querying too far into the
+# future).
 # CLI flag: -validation.create-grace-period
 [creation_grace_period: <duration> | default = 10m]
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -96,12 +96,13 @@ const (
 	instanceIngestionRateTickInterval = time.Second
 
 	// Reasons for discarding samples
-	sampleOutOfOrder     = "sample-out-of-order"
-	sampleTooOld         = "sample-too-old"
-	newValueForTimestamp = "new-value-for-timestamp"
-	sampleOutOfBounds    = "sample-out-of-bounds"
-	perUserSeriesLimit   = "per_user_series_limit"
-	perMetricSeriesLimit = "per_metric_series_limit"
+	reasonSampleOutOfOrder     = "sample-out-of-order"
+	reasonSampleTooOld         = "sample-too-old"
+	reasonSampleTooFarInFuture = "sample-too-far-in-future"
+	reasonNewValueForTimestamp = "new-value-for-timestamp"
+	reasonSampleOutOfBounds    = "sample-out-of-bounds"
+	reasonPerUserSeriesLimit   = "per_user_series_limit"
+	reasonPerMetricSeriesLimit = "per_metric_series_limit"
 
 	replicationFactorStatsName             = "ingester_replication_factor"
 	ringStoreStatsName                     = "ingester_ring_store"
@@ -702,6 +703,7 @@ type pushStats struct {
 	sampleOutOfBoundsCount    int
 	sampleOutOfOrderCount     int
 	sampleTooOldCount         int
+	sampleTooFarInFutureCount int
 	newValueForTimestampCount int
 	perUserSeriesLimitCount   int
 	perMetricSeriesLimitCount int
@@ -879,6 +881,9 @@ func (i *Ingester) updateMetricsFromPushStats(userID string, group string, stats
 	if stats.sampleTooOldCount > 0 {
 		discarded.sampleTooOld.WithLabelValues(userID, group).Add(float64(stats.sampleTooOldCount))
 	}
+	if stats.sampleTooFarInFutureCount > 0 {
+		discarded.sampleTooFarInFuture.WithLabelValues(userID, group).Add(float64(stats.sampleTooFarInFutureCount))
+	}
 	if stats.newValueForTimestampCount > 0 {
 		discarded.newValueForTimestamp.WithLabelValues(userID, group).Add(float64(stats.newValueForTimestampCount))
 	}
@@ -907,6 +912,8 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 
 	// Return true if handled as soft error, and we can ingest more series.
 	handleAppendError := func(err error, timestamp int64, labels []mimirpb.LabelAdapter) bool {
+		stats.failedSamplesCount++
+
 		// Check if the error is a soft error we can proceed on. If so, we keep track
 		// of it, so that we can return it back to the distributor, which will return a
 		// 400 error to the client. The client (Prometheus) will not retry on 400, and
@@ -934,6 +941,13 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 			})
 			return true
 
+		case globalerror.SampleTooFarInFuture:
+			stats.sampleTooFarInFutureCount++
+			updateFirstPartial(func() error {
+				return newIngestErrSampleTimestampTooFarInFuture(model.Time(timestamp), labels)
+			})
+			return true
+
 		case storage.ErrDuplicateSampleForTimestamp:
 			stats.newValueForTimestampCount++
 			updateFirstPartial(func() error {
@@ -958,8 +972,11 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 		return false
 	}
 
-	// fetch once per push request to avoid processing half the request differently
-	nativeHistogramsIngestionEnabled := i.limits.NativeHistogramsIngestionEnabled(userID)
+	// Fetch limits once per push request both to avoid processing half the request differently.
+	var (
+		nativeHistogramsIngestionEnabled = i.limits.NativeHistogramsIngestionEnabled(userID)
+		maxTimestampMs                   = startAppend.Add(i.limits.CreationGracePeriod(userID)).UnixMilli()
+	)
 
 	var builder labels.ScratchBuilder
 	var nonCopiedLabels labels.Labels
@@ -1023,6 +1040,12 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 		for _, s := range ts.Samples {
 			var err error
 
+			// Ensure the sample is not too far in the future.
+			if s.TimestampMs > maxTimestampMs {
+				handleAppendError(globalerror.SampleTooFarInFuture, s.TimestampMs, ts.Labels)
+				continue
+			}
+
 			// If the cached reference exists, we try to use it.
 			if ref != 0 {
 				if _, err = app.Append(ref, copiedLabels, s.TimestampMs, s.Value); err == nil {
@@ -1039,8 +1062,6 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 					continue
 				}
 			}
-
-			stats.failedSamplesCount++
 
 			// If it's a soft error it will be returned back to the distributor later as a 400.
 			if handleAppendError(err, s.TimestampMs, ts.Labels) {
@@ -1059,6 +1080,11 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 					ih  *histogram.Histogram
 					fh  *histogram.FloatHistogram
 				)
+
+				if h.Timestamp > maxTimestampMs {
+					handleAppendError(globalerror.SampleTooFarInFuture, h.Timestamp, ts.Labels)
+					continue
+				}
 
 				if h.IsFloatHistogram() {
 					fh = mimirpb.FromFloatHistogramProtoToFloatHistogram(&h)
@@ -1082,8 +1108,6 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 						continue
 					}
 				}
-
-				stats.failedSamplesCount++
 
 				if handleAppendError(err, h.Timestamp, ts.Labels) {
 					continue
@@ -1121,6 +1145,14 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 				stats.failedExemplarsCount += len(ts.Exemplars)
 			} else { // Note that else is explicit, rather than a continue in the above if, in case of additional logic post exemplar processing.
 				for _, ex := range ts.Exemplars {
+					if ex.TimestampMs > maxTimestampMs {
+						stats.failedExemplarsCount++
+						updateFirstPartial(func() error {
+							return newIngestErrExemplarTimestampTooFarInFuture(model.Time(ex.TimestampMs), ts.Labels, ex.Labels)
+						})
+						continue
+					}
+
 					e := exemplar.Exemplar{
 						Value:  ex.Value,
 						Ts:     ex.TimestampMs,
@@ -2859,33 +2891,44 @@ func (i *Ingester) FlushHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func newIngestErr(errID globalerror.ID, errMsg string, timestamp model.Time, labels []mimirpb.LabelAdapter) error {
+func newIngestErrSample(errID globalerror.ID, errMsg string, timestamp model.Time, labels []mimirpb.LabelAdapter) error {
 	return fmt.Errorf("%v. The affected sample has timestamp %s and is from series %s", errID.Message(errMsg), timestamp.Time().UTC().Format(time.RFC3339Nano), mimirpb.FromLabelAdaptersToLabels(labels).String())
 }
 
 func newIngestErrSampleTimestampTooOld(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
-	return newIngestErr(globalerror.SampleTimestampTooOld, "the sample has been rejected because its timestamp is too old", timestamp, labels)
+	return newIngestErrSample(globalerror.SampleTimestampTooOld, "the sample has been rejected because its timestamp is too old", timestamp, labels)
 }
 
 func newIngestErrSampleTimestampTooOldOOOEnabled(timestamp model.Time, labels []mimirpb.LabelAdapter, oooTimeWindow time.Duration) error {
-	return newIngestErr(globalerror.SampleTimestampTooOld, fmt.Sprintf("the sample has been rejected because another sample with a more recent timestamp has already been ingested and this sample is beyond the out-of-order time window of %s", model.Duration(oooTimeWindow).String()), timestamp, labels)
+	return newIngestErrSample(globalerror.SampleTimestampTooOld, fmt.Sprintf("the sample has been rejected because another sample with a more recent timestamp has already been ingested and this sample is beyond the out-of-order time window of %s", model.Duration(oooTimeWindow).String()), timestamp, labels)
+}
+
+func newIngestErrSampleTimestampTooFarInFuture(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
+	return newIngestErrSample(globalerror.SampleTooFarInFuture, "received a sample whose timestamp is too far in the future", timestamp, labels)
 }
 
 func newIngestErrSampleOutOfOrder(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
-	return newIngestErr(globalerror.SampleOutOfOrder, "the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed", timestamp, labels)
+	return newIngestErrSample(globalerror.SampleOutOfOrder, "the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed", timestamp, labels)
 }
 
 func newIngestErrSampleDuplicateTimestamp(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
-	return newIngestErr(globalerror.SampleDuplicateTimestamp, "the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested", timestamp, labels)
+	return newIngestErrSample(globalerror.SampleDuplicateTimestamp, "the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested", timestamp, labels)
+}
+
+func newIngestErrExemplar(errID globalerror.ID, errMsg string, timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
+	return fmt.Errorf("%v. The affected exemplar is %s with timestamp %s for series %s",
+		errID.Message(errMsg),
+		mimirpb.FromLabelAdaptersToLabels(exemplarLabels).String(),
+		timestamp.Time().UTC().Format(time.RFC3339Nano),
+		mimirpb.FromLabelAdaptersToLabels(seriesLabels).String())
 }
 
 func newIngestErrExemplarMissingSeries(timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
-	return fmt.Errorf("%v. The affected exemplar is %s with timestamp %s for series %s",
-		globalerror.ExemplarSeriesMissing.Message("the exemplar has been rejected because the related series has not been ingested yet"),
-		mimirpb.FromLabelAdaptersToLabels(exemplarLabels).String(),
-		timestamp.Time().UTC().Format(time.RFC3339Nano),
-		mimirpb.FromLabelAdaptersToLabels(seriesLabels).String(),
-	)
+	return newIngestErrExemplar(globalerror.ExemplarSeriesMissing, "the exemplar has been rejected because the related series has not been ingested yet", timestamp, seriesLabels, exemplarLabels)
+}
+
+func newIngestErrExemplarTimestampTooFarInFuture(timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
+	return newIngestErrExemplar(globalerror.ExemplarTooFarInFuture, "received an exemplar whose timestamp is too far in the future", timestamp, seriesLabels, exemplarLabels)
 }
 
 func wrappedTSDBIngestExemplarOtherErr(ingestErr error, timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {

--- a/pkg/ingester/ingester_early_compaction_test.go
+++ b/pkg/ingester/ingester_early_compaction_test.go
@@ -174,14 +174,17 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactHeadUpUntilNo
 		sampleTimes  []time.Time
 	)
 
-	cfg := defaultIngesterTestConfig(t)
-	cfg.ActiveSeriesMetrics.Enabled = true
-	cfg.ActiveSeriesMetrics.IdleTimeout = 20 * time.Minute
-	cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = time.Hour // Do not trigger it during the test, so that we trigger it manually.
-	cfg.BlocksStorageConfig.TSDB.EarlyHeadCompactionMinInMemorySeries = 1
-	cfg.BlocksStorageConfig.TSDB.EarlyHeadCompactionMinEstimatedSeriesReductionPercentage = 0
+	ingesterCfg := defaultIngesterTestConfig(t)
+	ingesterCfg.ActiveSeriesMetrics.Enabled = true
+	ingesterCfg.ActiveSeriesMetrics.IdleTimeout = 20 * time.Minute
+	ingesterCfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = time.Hour // Do not trigger it during the test, so that we trigger it manually.
+	ingesterCfg.BlocksStorageConfig.TSDB.EarlyHeadCompactionMinInMemorySeries = 1
+	ingesterCfg.BlocksStorageConfig.TSDB.EarlyHeadCompactionMinEstimatedSeriesReductionPercentage = 0
 
-	ingester, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
+	limitsCfg := defaultLimitsTestConfig()
+	limitsCfg.CreationGracePeriod = model.Duration(24 * time.Hour) // This test writes samples in the future.
+
+	ingester, err := prepareIngesterWithBlocksStorageAndLimits(t, ingesterCfg, limitsCfg, "", nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, ingester))
 	t.Cleanup(func() {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -78,7 +78,7 @@ func mustNewActiveSeriesCustomTrackersConfigFromMap(t *testing.T, source map[str
 }
 
 func TestIngester_Push(t *testing.T) {
-	metricLabelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "series_1"}}
+	metricLabelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "test"}}
 	metricLabelSet := mimirpb.FromLabelAdaptersToMetric(metricLabelAdapters)
 	metricNames := []string{
 		"cortex_ingester_ingested_samples_total",

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -78,8 +78,8 @@ func mustNewActiveSeriesCustomTrackersConfigFromMap(t *testing.T, source map[str
 }
 
 func TestIngester_Push(t *testing.T) {
-	metric1LabelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "series_1"}}
-	metric1LabelSet := mimirpb.FromLabelAdaptersToMetric(metric1LabelAdapters)
+	metricLabelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "series_1"}}
+	metricLabelSet := mimirpb.FromLabelAdaptersToMetric(metricLabelAdapters)
 	metricNames := []string{
 		"cortex_ingester_ingested_samples_total",
 		"cortex_ingester_ingested_samples_failures_total",
@@ -112,7 +112,7 @@ func TestIngester_Push(t *testing.T) {
 		"should succeed on valid series and metadata": {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 1, TimestampMs: 9}},
 					nil,
 					[]*mimirpb.MetricMetadata{
@@ -120,7 +120,7 @@ func TestIngester_Push(t *testing.T) {
 					},
 					mimirpb.API),
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 10}},
 					nil,
 					[]*mimirpb.MetricMetadata{
@@ -130,7 +130,7 @@ func TestIngester_Push(t *testing.T) {
 			},
 			expectedErr: nil,
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 9}, {Value: 2, Timestamp: 10}}},
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 9}, {Value: 2, Timestamp: 10}}},
 			},
 			expectedMetadataIngested: []*mimirpb.MetricMetadata{
 				{MetricFamilyName: "metric_name_2", Help: "a help for metric_name_2", Unit: "", Type: mimirpb.GAUGE},
@@ -183,16 +183,16 @@ func TestIngester_Push(t *testing.T) {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.NewWriteRequest([]*mimirpb.MetricMetadata{
 					{MetricFamilyName: "metric_name_1", Help: "a help for metric_name_1", Unit: "", Type: mimirpb.HISTOGRAM},
-				}, mimirpb.API).AddHistogramSeries([][]mimirpb.LabelAdapter{metric1LabelAdapters},
+				}, mimirpb.API).AddHistogramSeries([][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1, util_test.GenerateTestHistogram(1))}, nil),
 				mimirpb.NewWriteRequest([]*mimirpb.MetricMetadata{
 					{MetricFamilyName: "metric_name_2", Help: "a help for metric_name_2", Unit: "", Type: mimirpb.GAUGEHISTOGRAM},
-				}, mimirpb.API).AddHistogramSeries([][]mimirpb.LabelAdapter{metric1LabelAdapters},
+				}, mimirpb.API).AddHistogramSeries([][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(2, util_test.GenerateTestGaugeHistogram(2))}, nil),
 			},
 			expectedErr: nil,
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Histograms: []model.SampleHistogramPair{
+				&model.SampleStream{Metric: metricLabelSet, Histograms: []model.SampleHistogramPair{
 					{Timestamp: model.Time(1), Histogram: mimirpb.FromHistogramToPromHistogram(util_test.GenerateTestHistogram(1))},
 					{Timestamp: model.Time(2), Histogram: mimirpb.FromHistogramToPromHistogram(util_test.GenerateTestGaugeHistogram(2))},
 				}},
@@ -256,14 +256,14 @@ func TestIngester_Push(t *testing.T) {
 			reqs: []*mimirpb.WriteRequest{
 				// Ingesting an exemplar requires a sample to create the series first
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 1, TimestampMs: 9}},
 					nil,
 					nil,
 					mimirpb.API,
 				),
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 10}},
 					[]*mimirpb.Exemplar{
 						{
@@ -278,11 +278,11 @@ func TestIngester_Push(t *testing.T) {
 			},
 			expectedErr: nil,
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 9}, {Value: 2, Timestamp: 10}}},
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 9}, {Value: 2, Timestamp: 10}}},
 			},
 			expectedExemplarsIngested: []mimirpb.TimeSeries{
 				{
-					Labels: metric1LabelAdapters,
+					Labels: metricLabelAdapters,
 					Exemplars: []mimirpb.Exemplar{
 						{
 							Labels:      []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}},
@@ -348,13 +348,13 @@ func TestIngester_Push(t *testing.T) {
 			disableActiveSeries: true,
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 1, TimestampMs: 9}},
 					nil,
 					nil,
 					mimirpb.API),
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 10}},
 					nil,
 					nil,
@@ -362,7 +362,7 @@ func TestIngester_Push(t *testing.T) {
 			},
 			expectedErr: nil,
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 9}, {Value: 2, Timestamp: 10}}},
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 1, Timestamp: 9}, {Value: 2, Timestamp: 10}}},
 			},
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
@@ -388,23 +388,23 @@ func TestIngester_Push(t *testing.T) {
 		"should soft fail on sample out-of-order": {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 10}},
 					nil,
 					nil,
 					mimirpb.API,
 				),
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 1, TimestampMs: 9}},
 					nil,
 					nil,
 					mimirpb.API,
 				),
 			},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleOutOfOrder(model.Time(9), metric1LabelAdapters), userID).Error()),
+			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleOutOfOrder(model.Time(9), metricLabelAdapters), userID).Error()),
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 10}}},
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 10}}},
 			},
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
@@ -436,7 +436,7 @@ func TestIngester_Push(t *testing.T) {
 		"should soft fail on all samples out of bound in a write request": {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 1575043969}},
 					nil,
 					nil,
@@ -447,16 +447,16 @@ func TestIngester_Push(t *testing.T) {
 					Timeseries: []mimirpb.PreallocTimeseries{
 						{
 							TimeSeries: &mimirpb.TimeSeries{
-								Labels:  metric1LabelAdapters,
+								Labels:  metricLabelAdapters,
 								Samples: []mimirpb.Sample{{Value: 0, TimestampMs: 1575043969 - (86400 * 1000)}, {Value: 1, TimestampMs: 1575043969 - (86000 * 1000)}},
 							},
 						},
 					},
 				},
 			},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(1575043969-(86400*1000)), metric1LabelAdapters), userID).Error()),
+			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(1575043969-(86400*1000)), metricLabelAdapters), userID).Error()),
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
 			},
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
@@ -488,7 +488,7 @@ func TestIngester_Push(t *testing.T) {
 		"should soft fail on all samples with histograms out of bound in a write request": {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 1575043969}},
 					nil,
 					nil,
@@ -499,7 +499,7 @@ func TestIngester_Push(t *testing.T) {
 					Timeseries: []mimirpb.PreallocTimeseries{
 						{
 							TimeSeries: &mimirpb.TimeSeries{
-								Labels:     metric1LabelAdapters,
+								Labels:     metricLabelAdapters,
 								Samples:    []mimirpb.Sample{{Value: 0, TimestampMs: 1575043969 - (86400 * 1000)}, {Value: 1, TimestampMs: 1575043969 - (86000 * 1000)}},
 								Histograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1575043969-(86800*1000), util_test.GenerateTestHistogram(0))},
 							},
@@ -507,9 +507,9 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(1575043969-(86800*1000)), metric1LabelAdapters), userID).Error()),
+			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(1575043969-(86800*1000)), metricLabelAdapters), userID).Error()),
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
 			},
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
@@ -542,7 +542,7 @@ func TestIngester_Push(t *testing.T) {
 		"should succeed if histograms are out of bound but samples are not and histograms are not accepted": {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 1575043969}},
 					nil,
 					nil,
@@ -553,7 +553,7 @@ func TestIngester_Push(t *testing.T) {
 					Timeseries: []mimirpb.PreallocTimeseries{
 						{
 							TimeSeries: &mimirpb.TimeSeries{
-								Labels:     metric1LabelAdapters,
+								Labels:     metricLabelAdapters,
 								Samples:    []mimirpb.Sample{{Value: 0, TimestampMs: 1575043969 + 1000}},
 								Histograms: []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(1575043969-(86800*1000), util_test.GenerateTestHistogram(0))},
 							},
@@ -563,7 +563,7 @@ func TestIngester_Push(t *testing.T) {
 			},
 			expectedErr: nil,
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}, {Value: 0, Timestamp: 1575043969 + 1000}}},
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}, {Value: 0, Timestamp: 1575043969 + 1000}}},
 			},
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
@@ -593,7 +593,7 @@ func TestIngester_Push(t *testing.T) {
 		"should soft fail on some samples out of bound in a write request": {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 1575043969}},
 					nil,
 					nil,
@@ -604,7 +604,7 @@ func TestIngester_Push(t *testing.T) {
 					Timeseries: []mimirpb.PreallocTimeseries{
 						{
 							TimeSeries: &mimirpb.TimeSeries{
-								Labels: metric1LabelAdapters,
+								Labels: metricLabelAdapters,
 								Samples: []mimirpb.Sample{
 									{Value: 0, TimestampMs: 1575043969 - (86400 * 1000)},
 									{Value: 1, TimestampMs: 1575043969 - (86000 * 1000)},
@@ -614,9 +614,9 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(1575043969-(86400*1000)), metric1LabelAdapters), userID).Error()),
+			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooOld(model.Time(1575043969-(86400*1000)), metricLabelAdapters), userID).Error()),
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}, {Value: 3, Timestamp: 1575043969 + 1}}},
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}, {Value: 3, Timestamp: 1575043969 + 1}}},
 			},
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
@@ -648,7 +648,7 @@ func TestIngester_Push(t *testing.T) {
 		"should soft fail on some samples with timestamp too far in future in a write request": {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 1, TimestampMs: now.UnixMilli()}},
 					nil,
 					nil,
@@ -658,7 +658,7 @@ func TestIngester_Push(t *testing.T) {
 					Timeseries: []mimirpb.PreallocTimeseries{
 						{
 							TimeSeries: &mimirpb.TimeSeries{
-								Labels: metric1LabelAdapters,
+								Labels: metricLabelAdapters,
 								Samples: []mimirpb.Sample{
 									{Value: 2, TimestampMs: now.UnixMilli() + (86400 * 1000)},
 									{Value: 3, TimestampMs: now.UnixMilli() + 1}},
@@ -667,9 +667,9 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooFarInFuture(model.Time(now.UnixMilli()+(86400*1000)), metric1LabelAdapters), userID).Error()),
+			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooFarInFuture(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), userID).Error()),
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{
 					{Value: 1, Timestamp: model.Time(now.UnixMilli())},
 					{Value: 3, Timestamp: model.Time(now.UnixMilli() + 1)},
 				}},
@@ -708,7 +708,7 @@ func TestIngester_Push(t *testing.T) {
 					Timeseries: []mimirpb.PreallocTimeseries{
 						{
 							TimeSeries: &mimirpb.TimeSeries{
-								Labels: metric1LabelAdapters,
+								Labels: metricLabelAdapters,
 								Histograms: []mimirpb.Histogram{
 									mimirpb.FromHistogramToHistogramProto(now.UnixMilli(), util_test.GenerateTestHistogram(0)),
 									mimirpb.FromHistogramToHistogramProto(now.UnixMilli()+(86400*1000), util_test.GenerateTestHistogram(1))},
@@ -717,9 +717,9 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooFarInFuture(model.Time(now.UnixMilli()+(86400*1000)), metric1LabelAdapters), userID).Error()),
+			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleTimestampTooFarInFuture(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), userID).Error()),
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Histograms: []model.SampleHistogramPair{
+				&model.SampleStream{Metric: metricLabelSet, Histograms: []model.SampleHistogramPair{
 					{Timestamp: model.Time(now.UnixMilli()), Histogram: mimirpb.FromHistogramToPromHistogram(util_test.GenerateTestGaugeHistogram(0))},
 				}},
 			},
@@ -763,7 +763,7 @@ func TestIngester_Push(t *testing.T) {
 					Timeseries: []mimirpb.PreallocTimeseries{
 						{
 							TimeSeries: &mimirpb.TimeSeries{
-								Labels: metric1LabelAdapters,
+								Labels: metricLabelAdapters,
 								Samples: []mimirpb.Sample{
 									{Value: 1, TimestampMs: now.UnixMilli()}},
 								Exemplars: []mimirpb.Exemplar{
@@ -775,10 +775,10 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrExemplarTimestampTooFarInFuture(model.Time(now.UnixMilli()+(86400*1000)), metric1LabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), userID).Error()),
+			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrExemplarTimestampTooFarInFuture(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), userID).Error()),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{
-					Metric: metric1LabelSet,
+					Metric: metricLabelSet,
 					Values: []model.SamplePair{
 						{Value: 1, Timestamp: model.Time(now.UnixMilli())},
 					},
@@ -786,7 +786,7 @@ func TestIngester_Push(t *testing.T) {
 			},
 			expectedExemplarsIngested: []mimirpb.TimeSeries{
 				{
-					Labels: metric1LabelAdapters,
+					Labels: metricLabelAdapters,
 					Exemplars: []mimirpb.Exemplar{
 						{Labels: []mimirpb.LabelAdapter{{Name: "traceID", Value: "111"}}, TimestampMs: now.UnixMilli(), Value: 1},
 					},
@@ -829,23 +829,23 @@ func TestIngester_Push(t *testing.T) {
 		"should soft fail on two different sample values at the same timestamp": {
 			reqs: []*mimirpb.WriteRequest{
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 2, TimestampMs: 1575043969}},
 					nil,
 					nil,
 					mimirpb.API,
 				),
 				mimirpb.ToWriteRequest(
-					[][]mimirpb.LabelAdapter{metric1LabelAdapters},
+					[][]mimirpb.LabelAdapter{metricLabelAdapters},
 					[]mimirpb.Sample{{Value: 1, TimestampMs: 1575043969}},
 					nil,
 					nil,
 					mimirpb.API,
 				),
 			},
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleDuplicateTimestamp(model.Time(1575043969), metric1LabelAdapters), userID).Error()),
+			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrSampleDuplicateTimestamp(model.Time(1575043969), metricLabelAdapters), userID).Error()),
 			expectedIngested: model.Matrix{
-				&model.SampleStream{Metric: metric1LabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
+				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
 			},
 			expectedMetrics: `
 				# HELP cortex_ingester_ingested_samples_total The total number of samples ingested per user.
@@ -883,7 +883,7 @@ func TestIngester_Push(t *testing.T) {
 					Timeseries: []mimirpb.PreallocTimeseries{
 						{
 							TimeSeries: &mimirpb.TimeSeries{
-								Labels: []mimirpb.LabelAdapter{metric1LabelAdapters[0]}, // Cannot reuse test slice var because it is cleared and returned to the pool
+								Labels: []mimirpb.LabelAdapter{metricLabelAdapters[0]}, // Cannot reuse test slice var because it is cleared and returned to the pool
 								Exemplars: []mimirpb.Exemplar{
 									{
 										Labels:      []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}},
@@ -896,7 +896,7 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr:              httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrExemplarMissingSeries(model.Time(1000), metric1LabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), userID).Error()),
+			expectedErr:              httpgrpc.Errorf(http.StatusBadRequest, wrapWithUser(newIngestErrExemplarMissingSeries(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), userID).Error()),
 			expectedIngested:         nil,
 			expectedMetadataIngested: nil,
 			additionalMetrics: []string{

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -367,6 +367,7 @@ type discardedMetrics struct {
 	sampleOutOfBounds    *prometheus.CounterVec
 	sampleOutOfOrder     *prometheus.CounterVec
 	sampleTooOld         *prometheus.CounterVec
+	sampleTooFarInFuture *prometheus.CounterVec
 	newValueForTimestamp *prometheus.CounterVec
 	perUserSeriesLimit   *prometheus.CounterVec
 	perMetricSeriesLimit *prometheus.CounterVec
@@ -374,12 +375,13 @@ type discardedMetrics struct {
 
 func newDiscardedMetrics(r prometheus.Registerer) *discardedMetrics {
 	return &discardedMetrics{
-		sampleOutOfBounds:    validation.DiscardedSamplesCounter(r, sampleOutOfBounds),
-		sampleOutOfOrder:     validation.DiscardedSamplesCounter(r, sampleOutOfOrder),
-		sampleTooOld:         validation.DiscardedSamplesCounter(r, sampleTooOld),
-		newValueForTimestamp: validation.DiscardedSamplesCounter(r, newValueForTimestamp),
-		perUserSeriesLimit:   validation.DiscardedSamplesCounter(r, perUserSeriesLimit),
-		perMetricSeriesLimit: validation.DiscardedSamplesCounter(r, perMetricSeriesLimit),
+		sampleOutOfBounds:    validation.DiscardedSamplesCounter(r, reasonSampleOutOfBounds),
+		sampleOutOfOrder:     validation.DiscardedSamplesCounter(r, reasonSampleOutOfOrder),
+		sampleTooOld:         validation.DiscardedSamplesCounter(r, reasonSampleTooOld),
+		sampleTooFarInFuture: validation.DiscardedSamplesCounter(r, reasonSampleTooFarInFuture),
+		newValueForTimestamp: validation.DiscardedSamplesCounter(r, reasonNewValueForTimestamp),
+		perUserSeriesLimit:   validation.DiscardedSamplesCounter(r, reasonPerUserSeriesLimit),
+		perMetricSeriesLimit: validation.DiscardedSamplesCounter(r, reasonPerMetricSeriesLimit),
 	}
 }
 
@@ -387,6 +389,7 @@ func (m *discardedMetrics) DeletePartialMatch(filter prometheus.Labels) {
 	m.sampleOutOfBounds.DeletePartialMatch(filter)
 	m.sampleOutOfOrder.DeletePartialMatch(filter)
 	m.sampleTooOld.DeletePartialMatch(filter)
+	m.sampleTooFarInFuture.DeletePartialMatch(filter)
 	m.newValueForTimestamp.DeletePartialMatch(filter)
 	m.perUserSeriesLimit.DeletePartialMatch(filter)
 	m.perMetricSeriesLimit.DeletePartialMatch(filter)
@@ -396,6 +399,7 @@ func (m *discardedMetrics) DeleteLabelValues(userID string, group string) {
 	m.sampleOutOfBounds.DeleteLabelValues(userID, group)
 	m.sampleOutOfOrder.DeleteLabelValues(userID, group)
 	m.sampleTooOld.DeleteLabelValues(userID, group)
+	m.sampleTooFarInFuture.DeleteLabelValues(userID, group)
 	m.newValueForTimestamp.DeleteLabelValues(userID, group)
 	m.perUserSeriesLimit.DeleteLabelValues(userID, group)
 	m.perMetricSeriesLimit.DeleteLabelValues(userID, group)

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -61,6 +61,7 @@ const (
 	SampleOutOfOrder         ID = "sample-out-of-order"
 	SampleDuplicateTimestamp ID = "sample-duplicate-timestamp"
 	ExemplarSeriesMissing    ID = "exemplar-series-missing"
+	ExemplarTooFarInFuture   ID = "exemplar-too-far-in-future"
 
 	StoreConsistencyCheckFailed ID = "store-consistency-check-failed"
 	BucketIndexTooOld           ID = "bucket-index-too-old"
@@ -99,6 +100,11 @@ func (id ID) MessageWithStrategyAndPerTenantLimitConfig(msg, strategy, flag stri
 // LabelValue returns the error ID converted to a form suitable for use as a Prometheus label value.
 func (id ID) LabelValue() string {
 	return strings.ReplaceAll(string(id), "-", "_")
+}
+
+// Error implements error.
+func (id ID) Error() string {
+	return string(id)
 }
 
 func buildFlagsList(flag string, addFlags ...string) (string, string) {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -199,7 +199,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxMetadataLength, maxMetadataLengthFlag, 1024, "Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. Longer metadata is dropped except for HELP which is truncated.")
 	f.IntVar(&l.MaxNativeHistogramBuckets, maxNativeHistogramBucketsFlag, 0, "Maximum number of buckets per native histogram sample. 0 to disable the limit.")
 	_ = l.CreationGracePeriod.Set("10m")
-	f.Var(&l.CreationGracePeriod, creationGracePeriodFlag, "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample with timestamp `t` will be rejected if `t > (now + validation.create-grace-period)`. Also used by query-frontend to avoid querying too far into the future. 0 to disable.")
+	f.Var(&l.CreationGracePeriod, creationGracePeriodFlag, fmt.Sprintf("Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -%s)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future).", creationGracePeriodFlag))
 	f.BoolVar(&l.EnforceMetadataMetricName, "validation.enforce-metadata-metric-name", true, "Enforce every metadata has a metric name.")
 
 	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -199,7 +199,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxMetadataLength, maxMetadataLengthFlag, 1024, "Maximum length accepted for metric metadata. Metadata refers to Metric Name, HELP and UNIT. Longer metadata is dropped except for HELP which is truncated.")
 	f.IntVar(&l.MaxNativeHistogramBuckets, maxNativeHistogramBucketsFlag, 0, "Maximum number of buckets per native histogram sample. 0 to disable the limit.")
 	_ = l.CreationGracePeriod.Set("10m")
-	f.Var(&l.CreationGracePeriod, creationGracePeriodFlag, fmt.Sprintf("Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + -%s)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future).", creationGracePeriodFlag))
+	f.Var(&l.CreationGracePeriod, creationGracePeriodFlag, "Controls how far into the future incoming samples are accepted compared to the wall clock. Any sample will be rejected if its timestamp is greater than '(now + grace_period)'. This configuration is enforced in the distributor, ingester and query-frontend (to avoid querying too far into the future).")
 	f.BoolVar(&l.EnforceMetadataMetricName, "validation.enforce-metadata-metric-name", true, "Enforce every metadata has a metric name.")
 
 	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable.")


### PR DESCRIPTION
#### What this PR does
In this PR I propose to enforce the configured `-validation.create-grace-period` in the ingester too. The reason is that we've experienced an issue where a sample with a timestamp very far in the future has reached the ingester, and so screwed up the TSDB. We're still investigating the root cause (apparently looks like caused by few bit flipped) but in the meanwhile I would like to enforce the `-validation.create-grace-period` in the ingester too.

Note to reviewers:
- I removed "0 to disable" from the `-validation.create-grace-period` CLI flag description because it wasn't true. 0 didn't disabled it. It's always enforced.
- I noticed that `-validation.create-grace-period` is not checked against exemplar timestamp in the distributor. I will do it in a follow up PR.
- I also manually tested it, running a modified version of [`load-generator`](https://github.com/pracucci/cortex-load-generator) to generate samples in the future and commenting the sample validation code run in the distributor. The samples with timestamp in the future reached ingesters and ingesters rejected them.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
