### PR TITLE
Add query-scheduler enqueue and Go mutex wait time metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Grafana Mimir
 
+* [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879
+* [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request when not using the query-scheduler. #5879
+* [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
+
 ### Mixin
 
 ### Jsonnet

--- a/cmd/mimir/main_test.go
+++ b/cmd/mimir/main_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -338,6 +339,11 @@ func testSingle(t *testing.T, arguments []string, configYAML string, stdoutMessa
 
 	// reset default flags
 	flag.CommandLine = flag.NewFlagSet(arguments[0], flag.ExitOnError)
+
+	// reset Prometheus registerer and gatherer to default state to avoid "duplicate registration" errors
+	reg := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = reg
+	prometheus.DefaultGatherer = reg
 
 	main()
 

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -135,6 +135,7 @@ func TestFrontendCheckReady(t *testing.T) {
 				requestQueue: queue.NewRequestQueue(5, 0,
 					promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 					promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
+					promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
 				),
 			}
 			for i := 0; i < tt.connectedClients; i++ {

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -31,6 +31,7 @@ func BenchmarkGetNextRequest(b *testing.B) {
 		queue := NewRequestQueue(maxOutstandingPerTenant, 0,
 			promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 			promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
+			promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
 		)
 		queues = append(queues, queue)
 
@@ -88,6 +89,7 @@ func BenchmarkQueueRequest(b *testing.B) {
 		q := NewRequestQueue(maxOutstandingPerTenant, 0,
 			promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 			promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
+			promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
 		)
 
 		for ix := 0; ix < queriers; ix++ {
@@ -120,7 +122,8 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBe
 
 	queue := NewRequestQueue(1, forgetDelay,
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
-		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}))
+		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
+		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
 
 	// Start the queue service.
 	ctx := context.Background()


### PR DESCRIPTION
#### What this PR does

This PR adds two metrics that would have been useful during a recent performance investigation:

* it adds a histogram for the time taken to enqueue a request in the query-scheduler, and a corresponding metric for the query-frontend when the query-scheduler is not in use
* it exposes the `/sync/mutex/wait/total:seconds` metric exposed by the Go runtime (see https://github.com/golang/go/issues/49881)

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
