### PR TITLE
Add support for paging when searching for dashboards with mimirtool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@
 
 ### Mimirtool
 
-* [ENHANCEMENT] Mimirtool uses paging to fetch all dashboards from Grafana when running `mimirtool analyse grafana`. This allows the tool to correctly work when there are more than a 1000 dashboards being analysed. #5825
+* [ENHANCEMENT] Mimirtool uses paging to fetch all dashboards from Grafana when running `mimirtool analyse grafana`. This allows the tool to work correctly when running against Grafana instances with more than a 1000 dashboards. #5825
 
 ### Mimir Continuous Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,8 @@
 
 ### Mimirtool
 
+* [ENHANCEMENT] Mimirtool uses paging to fetch all dashboards from Grafana when running `mimirtool analyse grafana`. This allows the tool to correctly work when there are more than a 1000 dashboards being analysed. #5825
+
 ### Mimir Continuous Test
 
 ### Query-tee

--- a/pkg/mimirtool/commands/analyse_grafana.go
+++ b/pkg/mimirtool/commands/analyse_grafana.go
@@ -122,7 +122,7 @@ func getAllDashboards(ctx context.Context, c *sdk.Client) ([]sdk.FoundBoard, err
 		}
 		// we found more results, let's keep going
 		results = append(results, nextPageResults...)
-		currentPage += 1
+		currentPage++
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

`mimirtool analyze grafana` used to search for dashboards without any paging. The [Search API](https://grafana.com/docs/grafana/latest/developers/http_api/folder_dashboard_search/) has a default limit of 1000 and so folks with more than a 1000 dashboards are currently unable to use this tool. The API supports paging and so this PR updates mimirtool to try and fetch all pages with the default limit (1000).

#### Which issue(s) this PR fixes or relates to


#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
