### PR TITLE
CI: build with -tags stringlabels

### DIFF
--- a/.github/workflows/scripts/run-integration-tests-group.sh
+++ b/.github/workflows/scripts/run-integration-tests-group.sh
@@ -37,7 +37,7 @@ if [[ -z "$TOTAL" ]]; then
 fi
 
 # List all tests.
-ALL_TESTS=$(go test -tags=requires_docker -list 'Test.*' "${INTEGRATION_DIR}/..." | grep -E '^Test.*' | sort)
+ALL_TESTS=$(go test -tags=requires_docker,stringlabels -list 'Test.*' "${INTEGRATION_DIR}/..." | grep -E '^Test.*' | sort)
 
 # Filter tests by the requested group.
 GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL=$TOTAL -v INDEX=$INDEX 'NR % TOTAL == INDEX')
@@ -53,4 +53,4 @@ for TEST in $GROUP_TESTS; do
 done
 REGEX="${REGEX})$"
 
-exec go test -tags=requires_docker -timeout 2400s -v -count=1 -run "${REGEX}" "${INTEGRATION_DIR}/..."
+exec go test -tags=requires_docker,stringlabels -timeout 2400s -v -count=1 -run "${REGEX}" "${INTEGRATION_DIR}/..."

--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -47,4 +47,4 @@ echo "$GROUP_TESTS"
 echo ""
 
 # shellcheck disable=SC2086 # we *want* word splitting of GROUP_TESTS.
-exec go test -tags=netgo -timeout 30m -race -count 1 ${GROUP_TESTS}
+exec go test -tags=netgo,stringlabels -timeout 30m -race -count 1 ${GROUP_TESTS}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -228,34 +228,6 @@ jobs:
           echo "Running unit tests (group ${{ matrix.test_group_id }} of ${{ matrix.test_group_total }}) with Go version: $(go version)"
           ./.github/workflows/scripts/run-unit-tests-group.sh --index ${{ matrix.test_group_id }} --total ${{ matrix.test_group_total }}
 
-  test-stringlabels:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare
-    container:
-      image: ${{ needs.prepare.outputs.build_image }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-      - name: Run Git Config
-        run: git config --global --add safe.directory '*'
-      - name: Symlink Expected Path to Workspace
-        run: |
-          mkdir -p /go/src/github.com/grafana/mimir
-          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      - name: Get Go build cache path
-        id: gocache
-        run: |
-          echo "path=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-      - name: Cache Go build cache
-        uses: actions/cache@v3
-        with:
-          key: build-go-test-stringlabels-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
-          path: ${{ steps.gocache.outputs.path }}
-      - name: Run Tests with -tags stringlabels
-        run: |
-          go test -tags=netgo,stringlabels -timeout 5m -count 1 ./...
-
   test-docs:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ run:
   # List of build tags, all linters use it.
   build-tags:
     - netgo
+    - stringlabels
     - requires_docker
     - requires_libpcap
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 * [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. #5195 #5389
 * [ENHANCEMENT] Querier: add experimental `-querier.minimize-ingester-requests` option to initially query only the minimum set of ingesters required to reach quorum. #5202 #5259 #5263
 * [ENHANCEMENT] Querier: improve error message when streaming chunks from ingesters to queriers and a query limit is reached. #5245
-* [ENHANCEMENT] Use new data structure for labels, to reduce memory consumption. #3555
+* [ENHANCEMENT] Use new data structure for labels, to reduce memory consumption. #3555, #5731
 * [ENHANCEMENT] Update alpine base image to 3.18.2. #5276
 * [ENHANCEMENT] Ruler: add `cortex_ruler_sync_rules_duration_seconds` metric, tracking the time spent syncing all rule groups owned by the ruler instance. #5311
 * [ENHANCEMENT] Store-gateway: add experimental `blocks-storage.bucket-store.index-header-lazy-loading-concurrency` config option to limit the number of concurrent index-headers loads when lazy loading. #5313 #5605

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 * [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. #5195 #5389
 * [ENHANCEMENT] Querier: add experimental `-querier.minimize-ingester-requests` option to initially query only the minimum set of ingesters required to reach quorum. #5202 #5259 #5263
 * [ENHANCEMENT] Querier: improve error message when streaming chunks from ingesters to queriers and a query limit is reached. #5245
-* [ENHANCEMENT] Use new data structure for labels, to reduce memory consumption. #3555, #5731
+* [ENHANCEMENT] Use new data structure for labels, to reduce memory consumption. #3555 #5731
 * [ENHANCEMENT] Update alpine base image to 3.18.2. #5276
 * [ENHANCEMENT] Ruler: add `cortex_ruler_sync_rules_duration_seconds` metric, tracking the time spent syncing all rule groups owned by the ruler instance. #5311
 * [ENHANCEMENT] Store-gateway: add experimental `blocks-storage.bucket-store.index-header-lazy-loading-concurrency` config option to limit the number of concurrent index-headers loads when lazy loading. #5313 #5605

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ GO_FLAGS := -ldflags "\
 		-X $(MIMIR_VERSION).Branch=$(GIT_BRANCH) \
 		-X $(MIMIR_VERSION).Revision=$(GIT_REVISION) \
 		-X $(MIMIR_VERSION).Version=$(VERSION) \
-		-extldflags \"-static\" -s -w" -tags netgo
+		-extldflags \"-static\" -s -w" -tags netgo,stringlabels
 
 ifeq ($(BUILD_IN_CONTAINER),true)
 
@@ -242,7 +242,7 @@ lint: check-makefiles
 	golangci-lint run
 
 	# Ensure no blocklisted package is imported.
-	GOFLAGS="-tags=requires_docker" faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
+	GOFLAGS="-tags=requires_docker,stringlabels" faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
 		golang.org/x/net/context=context,\
 		sync/atomic=go.uber.org/atomic,\
 		regexp=github.com/grafana/regexp,\
@@ -297,7 +297,7 @@ lint: check-makefiles
 		./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Ensure packages we imported from Thanos are no longer used.
-	GOFLAGS="-tags=requires_docker" faillint -paths \
+	GOFLAGS="-tags=requires_docker,stringlabels" faillint -paths \
 		"github.com/thanos-io/thanos/pkg/..." \
 		./pkg/... ./cmd/... ./tools/... ./integration/...
 
@@ -338,12 +338,12 @@ print-go-version: ## Print the go version.
 	@go version | awk '{print $$3}' | sed 's/go//'
 
 test-with-race: ## Run all unit tests with data race detect.
-	go test -tags netgo -timeout 30m -race -count 1 ./...
+	go test -tags netgo,stringlabels -timeout 30m -race -count 1 ./...
 
 cover: ## Run all unit tests with code coverage and generates reports.
 	$(eval COVERDIR := $(shell mktemp -d coverage.XXXXXXXXXX))
 	$(eval COVERFILE := $(shell mktemp $(COVERDIR)/unit.XXXXXXXXXX))
-	go test -tags netgo -timeout 30m -race -count 1 -coverprofile=$(COVERFILE) ./...
+	go test -tags netgo,stringlabels -timeout 30m -race -count 1 -coverprofile=$(COVERFILE) ./...
 	go tool cover -html=$(COVERFILE) -o cover.html
 	go tool cover -func=cover.html | tail -n1
 
@@ -606,7 +606,7 @@ check-mimir-read-write-mode-docker-compose-yaml: ## Check the jsonnet and docker
 
 integration-tests: ## Run all integration tests.
 integration-tests: cmd/mimir/$(UPTODATE)
-	go test -tags=requires_docker ./integration/...
+	go test -tags=requires_docker,stringlabels ./integration/...
 
 web-serve:
 	cd website && hugo --config config.toml --minify -v server


### PR DESCRIPTION
#### What this PR does

Change the tags used in CI to include `stringlabels`.
This uses less memory, especially in ingesters.  See #3555.

#### Checklist

- [x] Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
