### PR TITLE
Increase required Go version to 1.20 for better generics support

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -11,12 +11,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"runtime"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
@@ -189,9 +187,6 @@ func main() {
 			defer trace.Close()
 		}
 	}
-
-	// Initialise seed for randomness usage.
-	rand.Seed(time.Now().UnixNano())
 
 	t, err := mimir.New(cfg, prometheus.DefaultRegisterer)
 	util_log.CheckFatal("initializing application", err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/mimir
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -789,7 +789,7 @@ func TestSplitAndCacheMiddleware_ResultsCacheFuzzy(t *testing.T) {
 
 	// Randomise the seed but log it in case we need to reproduce the test on failure.
 	seed := time.Now().UnixNano()
-	rand.Seed(seed)
+	rnd := rand.New(rand.NewSource(seed))
 	t.Log("random generator seed:", seed)
 
 	// The mocked storage contains samples within the following min/max time.
@@ -816,8 +816,8 @@ func TestSplitAndCacheMiddleware_ResultsCacheFuzzy(t *testing.T) {
 	reqs := make([]Request, 0, numQueries)
 	for q := 0; q < numQueries; q++ {
 		// Generate a random time range within min/max time.
-		startTime := minTime.Add(time.Duration(rand.Int63n(maxTime.Sub(minTime).Milliseconds())) * time.Millisecond)
-		endTime := startTime.Add(time.Duration(rand.Int63n(maxTime.Sub(startTime).Milliseconds())) * time.Millisecond)
+		startTime := minTime.Add(time.Duration(rnd.Int63n(maxTime.Sub(minTime).Milliseconds())) * time.Millisecond)
+		endTime := startTime.Add(time.Duration(rnd.Int63n(maxTime.Sub(startTime).Milliseconds())) * time.Millisecond)
 
 		reqs = append(reqs, &PrometheusRangeQueryRequest{
 			Id:    int64(q),

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1876,7 +1876,6 @@ func TestCanBlockWithCompactorShardIdContainQueryShard(t *testing.T) {
 	const numSeries = 1000
 	const maxShards = 512
 
-	rand.Seed(time.Now().UnixNano())
 	hashes := make([]uint64, numSeries)
 	for ix := 0; ix < numSeries; ix++ {
 		hashes[ix] = rand.Uint64()

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
 	"net/http"
 	"os"
 	"path"
@@ -295,11 +294,6 @@ func TestStoreGateway_InitialSyncWithWaitRingTokensStability(t *testing.T) {
 			bucketIndexEnabled := bucketIndexEnabled
 			t.Run(fmt.Sprintf("%s (bucket index enabled = %v)", testName, bucketIndexEnabled), func(t *testing.T) {
 				t.Parallel()
-				// Randomize the seed but log it in case we need to reproduce the test on failure.
-				seed := time.Now().UnixNano()
-				rand.Seed(seed)
-				t.Log("random generator seed:", seed)
-
 				ctx := context.Background()
 				ringStore, closer := consul.NewInMemoryClientWithConfig(ring.GetCodec(), consul.Config{
 					MaxCasRetries: 20,
@@ -396,11 +390,6 @@ func TestStoreGateway_BlocksSyncWithDefaultSharding_RingTopologyChangedAfterScal
 	for _, userID := range []string{"user-1", "user-2"} {
 		createBucketIndex(t, bucketClient, userID)
 	}
-
-	// Randomise the seed but log it in case we need to reproduce the test on failure.
-	seed := time.Now().UnixNano()
-	rand.Seed(seed)
-	t.Log("random generator seed:", seed)
 
 	ctx := context.Background()
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -4,6 +4,7 @@ package storegateway
 
 import (
 	"context"
+	crand "crypto/rand"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -1149,7 +1150,7 @@ func generateSeriesEntriesWithChunksSize(t testing.TB, numSeries, numChunksPerSe
 
 		for j := 0; j < numChunksPerSeries; j++ {
 			chunkBytes := make([]byte, chunkDataLenBytes)
-			readBytes, err := rand.Read(chunkBytes)
+			readBytes, err := crand.Read(chunkBytes)
 			require.NoError(t, err, "couldn't generate test data")
 			require.Equal(t, chunkDataLenBytes, readBytes, "couldn't generate test data")
 


### PR DESCRIPTION
#### What this PR does
Increase required Go version in go.mod from 1.19 to 1.20, and stop using [`math/rand.Seed`](https://pkg.go.dev/math/rand#Seed) as it's deprecated, and seeding happens automatically at program start, from this version of Go (causes a linter failure). Also deprecated (and failing linter), replace `math/rand.Read` with `crypto/rand.Read`.

`rand.Seed` should only be necessary where deterministic behaviour is needed, in which case you can replace it with a local (explicitly seeded) generator; I could only find one test explicitly using seeded randomness (for reproducibility), so I converted that one to using a local, explicitly seeded, generator. I removed `rand.Seed` from other tests, where I can't see it making a difference. If it should turn out to be useful from implicit `rand` uses, we could fix those cases to use a local generator in retrospect.

Requiring Go 1.20+ is necessary for my [PR](https://github.com/grafana/mimir/pull/5730) to upgrade to github.com/hashicorp/golang-lru v2 (v0/v1 are discontinued), as Go 1.19 can't compile involved generics code.

This PR should cause _no_ behavioral changes.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
