### PR TITLE
check-changelog.sh: ignore certain paths

### DIFF
--- a/tools/release/check-changelog.sh
+++ b/tools/release/check-changelog.sh
@@ -18,7 +18,7 @@ if [ $# -ne 1 ]; then
 fi
 
 # Find all merged PRs.
-GIT_LOG=$(git log --pretty=format:"%s" $1)
+GIT_LOG=$(git log --pretty=format:"%s" $1 -- . ':!integration' ':!operations/helm' ':!CHANGELOG.md' ':!docs')
 PR_LIST=$(echo "$GIT_LOG" | grep -Eo '#[0-9]+')
 PR_LIST_COUNT=$(echo "$PR_LIST" | wc -l | grep -Eo '[0-9]+')
 PR_AUTHORS_COUNT=$(git log --pretty=format:"%an" $1 | sort | uniq -i | wc -l | grep -Eo '[0-9]+')


### PR DESCRIPTION
#### What this PR does

Makes check-changelog.sh ignore certain paths:

- Integration tests are never user-facing changes
- Helm has its own changelog
- CHANGELOG.md are not user-facing
- Docs describe what we're shipping

This reduces the number of PRs to review for 2.10 from 270 to 200.

#### Which issue(s) this PR fixes or relates to

Ref: [Release 2.10](https://github.com/grafana/mimir/issues/5849)

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
