### PR TITLE
scheduler: add trace span around enqueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 * [ENHANCEMENT] Ingester: add UI for listing tenants with TSDB on given ingester and viewing details of tenants's TSDB on given ingester. #5803 #5824
 * [ENHANCEMENT] Querier: improve observability of calls to store-gateways during queries. #5809
 * [ENHANCEMENT] Query-frontend: improve tracing of interactions with query-scheduler. #5818
+* [ENHANCEMENT] Query-scheduler: improve tracing of requests when request is rejected by query-scheduler. #5848
 * [BUGFIX] Ingester: Handle when previous ring state is leaving and the number of tokens has changed. #5204
 * [BUGFIX] Querier: fix issue where queries that use the `timestamp()` function fail with `execution: attempted to read series at index 0 from stream, but the stream has already been exhausted` if streaming chunks from ingesters to queriers is enabled. #5370
 * [BUGFIX] memberlist: bring back `memberlist_client_kv_store_count` metric that used to exist in Cortex, but got lost during dskit updates before Mimir 2.0. #5377

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -237,16 +237,29 @@ func (s *Scheduler) FrontendLoop(frontend schedulerpb.SchedulerForFrontend_Front
 
 		switch msg.GetType() {
 		case schedulerpb.ENQUEUE:
-			err = s.enqueueRequest(frontendCtx, frontendAddress, msg)
+			// Extract tracing information from headers in HTTP request. FrontendContext doesn't have the correct tracing
+			// information, since that is a long-running request.
+			tracer := opentracing.GlobalTracer()
+			parentSpanContext, err := httpgrpcutil.GetParentSpanForRequest(tracer, msg.HttpRequest)
+			if err != nil {
+				return err
+			}
+
+			enqueueSpan, _ := opentracing.StartSpanFromContextWithTracer(frontendCtx, tracer, "enqueue", opentracing.ChildOf(parentSpanContext))
+
+			err = s.enqueueRequest(frontendCtx, frontendAddress, msg, enqueueSpan.Context())
 			switch {
 			case err == nil:
 				resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
 			case errors.Is(err, queue.ErrTooManyRequests):
+				enqueueSpan.LogKV("error", err.Error())
 				resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.TOO_MANY_REQUESTS_PER_TENANT}
 			default:
+				enqueueSpan.LogKV("error", err.Error())
 				resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.ERROR, Error: err.Error()}
 			}
 
+			enqueueSpan.Finish()
 		case schedulerpb.CANCEL:
 			s.cancelRequestAndRemoveFromPending(frontendAddress, msg.QueryID)
 			resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
@@ -304,7 +317,7 @@ func (s *Scheduler) frontendDisconnected(frontendAddress string) {
 	}
 }
 
-func (s *Scheduler) enqueueRequest(frontendContext context.Context, frontendAddr string, msg *schedulerpb.FrontendToScheduler) error {
+func (s *Scheduler) enqueueRequest(frontendContext context.Context, frontendAddr string, msg *schedulerpb.FrontendToScheduler, parentSpanContext opentracing.SpanContext) error {
 	// Create new context for this request, to support cancellation.
 	ctx, cancel := context.WithCancel(frontendContext)
 	shouldCancel := true
@@ -313,14 +326,6 @@ func (s *Scheduler) enqueueRequest(frontendContext context.Context, frontendAddr
 			cancel()
 		}
 	}()
-
-	// Extract tracing information from headers in HTTP request. FrontendContext doesn't have the correct tracing
-	// information, since that is a long-running request.
-	tracer := opentracing.GlobalTracer()
-	parentSpanContext, err := httpgrpcutil.GetParentSpanForRequest(tracer, msg.HttpRequest)
-	if err != nil {
-		return err
-	}
 
 	userID := msg.GetUserID()
 
@@ -335,7 +340,7 @@ func (s *Scheduler) enqueueRequest(frontendContext context.Context, frontendAddr
 	now := time.Now()
 
 	req.parentSpanContext = parentSpanContext
-	req.queueSpan, req.ctx = opentracing.StartSpanFromContextWithTracer(ctx, tracer, "queued", opentracing.ChildOf(parentSpanContext))
+	req.queueSpan, req.ctx = opentracing.StartSpanFromContext(ctx, "queued", opentracing.ChildOf(parentSpanContext))
 	req.enqueueTime = now
 	req.ctxCancel = cancel
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -242,24 +242,24 @@ func (s *Scheduler) FrontendLoop(frontend schedulerpb.SchedulerForFrontend_Front
 			tracer := opentracing.GlobalTracer()
 			parentSpanContext, err := httpgrpcutil.GetParentSpanForRequest(tracer, msg.HttpRequest)
 			if err != nil {
-				return err
-			}
-
-			enqueueSpan, _ := opentracing.StartSpanFromContextWithTracer(frontendCtx, tracer, "enqueue", opentracing.ChildOf(parentSpanContext))
-
-			err = s.enqueueRequest(frontendCtx, frontendAddress, msg, enqueueSpan.Context())
-			switch {
-			case err == nil:
-				resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
-			case errors.Is(err, queue.ErrTooManyRequests):
-				enqueueSpan.LogKV("error", err.Error())
-				resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.TOO_MANY_REQUESTS_PER_TENANT}
-			default:
-				enqueueSpan.LogKV("error", err.Error())
 				resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.ERROR, Error: err.Error()}
-			}
+			} else {
+				enqueueSpan, _ := opentracing.StartSpanFromContextWithTracer(frontendCtx, tracer, "enqueue", opentracing.ChildOf(parentSpanContext))
 
-			enqueueSpan.Finish()
+				err = s.enqueueRequest(frontendCtx, frontendAddress, msg, enqueueSpan.Context())
+				switch {
+				case err == nil:
+					resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
+				case errors.Is(err, queue.ErrTooManyRequests):
+					enqueueSpan.LogKV("error", err.Error())
+					resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.TOO_MANY_REQUESTS_PER_TENANT}
+				default:
+					enqueueSpan.LogKV("error", err.Error())
+					resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.ERROR, Error: err.Error()}
+				}
+
+				enqueueSpan.Finish()
+			}
 		case schedulerpb.CANCEL:
 			s.cancelRequestAndRemoveFromPending(frontendAddress, msg.QueryID)
 			resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -352,7 +352,7 @@ func TestSchedulerMaxOutstandingRequests(t *testing.T) {
 	mockTracer := mocktracer.New()
 	opentracing.SetGlobalTracer(mockTracer)
 	sp, _ := opentracing.StartSpanFromContextWithTracer(context.Background(), mockTracer, "client")
-	mockTracer.Inject(sp.Context(), opentracing.HTTPHeaders, (*httpgrpcutil.HttpgrpcHeadersCarrier)(req.HttpRequest))
+	require.NoError(t, mockTracer.Inject(sp.Context(), opentracing.HTTPHeaders, (*httpgrpcutil.HttpgrpcHeadersCarrier)(req.HttpRequest)))
 
 	require.NoError(t, fl.Send(&req))
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -339,16 +340,28 @@ func TestSchedulerMaxOutstandingRequests(t *testing.T) {
 
 	// One more query from the same user will trigger an error.
 	fl := initFrontendLoop(t, frontendClient, "extra-frontend")
-	require.NoError(t, fl.Send(&schedulerpb.FrontendToScheduler{
+
+	req := schedulerpb.FrontendToScheduler{
 		Type:        schedulerpb.ENQUEUE,
 		QueryID:     0,
 		UserID:      "test",
 		HttpRequest: &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"},
-	}))
+	}
+
+	// Inject span context to the request so we can check handling of max outstanding requests.
+	mockTracer := mocktracer.New()
+	opentracing.SetGlobalTracer(mockTracer)
+	sp, _ := opentracing.StartSpanFromContextWithTracer(context.Background(), mockTracer, "client")
+	mockTracer.Inject(sp.Context(), opentracing.HTTPHeaders, (*httpgrpcutil.HttpgrpcHeadersCarrier)(req.HttpRequest))
+
+	require.NoError(t, fl.Send(&req))
 
 	msg, err := fl.Recv()
 	require.NoError(t, err)
 	require.Equal(t, schedulerpb.TOO_MANY_REQUESTS_PER_TENANT, msg.Status)
+
+	spans := mockTracer.FinishedSpans()
+	require.Greater(t, len(spans), 0, "expected at least one span even if rejected by queue full")
 }
 
 func TestSchedulerForwardsErrorToFrontend(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

When dealing with a support case I was confronted with a trace where the trace ended in the frontend component, but actually the request was rejected in the scheduler. The problem is that we only trace requests that we successfully enqueued.

#### Which issue(s) this PR fixes or relates to

Internal ref: 7262

#### Checklist

- [x] Tests updated
- [N/A] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
