### PR TITLE
apply enhanced server-side tracing for httpgrpc.HTTP/Handle method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
   * `-log.rate-limit-enabled`
   * `-log.rate-limit-logs-per-second`
   * `-log.rate-limit-logs-per-second-burst`
+* [ENHANCEMENT] Apply dskit HTTPGRPCTracer for more detailed server-side tracing spans and tags on httpgrpc.HTTP/Handle requests
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@
   * `-log.rate-limit-enabled`
   * `-log.rate-limit-logs-per-second`
   * `-log.rate-limit-logs-per-second-burst`
-* [ENHANCEMENT] Apply dskit HTTPGRPCTracer for more detailed server-side tracing spans and tags on httpgrpc.HTTP/Handle requests
+* [ENHANCEMENT] Querier: cancel query requests to ingesters in a zone upon first error received from the zone, to reduce wasted effort spent computing results that won't be used #5764
+* [ENHANCEMENT] Apply dskit HTTPGRPCTracer for more detailed server-side tracing spans and tags on httpgrpc.HTTP/Handle requests #5782
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -18,9 +18,11 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/kv/memberlist"
+	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/modules"
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/ring"
@@ -750,6 +752,9 @@ func New(cfg Config, reg prometheus.Registerer) (*Mimir, error) {
 
 	mimir.setupObjstoreTracing()
 	otel.SetTracerProvider(NewOpenTelemetryProviderBridge(opentracing.GlobalTracer()))
+
+	mimir.Cfg.Server.Router = mux.NewRouter()
+	middleware.InitHTTPGRPCMiddleware(mimir.Cfg.Server.Router)
 
 	if err := mimir.setupModuleManager(); err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Applies the httpgrpc tracing middleware created in https://github.com/grafana/dskit/commit/0ef13fb65a5363eec6f14042d12554cf33cc8640.

This middleware increases the observability of http-over-grpc requests, which are all handled by the generic `httpgrpc.HTTP/Handle` method, by tagging the incoming `httpgrpc.HTTP/Handle` span with relevant opentracing http span tags, and by starting a child span mirroring the existing opentracing spans created for vanilla http requests.

This fixes the fact that all `httpgrpc.HTTP/Handle` tracing spans were identical, with no indication of which http request/endpoint type was being handled (e.g. /otlp/v1/metrics vs. /api/v1/push).

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
