### PR TITLE
store-gateway: stop relying on fixed number of samples per chunk

### DIFF
--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -59,6 +59,9 @@ const (
 	DeletionMarkCheckInterval = 1 * time.Hour
 
 	// EstimatedMaxChunkSize is average max of chunk size. This can be exceeded though in very rare (valid) cases.
+	// This changed in prometheus as of https://github.com/prometheus/prometheus/commit/8ef7dfdeebf0a7491973303c7fb6b68ec5cc065b
+	// which capped the max XOR and histogram chunk size to 1KiB.
+	// Once block with this limit become more common this constant can be revisited.
 	EstimatedMaxChunkSize = 16000
 
 	// EstimatedSeriesP99Size is the size in bytes of a single series in the TSDB index. This includes the symbol IDs in

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -57,14 +57,6 @@ import (
 )
 
 const (
-	// MaxSamplesPerChunk is approximately the max number of samples that we may have in any given chunk. This is needed
-	// for precalculating the number of samples that we may have to retrieve and decode for any given query
-	// without downloading them. Please take a look at https://github.com/prometheus/tsdb/pull/397 to know
-	// where this number comes from. Long story short: TSDB is made in such a way, and it is made in such a way
-	// because you barely get any improvements in compression when the number of samples is beyond this.
-	// Take a look at Figure 6 in this whitepaper http://www.vldb.org/pvldb/vol8/p1816-teller.pdf.
-	MaxSamplesPerChunk = 120
-
 	// Labels for metrics.
 	labelEncode = "encode"
 	labelDecode = "decode"

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2259,9 +2259,7 @@ func testBucketStoreSeriesBlockWithMultipleChunks(
 					if streamingBatchSize == 0 {
 						require.Zero(t, estimatedChunks)
 					} else {
-						promChunks := queryPromSeriesChunkMetas(t, mimirpb.FromLabelAdaptersToLabels(seriesSet[0].Labels), promBlock)
-						promChunks = filterPromChunksByTime(promChunks, testData.reqMinTime, testData.reqMaxTime)
-						require.InDelta(t, len(promChunks), estimatedChunks, 0.1, "number of chunks estimations should be within 10% of the actual number of chunks on disk")
+						require.InDelta(t, len(seriesSet[0].Chunks), estimatedChunks, 0.1, "number of chunks estimations should be within 10% of the actual number of chunks")
 					}
 
 					compareToPromChunks(t, seriesSet[0].Chunks, mimirpb.FromLabelAdaptersToLabels(seriesSet[0].Labels), testData.reqMinTime, testData.reqMaxTime, promBlock)

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1944,7 +1944,7 @@ func TestBucketStore_Series_ErrorUnmarshallingRequestHints(t *testing.T) {
 			},
 		},
 		selectAllStrategy{},
-		newStaticChunksLimiterFactory(10000/MaxSamplesPerChunk),
+		newStaticChunksLimiterFactory(100),
 		newStaticSeriesLimiterFactory(0),
 		newGapBasedPartitioners(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		hashcache.NewSeriesHashCache(1024*1024),
@@ -2002,7 +2002,7 @@ func TestBucketStore_Series_CanceledRequest(t *testing.T) {
 			},
 		},
 		selectAllStrategy{},
-		newStaticChunksLimiterFactory(10000/MaxSamplesPerChunk),
+		newStaticChunksLimiterFactory(100),
 		newStaticSeriesLimiterFactory(0),
 		newGapBasedPartitioners(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		hashcache.NewSeriesHashCache(1024*1024),
@@ -2068,7 +2068,7 @@ func TestBucketStore_Series_InvalidRequest(t *testing.T) {
 			},
 		},
 		selectAllStrategy{},
-		newStaticChunksLimiterFactory(10000/MaxSamplesPerChunk),
+		newStaticChunksLimiterFactory(100),
 		newStaticSeriesLimiterFactory(0),
 		newGapBasedPartitioners(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		hashcache.NewSeriesHashCache(1024*1024),
@@ -2151,6 +2151,8 @@ func testBucketStoreSeriesBlockWithMultipleChunks(
 
 	blk := createBlockFromHead(t, headOpts.ChunkDirRoot, h)
 
+	promBlock := openPromBlocks(t, headOpts.ChunkDirRoot)[0]
+
 	thanosMeta := block.ThanosMeta{
 		Labels: labels.FromStrings("ext1", "1").Map(),
 		Source: block.TestSource,
@@ -2193,7 +2195,7 @@ func testBucketStoreSeriesBlockWithMultipleChunks(
 			},
 		},
 		selectAllStrategy{},
-		newStaticChunksLimiterFactory(100000/MaxSamplesPerChunk),
+		newStaticChunksLimiterFactory(1000),
 		newStaticSeriesLimiterFactory(0),
 		newGapBasedPartitioners(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		hashcache.NewSeriesHashCache(1024*1024),
@@ -2207,34 +2209,24 @@ func testBucketStoreSeriesBlockWithMultipleChunks(
 	srv := newBucketStoreTestServer(t, store)
 
 	tests := map[string]struct {
-		reqMinTime             int64
-		reqMaxTime             int64
-		expectedSamples        int
-		expectedChunksEstimate uint64
+		reqMinTime int64
+		reqMaxTime int64
 	}{
 		"query the entire block": {
-			reqMinTime:             math.MinInt64,
-			reqMaxTime:             math.MaxInt64,
-			expectedSamples:        10000,
-			expectedChunksEstimate: uint64(math.Ceil(10000.0 / MaxSamplesPerChunk)),
+			reqMinTime: math.MinInt64,
+			reqMaxTime: math.MaxInt64,
 		},
 		"query the beginning of the block": {
-			reqMinTime:             0,
-			reqMaxTime:             100,
-			expectedSamples:        MaxSamplesPerChunk,
-			expectedChunksEstimate: 1,
+			reqMinTime: 0,
+			reqMaxTime: 100,
 		},
 		"query the middle of the block": {
-			reqMinTime:             4000,
-			reqMaxTime:             4050,
-			expectedSamples:        MaxSamplesPerChunk,
-			expectedChunksEstimate: 1,
+			reqMinTime: 4000,
+			reqMaxTime: 4050,
 		},
 		"query the end of the block": {
-			reqMinTime:             9800,
-			reqMaxTime:             10000,
-			expectedSamples:        (MaxSamplesPerChunk * 2) + (10000 % MaxSamplesPerChunk),
-			expectedChunksEstimate: 3,
+			reqMinTime: 9800,
+			reqMaxTime: 10000,
 		},
 	}
 
@@ -2267,10 +2259,12 @@ func testBucketStoreSeriesBlockWithMultipleChunks(
 					if streamingBatchSize == 0 {
 						require.Zero(t, estimatedChunks)
 					} else {
-						require.Equal(t, testData.expectedChunksEstimate, estimatedChunks)
+						promChunks := queryPromSeriesChunkMetas(t, mimirpb.FromLabelAdaptersToLabels(seriesSet[0].Labels), promBlock)
+						promChunks = filterPromChunksByTime(promChunks, testData.reqMinTime, testData.reqMaxTime)
+						require.InDelta(t, len(promChunks), estimatedChunks, 0.1, "number of chunks estimations should be within 10% of the actual number of chunks on disk")
 					}
 
-					assert.True(t, testData.expectedSamples == numSamples, "expected: %d, actual: %d", testData.expectedSamples, numSamples)
+					compareToPromChunks(t, seriesSet[0].Chunks, mimirpb.FromLabelAdaptersToLabels(seriesSet[0].Labels), testData.reqMinTime, testData.reqMaxTime, promBlock)
 				})
 			}
 		})
@@ -2488,7 +2482,7 @@ func setupStoreForHintsTest(t *testing.T, maxSeriesPerBatch int, opts ...BucketS
 			},
 		},
 		selectAllStrategy{},
-		newStaticChunksLimiterFactory(10000/MaxSamplesPerChunk),
+		newStaticChunksLimiterFactory(100),
 		newStaticSeriesLimiterFactory(0),
 		newGapBasedPartitioners(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		hashcache.NewSeriesHashCache(1024*1024),

--- a/pkg/storegateway/prometheus_test.go
+++ b/pkg/storegateway/prometheus_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegateway
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
+	promtsdb "github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util"
+)
+
+func openPromBlocks(t testing.TB, dir string) []promtsdb.BlockReader {
+	promDB, err := promtsdb.OpenDBReadOnly(dir, log.NewNopLogger())
+	require.NoError(t, err)
+	promBlocks, err := promDB.Blocks()
+	require.NoError(t, err)
+	return promBlocks
+}
+
+func queryPromSeriesChunkMetas(t testing.TB, series labels.Labels, block promtsdb.BlockReader) []chunks.Meta {
+	promReader, err := block.Index()
+	require.NoError(t, err)
+	defer promReader.Close()
+
+	matchers := make([]*labels.Matcher, 0, series.Len())
+	series.Range(func(l labels.Label) {
+		matchers = append(matchers, labels.MustNewMatcher(labels.MatchEqual, l.Name, l.Value))
+	})
+	postings, err := promReader.PostingsForMatchers(false, matchers...)
+	require.NoError(t, err)
+
+	require.Truef(t, postings.Next(), "selecting from prometheus returned no series for %s", util.MatchersStringer(matchers))
+
+	var metas []chunks.Meta
+	err = promReader.Series(postings.At(), &labels.ScratchBuilder{}, &metas)
+	require.NoError(t, err)
+
+	require.Falsef(t, postings.Next(), "selecting %s returned more series than expected", util.MatchersStringer(matchers))
+	return metas
+}
+
+// loadPromChunks sets metas[].Chunk
+func loadPromChunks(t testing.TB, metas []chunks.Meta, block promtsdb.BlockReader) {
+	promReader, err := block.Chunks()
+	require.NoError(t, err)
+	defer promReader.Close()
+
+	for i := range metas {
+		metas[i].Chunk, err = promReader.Chunk(metas[i])
+		require.NoError(t, err)
+	}
+}
+
+func compareToPromChunks(t testing.TB, chks []storepb.AggrChunk, lbls labels.Labels, minT, maxT int64, promBlock promtsdb.BlockReader) {
+	// Query the persisted block using prometheus
+	promChunks := queryPromSeriesChunkMetas(t, lbls, promBlock)
+	promChunks = filterPromChunksByTime(promChunks, minT, maxT)
+	loadPromChunks(t, promChunks, promBlock)
+
+	// Compare the chunks that prometheus returns with the chunks the store-gateway returns.
+	// NB: Order of chunks isn't guaranteed by the store-gateway.
+	actualChunkData := make([][]byte, 0, len(chks))
+	for _, c := range chks {
+		actualChunkData = append(actualChunkData, c.Raw.Data)
+	}
+	assert.Len(t, actualChunkData, len(promChunks))
+	for _, c := range promChunks {
+		assert.Contains(t, actualChunkData, c.Chunk.Bytes())
+	}
+}
+
+// filterPromChunksByTime filters metas in place
+func filterPromChunksByTime(metas []chunks.Meta, minT, maxT int64) []chunks.Meta {
+	writeIdx := 0
+	for _, c := range metas {
+		if !c.OverlapsClosedInterval(minT, maxT) {
+			continue
+		}
+		metas[writeIdx] = c
+		writeIdx++
+	}
+	return metas[:writeIdx]
+}


### PR DESCRIPTION
This is a prerequisite to #5927

Number of samples per chunk is changing in prometheus. Currently, only for native histograms, but also regular XOR chunks are capped at 1KiB.

This PR changes some tests to not rely on a hardcoded number of samples and also updates/removes some constants in the code. Instead it queries the blocks on disk using Prometheus code and compares this to what the store-gateway returns.

For chunk estimations I changed the tests to assert that the estimation is not off by more than 10% from the real number of chunks. I'd like to get a review from @charleskorn on whether this is an appropriate approach.