### PR TITLE
Fix bug in LazyBinaryReader.SymbolsReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 * [BUGFIX] Querier: fix issue where `cortex_ingester_client_request_duration_seconds` metric did not include streaming query requests that did not return any series. #5695
 * [BUGFIX] Ingester: Fix ActiveSeries tracker double-counting series that have been deleted from the Head while still being active and then recreated again. #5678
 * [BUGFIX] Ingester: Don't set "last update time" of TSDB into the future when opening TSDB. This could prevent detecting of idle TSDB for a long time, if sample in distant future was ingested. #5787
+* [BUGFIX] Store-gateway: fix bug when lazy index header could be closed prematurely even when still in use. #5795
 
 ### Mixin
 

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -399,11 +399,16 @@ func TestLazyBinaryReader_SymbolReaderAndUnload(t *testing.T) {
 
 		sr, err := r.SymbolsReader()
 		require.NoError(t, err)
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
+
 			<-time.After(1 * time.Second)
-			require.NoError(t, sr.Close())
 
 			closed.Store(true)
+			require.NoError(t, sr.Close()) // sr.Close() unblocks unloadIfIdleSince
 
 			// Multiple close calls should not panic (wg.Done could panic if called too many times).
 			// (It can return error, or not. We don't care).
@@ -415,5 +420,7 @@ func TestLazyBinaryReader_SymbolReaderAndUnload(t *testing.T) {
 
 		// We should only get here if symbols reader was already closed. If it wasn't, unload unloaded unclosed reader :(
 		require.True(t, closed.Load(), "symbols reader is not closed yet")
+
+		wg.Wait()
 	})
 }

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -385,6 +385,7 @@ func TestLazyBinaryReader_ConcurrentLoadingOfSameIndexReader(t *testing.T) {
 }
 
 func TestLazyBinaryReader_SymbolReaderAndUnload(t *testing.T) {
+	t.Parallel()
 	tmpDir, bkt, blockID := initBucketAndBlocksForTest(t)
 
 	testLazyBinaryReader(t, bkt, tmpDir, blockID, func(t *testing.T, r *LazyBinaryReader, err error) {


### PR DESCRIPTION
#### What this PR does

`(*LazyBinaryReader).SymbolsReader` method reports that usage of "reader" is done, however it also returns `SymbolsReader` that still uses underlying indexheader reader.

This PR fixes that bug. First reported by @dimitarvdimitrov in https://github.com/grafana/mimir/pull/5608#discussion_r1279186745. 

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
