### PR TITLE
Add new metric in ruler to track rules that fetched no series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request when not using the query-scheduler. #5879
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
+* [ENHANCEMENT] Ruler: add new per-tenant `cortex_ruler_queries_zero_fetched_series_total` metric to track rules that fetched no series. #5925
 * [ENHANCEMENT] Implement support for `limit`, `limit_per_metric` and `metric` parameters for `<Prometheus HTTP prefix>/api/v1/metadata` endpoint. #5890
 * [ENHANCEMENT] Go: updated to 1.21.1. #5955
 * [ENHANCEMENT] Distributor: add experimental support for storing metadata when ingesting metrics via OTLP. This makes metrics description and type available when ingesting metrics via OTLP. Enable with `-distributor.enable-otlp-metadata-storage=true`. #5693

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -610,6 +610,33 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 	totalQueries, err := ruler.SumMetrics([]string{"cortex_ruler_queries_total"})
 	require.NoError(t, err)
 
+	addNewRuleAndWait := func(groupName, expression string, shouldFail bool) {
+		require.NoError(t, c.SetRuleGroup(ruleGroupWithRecordingRule(groupName, "rule", expression), namespace))
+		m := ruleGroupMatcher(user, namespace, groupName)
+
+		// Wait until ruler has loaded the group.
+		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_prometheus_rule_group_rules"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
+
+		// Wait until rule group has tried to evaluate the rule, and succeeded.
+		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
+
+		if shouldFail {
+			// Verify that evaluation of the rule failed.
+			require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluation_failures_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
+		} else {
+			// Verify that evaluation of the rule succeeded.
+			require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_prometheus_rule_evaluation_failures_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
+		}
+	}
+
+	deleteRuleAndWait := func(groupName string) {
+		// Delete rule to prepare for next part of test.
+		require.NoError(t, c.DeleteRuleGroup(namespace, groupName))
+
+		// Wait until ruler has unloaded the group. We don't use any matcher, so there should be no groups (in fact, metric disappears).
+		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_prometheus_rule_group_rules"}, e2e.SkipMissingMetrics))
+	}
+
 	// Verify that user-failures don't increase cortex_ruler_queries_failed_total
 	for groupName, expression := range map[string]string{
 		// Syntactically correct expression (passes check in ruler), but failing because of invalid regex. This fails in PromQL engine.
@@ -619,28 +646,15 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 		"too_many_chunks_group": `sum(metric)`,
 	} {
 		t.Run(groupName, func(t *testing.T) {
-			require.NoError(t, c.SetRuleGroup(ruleGroupWithRecordingRule(groupName, "rule", expression), namespace))
-			m := ruleGroupMatcher(user, namespace, groupName)
+			addNewRuleAndWait(groupName, expression, true)
 
-			// Wait until ruler has loaded the group.
-			require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_prometheus_rule_group_rules"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
-
-			// Wait until rule group has tried to evaluate the rule.
-			require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
-
-			// Verify that evaluation of the rule failed.
-			require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluation_failures_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
-
-			// But these failures were not reported as "failed queries"
+			// Ensure that these failures were not reported as "failed queries"
 			sum, err := ruler.SumMetrics([]string{"cortex_ruler_queries_failed_total"})
 			require.NoError(t, err)
 			require.Equal(t, float64(0), sum[0])
 
 			// Delete rule before checking "cortex_ruler_queries_total", as we want to reuse value for next test.
-			require.NoError(t, c.DeleteRuleGroup(namespace, groupName))
-
-			// Wait until ruler has unloaded the group. We don't use any matcher, so there should be no groups (in fact, metric disappears).
-			require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_prometheus_rule_group_rules"}, e2e.SkipMissingMetrics))
+			deleteRuleAndWait(groupName)
 
 			// Check that cortex_ruler_queries_total went up since last test.
 			newTotalQueries, err := ruler.SumMetrics([]string{"cortex_ruler_queries_total"})
@@ -656,41 +670,21 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 	t.Run("real_error", func(t *testing.T) {
 		const groupName = "good_rule"
 		const expression = `sum(metric{foo=~"1|2"})`
-
-		require.NoError(t, c.SetRuleGroup(ruleGroupWithRecordingRule(groupName, "rule", expression), namespace))
-		m := ruleGroupMatcher(user, namespace, groupName)
-
-		// Wait until ruler has loaded the group.
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_prometheus_rule_group_rules"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
-
-		// Wait until rule group has tried to evaluate the rule, and succeeded.
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_prometheus_rule_evaluation_failures_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
+		addNewRuleAndWait(groupName, expression, false)
 
 		// Still no failures.
 		sum, err := ruler.SumMetrics([]string{"cortex_ruler_queries_failed_total"})
 		require.NoError(t, err)
 		require.Equal(t, float64(0), sum[0])
 
-		// Delete rule to prepare for next test, and wait until ruler has unloaded the group.
-		require.NoError(t, c.DeleteRuleGroup(namespace, groupName))
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_prometheus_rule_group_rules"}, e2e.SkipMissingMetrics))
+		deleteRuleAndWait(groupName)
 	})
 
 	// Now let's test the metric for no fetched series.
 	t.Run("no_fetched_series_metric", func(t *testing.T) {
 		const groupName = "good_rule_with_fetched_series_but_no_samples"
 		const expression = `sum(metric{foo=~"1|2"}) < -1`
-
-		require.NoError(t, c.SetRuleGroup(ruleGroupWithRecordingRule(groupName, "rule", expression), namespace))
-		m := ruleGroupMatcher(user, namespace, groupName)
-
-		// Wait until ruler has loaded the group.
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_prometheus_rule_group_rules"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
-
-		// Wait until rule group has tried to evaluate the rule, and succeeded.
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_prometheus_rule_evaluation_failures_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
+		addNewRuleAndWait(groupName, expression, false)
 
 		// Ensure that no samples were returned.
 		sum, err := ruler.SumMetrics([]string{"cortex_prometheus_last_evaluation_samples"})
@@ -702,22 +696,11 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, float64(0), sum[0])
 
-		// Delete rule to prepare for next part of test, and wait until ruler has unloaded the group.
-		require.NoError(t, c.DeleteRuleGroup(namespace, groupName))
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_prometheus_rule_group_rules"}, e2e.SkipMissingMetrics))
+		deleteRuleAndWait(groupName)
 
 		const groupName2 = "good_rule_with_no_fetched_series_and_no_samples"
 		const expression2 = `sum(metric{foo="10000"})`
-
-		require.NoError(t, c.SetRuleGroup(ruleGroupWithRecordingRule(groupName2, "rule", expression2), namespace))
-		m = ruleGroupMatcher(user, namespace, groupName2)
-
-		// Wait until ruler has loaded the group.
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_prometheus_rule_group_rules"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
-
-		// Wait until rule group has tried to evaluate the rule, and succeeded.
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
-		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(0), []string{"cortex_prometheus_rule_evaluation_failures_total"}, e2e.WithLabelMatchers(m), e2e.WaitMissingMetrics))
+		addNewRuleAndWait(groupName2, expression2, false)
 
 		// Ensure that no samples were returned.
 		sum, err = ruler.SumMetrics([]string{"cortex_prometheus_last_evaluation_samples"})

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -184,8 +184,8 @@ func MetricsQueryFunc(qf rules.QueryFunc, queries, failedQueries prometheus.Coun
 	}
 }
 
-func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime prometheus.Counter, logger log.Logger) rules.QueryFunc {
-	if queryTime == nil {
+func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedSeriesCount prometheus.Counter, logger log.Logger) rules.QueryFunc {
+	if queryTime == nil || zeroFetchedSeriesCount == nil {
 		return qf
 	}
 
@@ -207,6 +207,9 @@ func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime prometheus.Co
 			shardedQueries := stats.LoadShardedQueries()
 
 			queryTime.Add(wallTime.Seconds())
+			if numSeries == 0 {
+				zeroFetchedSeriesCount.Add(1)
+			}
 
 			// Log ruler query stats.
 			logMessage := []interface{}{
@@ -271,21 +274,28 @@ func DefaultTenantManagerFactory(
 		Help: "Number of failed queries by ruler.",
 	})
 	var rulerQuerySeconds *prometheus.CounterVec
+	var zeroFetchedSeriesQueries *prometheus.CounterVec
 	if cfg.EnableQueryStats {
 		rulerQuerySeconds = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_ruler_query_seconds_total",
 			Help: "Total amount of wall clock time spent processing queries by the ruler.",
 		}, []string{"user"})
+		zeroFetchedSeriesQueries = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_ruler_queries_zero_fetched_series_total",
+			Help: "Number of queries that did not fetch any series by ruler.",
+		}, []string{"user"})
 	}
 	return func(ctx context.Context, userID string, notifier *notifier.Manager, logger log.Logger, reg prometheus.Registerer) RulesManager {
 		var queryTime prometheus.Counter
+		var zeroFetchedSeriesCount prometheus.Counter
 		if rulerQuerySeconds != nil {
 			queryTime = rulerQuerySeconds.WithLabelValues(userID)
+			zeroFetchedSeriesCount = zeroFetchedSeriesQueries.WithLabelValues(userID)
 		}
 		var wrappedQueryFunc rules.QueryFunc
 
 		wrappedQueryFunc = MetricsQueryFunc(queryFunc, totalQueries, failedQueries)
-		wrappedQueryFunc = RecordAndReportRuleQueryMetrics(wrappedQueryFunc, queryTime, logger)
+		wrappedQueryFunc = RecordAndReportRuleQueryMetrics(wrappedQueryFunc, queryTime, zeroFetchedSeriesCount, logger)
 
 		return rules.NewManager(&rules.ManagerOptions{
 			Appendable:                 NewPusherAppendable(p, userID, totalWrites, failedWrites),

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -196,6 +196,7 @@ func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedS
 		stats, ctx := querier_stats.ContextWithEmptyStats(ctx)
 		// If we've been passed a counter we want to record the wall time spent executing this request.
 		timer := prometheus.NewTimer(nil)
+		var err error
 		defer func() {
 			// Update stats wall time based on the timer created above.
 			stats.AddWallTime(timer.ObserveDuration())
@@ -207,7 +208,7 @@ func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedS
 			shardedQueries := stats.LoadShardedQueries()
 
 			queryTime.Add(wallTime.Seconds())
-			if numSeries == 0 {
+			if err == nil && numSeries == 0 { // Do not count queries with errors for zero fetched series.
 				zeroFetchedSeriesCount.Add(1)
 			}
 

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -346,12 +346,13 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 
 func TestRecordAndReportRuleQueryMetrics(t *testing.T) {
 	queryTime := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"})
+	zeroFetchedSeriesCount := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"})
 
 	mockFunc := func(ctx context.Context, q string, t time.Time) (promql.Vector, error) {
 		time.Sleep(1 * time.Second)
 		return promql.Vector{}, nil
 	}
-	qf := RecordAndReportRuleQueryMetrics(mockFunc, queryTime.WithLabelValues("userID"), log.NewNopLogger())
+	qf := RecordAndReportRuleQueryMetrics(mockFunc, queryTime.WithLabelValues("userID"), zeroFetchedSeriesCount.WithLabelValues("userID"), log.NewNopLogger())
 	_, _ = qf(context.Background(), "test", time.Now())
 
 	require.GreaterOrEqual(t, testutil.ToFloat64(queryTime.WithLabelValues("userID")), float64(1))

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -353,9 +353,14 @@ func TestRecordAndReportRuleQueryMetrics(t *testing.T) {
 		return promql.Vector{}, nil
 	}
 	qf := RecordAndReportRuleQueryMetrics(mockFunc, queryTime.WithLabelValues("userID"), zeroFetchedSeriesCount.WithLabelValues("userID"), log.NewNopLogger())
-	_, _ = qf(context.Background(), "test", time.Now())
 
-	require.GreaterOrEqual(t, testutil.ToFloat64(queryTime.WithLabelValues("userID")), float64(1))
+	_, _ = qf(context.Background(), "test", time.Now())
+	require.LessOrEqual(t, float64(1), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
+	require.Equal(t, float64(1), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
+
+	_, _ = qf(context.Background(), "test", time.Now())
+	require.LessOrEqual(t, float64(2), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
+	require.Equal(t, float64(2), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
 }
 
 // TestManagerFactory_CorrectQueryableUsed ensures that when evaluating a group with non-empty SourceTenants


### PR DESCRIPTION
#### What this PR does

Adds a new per-tenant metric `cortex_ruler_queries_zero_fetched_series_total` in ruler to track rules that fetched no series, so that users can add an alert on this metric to see if there is any late data affecting the rules, which could potentially result in alerts not firing when they should (we have had cases of that in the past). When they see this counter increase, they can search the logs for `fetched_series_count=0` to find the affected query. Since this metric relies on query stats, it needs to be enabled before the metric is available, similar to `cortex_ruler_query_seconds_total`.

~~Haven't added tests yet as I'm not sure if we want to take this approach (is enabling query stats too heavy? but I'm not sure how else to track this), but if we decide to go with this then I'll add them.~~ It's been manually tested, I added some rules locally that fetch zero series on purpose and it incremented the counter accordingly, and also some rules that return no data but still fetch some series and they correctly do not increment the counter.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/1393

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
