### PR TITLE
Dependencies: Update dependabot.yml to remove group update on dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,21 +11,12 @@ updates:
       interval: "weekly"
       time: "06:00"
     open-pull-requests-limit: 5 
-    groups:
-      github-action:
-        update-types:
-        - "minor"
-        - "patch"
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: "weekly"
       time: "06:02"
     open-pull-requests-limit: 5 
-    groups:
-      golang:
-        update-types:
-        - "patch"
   - package-ecosystem: docker
     directory: /mimir-build-image/
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,119 +11,68 @@ updates:
       interval: "weekly"
       time: "06:00"
     open-pull-requests-limit: 5 
+    groups:
+      github-action:
+        update-types:
+        - "minor"
+        - "patch"
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: "weekly"
       time: "06:02"
     open-pull-requests-limit: 5 
+    groups:
+      golang:
+        update-types:
+        - "patch"
   - package-ecosystem: docker
     directory: /mimir-build-image/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update:
-        update-types:
-        - "minor" 
-        - "patch"
-        - "major"
   - package-ecosystem: docker
     directory: /cmd/metaconvert/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update: 
-        update-types: 
-        - "minor"
-        - "patch"
-        - "major"
   - package-ecosystem: docker
     directory: /cmd/mimir/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update:
-        update-types:
-        - "minor"
-        - "patch"
-        - "major"
   - package-ecosystem: docker
     directory: /cmd/mimir-continuous-test/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update:
-        update-types:
-        - "minor"  
-        - "patch"
-        - "major"
   - package-ecosystem: docker
     directory: /cmd/mimirtool/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update: 
-        update-types:
-        - "minor"
-        - "patch"
-        - "major"
   - package-ecosystem: docker
     directory: /cmd/query-tee/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update:
-        update-types:
-        - "minor"
-        - "patch"
-        - "major"
   - package-ecosystem: docker
     directory: /development/mimir-microservices-mode/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update:
-        update-types:
-        - "minor"
-        - "patch"
-        - "major"
   - package-ecosystem: docker
     directory: /development/mimir-monolithic-mode/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update:
-        update-types:
-        - "minor"
-        - "patch"
-        - "major"
   - package-ecosystem: docker
     directory: /development/mimir-monolithic-mode-with-swift-storage/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update:
-        update-types:
-        - "minor"
-        - "patch"
-        - "major"
   - package-ecosystem: docker
     directory: /development/mimir-read-write-mode/
     schedule:
       interval: "daily"
       time: "06:04"
-    groups:
-      docker-dependencies-update:
-        update-types:
-        - "minor"
-        - "patch"
-        - "major"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
The current group update doesn't work on dockerfile, see https://github.com/grafana/mimir/network/updates/716202916, and it is blocking the dependabot from running. Opened a [ticket](https://github.com/dependabot/dependabot-core/issues/7938) on dependabot/core, in the meanwhile remove group configuration for docker.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
