### PR TITLE
helm: pin kubernetes version to 1.20.8

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -14,6 +14,7 @@ jobs:
       ct_configfile: operations/helm/ct.yaml
       ct_check_version_increment: false
       helm_version: v3.8.2
+      k8s_version: v1.20.8
 
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
After an upgrade of the kind HitHub action in grafana/helm-charts we ended up running with 1.26. This broke our CI because our manifests are expliticly pinned to 1.20. This lead to rendering outdated object versions (policy/v1beta1/PodSecurityPolicy)

After this PR https://github.com/grafana/helm-charts/pull/2618 we can now pin the k8s version in CI
