### PR TITLE
Update Grafana analysis timeout behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Mimirtool
 
 * [BUGFIX] Fix out of bounds error on export with large timespans and/or series count. #5700
+* [BUGFIX] Fix the issue where `--read-timeout` was applied to the entire `mimirtool analyze grafana` invocation rather than to individual Grafana API calls. #5915
 
 ### Mimir Continuous Test
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
The previous implementation applied the timeout for read requests to the entire command execution, which caused issues when fetching individual dashboards. Instead of protecting against individual long requests, the timeout was affecting the entire command execution, leading to timeouts during dashboard analysis.
  
To resolve this issue and improve the behavior of the `mimirtool analyze grafana` command, the following changes were made:

- Modified the `AnalyzeGrafana` function to accept a `readTimeout` parameter.
- Moved the body of the loop responsible for fetching dashboards to its own function called `analyzeDashboard`.
- Within `analyzeDashboard`,  create a child context for each dashboard request and cancel it before moving to the next iteration. This ensures that each context is canceled before the next iteration of the loop, preventing timeouts from affecting the entire process.



#### Which issue(s) this PR fixes or relates to

Fixes #5915 

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
