### PR TITLE
block TestRewrite should not depend on chunk sizes

### DIFF
--- a/pkg/storage/tsdb/block/index_test.go
+++ b/pkg/storage/tsdb/block/index_test.go
@@ -69,8 +69,8 @@ func TestRewrite(t *testing.T) {
 		}
 		return false, nil
 	}}))
-	require.NotZero(t, tocalChunks)   // Sanity check.
-	require.NotZero(t, ignoredChunks) // Sanity check.
+	require.Greater(t, ignoredChunks, 0)           // Sanity check.
+	require.Greater(t, tocalChunks, ignoredChunks) // Sanity check.
 
 	require.NoError(t, iw.Close())
 	require.NoError(t, cw.Close())

--- a/pkg/storage/tsdb/block/index_test.go
+++ b/pkg/storage/tsdb/block/index_test.go
@@ -94,7 +94,7 @@ func TestRewrite(t *testing.T) {
 		require.NoError(t, ir2.Series(p.At(), &builder, &chks))
 		for _, chkMeta := range chks {
 			require.NoError(t, err)
-			require.True(t, chkMeta.MinTime > 600 || chkMeta.MaxTime < 600)
+			require.True(t, chkMeta.MinTime > excludeTime || chkMeta.MaxTime < excludeTime)
 		}
 		resultChunks += len(chks)
 	}


### PR DESCRIPTION
#### What this PR does

Followup to https://github.com/prometheus/prometheus/pull/12054

Instead of hardcoding the chunk boundary, ignore chunks that contain time 600.
Instead of only checking the number of result chunks, verify that the right chunks are ignored and that there was ignore going on.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [X] Tests updated
- N/A Documentation added
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
