### PR TITLE
querier: fix performance when ingesters stream samples (#5836)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@
 * [BUGFIX] Querier: fix issue where `cortex_ingester_client_request_duration_seconds` metric did not include streaming query requests that did not return any series. #5695
 * [BUGFIX] Ingester: Fix ActiveSeries tracker double-counting series that have been deleted from the Head while still being active and then recreated again. #5678
 * [BUGFIX] Ingester: Don't set "last update time" of TSDB into the future when opening TSDB. This could prevent detecting of idle TSDB for a long time, if sample in distant future was ingested. #5787
+* [BUGFIX] Store-gateway: fix bug when lazy index header could be closed prematurely even when still in use. #5795
+* [BUGFIX] Ruler: gracefully shut down rule evaluations. #5778
+* [BUGFIX] Querier: fix performance when ingesters stream samples. #5836
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,6 @@
 * [BUGFIX] Querier: fix issue where `cortex_ingester_client_request_duration_seconds` metric did not include streaming query requests that did not return any series. #5695
 * [BUGFIX] Ingester: Fix ActiveSeries tracker double-counting series that have been deleted from the Head while still being active and then recreated again. #5678
 * [BUGFIX] Ingester: Don't set "last update time" of TSDB into the future when opening TSDB. This could prevent detecting of idle TSDB for a long time, if sample in distant future was ingested. #5787
-* [BUGFIX] Store-gateway: fix bug when lazy index header could be closed prematurely even when still in use. #5795
-* [BUGFIX] Ruler: gracefully shut down rule evaluations. #5778
 * [BUGFIX] Querier: fix performance when ingesters stream samples. #5836
 
 ### Mixin

--- a/pkg/mimirpb/compat_slice.go
+++ b/pkg/mimirpb/compat_slice.go
@@ -85,3 +85,8 @@ func FromBuilderToLabelAdapters(builder *labels.Builder, _ []LabelAdapter) []Lab
 func FromLabelsToLabelAdapters(ls labels.Labels) []LabelAdapter {
 	return *(*[]LabelAdapter)(unsafe.Pointer(&ls))
 }
+
+// The result will be 0 if a==b, <0 if a < b, and >0 if a > b.
+func CompareLabelAdapters(a, b []LabelAdapter) int {
+	return labels.Compare(FromLabelAdaptersToLabels(a), FromLabelAdaptersToLabels(b))
+}

--- a/pkg/mimirpb/compat_stringlabels.go
+++ b/pkg/mimirpb/compat_stringlabels.go
@@ -65,3 +65,28 @@ func FromLabelsToLabelAdapters(ls labels.Labels) []LabelAdapter {
 	})
 	return r
 }
+
+// The result will be 0 if a==b, <0 if a < b, and >0 if a > b.
+func CompareLabelAdapters(a, b []LabelAdapter) int {
+	l := len(a)
+	if len(b) < l {
+		l = len(b)
+	}
+
+	for i := 0; i < l; i++ {
+		if a[i].Name != b[i].Name {
+			if a[i].Name < b[i].Name {
+				return -1
+			}
+			return 1
+		}
+		if a[i].Value != b[i].Value {
+			if a[i].Value < b[i].Value {
+				return -1
+			}
+			return 1
+		}
+	}
+	// If all labels so far were in common, the set with fewer labels comes first.
+	return len(a) - len(b)
+}

--- a/pkg/querier/timeseries_series_set.go
+++ b/pkg/querier/timeseries_series_set.go
@@ -66,7 +66,7 @@ type byTimeSeriesLabels []mimirpb.TimeSeries
 func (b byTimeSeriesLabels) Len() int      { return len(b) }
 func (b byTimeSeriesLabels) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
 func (b byTimeSeriesLabels) Less(i, j int) bool {
-	return labels.Compare(mimirpb.FromLabelAdaptersToLabels(b[i].Labels), mimirpb.FromLabelAdaptersToLabels(b[j].Labels)) < 0
+	return mimirpb.CompareLabelAdapters(b[i].Labels, b[j].Labels) < 0
 }
 
 // Labels implements the storage.Series interface.

--- a/pkg/querier/timeseries_series_set_test.go
+++ b/pkg/querier/timeseries_series_set_test.go
@@ -6,6 +6,8 @@
 package querier
 
 import (
+	"math"
+	"strconv"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -25,18 +27,19 @@ func TestTimeSeriesSeriesSet(t *testing.T) {
 
 	timeseries := []mimirpb.TimeSeries{
 		{
-			Labels: []mimirpb.LabelAdapter{
-				{
-					Name:  "label1",
-					Value: "value1",
-				},
-			},
+			Labels:  []mimirpb.LabelAdapter{{Name: "label1", Value: "value3"}},
+			Samples: []mimirpb.Sample{{Value: 3.14, TimestampMs: 1234}},
+		},
+		{
+			Labels: []mimirpb.LabelAdapter{{Name: "label1", Value: "value2"}},
 			Samples: []mimirpb.Sample{
-				{
-					Value:       3.14,
-					TimestampMs: 1234,
-				},
+				{Value: 3.14, TimestampMs: 1234},
+				{Value: 1.618, TimestampMs: 2345},
 			},
+		},
+		{
+			Labels:  []mimirpb.LabelAdapter{{Name: "label1", Value: "value1"}},
+			Samples: []mimirpb.Sample{{Value: 3.14, TimestampMs: 1234}},
 		},
 	}
 
@@ -45,6 +48,7 @@ func TestTimeSeriesSeriesSet(t *testing.T) {
 	require.True(t, ss.Next())
 	series := ss.At()
 
+	// Series should sort into alphabetical order by labels.
 	require.Equal(t, labels.FromStrings("label1", "value1"), series.Labels())
 
 	it := series.Iterator(nil)
@@ -52,21 +56,45 @@ func TestTimeSeriesSeriesSet(t *testing.T) {
 	ts, v := it.At()
 	require.Equal(t, 3.14, v)
 	require.Equal(t, int64(1234), ts)
-	require.False(t, ss.Next())
-
-	// Append a new sample to seek to
-	timeseries[0].Samples = append(timeseries[0].Samples, mimirpb.Sample{
-		Value:       1.618,
-		TimestampMs: 2345,
-	})
-	ss = newTimeSeriesSeriesSet(timeseries)
 
 	require.True(t, ss.Next())
+	require.Equal(t, labels.FromStrings("label1", "value2"), ss.At().Labels())
 	it = ss.At().Iterator(it)
 	require.Equal(t, chunkenc.ValFloat, it.Seek(2000))
 	ts, v = it.At()
 	require.Equal(t, 1.618, v)
 	require.Equal(t, int64(2345), ts)
+
+	require.True(t, ss.Next())
+	require.Equal(t, labels.FromStrings("label1", "value3"), ss.At().Labels())
+	require.False(t, ss.Next())
+}
+
+func BenchmarkTimeSeriesSeriesSet(b *testing.B) {
+	const (
+		numSeries           = 8000
+		numSamplesPerSeries = 24 * 240
+	)
+
+	// Generate series.
+	timeseries := []mimirpb.TimeSeries{}
+	for seriesID := 0; seriesID < numSeries; seriesID++ {
+		lbls := mkZLabels("__name__", "test", "series_id", strconv.Itoa(seriesID))
+		var samples []mimirpb.Sample
+		for t := int64(0); t <= numSamplesPerSeries; t++ {
+			samples = append(samples, mimirpb.Sample{TimestampMs: t, Value: math.Sin(float64(t))})
+		}
+		timeseries = append(timeseries, mimirpb.TimeSeries{
+			Labels:  lbls,
+			Samples: samples,
+		})
+	}
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		_ = newTimeSeriesSeriesSet(timeseries)
+	}
 }
 
 func TestTimeSeriesIterator(t *testing.T) {


### PR DESCRIPTION
Backport of #5836 to r252

* querier: fix performance when ingesters stream samples

The conversion from LabelAdapters to Labels is expensive, now the underlying data structure is not identical, so do the comparison without converting.

Code copied from old Labels implementation.

* querier: add BenchmarkTimeSeriesSeriesSet and extend test

* CHANGELOG

* lint
