### PR TITLE
Check if ingester can accept push request before reading full request into memory.

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -721,6 +721,7 @@ type pushStats struct {
 
 // AcceptPushRequest returns error if push request cannot be accepted at the moment.
 // When this method returns error, it increases relevant metrics.
+// All errors returned by this method can be converted via to status.Status by using status.FromError.
 func (i *Ingester) AcceptPushRequest() error {
 	if err := i.checkRunning(); err != nil {
 		return util_log.DoNotLogError{Err: err}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -5885,6 +5885,10 @@ func TestIngester_PushInstanceLimits(t *testing.T) {
 
 						if testData.expectedAcceptErr != nil {
 							assert.ErrorIs(t, acceptErr, testData.expectedAcceptErr)
+
+							s, ok := status.FromError(err)
+							require.True(t, ok, "expected to be able to convert to gRPC status")
+							assert.Equal(t, codes.Unavailable, s.Code())
 						} else {
 							assert.NoError(t, acceptErr)
 						}

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -226,6 +226,7 @@ func (t *Mimir) initServer() (services.Service, error) {
 	t.Cfg.Server.GRPCOptions = append(t.Cfg.Server.GRPCOptions, grpc.InTapHandle(func(ctx context.Context, info *tap.Info) (context.Context, error) {
 		var err error
 		if info.FullMethodName == "/cortex.Ingester/Push" && t.Ingester != nil {
+			// All errors returned by AcceptPushRequest can be converted to gRPC status.Status.
 			err = t.Ingester.AcceptPushRequest()
 		}
 		return ctx, err


### PR DESCRIPTION
#### What this PR does

This PR adds early check into gRPC layer to reject push requests before reading full request into memory if ingester is unable to accept them.

This approach has some negatives:
- rejected request will not be correctly accounted for in various metrics on ingester like `cortex_request_duration_seconds`, `cortex_request_message_bytes` or `cortex_inflight_requests`. All these metrics are updated later in grpc handling pipeline.
- some requests may pass the check, but still be eventually rejected due to the same limits when handling reaches Push method in ingester. The check is not perfect.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
