### PR TITLE
store-gateway: fix default seriesIteratorStrategy

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -996,7 +996,7 @@ func (s *BucketStore) nonStreamingSeriesSetForBlocks(
 	seriesLimiter SeriesLimiter, // Rate limiter for loading series.
 	stats *safeQueryStats,
 ) (storepb.SeriesSet, error) {
-	var strategy seriesIteratorStrategy
+	strategy := defaultStrategy
 	if req.SkipChunks {
 		strategy = noChunkRefs
 	}

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -836,7 +836,7 @@ const (
 	// By default, the strategy is to fetch series labels AND chunk refs
 	// for time ranges overlapping mint and maxt provided.
 	// To change the default behavior, use the flags below this.
-	defaultStrategy seriesIteratorStrategy = 0
+	defaultStrategy = overlapMintMaxt
 
 	// noChunkRefs flag when used by itself fetches only series labels for series in the entire block.
 	noChunkRefs seriesIteratorStrategy = 0b00000001

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1448,6 +1448,9 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			if hasher == nil {
 				hasher = cachedSeriesHasher{hashcache.NewSeriesHashCache(100).GetBlockCache("")}
 			}
+			if tc.strategy == 0 {
+				tc.strategy = defaultStrategy // the `0` strategy is not usable, so test cases probably meant to not set it
+			}
 			loadingIterator := newLoadingSeriesChunkRefsSetIterator(
 				context.Background(),
 				postingsIterator,
@@ -1730,9 +1733,9 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 				maxT = testCase.maxT
 			}
 
-			var strategy seriesIteratorStrategy
+			strategy := defaultStrategy
 			if testCase.skipChunks {
-				strategy |= noChunkRefs
+				strategy = noChunkRefs
 			}
 			iterator, err := openBlockSeriesChunkRefsSetsIterator(
 				ctx,


### PR DESCRIPTION
This is an internal cleanup PR that could have manifested in a bug, but was harmless because this code path wasn't exercised.

### Context

The store-gateway iterators in `series_refs.go` support a series strategy which controls whether to select series based on the minT/maxT of their chunks and whether to load the chuks in memory or only scan them.

### Issue

The existing `defaultStrategy` didn't do what it was supposed to. It was a strategy which doesn't respect the request's minT/maxT. Even the comment on the strategy claims that it does respect minT/maxT:

```
	// By default, the strategy is to fetch series labels AND chunk refs
	// for time ranges overlapping mint and maxt provided.
	// To change the default behavior, use the flags below this.
```

### What this PR does

Remove the usage of the zero-value `seriesIteratorStrategy` and update the value of `defaultStrategy` to do mean it claims to mean.

### Why this didn't show as a bug

This didn't lead to bug because the default strategy wasn't used in a way that breaks:
* the only place which checks the `overlapMintMaxt` flag was also checking the other flag `noChunkRefs` too - [code](https://github.com/grafana/mimir/blob/2f0dd8923626bb1796a2e7c39f2d63c48c8f4b88/pkg/storegateway/series_refs.go#L852-L862)
  * because of this forgetting to set `overlapMintMaxt` didn't have any effect without also setting `noChunkRefs`
* five places set `noChunkRefs`
	* four of the places don't rely on `defaultStrategy`, so they never had a forgotten `overlapMintMaxt` - [code](https://github.com/grafana/mimir/blob/2f0dd8923626bb1796a2e7c39f2d63c48c8f4b88/pkg/storegateway/bucket.go#L1397), [code](https://github.com/grafana/mimir/blob/2f0dd8923626bb1796a2e7c39f2d63c48c8f4b88/pkg/storegateway/bucket.go#L1616), [code](https://github.com/grafana/mimir/blob/2f0dd8923626bb1796a2e7c39f2d63c48c8f4b88/pkg/storegateway/bucket.go#L1001), [code](https://github.com/grafana/mimir/blob/2f0dd8923626bb1796a2e7c39f2d63c48c8f4b88/pkg/storegateway/bucket.go#L1034)
	* the fifth place was a test that also needed an __unset__ `overlapMintMaxt`, so the previous behaviour was working well for it - [code](https://github.com/grafana/mimir/blob/2f0dd8923626bb1796a2e7c39f2d63c48c8f4b88/pkg/storegateway/series_refs_test.go#L1735)

However, if we apply a patch to explicitly respect this flag, the code started failing tests

```patch
diff --git a/pkg/storegateway/series_refs.go b/pkg/storegateway/series_refs.go
index 1b85c7a36..f1e82234d 100644
--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -1012,7 +1012,11 @@ func (s *loadingSeriesChunkRefsSetIterator) symbolizedSet(ctx context.Context, p
 			}
 		case !s.strategy.isNoChunkRefs():
 			clampLastChunkLength(symbolizedSet.series, metas)
-			series.chunksRanges = metasToRanges([][]chunks.Meta{metas}, s.blockID, s.minTime, s.maxTime)
+			minT, maxT := s.minTime, s.maxTime
+			if !s.strategy.isOverlapMintMaxt() {
+				minT, maxT = math.MinInt64, math.MaxInt64
+			}
+			series.chunksRanges = metasToRanges([][]chunks.Meta{metas}, s.blockID, minT, maxT)
 		}
 		symbolizedSet.series = append(symbolizedSet.series, series)
 	}
```
