### PR TITLE
Docs: clarify ingester_stream_chunks_when_using_blocks setting

### DIFF
--- a/docs/sources/mimir/configure/about-runtime-configuration.md
+++ b/docs/sources/mimir/configure/about-runtime-configuration.md
@@ -98,4 +98,4 @@ An advanced runtime configuration option controls if ingesters transfer encoded 
 The parameter `ingester_stream_chunks_when_using_blocks` might only be used in runtime configuration.
 A value of `true` transfers encoded chunks, and a value of `false` transfers decoded series.
 
-> **Note:** The parameter `ingester_stream_chunks_when_using_blocks` in the runtime configuration can override the setting of `-ingester.stream-chunks-when-using-blocks` (CLI flag), which is enabled by default. We strongly recommend to keep it enabled, except in rare cases where users observe Grafana Mimir rules evaluation slowing down.
+> **Note:** The parameter `ingester_stream_chunks_when_using_blocks` in the runtime configuration can override the CLI flag `-ingester.stream-chunks-when-using-blocks`, which is enabled by default. We strongly recommend to keep it enabled, except in rare cases where you observe rules evaluation slowing down.

--- a/docs/sources/mimir/configure/about-runtime-configuration.md
+++ b/docs/sources/mimir/configure/about-runtime-configuration.md
@@ -98,4 +98,4 @@ An advanced runtime configuration option controls if ingesters transfer encoded 
 The parameter `ingester_stream_chunks_when_using_blocks` might only be used in runtime configuration.
 A value of `true` transfers encoded chunks, and a value of `false` transfers decoded series.
 
-> **Note:** We strongly recommend that you use the default setting, which is `true`, except in rare cases where users observe Grafana Mimir rules evaluation slowing down.
+> **Note:** The parameter `ingester_stream_chunks_when_using_blocks` in the runtime configuration can override the setting of `-ingester.stream-chunks-when-using-blocks` (CLI flag), which is enabled by default. We strongly recommend to keep it enabled, except in rare cases where users observe Grafana Mimir rules evaluation slowing down.


### PR DESCRIPTION
#### What this PR does
After an internal conversation at Grafana Labs, we realised there's some misunderstanding around the `ingester_stream_chunks_when_using_blocks` note in the doc. In this PR I'm rephrasing based on a feedback received from @bboreham.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
