### PR TITLE
Ingester: Add metric to track inflight requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Store-gateway: enable sparse index headers by default. Sparse index headers reduce the time to load an index header up to 90%. #6005
 * [CHANGE] Store-gateway: lazy-loading concurrency limit default value is now 4. #6004
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
+* [ENHANCEMENT] Ingester: exported summary `cortex_ingester_inflight_push_requests_summary` tracking total number of inflight requests in percentile buckets. #5845
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879
 * [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request when not using the query-scheduler. #5879
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -336,7 +336,7 @@ func New(cfg Config, limits *validation.Overrides, activeGroupsCleanupService *u
 		return nil, err
 	}
 	i.ingestionRate = util_math.NewEWMARate(0.2, instanceIngestionRateTickInterval)
-	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetrics.Enabled, i.getInstanceLimits, i.ingestionRate)
+	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetrics.Enabled, i.getInstanceLimits, i.ingestionRate, &i.inflightPushRequests)
 	i.activeGroups = activeGroupsCleanupService
 
 	if registerer != nil {
@@ -396,7 +396,7 @@ func NewForFlusher(cfg Config, limits *validation.Overrides, registerer promethe
 	if err != nil {
 		return nil, err
 	}
-	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil)
+	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil, &i.inflightPushRequests)
 
 	i.shipperIngesterID = "flusher"
 
@@ -539,7 +539,7 @@ func (i *Ingester) updateLoop(ctx context.Context) error {
 	for {
 		select {
 		case <-inflightRequestsTicker.C:
-			i.metrics.inflightRequests.Observe(float64(i.inflightPushRequests.Load()))
+			i.metrics.inflightRequestsSummary.Observe(float64(i.inflightPushRequests.Load()))
 		case <-metadataPurgeTicker.C:
 			i.purgeUserMetricsMetadata()
 		case <-ingestionRateTicker.C:

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -510,6 +510,23 @@ func (i *Ingester) stopping(_ error) error {
 }
 
 func (i *Ingester) updateLoop(ctx context.Context) error {
+
+	// Launch a dedicated goroutine for inflightRequestsTicker
+	// to ensure it operates independently, unaffected by delays from other logics in updateLoop.
+	go func() {
+		inflightRequestsTicker := time.NewTicker(250 * time.Millisecond)
+		defer inflightRequestsTicker.Stop()
+
+		for {
+			select {
+			case <-inflightRequestsTicker.C:
+				i.metrics.inflightRequestsSummary.Observe(float64(i.inflightPushRequests.Load()))
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	rateUpdateTicker := time.NewTicker(i.cfg.RateUpdatePeriod)
 	defer rateUpdateTicker.Stop()
 
@@ -533,13 +550,8 @@ func (i *Ingester) updateLoop(ctx context.Context) error {
 	usageStatsUpdateTicker := time.NewTicker(usageStatsUpdateInterval)
 	defer usageStatsUpdateTicker.Stop()
 
-	inflightRequestsTicker := time.NewTicker(250 * time.Millisecond)
-	defer inflightRequestsTicker.Stop()
-
 	for {
 		select {
-		case <-inflightRequestsTicker.C:
-			i.metrics.inflightRequestsSummary.Observe(float64(i.inflightPushRequests.Load()))
 		case <-metadataPurgeTicker.C:
 			i.purgeUserMetricsMetadata()
 		case <-ingestionRateTicker.C:

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -6,11 +6,12 @@
 package ingester
 
 import (
+	"time"
+
 	"github.com/go-kit/log"
 	dskit_metrics "github.com/grafana/dskit/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/atomic"
 
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -48,7 +49,7 @@ type ingesterMetrics struct {
 	maxIngestionRate        prometheus.GaugeFunc
 	ingestionRate           prometheus.GaugeFunc
 	maxInflightPushRequests prometheus.GaugeFunc
-	inflightRequests        prometheus.GaugeFunc
+	inflightRequests        prometheus.Summary
 
 	// Head compactions metrics.
 	compactionsTriggered   prometheus.Counter
@@ -79,7 +80,6 @@ func newIngesterMetrics(
 	activeSeriesEnabled bool,
 	instanceLimitsFn func() *InstanceLimits,
 	ingestionRate *util_math.EwmaRate,
-	inflightRequests *atomic.Int64,
 ) *ingesterMetrics {
 	const (
 		instanceLimits     = "cortex_ingester_instance_limits"
@@ -231,14 +231,12 @@ func newIngesterMetrics(
 			return 0
 		}),
 
-		inflightRequests: promauto.With(r).NewGaugeFunc(prometheus.GaugeOpts{
-			Name: "cortex_ingester_inflight_push_requests",
-			Help: "Current number of inflight push requests in ingester.",
-		}, func() float64 {
-			if inflightRequests != nil {
-				return float64(inflightRequests.Load())
-			}
-			return 0
+		inflightRequests: promauto.With(r).NewSummary(prometheus.SummaryOpts{
+			Name:       "cortex_ingester_inflight_push_requests",
+			Help:       "Number of inflight requests sampled at a regular interval. Quantile buckets keep track of inflight requests over the last 60s.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
+			MaxAge:     time.Minute,
+			AgeBuckets: 6,
 		}),
 
 		// Not registered automatically, but only if activeSeriesEnabled is true.

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -247,7 +247,7 @@ func newIngesterMetrics(
 		inflightRequestsSummary: promauto.With(r).NewSummary(prometheus.SummaryOpts{
 			Name:       "cortex_ingester_inflight_push_requests_summary",
 			Help:       "Number of inflight requests sampled at a regular interval. Quantile buckets keep track of inflight requests over the last 60s.",
-			Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001, 1.00: 0.001},
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001, 1.00: 0.001},
 			MaxAge:     time.Minute,
 			AgeBuckets: 6,
 		}),

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -90,6 +90,7 @@ func TestUserMetricsMetadata(t *testing.T) {
 				true,
 				func() *InstanceLimits { return nil },
 				nil,
+				nil,
 			)
 
 			mm := newMetadataMap(limiter, metrics, errorSamplers, "test")

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -90,7 +90,6 @@ func TestUserMetricsMetadata(t *testing.T) {
 				true,
 				func() *InstanceLimits { return nil },
 				nil,
-				nil,
 			)
 
 			mm := newMetadataMap(limiter, metrics, errorSamplers, "test")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Enhanced Precision Alerting: Utilising Quantile Analysis for In-Flight Requests
Replaced gauge with summary metric, leveraging quantile analysis on Ingester in-flight requests, resulting in more precise alerts.
#### Checklist

- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
