### PR TITLE
Add support for building binaries and docker images with enabled race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ DOC_EMBED := $(DOC_SOURCES_PATH)/configure/configure-the-query-frontend-work-wit
 image-tag: ## Print the docker image tag.
 	@echo $(IMAGE_TAG)
 
-image-tag-race: ## Print the docker image tag.
+image-tag-race: ## Print the docker image tag for race-enabled image.
 	@echo $(IMAGE_TAG_RACE)
 
 # Support gsed on OSX (installed via brew), falling back to sed. On Linux

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 %/$(UPTODATE_RACE): GOOS=linux
 %/$(UPTODATE_RACE): %/Dockerfile
 	@echo
-	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true --build-arg=BINARY_SUFFIX=_race -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG_RACE) $(@D)/
+	# We need gcompat -- compatibility layer with glibc, as race-detector currently requires glibc, but Alpine uses musl libc instead.
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true --build-arg=BINARY_SUFFIX=_race --build-arg=EXTRA_PACKAGES="gcompat" -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG_RACE) $(@D)/
 	@echo
 	@echo Go binaries were built using GOOS=$(GOOS) and GOARCH=$(GOARCH)
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,11 @@ DOC_EMBED := $(DOC_SOURCES_PATH)/configure/configure-the-query-frontend-work-wit
 	$(DOC_SOURCES_PATH)/get-started/_index.md \
 	$(DOC_SOURCES_PATH)/set-up/jsonnet/deploy.md
 
-.PHONY: image-tag image-tag-race
+.PHONY: image-tag
 image-tag: ## Print the docker image tag.
 	@echo $(IMAGE_TAG)
 
+.PHONY: image-tag-race
 image-tag-race: ## Print the docker image tag for race-enabled image.
 	@echo $(IMAGE_TAG_RACE)
 

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 	@echo
 	@echo Go binaries were built using GOOS=$(GOOS) and GOARCH=$(GOARCH)
 	@echo
+	@echo Image name: $(IMAGE_PREFIX)$(shell basename $(@D))
+	@echo Image name: $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG)
+	@echo
 	@echo Please use '"make push-multiarch-build-image"' to build and push build image.
 	@echo Please use '"make push-multiarch-mimir"' to build and push Mimir image.
 	@echo
@@ -112,6 +115,8 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true --build-arg=BINARY_SUFFIX=_race -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG_RACE) $(@D)/
 	@echo
 	@echo Go binaries were built using GOOS=$(GOOS) and GOARCH=$(GOARCH)
+	@echo
+	@echo Image name: $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG_RACE)
 	@echo
 	@touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 %/$(UPTODATE_RACE): GOOS=linux
 %/$(UPTODATE_RACE): %/Dockerfile
 	@echo
-	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true --build-arg=BINARY_SUFFIX=_race -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG_RACE) $(@D)/
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true --build-arg=BINARY_SUFFIX=_race -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG_RACE) $(@D)/
 	@echo
 	@echo Go binaries were built using GOOS=$(GOOS) and GOARCH=$(GOARCH)
 	@echo

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -4,7 +4,8 @@
 # Provenance-includes-copyright: The Cortex Authors.
 
 FROM       alpine:3.18.3
-RUN        apk add --no-cache ca-certificates tzdata
+ARG        EXTRA_PACKAGES
+RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -9,7 +9,7 @@ RUN        apk add --no-cache ca-certificates tzdata
 ARG        TARGETOS
 ARG        TARGETARCH
 ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
-# Set to non-empty value to use ${TARGET_SUFFIX} when copying binary, leave unset to use no suffix.
+# Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       metaconvert${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /metaconvert
 ENTRYPOINT ["/metaconvert"]

--- a/cmd/mimir-continuous-test/Dockerfile
+++ b/cmd/mimir-continuous-test/Dockerfile
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 FROM       alpine:3.18.3
-RUN        apk add --no-cache ca-certificates tzdata
+ARG        EXTRA_PACKAGES
+RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/cmd/mimir-continuous-test/Dockerfile
+++ b/cmd/mimir-continuous-test/Dockerfile
@@ -6,7 +6,7 @@ RUN        apk add --no-cache ca-certificates tzdata
 ARG        TARGETOS
 ARG        TARGETARCH
 ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
-# Set to non-empty value to use ${TARGET_SUFFIX} when copying binary, leave unset to use no suffix.
+# Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       mimir-continuous-test${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /mimir-continuous-test
 ENTRYPOINT ["/mimir-continuous-test"]

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -9,7 +9,7 @@ RUN        apk add --no-cache ca-certificates tzdata
 ARG        TARGETOS
 ARG        TARGETARCH
 ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
-# Set to non-empty value to use ${TARGET_SUFFIX} when copying mimir binary, leave unset to use no suffix.
+# Set to non-empty value to use ${BINARY_SUFFIX} when copying mimir binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       mimir${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /bin/mimir
 EXPOSE     8080

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -4,7 +4,8 @@
 # Provenance-includes-copyright: The Cortex Authors.
 
 FROM       alpine:3.18.3
-RUN        apk add --no-cache ca-certificates tzdata
+ARG        EXTRA_PACKAGES
+RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM       alpine:3.18.3
-RUN        apk add --no-cache ca-certificates tzdata
+ARG        EXTRA_PACKAGES
+RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -6,7 +6,7 @@ RUN        apk add --no-cache ca-certificates tzdata
 ARG        TARGETOS
 ARG        TARGETARCH
 ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
-# Set to non-empty value to use ${TARGET_SUFFIX} when copying binary, leave unset to use no suffix.
+# Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       mimirtool${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /bin/mimirtool
 ENTRYPOINT [ "/bin/mimirtool" ]

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -4,7 +4,8 @@
 # Provenance-includes-copyright: The Cortex Authors.
 
 FROM       alpine:3.18.3
-RUN        apk add --no-cache ca-certificates tzdata
+ARG        EXTRA_PACKAGES
+RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -9,7 +9,7 @@ RUN        apk add --no-cache ca-certificates tzdata
 ARG        TARGETOS
 ARG        TARGETARCH
 ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
-# Set to non-empty value to use ${TARGET_SUFFIX} when copying binary, leave unset to use no suffix.
+# Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       query-tee${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /query-tee
 ENTRYPOINT ["/query-tee"]


### PR DESCRIPTION
#### What this PR does

This PR adds `_race` version of binary targets (eg. `make cmd/mimir/mimir_race`) and single-platform Docker image targets  (`make cmd/mimir/.uptodate_race`).
 
#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
