### PR TITLE
Add alert when data too far in the future is ingested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@
 * [ENHANCEMENT] Dashboards: add native histogram active series and active buckets to "tenants" dashboard. #5543
 * [ENHANCEMENT] Dashboards: add panels to "Mimir / Writes" for requests rejected for per-instance limits. #5638
 * [ENHANCEMENT] Dashboards: rename "Blocks currently loaded" to "Blocks currently owned" in the "Mimir / Queries" dashboard. #5705
+* [ENHANCEMENT] Alerts: Add `MimirIngestedDataTooFarInTheFuture` warning alert that triggers when Mimir ingests sample with timestamp more than 1h in the future. #5822
 * [BUGFIX] Alerts: fix `MimirIngesterRestarts` to fire only when the ingester container is restarted, excluding the cases the pod is rescheduled. #5397
 * [BUGFIX] Dashboards: fix "unhealthy pods" panel on "rollout progress" dashboard showing only a number rather than the name of the workload and the number of unhealthy pods if only one workload has unhealthy pods. #5113 #5200
 * [BUGFIX] Alerts: fixed `MimirIngesterHasNotShippedBlocks` and `MimirIngesterHasNotShippedBlocksSinceStart` alerts. #5396

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1190,7 +1190,7 @@ How it **works**:
 
 How to **investigate**
 
-- Find the tenant with bad sample on ingester's tenants list, where a warning is displayed if Head MaxT is too far in the future.
+- Find the tenant with bad sample on ingester's tenants list, where a warning "maxT too far in the future" is displayed.
 - Flush tenant's data to blocks storage.
 - Remove tenant's directory on disk and restart ingester.
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1190,7 +1190,7 @@ How it **works**:
 
 How to **investigate**
 
-- Find the tenant with bad sample on ingester's tenants list, where a warning "maximum time too far in the future" is displayed.
+- Find the tenant with bad sample on ingester's tenants list, where a warning "TSDB Head max timestamp too far in the future" is displayed.
 - Flush tenant's data to blocks storage.
 - Remove tenant's directory on disk and restart ingester.
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1178,6 +1178,22 @@ How to **investigate**:
   {name="rollout-operator",namespace="<namespace>"}
   ```
 
+### MimirIngestedDataTooFarInTheFuture
+
+This alert fires when Mimir ingester accepts a sample with timestamp that is too far in the future.
+This is typically a result of processing of corrupted message, and it can cause rejection of other samples (from "now").
+
+How it **works**:
+
+- The metric exported by ingester computes maximum timestamp from all TSDBs open in ingester.
+- Alert checks this exported metric and fires if maximum timestamp is more than 1h in the future.
+
+How to **investigate**
+
+- Find the tenant with bad sample on ingester's tenants list, where a warning is displayed if Head MaxT is too far in the future.
+- Flush tenant's data to blocks storage.
+- Remove tenant's directory on disk and restart ingester.
+
 ## Errors catalog
 
 Mimir has some codified error IDs that you might see in HTTP responses or logs.

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1181,7 +1181,7 @@ How to **investigate**:
 ### MimirIngestedDataTooFarInTheFuture
 
 This alert fires when Mimir ingester accepts a sample with timestamp that is too far in the future.
-This is typically a result of processing of corrupted message, and it can cause rejection of other samples (from "now").
+This is typically a result of processing of corrupted message, and it can cause rejection of other samples with timestamp close to "now" (real-world time).
 
 How it **works**:
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1190,7 +1190,7 @@ How it **works**:
 
 How to **investigate**
 
-- Find the tenant with bad sample on ingester's tenants list, where a warning "maxT too far in the future" is displayed.
+- Find the tenant with bad sample on ingester's tenants list, where a warning "maximum time too far in the future" is displayed.
 - Flush tenant's data to blocks storage.
 - Remove tenant's directory on disk and restart ingester.
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -201,6 +201,20 @@ spec:
       for: 1h
       labels:
         severity: warning
+    - alert: MimirIngestedDataTooFarInTheFuture
+      annotations:
+        message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+          }} has ingested samples with timestamps more than 1h in the future.
+        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
+      expr: |
+        max by(cluster, namespace, pod) (
+            cortex_ingester_tsdb_head_max_timestamp_seconds - time()
+            and
+            cortex_ingester_tsdb_head_max_timestamp_seconds > 0
+        ) > 60*60
+      for: 5m
+      labels:
+        severity: warning
     - alert: MimirRingMembersMismatch
       annotations:
         message: |

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -189,6 +189,20 @@ groups:
     for: 1h
     labels:
       severity: warning
+  - alert: MimirIngestedDataTooFarInTheFuture
+    annotations:
+      message: Mimir ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} has ingested samples with timestamps more than 1h in the future.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
+    expr: |
+      max by(cluster, namespace, instance) (
+          cortex_ingester_tsdb_head_max_timestamp_seconds - time()
+          and
+          cortex_ingester_tsdb_head_max_timestamp_seconds > 0
+      ) > 60*60
+    for: 5m
+    labels:
+      severity: warning
   - alert: MimirRingMembersMismatch
     annotations:
       message: |

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -189,6 +189,20 @@ groups:
     for: 1h
     labels:
       severity: warning
+  - alert: MimirIngestedDataTooFarInTheFuture
+    annotations:
+      message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} has ingested samples with timestamps more than 1h in the future.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
+    expr: |
+      max by(cluster, namespace, pod) (
+          cortex_ingester_tsdb_head_max_timestamp_seconds - time()
+          and
+          cortex_ingester_tsdb_head_max_timestamp_seconds > 0
+      ) > 60*60
+    for: 5m
+    labels:
+      severity: warning
   - alert: MimirRingMembersMismatch
     annotations:
       message: |

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -294,7 +294,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         {
           // Alert if a ruler instance has no rule groups assigned while other instances in the same cell do.
           alert: $.alertName('IngestedDataTooFarInTheFuture'),
-          'for': '15m',
+          'for': '5m',
           expr: |||
             max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (
                 cortex_ingester_tsdb_head_max_timestamp_seconds - time()

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -291,6 +291,27 @@ local utils = import 'mixin-utils/utils.libsonnet';
             message: '%(product)s ruler %(alert_instance_variable)s in %(alert_aggregation_variables)s has no rule groups assigned.' % $._config,
           },
         },
+        {
+          // Alert if a ruler instance has no rule groups assigned while other instances in the same cell do.
+          alert: $.alertName('IngestedDataTooFarInTheFuture'),
+          'for': '15m',
+          expr: |||
+            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (
+                cortex_ingester_tsdb_head_max_timestamp_seconds - time()
+                and
+                cortex_ingester_tsdb_head_max_timestamp_seconds > 0
+            ) > 60*60
+          ||| % {
+            alert_aggregation_labels: $._config.alert_aggregation_labels,
+            per_instance_label: $._config.per_instance_label,
+          },
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s ingester %(alert_instance_variable)s in %(alert_aggregation_variables)s has ingested samples with timestamps more than 1h in the future.' % $._config,
+          },
+        },
       ] + [
         {
           alert: $.alertName('RingMembersMismatch'),

--- a/pkg/ingester/tenants_http.go
+++ b/pkg/ingester/tenants_http.go
@@ -87,7 +87,7 @@ func (i *Ingester) TenantsHandler(w http.ResponseWriter, req *http.Request) {
 		s.MaxTime = formatMillisTime(maxMillis)
 
 		if maxMillis-nowMillis > i.limits.CreationGracePeriod(t).Milliseconds() {
-			s.Warning = "maximum time too far in the future"
+			s.Warning = "TSDB Head max timestamp too far in the future"
 		}
 
 		tss = append(tss, s)

--- a/pkg/ingester/tenants_http.go
+++ b/pkg/ingester/tenants_http.go
@@ -87,7 +87,7 @@ func (i *Ingester) TenantsHandler(w http.ResponseWriter, req *http.Request) {
 		s.MaxTime = formatMillisTime(maxMillis)
 
 		if maxMillis-nowMillis > i.limits.CreationGracePeriod(t).Milliseconds() {
-			s.Warning = "maxT too far in the future"
+			s.Warning = "maximum time too far in the future"
 		}
 
 		tss = append(tss, s)


### PR DESCRIPTION
#### What this PR does

This PR adds alert that triggers when samples with timestamps more than 1h in the future are ingested.

We have seen this happen as a result of processing of corrupted messages in ingester. We would like to detect this situation sooner.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
