### PR TITLE
ruler: graceful shutdown during evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 * [BUGFIX] Dashboards: fix "unhealthy pods" panel on "rollout progress" dashboard showing only a number rather than the name of the workload and the number of unhealthy pods if only one workload has unhealthy pods. #5113 #5200
 * [BUGFIX] Alerts: fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts. #5396
 * [BUGFIX] Alerts: Fix `MimirGossipMembersMismatch` to include `admin-api` pods so that it does not always fire in GEM deployments. #5641
+* [BUGFIX] Ruler: gracefully shut down rule evaluations. #5778
 
 ### Jsonnet
 

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -171,12 +171,9 @@ func (r *DefaultMultiTenantManager) syncRulesToManagerConcurrently(ctx context.C
 		users = append(users, userID)
 	}
 
-	// concurrency.ForEachJob is a helper function that runs a function for each job in parallel.
-	// It cancel context of jobFunc once iteration is done.
-	// That is why the context passed to syncRulesToManager should be the global context not the context of jobFunc.
 	err := concurrency.ForEachJob(ctx, len(users), 10, func(_ context.Context, idx int) error {
 		userID := users[idx]
-		r.syncRulesToManager(ctx, userID, ruleGroups[userID])
+		r.syncRulesToManager(userID, ruleGroups[userID])
 		return nil
 	})
 
@@ -191,7 +188,7 @@ func (r *DefaultMultiTenantManager) syncRulesToManagerConcurrently(ctx context.C
 // syncRulesToManager maps the rule files to disk, detects any changes and will create/update
 // the user's Prometheus Rules Manager. Since this method writes to disk it is not safe to call
 // concurrently for the same user.
-func (r *DefaultMultiTenantManager) syncRulesToManager(ctx context.Context, user string, groups rulespb.RuleGroupList) {
+func (r *DefaultMultiTenantManager) syncRulesToManager(user string, groups rulespb.RuleGroupList) {
 	// Map the files to disk and return the file names to be passed to the users manager if they
 	// have been updated
 	update, files, err := r.mapper.MapRules(user, groups.Formatted())
@@ -201,7 +198,7 @@ func (r *DefaultMultiTenantManager) syncRulesToManager(ctx context.Context, user
 		return
 	}
 
-	manager, created, err := r.getOrCreateManager(ctx, user)
+	manager, created, err := r.getOrCreateManager(user)
 	if err != nil {
 		r.lastReloadSuccessful.WithLabelValues(user).Set(0)
 		level.Error(r.logger).Log("msg", "unable to create rule manager", "user", user, "err", err)
@@ -229,7 +226,7 @@ func (r *DefaultMultiTenantManager) syncRulesToManager(ctx context.Context, user
 }
 
 // getOrCreateManager retrieves the user manager. If it doesn't exist, it will create and start it first.
-func (r *DefaultMultiTenantManager) getOrCreateManager(ctx context.Context, user string) (RulesManager, bool, error) {
+func (r *DefaultMultiTenantManager) getOrCreateManager(user string) (RulesManager, bool, error) {
 	// Check if it already exists. Since rules are synched frequently, we expect to already exist
 	// most of the times.
 	r.userManagerMtx.RLock()
@@ -251,7 +248,7 @@ func (r *DefaultMultiTenantManager) getOrCreateManager(ctx context.Context, user
 	}
 
 	level.Debug(r.logger).Log("msg", "creating rule manager for user", "user", user)
-	manager, err := r.newManager(ctx, user)
+	manager, err := r.newManager(user)
 	if err != nil {
 		return nil, false, err
 	}
@@ -269,7 +266,7 @@ func (r *DefaultMultiTenantManager) getOrCreateManager(ctx context.Context, user
 
 // newManager creates a prometheus rule manager wrapped with a user id
 // configured storage, appendable, notifier, and instrumentation
-func (r *DefaultMultiTenantManager) newManager(ctx context.Context, userID string) (RulesManager, error) {
+func (r *DefaultMultiTenantManager) newManager(userID string) (RulesManager, error) {
 	notifier, err := r.getOrCreateNotifier(userID)
 	if err != nil {
 		return nil, err
@@ -280,7 +277,10 @@ func (r *DefaultMultiTenantManager) newManager(ctx context.Context, userID strin
 	reg := prometheus.NewRegistry()
 	r.userManagerMetrics.AddUserRegistry(userID, reg)
 
-	return r.managerFactory(ctx, userID, notifier, r.logger, reg), nil
+	// We pass context.Background() to the managerFactory because the manager is shut down via Stop()
+	// instead of context cancellations. Cancelling the context might cause inflight evaluations to be immediately
+	// aborted. We want a graceful shutdown of evaluations.
+	return r.managerFactory(context.Background(), userID, notifier, r.logger, reg), nil
 }
 
 func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifier.Manager, error) {


### PR DESCRIPTION
#### Issue

The context passed to the remote ruler evaluation querier is passed all the way down from the root context of the `Ruler.starting` and `Ruler.run` methods. This context is cancelled when the ruler receives a SIGINT.

The remote ruler evaluation immediately aborts remote evaluations upon context cancelations. This results in failed rule evaluations. In addition to that, each ruler manager has a `Stop()` method which gracefully stops rule groups and waits for them to complete any ongoing evaluations.

An example of this is in this error emitted [here](https://github.com/grafana/mimir/blob/ff4a68a0e5cc2b183c7fdc82fd4c1be66ed5dcc2/pkg/ruler/remotequerier.go#L229) while remotely evaluating the rule's query

```
ts=2023-08-16T18:26:47.929746821Z caller=spanlogger.go:85 user=234002 method=ruler.RemoteQuerier.Query level=warn msg="failed to remotely evaluate query expression" err="rpc error: code = Canceled desc = context canceled" qs="<redacted>" tm=2023-08-16T18:25:36.12110522Z
```

followed by this log line saying that the rule evaluation failed
```
ts=2023-08-16T18:26:48.278643311Z caller=manager.go:696 level=warn component=ruler insight=true user=234002 file=/rules/XXX/YYY group="<redacted>" name=<redacted> index=1 msg="Evaluating rule failed" rule="<same rule as the qs in the above log line>" err="rpc error: code = Canceled desc = context canceled"
```

#### What this PR does

This PR changes the context passed to a RulerManager to be `context.Background()`. This way a SIGINT doesn't immediately cancel ongoing evaluations. Instead, rule groups will be gracefully cleaned up upon `RulerManager.Stop()`

I've verified the path of the context and I couldn't find any additional information being attached to the context before it was passed to the ManagerFactory


#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
