### PR TITLE
Increase `multi_zone_store_gateway_max_unavailable` when store gateway lazy loading is disabled 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@
 * [ENHANCEMENT] Gossip-ring: add appProtocol for istio compatibility. #5680
 * [ENHANCEMENT] Add _config.commonConfig to allow adding common configuration parameters for all Mimir components. #5703
 * [ENHANCEMENT] Update rollout-operator to `v0.7.0`. #5718
+* [ENHANCEMENT] Increase the default rollout speed for store-gateway when lazy loading is disabled. #5823
 * [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
 
 ### Mimirtool

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -24,7 +24,9 @@
     multi_zone_store_gateway_read_path_enabled: $._config.multi_zone_store_gateway_enabled,
     multi_zone_store_gateway_migration_enabled: false,
     multi_zone_store_gateway_replicas: 0,
-    multi_zone_store_gateway_max_unavailable: 50,
+    // When store-gateway lazy loading is disabled, store-gateway may take a long time to startup.
+    // To speed up rollouts, we increase the max unavailable to rollout all store-gateways in a zone in a single batch.
+    multi_zone_store_gateway_max_unavailable: if $._config.store_gateway_lazy_loading_enabled then 50 else 1000,
 
     // We can update the queryBlocksStorageConfig only once the migration is over. During the migration
     // we don't want to apply these changes to single-zone store-gateways too.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

To speed up rollouts, this increases the number of max unavailable store-gateways from 50 to 1000 when lazy loading is disabled. (This is upstreamed from internal jsonnet at GL).

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
