### PR TITLE
Update rule groups per tenant defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@
 * [ENHANCEMENT] Add _config.commonConfig to allow adding common configuration parameters for all Mimir components. #5703
 * [ENHANCEMENT] Update rollout-operator to `v0.7.0`. #5718
 * [ENHANCEMENT] Increase the default rollout speed for store-gateway when lazy loading is disabled. #5823
-* [ENHANCEMENT] Double the amount of rule groups for each user tier. #5896
+* [ENHANCEMENT] Double the amount of rule groups for each user tier. #5897
 * [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
 
 ### Mimirtool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@
 
 ### Jsonnet
 
+* [ENHANCEMENT] Double the amount of rule groups for each user tier. #5897
+
 ### Mimirtool
+
 * [BUGFIX] Fix out of bounds error on export with large timespans and/or series count. #5700
 
 ### Mimir Continuous Test
@@ -194,7 +197,6 @@
 * [ENHANCEMENT] Add _config.commonConfig to allow adding common configuration parameters for all Mimir components. #5703
 * [ENHANCEMENT] Update rollout-operator to `v0.7.0`. #5718
 * [ENHANCEMENT] Increase the default rollout speed for store-gateway when lazy loading is disabled. #5823
-* [ENHANCEMENT] Double the amount of rule groups for each user tier. #5897
 * [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
 
 ### Mimirtool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,7 @@
 * [ENHANCEMENT] Add _config.commonConfig to allow adding common configuration parameters for all Mimir components. #5703
 * [ENHANCEMENT] Update rollout-operator to `v0.7.0`. #5718
 * [ENHANCEMENT] Increase the default rollout speed for store-gateway when lazy loading is disabled. #5823
+* [ENHANCEMENT] Double the amount of rule groups for each user tier. #5896
 * [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
 
 ### Mimirtool

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -958,7 +958,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///ruler-query-frontend.default.svc.cluster.local:9095
         - -ruler.query-frontend.grpc-client-config.grpc-max-recv-msg-size=104857600

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -958,7 +958,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///ruler-query-frontend.default.svc.cluster.local:9095
         - -ruler.query-frontend.grpc-client-config.grpc-max-recv-msg-size=104857600

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1222,7 +1222,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ruler.ring.store=consul

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1435,7 +1435,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ruler.ring.store=consul

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1469,7 +1469,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
@@ -2392,7 +2392,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
@@ -2576,7 +2576,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
@@ -2760,7 +2760,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -846,7 +846,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -845,7 +845,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -873,7 +873,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -633,7 +633,7 @@ spec:
         - -ingester.max-global-metadata-per-metric=10
         - -ingester.max-global-metadata-per-user=30000
         - -ingester.max-global-series-per-user=150000
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.http-listen-port=8080
@@ -942,7 +942,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=example-ruler-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -845,7 +845,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -848,7 +848,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -851,7 +851,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -848,7 +848,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1222,7 +1222,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ruler.ring.store=consul

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1282,7 +1282,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ruler.ring.multi.primary=consul

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1282,7 +1282,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ruler.ring.multi.primary=consul

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1282,7 +1282,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ruler.ring.multi.primary=consul

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1282,7 +1282,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ruler.ring.multi.primary=consul

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -848,7 +848,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -845,7 +845,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -905,7 +905,7 @@ spec:
         - -ruler-storage.cache.memcached.tls-server-name=memcached-cluster
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1070,7 +1070,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1138,7 +1138,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1232,7 +1232,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.consul.hostname=consul.default.svc.cluster.local:8500
         - -ruler.ring.store=consul

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -999,7 +999,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///ruler-query-frontend.default.svc.cluster.local:9095
         - -ruler.query-frontend.grpc-client-config.grpc-max-recv-msg-size=104857600

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -873,7 +873,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -861,7 +861,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -850,7 +850,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -971,7 +971,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
@@ -1156,7 +1156,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
@@ -1341,7 +1341,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -595,7 +595,7 @@ spec:
         - -query-scheduler.service-discovery-mode=ring
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
@@ -757,7 +757,7 @@ spec:
         - -query-scheduler.service-discovery-mode=ring
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
@@ -919,7 +919,7 @@ spec:
         - -query-scheduler.service-discovery-mode=ring
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -972,7 +972,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
@@ -1157,7 +1157,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist
@@ -1342,7 +1342,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://mimir-backend.default.svc.cluster.local:8080/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///mimir-read-headless.default.svc.cluster.local:9095
         - -ruler.ring.store=memberlist

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -962,7 +962,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.query-frontend.address=dns:///ruler-query-frontend.default.svc.cluster.local:9095
         - -ruler.query-frontend.grpc-client-config.grpc-max-recv-msg-size=104857600

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -962,7 +962,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -851,7 +851,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -852,7 +852,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -849,7 +849,7 @@ spec:
         - -ruler-storage.cache.memcached.max-async-concurrency=50
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -845,7 +845,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
@@ -714,7 +714,7 @@ spec:
         - -ruler-storage.cache.redis.max-item-size=1048576
         - -ruler-storage.gcs.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -847,7 +847,7 @@ spec:
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.s3.bucket-name=rules-bucket
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local/alertmanager
-        - -ruler.max-rule-groups-per-tenant=35
+        - -ruler.max-rule-groups-per-tenant=70
         - -ruler.max-rules-per-rule-group=20
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -367,9 +367,9 @@
         ingestion_rate: 10000,
         ingestion_burst_size: 200000,
 
-        // 700 rules
+        // 1400 rules
         ruler_max_rules_per_rule_group: 20,
-        ruler_max_rule_groups_per_tenant: 35,
+        ruler_max_rule_groups_per_tenant: 70,
 
         // No retention for now.
         compactor_blocks_retention_period: '0',
@@ -383,9 +383,9 @@
         ingestion_rate: 30000,
         ingestion_burst_size: 300000,
 
-        // 1000 rules
+        // 2000 rules
         ruler_max_rules_per_rule_group: 20,
-        ruler_max_rule_groups_per_tenant: 50,
+        ruler_max_rule_groups_per_tenant: 100,
       },
 
       small_user:: {
@@ -396,9 +396,9 @@
         ingestion_rate: 100000,
         ingestion_burst_size: 1000000,
 
-        // 1400 rules
+        // 2800 rules
         ruler_max_rules_per_rule_group: 20,
-        ruler_max_rule_groups_per_tenant: 70,
+        ruler_max_rule_groups_per_tenant: 140,
       },
 
       medium_user:: {
@@ -409,9 +409,9 @@
         ingestion_rate: 350000,  // 350K
         ingestion_burst_size: 3500000,  // 3.5M
 
-        // 1800 rules
+        // 3600 rules
         ruler_max_rules_per_rule_group: 20,
-        ruler_max_rule_groups_per_tenant: 90,
+        ruler_max_rule_groups_per_tenant: 180,
       },
 
       big_user:: {
@@ -422,9 +422,9 @@
         ingestion_rate: 700000,  // 700K
         ingestion_burst_size: 7000000,  // 7M
 
-        // 2200 rules
+        // 4400 rules
         ruler_max_rules_per_rule_group: 20,
-        ruler_max_rule_groups_per_tenant: 110,
+        ruler_max_rule_groups_per_tenant: 220,
       },
 
       super_user:: {
@@ -435,9 +435,9 @@
         ingestion_rate: 1500000,  // 1.5M
         ingestion_burst_size: 15000000,  // 15M
 
-        // 2600 rules
+        // 5200 rules
         ruler_max_rules_per_rule_group: 20,
-        ruler_max_rule_groups_per_tenant: 130,
+        ruler_max_rule_groups_per_tenant: 260,
 
         compactor_split_and_merge_shards: 2,
         compactor_tenant_shard_size: 2,
@@ -453,9 +453,9 @@
         ingestion_rate: 2250000,  // 2.25M
         ingestion_burst_size: 22500000,  // 22.5M
 
-        // 3000 rules
+        // 6000 rules
         ruler_max_rules_per_rule_group: 20,
-        ruler_max_rule_groups_per_tenant: 150,
+        ruler_max_rule_groups_per_tenant: 300,
 
         compactor_split_and_merge_shards: 2,
         compactor_tenant_shard_size: 2,
@@ -470,9 +470,9 @@
         ingestion_rate: 3500000,  // 3.5M
         ingestion_burst_size: 35000000,  // 35M
 
-        // 3500 rules
+        // 7000 rules
         ruler_max_rules_per_rule_group: 20,
-        ruler_max_rule_groups_per_tenant: 175,
+        ruler_max_rule_groups_per_tenant: 350,
 
         compactor_split_and_merge_shards: 4,
         compactor_tenant_shard_size: 4,
@@ -487,9 +487,9 @@
         ingestion_rate: 4500000,  // 4.5M
         ingestion_burst_size: 45000000,  // 45M
 
-        // 4000 rules
+        // 8000 rules
         ruler_max_rules_per_rule_group: 20,
-        ruler_max_rule_groups_per_tenant: 200,
+        ruler_max_rule_groups_per_tenant: 400,
 
         compactor_split_and_merge_shards: 4,
         compactor_tenant_shard_size: 4,


### PR DESCRIPTION
#### What this PR does
We found the default number of rule groups per user were out of line with the number of rules most tenants were creating so we increased the defaults to 2x for all user tiers in our jsonnet.

#### Which issue(s) this PR fixes or relates to


#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
