### PR TITLE
Replace context.DeadlineExceeded with "timeout"

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"flag"
 	"fmt"
@@ -43,6 +44,8 @@ func init() {
 	prometheus.MustRegister(version.NewCollector("mimir"))
 	prometheus.MustRegister(version.NewCollector("cortex"))
 	prometheus.MustRegister(configHash)
+
+	context.DeadlineExceeded = timeoutError{}
 }
 
 const (
@@ -310,3 +313,9 @@ func expandEnvironmentVariables(config []byte) []byte {
 		return v
 	}))
 }
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -279,7 +279,7 @@ func TestDistributor_Push(t *testing.T) {
 			samples:        samplesIn{num: 10, startTimestampMs: 123456789000},
 			timeOut:        true,
 			expectedError: httpgrpc.Errorf(http.StatusInternalServerError,
-				"exceeded configured distributor remote timeout: failed pushing to ingester: timeout"),
+				"exceeded configured distributor remote timeout: failed pushing to ingester: %s", context.DeadlineExceeded),
 			metricNames: []string{lastSeenTimestamp},
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -279,7 +279,7 @@ func TestDistributor_Push(t *testing.T) {
 			samples:        samplesIn{num: 10, startTimestampMs: 123456789000},
 			timeOut:        true,
 			expectedError: httpgrpc.Errorf(http.StatusInternalServerError,
-				"exceeded configured distributor remote timeout: failed pushing to ingester: context deadline exceeded"),
+				"exceeded configured distributor remote timeout: failed pushing to ingester: timeout"),
 			metricNames: []string{lastSeenTimestamp},
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.

--- a/pkg/querier/error_translate_queryable_test.go
+++ b/pkg/querier/error_translate_queryable_test.go
@@ -89,7 +89,7 @@ func TestApiStatusCodes(t *testing.T) {
 
 		{
 			err:            context.DeadlineExceeded,
-			expectedString: "timeout",
+			expectedString: context.DeadlineExceeded.Error(),
 			expectedCode:   500,
 		},
 

--- a/pkg/querier/error_translate_queryable_test.go
+++ b/pkg/querier/error_translate_queryable_test.go
@@ -89,7 +89,7 @@ func TestApiStatusCodes(t *testing.T) {
 
 		{
 			err:            context.DeadlineExceeded,
-			expectedString: "context deadline exceeded",
+			expectedString: "timeout",
 			expectedCode:   500,
 		},
 


### PR DESCRIPTION
#### What this PR does

Replaces `context.DeadlineExceeded` with an error with a more user-friendly message.

#### Which issue(s) this PR fixes or relates to

Ref: https://github.com/grafana/mimir/issues/5883

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
