### PR TITLE
Chore: Make grafanabot code owner of dependencies

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,3 +14,8 @@
 
 # No owners - allows sub-maintainers to merge changes.
 CHANGELOG.md
+
+# Dependencies
+go.mod @grafana/mimir-maintainers @grafanabot
+go.sum @grafana/mimir-maintainers @grafanabot
+/vendor/ @grafana/mimir-maintainers @grafanabot


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
The current auto-merge functionality is operational for whitelist dependencies. However, I've recently realized that there's still a requirement for the maintainer's approval regarding the dependency update, as highlighted in this [link](https://github.com/grafana/mimir/pull/5736). To address this, it's necessary to incorporate grafanabot as a designated code owner for overseeing dependency updates.
#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
