### PR TITLE
querier: fix performance when ingesters stream samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 * [BUGFIX] Ingester: Don't set "last update time" of TSDB into the future when opening TSDB. This could prevent detecting of idle TSDB for a long time, if sample in distant future was ingested. #5787
 * [BUGFIX] Store-gateway: fix bug when lazy index header could be closed prematurely even when still in use. #5795
 * [BUGFIX] Ruler: gracefully shut down rule evaluations. #5778
+* [BUGFIX] Querier: fix performance when ingesters stream samples. #5836
 
 ### Mixin
 

--- a/pkg/mimirpb/compat_slice.go
+++ b/pkg/mimirpb/compat_slice.go
@@ -85,3 +85,8 @@ func FromBuilderToLabelAdapters(builder *labels.Builder, _ []LabelAdapter) []Lab
 func FromLabelsToLabelAdapters(ls labels.Labels) []LabelAdapter {
 	return *(*[]LabelAdapter)(unsafe.Pointer(&ls))
 }
+
+// The result will be 0 if a==b, <0 if a < b, and >0 if a > b.
+func CompareLabelAdapters(a, b []LabelAdapter) int {
+	return labels.Compare(FromLabelAdaptersToLabels(a), FromLabelAdaptersToLabels(b))
+}

--- a/pkg/mimirpb/compat_stringlabels.go
+++ b/pkg/mimirpb/compat_stringlabels.go
@@ -65,3 +65,28 @@ func FromLabelsToLabelAdapters(ls labels.Labels) []LabelAdapter {
 	})
 	return r
 }
+
+// The result will be 0 if a==b, <0 if a < b, and >0 if a > b.
+func CompareLabelAdapters(a, b []LabelAdapter) int {
+	l := len(a)
+	if len(b) < l {
+		l = len(b)
+	}
+
+	for i := 0; i < l; i++ {
+		if a[i].Name != b[i].Name {
+			if a[i].Name < b[i].Name {
+				return -1
+			}
+			return 1
+		}
+		if a[i].Value != b[i].Value {
+			if a[i].Value < b[i].Value {
+				return -1
+			}
+			return 1
+		}
+	}
+	// If all labels so far were in common, the set with fewer labels comes first.
+	return len(a) - len(b)
+}

--- a/pkg/querier/timeseries_series_set.go
+++ b/pkg/querier/timeseries_series_set.go
@@ -66,7 +66,7 @@ type byTimeSeriesLabels []mimirpb.TimeSeries
 func (b byTimeSeriesLabels) Len() int      { return len(b) }
 func (b byTimeSeriesLabels) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 func (b byTimeSeriesLabels) Less(i, j int) bool {
-	return labels.Compare(mimirpb.FromLabelAdaptersToLabels(b[i].Labels), mimirpb.FromLabelAdaptersToLabels(b[j].Labels)) < 0
+	return mimirpb.CompareLabelAdapters(b[i].Labels, b[j].Labels) < 0
 }
 
 // Labels implements the storage.Series interface.

--- a/pkg/querier/timeseries_series_set_test.go
+++ b/pkg/querier/timeseries_series_set_test.go
@@ -81,7 +81,7 @@ func BenchmarkTimeSeriesSeriesSet(b *testing.B) {
 	for seriesID := 0; seriesID < numSeries; seriesID++ {
 		lbls := mkZLabels("__name__", "test", "series_id", strconv.Itoa(seriesID))
 		var samples []mimirpb.Sample
-		for t := int64(0); t <= numSamplesPerSeries; t += 1 {
+		for t := int64(0); t <= numSamplesPerSeries; t++ {
 			samples = append(samples, mimirpb.Sample{TimestampMs: t, Value: math.Sin(float64(t))})
 		}
 		timeseries = append(timeseries, mimirpb.TimeSeries{


### PR DESCRIPTION
#### What this PR does

The conversion from LabelAdapters to Labels is expensive, now the underlying data structure is not identical, so do the comparison without converting.

Code copied from old Labels implementation.

#### Checklist

- [x] Tests updated
- NA Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
