### PR TITLE
Use race-enabled Mimir when running integration tests

### DIFF
--- a/.github/workflows/scripts/run-integration-tests-group.sh
+++ b/.github/workflows/scripts/run-integration-tests-group.sh
@@ -54,6 +54,8 @@ done
 REGEX="${REGEX})$"
 
 # GORACE is only applied when running with race-enabled Mimir.
+# This setting tells Go runtime to exit the binary when data race is detected. This increases the chance
+# that integration tests will fail on data races.
 export MIMIR_ENV_VARS_JSON='{"GORACE": "halt_on_error=1"}'
 
 exec go test -tags=requires_docker,stringlabels -timeout 2400s -v -count=1 -run "${REGEX}" "${INTEGRATION_DIR}/..."

--- a/.github/workflows/scripts/run-integration-tests-group.sh
+++ b/.github/workflows/scripts/run-integration-tests-group.sh
@@ -53,4 +53,7 @@ for TEST in $GROUP_TESTS; do
 done
 REGEX="${REGEX})$"
 
+# GORACE is only applied when running with race-enabled Mimir.
+export MIMIR_ENV_VARS_JSON='{"GORACE": "halt_on_error=1"}'
+
 exec go test -tags=requires_docker,stringlabels -timeout 2400s -v -count=1 -run "${REGEX}" "${INTEGRATION_DIR}/..."

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -345,10 +345,7 @@ jobs:
         run: |
           export IMAGE_TAG=$(make image-tag)
           # skopeo will by default load system-specific version of the image (linux/amd64).
-          # skopeo copy oci-archive:/tmp/images/mimir.oci "docker-daemon:grafana/mimir:$IMAGE_TAG"
           skopeo copy oci-archive:/tmp/images/mimirtool.oci "docker-daemon:grafana/mimirtool:$IMAGE_TAG"
-          # Print Mimir version and architecture loaded to Docker.
-          # docker run "grafana/mimir:$IMAGE_TAG" --version
       - name: Download Archive with Docker Images
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -288,6 +288,17 @@ jobs:
         with:
           name: Docker Images
           path: ./images.tar
+      - name: Build Mimir with race-detector
+        run: |
+          export IMAGE_TAG_RACE=$(make image-tag-race)
+          export MIMIR_IMAGE="grafana/mimir:$IMAGE_TAG_RACE"
+          make BUILD_IN_CONTAINER=false cmd/mimir/.uptodate_race
+          docker save $MIMIR_IMAGE -o ./mimir_race_image
+      - name: Upload archive with race-enabled Mimir
+        uses: actions/upload-artifact@v3
+        with:
+          name: Race-enabled Mimir
+          path: ./mimir_race_image
 
   integration:
     needs: [goversion, build]
@@ -330,14 +341,23 @@ jobs:
           name: Docker Images
       - name: Extract Docker Images from Archive
         run: tar xvf images.tar -C /
-      - name: Load Mimir Image into Docker
+      - name: Load Mimirtool Image into Docker
         run: |
           export IMAGE_TAG=$(make image-tag)
           # skopeo will by default load system-specific version of the image (linux/amd64).
-          skopeo copy oci-archive:/tmp/images/mimir.oci "docker-daemon:grafana/mimir:$IMAGE_TAG"
+          # skopeo copy oci-archive:/tmp/images/mimir.oci "docker-daemon:grafana/mimir:$IMAGE_TAG"
           skopeo copy oci-archive:/tmp/images/mimirtool.oci "docker-daemon:grafana/mimirtool:$IMAGE_TAG"
           # Print Mimir version and architecture loaded to Docker.
-          docker run "grafana/mimir:$IMAGE_TAG" --version
+          # docker run "grafana/mimir:$IMAGE_TAG" --version
+      - name: Download Archive with Docker Images
+        uses: actions/download-artifact@v3
+        with:
+          name: Race-enabled Mimir
+      - name: Load race-enabled mimir into Docker
+        run: |
+          docker load -i ./mimir_race_image
+          export IMAGE_TAG_RACE=$(make image-tag-race)
+          docker run "grafana/mimir:$IMAGE_TAG_RACE" --version
       - name: Preload Images
         # We download docker images used by integration tests so that all images are available
         # locally and the download time doesn't account in the test execution time, which is subject
@@ -345,8 +365,9 @@ jobs:
         run: go run ./tools/pre-pull-images | xargs -n1 -P4 docker pull
       - name: Integration Tests
         run: |
+          export IMAGE_TAG_RACE=$(make image-tag-race)
+          export MIMIR_IMAGE="grafana/mimir:$IMAGE_TAG_RACE"
           export IMAGE_TAG=$(make image-tag)
-          export MIMIR_IMAGE="grafana/mimir:$IMAGE_TAG"
           export MIMIRTOOL_IMAGE="grafana/mimirtool:$IMAGE_TAG"
           export MIMIR_CHECKOUT_DIR="/go/src/github.com/grafana/mimir"
           echo "Running integration tests with image: $MIMIR_IMAGE (Mimir), $MIMIRTOOL_IMAGE (Mimirtool)"

--- a/Makefile
+++ b/Makefile
@@ -643,6 +643,11 @@ integration-tests: ## Run all integration tests.
 integration-tests: cmd/mimir/$(UPTODATE)
 	go test -tags=requires_docker,stringlabels ./integration/...
 
+integration-tests-race: ## Run all integration tests with race-enabled Mimir docker image.
+integration-tests-race: export MIMIR_IMAGE=$(IMAGE_PREFIX)mimir:$(IMAGE_TAG_RACE)
+integration-tests-race: cmd/mimir/$(UPTODATE_RACE)
+	go test -timeout 30m -tags=requires_docker,stringlabels ./integration/...
+
 web-serve:
 	cd website && hugo --config config.toml --minify -v server
 

--- a/go.mod
+++ b/go.mod
@@ -268,4 +268,3 @@ replace github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-
 // Replace opentracing-contrib/go-stdlib with a fork until https://github.com/opentracing-contrib/go-stdlib/pull/68 is merged.
 replace github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
 
-replace github.com/grafana/e2e => ../e2e

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.0
 	github.com/grafana/dskit v0.0.0-20230823104051-002b55ecf009
-	github.com/grafana/e2e v0.1.1-0.20230221201045-21ebba73580b
+	github.com/grafana/e2e v0.1.1-0.20230828072146-510b1706a292
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/json-iterator/go v1.1.12
 	github.com/minio/minio-go/v7 v7.0.62
@@ -267,3 +267,5 @@ replace github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-
 
 // Replace opentracing-contrib/go-stdlib with a fork until https://github.com/opentracing-contrib/go-stdlib/pull/68 is merged.
 replace github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
+
+replace github.com/grafana/e2e => ../e2e

--- a/go.mod
+++ b/go.mod
@@ -267,4 +267,3 @@ replace github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-
 
 // Replace opentracing-contrib/go-stdlib with a fork until https://github.com/opentracing-contrib/go-stdlib/pull/68 is merged.
 replace github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
-

--- a/go.sum
+++ b/go.sum
@@ -859,6 +859,8 @@ github.com/grafana-tools/sdk v0.0.0-20211220201350-966b3088eec9 h1:LQAhgcUPnzdjU
 github.com/grafana-tools/sdk v0.0.0-20211220201350-966b3088eec9/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/dskit v0.0.0-20230823104051-002b55ecf009 h1:SRl8hp9MtwpkAwnh5/DsQmbwTgCKar8tR8rf5r9gi9U=
 github.com/grafana/dskit v0.0.0-20230823104051-002b55ecf009/go.mod h1:3u7fr4hmOhuUL9Yc1QP/oa3za73kxvqJnRJH4BA5fOM=
+github.com/grafana/e2e v0.1.1-0.20230828072146-510b1706a292 h1:t+QoVWpA+KIgwMmcNI3TDin2CUWFz3f12GdKWIfB1/g=
+github.com/grafana/e2e v0.1.1-0.20230828072146-510b1706a292/go.mod h1:3UsooRp7yW5/NJQBlXcTsAHOoykEhNUYXkQ3r6ehEEY=
 github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9 h1:WB3bGH2f1UN6jkd6uAEWfHB8OD7dKJ0v2Oo6SNfhpfQ=
 github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=

--- a/go.sum
+++ b/go.sum
@@ -859,8 +859,6 @@ github.com/grafana-tools/sdk v0.0.0-20211220201350-966b3088eec9 h1:LQAhgcUPnzdjU
 github.com/grafana-tools/sdk v0.0.0-20211220201350-966b3088eec9/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/dskit v0.0.0-20230823104051-002b55ecf009 h1:SRl8hp9MtwpkAwnh5/DsQmbwTgCKar8tR8rf5r9gi9U=
 github.com/grafana/dskit v0.0.0-20230823104051-002b55ecf009/go.mod h1:3u7fr4hmOhuUL9Yc1QP/oa3za73kxvqJnRJH4BA5fOM=
-github.com/grafana/e2e v0.1.1-0.20230221201045-21ebba73580b h1:dzle+89/D0hOxscjZlkb6ovYA52t9hl6h/S+hI8ek1Q=
-github.com/grafana/e2e v0.1.1-0.20230221201045-21ebba73580b/go.mod h1:3UsooRp7yW5/NJQBlXcTsAHOoykEhNUYXkQ3r6ehEEY=
 github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9 h1:WB3bGH2f1UN6jkd6uAEWfHB8OD7dKJ0v2Oo6SNfhpfQ=
 github.com/grafana/gomemcache v0.0.0-20230316202710-a081dae0aba9/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -170,13 +170,19 @@ func (c *Client) PushOTLP(timeseries []prompb.TimeSeries) (*http.Response, error
 
 // Query runs an instant query.
 func (c *Client) Query(query string, ts time.Time) (model.Value, error) {
-	value, _, err := c.querierClient.Query(context.Background(), query, ts)
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	value, _, err := c.querierClient.Query(ctx, query, ts)
 	return value, err
 }
 
 // Query runs a query range.
 func (c *Client) QueryRange(query string, start, end time.Time, step time.Duration) (model.Value, error) {
-	value, _, err := c.querierClient.QueryRange(context.Background(), query, promv1.Range{
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	value, _, err := c.querierClient.QueryRange(ctx, query, promv1.Range{
 		Start: start,
 		End:   end,
 		Step:  step,
@@ -200,7 +206,9 @@ func (c *Client) QueryRangeRaw(query string, start, end time.Time, step time.Dur
 
 // QueryExemplars runs an exemplar query.
 func (c *Client) QueryExemplars(query string, start, end time.Time) ([]promv1.ExemplarQueryResult, error) {
-	return c.querierClient.QueryExemplars(context.Background(), query, start, end)
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	return c.querierClient.QueryExemplars(ctx, query, start, end)
 }
 
 // QuerierAddress returns the address of the querier
@@ -223,19 +231,28 @@ func (c *Client) QueryRawAt(query string, ts time.Time) (*http.Response, []byte,
 
 // Series finds series by label matchers.
 func (c *Client) Series(matches []string, start, end time.Time) ([]model.LabelSet, error) {
-	result, _, err := c.querierClient.Series(context.Background(), matches, start, end)
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	result, _, err := c.querierClient.Series(ctx, matches, start, end)
 	return result, err
 }
 
 // LabelValues gets label values
 func (c *Client) LabelValues(label string, start, end time.Time, matches []string) (model.LabelValues, error) {
-	result, _, err := c.querierClient.LabelValues(context.Background(), label, matches, start, end)
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	result, _, err := c.querierClient.LabelValues(ctx, label, matches, start, end)
 	return result, err
 }
 
 // LabelNames gets label names
 func (c *Client) LabelNames(start, end time.Time) ([]string, error) {
-	result, _, err := c.querierClient.LabelNames(context.Background(), nil, start, end)
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	result, _, err := c.querierClient.LabelNames(ctx, nil, start, end)
 	return result, err
 }
 

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -100,6 +100,10 @@ func NewClient(
 	return c, nil
 }
 
+func (c *Client) SetTimeout(t time.Duration) {
+	c.timeout = t
+}
+
 // Push the input timeseries to the remote endpoint
 func (c *Client) Push(timeseries []prompb.TimeSeries) (*http.Response, error) {
 	// Create write request

--- a/integration/e2emimir/service.go
+++ b/integration/e2emimir/service.go
@@ -19,6 +19,7 @@ func NewMimirService(
 	image string,
 	command *e2e.Command,
 	readiness e2e.ReadinessProbe,
+	envVars map[string]string,
 	httpPort int,
 	grpcPort int,
 	otherPorts ...int,
@@ -29,12 +30,7 @@ func NewMimirService(
 		HTTPService: e2e.NewHTTPService(name, image, command, readiness, httpPort, otherPorts...),
 		grpcPort:    grpcPort,
 	}
-	// Add jaeger configuration with a 50% sampling rate so that we can trigger
-	// code paths that rely on a trace being sampled.
-	s.SetEnvVars(map[string]string{
-		"JAEGER_SAMPLER_TYPE":  "probabilistic",
-		"JAEGER_SAMPLER_PARAM": "0.5",
-	})
+	s.SetEnvVars(envVars)
 	return s
 }
 

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -30,6 +30,24 @@ func GetDefaultImage() string {
 	return "grafana/mimir:latest"
 }
 
+func GetDefaultEnvVariables() map[string]string {
+	// Add jaeger configuration with a 50% sampling rate so that we can trigger
+	// code paths that rely on a trace being sampled.
+	envVars := map[string]string{
+		"JAEGER_SAMPLER_TYPE":  "probabilistic",
+		"JAEGER_SAMPLER_PARAM": "0.5",
+	}
+
+	str := os.Getenv("MIMIR_ENV_VARS_JSON")
+	if str == "" {
+		return envVars
+	}
+	if err := json.Unmarshal([]byte(str), &envVars); err != nil {
+		panic(fmt.Errorf("can't unmarshal MIMIR_ENV_VARS_JSON as JSON, it should be a map of env var name to value: %s", err))
+	}
+	return envVars
+}
+
 func GetMimirtoolImage() string {
 	if img := os.Getenv("MIMIRTOOL_IMAGE"); img != "" {
 		return img
@@ -60,6 +78,7 @@ func newMimirServiceFromOptions(name string, defaultFlags, flags map[string]stri
 		o.Image,
 		e2e.NewCommandWithoutEntrypoint(binaryName, e2e.BuildArgs(serviceFlags)...),
 		e2e.NewHTTPReadinessProbe(o.HTTPPort, "/ready", 200, 299),
+		o.Environment,
 		o.HTTPPort,
 		o.GRPCPort,
 		o.OtherPorts...,
@@ -284,6 +303,7 @@ func NewAlertmanagerWithTLS(name string, flags map[string]string, options ...Opt
 		o.Image,
 		e2e.NewCommandWithoutEntrypoint(binaryName, e2e.BuildArgs(serviceFlags)...),
 		e2e.NewTCPReadinessProbe(o.HTTPPort),
+		o.Environment,
 		o.HTTPPort,
 		o.GRPCPort,
 		o.OtherPorts...,
@@ -319,11 +339,12 @@ func NewOverridesExporter(name string, consulAddress string, flags map[string]st
 
 // Options holds a set of options for running services, they can be altered passing Option funcs.
 type Options struct {
-	Image      string
-	MapFlags   FlagMapper
-	OtherPorts []int
-	HTTPPort   int
-	GRPCPort   int
+	Image       string
+	MapFlags    FlagMapper
+	OtherPorts  []int
+	HTTPPort    int
+	GRPCPort    int
+	Environment map[string]string
 }
 
 // Option modifies options.
@@ -332,10 +353,11 @@ type Option func(*Options)
 // newOptions creates an Options with default values and applies the options provided.
 func newOptions(options []Option) *Options {
 	o := &Options{
-		Image:    GetDefaultImage(),
-		MapFlags: NoopFlagMapper,
-		HTTPPort: httpPort,
-		GRPCPort: grpcPort,
+		Image:       GetDefaultImage(),
+		MapFlags:    NoopFlagMapper,
+		HTTPPort:    httpPort,
+		GRPCPort:    grpcPort,
+		Environment: GetDefaultEnvVariables(),
 	}
 	for _, opt := range options {
 		opt(o)

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -189,16 +189,14 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 			"-memberlist.packet-dial-timeout":  "10s",
 			"-memberlist.packet-write-timeout": "10s",
 		})
+		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
 		nextInstances = append(nextInstances, c)
 		instances = append(instances, c)
 	}
 	require.NoError(t, s.StartAndWaitReady(nextInstances...))
 
 	// Sanity check the ring membership and give each instance time to see every other instance.
-
 	for _, c := range instances {
-		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
-
 		// we expect 5*maxMimir to account for ingester, distributor, compactor, store-gateway and store-gateway-client rings
 		require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(maxMimir*5)), "cortex_ring_members"))
 		require.NoError(t, c.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -189,7 +189,9 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 			"-memberlist.packet-dial-timeout":  "10s",
 			"-memberlist.packet-write-timeout": "10s",
 		})
+		// Increase timeouts for checks.
 		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
+		c.SetMetricsTimeout(5 * time.Second)
 		nextInstances = append(nextInstances, c)
 		instances = append(instances, c)
 	}

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -191,7 +191,7 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 		})
 		// Increase timeouts for checks.
 		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
-		c.SetMetricsTimeout(5 * time.Second)
+		c.SetMetricsTimeout(30 * time.Second)
 		nextInstances = append(nextInstances, c)
 		instances = append(instances, c)
 	}
@@ -200,8 +200,8 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	// Sanity check the ring membership and give each instance time to see every other instance.
 	for _, c := range instances {
 		// we expect 5*maxMimir to account for ingester, distributor, compactor, store-gateway and store-gateway-client rings
-		require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(maxMimir*5)), "cortex_ring_members"))
-		require.NoError(t, c.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))
+		require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(maxMimir*5)), "cortex_ring_members"), "instance: %s", c.Name())
+		require.NoError(t, c.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"), "instance: %s", c.Name())
 	}
 
 	// Scale down as fast as possible but cleanly, in order to send out tombstones.

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -185,7 +185,10 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	for i := 2; i <= maxMimir; i++ {
 		name := fmt.Sprintf("mimir-%d", i)
 		join := e2e.NetworkContainerHostPort(networkName, firstInstance.Name(), 8000)
-		c := newSingleBinary(name, "", join, nil)
+		c := newSingleBinary(name, "", join, map[string]string{
+			"-memberlist.packet-dial-timeout":  "10s",
+			"-memberlist.packet-write-timeout": "10s",
+		})
 		nextInstances = append(nextInstances, c)
 		instances = append(instances, c)
 	}

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -175,10 +175,13 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	minMimir := 3
 	instances := make([]*e2emimir.MimirService, 0)
 
+	const metricsTimeout = 30 * time.Second
+	backoffConfig := backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50}
+
 	// Start the 1st instance. This will provide the initial state to other members.
 	firstInstance := newSingleBinary("mimir-1", "", "", nil)
-	firstInstance.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
-	firstInstance.SetMetricsTimeout(5 * time.Second)
+	firstInstance.SetBackoff(backoffConfig)
+	firstInstance.SetMetricsTimeout(metricsTimeout)
 
 	require.NoError(t, s.StartAndWaitReady(firstInstance))
 	instances = append(instances, firstInstance)
@@ -193,8 +196,8 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 			"-memberlist.packet-write-timeout": "10s",
 		})
 		// Increase timeouts for checks.
-		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
-		c.SetMetricsTimeout(5 * time.Second)
+		c.SetBackoff(backoffConfig)
+		c.SetMetricsTimeout(metricsTimeout)
 		nextInstances = append(nextInstances, c)
 		instances = append(instances, c)
 	}

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -177,6 +177,9 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 
 	// Start the 1st instance. This will provide the initial state to other members.
 	firstInstance := newSingleBinary("mimir-1", "", "", nil)
+	firstInstance.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
+	firstInstance.SetMetricsTimeout(5 * time.Second)
+
 	require.NoError(t, s.StartAndWaitReady(firstInstance))
 	instances = append(instances, firstInstance)
 
@@ -190,8 +193,8 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 			"-memberlist.packet-write-timeout": "10s",
 		})
 		// Increase timeouts for checks.
-		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 5 * time.Second, MaxRetries: 100})
-		c.SetMetricsTimeout(30 * time.Second)
+		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
+		c.SetMetricsTimeout(5 * time.Second)
 		nextInstances = append(nextInstances, c)
 		instances = append(instances, c)
 	}

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -190,7 +190,7 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 			"-memberlist.packet-write-timeout": "10s",
 		})
 		// Increase timeouts for checks.
-		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
+		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 5 * time.Second, MaxRetries: 100})
 		c.SetMetricsTimeout(30 * time.Second)
 		nextInstances = append(nextInstances, c)
 		instances = append(instances, c)

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -194,6 +194,8 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	// Sanity check the ring membership and give each instance time to see every other instance.
 
 	for _, c := range instances {
+		c.SetBackoff(backoff.Config{MinBackoff: 250 * time.Millisecond, MaxBackoff: 1 * time.Second, MaxRetries: 50})
+
 		// we expect 5*maxMimir to account for ingester, distributor, compactor, store-gateway and store-gateway-client rings
 		require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(maxMimir*5)), "cortex_ring_members"))
 		require.NoError(t, c.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -223,6 +223,7 @@ func TestQuerierStreamingRemoteRead(t *testing.T) {
 			now := time.Now()
 
 			c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
+			c.SetTimeout(10 * time.Second)
 			require.NoError(t, err)
 
 			// Generate the series

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -196,6 +196,7 @@ func TestQuerierStreamingRemoteRead(t *testing.T) {
 			flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), map[string]string{
 				"-distributor.ingestion-rate-limit": "1048576",
 				"-distributor.ingestion-burst-size": "1048576",
+				"-distributor.remote-timeout":       "10s",
 			})
 
 			// Start dependencies.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -269,11 +269,12 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 			Start: q.mint,
 			End:   q.maxt,
 		}
-	} else {
-		// Make a copy, to avoid changing shared SelectHints.
-		scp := *sp
-		sp = &scp
 	}
+	//else {
+	//	// Make a copy, to avoid changing shared SelectHints.
+	//	scp := *sp
+	//	sp = &scp
+	//}
 
 	level.Debug(log).Log("hint.func", sp.Func, "start", util.TimeFromMillis(sp.Start).UTC().String(), "end",
 		util.TimeFromMillis(sp.End).UTC().String(), "step", sp.Step, "matchers", util.MatchersStringer(matchers))

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -269,12 +269,11 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 			Start: q.mint,
 			End:   q.maxt,
 		}
+	} else {
+		// Make a copy, to avoid changing shared SelectHints.
+		scp := *sp
+		sp = &scp
 	}
-	//else {
-	//	// Make a copy, to avoid changing shared SelectHints.
-	//	scp := *sp
-	//	sp = &scp
-	//}
 
 	level.Debug(log).Log("hint.func", sp.Func, "start", util.TimeFromMillis(sp.Start).UTC().String(), "end",
 		util.TimeFromMillis(sp.End).UTC().String(), "step", sp.Step, "matchers", util.MatchersStringer(matchers))

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -269,6 +269,10 @@ func (q querier) Select(_ bool, sp *storage.SelectHints, matchers ...*labels.Mat
 			Start: q.mint,
 			End:   q.maxt,
 		}
+	} else {
+		// Make a copy, to avoid changing shared SelectHints.
+		scp := *sp
+		sp = &scp
 	}
 
 	level.Debug(log).Log("hint.func", sp.Func, "start", util.TimeFromMillis(sp.Start).UTC().String(), "end",

--- a/vendor/github.com/grafana/e2e/util.go
+++ b/vendor/github.com/grafana/e2e/util.go
@@ -74,31 +74,37 @@ func BuildArgs(flags map[string]string) []string {
 	return args
 }
 
-// DoGet performs a HTTP GET request towards the supplied URL and using a
+// DoGet performs an HTTP GET request towards the supplied URL and using a
 // timeout of 1 second.
 func DoGet(url string) (*http.Response, error) {
-	return doRequest("GET", url, nil, nil)
+	return doRequestWithTimeout("GET", url, nil, nil, time.Second)
+}
+
+// DoGetWithTimeout performs an HTTP GET request towards the supplied URL and using a
+// specified timeout.
+func DoGetWithTimeout(url string, timeout time.Duration) (*http.Response, error) {
+	return doRequestWithTimeout("GET", url, nil, nil, timeout)
 }
 
 // DoGetTLS is like DoGet but allows to configure a TLS config.
 func DoGetTLS(url string, tlsConfig *tls.Config) (*http.Response, error) {
-	return doRequest("GET", url, nil, tlsConfig)
+	return doRequestWithTimeout("GET", url, nil, tlsConfig, time.Second)
 }
 
 // DoPost performs a HTTP POST request towards the supplied URL with an empty
 // body and using a timeout of 1 second.
 func DoPost(url string) (*http.Response, error) {
-	return doRequest("POST", url, strings.NewReader(""), nil)
+	return doRequestWithTimeout("POST", url, strings.NewReader(""), nil, time.Second)
 }
 
-func doRequest(method, url string, body io.Reader, tlsConfig *tls.Config) (*http.Response, error) {
+func doRequestWithTimeout(method, url string, body io.Reader, tlsConfig *tls.Config, timeout time.Duration) (*http.Response, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
 	}
 
 	client := &http.Client{
-		Timeout: time.Second,
+		Timeout: timeout,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -603,7 +603,7 @@ github.com/grafana/dskit/tenant
 github.com/grafana/dskit/test
 github.com/grafana/dskit/tracing
 github.com/grafana/dskit/user
-# github.com/grafana/e2e v0.1.1-0.20230221201045-21ebba73580b
+# github.com/grafana/e2e v0.1.1-0.20230828072146-510b1706a292 => ../e2e
 ## explicit; go 1.17
 github.com/grafana/e2e
 github.com/grafana/e2e/cache
@@ -1484,3 +1484,4 @@ sigs.k8s.io/yaml
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
 # github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-20230303030534-7248a2f4c9cc
 # github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
+# github.com/grafana/e2e => ../e2e

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -603,7 +603,7 @@ github.com/grafana/dskit/tenant
 github.com/grafana/dskit/test
 github.com/grafana/dskit/tracing
 github.com/grafana/dskit/user
-# github.com/grafana/e2e v0.1.1-0.20230828072146-510b1706a292 => ../e2e
+# github.com/grafana/e2e v0.1.1-0.20230828072146-510b1706a292
 ## explicit; go 1.17
 github.com/grafana/e2e
 github.com/grafana/e2e/cache
@@ -1484,4 +1484,3 @@ sigs.k8s.io/yaml
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
 # github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-20230303030534-7248a2f4c9cc
 # github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
-# github.com/grafana/e2e => ../e2e


### PR DESCRIPTION
#### What this PR does

This PR uses race-enabled Mimir when running integration tests. To make integration tests fail on data races we pass extra `GORACE` environment variable to make Mimir exit when data race is encountered. We had to modify HTTP client to use timeouts to detect when target service stopped.

There was one data race found with these tests in `querier.go` (see run https://github.com/grafana/mimir/actions/runs/5999120207?pr=5835). Other changes in integration tests were done to make tests pass when running slower.

This has some drawbacks:
- tests will be slower (https://go.dev/doc/articles/race_detector says that race-enabled binaries can be 2-20x slower). **Update: integration tests are about 15-20% slower on average, see next comment for timing.**
- we are no longer testing the image that's pushed to Docker repository.

Fixes https://github.com/grafana/mimir/issues/5801.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
