### PR TITLE
Fix linting issue

### DIFF
--- a/pkg/querier/worker/frontend_processor.go
+++ b/pkg/querier/worker/frontend_processor.go
@@ -99,7 +99,7 @@ func (fp *frontendProcessor) process(c frontendv1pb.Frontend_ProcessClient, infl
 	ctx, cancel := context.WithCancel(c.Context())
 	defer cancel()
 
-	for {
+	for ctx.Err() == nil {
 		request, err := c.Recv()
 		if err != nil {
 			return err
@@ -133,6 +133,8 @@ func (fp *frontendProcessor) process(c frontendv1pb.Frontend_ProcessClient, infl
 			return fmt.Errorf("unknown request type: %v", request.Type)
 		}
 	}
+
+	return ctx.Err()
 }
 
 func (fp *frontendProcessor) runRequest(ctx context.Context, request *httpgrpc.HTTPRequest, statsEnabled bool, sendHTTPResponse func(response *httpgrpc.HTTPResponse, stats *querier_stats.Stats) error) {


### PR DESCRIPTION
#### What this PR does
I currently get a linting failure when running `make lint` locally, in pkg/querier/worker:

```
$ make lint
[...]
pkg/querier/worker/frontend_processor.go:86:43: SA4023: this comparison is always true (staticcheck)
		if err := fp.process(c, inflightQuery); err != nil {
		                                       ^
pkg/querier/worker/frontend_processor.go:97:30: SA4023(related information): (*github.com/grafana/mimir/pkg/querier/worker.frontendProcessor).process never returns a nil interface value (staticcheck)
func (fp *frontendProcessor) process(c frontendv1pb.Frontend_ProcessClient, inflightQuery *atomic.Bool) error {
[...]
```

What the linter reacts to is that `pkg/querier/worker.frontendProcessor.process` executes a `for` loop, that seemingly never terminates until there's an error. By making `ctx.Err() == nil` a condition for the `for` loop, the linting failure goes away. I think the change should make no behavioral difference.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
