### PR TITLE
Enforce -validation.create-grace-period in the query-frontend when the configured value is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [CHANGE] The `-shutdown-delay` flag is no longer experimental. #5701
 * [CHANGE] The `-validation.create-grace-period` is now enforced in the ingester too, other than distributor and query-frontend. If you've configured `-validation.create-grace-period` then make sure the configuration is applied to ingesters too. #5712
 * [CHANGE] The `-validation.create-grace-period` is now enforced for examplars too in the distributor. If an examplar has timestamp greater than "now + grace_period", then the exemplar will be dropped and the metric `cortex_discarded_exemplars_total{reason="exemplar_too_far_in_future",user="..."}` increased. #5761
+* [CHANGE] The `-validation.create-grace-period` is now enforced in the query-frontend even when the configured value is 0. When the value is 0, the query end time range is truncated to the current real-world time. #5829
 * [CHANGE] Store-gateway: deprecate configuration parameters for index header under `blocks-storage.bucket-store` and use a new configurations in `blocks-storage.bucket-store.index-header`, deprecated configuration will be removed in Mimir 2.12. Configuration changes: #5726
   * `-blocks-storage.bucket-store.index-header-lazy-loading-enabled` is deprecated, use the new configuration `-blocks-storage.bucket-store.index-header.lazy-loading-enabled`
   * `-blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout` is deprecated, use the new configuration `-blocks-storage.bucket-store.index-header.lazy-loading-idle-timeout`

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -156,18 +156,16 @@ func (l limitsMiddleware) Do(ctx context.Context, r Request) (Response, error) {
 
 	// Enforce the max end time.
 	creationGracePeriod := validation.LargestPositiveNonZeroDurationPerTenant(tenantIDs, l.CreationGracePeriod)
-	if creationGracePeriod > 0 {
-		maxEndTime := util.TimeToMillis(time.Now().Add(creationGracePeriod))
-		if r.GetEnd() > maxEndTime {
-			// Replace the end time in the request.
-			level.Debug(log).Log(
-				"msg", "the end time of the query has been manipulated because of the 'creation grace period' setting",
-				"original", util.FormatTimeMillis(r.GetEnd()),
-				"updated", util.FormatTimeMillis(maxEndTime),
-				"creationGracePeriod", creationGracePeriod)
+	maxEndTime := util.TimeToMillis(time.Now().Add(creationGracePeriod))
+	if r.GetEnd() > maxEndTime {
+		// Replace the end time in the request.
+		level.Debug(log).Log(
+			"msg", "the end time of the query has been manipulated because of the 'creation grace period' setting",
+			"original", util.FormatTimeMillis(r.GetEnd()),
+			"updated", util.FormatTimeMillis(maxEndTime),
+			"creationGracePeriod", creationGracePeriod)
 
-			r = r.WithStartEnd(r.GetStart(), maxEndTime)
-		}
+		r = r.WithStartEnd(r.GetStart(), maxEndTime)
 	}
 
 	// Enforce max query size, in bytes.

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -300,11 +300,11 @@ func TestLimitsMiddleware_CreationGracePeriod(t *testing.T) {
 		creationGracePeriod time.Duration
 		expectedEndTime     time.Time
 	}{
-		"should not manipulate time range if creation grace period is disabled": {
+		"should manipulate time range if creation grace period is set to 0": {
 			reqStartTime:        now.Add(-time.Hour),
 			reqEndTime:          now.Add(2 * time.Hour),
 			creationGracePeriod: 0,
-			expectedEndTime:     now.Add(2 * time.Hour),
+			expectedEndTime:     now,
 		},
 		"should not manipulate time range for a query in now + creation_grace_period": {
 			reqStartTime:        now.Add(-time.Hour),


### PR DESCRIPTION
#### What this PR does
The `-validation.create-grace-period` is always enforced in distributors and ingesters, even when the configured value is 0. However, in the query-frontend we consider the value 0 as "disabled". In this PR I propose to align the behaviour between query-frontend and distributor/ingester.

The default value for this setting is 10 minutes, so the behaviour will not change for anyone unless they explicitly set a value of 0. If they explicitly set a value of 0, the distributor/ingester will not ingest any sample with timestamp > real-world time, so in practice there should be no sample in the future to query as well.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
