### PR TITLE
Fix regex for label_values metric extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@
 ### Mimirtool
 
 * [ENHANCEMENT] Mimirtool uses paging to fetch all dashboards from Grafana when running `mimirtool analyse grafana`. This allows the tool to work correctly when running against Grafana instances with more than a 1000 dashboards. #5825
+* [BUGFIX] Mimirtool no longer parses label names as metric names when handling templating variables that are populated using `label_values(<label_name>)` when running `mimirtool analyse grafana`. #5832
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/analyze/grafana.go
+++ b/pkg/mimirtool/analyze/grafana.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	lvRegexp = regexp.MustCompile(`label_values\(([a-zA-Z0-9_]+)`)
+	lvRegexp = regexp.MustCompile(`label_values\((.+),`)
 	qrRegexp = regexp.MustCompile(`query_result\((.+)\)`)
 )
 

--- a/pkg/mimirtool/commands/testdata/apiserver.json
+++ b/pkg/mimirtool/commands/testdata/apiserver.json
@@ -1470,7 +1470,7 @@
             "multi": false,
             "name": "cluster",
             "options": [ ],
-            "query": "label_values(apiserver_request_total, cluster)",
+            "query": "label_values(cluster)",
             "refresh": 2,
             "regex": "",
             "sort": 1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The current regex we use for extracting metric names from template variables that use the `label_values` function doesn't wuite work correctly because `label_values` can be used one of two ways:
1. It can be used with a label name such that it returns all label values across all metrics for that label, eg. `label_values(cluster)`
2. It can be used with a label name along with a metric expression such that only label values that appear on that metric are returned. eg. `label_values(kube_pod_info, pod)`. *Note that this can also involve metric expressions with additional filters, for example `label_values(kube_pod_info{"cluster"="cluster1"}, pod)`*.

The current regex we use incorrectly interprets label keys as metric names in the first situation, and doesn't handle metric expressions that contain filters in the second situation. The only care it works is if one uses something like `label_values(kube_pod_info, pod)`

This PR updates the regex used to handle all cases correctly. We dont match anything in the first situation, and in the second situation, we match the entire metric expression.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
