### PR TITLE
makefile: avoid docker pull on most make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,8 @@ push-multiarch-mimir: push-multiarch-cmd/mimir/.uptodate
 
 # This target fetches current build image, and tags it with "latest" tag. It can be used instead of building the image locally.
 .PHONY: fetch-build-image
-fetch-build-image: ## Fetch latest the docker build image. It can be used instead of building the image locally.
-	docker pull $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG)
+fetch-build-image: ## Fetch latest the docker build image if it isn't already present. It can be used instead of building the image locally.
+	docker image inspect $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG) >/dev/null 2>&1 || docker pull $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG)
 	docker tag $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG) $(BUILD_IMAGE):latest
 	touch mimir-build-image/.uptodate
 


### PR DESCRIPTION
The current make target fetch-build-image ensures that the build image is present locally after pulling it from DockerHub.

This PR changes the target to first check whether the image isn't present locally before doing `docker pull`. This speeds up the target and allows it to run without an internet connection.
