### PR TITLE
Ignore template variable queries correctly when using label_values wi…

### DIFF
--- a/pkg/mimirtool/analyze/grafana.go
+++ b/pkg/mimirtool/analyze/grafana.go
@@ -122,6 +122,8 @@ func metricsFromTemplating(templating minisdk.Templating, metrics map[string]str
 			// In case of really gross queries, like - https://github.com/grafana/jsonnet-libs/blob/e97ab17f67ab40d5fe3af7e59151dd43be03f631/hass-mixin/dashboard.libsonnet#L93
 			if len(sm) > 0 {
 				query = sm[1]
+			} else {
+				continue
 			}
 		}
 		// query_result

--- a/pkg/mimirtool/commands/analyse_grafana_test.go
+++ b/pkg/mimirtool/commands/analyse_grafana_test.go
@@ -30,6 +30,10 @@ var dashboardMetrics = []string{
 	"workqueue_queue_duration_seconds_bucket",
 }
 
+var expectedParseErrors = []string{
+	"unsupported panel type: \"text\"",
+}
+
 func TestParseMetricsInBoard(t *testing.T) {
 	var board minisdk.Board
 	output := &analyze.MetricsInGrafana{}
@@ -43,6 +47,7 @@ func TestParseMetricsInBoard(t *testing.T) {
 
 	analyze.ParseMetricsInBoard(output, board)
 	assert.Equal(t, dashboardMetrics, output.Dashboards[0].Metrics)
+	assert.Equal(t, expectedParseErrors, output.Dashboards[0].ParseErrors)
 }
 
 func BenchmarkParseMetricsInBoard(b *testing.B) {


### PR DESCRIPTION
When we dont match `lvRegex`, we should not try and parse the query string anymore, because it means we are using `label_values(<label_name>)` instead of scoping it down to a metric series.

Not adding a changelog because this bug is unreleased.