### PR TITLE
Allow configuration of podManagementPolicy 

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,6 +33,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Sets the `appProtocol` value to `tcp` for the `gossip-ring-svc` service template. This allows memberlist to work with istio protocol selection. #5673
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.8.0`. #5718
 * [BUGFIX] Fix `global.podLabels` causing invalid indentation. #5625
+* [ENHANCEMENT] Make store_gateway podManagementPolicy configurable. #5733
 
 ## 5.0.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,8 +32,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Querier: dynamically set `GOMAXPROCS` based on the CPU request. This should reduce noisy neighbour issues created by the querier, whose CPU utilization could eventually saturate the Kubernetes node if unbounded. #5646
 * [ENHANCEMENT] Sets the `appProtocol` value to `tcp` for the `gossip-ring-svc` service template. This allows memberlist to work with istio protocol selection. #5673
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.8.0`. #5718
+* [ENHANCEMENT] Make store_gateway podManagementPolicy configurable. #5757
 * [BUGFIX] Fix `global.podLabels` causing invalid indentation. #5625
-* [ENHANCEMENT] Make store_gateway podManagementPolicy configurable. #5733
 
 ## 5.0.0
 

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- include "mimir.componentAnnotations" $args | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  podManagementPolicy: {{ .Values.store_gateway.podManagementPolicy }}
   replicas: {{ $rolloutZone.replicas }}
   selector:
     matchLabels:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1367,7 +1367,9 @@ store_gateway:
   podAnnotations: {}
 
   # -- Management policy for store-gateway pods
-  podManagementPolicy: Parallel
+  # New variable introduced with Helm chart version 5.1.0. For backwards compatibility it is set to `OrderedReady`
+  # On new deployments it is highly recommended to switch it to `Parallel` as this will be the new default from 6.0.0
+  podManagementPolicy: OrderedReady
 
   # -- Pod Disruption Budget for store-gateway, this will be applied across availability zones to prevent losing redundancy
   podDisruptionBudget:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1366,6 +1366,9 @@ store_gateway:
   # Pod Annotations
   podAnnotations: {}
 
+  # -- Management policy for chunks-cache pods
+  podManagementPolicy: Parallel
+
   # -- Pod Disruption Budget for store-gateway, this will be applied across availability zones to prevent losing redundancy
   podDisruptionBudget:
     maxUnavailable: 1

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1366,7 +1366,7 @@ store_gateway:
   # Pod Annotations
   podAnnotations: {}
 
-  # -- Management policy for chunks-cache pods
+  # -- Management policy for store-gateway pods
   podManagementPolicy: Parallel
 
   # -- Pod Disruption Budget for store-gateway, this will be applied across availability zones to prevent losing redundancy

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -173,7 +173,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -329,7 +329,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -172,6 +173,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -327,6 +329,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -164,7 +164,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -311,7 +311,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -163,6 +164,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -309,6 +311,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -158,6 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -299,6 +301,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -159,7 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -301,7 +301,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 2
   selector:
     matchLabels:
@@ -172,6 +173,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 2
   selector:
     matchLabels:
@@ -327,6 +329,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 2
   selector:
     matchLabels:
@@ -173,7 +173,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 2
   selector:
     matchLabels:
@@ -329,7 +329,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -161,7 +161,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -305,7 +305,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -160,6 +161,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -303,6 +305,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -158,6 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -299,6 +301,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -159,7 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -301,7 +301,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -173,7 +173,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -329,7 +329,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -172,6 +173,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -327,6 +329,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -164,7 +164,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -311,7 +311,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -163,6 +164,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -309,6 +311,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -15,6 +15,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -153,6 +154,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -291,6 +293,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -15,7 +15,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -154,7 +154,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -293,7 +293,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -161,7 +161,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -305,7 +305,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -160,6 +161,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -303,6 +305,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -158,6 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -299,6 +301,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -159,7 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -301,7 +301,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -146,7 +146,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -275,7 +275,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -145,6 +146,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -273,6 +275,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -170,6 +171,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -323,6 +325,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -171,7 +171,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -325,7 +325,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -164,7 +164,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -311,7 +311,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -163,6 +164,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -309,6 +311,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,7 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -166,7 +166,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:
@@ -315,7 +315,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -165,6 +166,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -313,6 +315,7 @@ metadata:
     rollout-max-unavailable: "50"
   namespace: "citestns"
 spec:
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
#### What this PR does
This PR allows the configuration of the podManagementPolicy for the store-gateway statefulset through the helm chart.

#### Which issue(s) this PR fixes or relates to

Fixes #5733

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
