### PR TITLE
Verify time range of compacted block matches time range of input blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * [ENHANCEMENT] Compactor: Delete bucket-index, markers and debug files if there are no blocks left in the bucket index. This cleanup must be enabled by using `-compactor.no-blocks-file-cleanup-enabled` option. #5648
 * [ENHANCEMENT] Ingester: reduce memory usage of active series tracker. #5665
 * [ENHANCEMENT] Store-gateway: added `-store-gateway.sharding-ring.auto-forget-enabled` configuration parameter to control whether store-gateway auto-forget feature should be enabled or disabled (enabled by default). #5702
+* [ENHANCEMENT] Compactor: Verify time range of compacted block(s) matches the time range of input blocks. #5760
 * [ENHANCEMENT] Querier: improved observability of calls to ingesters during queries. #5724
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -363,9 +363,8 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 	uploadedBlocks := atomic.NewInt64(0)
 
 	if err = verifyCompactedBlocksTimeRanges(ctx, compIDs, toCompactMinTime.UnixMilli(), toCompactMaxTime.UnixMilli(), c.blockSyncConcurrency, subDir); err != nil {
-		level.Error(jobLogger).Log("msg", "compacted blocks do not satisfy the min/max time ranges from the input blocks")
+		level.Error(jobLogger).Log("msg", err)
 		c.metrics.groupCompactionBlocksVerificationFailed.Inc()
-		return false, nil, err
 	}
 
 	blocksToUpload := convertCompactionResultToForEachJobs(compIDs, job.UseSplitting(), jobLogger)

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -364,7 +364,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 	uploadedBlocks := atomic.NewInt64(0)
 
 	if err = verifyCompactedBlocksTimeRanges(compIDs, toCompactMinTime.UnixMilli(), toCompactMaxTime.UnixMilli(), subDir); err != nil {
-		level.Error(jobLogger).Log("msg", "compacted blocks verification failed", "err", err)
+		level.Warn(jobLogger).Log("msg", "compacted blocks verification failed", "err", err)
 		c.metrics.compactionBlocksVerificationFailed.Inc()
 	}
 

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -364,7 +364,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 	uploadedBlocks := atomic.NewInt64(0)
 
 	if err = verifyCompactedBlocksTimeRanges(compIDs, toCompactMinTime.UnixMilli(), toCompactMaxTime.UnixMilli(), subDir); err != nil {
-		level.Error(jobLogger).Log("msg", err)
+		level.Error(jobLogger).Log("msg", "compacted blocks verification failed", "err", err)
 		c.metrics.compactionBlocksVerificationFailed.Inc()
 	}
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -752,7 +752,7 @@ func (c *MultitenantCompactor) compactUser(ctx context.Context, userID string) e
 		path.Join(c.compactorCfg.DataDir, "compact"),
 		userBucket,
 		c.compactorCfg.CompactionConcurrency,
-		true, // Skip blocks without of order chunks, and mark them for no-compaction.
+		true, // Skip blocks with out of order chunks, and mark them for no-compaction.
 		c.shardingStrategy.ownJob,
 		c.jobsOrder,
 		c.compactorCfg.CompactionWaitPeriod,

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1291,9 +1291,12 @@ func TestMultitenantCompactor_ShouldFailWithInvalidTSDBCompactOutput(t *testing.
 	mockCall := tsdbCompactor.On("Compact", mock.Anything, mock.Anything, mock.Anything)
 	mockCall.RunFn = func(args mock.Arguments) {
 		dir := args.Get(0).(string)
+
 		compactedMeta, err := block.GenerateBlockFromSpec(user, dir, outputBlockSpec)
 		require.NoError(t, err)
-		os.OpenFile(filepath.Join(dir, compactedMeta.ULID.String(), "tombstones"), os.O_RDONLY|os.O_CREATE, 0666)
+
+		_, err = os.OpenFile(filepath.Join(dir, compactedMeta.ULID.String(), "tombstones"), os.O_RDONLY|os.O_CREATE, 0666)
+		require.NoError(t, err)
 
 		mockCall.ReturnArguments = mock.Arguments{compactedMeta.ULID, nil}
 	}

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1287,6 +1287,7 @@ func TestMultitenantCompactor_ShouldFailWithInvalidTSDBCompactOutput(t *testing.
 	c, tsdbCompactor, tsdbPlanner, logs, _ := prepare(t, cfg, bkt)
 
 	tsdbPlanner.On("Plan", mock.Anything, mock.Anything).Return([]*block.Meta{meta1, meta2}, nil).Once()
+	tsdbPlanner.On("Plan", mock.Anything, mock.Anything).Return([]*block.Meta{}, nil).Once()
 	mockCall := tsdbCompactor.On("Compact", mock.Anything, mock.Anything, mock.Anything)
 	mockCall.RunFn = func(args mock.Arguments) {
 		dir := args.Get(0).(string)
@@ -1303,7 +1304,7 @@ func TestMultitenantCompactor_ShouldFailWithInvalidTSDBCompactOutput(t *testing.
 	// Start the compactor
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
-	// Compaction run should error due to invalid output block
+	// Compaction block verification should fail due to invalid output block
 	test.Poll(t, 5*time.Second, 1.0, func() interface{} {
 		return prom_testutil.ToFloat64(c.bucketCompactorMetrics.groupCompactionBlocksVerificationFailed)
 	})

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1220,6 +1220,147 @@ func TestMultitenantCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnSharding
 	}
 }
 
+func TestMultitenantCompactor_ShouldFailWithInvalidTSDBCompactOutput(t *testing.T) {
+	// Two blocks with overlapping time range
+	inputBlock1Spec := []*block.SeriesSpec{
+		{
+			Labels: labels.FromStrings("case", "input_spec_1"),
+			Chunks: []chunks.Meta{
+				must(tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(1000, 1000, nil, nil),
+					newSample(2000, 2000, nil, nil)})),
+			},
+		},
+	}
+
+	inputBlock2Spec := []*block.SeriesSpec{
+		{
+			Labels: labels.FromStrings("case", "input_spec_2"),
+			Chunks: []chunks.Meta{
+				must(tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(1500, 1500, nil, nil),
+					newSample(2500, 2500, nil, nil)})),
+			},
+		},
+	}
+
+	// Block with sufficient time range so compaction job gets triggered
+	inputBlock3Spec := []*block.SeriesSpec{
+		{
+			Labels: labels.FromStrings("case", "input_spec_3"),
+			Chunks: []chunks.Meta{
+				must(tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(0, 0, nil, nil),
+					newSample(2*time.Hour.Milliseconds()-1, 0, nil, nil)})),
+			},
+		},
+	}
+
+	// Output block minTime/maxTime is greater/less than the input blocks minTime/maxTime
+	outputBlockSpec := []*block.SeriesSpec{
+		{
+			Labels: labels.FromStrings("case", "output_spec"),
+			Chunks: []chunks.Meta{
+				must(tsdbutil.ChunkFromSamples([]tsdbutil.Sample{
+					newSample(1250, 1250, nil, nil),
+					newSample(2250, 2250, nil, nil)})),
+			},
+		},
+	}
+
+	const user = "user-1"
+
+	storageDir := t.TempDir()
+
+	meta1, err := block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), inputBlock1Spec)
+	require.NoError(t, err)
+	meta2, err := block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), inputBlock2Spec)
+	require.NoError(t, err)
+	_, err = block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), inputBlock3Spec)
+	require.NoError(t, err)
+
+	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
+	require.NoError(t, err)
+
+	cfg := prepareConfig(t)
+	cfg.CompactionRetries = 1 // No need to retry as we're testing for failure
+	c, tsdbCompactor, tsdbPlanner, logs, registry := prepare(t, cfg, bkt)
+
+	tsdbPlanner.On("Plan", mock.Anything, mock.Anything).Return([]*block.Meta{meta1, meta2}, nil)
+
+	mockCall := tsdbCompactor.On("Compact", mock.Anything, mock.Anything, mock.Anything)
+	mockCall.RunFn = func(args mock.Arguments) {
+		dir := args.Get(0).(string)
+		compactedMeta, err := block.GenerateBlockFromSpec(user, dir, outputBlockSpec)
+		require.NoError(t, err)
+		os.OpenFile(filepath.Join(dir, compactedMeta.ULID.String(), "tombstones"), os.O_RDONLY|os.O_CREATE, 0666)
+
+		mockCall.ReturnArguments = mock.Arguments{compactedMeta.ULID, nil}
+	}
+
+	// Start the compactor
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+
+	// Compaction run should error due to invalid output block
+	test.Poll(t, 10*time.Second, 1.0, func() interface{} {
+		return prom_testutil.ToFloat64(c.compactionRunsErred)
+	})
+
+	// Stop the compactor.
+	require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c))
+
+	// Ensure that the compaction job failed due to invalid minTime/maxTime
+	assert.Contains(t, strings.Split(strings.TrimSpace(logs.String()), "\n"),
+		fmt.Sprintf(`level=error component=compactor msg="failed to compact user blocks" user=%s err="compaction: group 0@17241709254077376921-merge--0-7200000: compacted block(s) do not contain minTime and maxTime from the input blocks"`, user))
+
+	// Check metrics
+	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
+		# TYPE cortex_compactor_runs_started_total counter
+		# HELP cortex_compactor_runs_started_total Total number of compaction runs started.
+		cortex_compactor_runs_started_total 1
+
+		# TYPE cortex_compactor_runs_completed_total counter
+		# HELP cortex_compactor_runs_completed_total Total number of compaction runs successfully completed.
+		cortex_compactor_runs_completed_total 0
+
+		# TYPE cortex_compactor_runs_failed_total counter
+		# HELP cortex_compactor_runs_failed_total Total number of compaction runs failed.
+		cortex_compactor_runs_failed_total{reason="error"} 1
+		cortex_compactor_runs_failed_total{reason="shutdown"} 0
+
+		# HELP cortex_compactor_group_compaction_runs_completed_total Total number of group completed compaction runs. This also includes compactor group runs that resulted with no compaction.
+		# TYPE cortex_compactor_group_compaction_runs_completed_total counter
+		cortex_compactor_group_compaction_runs_completed_total 0
+
+		# HELP cortex_compactor_group_compaction_runs_started_total Total number of group compaction attempts.
+		# TYPE cortex_compactor_group_compaction_runs_started_total counter
+		cortex_compactor_group_compaction_runs_started_total 1
+
+		# HELP cortex_compactor_group_compactions_failures_total Total number of failed group compactions.
+		# TYPE cortex_compactor_group_compactions_failures_total counter
+		cortex_compactor_group_compactions_failures_total 1
+
+		# HELP cortex_compactor_group_compactions_total Total number of group compaction attempts that resulted in new block(s).
+		# TYPE cortex_compactor_group_compactions_total counter
+		cortex_compactor_group_compactions_total 0
+
+		# HELP cortex_compactor_blocks_marked_for_deletion_total Total number of blocks marked for deletion in compactor.
+		# TYPE cortex_compactor_blocks_marked_for_deletion_total counter
+		cortex_compactor_blocks_marked_for_deletion_total{reason="compaction"} 0
+		cortex_compactor_blocks_marked_for_deletion_total{reason="partial"} 0
+		cortex_compactor_blocks_marked_for_deletion_total{reason="retention"} 0
+	`),
+		"cortex_compactor_runs_started_total",
+		"cortex_compactor_runs_completed_total",
+		"cortex_compactor_runs_failed_total",
+		"cortex_compactor_group_compaction_runs_completed_total",
+		"cortex_compactor_group_compaction_runs_started_total",
+		"cortex_compactor_group_compactions_failures_total",
+		"cortex_compactor_group_compactions_total",
+		"cortex_compactor_blocks_marked_for_deletion_total",
+	))
+}
+
 func TestMultitenantCompactor_ShouldSkipCompactionForJobsNoMoreOwnedAfterPlanning(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/compactor/job.go
+++ b/pkg/compactor/job.go
@@ -133,7 +133,7 @@ func (job *Job) Resolution() int64 {
 	return job.resolution
 }
 
-// UseSplitting returns whether blocks should be splitted into multiple shards when compacted.
+// UseSplitting returns whether blocks should be split into multiple shards when compacted.
 func (job *Job) UseSplitting() bool {
 	return job.useSplitting
 }


### PR DESCRIPTION
#### What this PR does
Verifies the time range of compacted block(s) matches the time range of the input blocks. Provides an extra layer of protection in Mimir in case of any bugs during block compaction. 

#### Which issue(s) this PR fixes or relates to
Fixes #816 

#### Checklist

- [x] Tests updated
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
