### PR TITLE
Fix cortex_ingester_tsdb_mmap_chunk_write_queue_operations_total metric description

### DIFF
--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -540,7 +540,7 @@ func newTSDBMetrics(r prometheus.Registerer, logger log.Logger) *tsdbMetrics {
 			nil, nil),
 		tsdbMmapChunkQueueOperationsTotal: prometheus.NewDesc(
 			"cortex_ingester_tsdb_mmap_chunk_write_queue_operations_total",
-			"Total number of memory-mapped TSDB chunk corruptions.",
+			"Total number of memory-mapped TSDB chunk operations.",
 			[]string{"operation"}, nil),
 		tsdbOOOHistogram: prometheus.NewDesc(
 			"cortex_ingester_tsdb_sample_out_of_order_delta_seconds",


### PR DESCRIPTION
#### What this PR does
I just noticed the description of `cortex_ingester_tsdb_mmap_chunk_write_queue_operations_total` says "corruptions" instead of "operations". Fixing it.

_Don't think it's worth a CHANGELOG entry._

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
