### PR TITLE
[release-2.10] Add support for paging when searching for dashboards with mimirtool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,10 @@
 * [ENHANCEMENT] Increase the default rollout speed for store-gateway when lazy loading is disabled. #5823
 * [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
 
+### Mimirtool
+
+* [ENHANCEMENT] Mimirtool uses paging to fetch all dashboards from Grafana when running `mimirtool analyse grafana`. This allows the tool to work correctly when running against Grafana instances with more than a 1000 dashboards. #5825
+
 ### Query-tee
 
 * [CHANGE] Proxy `Content-Type` response header from backend. Previously `Content-Type: text/plain; charset=utf-8` was returned on all requests. #5183

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 * [BUGFIX] Store-gateway: fix chunks corruption bug introduced in rc.0. #5875
 * [BUGFIX] Update Minio object storage client from 7.0.62 to 7.0.63 to fix auto-detection of AWS GovCloud environments. #5905
 
+### Mimirtool
+
+* [ENHANCEMENT] Mimirtool uses paging to fetch all dashboards from Grafana when running `mimirtool analyse grafana`. This allows the tool to work correctly when running against Grafana instances with more than a 1000 dashboards. #5825
+
 ## 2.10.0-rc.0
 
 ### Grafana Mimir
@@ -192,10 +196,6 @@
 * [ENHANCEMENT] Update rollout-operator to `v0.7.0`. #5718
 * [ENHANCEMENT] Increase the default rollout speed for store-gateway when lazy loading is disabled. #5823
 * [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
-
-### Mimirtool
-
-* [ENHANCEMENT] Mimirtool uses paging to fetch all dashboards from Grafana when running `mimirtool analyse grafana`. This allows the tool to work correctly when running against Grafana instances with more than a 1000 dashboards. #5825
 
 ### Query-tee
 

--- a/pkg/mimirtool/commands/analyse_grafana.go
+++ b/pkg/mimirtool/commands/analyse_grafana.go
@@ -74,7 +74,7 @@ func AnalyzeGrafana(ctx context.Context, c *sdk.Client, folders []string) (*anal
 	output := &analyze.MetricsInGrafana{}
 	output.OverallMetrics = make(map[string]struct{})
 
-	boardLinks, err := c.SearchDashboards(ctx, "", false)
+	boardLinks, err := getAllDashboards(ctx, c)
 	if err != nil {
 		return nil, err
 	}
@@ -106,6 +106,24 @@ func AnalyzeGrafana(ctx context.Context, c *sdk.Client, folders []string) (*anal
 	output.MetricsUsed = metricsUsed
 
 	return output, nil
+}
+
+func getAllDashboards(ctx context.Context, c *sdk.Client) ([]sdk.FoundBoard, error) {
+	var currentPage uint = 1
+	var results []sdk.FoundBoard
+	for {
+		nextPageResults, err := c.Search(ctx, sdk.SearchType(sdk.SearchTypeDashboard), sdk.SearchPage(currentPage))
+		if err != nil {
+			return nil, err
+		}
+		// no more pages, we got everything
+		if len(nextPageResults) == 0 {
+			return results, nil
+		}
+		// we found more results, let's keep going
+		results = append(results, nextPageResults...)
+		currentPage++
+	}
 }
 
 func unmarshalDashboard(data []byte, link sdk.FoundBoard) (minisdk.Board, error) {


### PR DESCRIPTION
* Add support for paging when searching for dashboards with mimirtool

(cherry picked from commit c7d8cb6d4b98b8782381cfab3d82ea8089375efe https://github.com/grafana/mimir/pull/5825)