### PR TITLE
[release-2.10] Fix regex for label_values metric extraction (#5832)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Mimirtool
 
 * [ENHANCEMENT] Mimirtool uses paging to fetch all dashboards from Grafana when running `mimirtool analyse grafana`. This allows the tool to work correctly when running against Grafana instances with more than a 1000 dashboards. #5825
+* [BUGFIX] Mimirtool no longer parses label names as metric names when handling templating variables that are populated using `label_values(<label_name>)` when running `mimirtool analyse grafana`. #5832
 
 ## 2.10.0-rc.0
 

--- a/pkg/mimirtool/analyze/grafana.go
+++ b/pkg/mimirtool/analyze/grafana.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	lvRegexp = regexp.MustCompile(`label_values\(([a-zA-Z0-9_]+)`)
+	lvRegexp = regexp.MustCompile(`label_values\((.+),`)
 	qrRegexp = regexp.MustCompile(`query_result\((.+)\)`)
 )
 

--- a/pkg/mimirtool/commands/testdata/apiserver.json
+++ b/pkg/mimirtool/commands/testdata/apiserver.json
@@ -1470,7 +1470,7 @@
             "multi": false,
             "name": "cluster",
             "options": [ ],
-            "query": "label_values(apiserver_request_total, cluster)",
+            "query": "label_values(cluster)",
             "refresh": 2,
             "regex": "",
             "sort": 1,


### PR DESCRIPTION
* Fix regex for label_values metric extraction
* Exercise new functionality with a test
* Add changelog

(cherry picked from commit a03417fca779e7acca5cc9dfccf3d3d8406645ed https://github.com/grafana/mimir/pull/5832)

I'm backporting this to `release-2.10` because I want to backport https://github.com/grafana/mimir/pull/5911 which was made on top of it.