### PR TITLE
UtilizationBasedLimiter: Sample also cgroup CPU utilization

### DIFF
--- a/pkg/util/limiter/utilization_test.go
+++ b/pkg/util/limiter/utilization_test.go
@@ -356,11 +356,11 @@ type fakeUtilizationScanner struct {
 	memoryUtilization uint64
 }
 
-func (s *fakeUtilizationScanner) Scan() (float64, uint64, error) {
+func (s *fakeUtilizationScanner) Scan() (float64, float64, uint64, error) {
 	s.totalTime += float64(1) / float64(60-s.counter)
 	s.counter++
 	s.counter %= 60
-	return s.totalTime, s.memoryUtilization, nil
+	return s.totalTime, s.totalTime, s.memoryUtilization, nil
 }
 
 func (s *fakeUtilizationScanner) String() string {
@@ -375,14 +375,14 @@ type preRecordedUtilizationScanner struct {
 	totalCPUUtilization float64
 }
 
-func (s *preRecordedUtilizationScanner) Scan() (float64, uint64, error) {
+func (s *preRecordedUtilizationScanner) Scan() (float64, float64, uint64, error) {
 	if len(s.instantCPUValues) == 0 {
-		return s.totalCPUUtilization, 0, nil
+		return s.totalCPUUtilization, 0, 0, nil
 	}
 
 	s.totalCPUUtilization += s.instantCPUValues[0]
 	s.instantCPUValues = s.instantCPUValues[1:]
-	return s.totalCPUUtilization, 0, nil
+	return s.totalCPUUtilization, s.totalCPUUtilization, 0, nil
 }
 
 func (s *preRecordedUtilizationScanner) String() string {


### PR DESCRIPTION
#### What this PR does
I propose modifying `pkg/util/limiter.UtilizationBasedLimiter` to sample also cgroup CPU utilization, for comparison with the samples obtained from /proc, when enabling limiting. This is to understand whether cgroup CPU sampling may be more accurate, than the /proc based method. If logging of input CPU samples is enabled, the maximum cgroup CPU sample is also logged (as the maximum should give enough insight).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
