### PR TITLE
Upgrade Delve to a version compatible with Go 1.21.

### DIFF
--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_IMAGE # Use ./compose-up.sh to build this image.
 FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
 
 FROM alpine:3.18.2
 

--- a/development/mimir-read-write-mode/dev.dockerfile
+++ b/development/mimir-read-write-mode/dev.dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_IMAGE # Use ./compose-up.sh to build this image.
 FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.20.2
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
 
 FROM alpine:3.18.2
 


### PR DESCRIPTION
#### What this PR does

This PR upgrades Delve to a version compatible with Go 1.21. Without this, starting either Docker Compose stack with debugging enabled fails.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
