### PR TITLE
Correctly build Mimir and Helm chart docs with link checking

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -14,15 +14,42 @@ jobs:
     steps:
     - name: "Check out code"
       uses: "actions/checkout@v3"
-    - name: "Build website"
+    - name: Determine Mimir version targeted by Helm chart documentation
+      id: mimir_version
       run: |
+        MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+        echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
+    - name: Determine Mimir branch for targeted version
+      id: mimir_branch
+      env:
+        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
+      run: |
+        if [[ "${MIMIR_VERSION}" = next ]]; then
+          echo 'branch=main' | tee "${GITHUB_OUTPUT}"
+        else
+          MIMIR_VERSION_WITHOUT_PREFIX="${MIMIR_VERSION#v}"
+          echo "branch=release-${MIMIR_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
+        fi
+    - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
+      uses: actions/checkout@v3
+      with:
+        path: ${{ steps.mimir_branch.outputs.branch }}
+        ref: ${{ steps.mimir_branch.outputs.branch }}
+    - name: Run Git Config
+      run: git config --global --add safe.directory '*'
+    - name: Build website
+      env:
+        MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
+        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
+      run: |
+        set -x
         docker run \
-          -v ${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest \
-          -v ${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest \
+          -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
+          -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
           -e HUGO_REFLINKSERRORLEVEL=ERROR \
           --rm \
-            grafana/docs-base:latest \
-              /bin/bash -c 'make hugo'
+          grafana/docs-base:latest \
+            /bin/bash -c 'make hugo'
 
   sync:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -37,7 +37,7 @@ jobs:
         ref: ${{ steps.mimir_branch.outputs.branch }}
     - name: Run Git Config
       run: git config --global --add safe.directory '*'
-    - name: Build website
+    - name: Build website to test Helm chart documentation
       env:
         MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
         MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
@@ -46,6 +46,15 @@ jobs:
         docker run \
           -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
           -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
+          -e HUGO_REFLINKSERRORLEVEL=ERROR \
+          --rm \
+          grafana/docs-base:latest \
+            /bin/bash -c 'make hugo'
+    - name: Build website to test Mimir documentation
+      run: |
+        set -x
+        docker run \
+          -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
           -e HUGO_REFLINKSERRORLEVEL=ERROR \
           --rm \
           grafana/docs-base:latest \

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -10,55 +10,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: "ubuntu-latest"
-    steps:
-    - name: "Check out code"
-      uses: "actions/checkout@v3"
-    - name: Determine Mimir version targeted by Helm chart documentation
-      id: mimir_version
-      run: |
-        MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
-        echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
-    - name: Determine Mimir branch for targeted version
-      id: mimir_branch
-      env:
-        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
-      run: |
-        if [[ "${MIMIR_VERSION}" = next ]]; then
-          echo 'branch=main' | tee "${GITHUB_OUTPUT}"
-        else
-          MIMIR_VERSION_WITHOUT_PREFIX="${MIMIR_VERSION#v}"
-          echo "branch=release-${MIMIR_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
-        fi
-    - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
-      uses: actions/checkout@v3
-      with:
-        path: ${{ steps.mimir_branch.outputs.branch }}
-        ref: ${{ steps.mimir_branch.outputs.branch }}
-    - name: Run Git Config
-      run: git config --global --add safe.directory '*'
-    - name: Build website to test Helm chart documentation
-      env:
-        MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
-        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
-      run: |
-        set -x
-        docker run \
-          -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
-          -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
-          -e HUGO_REFLINKSERRORLEVEL=ERROR \
-          --rm \
-          grafana/docs-base:latest \
-            /bin/bash -c 'make hugo'
-    - name: Build website to test Mimir documentation
-      run: |
-        set -x
-        docker run \
-          -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
-          -e HUGO_REFLINKSERRORLEVEL=ERROR \
-          --rm \
-          grafana/docs-base:latest \
-            /bin/bash -c 'make hugo'
+    uses: ./.github/workflows/test-docs.yml
 
   sync:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation-release-helm-charts.yml
+++ b/.github/workflows/publish-technical-documentation-release-helm-charts.yml
@@ -41,7 +41,7 @@ jobs:
         ref: ${{ steps.mimir_branch.outputs.branch }}
     - name: Run Git Config
       run: git config --global --add safe.directory '*'
-    - name: Build website
+    - name: Build website to test Helm chart documentation
       env:
         MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
         MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
@@ -50,6 +50,15 @@ jobs:
         docker run \
           -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
           -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
+          -e HUGO_REFLINKSERRORLEVEL=ERROR \
+          --rm \
+          grafana/docs-base:latest \
+            /bin/bash -c 'make hugo'
+    - name: Build website to test Mimir documentation
+      run: |
+        set -x
+        docker run \
+          -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
           -e HUGO_REFLINKSERRORLEVEL=ERROR \
           --rm \
           grafana/docs-base:latest \

--- a/.github/workflows/publish-technical-documentation-release-helm-charts.yml
+++ b/.github/workflows/publish-technical-documentation-release-helm-charts.yml
@@ -18,15 +18,42 @@ jobs:
     steps:
     - name: "Check out code"
       uses: "actions/checkout@v3"
-    - name: "Build website"
+    - name: Determine Mimir version targeted by Helm chart documentation
+      id: mimir_version
       run: |
+        MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+        echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
+    - name: Determine Mimir branch for targeted version
+      id: mimir_branch
+      env:
+        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
+      run: |
+        if [[ "${MIMIR_VERSION}" = next ]]; then
+          echo 'branch=main' | tee "${GITHUB_OUTPUT}"
+        else
+          MIMIR_VERSION_WITHOUT_PREFIX="${MIMIR_VERSION#v}"
+          echo "branch=release-${MIMIR_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
+        fi
+    - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
+      uses: actions/checkout@v3
+      with:
+        path: ${{ steps.mimir_branch.outputs.branch }}
+        ref: ${{ steps.mimir_branch.outputs.branch }}
+    - name: Run Git Config
+      run: git config --global --add safe.directory '*'
+    - name: Build website
+      env:
+        MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
+        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
+      run: |
+        set -x
         docker run \
-          -v ${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest \
-          -v ${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest \
+          -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
+          -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
           -e HUGO_REFLINKSERRORLEVEL=ERROR \
           --rm \
-            grafana/docs-base:latest \
-              /bin/bash -c 'make hugo'
+          grafana/docs-base:latest \
+            /bin/bash -c 'make hugo'
 
   sync:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation-release-helm-charts.yml
+++ b/.github/workflows/publish-technical-documentation-release-helm-charts.yml
@@ -14,55 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: "ubuntu-latest"
-    steps:
-    - name: "Check out code"
-      uses: "actions/checkout@v3"
-    - name: Determine Mimir version targeted by Helm chart documentation
-      id: mimir_version
-      run: |
-        MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
-        echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
-    - name: Determine Mimir branch for targeted version
-      id: mimir_branch
-      env:
-        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
-      run: |
-        if [[ "${MIMIR_VERSION}" = next ]]; then
-          echo 'branch=main' | tee "${GITHUB_OUTPUT}"
-        else
-          MIMIR_VERSION_WITHOUT_PREFIX="${MIMIR_VERSION#v}"
-          echo "branch=release-${MIMIR_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
-        fi
-    - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
-      uses: actions/checkout@v3
-      with:
-        path: ${{ steps.mimir_branch.outputs.branch }}
-        ref: ${{ steps.mimir_branch.outputs.branch }}
-    - name: Run Git Config
-      run: git config --global --add safe.directory '*'
-    - name: Build website to test Helm chart documentation
-      env:
-        MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
-        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
-      run: |
-        set -x
-        docker run \
-          -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
-          -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
-          -e HUGO_REFLINKSERRORLEVEL=ERROR \
-          --rm \
-          grafana/docs-base:latest \
-            /bin/bash -c 'make hugo'
-    - name: Build website to test Mimir documentation
-      run: |
-        set -x
-        docker run \
-          -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
-          -e HUGO_REFLINKSERRORLEVEL=ERROR \
-          --rm \
-          grafana/docs-base:latest \
-            /bin/bash -c 'make hugo'
+    uses: ./.github/workflows/test-docs.yml
 
   sync:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation-release-mimir.yml
+++ b/.github/workflows/publish-technical-documentation-release-mimir.yml
@@ -13,55 +13,7 @@ on:
 
 jobs:
   test:
-    runs-on: "ubuntu-latest"
-    steps:
-    - name: "Check out code"
-      uses: "actions/checkout@v3"
-    - name: Determine Mimir version targeted by Helm chart documentation
-      id: mimir_version
-      run: |
-        MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
-        echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
-    - name: Determine Mimir branch for targeted version
-      id: mimir_branch
-      env:
-        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
-      run: |
-        if [[ "${MIMIR_VERSION}" = next ]]; then
-          echo 'branch=main' | tee "${GITHUB_OUTPUT}"
-        else
-          MIMIR_VERSION_WITHOUT_PREFIX="${MIMIR_VERSION#v}"
-          echo "branch=release-${MIMIR_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
-        fi
-    - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
-      uses: actions/checkout@v3
-      with:
-        path: ${{ steps.mimir_branch.outputs.branch }}
-        ref: ${{ steps.mimir_branch.outputs.branch }}
-    - name: Run Git Config
-      run: git config --global --add safe.directory '*'
-    - name: Build website to test Helm chart documentation
-      env:
-        MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
-        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
-      run: |
-        set -x
-        docker run \
-          -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
-          -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
-          -e HUGO_REFLINKSERRORLEVEL=ERROR \
-          --rm \
-          grafana/docs-base:latest \
-            /bin/bash -c 'make hugo'
-    - name: Build website to test Mimir documentation
-      run: |
-        set -x
-        docker run \
-          -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
-          -e HUGO_REFLINKSERRORLEVEL=ERROR \
-          --rm \
-          grafana/docs-base:latest \
-            /bin/bash -c 'make hugo'
+    uses: ./.github/workflows/test-docs.yml
 
   sync:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation-release-mimir.yml
+++ b/.github/workflows/publish-technical-documentation-release-mimir.yml
@@ -40,7 +40,7 @@ jobs:
         ref: ${{ steps.mimir_branch.outputs.branch }}
     - name: Run Git Config
       run: git config --global --add safe.directory '*'
-    - name: Build website
+    - name: Build website to test Helm chart documentation
       env:
         MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
         MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
@@ -49,6 +49,15 @@ jobs:
         docker run \
           -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
           -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
+          -e HUGO_REFLINKSERRORLEVEL=ERROR \
+          --rm \
+          grafana/docs-base:latest \
+            /bin/bash -c 'make hugo'
+    - name: Build website to test Mimir documentation
+      run: |
+        set -x
+        docker run \
+          -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
           -e HUGO_REFLINKSERRORLEVEL=ERROR \
           --rm \
           grafana/docs-base:latest \

--- a/.github/workflows/publish-technical-documentation-release-mimir.yml
+++ b/.github/workflows/publish-technical-documentation-release-mimir.yml
@@ -17,15 +17,42 @@ jobs:
     steps:
     - name: "Check out code"
       uses: "actions/checkout@v3"
-    - name: "Build website"
+    - name: Determine Mimir version targeted by Helm chart documentation
+      id: mimir_version
       run: |
+        MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+        echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
+    - name: Determine Mimir branch for targeted version
+      id: mimir_branch
+      env:
+        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
+      run: |
+        if [[ "${MIMIR_VERSION}" = next ]]; then
+          echo 'branch=main' | tee "${GITHUB_OUTPUT}"
+        else
+          MIMIR_VERSION_WITHOUT_PREFIX="${MIMIR_VERSION#v}"
+          echo "branch=release-${MIMIR_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
+        fi
+    - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
+      uses: actions/checkout@v3
+      with:
+        path: ${{ steps.mimir_branch.outputs.branch }}
+        ref: ${{ steps.mimir_branch.outputs.branch }}
+    - name: Run Git Config
+      run: git config --global --add safe.directory '*'
+    - name: Build website
+      env:
+        MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
+        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
+      run: |
+        set -x
         docker run \
-          -v ${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest \
-          -v ${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest \
+          -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
+          -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
           -e HUGO_REFLINKSERRORLEVEL=ERROR \
           --rm \
-            grafana/docs-base:latest \
-              /bin/bash -c 'make hugo'
+          grafana/docs-base:latest \
+            /bin/bash -c 'make hugo'
 
   sync:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -238,12 +238,14 @@ jobs:
       - name: "Build website"
         run: |
           docker run \
-            -v ${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest \
-            -v ${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest \
+            -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
+            -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
             -e HUGO_REFLINKSERRORLEVEL=ERROR \
             --rm \
             grafana/docs-base:latest \
               /bin/bash -c 'make hugo'
+        env:
+          MIMIR_VERSION: v2.9.x
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Determine Mimir version targeted by Helm chart documentation and the source branch that provides that version
         id: mimir_version
         run: |
-          MIMIR_DOCS_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR DOCS VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+          MIMIR_DOCS_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
 
           echo "version=${MIMIR_DOCS_VERSION}" | tee "${GITHUB_OUTPUT}"
           if [[ "${MIMIR_DOCS_VERSION}" = next ]]; then

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -247,18 +247,18 @@ jobs:
             echo "branch=release-${MIMIR_DOCS_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
           fi
 
-      - name: Check out ${{ steps.mimir_version.output.branch }} documentation
+      - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.mimir_version.output.branch }}
+          ref: ${{ steps.mimir_version.outputs.branch }}
 
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
 
       - name: Build website
         env:
-          MIMIR_BRANCH: ${{ steps.mimir_version.output.branch }}
-          MIMIR_VERSION: ${{ steps.mimir_version.output.version }}
+          MIMIR_BRANCH: ${{ steps.mimir_version.outputs.branch }}
+          MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
         run: |
           docker run \
             -v "${PWD}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -229,9 +229,6 @@ jobs:
           ./.github/workflows/scripts/run-unit-tests-group.sh --index ${{ matrix.test_group_id }} --total ${{ matrix.test_group_total }}
 
   test-docs:
-    env:
-      MIMIR_VERSION: v2.9.x
-      MIMIR_BRANCH: release-2.9
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -242,13 +239,12 @@ jobs:
         run: |
           MIMIR_DOCS_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *mimir_docs_version: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
 
-          echo "version=${MIMIR_DOCS_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "version=${MIMIR_DOCS_VERSION}" | tee "${GITHUB_OUTPUT}"
           if [[ "${MIMIR_DOCS_VERSION}" = next ]]; then
             echo 'branch=main' >> "${GITHUB_OUTPUT}"
           else
             MIMIR_DOCS_VERSION_WITHOUT_PREFIX="${MIMIR_DOCS_VERSION#v}"
-
-            echo "branch=release-${MIMIR_DOCS_VERSION_WITHOUT_PREFIX%.x}" >> "${GITHUB_OUTPUT}"
+            echo "branch=release-${MIMIR_DOCS_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
           fi
 
       - name: Check out ${{ steps.mimir_version.output.branch }} documentation
@@ -259,7 +255,7 @@ jobs:
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
 
-      - name: "Build website"
+      - name: Build website
         env:
           MIMIR_BRANCH: ${{ steps.mimir_version.output.branch }}
           MIMIR_VERSION: ${{ steps.mimir_version.output.version }}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -229,23 +229,28 @@ jobs:
           ./.github/workflows/scripts/run-unit-tests-group.sh --index ${{ matrix.test_group_id }} --total ${{ matrix.test_group_total }}
 
   test-docs:
+    env:
+      MIMIR_VERSION: v2.9.x
+      MIMIR_BRANCH: release-2.9
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+      - name: Check out ${{ env.MIMIR_BRANCH }} documentation
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.MIMIR_BRANCH }}
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: "Build website"
         run: |
           docker run \
-            -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
+            -v "${PWD}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
             -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
             -e HUGO_REFLINKSERRORLEVEL=ERROR \
             --rm \
             grafana/docs-base:latest \
               /bin/bash -c 'make hugo'
-        env:
-          MIMIR_VERSION: v2.9.x
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Determine Mimir version targeted by Helm chart documentation and the source branch that provides that version
         id: mimir_version
         run: |
-          MIMIR_DOCS_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *mimir_docs_version: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+          MIMIR_DOCS_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR DOCS VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
 
           echo "version=${MIMIR_DOCS_VERSION}" | tee "${GITHUB_OUTPUT}"
           if [[ "${MIMIR_DOCS_VERSION}" = next ]]; then

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -261,7 +261,7 @@ jobs:
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
 
-      - name: Build website
+      - name: Build website to test Helm chart documentation
         env:
           MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
           MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
@@ -270,6 +270,15 @@ jobs:
           docker run \
             -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
             -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
+            -e HUGO_REFLINKSERRORLEVEL=ERROR \
+            --rm \
+            grafana/docs-base:latest \
+              /bin/bash -c 'make hugo'
+      - name: Build website to test Mimir documentation
+        run: |
+          set -x
+          docker run \
+            -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
             -e HUGO_REFLINKSERRORLEVEL=ERROR \
             --rm \
             grafana/docs-base:latest \

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -229,60 +229,7 @@ jobs:
           ./.github/workflows/scripts/run-unit-tests-group.sh --index ${{ matrix.test_group_id }} --total ${{ matrix.test_group_total }}
 
   test-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Determine Mimir version targeted by Helm chart documentation
-        id: mimir_version
-        run: |
-          MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
-          echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
-
-      - name: Determine Mimir branch for targeted version
-        id: mimir_branch
-        env:
-          MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
-        run: |
-          if [[ "${MIMIR_VERSION}" = next ]]; then
-            echo 'branch=main' | tee "${GITHUB_OUTPUT}"
-          else
-            MIMIR_VERSION_WITHOUT_PREFIX="${MIMIR_VERSION#v}"
-            echo "branch=release-${MIMIR_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
-        uses: actions/checkout@v3
-        with:
-          path: ${{ steps.mimir_branch.outputs.branch }}
-          ref: ${{ steps.mimir_branch.outputs.branch }}
-
-      - name: Run Git Config
-        run: git config --global --add safe.directory '*'
-
-      - name: Build website to test Helm chart documentation
-        env:
-          MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
-          MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
-        run: |
-          set -x
-          docker run \
-            -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
-            -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
-            -e HUGO_REFLINKSERRORLEVEL=ERROR \
-            --rm \
-            grafana/docs-base:latest \
-              /bin/bash -c 'make hugo'
-      - name: Build website to test Mimir documentation
-        run: |
-          set -x
-          docker run \
-            -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
-            -e HUGO_REFLINKSERRORLEVEL=ERROR \
-            --rm \
-            grafana/docs-base:latest \
-              /bin/bash -c 'make hugo'
+    uses: ./.github/workflows/test-docs.yml
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -236,13 +236,33 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Check out ${{ env.MIMIR_BRANCH }} documentation
+
+      - name: Determine Mimir version targeted by Helm chart documentation and the source branch that provides that version
+        id: mimir_version
+        run: |
+          MIMIR_DOCS_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *mimir_docs_version: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+
+          echo "version=${MIMIR_DOCS_VERSION}" >> "${GITHUB_OUTPUT}"
+          if [[ "${MIMIR_DOCS_VERSION}" = next ]]; then
+            echo 'branch=main' >> "${GITHUB_OUTPUT}"
+          else
+            MIMIR_DOCS_VERSION_WITHOUT_PREFIX="${MIMIR_DOCS_VERSION#v}"
+
+            echo "branch=release-${MIMIR_DOCS_VERSION_WITHOUT_PREFIX%.x}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Check out ${{ steps.mimir_version.output.branch }} documentation
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.MIMIR_BRANCH }}
+          ref: ${{ steps.mimir_version.output.branch }}
+
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
+
       - name: "Build website"
+        env:
+          MIMIR_BRANCH: ${{ steps.mimir_version.output.branch }}
+          MIMIR_VERSION: ${{ steps.mimir_version.output.version }}
         run: |
           docker run \
             -v "${PWD}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -234,34 +234,41 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Determine Mimir version targeted by Helm chart documentation and the source branch that provides that version
+      - name: Determine Mimir version targeted by Helm chart documentation
         id: mimir_version
         run: |
-          MIMIR_DOCS_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+          MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+          echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
 
-          echo "version=${MIMIR_DOCS_VERSION}" | tee "${GITHUB_OUTPUT}"
-          if [[ "${MIMIR_DOCS_VERSION}" = next ]]; then
-            echo 'branch=main' >> "${GITHUB_OUTPUT}"
+      - name: Determine Mimir branch for targeted version
+        id: mimir_branch
+        env:
+          MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
+        run: |
+          if [[ "${MIMIR_VERSION}" = next ]]; then
+            echo 'branch=main' | tee "${GITHUB_OUTPUT}"
           else
-            MIMIR_DOCS_VERSION_WITHOUT_PREFIX="${MIMIR_DOCS_VERSION#v}"
-            echo "branch=release-${MIMIR_DOCS_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
+            MIMIR_VERSION_WITHOUT_PREFIX="${MIMIR_VERSION#v}"
+            echo "branch=release-${MIMIR_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
           fi
 
       - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.mimir_version.outputs.branch }}
+          path: ${{ steps.mimir_branch.outputs.branch }}
+          ref: ${{ steps.mimir_branch.outputs.branch }}
 
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
 
       - name: Build website
         env:
-          MIMIR_BRANCH: ${{ steps.mimir_version.outputs.branch }}
+          MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
           MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
         run: |
+          set -x
           docker run \
-            -v "${PWD}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
+            -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
             -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
             -e HUGO_REFLINKSERRORLEVEL=ERROR \
             --rm \

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,56 @@
+name: "Test build of documentation"
+
+on:
+  workflow_call:
+
+jobs:
+  test-docs:
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: "Check out code"
+      uses: "actions/checkout@v3"
+    - name: Run Git Config
+      run: git config --global --add safe.directory '*'
+    - name: Build website to test Mimir documentation
+      run: |
+        set -x
+        docker run \
+          -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
+          -e HUGO_REFLINKSERRORLEVEL=ERROR \
+          --rm \
+          grafana/docs-base:latest \
+          /bin/bash -c 'make hugo'
+    - name: Determine Mimir version targeted by Helm chart documentation
+      id: mimir_version
+      run: |
+        MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+        echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
+    - name: Determine Mimir branch for targeted version
+      id: mimir_branch
+      env:
+        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
+      run: |
+        if [[ "${MIMIR_VERSION}" = next ]]; then
+            echo 'branch=main' | tee "${GITHUB_OUTPUT}"
+        else
+            MIMIR_VERSION_WITHOUT_PREFIX="${MIMIR_VERSION#v}"
+            echo "branch=release-${MIMIR_VERSION_WITHOUT_PREFIX%.x}" | tee "${GITHUB_OUTPUT}"
+        fi
+    - name: Check out ${{ steps.mimir_version.outputs.branch }} documentation
+      uses: actions/checkout@v3
+      with:
+        path: ${{ steps.mimir_branch.outputs.branch }}
+        ref: ${{ steps.mimir_branch.outputs.branch }}
+    - name: Build website to test Helm chart documentation
+      env:
+        MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}
+        MIMIR_VERSION: ${{ steps.mimir_version.outputs.version }}
+      run: |
+        set -x
+        docker run \
+          -v "${GITHUB_WORKSPACE}/${MIMIR_BRANCH}/docs/sources/mimir:/hugo/content/docs/mimir/${MIMIR_VERSION}" \
+          -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
+          -e HUGO_REFLINKSERRORLEVEL=ERROR \
+          --rm \
+          grafana/docs-base:latest \
+          /bin/bash -c 'make hugo'

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,4 +1,4 @@
-name: "Test build of documentation"
+name: "test-docs"
 
 on:
   workflow_call:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,7 @@ MAKEFLAGS += --no-builtin-rule
 
 include docs.mk
 
-$(REPOS_PATH)/mimir-$(MIMIR_DOCS_VERSION):
+$(GIT_ROOT_PARENT)/mimir-$(MIMIR_DOCS_VERSION):
 	git worktree add -f $@ origin/$(MIMIR_DOCS_BRANCH)
 
-docs: $(realpath $(GIT_ROOT)/..)/mimir-$(MIMIR_DOCS_VERSION)
+docs: $(GIT_ROOT_PARENT)/mimir-$(MIMIR_DOCS_VERSION)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,4 +10,4 @@ include docs.mk
 $(REPOS_PATH)/mimir-$(MIMIR_DOCS_VERSION):
 	git worktree add -f $@ origin/$(MIMIR_DOCS_BRANCH)
 
-docs: $(REPOS_PATH)/mimir-$(MIMIR_DOCS_VERSION)
+docs: $(realpath $(GIT_ROOT)/..)/mimir-$(MIMIR_DOCS_VERSION)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,3 +6,8 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rule
 
 include docs.mk
+
+$(REPOS_PATH)/mimir-$(MIMIR_DOCS_VERSION):
+	git worktree add -f $@ origin/$(MIMIR_DOCS_BRANCH)
+
+docs: $(REPOS_PATH)/mimir-$(MIMIR_DOCS_VERSION)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation
+
+## Test Mimir and Helm chart documentation together locally
+
+Testing the documentation accurately requires a copy of Mimir documentation at the target version of the Helm chart.
+
+One way to do this is to use a git worktree to checkout the version branch of Mimir that matches the Helm chart target version.
+For example, if the Helm chart target version is `v2.9.x`, checkout the `release-2.9` branch:
+
+```console
+$ git worktree add --checkout "$(git rev-parse --show-toplevel)/../mimir-v2.9.x" origin/release-2.9
+Preparing worktree (detached HEAD 761114d8b)
+HEAD is now at 761114d8b Bump version to 2.9.0 (#5289)
+```

--- a/docs/make-docs
+++ b/docs/make-docs
@@ -1,6 +1,127 @@
 #!/bin/sh
 # The source of this file is https://raw.githubusercontent.com/grafana/writers-toolkit/main/docs/make-docs.
-# 3.0.0 (2023-05-18)
+# # `make-docs` procedure changelog
+#
+# Updates should conform to the guidelines in https://keepachangelog.com/en/1.1.0/.
+# [Semantic versioning](https://semver.org/) is used to help the reader identify the significance of changes.
+# Changes are relevant to this script and the support docs.mk GNU Make interface.
+
+# ## 4.2.0 (2023-09-01)
+
+# ### Added
+
+# - Retry the initial webserver request up to ten times to allow for the process to start.
+#   If it is still failing after ten seconds, an error message is logged.
+
+# ## 4.1.1 (2023-07-20)
+
+# ### Fixed
+
+# - Replaced use of `realpath` with POSIX compatible alternative to determine default value for REPOS_PATH.
+
+# ## 4.1.0 (2023-06-16)
+
+# ### Added
+
+# - Mounts of `layouts` and `config` directories for the `website` project.
+#   Ensures that local changes to mounts or shortcodes are reflected in the development server.
+
+# ### Fixed
+
+# - Version inference for versioned docs pages.
+#   Pages in versioned projects now have the `versioned: true` front matter set to ensure that "version" in $.Page.Scratch is set on builds.
+
+# ## 4.0.0 (2023-06-06)
+
+# ### Removed
+
+# - `doc-validator/%` target.
+#   The behavior of the target was not as described.
+#   Instead, to limit `doc-validator` to only specific files, refer to https://grafana.com/docs/writers-toolkit/writing-guide/tooling-and-workflows/validate-technical-documentation/#run-on-specific-files.
+
+# ## 3.0.0 (2023-05-18)
+
+# ### Fixed
+
+# - Compatibility with the updated Make targets in the `website` repository.
+#   `docs` now runs this script itself, `server-docs` builds the site with the `docs` Hugo environment.
+
+# ## 2.0.0 (2023-05-18)
+
+# ### Added
+
+# - Support for the grafana-cloud/frontend-observability/faro-web-sdk project.
+# - Use of `doc-validator` v2.0.x which includes breaking changes to command line options.
+
+# ### Fixed
+
+# - Source grafana-cloud project from website repository.
+
+# ### Added
+
+# - Support for running the Vale linter with `make vale`.
+
+# ## 1.2.1 (2023-05-05)
+
+# ### Fixed
+
+# - Use `latest` tag of `grafana/vale` image by default instead of hardcoded older version.
+# - Fix mounting multiple projects broken by the changes in 1.0.1
+
+# ## 1.2.0 (2023-05-05)
+
+# ### Added
+
+# - Support for running the Vale linter with `make vale`.
+
+# ### Fixed
+
+# ## 1.1.0 (2023-05-05)
+
+# ### Added
+
+# - Rewrite error output so it can be followed by text editors.
+
+# ### Fixed
+
+# - Fix `docs-debug` container process port.
+
+# ## 1.0.1 (2023-05-04)
+
+# ### Fixed
+
+# - Ensure complete section hierarchy so that all projects have a visible menu.
+
+# ## 1.0.0 (2023-05-04)
+
+# ### Added
+
+# - Build multiple projects simultaneously if all projects are checked out locally.
+# - Run [`doc-validator`](https://github.com/grafana/technical-documentation/tree/main/tools/cmd/doc-validator) over projects.
+# - Redirect project root to mounted version.
+#   For example redirect `/docs/grafana/` to `/docs/grafana/latest/`.
+# - Support for Podman or Docker containers with `PODMAN` environment variable.
+# - Support for projects:
+#   - agent
+#   - enterprise-logs
+#   - enterprise-metrics
+#   - enterprise-traces
+#   - grafana
+#   - grafana-cloud
+#   - grafana-cloud/machine-learning
+#   - helm-charts/mimir-distributed
+#   - helm-charts/tempo-distributed
+#   - incident
+#   - loki
+#   - mimir
+#   - oncall
+#   - opentelemetry
+#   - phlare
+#   - plugins
+#   - slo
+#   - tempo
+#   - writers-toolkit
+
 
 set -ef
 
@@ -18,6 +139,21 @@ readonly WEBSITE_EXEC="${WEBSITE_EXEC:-make server-docs}"
 readonly WEBSITE_MOUNTS="${WEBSITE_MOUNTS:-}"
 
 PODMAN="$(if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)"
+
+if ! command -v curl >/dev/null 2>&1; then
+  if ! command -v wget >/dev/null 2>&1; then
+    errr 'either `curl` or `wget` must be installed for this script to work.'
+
+    exit 1
+  fi
+fi
+
+if ! command -v "${PODMAN}" >/dev/null 2>&1; then
+  errr 'either `podman` or `docker` must be installed for this script to work.'
+
+  exit 1
+fi
+
 
 about() {
   cat <<EOF
@@ -48,7 +184,7 @@ EOF
   exit 1
 fi
 
-readonly REPOS_PATH="${REPOS_PATH:-$(realpath "$(git rev-parse --show-toplevel)/..")}"
+readonly REPOS_PATH="${REPOS_PATH:-$(cd "$(git rev-parse --show-toplevel)/.." && echo "${PWD}")}"
 
 if [ -z "${REPOS_PATH}" ]; then
   cat <<EOF >&2
@@ -63,20 +199,23 @@ SOURCES_as_code='as-code-docs'
 SOURCES_enterprise_metrics='backend-enterprise'
 SOURCES_enterprise_metrics_='backend-enterprise'
 SOURCES_grafana_cloud='website'
+SOURCES_grafana_cloud_alerting_and_irm_machine_learning='machine-learning'
+SOURCES_grafana_cloud_alerting_and_irm_slo='slo'
 SOURCES_grafana_cloud_k6='k6-docs'
 SOURCES_grafana_cloud_data_configuration_integrations='cloud-onboarding'
 SOURCES_grafana_cloud_frontend_observability_faro_web_sdk='faro-web-sdk'
-SOURCES_grafana_cloud_machine_learning='machine-learning'
 SOURCES_helm_charts_mimir_distributed='mimir'
 SOURCES_helm_charts_tempo_distributed='tempo'
 SOURCES_opentelemetry='opentelemetry-docs'
+SOURCES_plugins_grafana_splunk_datasource='splunk-datasource'
 
 VERSIONS_as_code='UNVERSIONED'
 VERSIONS_grafana_cloud='UNVERSIONED'
+VERSIONS_grafana_cloud_alerting_and_irm_machine_learning='UNVERSIONED'
+VERSIONS_grafana_cloud_alerting_and_irm_slo='UNVERSIONED'
 VERSIONS_grafana_cloud_k6='UNVERSIONED'
 VERSIONS_grafana_cloud_data_configuration_integrations='UNVERSIONED'
 VERSIONS_grafana_cloud_frontend_observability_faro_web_sdk='UNVERSIONED'
-VERSIONS_grafana_cloud_machine_learning='UNVERSIONED'
 VERSIONS_opentelemetry='UNVERSIONED'
 VERSIONS_technical_documentation='UNVERSIONED'
 VERSIONS_website='UNVERSIONED'
@@ -200,6 +339,28 @@ POSIX_HERESTRING
   unset _project _version
 }
 
+# repo_path returns the host path to the project repository.
+# It looks for the provided repository name in each of the paths specified in the REPOS_PATH environment variable.
+repo_path() {
+  _repo="$1"
+  IFS=:
+  for lookup in ${REPOS_PATH}; do
+    if [ -d "${lookup}/${_repo}" ]; then
+      echo "${lookup}/${_repo}"
+      unset _path _repo
+      return
+    fi
+  done
+  unset IFS
+
+  errr "could not find project '${_repo}' in any of the paths in REPOS_PATH '${REPOS_PATH}'."
+  note "you must have a checkout of the project '${_repo}' at '${REPOS_PATH##:*}/${_repo}'."
+  note "if you have cloned the repository into a directory with a different name, consider changing it to ${_repo}."
+
+  unset _repo
+  exit 1
+}
+
 # proj_src returns the host path to content source for a project.
 # It expects a complete project structure as input.
 # It looks for the provided repository name in each of the paths specified in the REPOS_PATH environment variable.
@@ -208,21 +369,10 @@ proj_src() {
 $1
 POSIX_HERESTRING
 
-  IFS=:
-  for lookup in ${REPOS_PATH}; do
-    if [ -d "${lookup}/${_repo}" ]; then
-      echo "${lookup}/${_repo}/${_path}"
-      unset _path _repo
-      return
-    fi
-  done
-  unset IFS
+  _repo="$(repo_path "${_repo}")"
+  echo "${_repo}/${_path}"
 
-  echo "ERRR: could not find project '${_repo}' in any of the paths in REPOS_PATH '${REPOS_PATH}'." >&2
-  echo "NOTE: you must have a checkout of the project '${_repo}' at '${REPOS_PATH##:*}/${_repo}'." >&2
-  echo "NOTE: if you have cloned the repository into a directory with a different name, consider changing it to ${_repo}." >&2
   unset _path _repo
-  exit 1
 }
 
 # proj_canonical returns the canonical absolute path partial URI for a project.
@@ -292,10 +442,76 @@ POSIX_HERESTRING
   unset _project _version _repo _path
 }
 
+await_build() {
+  url="$1"
+  req="$(if command -v curl >/dev/null 2>&1; then echo 'curl -s -o /dev/null'; else echo 'wget -q'; fi)"
+
+  i=1
+  max=10
+  while [ "${i}" -ne "${max}" ]
+  do
+    sleep 1
+    debg "Retrying request to webserver assuming the process is still starting up."
+    i=$((i + 1))
+
+    if ${req} "${url}"; then
+      echo
+      echo "View documentation locally:"
+      for x in ${url_src_dst_vers}; do
+        IFS='^' read -r url _ _ <<POSIX_HERESTRING
+$x
+POSIX_HERESTRING
+
+        if [ -n "${url}" ]; then
+          if [ "${_url}" != "arbitrary" ]; then
+            echo "  ${url}"
+          fi
+        fi
+      done
+      echo
+      echo 'Press Ctrl+C to stop the server'
+
+      unset i max req url
+      return
+    fi
+  done
+
+  echo
+  errr 'The build was interrupted or a build error occurred, check the previous logs for possible causes.'
+  unset i max req url
+}
+
+debg() {
+  if [ -n "${DEBUG}" ]; then
+    echo "DEBG: $1" >&2
+  fi
+}
+
+errr() {
+  echo "ERRR: $1" >&2
+}
+
+note() {
+  echo "NOTE: $1" >&2
+}
+
 url_src_dst_vers="$(url_src_dst_vers "$@")"
 
 volumes=""
 redirects=""
+
+for arg in "$@"; do
+  IFS=: read -r _project _ _repo _ <<POSIX_HERESTRING
+${arg}
+POSIX_HERESTRING
+  if [ "${_project}" = website ]; then
+    _repo="$(repo_path website)"
+    volumes="--volume=${_repo}/config:/hugo/config"
+    volumes="${volumes} --volume=${_repo}/layouts/partials:/hugo/layouts/partials"
+    volumes="${volumes} --volume=${_repo}/layouts/shortcodes:/hugo/layouts/shortcodes"
+  fi
+  unset _project _repo
+done
 
 for x in ${url_src_dst_vers}; do
   IFS='^' read -r _url _src _dst _ver <<POSIX_HERESTRING
@@ -304,13 +520,14 @@ POSIX_HERESTRING
 
   if [ "${_url}" != "arbitrary" ]; then
     if [ ! -f "${_src}/_index.md" ]; then
-      echo "ERRR: Index file '${_src}/_index.md' does not exist." >&2
-      echo "Is '${_src}' the correct source directory?" >&2
+      errr "Index file '${_src}/_index.md' does not exist."
+      note "Is '${_src}' the correct source directory?"
       exit 1
     fi
   fi
 
-  echo "DEBG: Mounting '${_src}' at container path '${_dst}'" >&2
+  debg "DEBG: Mounting '${_src}' at container path '${_dst}'"
+
   if [ -z "${volumes}" ]; then
     volumes="--volume=${_src}:${_dst}"
   else
@@ -336,35 +553,35 @@ case "${image}" in
     proj="$(new_proj "$1")"
     echo
     "${PODMAN}" run \
-      --init \
-      --interactive \
-      --name "${DOCS_CONTAINER}" \
-      --platform linux/amd64 \
-      --rm \
-      --tty \
-      ${volumes} \
-      "${DOCS_IMAGE}" \
-      --include="${DOC_VALIDATOR_INCLUDE}" \
-      --skip-checks="${DOC_VALIDATOR_SKIP_CHECKS}" \
-      /hugo/content/docs \
-      "$(proj_canonical "${proj}")" | sed "s#$(proj_dst "${proj}")#sources#"
+                --init \
+                --interactive \
+                --name "${DOCS_CONTAINER}" \
+                --platform linux/amd64 \
+                --rm \
+                --tty \
+                ${volumes} \
+                "${DOCS_IMAGE}" \
+                "--include=${DOC_VALIDATOR_INCLUDE}" \
+                "--skip-checks=${DOC_VALIDATOR_SKIP_CHECKS}" \
+                /hugo/content/docs \
+                "$(proj_canonical "${proj}")" | sed "s#$(proj_dst "${proj}")#sources#"
     ;;
   'grafana/vale')
     proj="$(new_proj "$1")"
     echo
     "${PODMAN}" run \
-      --init \
-      --interactive \
-      --name "${DOCS_CONTAINER}" \
-      --platform linux/amd64 \
-      --rm \
-      --tty \
-      ${volumes} \
-      "${DOCS_IMAGE}" \
-      --minAlertLevel="${VALE_MINALERTLEVEL}" \
-      --config=/etc/vale/.vale.ini \
-      --output=line \
-      /hugo/content/docs | sed "s#$(proj_dst "${proj}")#sources#"
+                --init \
+                --interactive \
+                --name "${DOCS_CONTAINER}" \
+                --platform linux/amd64 \
+                --rm \
+                --tty \
+                ${volumes} \
+                "${DOCS_IMAGE}" \
+                "--minAlertLevel=${VALE_MINALERTLEVEL}" \
+                --config=/etc/vale/.vale.ini \
+                --output=line \
+                /hugo/content/docs | sed "s#$(proj_dst "${proj}")#sources#"
     ;;
   *)
     tempfile="$(mktemp -t make-docs.XXX)"
@@ -372,7 +589,7 @@ case "${image}" in
 #!/usr/bin/env bash
 for redirect in ${redirects}; do
   IFS='^' read -r path ver <<<"\${redirect}"
-  echo -e "---\\nredirectURL: \"\${path/\/hugo\/content/}\"\\ntype: redirect\\n---\\n" > "\${path/\${ver}/_index.md}"
+  echo -e "---\\nredirectURL: \"\${path/\/hugo\/content/}\"\\ntype: redirect\\nversioned: true\\n---\\n" > "\${path/\${ver}/_index.md}"
 done
 
 for x in "${url_src_dst_vers}"; do
@@ -391,36 +608,41 @@ fi
 ${WEBSITE_EXEC}
 EOF
     chmod +x "${tempfile}"
-    volumes="${volumes} --volume=$(realpath "${tempfile}"):/entrypoint"
+    volumes="${volumes} --volume=${tempfile}:/entrypoint"
     readonly volumes
 
-    echo
-    echo "Documentation will be served at the following URLs:"
-    for x in ${url_src_dst_vers}; do
-      IFS='^' read -r url _ _ <<POSIX_HERESTRING
-$x
-POSIX_HERESTRING
+    IFS='' read -r cmd <<EOF
+${PODMAN} run \
+  --env=HUGO_REFLINKSERRORLEVEL=${HUGO_REFLINKSERRORLEVEL} \
+  --init \
+  --interactive \
+  --name=${DOCS_CONTAINER} \
+  --platform=linux/amd64 \
+  --publish=${DOCS_HOST_PORT}:3002 \
+  --publish=3003:3003 \
+  --rm \
+  --tty \
+  ${volumes} \
+  ${DOCS_IMAGE} \
+  /entrypoint
+EOF
+    await_build http://localhost:3002 &
 
-      if [ -n "${url}" ]; then
-        if [ "${_url}" != "arbitrary" ]; then
-          echo "  ${url}"
-        fi
-      fi
-    done
-
-    echo
-    "${PODMAN}" run \
-      --env "HUGO_REFLINKSERRORLEVEL=${HUGO_REFLINKSERRORLEVEL}" \
-      --init \
-      --interactive \
-      --name "${DOCS_CONTAINER}" \
-      --platform linux/amd64 \
-      --publish "${DOCS_HOST_PORT}:3002" \
-      --publish "3003:3003" \
-      --rm \
-      --tty \
-      ${volumes} \
-      "${DOCS_IMAGE}" \
-      /entrypoint
+    if [ -n "${DEBUG}" ]; then
+      ${cmd}
+    else
+      ${cmd} 2>&1| sed \
+                     -e '/Web Server is available at http:\/\/localhost:3003\/ (bind address 0.0.0.0)/ d' \
+                     -e '/^hugo server/ d' \
+                     -e '/fatal: not a git repository (or any parent up to mount point \/)/ d' \
+                     -e '/Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)./ d' \
+                     -e "/Makefile:[0-9]*: warning: overriding recipe for target 'docs'/ d" \
+                     -e "/docs.mk:[0-9]*: warning: ignoring old recipe for target 'docs'/ d" \
+                     -e '/\/usr\/bin\/make -j 2 proxy hserver-docs HUGO_PORT=3003/ d' \
+                     -e '/website-proxy/ d' \
+                     -e '/rm -rf dist*/ d' \
+                     -e '/Press Ctrl+C to stop/ d' \
+                     -e '/make/ d' || echo
+    fi
     ;;
 esac

--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -8,7 +8,7 @@ keywords:
   - Grafana Enterprise Metrics
   - Grafana metrics
 cascade:
-  MIMIR DOCS VERSION: "v2.9.x"
+  MIMIR_DOCS_VERSION: "v2.9.x"
   gem_docs_version: "v2.9.x"
 ---
 
@@ -21,5 +21,5 @@ The mimir-distributed Helm chart for [Grafana Mimir] and [Grafana Enterprise Met
 {{< section menuTitle="true" >}}
 
 {{% docs/reference %}}
-[Grafana Mimir]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>"
+[Grafana Mimir]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -8,7 +8,7 @@ keywords:
   - Grafana Enterprise Metrics
   - Grafana metrics
 cascade:
-  mimir_docs_version: "v2.9.x"
+  MIMIR DOCS VERSION: "v2.9.x"
   gem_docs_version: "v2.9.x"
 ---
 

--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -8,15 +8,18 @@ keywords:
   - Grafana Enterprise Metrics
   - Grafana metrics
 cascade:
-  # Used to generate relative URL paths to related documentation
   mimir_docs_version: "v2.9.x"
   gem_docs_version: "v2.9.x"
 ---
 
 # Grafana mimir-distributed Helm chart documentation
 
-The mimir-distributed Helm chart for [Grafana Mimir](/docs/mimir/{{< param "mimir_docs_version" >}}/) and [Grafana Enterprise Metrics](/docs/enterprise-metrics/{{< param "gem_docs_version" >}}/) (GEM) allows you to configure, install, and upgrade Grafana Mimir or Grafana Enterprise Metrics within a Kubernetes cluster.
+The mimir-distributed Helm chart for [Grafana Mimir] and [Grafana Enterprise Metrics](/docs/enterprise-metrics/{{< param "gem_docs_version" >}}/) (GEM) allows you to configure, install, and upgrade Grafana Mimir or Grafana Enterprise Metrics within a Kubernetes cluster.
 
 > **Note:** By default, the mimir-distributed Helm chart documentation applies to both Grafana Mimir and GEM. If it only applies to GEM, it is explicitly stated.
 
 {{< section menuTitle="true" >}}
+
+{{% docs/reference %}}
+[Grafana Mimir]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>"
+{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
@@ -65,4 +65,8 @@ spec:
 
 For more information about Vault and Vault Agent, see [Injecting Vault Secrets Into Kubernetes Pods via a Sidecar](https://www.hashicorp.com/blog/injecting-vault-secrets-into-kubernetes-pods-via-a-sidecar).
 
-To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/secure/securing-communications-with-tls/)
+To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS].
+
+{{% docs/reference %}}
+[Injecting Vault Secrets Into Kubernetes Pods via a Sidecar]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/secure/securing-communications-with-tls"
+{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
@@ -68,5 +68,5 @@ For more information about Vault and Vault Agent, see [Injecting Vault Secrets I
 To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS].
 
 {{% docs/reference %}}
-[Injecting Vault Secrets Into Kubernetes Pods via a Sidecar]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/secure/securing-communications-with-tls"
+[Injecting Vault Secrets Into Kubernetes Pods via a Sidecar]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/operators-guide/secure/securing-communications-with-tls"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
@@ -68,5 +68,5 @@ For more information about Vault and Vault Agent, see [Injecting Vault Secrets I
 To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS].
 
 {{% docs/reference %}}
-[Injecting Vault Secrets Into Kubernetes Pods via a Sidecar]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/secure/securing-communications-with-tls"
+[Injecting Vault Secrets Into Kubernetes Pods via a Sidecar]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/secure/securing-communications-with-tls"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
@@ -6,9 +6,9 @@ description: "Learn how to configure Grafana Mimir to ingest and query native hi
 
 # Configure native histograms
 
-To enable support for ingesting Prometheus native histograms over the [remote write API](/docs/mimir/{{< param "mimir_docs_version" >}}/references/http-api/#remote-write) endpoint, set the configuration parameter `native_histograms_ingestion_enabled` to true.
+To enable support for ingesting Prometheus native histograms over the [remote write API] endpoint, set the configuration parameter `native_histograms_ingestion_enabled` to true.
 
-To enable support for querying native histograms together with [Grafana Mimir query sharding](/docs/mimir/{{< param "mimir_docs_version" >}}/references/architecture/query-sharding/), set the configuration parameter `query_result_response_format` to `protobuf`.
+To enable support for querying native histograms together with [Grafana Mimir query sharding], set the configuration parameter `query_result_response_format` to `protobuf`.
 
 Example values file:
 
@@ -34,3 +34,8 @@ remote_write:
   - url: <your-url>
     send_native_histograms: true
 ```
+
+{{% docs/reference %}}
+[remote write API]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/http-api#remote-write"
+[Grafana Mimir query sharding]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/query-sharding/"
+{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
@@ -37,5 +37,5 @@ remote_write:
 
 {{% docs/reference %}}
 [remote write API]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/http-api#remote-write"
-[Grafana Mimir query sharding]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/query-sharding/"
+[Grafana Mimir query sharding]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/query-sharding"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
@@ -36,6 +36,6 @@ remote_write:
 ```
 
 {{% docs/reference %}}
-[remote write API]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/http-api#remote-write"
-[Grafana Mimir query sharding]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/query-sharding"
+[remote write API]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/http-api#remote-write"
+[Grafana Mimir query sharding]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/query-sharding"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
@@ -49,5 +49,5 @@ mimir:
 ```
 
 {{% docs/reference %}}
-[the configuration parameters reference]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/configuration-parameters#redis"
+[the configuration parameters reference]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/configuration-parameters#redis"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
@@ -21,7 +21,7 @@ results-cache:
   enabled: false
 ```
 
-Next, configure Mimir to connect to Redis using `structuredConfig`. Refer to [the configuration parameters reference](/docs/mimir/{{< param "mimir_docs_version" >}}/references/configuration-parameters/#redis) for Redis connection configuration options. For example:
+Next, configure Mimir to connect to Redis using `structuredConfig`. Refer to [the configuration parameters reference] for Redis connection configuration options. For example:
 
 ```yaml
 mimir:
@@ -47,3 +47,7 @@ mimir:
         redis:
           endpoint: <redis-url>:6379
 ```
+
+{{% docs/reference %}}
+[the configuration parameters reference]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/configuration-parameters#redis"
+{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
@@ -8,11 +8,11 @@ weight: 10
 # Migrate from Cortex to Grafana Mimir
 
 As an operator, you can migrate a Helm deployment of [Cortex](https://cortexmetrics.io/) to Grafana Mimir.
-The overview includes the steps required for any environment. To migrate deployment environments with Helm, see [Migrate to Grafana Mimir using Helm]({{< relref "#migrate-to-grafana-mimir-using-helm" >}}).
+The overview includes the steps required for any environment. To migrate deployment environments with Helm, see [Migrate to Grafana Mimir using Helm](#migrate-to-grafana-mimir-using-helm).
 
 > **Note:** This document was tested with Cortex versions 1.10 and 1.11. It might work with more recent versions of Cortex, but that is not guaranteed.
 
-To migrate a Jsonnet deployment of Cortex refer to [Migrate from Cortex](/docs/mimir/{{< param "mimir_docs_version" >}}/migration-guides/migrate-from-cortex).
+To migrate a Jsonnet deployment of Cortex refer to [Migrate from Cortex].
 
 Grafana Mimir includes significant changes that simplify the deployment and continued operation of a horizontally scalable, multi-tenant time series database with long-term storage.
 
@@ -36,8 +36,9 @@ It provides a simple migration by generating Mimir configuration from Cortex con
   Using the monitoring mixin, you need to install both alerting and recording rules in either Prometheus or Cortex. You also need to install dashboards in Grafana.
   To download a prebuilt ZIP file that contains the alerting and recording rules, refer to [Release Cortex-jsonnet 1.11.0](https://github.com/grafana/cortex-jsonnet/releases/download/1.11.0/cortex-mixin.zip).
 
-  To upload rules to the ruler using mimirtool, refer to [mimirtool rules](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/tools/mimirtool/#rules).
-  To import the dashboards into Grafana, refer to [Import dashboard](/docs/grafana/{{< param "mimir_docs_version" >}}/dashboards/export-import/#import-dashboard).
+  To upload rules to the ruler using mimirtool, refer to [mimirtool rules].
+  To import the dashboards into Grafana, refer to [Import dashboard](/docs/grafana/latest/dashboards/export-import/#import-dashboard)
+.
 
 ## Notable changes
 
@@ -106,7 +107,7 @@ It provides a simple migration by generating Mimir configuration from Cortex con
 
 ## Generate the configuration for Grafana Mimir
 
-The [`mimirtool config convert`](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/tools/mimirtool/#convert) command converts Cortex configuration to Mimir configuration. You can use it to update both flags and configuration files.
+The [`mimirtool config convert`] command converts Cortex configuration to Mimir configuration. You can use it to update both flags and configuration files.
 
 ### Install mimirtool
 
@@ -125,7 +126,7 @@ The `mimirtool config convert` command converts Cortex 1.11 configuration files 
 It removes any configuration parameters that are no longer available in Grafana Mimir, and it renames configuration parameters that have a new name.
 If you have explicitly set configuration parameters to a value matching the Cortex default, by default, `mimirtool config convert` doesn't update the value.
 To have `mimirtool config convert` update explicitly set values from the Cortex defaults to the new Grafana Mimir defaults, provide the `--update-defaults` flag.
-Refer to [convert](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/tools/mimirtool/#convert) for more information on using `mimirtool` for configuration conversion.
+Refer to [convert] for more information on using `mimirtool` for configuration conversion.
 
 ## Migrate to Grafana Mimir using Helm
 
@@ -157,7 +158,7 @@ You can migrate to the Grafana Mimir Helm chart (`grafana/mimir-distributed` v3.
    a. Add the dashboards to Grafana. The dashboards replace your Cortex dashboards and continue to work for monitoring Cortex deployments.
 
    > **Note:** Resource dashboards are now enabled by default and require additional metrics sources.
-   > To understand the required metrics sources, refer to [Additional resources metrics](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/monitor-grafana-mimir/requirements/#additional-resources-metrics).
+   > To understand the required metrics sources, refer to [Additional resources metrics].
 
    b. Install the recording and alerting rules into the ruler or a Prometheus server.
 
@@ -252,4 +253,13 @@ You can migrate to the Grafana Mimir Helm chart (`grafana/mimir-distributed` v3.
    helm upgrade <RELEASE> grafana/mimir-distributed [-n <NAMESPACE>]
    ```
 
-To verify that the cluster is operating correctly, use the [monitoring mixin dashboards](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/monitor-grafana-mimir/dashboards/).
+To verify that the cluster is operating correctly, use the [monitoring mixin dashboards].
+
+{{% docs/reference %}}
+[Migrate from Cortex]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/migration-guides/migrate-from-cortex"
+[mimirtool_rules]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool#rules"
+[`mimirtool config convert`]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool#convert"
+[convert]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool#convert"
+[Additional resources metrics]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/requirements#additional-resources-metrics"
+[monitoring mixin dashboards]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/dashboards"
+{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
@@ -38,7 +38,7 @@ It provides a simple migration by generating Mimir configuration from Cortex con
 
   To upload rules to the ruler using mimirtool, refer to [mimirtool rules].
   To import the dashboards into Grafana, refer to [Import dashboard](/docs/grafana/latest/dashboards/export-import/#import-dashboard)
-.
+  .
 
 ## Notable changes
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
@@ -256,10 +256,10 @@ You can migrate to the Grafana Mimir Helm chart (`grafana/mimir-distributed` v3.
 To verify that the cluster is operating correctly, use the [monitoring mixin dashboards].
 
 {{% docs/reference %}}
-[Migrate from Cortex]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/migration-guides/migrate-from-cortex"
-[mimirtool_rules]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool#rules"
-[`mimirtool config convert`]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool#convert"
-[convert]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool#convert"
-[Additional resources metrics]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/requirements#additional-resources-metrics"
-[monitoring mixin dashboards]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/dashboards"
+[Migrate from Cortex]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/migrate/migrate-from-cortex"
+[mimirtool_rules]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/tools/mimirtool#rules"
+[`mimirtool config convert`]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/tools/mimirtool#convert"
+[convert]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/tools/mimirtool#convert"
+[Additional resources metrics]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/requirements#additional-resources-metrics"
+[monitoring mixin dashboards]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/dashboards"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
@@ -790,9 +790,9 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
 {{% docs/reference %}}
-[zone-aware replication]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-zone-aware-replication"
-[alertmanager]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/alertmanager"
-[store-gateway]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/store-gateway"
-[ingester]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/ingester"
-[shuffle sharding]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-shuffle-sharding"
+[zone-aware replication]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-zone-aware-replication"
+[alertmanager]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/alertmanager"
+[store-gateway]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/store-gateway"
+[ingester]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/ingester"
+[shuffle sharding]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-shuffle-sharding"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
@@ -9,7 +9,7 @@ weight: 10
 
 The `mimir-distributed` Helm chart version 4.0 enables zone-aware replication by default. This is a breaking change for existing installations and requires a migration.
 
-This document explains how to migrate stateful components from single zone to [zone-aware replication](/docs/mimir/{{< param "mimir_docs_version" >}}/configure/configure-zone-aware-replication/) with Helm. The three components in question are the [alertmanager](/docs/mimir/{{< param "mimir_docs_version" >}}/references/architecture/components/alertmanager/), the [store-gateway](/docs/mimir/{{< param "mimir_docs_version" >}}/references/architecture/components/store-gateway/) and the [ingester](/docs/mimir/{{< param "mimir_docs_version" >}}/references/architecture/components/ingester/).
+This document explains how to migrate stateful components from single zone to [zone-aware replication] with Helm. The three components in question are the [alertmanager], the [store-gateway] and the [ingester].
 
 The migration path of Alertmanager and store-gateway is straight forward, however migrating ingesters is more complicated.
 
@@ -612,7 +612,7 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    1. If the current `<N>` above in `ingester.zoneAwareReplication.migration.replicas` is less than `ingester.replicas`, go back and increase `<N>` with at most 21 and repeat these four steps.
 
-1. If you are using [shuffle sharding](/docs/mimir/{{< param "mimir_docs_version" >}}/configure/configure-shuffle-sharding/), it must be turned off on the read path at this point.
+1. If you are using [shuffle sharding], it must be turned off on the read path at this point.
 
    1. Update your configuration with these values and keep them until otherwise instructed.
 
@@ -762,7 +762,7 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    The 3 hours is calculated from 2h TSDB block range period + `blocks_storage.tsdb.head_compaction_idle_timeout` Grafana Mimir parameters to give enough time for ingesters to remove stale series from memory. Stale series will be there due to series being moved between ingesters.
 
-1. If you are using [shuffle sharding](/docs/mimir/{{< param "mimir_docs_version" >}}/configure/configure-shuffle-sharding/):
+1. If you are using [shuffle sharding]:
 
    1. Wait an extra 12 hours.
 
@@ -788,3 +788,11 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 1. Undo the doubling of series limits done in the first step.
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
+
+{{% docs/reference %}}
+[zone-aware replication]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-zone-aware-replication"
+[alertmanager]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/alertmanager"
+[store-gateway]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/store-gateway"
+[ingester]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/ingester"
+[shuffle sharding]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-shuffle-sharding"
+{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
@@ -343,11 +343,11 @@ rollout_operator:
 > ```
 
 {{% docs/reference %}}
-[Planning Grafana Mimir capacity]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/run-production-environment/planning-capacity"
-[Ingesters failure and data loss]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/ingester#ingesters-failure-and-data-loss"
-[Collecting metrics and logs from Grafana Mimir]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs"
-[Store-gateway: Blocks sharding and replication]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/store-gateway#blocks-sharding-and-replication"
-[replication across availability zones]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-zone-aware-replication"
-[Configure Grafana Mimir object storage backend]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-object-storage-backend"
-[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts"
+[Planning Grafana Mimir capacity]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/operators-guide/run-production-environment/planning-capacity"
+[Ingesters failure and data loss]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/ingester#ingesters-failure-and-data-loss"
+[Collecting metrics and logs from Grafana Mimir]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs"
+[Store-gateway: Blocks sharding and replication]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/store-gateway#blocks-sharding-and-replication"
+[replication across availability zones]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-zone-aware-replication"
+[Configure Grafana Mimir object storage backend]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-object-storage-backend"
+[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
@@ -62,7 +62,7 @@ usage patterns. Therefore, use the sizing plans as starting
 point for sizing your Grafana Mimir cluster, rather than as strict guidelines.
 To get a better idea of how to plan capacity, refer to the YAML comments at
 the beginning of `small.yaml` and `large.yaml` files, which relate to read and write workloads.
-See also [Planning Grafana Mimir capacity](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/run-production-environment/planning-capacity/).
+See also [Planning Grafana Mimir capacity].
 
 To use a sizing plan, copy it from the [mimir](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed)
 GitHub repository, and pass it as a values file to the `helm` command. Note that sizing plans may change with new
@@ -91,8 +91,8 @@ number_of_nodes >= max(number_of_ingesters_pods, number_of_store_gateway_pods)
 ```
 
 For more information about the failure modes of either the ingester or store-gateway
-component, refer to [Ingesters failure and data loss](/docs/mimir/{{< param "mimir_docs_version" >}}/references/architecture/components/ingester/#ingesters-failure-and-data-loss/)
-or [Store-gateway: Blocks sharding and replication](/docs/mimir/{{< param "mimir_docs_version" >}}/references/architecture/components/store-gateway/#blocks-sharding-and-replication/).
+component, refer to [Ingesters failure and data loss]
+or [Store-gateway: Blocks sharding and replication].
 
 ## Decide whether you need geographical redundancy, fast rolling updates, or both.
 
@@ -105,7 +105,7 @@ configure the Helm chart to deploy Grafana Mimir with zone-aware replication.
 
 ### New installations
 
-Grafana Mimir supports [replication across availability zones](/docs/mimir/{{< param "mimir_docs_version" >}}/configure/configure-zone-aware-replication/)
+Grafana Mimir supports [replication across availability zones]
 within your Kubernetes cluster.
 This further increases fault tolerance of the Mimir cluster. Even if you
 do not currently have multiple zones across your Kubernetes cluster, you
@@ -160,7 +160,7 @@ zone-aware replication.
 ## Configure Mimir to use object storage
 
 For the different object storage types that Mimir supports, and examples,
-see [Configure Grafana Mimir object storage backend](/docs/mimir/{{< param "mimir_docs_version" >}}/configure/configure-object-storage-backend).
+see [Configure Grafana Mimir object storage backend].
 
 1. Add the following YAML to your values file, if you are not using the sizing
    plans that are mentioned in [Plan capacity](#plan-capacity):
@@ -232,7 +232,7 @@ For OpenShift-specific instructions see [Deploy on OpenShift](#deploy-on-openshi
 To monitor the health of your Grafana Mimir cluster, which is also known as
 _metamonitoring_, you can use ready-made Grafana dashboards, and Prometheus
 alerting and recording rules.
-For more information, see [Installing Grafana Mimir dashboards and alerts](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/monitor-grafana-mimir/installing-dashboards-and-alerts/).
+For more information, see [Installing Grafana Mimir dashboards and alerts].
 
 The `mimir-distributed` Helm chart makes it easy for you to collect metrics and
 logs from Mimir. It assigns the correct labels for you so that the dashboards
@@ -273,8 +273,7 @@ Metrics) server.
              X-Scope-OrgID: metamonitoring
    ```
 
-   For details about how to set up the credentials, see [Collecting
-   metrics and logs from Grafana Mimir](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/monitor-grafana-mimir/collecting-metrics-and-logs/).
+   For details about how to set up the credentials, see [Collecting metrics and logs from Grafana Mimir].
 
 Your Grafana Mimir cluster can now ingest metrics in production.
 
@@ -342,3 +341,13 @@ rollout_operator:
 >   --set 'mimir-distributed.rollout_operator.podSecurityContext.runAsUser=null' \
 >   --set 'mimir-distributed.rollout_operator.podSecurityContext.runAsGroup=null'
 > ```
+
+{{% docs/reference %}}
+[Planning Grafana Mimir capacity]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/run-production-environment/planning-capacity"
+[Ingesters failure and data loss]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/ingester#ingesters-failure-and-data-loss"
+[Collecting metrics and logs from Grafana Mimir]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs"
+[Store-gateway: Blocks sharding and replication]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/store-gateway#blocks-sharding-and-replication"
+[replication across availability zones]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-zone-aware-replication"
+[Configure Grafana Mimir object storage backend]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-object-storage-backend"
+[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts"
+{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
@@ -343,11 +343,11 @@ rollout_operator:
 > ```
 
 {{% docs/reference %}}
-[Planning Grafana Mimir capacity]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/run-production-environment/planning-capacity"
+[Planning Grafana Mimir capacity]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/run-production-environment/planning-capacity"
 [Ingesters failure and data loss]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/ingester#ingesters-failure-and-data-loss"
-[Collecting metrics and logs from Grafana Mimir]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs"
+[Collecting metrics and logs from Grafana Mimir]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs"
 [Store-gateway: Blocks sharding and replication]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/store-gateway#blocks-sharding-and-replication"
 [replication across availability zones]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-zone-aware-replication"
 [Configure Grafana Mimir object storage backend]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-object-storage-backend"
-[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts"
+[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
@@ -536,5 +536,5 @@ The example is generated with the following steps:
    Lines starting with "`-`" were removed and lines starting with "`+`" were added. The change to the annotation `checksum/config` means the pods will be restarted when this change is applied.
 
 {{% docs/reference %}}
-[configuration parameters]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/configuration-parameters"
+[configuration parameters]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/configuration-parameters"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
@@ -10,7 +10,7 @@ aliases:
 
 # Manage the configuration of Grafana Mimir with Helm
 
-The `mimir-distributed` Helm chart provides interfaces to set Grafana Mimir [configuration parameters](/docs/mimir/{{< param "mimir_docs_version" >}}/references/configuration-parameters/) and customize how Grafana Mimir is deployed on a Kubernetes cluster. This document describes the configuration parameters.
+The `mimir-distributed` Helm chart provides interfaces to set Grafana Mimir [configuration parameters] and customize how Grafana Mimir is deployed on a Kubernetes cluster. This document describes the configuration parameters.
 
 ## Overview
 
@@ -534,3 +534,7 @@ The example is generated with the following steps:
    ```
 
    Lines starting with "`-`" were removed and lines starting with "`+`" were added. The change to the annotation `checksum/config` means the pods will be restarted when this change is applied.
+
+{{% docs/reference %}}
+[configuration parameters]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/configuration-parameters"
+{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
@@ -14,13 +14,13 @@ weight: 70
 # Configuring Grafana Mimir-Distributed Helm Chart for high-availability deduplication with Consul
 
 Grafana Mimir can deduplicate data from a high-availability (HA) Prometheus setup. You can configure
-the deduplication by using the Grafana Mimir helm chart deployment that uses external Consul. For more information, see [Configure high availability](/docs/mimir/{{< param "mimir_docs_version" >}}/configure/configure-high-availability-deduplication/).
+the deduplication by using the Grafana Mimir helm chart deployment that uses external Consul. For more information, see [Configure high availability].
 
 ## Before you begin
 
 You need to have a Grafana Mimir installed via the mimir-distributed Helm chart.
 
-For conceptual information about how Mimir deduplicates incoming HA samples, refer to [Configure high availability](/docs/mimir/{{< param "mimir_docs_version" >}}/configure/configure-high-availability-deduplication/).
+For conceptual information about how Mimir deduplicates incoming HA samples, refer to [Configure high availability].
 
 You also need to configure HA for Prometheus or Grafana Agent. Lastly, you need a key-value store such as Consul KV.
 
@@ -42,7 +42,7 @@ global:
 
 Reload or restart Prometheus or Grafana Agent after you update the configuration.
 
-> **Note:** [Configure high availability](/docs/mimir/{{< param "mimir_docs_version" >}}/configure/configure-high-availability-deduplication/).
+> **Note:** [Configure high availability].
 > document contains the same information on Prometheus setup for HA dedup.
 
 ## Install Consul using Helm
@@ -151,7 +151,7 @@ If the table is empty, it means there is something wrong with the configuration.
 
 If you have set up [metamonitoring]({{< relref "../monitor-system-health.md" >}}) or if you
 run GEM with built-in system monitoring,
-Mimir [distributor](/docs/mimir/{{< param "mimir_docs_version" >}}/references/architecture/components/distributor/)
+Mimir [distributor]
 exposes some metrics related to HA deduplication. The relevant metrics are those with `cortex_ha_tracker_` prefix.
 
 ### Ensure HA metrics are deduplicated
@@ -163,3 +163,8 @@ select Format = Table. In the result you can see the several time series with di
 
 The most important thing is you will not find `__replica__` label (or any label that you set in `ha_replica_label`
 config) anymore. This means you have configured the deduplication successfully.
+
+{{% docs/reference %}}
+[Configure high availability]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-high-availability-deduplication"
+[distributor]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/distributor"
+{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
@@ -165,6 +165,6 @@ The most important thing is you will not find `__replica__` label (or any label 
 config) anymore. This means you have configured the deduplication successfully.
 
 {{% docs/reference %}}
-[Configure high availability]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/configure/configure-high-availability-deduplication"
-[distributor]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/references/architecture/components/distributor"
+[Configure high availability]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-high-availability-deduplication"
+[distributor]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/distributor"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -140,6 +140,6 @@ metaMonitoring:
 ```
 
 {{% docs/reference %}}
-[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts"
-[Collect metrics and logs without the Helm chart]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs#collect-metrics-and-logs-without-the-helm-chart"
+[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts"
+[Collect metrics and logs without the Helm chart]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs#collect-metrics-and-logs-without-the-helm-chart"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -140,6 +140,6 @@ metaMonitoring:
 ```
 
 {{% docs/reference %}}
-[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts"
-[Collect metrics and logs without the Helm chart]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs#collect-metrics-and-logs-without-the-helm-chart"
+[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/installing-dashboards-and-alerts"
+[Collect metrics and logs without the Helm chart]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/operators-guide/monitor-grafana-mimir/collecting-metrics-and-logs#collect-metrics-and-logs-without-the-helm-chart"
 {{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -12,9 +12,9 @@ weight: 60
 You can monitor Grafana Mimir or Grafana Enterprise Metrics itself, by collecting metrics and logs from Mimir or GEM that is running on a Kubernetes cluster. This is called _metamonitoring_.
 
 > **Note:** In Grafana, you can create dashboards and receive alerts about those metrics and logs. To set up dashboards and alerts,
-> see [Installing Grafana Mimir dashboards and alerts](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/monitor-grafana-mimir/installing-dashboards-and-alerts/) or [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/).
+> see [Installing Grafana Mimir dashboards and alerts] or [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/).
 
-Alternatively, to monitor the health of your system without using the Helm chart, see [Collect metrics and logs without the Helm chart](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-without-the-helm-chart).
+Alternatively, to monitor the health of your system without using the Helm chart, see [Collect metrics and logs without the Helm chart].
 
 ## Configure the Grafana Agent operator via the Helm chart
 
@@ -138,3 +138,8 @@ metaMonitoring:
           passwordSecretName: gem-tokens
           passwordSecretKey: metamonitoring
 ```
+
+{{% docs/reference %}}
+[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts"
+[Collect metrics and logs without the Helm chart]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs#collect-metrics-and-logs-without-the-helm-chart"
+{{% /docs/reference %}}

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,6 +1,6 @@
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
-MIMIR_DOCS_VERSION := $(shell sed -n 's, *mimir_docs_version: "\([^"]*\)",\1,p' "$(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md")
+MIMIR_DOCS_VERSION := $(shell sed -ne '/^---$/,/^---$/{ s/^ *mimir_docs_version: "\([^"]\{1,\}\)"/\1/p; }' $(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md)
 
 # List of projects to provide to the make-docs script.
 PROJECTS := mimir:$(MIMIR_DOCS_VERSION):mimir-$(MIMIR_DOCS_VERSION) helm-charts/mimir-distributed

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -10,7 +10,8 @@ endif
 # List of projects to provide to the make-docs script.
 PROJECTS := mimir:$(MIMIR_DOCS_VERSION):mimir-$(MIMIR_DOCS_VERSION) helm-charts/mimir-distributed
 
-export REPOS_PATH := $(realpath $(GIT_ROOT)/..)
+GIT_ROOT_PARENT := $(realpath $(GIT_ROOT)/..)
+export REPOS_PATH := $(GIT_ROOT_PARENT)
 
 # Use the doc-validator image defined in CI by default.
 export DOC_VALIDATOR_IMAGE := $(shell sed -n 's, *image: \(grafana/doc-validator.*\),\1,p' "$(GIT_ROOT)/.github/workflows/test-build-deploy.yml")

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -8,7 +8,7 @@ MIMIR_DOCS_BRANCH := $(patsubst v%.x,release-%,$(MIMIR_DOCS_VERSION))
 endif
 
 # List of projects to provide to the make-docs script.
-PROJECTS := mimir:$(MIMIR_DOCS_VERSION):mimir-$(MIMIR_DOCS_VERSION) helm-charts/mimir-distributed
+PROJECTS := mimir:next:mimir mimir:$(MIMIR_DOCS_VERSION):mimir-$(MIMIR_DOCS_VERSION) helm-charts/mimir-distributed
 
 # Parent directory of the current git repository.
 GIT_ROOT_PARENT := $(realpath $(GIT_ROOT)/..)

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -10,8 +10,8 @@ endif
 # List of projects to provide to the make-docs script.
 PROJECTS := mimir:$(MIMIR_DOCS_VERSION):mimir-$(MIMIR_DOCS_VERSION) helm-charts/mimir-distributed
 
+# Parent directory of the current git repository.
 GIT_ROOT_PARENT := $(realpath $(GIT_ROOT)/..)
-export REPOS_PATH := $(GIT_ROOT_PARENT)
 
 # Use the doc-validator image defined in CI by default.
 export DOC_VALIDATOR_IMAGE := $(shell sed -n 's, *image: \(grafana/doc-validator.*\),\1,p' "$(GIT_ROOT)/.github/workflows/test-build-deploy.yml")

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,11 +1,12 @@
+GIT_ROOT := $(shell git rev-parse --show-toplevel)
+
+MIMIR_DOCS_VERSION := $(shell sed -n 's, *mimir_docs_version: "\([^"]*\)",\1,p' "$(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md")
+
 # List of projects to provide to the make-docs script.
-PROJECTS := mimir helm-charts/mimir-distributed
+PROJECTS := mimir:$(MIMIR_DOCS_VERSION):mimir-$(MIMIR_DOCS_VERSION) helm-charts/mimir-distributed
 
 # Use the doc-validator image defined in CI by default.
-export DOC_VALIDATOR_IMAGE := $(shell sed -n 's, *image: \(grafana/doc-validator.*\),\1,p' "$(shell git rev-parse --show-toplevel)/.github/workflows/test-build-deploy.yml")
-
-# Use alternative image until make-docs 3.0.0 is rolled out.
-export DOCS_IMAGE := grafana/docs-base:dbd975af06
+export DOC_VALIDATOR_IMAGE := $(shell sed -n 's, *image: \(grafana/doc-validator.*\),\1,p' "$(GIT_ROOT)/.github/workflows/test-build-deploy.yml")
 
 # Skip some doc-validator checks.
 export DOC_VALIDATOR_SKIP_CHECKS := ^canonical-does-not-match-pretty-URL$

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,9 +1,16 @@
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
-MIMIR_DOCS_VERSION := $(shell sed -ne '/^---$/,/^---$/{ s/^ *mimir_docs_version: "\([^"]\{1,\}\)"/\1/p; }' $(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md)
+MIMIR_DOCS_VERSION := $(shell sed -n 's, *mimir_docs_version: "\([^"]*\)",\1,p' "$(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md")
+ifeq ($(MIMIR_DOCS_VERSION),next)
+MIMIR_DOCS_BRANCH := main
+else
+MIMIR_DOCS_BRANCH := $(patsubst v%.x,release-%,$(MIMIR_DOCS_VERSION))
+endif
 
 # List of projects to provide to the make-docs script.
 PROJECTS := mimir:$(MIMIR_DOCS_VERSION):mimir-$(MIMIR_DOCS_VERSION) helm-charts/mimir-distributed
+
+export REPOS_PATH := $(realpath $(GIT_ROOT)/..)
 
 # Use the doc-validator image defined in CI by default.
 export DOC_VALIDATOR_IMAGE := $(shell sed -n 's, *image: \(grafana/doc-validator.*\),\1,p' "$(GIT_ROOT)/.github/workflows/test-build-deploy.yml")

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,6 +1,6 @@
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
-MIMIR_DOCS_VERSION := $(shell sed -n 's, *mimir_docs_version: "\([^"]*\)",\1,p' "$(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md")
+MIMIR_DOCS_VERSION := $(shell sed -n 's, *MIMIR DOCS VERSION: "\([^"]*\)",\1,p' "$(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md")
 ifeq ($(MIMIR_DOCS_VERSION),next)
 MIMIR_DOCS_BRANCH := main
 else

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,6 +1,6 @@
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
-MIMIR_DOCS_VERSION := $(shell sed -n 's, *MIMIR DOCS VERSION: "\([^"]*\)",\1,p' "$(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md")
+MIMIR_DOCS_VERSION := $(shell sed -n 's, *MIMIR_DOCS_VERSION: "\([^"]*\)",\1,p' "$(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md")
 ifeq ($(MIMIR_DOCS_VERSION),next)
 MIMIR_DOCS_BRANCH := main
 else

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -83,7 +83,7 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
    - Update the Mimir and GEM documentation version parameters in [\_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
 
-     The two parameters are `mimir_docs_version` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
+     The two parameters are `MIMIR DOCS VERSION` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
 
    - From the root directory of the repository, run `make doc` to update [README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md) file.
 

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -83,7 +83,7 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
    - Update the Mimir and GEM documentation version parameters in [\_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
 
-     The two parameters are `MIMIR DOCS VERSION` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
+     The two parameters are `MIMIR_DOCS_VERSION` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
 
    - From the root directory of the repository, run `make doc` to update [README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md) file.
 


### PR DESCRIPTION
This fixes links such as https://grafana.com/docs/helm-charts/mimir-distributed/latest/run-production-environment-with-helm/monitor-system-health/#monitor-the-health-of-your-system:~:text=Collect%20metrics%20and%20logs%20without%20the%20Helm%20chart which come from using the information architecture in `main` rather than that of the version referenced by the Helm chart (`release-2.9`).

- Replace all Mimir docs links with `docs/reference` shortcode
  Supports compile time link checking but requires specific build steps that still need to be properly automated.
  At the moment, the `README.md` explains the steps.
  For more information about the shortcode, refer to https://grafana.com/docs/writers-toolkit/write/shortcodes/#docsreference-shortcode.
- Fix links broken due to referencing wrong information architecture.

- Attempt to correctly build documentation in CI.
   
Closes https://github.com/grafana/mimir/issues/5715

**Notes to reviewers:**

1. Please ensure that you can run `make docs` locally and that you see no build errors.
1. Please ensure that you understand the additional magic in `docs/Makefile` and `docs/variables.mk`.
  If not, let me know how I can help with that. Perhaps you want a extra information in the `docs/README.md`?

