### PR TITLE
Security: Group docker update into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,28 +22,108 @@ updates:
     schedule:
       interval: "daily"
       time: "06:04"
+    groups:
+      docker-dependencies-update:
+        update-types:
+        - "minor" 
+        - "patch"
+        - "major"
   - package-ecosystem: docker
     directory: /cmd/metaconvert/
     schedule:
       interval: "daily"
-      time: "06:06"
+      time: "06:04"
+    groups:
+      docker-dependencies-update: 
+        update-types: 
+        - "minor"
+        - "patch"
+        - "major"
   - package-ecosystem: docker
     directory: /cmd/mimir/
     schedule:
       interval: "daily"
-      time: "06:08"
+      time: "06:04"
+    groups:
+      docker-dependencies-update:
+        update-types:
+        - "minor"
+        - "patch"
+        - "major"
   - package-ecosystem: docker
     directory: /cmd/mimir-continuous-test/
     schedule:
       interval: "daily"
-      time: "06:10"
+      time: "06:04"
+    groups:
+      docker-dependencies-update:
+        update-types:
+        - "minor"  
+        - "patch"
+        - "major"
   - package-ecosystem: docker
     directory: /cmd/mimirtool/
     schedule:
       interval: "daily"
-      time: "06:12"
+      time: "06:04"
+    groups:
+      docker-dependencies-update: 
+        update-types:
+        - "minor"
+        - "patch"
+        - "major"
   - package-ecosystem: docker
     directory: /cmd/query-tee/
     schedule:
       interval: "daily"
-      time: "06:14"
+      time: "06:04"
+    groups:
+      docker-dependencies-update:
+        update-types:
+        - "minor"
+        - "patch"
+        - "major"
+  - package-ecosystem: docker
+    directory: /development/mimir-microservices-mode/
+    schedule:
+      interval: "daily"
+      time: "06:04"
+    groups:
+      docker-dependencies-update:
+        update-types:
+        - "minor"
+        - "patch"
+        - "major"
+  - package-ecosystem: docker
+    directory: /development/mimir-monolithic-mode/
+    schedule:
+      interval: "daily"
+      time: "06:04"
+    groups:
+      docker-dependencies-update:
+        update-types:
+        - "minor"
+        - "patch"
+        - "major"
+  - package-ecosystem: docker
+    directory: /development/mimir-monolithic-mode-with-swift-storage/
+    schedule:
+      interval: "daily"
+      time: "06:04"
+    groups:
+      docker-dependencies-update:
+        update-types:
+        - "minor"
+        - "patch"
+        - "major"
+  - package-ecosystem: docker
+    directory: /development/mimir-read-write-mode/
+    schedule:
+      interval: "daily"
+      time: "06:04"
+    groups:
+      docker-dependencies-update:
+        update-types:
+        - "minor"
+        - "patch"
+        - "major"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Presently, Dependabot generates multiple pull requests for each dependency, per file. This results in a surplus of notifications. Please explore the recently introduced Dependabot feature designed to consolidate these individual pull requests into a single, more organized PR.

For further context, please refer to the following link: [Issue #7795](https://github.com/dependabot/dependabot-core/issues/7795).

![](https://files.slack.com/files-pri/T02S4RCS0-F05MWGCTTBN/screenshot_2023-08-15_at_10.19.33.png)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
