### PR TITLE
mimirtool: analyze grafana fix metrics from tmpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
 ### Jsonnet
 
 ### Mimirtool
+
 * [BUGFIX] Fix out of bounds error on export with large timespans and/or series count. #5700
+* [BUGFIX] Fix panic when analyzing a grafana dashboard with multiline queries. #5911
+* [ENHANCEMENT] Extract metric name from queries that have a `__name__` matcher. #5911
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/analyze/grafana.go
+++ b/pkg/mimirtool/analyze/grafana.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
@@ -21,8 +22,10 @@ import (
 )
 
 var (
-	lvRegexp = regexp.MustCompile(`label_values\((.+),`)
-	qrRegexp = regexp.MustCompile(`query_result\((.+)\)`)
+	lvRegexp        = regexp.MustCompile(`(?s)label_values\((.+),.+\)`)
+	lvNoQueryRegexp = regexp.MustCompile(`(?s)label_values\((.+)\)`)
+	qrRegexp        = regexp.MustCompile(`(?s)query_result\((.+)\)`)
+	validMetricName = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 )
 
 type MetricsInGrafana struct {
@@ -116,8 +119,8 @@ func metricsFromTemplating(templating minisdk.Templating, metrics map[string]str
 			continue
 		}
 
-		// label_values
-		if strings.Contains(query, "label_values") {
+		// label_values(query, label)
+		if lvRegexp.MatchString(query) {
 			sm := lvRegexp.FindStringSubmatch(query)
 			// In case of really gross queries, like - https://github.com/grafana/jsonnet-libs/blob/e97ab17f67ab40d5fe3af7e59151dd43be03f631/hass-mixin/dashboard.libsonnet#L93
 			if len(sm) > 0 {
@@ -125,9 +128,11 @@ func metricsFromTemplating(templating minisdk.Templating, metrics map[string]str
 			} else {
 				continue
 			}
-		}
-		// query_result
-		if strings.Contains(query, "query_result") {
+		} else if lvNoQueryRegexp.MatchString(query) {
+			// No query so no metric.
+			continue
+		} else if qrRegexp.MatchString(query) {
+			// query_result(query)
 			query = qrRegexp.FindStringSubmatch(query)[1]
 		}
 		err = parseQuery(query, metrics)
@@ -214,7 +219,18 @@ func parseQuery(query string, metrics map[string]struct{}) error {
 
 	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
 		if n, ok := node.(*parser.VectorSelector); ok {
-			metrics[n.Name] = struct{}{}
+			// VectorSelector has .Name when it's explicitly set as `name{...}`.
+			// Otherwise we need to look into the matchers.
+			if n.Name != "" {
+				metrics[n.Name] = struct{}{}
+				return nil
+			}
+			for _, m := range n.LabelMatchers {
+				if m.Name == labels.MetricName && validMetricName.MatchString(m.Value) {
+					metrics[m.Value] = struct{}{}
+					return nil
+				}
+			}
 		}
 
 		return nil

--- a/pkg/mimirtool/analyze/grafana_test.go
+++ b/pkg/mimirtool/analyze/grafana_test.go
@@ -1,0 +1,167 @@
+package analyze
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/mimirtool/minisdk"
+)
+
+func TestMetricsFromTemplating(t *testing.T) {
+	t.Run("multiline query_result", func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query: `query_result(
+  quantile_over_time(0.95, foo{lbl="$var"}[$__range])
+)`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Len(t, metrics, 1)
+		require.Equal(t, map[string]struct{}{"foo": {}}, metrics)
+	})
+
+	t.Run("query is a metric containing 'query_result'", func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query:      `foo_bar_query_result_total{}`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Len(t, metrics, 1)
+		require.Equal(t, map[string]struct{}{"foo_bar_query_result_total": {}}, metrics)
+	})
+
+	t.Run("query is a metric containing 'label_values'", func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query:      `foo_bar_label_values_total{}`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Len(t, metrics, 1)
+		require.Equal(t, map[string]struct{}{"foo_bar_label_values_total": {}}, metrics)
+	})
+
+	t.Run(`label_values query with invalid metric name in __name__`, func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query:      `label_values({__name__=~"$prefix\\\\_?last_updated_time_seconds", job=~"$job", instance=~"$instance"}, entity)`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Empty(t, metrics)
+	})
+
+	t.Run(`label_values query with metric name in  __name__ label`, func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query:      `label_values({__name__=~"metric", job=~"$job", instance=~"$instance"}, entity)`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Len(t, metrics, 1)
+		require.Equal(t, map[string]struct{}{"metric": {}}, metrics)
+	})
+
+	t.Run(`label_values query with multiline metric`, func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query: `label_values(
+	metric,
+	label
+)`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Len(t, metrics, 1)
+		require.Equal(t, map[string]struct{}{"metric": {}}, metrics)
+	})
+
+	t.Run(`label_values query with no metric selector single line`, func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query:      `label_values(entity)`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Empty(t, metrics)
+	})
+
+	t.Run(`label_values query with no metric selector multiline `, func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query: `label_values(
+	entity
+)`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Empty(t, metrics)
+	})
+}

--- a/pkg/mimirtool/analyze/grafana_test.go
+++ b/pkg/mimirtool/analyze/grafana_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package analyze
 
 import (


### PR DESCRIPTION
#### What this PR does

The code didn't check whether `query_results` was matching before accessing the submatches, so it panicked when it didn't (in my case it didn't because it was a multiline query_results call).

I fixed that, and other issues around, adding unit tests.

Once in tests, I've added the query linked as _gross_ query, and fixed the metric name extraction when vector selector doesn't have the metric name part but only a `__name__` matcher.

#### Which issue(s) this PR fixes or relates to

None.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
