### PR TITLE
Fix cortex_ingester_tsdb_head_max_time_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
   * `-log.rate-limit-enabled`
   * `-log.rate-limit-logs-per-second`
   * `-log.rate-limit-logs-per-second-burst`
-* [ENHANCEMENT] Added `cortex_ingester_tsdb_head_max_time_seconds` metric which is a max time of all TSDB Heads open in an ingester. #5786 #5815
+* [ENHANCEMENT] Added `cortex_ingester_tsdb_head_min_timestamp_seconds` and `cortex_ingester_tsdb_head_max_timestamp_seconds` metrics which return min and max time of all TSDB Heads open in an ingester. #5786 #5815
 * [ENHANCEMENT] Querier: cancel query requests to ingesters in a zone upon first error received from the zone, to reduce wasted effort spent computing results that won't be used #5764
 * [ENHANCEMENT] Improve tracing of internal HTTP requests sent over httpgrpc #5782
 * [ENHANCEMENT] Querier: add experimental per-query chunks limit based on an estimate of the number of chunks that will be sent from ingesters and store-gateways that is enforced earlier during query evaluation. This limit is disabled by default and can be configured with `-querier.max-estimated-fetched-chunks-per-query-multiplier`. #5765

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
   * `-log.rate-limit-enabled`
   * `-log.rate-limit-logs-per-second`
   * `-log.rate-limit-logs-per-second-burst`
-* [ENHANCEMENT] Added `cortex_ingester_tsdb_head_max_time_seconds` metric which is a max time of all TSDB Heads open in an ingester. #5786
+* [ENHANCEMENT] Added `cortex_ingester_tsdb_head_max_time_seconds` metric which is a max time of all TSDB Heads open in an ingester. #5786 #5815
 * [ENHANCEMENT] Querier: cancel query requests to ingesters in a zone upon first error received from the zone, to reduce wasted effort spent computing results that won't be used #5764
 * [ENHANCEMENT] Improve tracing of internal HTTP requests sent over httpgrpc #5782
 * [ENHANCEMENT] Querier: add experimental per-query chunks limit based on an estimate of the number of chunks that will be sent from ingesters and store-gateways that is enforced earlier during query evaluation. This limit is disabled by default and can be configured with `-querier.max-estimated-fetched-chunks-per-query-multiplier`. #5765

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -331,6 +331,16 @@ func New(cfg Config, limits *validation.Overrides, activeGroupsCleanupService *u
 			Name: "cortex_ingester_oldest_unshipped_block_timestamp_seconds",
 			Help: "Unix timestamp of the oldest TSDB block not shipped to the storage yet. 0 if ingester has no blocks or all blocks have been shipped.",
 		}, i.getOldestUnshippedBlockMetric)
+
+		promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "cortex_ingester_tsdb_head_min_timestamp_seconds",
+			Help: "Minimum timestamp of the head block across all tenants.",
+		}, i.minTsdbHeadTimestamp)
+
+		promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "cortex_ingester_tsdb_head_max_timestamp_seconds",
+			Help: "Maximum timestamp of the head block across all tenants.",
+		}, i.maxTsdbHeadTimestamp)
 	}
 
 	i.lifecycler, err = ring.NewLifecycler(cfg.IngesterRing.ToLifecyclerConfig(logger), i, "ingester", IngesterRingKey, cfg.BlocksStorageConfig.TSDB.FlushBlocksOnShutdown, logger, prometheus.WrapRegistererWithPrefix("cortex_", registerer))
@@ -2151,13 +2161,6 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 	}
 	db.DisableCompactions() // we will compact on our own schedule
 
-	// Register metric that reports Head MaxTime in seconds.
-	// (TSDB library already exports prometheus_tsdb_head_max_time metric, but it's unit-neutral.)
-	promauto.With(tsdbPromReg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_max_time_seconds",
-		Help: "Maximum timestamp of the head block.",
-	}, func() float64 { return float64(db.Head().MaxTime()) / 1000 })
-
 	// Run compaction before using this TSDB. If there is data in head that needs to be put into blocks,
 	// this will actually create the blocks. If there is no data (empty TSDB), this is a no-op, although
 	// local blocks compaction may still take place if configured.
@@ -2401,6 +2404,38 @@ func (i *Ingester) getOldestUnshippedBlockMetric() float64 {
 	}
 
 	return float64(oldest / 1000)
+}
+
+func (i *Ingester) minTsdbHeadTimestamp() float64 {
+	i.tsdbsMtx.RLock()
+	defer i.tsdbsMtx.RUnlock()
+
+	minTime := int64(math.MaxInt64)
+	for _, db := range i.tsdbs {
+		minTime = util_math.Min(minTime, db.db.Head().MinTime())
+	}
+
+	if minTime == math.MaxInt64 {
+		return 0
+	}
+	// convert to seconds
+	return float64(minTime) / 1000
+}
+
+func (i *Ingester) maxTsdbHeadTimestamp() float64 {
+	i.tsdbsMtx.RLock()
+	defer i.tsdbsMtx.RUnlock()
+
+	maxTime := int64(math.MinInt64)
+	for _, db := range i.tsdbs {
+		maxTime = util_math.Max(maxTime, db.db.Head().MaxTime())
+	}
+
+	if maxTime == math.MinInt64 {
+		return 0
+	}
+	// convert to seconds
+	return float64(maxTime) / 1000
 }
 
 func (i *Ingester) shipBlocksLoop(ctx context.Context) error {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -91,7 +91,8 @@ func TestIngester_Push(t *testing.T) {
 		"cortex_ingester_active_series",
 		"cortex_ingester_active_native_histogram_series",
 		"cortex_ingester_active_native_histogram_buckets",
-		"cortex_ingester_tsdb_head_max_time_seconds",
+		"cortex_ingester_tsdb_head_min_timestamp_seconds",
+		"cortex_ingester_tsdb_head_max_timestamp_seconds",
 	}
 	userID := "test"
 	now := time.Now()
@@ -178,9 +179,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 0.01
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 0.009
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 0.01
 			`,
 		},
 		"should succeed on valid series with histograms and metadata": {
@@ -252,9 +256,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_native_histogram_buckets Number of currently active native histogram buckets per user.
 				# TYPE cortex_ingester_active_native_histogram_buckets gauge
 				cortex_ingester_active_native_histogram_buckets{user="test"} 8
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 0.002
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 0.001
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 0.002
 			`,
 			nativeHistograms: true,
 		},
@@ -350,9 +357,13 @@ func TestIngester_Push(t *testing.T) {
 				# TYPE cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total counter
 				cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total 0
 
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 0.01
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 0.009
+
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 0.01
 			`,
 		},
 		"successful push, active series disabled": {
@@ -394,9 +405,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
 				# TYPE cortex_ingester_memory_series_removed_total counter
 				cortex_ingester_memory_series_removed_total{user="test"} 0
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 0.01
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 0.009
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 0.01
 			`,
 		},
 		"should soft fail on sample out-of-order": {
@@ -445,9 +459,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 0.01
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 0.01
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 0.01
 			`,
 		},
 		"should soft fail on all samples out of bound in a write request": {
@@ -500,9 +517,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 1575043.969
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 1575043.969
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 1575043.969
 			`,
 		},
 		"should soft fail on all samples with histograms out of bound in a write request": {
@@ -556,9 +576,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 1575043.969
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 1575043.969
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 1575043.969
 			`,
 			nativeHistograms: true,
 		},
@@ -610,9 +633,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 1575044.969
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 1575043.969
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 1575044.969
 			`,
 			nativeHistograms: false,
 		},
@@ -669,9 +695,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 1575043.970
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 1575043.969
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 1575043.970
 			`,
 		},
 		"should soft fail on some samples with timestamp too far in future in a write request": {
@@ -728,9 +757,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli()+1)/1000) + `
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli())/1000) + `
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli()+1)/1000) + `
 			`,
 		},
 		"should soft fail on some histograms with timestamp too far in future in a write request": {
@@ -786,9 +818,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_native_histogram_series Number of currently active native histogram series per user.
 				# TYPE cortex_ingester_active_native_histogram_series gauge
 				cortex_ingester_active_native_histogram_series{user="test"} 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli())/1000) + `
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli())/1000) + `
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli())/1000) + `
 			`,
 		},
 		"should soft fail on some exemplars with timestamp too far in future in a write request": {
@@ -859,9 +894,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_ingested_exemplars_failures_total The total number of exemplars that errored on ingestion.
 				# TYPE cortex_ingester_ingested_exemplars_failures_total counter
 				cortex_ingester_ingested_exemplars_failures_total 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli())/1000) + `
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli())/1000) + `
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli())/1000) + `
 			`,
 		},
 		"should soft fail on two different sample values at the same timestamp": {
@@ -910,9 +948,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 1575043.969
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 1575043.969
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 1575043.969
 			`,
 		},
 		"should soft fail on exemplar with unknown series": {
@@ -987,9 +1028,13 @@ func TestIngester_Push(t *testing.T) {
 				# TYPE cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total counter
 				cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total 0
 
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds ` + fmt.Sprintf("%g", float64(math.MinInt64)/1000) + `
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 0
+
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 0
 			`,
 		},
 		"should succeed with a request containing only metadata": {
@@ -1021,9 +1066,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_tsdb_head_active_appenders Number of currently active TSDB appender transactions.
 				# TYPE cortex_ingester_tsdb_head_active_appenders gauge
 				cortex_ingester_tsdb_head_active_appenders 0
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 0
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 0
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 0
 			`,
 		},
 		"should discard metadata when max metadata per user exceeded": {
@@ -1072,9 +1120,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 0
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 0
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 0
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 0
 			`,
 		},
 		"should discard metadata when max metadata per metric exceeded": {
@@ -1123,9 +1174,12 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 0
-				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-				cortex_ingester_tsdb_head_max_time_seconds 0
+				# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_min_timestamp_seconds 0
+				# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+				cortex_ingester_tsdb_head_max_timestamp_seconds 0
 			`,
 		},
 	}
@@ -1262,7 +1316,8 @@ func TestIngester_Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *testi
 		"cortex_ingester_active_series",
 		"cortex_ingester_active_native_histogram_series",
 		"cortex_ingester_active_native_histogram_buckets",
-		"cortex_ingester_tsdb_head_max_time_seconds",
+		"cortex_ingester_tsdb_head_min_timestamp_seconds",
+		"cortex_ingester_tsdb_head_max_timestamp_seconds",
 	}
 
 	registry := prometheus.NewRegistry()
@@ -1349,9 +1404,12 @@ func TestIngester_Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *testi
 		# TYPE cortex_ingester_active_native_histogram_buckets gauge
 		cortex_ingester_active_native_histogram_buckets{user="test-1"} 8
 		cortex_ingester_active_native_histogram_buckets{user="test-2"} 8
-		# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-		# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-		cortex_ingester_tsdb_head_max_time_seconds 1.01
+		# HELP cortex_ingester_tsdb_head_min_timestamp_seconds Minimum timestamp of the head block across all tenants.
+		# TYPE cortex_ingester_tsdb_head_min_timestamp_seconds gauge
+		cortex_ingester_tsdb_head_min_timestamp_seconds 0.007
+		# HELP cortex_ingester_tsdb_head_max_timestamp_seconds Maximum timestamp of the head block across all tenants.
+		# TYPE cortex_ingester_tsdb_head_max_timestamp_seconds gauge
+		cortex_ingester_tsdb_head_max_timestamp_seconds 1.01
 	`
 
 	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...))

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -91,6 +91,7 @@ func TestIngester_Push(t *testing.T) {
 		"cortex_ingester_active_series",
 		"cortex_ingester_active_native_histogram_series",
 		"cortex_ingester_active_native_histogram_buckets",
+		"cortex_ingester_tsdb_head_max_time_seconds",
 	}
 	userID := "test"
 	now := time.Now()
@@ -177,6 +178,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 0.01
 			`,
 		},
 		"should succeed on valid series with histograms and metadata": {
@@ -248,6 +252,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_native_histogram_buckets Number of currently active native histogram buckets per user.
 				# TYPE cortex_ingester_active_native_histogram_buckets gauge
 				cortex_ingester_active_native_histogram_buckets{user="test"} 8
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 0.002
 			`,
 			nativeHistograms: true,
 		},
@@ -342,6 +349,10 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total Total number of out-of-order exemplar ingestion failed attempts.
 				# TYPE cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total counter
 				cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total 0
+
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 0.01
 			`,
 		},
 		"successful push, active series disabled": {
@@ -383,6 +394,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_memory_series_removed_total The total number of series that were removed per user.
 				# TYPE cortex_ingester_memory_series_removed_total counter
 				cortex_ingester_memory_series_removed_total{user="test"} 0
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 0.01
 			`,
 		},
 		"should soft fail on sample out-of-order": {
@@ -431,6 +445,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 0.01
 			`,
 		},
 		"should soft fail on all samples out of bound in a write request": {
@@ -483,6 +500,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 1575043.969
 			`,
 		},
 		"should soft fail on all samples with histograms out of bound in a write request": {
@@ -536,6 +556,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 1575043.969
 			`,
 			nativeHistograms: true,
 		},
@@ -587,6 +610,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 1575044.969
 			`,
 			nativeHistograms: false,
 		},
@@ -643,6 +669,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 1575043.970
 			`,
 		},
 		"should soft fail on some samples with timestamp too far in future in a write request": {
@@ -699,6 +728,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli()+1)/1000) + `
 			`,
 		},
 		"should soft fail on some histograms with timestamp too far in future in a write request": {
@@ -754,6 +786,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_native_histogram_series Number of currently active native histogram series per user.
 				# TYPE cortex_ingester_active_native_histogram_series gauge
 				cortex_ingester_active_native_histogram_series{user="test"} 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli())/1000) + `
 			`,
 		},
 		"should soft fail on some exemplars with timestamp too far in future in a write request": {
@@ -824,6 +859,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_ingested_exemplars_failures_total The total number of exemplars that errored on ingestion.
 				# TYPE cortex_ingester_ingested_exemplars_failures_total counter
 				cortex_ingester_ingested_exemplars_failures_total 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds ` + fmt.Sprintf("%g", float64(now.UnixMilli())/1000) + `
 			`,
 		},
 		"should soft fail on two different sample values at the same timestamp": {
@@ -872,6 +910,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 1575043.969
 			`,
 		},
 		"should soft fail on exemplar with unknown series": {
@@ -945,6 +986,10 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total Total number of out-of-order exemplar ingestion failed attempts.
 				# TYPE cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total counter
 				cortex_ingester_tsdb_exemplar_out_of_order_exemplars_total 0
+
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds ` + fmt.Sprintf("%g", float64(math.MinInt64)/1000) + `
 			`,
 		},
 		"should succeed with a request containing only metadata": {
@@ -976,6 +1021,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_tsdb_head_active_appenders Number of currently active TSDB appender transactions.
 				# TYPE cortex_ingester_tsdb_head_active_appenders gauge
 				cortex_ingester_tsdb_head_active_appenders 0
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 0
 			`,
 		},
 		"should discard metadata when max metadata per user exceeded": {
@@ -1024,6 +1072,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 0
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 0
 			`,
 		},
 		"should discard metadata when max metadata per metric exceeded": {
@@ -1072,6 +1123,9 @@ func TestIngester_Push(t *testing.T) {
 				# HELP cortex_ingester_memory_users The current number of users in memory.
 				# TYPE cortex_ingester_memory_users gauge
 				cortex_ingester_memory_users 0
+				# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+				# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+				cortex_ingester_tsdb_head_max_time_seconds 0
 			`,
 		},
 	}
@@ -1208,6 +1262,7 @@ func TestIngester_Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *testi
 		"cortex_ingester_active_series",
 		"cortex_ingester_active_native_histogram_series",
 		"cortex_ingester_active_native_histogram_buckets",
+		"cortex_ingester_tsdb_head_max_time_seconds",
 	}
 
 	registry := prometheus.NewRegistry()
@@ -1226,18 +1281,18 @@ func TestIngester_Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *testi
 	})
 
 	// Push timeseries for each user
-	for _, userID := range []string{"test-1", "test-2"} {
+	for ix, userID := range []string{"test-1", "test-2"} {
 		reqs := []*mimirpb.WriteRequest{
 			mimirpb.ToWriteRequest(
 				metricLabelAdapters,
-				[]mimirpb.Sample{{Value: 1, TimestampMs: 9}},
+				[]mimirpb.Sample{{Value: 1, TimestampMs: int64(ix)*1000 + 9}},
 				nil,
 				nil,
 				mimirpb.API,
 			),
 			mimirpb.ToWriteRequest(
 				metricLabelAdapters,
-				[]mimirpb.Sample{{Value: 2, TimestampMs: 10}},
+				[]mimirpb.Sample{{Value: 2, TimestampMs: int64(ix)*1000 + 10}},
 				nil,
 				nil,
 				mimirpb.API,
@@ -1294,6 +1349,9 @@ func TestIngester_Push_ShouldCorrectlyTrackMetricsInMultiTenantScenario(t *testi
 		# TYPE cortex_ingester_active_native_histogram_buckets gauge
 		cortex_ingester_active_native_histogram_buckets{user="test-1"} 8
 		cortex_ingester_active_native_histogram_buckets{user="test-2"} 8
+		# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
+		# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
+		cortex_ingester_tsdb_head_max_time_seconds 1.01
 	`
 
 	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...))

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -429,7 +429,6 @@ type tsdbMetrics struct {
 	tsdbMmapChunkCorruptionTotal      *prometheus.Desc
 	tsdbMmapChunkQueueOperationsTotal *prometheus.Desc
 	tsdbOOOHistogram                  *prometheus.Desc
-	tsdbMaxTime                       *prometheus.Desc
 
 	tsdbExemplarsTotal          *prometheus.Desc
 	tsdbExemplarsInStorage      *prometheus.Desc
@@ -547,10 +546,6 @@ func newTSDBMetrics(r prometheus.Registerer, logger log.Logger) *tsdbMetrics {
 			"cortex_ingester_tsdb_sample_out_of_order_delta_seconds",
 			"Delta in seconds by which a sample is considered out-of-order.",
 			nil, nil),
-		tsdbMaxTime: prometheus.NewDesc(
-			"cortex_ingester_tsdb_head_max_time_seconds",
-			"Maximum timestamp of the head block across all tenants.",
-			nil, nil),
 		tsdbLoadedBlocks: prometheus.NewDesc(
 			"cortex_ingester_tsdb_blocks_loaded",
 			"Number of currently loaded data blocks",
@@ -665,7 +660,6 @@ func (sm *tsdbMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- sm.tsdbMmapChunkCorruptionTotal
 	out <- sm.tsdbMmapChunkQueueOperationsTotal
 	out <- sm.tsdbOOOHistogram
-	out <- sm.tsdbMaxTime
 	out <- sm.tsdbLoadedBlocks
 	out <- sm.tsdbSymbolTableSize
 	out <- sm.tsdbReloads
@@ -714,7 +708,6 @@ func (sm *tsdbMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, sm.tsdbMmapChunkCorruptionTotal, "prometheus_tsdb_mmap_chunk_corruptions_total")
 	data.SendSumOfCountersWithLabels(out, sm.tsdbMmapChunkQueueOperationsTotal, "prometheus_tsdb_chunk_write_queue_operations_total", "operation")
 	data.SendSumOfHistograms(out, sm.tsdbOOOHistogram, "prometheus_tsdb_sample_ooo_delta")
-	data.SendMaxOfGauges(out, sm.tsdbMaxTime, "prometheus_tsdb_head_max_time_seconds")
 	data.SendSumOfGauges(out, sm.tsdbLoadedBlocks, "prometheus_tsdb_blocks_loaded")
 	data.SendSumOfGaugesPerTenant(out, sm.tsdbSymbolTableSize, "prometheus_tsdb_symbol_table_size_bytes")
 	data.SendSumOfCounters(out, sm.tsdbReloads, "prometheus_tsdb_reloads_total")

--- a/pkg/ingester/metrics_test.go
+++ b/pkg/ingester/metrics_test.go
@@ -235,10 +235,6 @@ func TestTSDBMetrics(t *testing.T) {
 			# HELP cortex_ingester_tsdb_exemplar_exemplars_in_storage Number of TSDB exemplars currently in storage.
 			# TYPE cortex_ingester_tsdb_exemplar_exemplars_in_storage gauge
 			cortex_ingester_tsdb_exemplar_exemplars_in_storage 30
-
-			# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-			# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-			cortex_ingester_tsdb_head_max_time_seconds 85787000
 	`))
 	require.NoError(t, err)
 }
@@ -453,10 +449,6 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_out_of_order_samples_appended_total counter
 			cortex_ingester_tsdb_out_of_order_samples_appended_total{user="user1"} 3
 			cortex_ingester_tsdb_out_of_order_samples_appended_total{user="user2"} 3
-
-			# HELP cortex_ingester_tsdb_head_max_time_seconds Maximum timestamp of the head block across all tenants.
-			# TYPE cortex_ingester_tsdb_head_max_time_seconds gauge
-			cortex_ingester_tsdb_head_max_time_seconds 85787000
 	`))
 	require.NoError(t, err)
 }
@@ -708,12 +700,6 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "Total number of appended out-of-order samples.",
 	})
 	outOfOrderSamplesAppendedTotal.Add(3)
-
-	maxTime := promauto.With(r).NewGauge(prometheus.GaugeOpts{
-		Name: "prometheus_tsdb_head_max_time_seconds",
-		Help: "Maximum timestamp of the head block.",
-	})
-	maxTime.Set(1000 * base)
 
 	return r
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes `cortex_ingester_tsdb_head_max_time_seconds` metric introduced in https://github.com/grafana/mimir/pull/5786.

`cortex_ingester_tsdb_head_max_time_seconds` is based on `prometheus_tsdb_head_max_time_seconds`, which however is NOT exported by TSDB library. TSDB library only exports `prometheus_tsdb_head_max_time` (without `_seconds` suffix). Metric with `_seconds` suffix is exported by Prometheus `main` package here:

https://github.com/grafana/mimir-prometheus/blob/32d87282addfaa2af9f7a6b953d17f3da6101d66/cmd/prometheus/main.go#L1194-L1201

~We fix Mimir metric by exporting the `prometheus_tsdb_head_max_time_seconds` on our own, registered into per-TSDB registry. Note that Prometheus metric exports it with seconds precision because of integer division, in Mimir we do float division instead.~

**Update:** We now compute max timestamp in the ingester, which simplifies the logic. Metric name was changed to `cortex_ingester_tsdb_head_max_timestamp_seconds` and "min" version was also added (`cortex_ingester_tsdb_head_min_timestamp_seconds`)

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
