### PR TITLE
Refactor ingester errors creation

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -99,8 +99,8 @@ func newIngestErrExemplarTimestampTooFarInFuture(timestamp model.Time, seriesLab
 	return newIngestErrExemplar(globalerror.ExemplarTooFarInFuture, "received an exemplar whose timestamp is too far in the future", timestamp, seriesLabels, exemplarLabels)
 }
 
-func formatMaxSeriesPerUserError(limiter *Limiter, userID string) error {
-	globalLimit := limiter.limits.MaxGlobalSeriesPerUser(userID)
+func formatMaxSeriesPerUserError(limits *validation.Overrides, userID string) error {
+	globalLimit := limits.MaxGlobalSeriesPerUser(userID)
 	err := errors.New(globalerror.MaxSeriesPerUser.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-user series limit of %d exceeded", globalLimit),
 		validation.MaxSeriesPerUserFlag,
@@ -108,8 +108,8 @@ func formatMaxSeriesPerUserError(limiter *Limiter, userID string) error {
 	return makeLimitError(err)
 }
 
-func formatMaxSeriesPerMetricError(limiter *Limiter, labels labels.Labels, userID string) error {
-	globalLimit := limiter.limits.MaxGlobalSeriesPerMetric(userID)
+func formatMaxSeriesPerMetricError(limits *validation.Overrides, labels labels.Labels, userID string) error {
+	globalLimit := limits.MaxGlobalSeriesPerMetric(userID)
 	err := errors.New(globalerror.MaxSeriesPerMetric.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-metric series limit of %d exceeded", globalLimit),
 		validation.MaxSeriesPerMetricFlag,
@@ -117,8 +117,8 @@ func formatMaxSeriesPerMetricError(limiter *Limiter, labels labels.Labels, userI
 	return makeMetricLimitError(labels, err)
 }
 
-func formatMaxMetadataPerUserError(limiter *Limiter, userID string) error {
-	globalLimit := limiter.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
+func formatMaxMetadataPerUserError(limits *validation.Overrides, userID string) error {
+	globalLimit := limits.MaxGlobalMetricsWithMetadataPerUser(userID)
 	err := errors.New(globalerror.MaxMetadataPerUser.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-user metric metadata limit of %d exceeded", globalLimit),
 		validation.MaxMetadataPerUserFlag,
@@ -126,8 +126,8 @@ func formatMaxMetadataPerUserError(limiter *Limiter, userID string) error {
 	return makeLimitError(err)
 }
 
-func formatMaxMetadataPerMetricError(limiter *Limiter, labels labels.Labels, userID string) error {
-	globalLimit := limiter.limits.MaxGlobalMetadataPerMetric(userID)
+func formatMaxMetadataPerMetricError(limits *validation.Overrides, labels labels.Labels, userID string) error {
+	globalLimit := limits.MaxGlobalMetadataPerMetric(userID)
 	err := errors.New(globalerror.MaxMetadataPerMetric.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("per-metric metadata limit of %d exceeded", globalLimit),
 		validation.MaxMetadataPerMetricFlag,

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -8,9 +8,16 @@ package ingester
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/grafana/dskit/httpgrpc"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/util/globalerror"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 var (
@@ -50,4 +57,80 @@ func (e *validationError) Error() string {
 // wrapWithUser prepends the user to the error. It does not retain a reference to err.
 func wrapWithUser(err error, userID string) error {
 	return fmt.Errorf("user=%s: %s", userID, err)
+}
+
+func newIngestErrSample(errID globalerror.ID, errMsg string, timestamp model.Time, labels []mimirpb.LabelAdapter) error {
+	return fmt.Errorf("%v. The affected sample has timestamp %s and is from series %s", errID.Message(errMsg), timestamp.Time().UTC().Format(time.RFC3339Nano), mimirpb.FromLabelAdaptersToLabels(labels).String())
+}
+
+func newIngestErrSampleTimestampTooOld(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
+	return newIngestErrSample(globalerror.SampleTimestampTooOld, "the sample has been rejected because its timestamp is too old", timestamp, labels)
+}
+
+func newIngestErrSampleTimestampTooOldOOOEnabled(timestamp model.Time, labels []mimirpb.LabelAdapter, oooTimeWindow time.Duration) error {
+	return newIngestErrSample(globalerror.SampleTimestampTooOld, fmt.Sprintf("the sample has been rejected because another sample with a more recent timestamp has already been ingested and this sample is beyond the out-of-order time window of %s", model.Duration(oooTimeWindow).String()), timestamp, labels)
+}
+
+func newIngestErrSampleTimestampTooFarInFuture(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
+	return newIngestErrSample(globalerror.SampleTooFarInFuture, "received a sample whose timestamp is too far in the future", timestamp, labels)
+}
+
+func newIngestErrSampleOutOfOrder(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
+	return newIngestErrSample(globalerror.SampleOutOfOrder, "the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed", timestamp, labels)
+}
+
+func newIngestErrSampleDuplicateTimestamp(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
+	return newIngestErrSample(globalerror.SampleDuplicateTimestamp, "the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested", timestamp, labels)
+}
+
+func newIngestErrExemplar(errID globalerror.ID, errMsg string, timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
+	return fmt.Errorf("%v. The affected exemplar is %s with timestamp %s for series %s",
+		errID.Message(errMsg),
+		mimirpb.FromLabelAdaptersToLabels(exemplarLabels).String(),
+		timestamp.Time().UTC().Format(time.RFC3339Nano),
+		mimirpb.FromLabelAdaptersToLabels(seriesLabels).String())
+}
+
+func newIngestErrExemplarMissingSeries(timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
+	return newIngestErrExemplar(globalerror.ExemplarSeriesMissing, "the exemplar has been rejected because the related series has not been ingested yet", timestamp, seriesLabels, exemplarLabels)
+}
+
+func newIngestErrExemplarTimestampTooFarInFuture(timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
+	return newIngestErrExemplar(globalerror.ExemplarTooFarInFuture, "received an exemplar whose timestamp is too far in the future", timestamp, seriesLabels, exemplarLabels)
+}
+
+func formatMaxSeriesPerUserError(limiter *Limiter, userID string) error {
+	globalLimit := limiter.limits.MaxGlobalSeriesPerUser(userID)
+	err := errors.New(globalerror.MaxSeriesPerUser.MessageWithPerTenantLimitConfig(
+		fmt.Sprintf("per-user series limit of %d exceeded", globalLimit),
+		validation.MaxSeriesPerUserFlag,
+	))
+	return makeLimitError(err)
+}
+
+func formatMaxSeriesPerMetricError(limiter *Limiter, labels labels.Labels, userID string) error {
+	globalLimit := limiter.limits.MaxGlobalSeriesPerMetric(userID)
+	err := errors.New(globalerror.MaxSeriesPerMetric.MessageWithPerTenantLimitConfig(
+		fmt.Sprintf("per-metric series limit of %d exceeded", globalLimit),
+		validation.MaxSeriesPerMetricFlag,
+	))
+	return makeMetricLimitError(labels, err)
+}
+
+func formatMaxMetadataPerUserError(limiter *Limiter, userID string) error {
+	globalLimit := limiter.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
+	err := errors.New(globalerror.MaxMetadataPerUser.MessageWithPerTenantLimitConfig(
+		fmt.Sprintf("per-user metric metadata limit of %d exceeded", globalLimit),
+		validation.MaxMetadataPerUserFlag,
+	))
+	return makeLimitError(err)
+}
+
+func formatMaxMetadataPerMetricError(limiter *Limiter, labels labels.Labels, userID string) error {
+	globalLimit := limiter.limits.MaxGlobalMetadataPerMetric(userID)
+	err := errors.New(globalerror.MaxMetadataPerMetric.MessageWithPerTenantLimitConfig(
+		fmt.Sprintf("per-metric metadata limit of %d exceeded", globalLimit),
+		validation.MaxMetadataPerMetricFlag,
+	))
+	return makeMetricLimitError(labels, err)
 }

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -88,7 +88,8 @@ func newIngestErrExemplar(errID globalerror.ID, errMsg string, timestamp model.T
 		errID.Message(errMsg),
 		mimirpb.FromLabelAdaptersToLabels(exemplarLabels).String(),
 		timestamp.Time().UTC().Format(time.RFC3339Nano),
-		mimirpb.FromLabelAdaptersToLabels(seriesLabels).String())
+		mimirpb.FromLabelAdaptersToLabels(seriesLabels).String(),
+	)
 }
 
 func newIngestErrExemplarMissingSeries(timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingester
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+func TestNewIngestErrMsgs(t *testing.T) {
+	timestamp := model.Time(1575043969)
+	metricLabelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "test"}}
+
+	tests := map[string]struct {
+		err error
+		msg string
+	}{
+		"newIngestErrSampleTimestampTooOld": {
+			err: newIngestErrSampleTimestampTooOld(timestamp, metricLabelAdapters),
+			msg: `the sample has been rejected because its timestamp is too old (err-mimir-sample-timestamp-too-old). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
+		},
+		"newIngestErrSampleTimestampTooOld_out_of_order_enabled": {
+			err: newIngestErrSampleTimestampTooOldOOOEnabled(timestamp, metricLabelAdapters, 2*time.Hour),
+			msg: `the sample has been rejected because another sample with a more recent timestamp has already been ingested and this sample is beyond the out-of-order time window of 2h (err-mimir-sample-timestamp-too-old). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
+		},
+		"newIngestErrSampleOutOfOrder": {
+			err: newIngestErrSampleOutOfOrder(timestamp, metricLabelAdapters),
+			msg: `the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed (err-mimir-sample-out-of-order). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
+		},
+		"newIngestErrSampleDuplicateTimestamp": {
+			err: newIngestErrSampleDuplicateTimestamp(timestamp, metricLabelAdapters),
+			msg: `the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested (err-mimir-sample-duplicate-timestamp). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
+		},
+		"newIngestErrExemplarMissingSeries": {
+			err: newIngestErrExemplarMissingSeries(timestamp, metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}),
+			msg: `the exemplar has been rejected because the related series has not been ingested yet (err-mimir-exemplar-series-missing). The affected exemplar is {traceID="123"} with timestamp 1970-01-19T05:30:43.969Z for series {__name__="test"}`,
+		},
+	}
+
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, tc.msg, tc.err.Error())
+		})
+	}
+}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -968,14 +968,14 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 		case errMaxSeriesPerUserLimitExceeded:
 			stats.perUserSeriesLimitCount++
 			updateFirstPartial(func() error {
-				return makeLimitError(i.limiter.FormatError(userID, cause))
+				return makeLimitError(i.limiter.formatMaxSeriesPerUserError(userID))
 			})
 			return true
 
 		case errMaxSeriesPerMetricLimitExceeded:
 			stats.perMetricSeriesLimitCount++
 			updateFirstPartial(func() error {
-				return makeMetricLimitError(mimirpb.FromLabelAdaptersToLabelsWithCopy(labels), i.limiter.FormatError(userID, cause))
+				return makeMetricLimitError(mimirpb.FromLabelAdaptersToLabelsWithCopy(labels), i.limiter.formatMaxSeriesPerMetricError(userID))
 			})
 			return true
 		}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -968,14 +968,14 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 		case errMaxSeriesPerUserLimitExceeded:
 			stats.perUserSeriesLimitCount++
 			updateFirstPartial(func() error {
-				return formatMaxSeriesPerUserError(i.limiter, userID)
+				return formatMaxSeriesPerUserError(i.limiter.limits, userID)
 			})
 			return true
 
 		case errMaxSeriesPerMetricLimitExceeded:
 			stats.perMetricSeriesLimitCount++
 			updateFirstPartial(func() error {
-				return formatMaxSeriesPerMetricError(i.limiter, mimirpb.FromLabelAdaptersToLabelsWithCopy(labels), userID)
+				return formatMaxSeriesPerMetricError(i.limiter.limits, mimirpb.FromLabelAdaptersToLabelsWithCopy(labels), userID)
 			})
 			return true
 		}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -968,14 +968,14 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 		case errMaxSeriesPerUserLimitExceeded:
 			stats.perUserSeriesLimitCount++
 			updateFirstPartial(func() error {
-				return makeLimitError(i.limiter.formatMaxSeriesPerUserError(userID))
+				return formatMaxSeriesPerUserError(i.limiter, userID)
 			})
 			return true
 
 		case errMaxSeriesPerMetricLimitExceeded:
 			stats.perMetricSeriesLimitCount++
 			updateFirstPartial(func() error {
-				return makeMetricLimitError(mimirpb.FromLabelAdaptersToLabelsWithCopy(labels), i.limiter.formatMaxSeriesPerMetricError(userID))
+				return formatMaxSeriesPerMetricError(i.limiter, mimirpb.FromLabelAdaptersToLabelsWithCopy(labels), userID)
 			})
 			return true
 		}
@@ -2937,46 +2937,6 @@ func (i *Ingester) FlushHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func newIngestErrSample(errID globalerror.ID, errMsg string, timestamp model.Time, labels []mimirpb.LabelAdapter) error {
-	return fmt.Errorf("%v. The affected sample has timestamp %s and is from series %s", errID.Message(errMsg), timestamp.Time().UTC().Format(time.RFC3339Nano), mimirpb.FromLabelAdaptersToLabels(labels).String())
-}
-
-func newIngestErrSampleTimestampTooOld(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
-	return newIngestErrSample(globalerror.SampleTimestampTooOld, "the sample has been rejected because its timestamp is too old", timestamp, labels)
-}
-
-func newIngestErrSampleTimestampTooOldOOOEnabled(timestamp model.Time, labels []mimirpb.LabelAdapter, oooTimeWindow time.Duration) error {
-	return newIngestErrSample(globalerror.SampleTimestampTooOld, fmt.Sprintf("the sample has been rejected because another sample with a more recent timestamp has already been ingested and this sample is beyond the out-of-order time window of %s", model.Duration(oooTimeWindow).String()), timestamp, labels)
-}
-
-func newIngestErrSampleTimestampTooFarInFuture(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
-	return newIngestErrSample(globalerror.SampleTooFarInFuture, "received a sample whose timestamp is too far in the future", timestamp, labels)
-}
-
-func newIngestErrSampleOutOfOrder(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
-	return newIngestErrSample(globalerror.SampleOutOfOrder, "the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed", timestamp, labels)
-}
-
-func newIngestErrSampleDuplicateTimestamp(timestamp model.Time, labels []mimirpb.LabelAdapter) error {
-	return newIngestErrSample(globalerror.SampleDuplicateTimestamp, "the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested", timestamp, labels)
-}
-
-func newIngestErrExemplar(errID globalerror.ID, errMsg string, timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
-	return fmt.Errorf("%v. The affected exemplar is %s with timestamp %s for series %s",
-		errID.Message(errMsg),
-		mimirpb.FromLabelAdaptersToLabels(exemplarLabels).String(),
-		timestamp.Time().UTC().Format(time.RFC3339Nano),
-		mimirpb.FromLabelAdaptersToLabels(seriesLabels).String())
-}
-
-func newIngestErrExemplarMissingSeries(timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
-	return newIngestErrExemplar(globalerror.ExemplarSeriesMissing, "the exemplar has been rejected because the related series has not been ingested yet", timestamp, seriesLabels, exemplarLabels)
-}
-
-func newIngestErrExemplarTimestampTooFarInFuture(timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
-	return newIngestErrExemplar(globalerror.ExemplarTooFarInFuture, "received an exemplar whose timestamp is too far in the future", timestamp, seriesLabels, exemplarLabels)
 }
 
 func wrappedTSDBIngestExemplarOtherErr(ingestErr error, timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6386,7 +6386,7 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 		require.True(t, ok, "returned error is not an httpgrpc response")
 		assert.Equal(t, http.StatusBadRequest, int(httpResp.Code))
-		assert.Equal(t, wrapWithUser(makeLimitError(ing.limiter.FormatError(userID, errMaxSeriesPerUserLimitExceeded)), userID).Error(), string(httpResp.Body))
+		assert.Equal(t, wrapWithUser(makeLimitError(ing.limiter.formatMaxSeriesPerUserError(userID)), userID).Error(), string(httpResp.Body))
 
 		// Append two metadata, expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))
@@ -6491,7 +6491,7 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 		require.True(t, ok, "returned error is not an httpgrpc response")
 		assert.Equal(t, http.StatusBadRequest, int(httpResp.Code))
-		assert.Equal(t, wrapWithUser(makeMetricLimitError(mimirpb.FromLabelAdaptersToLabels(labels3), ing.limiter.FormatError(userID, errMaxSeriesPerMetricLimitExceeded)), userID).Error(), string(httpResp.Body))
+		assert.Equal(t, wrapWithUser(makeMetricLimitError(mimirpb.FromLabelAdaptersToLabels(labels3), ing.limiter.formatMaxSeriesPerMetricError(userID)), userID).Error(), string(httpResp.Body))
 
 		// Append two metadata for the same metric. Drop the second one, and expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6386,7 +6386,7 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 		require.True(t, ok, "returned error is not an httpgrpc response")
 		assert.Equal(t, http.StatusBadRequest, int(httpResp.Code))
-		assert.Equal(t, wrapWithUser(makeLimitError(ing.limiter.formatMaxSeriesPerUserError(userID)), userID).Error(), string(httpResp.Body))
+		assert.Equal(t, wrapWithUser(formatMaxSeriesPerUserError(ing.limiter, userID), userID).Error(), string(httpResp.Body))
 
 		// Append two metadata, expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))
@@ -6491,7 +6491,7 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 		require.True(t, ok, "returned error is not an httpgrpc response")
 		assert.Equal(t, http.StatusBadRequest, int(httpResp.Code))
-		assert.Equal(t, wrapWithUser(makeMetricLimitError(mimirpb.FromLabelAdaptersToLabels(labels3), ing.limiter.formatMaxSeriesPerMetricError(userID)), userID).Error(), string(httpResp.Body))
+		assert.Equal(t, wrapWithUser(formatMaxSeriesPerMetricError(ing.limiter, mimirpb.FromLabelAdaptersToLabels(labels3), userID), userID).Error(), string(httpResp.Body))
 
 		// Append two metadata for the same metric. Drop the second one, and expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -7839,43 +7839,6 @@ func Test_Ingester_ShipperLabelsOutOfOrderBlocksOnUpload(t *testing.T) {
 	}
 }
 
-func TestNewIngestErrMsgs(t *testing.T) {
-	timestamp := model.Time(1575043969)
-	metricLabelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "test"}}
-
-	tests := map[string]struct {
-		err error
-		msg string
-	}{
-		"newIngestErrSampleTimestampTooOld": {
-			err: newIngestErrSampleTimestampTooOld(timestamp, metricLabelAdapters),
-			msg: `the sample has been rejected because its timestamp is too old (err-mimir-sample-timestamp-too-old). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
-		},
-		"newIngestErrSampleTimestampTooOld_out_of_order_enabled": {
-			err: newIngestErrSampleTimestampTooOldOOOEnabled(timestamp, metricLabelAdapters, 2*time.Hour),
-			msg: `the sample has been rejected because another sample with a more recent timestamp has already been ingested and this sample is beyond the out-of-order time window of 2h (err-mimir-sample-timestamp-too-old). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
-		},
-		"newIngestErrSampleOutOfOrder": {
-			err: newIngestErrSampleOutOfOrder(timestamp, metricLabelAdapters),
-			msg: `the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed (err-mimir-sample-out-of-order). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
-		},
-		"newIngestErrSampleDuplicateTimestamp": {
-			err: newIngestErrSampleDuplicateTimestamp(timestamp, metricLabelAdapters),
-			msg: `the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested (err-mimir-sample-duplicate-timestamp). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series {__name__="test"}`,
-		},
-		"newIngestErrExemplarMissingSeries": {
-			err: newIngestErrExemplarMissingSeries(timestamp, metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}),
-			msg: `the exemplar has been rejected because the related series has not been ingested yet (err-mimir-exemplar-series-missing). The affected exemplar is {traceID="123"} with timestamp 1970-01-19T05:30:43.969Z for series {__name__="test"}`,
-		},
-	}
-
-	for testName, tc := range tests {
-		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, tc.msg, tc.err.Error())
-		})
-	}
-}
-
 func TestIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T) {
 	expectedSampleHistogram := mimirpb.FromMimirSampleToPromHistogram(mimirpb.FromFloatHistogramToSampleHistogram(util_test.GenerateTestFloatHistogram(0)))
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6386,7 +6386,7 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 		require.True(t, ok, "returned error is not an httpgrpc response")
 		assert.Equal(t, http.StatusBadRequest, int(httpResp.Code))
-		assert.Equal(t, wrapWithUser(formatMaxSeriesPerUserError(ing.limiter, userID), userID).Error(), string(httpResp.Body))
+		assert.Equal(t, wrapWithUser(formatMaxSeriesPerUserError(ing.limiter.limits, userID), userID).Error(), string(httpResp.Body))
 
 		// Append two metadata, expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))
@@ -6491,7 +6491,7 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 		httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 		require.True(t, ok, "returned error is not an httpgrpc response")
 		assert.Equal(t, http.StatusBadRequest, int(httpResp.Code))
-		assert.Equal(t, wrapWithUser(formatMaxSeriesPerMetricError(ing.limiter, mimirpb.FromLabelAdaptersToLabels(labels3), userID), userID).Error(), string(httpResp.Body))
+		assert.Equal(t, wrapWithUser(formatMaxSeriesPerMetricError(ing.limiter.limits, mimirpb.FromLabelAdaptersToLabels(labels3), userID), userID).Error(), string(httpResp.Body))
 
 		// Append two metadata for the same metric. Drop the second one, and expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -6,13 +6,11 @@
 package ingester
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/pkg/errors"
 
 	"github.com/grafana/mimir/pkg/util"
-	"github.com/grafana/mimir/pkg/util/globalerror"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -95,42 +93,6 @@ func (l *Limiter) AssertMaxMetricsWithMetadataPerUser(userID string, metrics int
 	}
 
 	return errMaxMetadataPerUserLimitExceeded
-}
-
-func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
-	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
-
-	return errors.New(globalerror.MaxSeriesPerUser.MessageWithPerTenantLimitConfig(
-		fmt.Sprintf("per-user series limit of %d exceeded", globalLimit),
-		validation.MaxSeriesPerUserFlag,
-	))
-}
-
-func (l *Limiter) formatMaxSeriesPerMetricError(userID string) error {
-	globalLimit := l.limits.MaxGlobalSeriesPerMetric(userID)
-
-	return errors.New(globalerror.MaxSeriesPerMetric.MessageWithPerTenantLimitConfig(
-		fmt.Sprintf("per-metric series limit of %d exceeded", globalLimit),
-		validation.MaxSeriesPerMetricFlag,
-	))
-}
-
-func (l *Limiter) formatMaxMetadataPerUserError(userID string) error {
-	globalLimit := l.limits.MaxGlobalMetricsWithMetadataPerUser(userID)
-
-	return errors.New(globalerror.MaxMetadataPerUser.MessageWithPerTenantLimitConfig(
-		fmt.Sprintf("per-user metric metadata limit of %d exceeded", globalLimit),
-		validation.MaxMetadataPerUserFlag,
-	))
-}
-
-func (l *Limiter) formatMaxMetadataPerMetricError(userID string) error {
-	globalLimit := l.limits.MaxGlobalMetadataPerMetric(userID)
-
-	return errors.New(globalerror.MaxMetadataPerMetric.MessageWithPerTenantLimitConfig(
-		fmt.Sprintf("per-metric metadata limit of %d exceeded", globalLimit),
-		validation.MaxMetadataPerMetricFlag,
-	))
 }
 
 func (l *Limiter) maxSeriesPerMetric(userID string) int {

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -97,24 +97,6 @@ func (l *Limiter) AssertMaxMetricsWithMetadataPerUser(userID string, metrics int
 	return errMaxMetadataPerUserLimitExceeded
 }
 
-// FormatError returns the input error enriched with the actual limits for the given user.
-// It acts as pass-through if the input error is unknown.
-func (l *Limiter) FormatError(userID string, err error) error {
-	//nolint:errorlint // We don't expect wrapped errors.
-	switch err {
-	case errMaxSeriesPerUserLimitExceeded:
-		return l.formatMaxSeriesPerUserError(userID)
-	case errMaxSeriesPerMetricLimitExceeded:
-		return l.formatMaxSeriesPerMetricError(userID)
-	case errMaxMetadataPerUserLimitExceeded:
-		return l.formatMaxMetadataPerUserError(userID)
-	case errMaxMetadataPerMetricLimitExceeded:
-		return l.formatMaxMetadataPerMetricError(userID)
-	default:
-		return err
-	}
-}
-
 func (l *Limiter) formatMaxSeriesPerUserError(userID string) error {
 	globalLimit := l.limits.MaxGlobalSeriesPerUser(userID)
 

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -17,10 +17,8 @@ import (
 
 var (
 	// These errors are only internal, to change the API error messages, see Limiter's methods below.
-	errMaxSeriesPerMetricLimitExceeded   = errors.New("per-metric series limit exceeded")
-	errMaxMetadataPerMetricLimitExceeded = errors.New("per-metric metadata limit exceeded")
-	errMaxSeriesPerUserLimitExceeded     = errors.New("per-user series limit exceeded")
-	errMaxMetadataPerUserLimitExceeded   = errors.New("per-user metric metadata limit exceeded")
+	errMaxSeriesPerMetricLimitExceeded = errors.New("per-metric series limit exceeded")
+	errMaxSeriesPerUserLimitExceeded   = errors.New("per-user series limit exceeded")
 )
 
 // RingCount is the interface exposed by a ring implementation which allows
@@ -55,44 +53,32 @@ func NewLimiter(
 	}
 }
 
-// AssertMaxSeriesPerMetric limit has not been reached compared to the current
-// number of series in input and returns an error if so.
-func (l *Limiter) AssertMaxSeriesPerMetric(userID string, series int) error {
-	if actualLimit := l.maxSeriesPerMetric(userID); series < actualLimit {
-		return nil
-	}
-
-	return errMaxSeriesPerMetricLimitExceeded
+// AssertMaxSeriesPerMetric returns true if limit has not been reached compared to the current
+// number of series in input; otherwise returns false.
+func (l *Limiter) AssertMaxSeriesPerMetric(userID string, series int) bool {
+	actualLimit := l.maxSeriesPerMetric(userID)
+	return series < actualLimit
 }
 
-// AssertMaxMetadataPerMetric limit has not been reached compared to the current
-// number of metadata per metric in input and returns an error if so.
-func (l *Limiter) AssertMaxMetadataPerMetric(userID string, metadata int) error {
-	if actualLimit := l.maxMetadataPerMetric(userID); metadata < actualLimit {
-		return nil
-	}
-
-	return errMaxMetadataPerMetricLimitExceeded
+// AssertMaxMetadataPerMetric returns true if limit has not been reached compared to the current
+// number of metadata per metric in input; otherwise returns false.
+func (l *Limiter) AssertMaxMetadataPerMetric(userID string, metadata int) bool {
+	actualLimit := l.maxMetadataPerMetric(userID)
+	return metadata < actualLimit
 }
 
-// AssertMaxSeriesPerUser limit has not been reached compared to the current
-// number of series in input and returns an error if so.
-func (l *Limiter) AssertMaxSeriesPerUser(userID string, series int) error {
-	if actualLimit := l.maxSeriesPerUser(userID); series < actualLimit {
-		return nil
-	}
-
-	return errMaxSeriesPerUserLimitExceeded
+// AssertMaxSeriesPerUser returns true if limit has not been reached compared to the current
+// number of series in input; otherwise returns false.
+func (l *Limiter) AssertMaxSeriesPerUser(userID string, series int) bool {
+	actualLimit := l.maxSeriesPerUser(userID)
+	return series < actualLimit
 }
 
-// AssertMaxMetricsWithMetadataPerUser limit has not been reached compared to the current
-// number of metrics with metadata in input and returns an error if so.
-func (l *Limiter) AssertMaxMetricsWithMetadataPerUser(userID string, metrics int) error {
-	if actualLimit := l.maxMetadataPerUser(userID); metrics < actualLimit {
-		return nil
-	}
-
-	return errMaxMetadataPerUserLimitExceeded
+// AssertMaxMetricsWithMetadataPerUser returns true if limit has not been reached compared to the current
+// number of metrics with metadata in input; otherwise returns false.
+func (l *Limiter) AssertMaxMetricsWithMetadataPerUser(userID string, metrics int) bool {
+	actualLimit := l.maxMetadataPerUser(userID)
+	return metrics < actualLimit
 }
 
 func (l *Limiter) maxSeriesPerMetric(userID string) int {

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -53,30 +53,30 @@ func NewLimiter(
 	}
 }
 
-// AssertMaxSeriesPerMetric returns true if limit has not been reached compared to the current
+// IsWithinMaxSeriesPerMetric returns true if limit has not been reached compared to the current
 // number of series in input; otherwise returns false.
-func (l *Limiter) AssertMaxSeriesPerMetric(userID string, series int) bool {
+func (l *Limiter) IsWithinMaxSeriesPerMetric(userID string, series int) bool {
 	actualLimit := l.maxSeriesPerMetric(userID)
 	return series < actualLimit
 }
 
-// AssertMaxMetadataPerMetric returns true if limit has not been reached compared to the current
+// IsWithinMaxMetadataPerMetric returns true if limit has not been reached compared to the current
 // number of metadata per metric in input; otherwise returns false.
-func (l *Limiter) AssertMaxMetadataPerMetric(userID string, metadata int) bool {
+func (l *Limiter) IsWithinMaxMetadataPerMetric(userID string, metadata int) bool {
 	actualLimit := l.maxMetadataPerMetric(userID)
 	return metadata < actualLimit
 }
 
-// AssertMaxSeriesPerUser returns true if limit has not been reached compared to the current
+// IsWithinMaxSeriesPerUser returns true if limit has not been reached compared to the current
 // number of series in input; otherwise returns false.
-func (l *Limiter) AssertMaxSeriesPerUser(userID string, series int) bool {
+func (l *Limiter) IsWithinMaxSeriesPerUser(userID string, series int) bool {
 	actualLimit := l.maxSeriesPerUser(userID)
 	return series < actualLimit
 }
 
-// AssertMaxMetricsWithMetadataPerUser returns true if limit has not been reached compared to the current
+// IsWithinMaxMetricsWithMetadataPerUser returns true if limit has not been reached compared to the current
 // number of metrics with metadata in input; otherwise returns false.
-func (l *Limiter) AssertMaxMetricsWithMetadataPerUser(userID string, metrics int) bool {
+func (l *Limiter) IsWithinMaxMetricsWithMetadataPerUser(userID string, metrics int) bool {
 	actualLimit := l.maxMetadataPerUser(userID)
 	return metrics < actualLimit
 }

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -6,7 +6,6 @@
 package ingester
 
 import (
-	"errors"
 	"math"
 	"testing"
 
@@ -520,40 +519,6 @@ func TestLimiter_AssertMaxMetricsWithMetadataPerUser(t *testing.T) {
 			assert.Equal(t, testData.expected, actual)
 		})
 	}
-}
-
-func TestLimiter_FormatError(t *testing.T) {
-	// Mock the ring
-	ring := &ringCountMock{}
-	ring.On("InstancesCount").Return(3)
-	ring.On("ZonesCount").Return(1)
-
-	// Mock limits
-	limits, err := validation.NewOverrides(validation.Limits{
-		MaxGlobalSeriesPerUser:              100,
-		MaxGlobalSeriesPerMetric:            20,
-		MaxGlobalMetricsWithMetadataPerUser: 10,
-		MaxGlobalMetadataPerMetric:          3,
-	}, nil)
-	require.NoError(t, err)
-
-	limiter := NewLimiter(limits, ring, 3, false)
-
-	actual := limiter.FormatError("user-1", errMaxSeriesPerUserLimitExceeded)
-	assert.ErrorContains(t, actual, "per-user series limit of 100 exceeded")
-
-	actual = limiter.FormatError("user-1", errMaxSeriesPerMetricLimitExceeded)
-	assert.ErrorContains(t, actual, "per-metric series limit of 20 exceeded")
-
-	actual = limiter.FormatError("user-1", errMaxMetadataPerUserLimitExceeded)
-	assert.ErrorContains(t, actual, "per-user metric metadata limit of 10 exceeded")
-
-	actual = limiter.FormatError("user-1", errMaxMetadataPerMetricLimitExceeded)
-	assert.ErrorContains(t, actual, "per-metric metadata limit of 3 exceeded")
-
-	input := errors.New("unknown error")
-	actual = limiter.FormatError("user-1", input)
-	assert.Equal(t, input, actual)
 }
 
 type ringCountMock struct {

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -353,7 +353,7 @@ func TestLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
 			require.NoError(t, err)
 
 			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false)
-			actual := limiter.AssertMaxSeriesPerMetric("test", testData.series)
+			actual := limiter.IsWithinMaxSeriesPerMetric("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
 		})
@@ -406,7 +406,7 @@ func TestLimiter_AssertMaxMetadataPerMetric(t *testing.T) {
 			require.NoError(t, err)
 
 			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false)
-			actual := limiter.AssertMaxMetadataPerMetric("test", testData.metadata)
+			actual := limiter.IsWithinMaxMetadataPerMetric("test", testData.metadata)
 
 			assert.Equal(t, testData.expected, actual)
 		})
@@ -460,7 +460,7 @@ func TestLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 			require.NoError(t, err)
 
 			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false)
-			actual := limiter.AssertMaxSeriesPerUser("test", testData.series)
+			actual := limiter.IsWithinMaxSeriesPerUser("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
 		})
@@ -514,7 +514,7 @@ func TestLimiter_AssertMaxMetricsWithMetadataPerUser(t *testing.T) {
 			require.NoError(t, err)
 
 			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false)
-			actual := limiter.AssertMaxMetricsWithMetadataPerUser("test", testData.metadata)
+			actual := limiter.IsWithinMaxMetricsWithMetadataPerUser("test", testData.metadata)
 
 			assert.Equal(t, testData.expected, actual)
 		})

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -312,28 +312,28 @@ func TestLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
 		ringReplicationFactor    int
 		ringIngesterCount        int
 		series                   int
-		expected                 error
+		expected                 bool
 	}{
 		"limit is disabled": {
 			maxGlobalSeriesPerMetric: 0,
 			ringReplicationFactor:    1,
 			ringIngesterCount:        1,
 			series:                   100,
-			expected:                 nil,
+			expected:                 true,
 		},
 		"current number of series is below the limit": {
 			maxGlobalSeriesPerMetric: 1000,
 			ringReplicationFactor:    3,
 			ringIngesterCount:        10,
 			series:                   299,
-			expected:                 nil,
+			expected:                 true,
 		},
 		"current number of series is above the limit": {
 			maxGlobalSeriesPerMetric: 1000,
 			ringReplicationFactor:    3,
 			ringIngesterCount:        10,
 			series:                   300,
-			expected:                 errMaxSeriesPerMetricLimitExceeded,
+			expected:                 false,
 		},
 	}
 
@@ -365,28 +365,28 @@ func TestLimiter_AssertMaxMetadataPerMetric(t *testing.T) {
 		ringReplicationFactor      int
 		ringIngesterCount          int
 		metadata                   int
-		expected                   error
+		expected                   bool
 	}{
 		"limit is disabled": {
 			maxGlobalMetadataPerMetric: 0,
 			ringReplicationFactor:      1,
 			ringIngesterCount:          1,
 			metadata:                   100,
-			expected:                   nil,
+			expected:                   true,
 		},
 		"current number of metadata is below the limit": {
 			maxGlobalMetadataPerMetric: 1000,
 			ringReplicationFactor:      3,
 			ringIngesterCount:          10,
 			metadata:                   299,
-			expected:                   nil,
+			expected:                   true,
 		},
 		"current number of metadata is above the limit": {
 			maxGlobalMetadataPerMetric: 1000,
 			ringReplicationFactor:      3,
 			ringIngesterCount:          10,
 			metadata:                   300,
-			expected:                   errMaxMetadataPerMetricLimitExceeded,
+			expected:                   false,
 		},
 	}
 
@@ -419,28 +419,28 @@ func TestLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 		ringReplicationFactor  int
 		ringIngesterCount      int
 		series                 int
-		expected               error
+		expected               bool
 	}{
 		"limit is disabled": {
 			maxGlobalSeriesPerUser: 0,
 			ringReplicationFactor:  1,
 			ringIngesterCount:      1,
 			series:                 100,
-			expected:               nil,
+			expected:               true,
 		},
 		"current number of series is below the limit": {
 			maxGlobalSeriesPerUser: 1000,
 			ringReplicationFactor:  3,
 			ringIngesterCount:      10,
 			series:                 299,
-			expected:               nil,
+			expected:               true,
 		},
 		"current number of series is above the limit": {
 			maxGlobalSeriesPerUser: 1000,
 			ringReplicationFactor:  3,
 			ringIngesterCount:      10,
 			series:                 300,
-			expected:               errMaxSeriesPerUserLimitExceeded,
+			expected:               false,
 		},
 	}
 
@@ -473,28 +473,28 @@ func TestLimiter_AssertMaxMetricsWithMetadataPerUser(t *testing.T) {
 		ringReplicationFactor    int
 		ringIngesterCount        int
 		metadata                 int
-		expected                 error
+		expected                 bool
 	}{
 		"limit is disabled": {
 			maxGlobalMetadataPerUser: 0,
 			ringReplicationFactor:    1,
 			ringIngesterCount:        1,
 			metadata:                 100,
-			expected:                 nil,
+			expected:                 true,
 		},
 		"current number of metadata is below the limit": {
 			maxGlobalMetadataPerUser: 1000,
 			ringReplicationFactor:    3,
 			ringIngesterCount:        10,
 			metadata:                 299,
-			expected:                 nil,
+			expected:                 true,
 		},
 		"current number of metadata is above the limit": {
 			maxGlobalMetadataPerUser: 1000,
 			ringReplicationFactor:    3,
 			ringIngesterCount:        10,
 			metadata:                 300,
-			expected:                 errMaxMetadataPerUserLimitExceeded,
+			expected:                 false,
 		},
 	}
 

--- a/pkg/ingester/metric_counter.go
+++ b/pkg/ingester/metric_counter.go
@@ -66,7 +66,7 @@ func (m *metricCounter) canAddSeriesFor(userID, metric string) bool {
 	shard.mtx.Lock()
 	defer shard.mtx.Unlock()
 
-	return m.limiter.AssertMaxSeriesPerMetric(userID, shard.m[metric])
+	return m.limiter.IsWithinMaxSeriesPerMetric(userID, shard.m[metric])
 }
 
 func (m *metricCounter) increaseSeriesForMetric(metric string) {

--- a/pkg/ingester/metric_counter.go
+++ b/pkg/ingester/metric_counter.go
@@ -57,9 +57,9 @@ func (m *metricCounter) getShard(metricName string) *metricCounterShard {
 	return shard
 }
 
-func (m *metricCounter) canAddSeriesFor(userID, metric string) error {
+func (m *metricCounter) canAddSeriesFor(userID, metric string) bool {
 	if _, ok := m.ignoredMetrics[metric]; ok {
-		return nil
+		return true
 	}
 
 	shard := m.getShard(metric)

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -45,7 +45,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 	set, ok := mm.metricToMetadata[metric]
 	if !ok {
 		// Verify that the user can create more metric metadata given we don't have a set for that metric name.
-		if !mm.limiter.AssertMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)) {
+		if !mm.limiter.IsWithinMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)) {
 			mm.metrics.discardedMetadataPerUserMetadataLimit.WithLabelValues(mm.userID).Inc()
 			return formatMaxMetadataPerUserError(mm.limiter.limits, mm.userID)
 		}
@@ -53,7 +53,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 		mm.metricToMetadata[metric] = set
 	}
 
-	if !mm.limiter.AssertMaxMetadataPerMetric(mm.userID, len(set)) {
+	if !mm.limiter.IsWithinMaxMetadataPerMetric(mm.userID, len(set)) {
 		mm.metrics.discardedMetadataPerMetricMetadataLimit.WithLabelValues(mm.userID).Inc()
 		return formatMaxMetadataPerMetricError(mm.limiter.limits, labels.FromStrings(labels.MetricName, metric), mm.userID)
 	}

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -47,7 +47,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 		// Verify that the user can create more metric metadata given we don't have a set for that metric name.
 		if err := mm.limiter.AssertMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)); err != nil {
 			mm.metrics.discardedMetadataPerUserMetadataLimit.WithLabelValues(mm.userID).Inc()
-			return makeLimitError(mm.limiter.formatMaxMetadataPerUserError(mm.userID))
+			return formatMaxMetadataPerUserError(mm.limiter, mm.userID)
 		}
 		set = metricMetadataSet{}
 		mm.metricToMetadata[metric] = set
@@ -55,7 +55,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 
 	if err := mm.limiter.AssertMaxMetadataPerMetric(mm.userID, len(set)); err != nil {
 		mm.metrics.discardedMetadataPerMetricMetadataLimit.WithLabelValues(mm.userID).Inc()
-		return makeMetricLimitError(labels.FromStrings(labels.MetricName, metric), mm.limiter.formatMaxMetadataPerMetricError(mm.userID))
+		return formatMaxMetadataPerMetricError(mm.limiter, labels.FromStrings(labels.MetricName, metric), mm.userID)
 	}
 
 	// if we have seen this metadata before, it is a no-op and we don't need to change our metrics.

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -45,17 +45,17 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 	set, ok := mm.metricToMetadata[metric]
 	if !ok {
 		// Verify that the user can create more metric metadata given we don't have a set for that metric name.
-		if err := mm.limiter.AssertMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)); err != nil {
+		if !mm.limiter.AssertMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)) {
 			mm.metrics.discardedMetadataPerUserMetadataLimit.WithLabelValues(mm.userID).Inc()
-			return formatMaxMetadataPerUserError(mm.limiter, mm.userID)
+			return formatMaxMetadataPerUserError(mm.limiter.limits, mm.userID)
 		}
 		set = metricMetadataSet{}
 		mm.metricToMetadata[metric] = set
 	}
 
-	if err := mm.limiter.AssertMaxMetadataPerMetric(mm.userID, len(set)); err != nil {
+	if !mm.limiter.AssertMaxMetadataPerMetric(mm.userID, len(set)) {
 		mm.metrics.discardedMetadataPerMetricMetadataLimit.WithLabelValues(mm.userID).Inc()
-		return formatMaxMetadataPerMetricError(mm.limiter, labels.FromStrings(labels.MetricName, metric), mm.userID)
+		return formatMaxMetadataPerMetricError(mm.limiter.limits, labels.FromStrings(labels.MetricName, metric), mm.userID)
 	}
 
 	// if we have seen this metadata before, it is a no-op and we don't need to change our metrics.

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -47,7 +47,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 		// Verify that the user can create more metric metadata given we don't have a set for that metric name.
 		if err := mm.limiter.AssertMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)); err != nil {
 			mm.metrics.discardedMetadataPerUserMetadataLimit.WithLabelValues(mm.userID).Inc()
-			return makeLimitError(mm.limiter.FormatError(mm.userID, err))
+			return makeLimitError(mm.limiter.formatMaxMetadataPerUserError(mm.userID))
 		}
 		set = metricMetadataSet{}
 		mm.metricToMetadata[metric] = set
@@ -55,7 +55,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 
 	if err := mm.limiter.AssertMaxMetadataPerMetric(mm.userID, len(set)); err != nil {
 		mm.metrics.discardedMetadataPerMetricMetadataLimit.WithLabelValues(mm.userID).Inc()
-		return makeMetricLimitError(labels.FromStrings(labels.MetricName, metric), mm.limiter.FormatError(mm.userID, err))
+		return makeMetricLimitError(labels.FromStrings(labels.MetricName, metric), mm.limiter.formatMaxMetadataPerMetricError(mm.userID))
 	}
 
 	// if we have seen this metadata before, it is a no-op and we don't need to change our metrics.

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -273,8 +273,8 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 	}
 
 	// Total series limit.
-	if err := u.limiter.AssertMaxSeriesPerUser(u.userID, int(u.Head().NumSeries())); err != nil {
-		return err
+	if !u.limiter.AssertMaxSeriesPerUser(u.userID, int(u.Head().NumSeries())) {
+		return errMaxSeriesPerUserLimitExceeded
 	}
 
 	// Series per metric name limit.
@@ -282,8 +282,8 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 	if err != nil {
 		return err
 	}
-	if err := u.seriesInMetric.canAddSeriesFor(u.userID, metricName); err != nil {
-		return err
+	if !u.seriesInMetric.canAddSeriesFor(u.userID, metricName) {
+		return errMaxSeriesPerMetricLimitExceeded
 	}
 
 	return nil

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -273,7 +273,7 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 	}
 
 	// Total series limit.
-	if !u.limiter.AssertMaxSeriesPerUser(u.userID, int(u.Head().NumSeries())) {
+	if !u.limiter.IsWithinMaxSeriesPerUser(u.userID, int(u.Head().NumSeries())) {
 		return errMaxSeriesPerUserLimitExceeded
 	}
 


### PR DESCRIPTION
#### What this PR does
This PR refactors ingester errors creation in such a way that the latter is done in `ingester/errors.go`.

In particular:
- it gets rid of `ingester.Limiter.FormatError()` method, which is not needed anymore.
- all `newIngestErrXXX()` methods are moved from `ingester/ingester.go` to `ingester/errors.go`.
- all `formatMaxXXXError()` methods are moved from `ingester/limiter.go` to `ingester/errors.go`.
- all `AssertMaxXXX()` methods from `ingester/limiter.go` do not throw any error anymore, but return a `bool` representing the outcome of the check. Their names have been changed into `IsWithinMaxXXX()`.

#### Checklist
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`