### PR TITLE
Scale on OOMs for autoscaling components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,8 +189,9 @@
 * [ENHANCEMENT] Add _config.commonConfig to allow adding common configuration parameters for all Mimir components. #5703
 * [ENHANCEMENT] Update rollout-operator to `v0.7.0`. #5718
 * [ENHANCEMENT] Increase the default rollout speed for store-gateway when lazy loading is disabled. #5823
+* [ENHANCEMENT] Add autoscaling on memory for ruler-queriers. #5739
 * [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
-* [ENHANCEMENT] Autoscaling: treat OOMing containers as though they are using their full memory request. #5739
+* [BUGFIX] Autoscaling: treat OOMing containers as though they are using their full memory request. #5739
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@
 * [BUGFIX] Alerts: fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts. #5396
 * [BUGFIX] Alerts: Fix `MimirGossipMembersMismatch` to include `admin-api` and custom compactor pods. `admin-api` is a GEM component. #5641 #5797
 * [BUGFIX] Dashboards: fix autoscaling dashboard panels that could show multiple series for a single component. #5810
+* [BUGFIX] Dashboards: fix ruler-querier scaling metric panel query and split into CPU and memory scaling metric panels. #5739
 
 ### Jsonnet
 
@@ -189,6 +190,7 @@
 * [ENHANCEMENT] Update rollout-operator to `v0.7.0`. #5718
 * [ENHANCEMENT] Increase the default rollout speed for store-gateway when lazy loading is disabled. #5823
 * [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
+* [ENHANCEMENT] Autoscaling: treat OOMing containers as though they are using their full memory request. #5739
 
 ### Mimirtool
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -26967,7 +26967,7 @@ data:
                       "renderer": "flot",
                       "seriesOverrides": [ ],
                       "spaceLength": 10,
-                      "span": 4,
+                      "span": 3,
                       "stack": false,
                       "steppedLine": false,
                       "targets": [
@@ -27062,7 +27062,7 @@ data:
                          }
                       ],
                       "spaceLength": 10,
-                      "span": 4,
+                      "span": 3,
                       "stack": false,
                       "steppedLine": false,
                       "targets": [
@@ -27123,7 +27123,7 @@ data:
                       "dashLength": 10,
                       "dashes": false,
                       "datasource": "$datasource",
-                      "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler does not work properly.\n\n",
+                      "description": "### Scaling metric (memory): Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold used.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
                       "fill": 1,
                       "id": 13,
                       "legend": {
@@ -27145,7 +27145,83 @@ data:
                       "renderer": "flot",
                       "seriesOverrides": [ ],
                       "spaceLength": 10,
-                      "span": 4,
+                      "span": 3,
+                      "stack": false,
+                      "steppedLine": false,
+                      "targets": [
+                         {
+                            "expr": "keda_metrics_adapter_scaler_metrics_value{metric=~\".*memory.*\"}\n/\non(metric) group_left label_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ruler-querier\"},\n    \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                            "format": "time_series",
+                            "intervalFactor": 2,
+                            "legendFormat": "{{ scaledObject }}",
+                            "legendLink": null
+                         }
+                      ],
+                      "thresholds": [ ],
+                      "timeFrom": null,
+                      "timeShift": null,
+                      "title": "Scaling metric (memory): Desired replicas",
+                      "tooltip": {
+                         "shared": false,
+                         "sort": 0,
+                         "value_type": "individual"
+                      },
+                      "type": "graph",
+                      "xaxis": {
+                         "buckets": null,
+                         "mode": "time",
+                         "name": null,
+                         "show": true,
+                         "values": [ ]
+                      },
+                      "yaxes": [
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                         },
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                         }
+                      ]
+                   },
+                   {
+                      "aliasColors": { },
+                      "bars": false,
+                      "dashLength": 10,
+                      "dashes": false,
+                      "datasource": "$datasource",
+                      "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler does not work properly.\n\n",
+                      "fill": 1,
+                      "id": 14,
+                      "legend": {
+                         "avg": false,
+                         "current": false,
+                         "max": false,
+                         "min": false,
+                         "show": true,
+                         "total": false,
+                         "values": false
+                      },
+                      "lines": true,
+                      "linewidth": 1,
+                      "links": [ ],
+                      "nullPointMode": "null as zero",
+                      "percentage": false,
+                      "pointradius": 5,
+                      "points": false,
+                      "renderer": "flot",
+                      "seriesOverrides": [ ],
+                      "spaceLength": 10,
+                      "span": 3,
                       "stack": false,
                       "steppedLine": false,
                       "targets": [

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -835,7 +835,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 4,
+                  "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -930,7 +930,7 @@
                      }
                   ],
                   "spaceLength": 10,
-                  "span": 4,
+                  "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -991,7 +991,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler does not work properly.\n\n",
+                  "description": "### Scaling metric (memory): Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold used.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
                   "fill": 1,
                   "id": 13,
                   "legend": {
@@ -1013,7 +1013,83 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 4,
+                  "span": 3,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "keda_metrics_adapter_scaler_metrics_value{metric=~\".*memory.*\"}\n/\non(metric) group_left label_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ruler-querier\"},\n    \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{ scaledObject }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Scaling metric (memory): Desired replicas",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler does not work properly.\n\n",
+                  "fill": 1,
+                  "id": 14,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -835,7 +835,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 4,
+                  "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -930,7 +930,7 @@
                      }
                   ],
                   "spaceLength": 10,
-                  "span": 4,
+                  "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -991,7 +991,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler does not work properly.\n\n",
+                  "description": "### Scaling metric (memory): Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold used.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
                   "fill": 1,
                   "id": 13,
                   "legend": {
@@ -1013,7 +1013,83 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 4,
+                  "span": 3,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "keda_metrics_adapter_scaler_metrics_value{metric=~\".*memory.*\"}\n/\non(metric) group_left label_replace(\n    kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ruler-querier\"},\n    \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{ scaledObject }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Scaling metric (memory): Desired replicas",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler does not work properly.\n\n",
+                  "fill": 1,
+                  "id": 14,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 3,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
@@ -144,6 +144,34 @@ local filename = 'mimir-remote-ruler-reads.json';
         $.panelAxisPlacement('Target per replica', 'right'),
       )
       .addPanel(
+        local title = 'Scaling metric (memory): Desired replicas';
+        $.panel(title) +
+        $.queryPanel(
+          [
+            |||
+              keda_metrics_adapter_scaler_metrics_value{metric=~".*memory.*"}
+              /
+              on(metric) group_left label_replace(
+                  kube_horizontalpodautoscaler_spec_target_metric{%(namespace)s, horizontalpodautoscaler=~"%(hpa_name)s"},
+                  "metric", "$1", "metric_name", "(.+)"
+              )
+            ||| % {
+              hpa_name: $._config.autoscaling.ruler_querier.hpa_name,
+              namespace: $.namespaceMatcher(),
+            },
+          ], [
+            '{{ scaledObject }}',
+          ]
+        ) +
+        $.panelDescription(
+          title,
+          |||
+            This panel shows the scaling metric exposed by KEDA divided by the target/threshold used.
+            It should represent the desired number of replicas, ignoring the min/max constraints applied later.
+          |||
+        ),
+      )
+      .addPanel(
         local title = 'Autoscaler failures rate';
         $.panel(title) +
         $.queryPanel(

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1948,6 +1948,16 @@ spec:
             max by (pod) (up{container="alertmanager",namespace="default"}) > 0
           )[15m:]
         )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "9556302233"
     type: prometheus
@@ -1993,6 +2003,16 @@ spec:
             sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
             and
             max by (pod) (up{container="distributor",namespace="default"}) > 0
+          )[15m:]
+        )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
           )[15m:]
         )
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2069,6 +2089,16 @@ spec:
             max by (pod) (up{container="query-frontend",namespace="default"}) > 0
           )[15m:]
         )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "559939584"
     type: prometheus
@@ -2114,6 +2144,16 @@ spec:
             sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
             and
             max by (pod) (up{container="ruler",namespace="default"}) > 0
+          )[15m:]
+        )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
           )[15m:]
         )
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2163,6 +2203,16 @@ spec:
             max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
           )[15m:]
         )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "955630223"
     type: prometheus
@@ -2208,6 +2258,16 @@ spec:
             sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
             and
             max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+          )[15m:]
+        )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
           )[15m:]
         )
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2153,6 +2153,19 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "178"
     type: prometheus
+  - metadata:
+      metricName: ruler_querier_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="ruler-querier",namespace="default"})
+            and
+            max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
+          )[15m:]
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "955630223"
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1949,14 +1949,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="alertmanager", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "9556302233"
@@ -2006,14 +2005,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "3058016714"
@@ -2090,14 +2088,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="query-frontend", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "559939584"
@@ -2147,14 +2144,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "5733781340"
@@ -2204,14 +2200,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-querier", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "955630223"
@@ -2261,14 +2256,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-query-frontend", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "559939584"

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization.jsonnet
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization.jsonnet
@@ -5,6 +5,7 @@
 
     autoscaling_querier_target_utilization: targetUtilization,
     autoscaling_ruler_querier_cpu_target_utilization: targetUtilization,
+    autoscaling_ruler_querier_memory_target_utilization: targetUtilization,
     autoscaling_distributor_cpu_target_utilization: targetUtilization,
     autoscaling_distributor_memory_target_utilization: targetUtilization,
     autoscaling_ruler_cpu_target_utilization: targetUtilization,

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1948,6 +1948,16 @@ spec:
             max by (pod) (up{container="alertmanager",namespace="default"}) > 0
           )[15m:]
         )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "10737418240"
     type: prometheus
@@ -1993,6 +2003,16 @@ spec:
             sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
             and
             max by (pod) (up{container="distributor",namespace="default"}) > 0
+          )[15m:]
+        )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
           )[15m:]
         )
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2069,6 +2089,16 @@ spec:
             max by (pod) (up{container="query-frontend",namespace="default"}) > 0
           )[15m:]
         )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"
     type: prometheus
@@ -2114,6 +2144,16 @@ spec:
             sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
             and
             max by (pod) (up{container="ruler",namespace="default"}) > 0
+          )[15m:]
+        )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
           )[15m:]
         )
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2163,6 +2203,16 @@ spec:
             max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
           )[15m:]
         )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
+          )[15m:]
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1073741824"
     type: prometheus
@@ -2208,6 +2258,16 @@ spec:
             sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
             and
             max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+          )[15m:]
+        )
+        +
+        max_over_time(
+          (
+            sum(
+              sum by (pod) (kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"})
+              and
+              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
+            ) or vector(0)
           )[15m:]
         )
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1949,14 +1949,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="alertmanager", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "10737418240"
@@ -2006,14 +2005,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "3435973836"
@@ -2090,14 +2088,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="query-frontend", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"
@@ -2147,14 +2144,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6442450944"
@@ -2204,14 +2200,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-querier", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1073741824"
@@ -2261,14 +2256,13 @@ spec:
           )[15m:]
         )
         +
-        max_over_time(
-          (
-            sum(
-              sum by (pod) (kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"})
-              and
-              max by (pod) (kube_pod_container_status_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
-            ) or vector(0)
-          )[15m:]
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-query-frontend", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2153,6 +2153,19 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "200"
     type: prometheus
+  - metadata:
+      metricName: ruler_querier_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (container_memory_working_set_bytes{container="ruler-querier",namespace="default"})
+            and
+            max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
+          )[15m:]
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "1073741824"
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -205,14 +205,13 @@
       )[15m:]
     )
     +
-    max_over_time(
-      (
-        sum(
-          sum by (pod) (kube_pod_container_resource_requests{container="%(container)s", namespace="%(namespace)s", resource="memory"})
-          and
-          max by (pod) (kube_pod_container_status_terminated_reason{container="%(container)s", namespace="%(namespace)s", reason="OOMKilled"})
-        ) or vector(0)
-      )[15m:]
+    sum(
+      sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="%(container)s", namespace="%(namespace)s", resource="memory"}[15m]))
+      and
+      max by (pod) (changes(kube_pod_container_status_restarts_total{container="%(container)s", namespace="%(namespace)s"}[15m]) > 0)
+      and
+      max by (pod) (kube_pod_container_status_last_terminated_reason{container="%(container)s", namespace="%(namespace)s", reason="OOMKilled"})
+      or vector(0)
     )
   |||,
 

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -417,7 +417,16 @@
   // Distributors
   //
 
-  newDistributorScaledObject(name, distributor_cpu_requests, distributor_memory_requests, min_replicas, max_replicas, cpu_target_utilization, memory_target_utilization):: self.newScaledObject(name, $._config.namespace, {
+  newDistributorScaledObject(
+    name,
+    distributor_cpu_requests,
+    distributor_memory_requests,
+    min_replicas,
+    max_replicas,
+    cpu_target_utilization,
+    memory_target_utilization,
+    use_oom_trigger=false
+  ):: self.newScaledObject(name, $._config.namespace, {
     min_replica_count: min_replicas,
     max_replica_count: max_replicas,
 
@@ -436,7 +445,7 @@
       {
         metric_name: 'cortex_%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-        query: memoryHPAQuery % {
+        query: (if use_oom_trigger then oomMemoryHPAQuery else memoryHPAQuery) % {
           container: name,
           namespace: $._config.namespace,
         },
@@ -465,7 +474,7 @@
 
   // Ruler
 
-  local newRulerScaledObject(name) = self.newScaledObject(
+  local newRulerScaledObject(name, use_oom_trigger=false) = self.newScaledObject(
     name, $._config.namespace, {
       min_replica_count: $._config.autoscaling_ruler_min_replicas,
       max_replica_count: $._config.autoscaling_ruler_max_replicas,
@@ -489,7 +498,7 @@
         {
           metric_name: '%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-          query: memoryHPAQuery % {
+          query: (if use_oom_trigger then oomMemoryHPAQuery else memoryHPAQuery) % {
             container: name,
             namespace: $._config.namespace,
           },
@@ -516,7 +525,16 @@
 
   // Alertmanager
 
-  newAlertmanagerScaledObject(name, alertmanager_cpu_requests, alertmanager_memory_requests, min_replicas, max_replicas, cpu_target_utilization, memory_target_utilization):: self.newScaledObject(name, $._config.namespace, {
+  newAlertmanagerScaledObject(
+    name,
+    alertmanager_cpu_requests,
+    alertmanager_memory_requests,
+    min_replicas,
+    max_replicas,
+    cpu_target_utilization,
+    memory_target_utilization,
+    use_oom_trigger=false,
+  ):: self.newScaledObject(name, $._config.namespace, {
     min_replica_count: min_replicas,
     max_replica_count: max_replicas,
 
@@ -537,7 +555,7 @@
       {
         metric_name: 'cortex_%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
-        query: memoryHPAQuery % {
+        query: (if use_oom_trigger then oomMemoryHPAQuery else memoryHPAQuery) % {
           container: name,
           namespace: $._config.namespace,
         },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR updates the memory scaling trigger for autoscaling components so that they treat OOMing containers as utilizing their entire memory request. It also adds a memory scaling trigger to ruler-queriers, which previously only scaled on CPU. Previously, if ruler-queriers OOMed and CPU usage went down, they would scale down, putting more memory pressure on the remaining ruler-queriers. 

This also updates the remote ruler reads dashboard to fix a panel query bug, and separates panels for ruler-querier CPU and memory scaling metrics.

#### Which issue(s) this PR fixes or relates to
(none)

#### Checklist

- [x] Tests updated
`N/A` Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
