### PR TITLE
Fix buffer-pooling ingester client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
   * `-<prefix>.initial-connection-window-size`
 * [ENHANCEMENT] Query-frontend: added "response_size_bytes" field to "query stats" log. #5196
 * [ENHANCEMENT] Querier: Refine error messages for per-tenant query limits, informing the user of the preferred strategy for not hitting the limit, in addition to how they may tweak the limit. #5059
-* [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. This optimization can be enabled by setting `-distributor.write-requests-buffer-pooling-enabled` to `true`. #5195 #5805
+* [ENHANCEMENT] Distributor: optimize sending of requests to ingesters by reusing memory buffers for marshalling requests. This optimization can be enabled by setting `-distributor.write-requests-buffer-pooling-enabled` to `true`. #5195 #5805 #5830
 * [ENHANCEMENT] Querier: add experimental `-querier.minimize-ingester-requests` option to initially query only the minimum set of ingesters required to reach quorum. #5202 #5259 #5263
 * [ENHANCEMENT] Querier: improve error message when streaming chunks from ingesters to queriers and a query limit is reached. #5245
 * [ENHANCEMENT] Use new data structure for labels, to reduce memory consumption. #3555 #5731

--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -92,6 +92,41 @@ func TestWriteRequestBufferingClient_Push(t *testing.T) {
 	})
 }
 
+func TestWriteRequestBufferingClient_PushWithCancelContext(t *testing.T) {
+	serv, conn := setupGrpc(t)
+
+	bufferingClient := IngesterClient(newBufferPoolingIngesterClient(NewIngesterClient(conn), conn))
+
+	var requestsToSend []*mimirpb.WriteRequest
+	for i := 0; i < 100; i++ {
+		requestsToSend = append(requestsToSend, createRequest("test", 100+10*i))
+	}
+
+	serv.clearRequests()
+
+	pool := &pool2.TrackedPool{Parent: &sync.Pool{}}
+	slabPool := pool2.NewFastReleasingSlabPool[byte](pool, 512*1024)
+
+	ctx := WithSlabPool(context.Background(), slabPool)
+
+	for _, r := range requestsToSend {
+		started := make(chan bool)
+
+		// start background goroutine to cancel context. We want to hit the moment after enqueuing data frame, but before it's sent.
+		cc, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+			close(started)
+			time.Sleep(1 * time.Millisecond)
+			cancel()
+		}()
+
+		<-started
+
+		_, _ = bufferingClient.Push(cc, r)
+	}
+}
+
 func TestWriteRequestBufferingClient_Push_WithMultipleMarshalCalls(t *testing.T) {
 	serv, conn := setupGrpc(t)
 

--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -93,7 +93,7 @@ func TestWriteRequestBufferingClient_Push(t *testing.T) {
 }
 
 func TestWriteRequestBufferingClient_PushWithCancelContext(t *testing.T) {
-	serv, conn := setupGrpc(t)
+	_, conn := setupGrpc(t)
 
 	bufferingClient := IngesterClient(newBufferPoolingIngesterClient(NewIngesterClient(conn), conn))
 
@@ -101,8 +101,6 @@ func TestWriteRequestBufferingClient_PushWithCancelContext(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		requestsToSend = append(requestsToSend, createRequest("test", 100+10*i))
 	}
-
-	serv.clearRequests()
 
 	pool := &pool2.TrackedPool{Parent: &sync.Pool{}}
 	slabPool := pool2.NewFastReleasingSlabPool[byte](pool, 512*1024)


### PR DESCRIPTION
#### What this PR does

This PR fixes data race caused by using buffer-pooling ingester client, originally introduced in https://github.com/grafana/mimir/pull/5195. Before this PR the client would always return buffers to the pool. However in case of context cancellations buffers could still be enqueued for sending inside gRPC client, and returning them back to pool would cause data race.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
