### PR TITLE
Make nginx listen on IPv6.

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,8 +33,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Sets the `appProtocol` value to `tcp` for the `gossip-ring-svc` service template. This allows memberlist to work with istio protocol selection. #5673
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.8.0`. #5718
 * [ENHANCEMENT] Make store_gateway podManagementPolicy configurable. #5757
-* [BUGFIX] Fix `global.podLabels` causing invalid indentation. #5625
 * [ENHANCEMENT] Nginx: listen on IPv6 addresses. #5948
+* [BUGFIX] Fix `global.podLabels` causing invalid indentation. #5625
 
 ## 5.0.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -34,6 +34,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.8.0`. #5718
 * [ENHANCEMENT] Make store_gateway podManagementPolicy configurable. #5757
 * [BUGFIX] Fix `global.podLabels` causing invalid indentation. #5625
+* [ENHANCEMENT] Nginx: listen on IPv6 addresses. #5948
 
 ## 5.0.0
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2347,6 +2347,7 @@ nginx:
         proxy_read_timeout 300;
         server {
           listen 8080;
+          listen [::]:8080;
 
           {{- if .Values.nginx.basicAuth.enabled }}
           auth_basic           "Mimir";

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -47,6 +47,7 @@ data:
       proxy_read_timeout 300;
       server {
         listen 8080;
+        listen [::]:8080;
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -47,6 +47,7 @@ data:
       proxy_read_timeout 300;
       server {
         listen 8080;
+        listen [::]:8080;
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -47,6 +47,7 @@ data:
       proxy_read_timeout 300;
       server {
         listen 8080;
+        listen [::]:8080;
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -47,6 +47,7 @@ data:
       proxy_read_timeout 300;
       server {
         listen 8080;
+        listen [::]:8080;
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -47,6 +47,7 @@ data:
       proxy_read_timeout 300;
       server {
         listen 8080;
+        listen [::]:8080;
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -47,6 +47,7 @@ data:
       proxy_read_timeout 300;
       server {
         listen 8080;
+        listen [::]:8080;
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -47,6 +47,7 @@ data:
       proxy_read_timeout 300;
       server {
         listen 8080;
+        listen [::]:8080;
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -47,6 +47,7 @@ data:
       proxy_read_timeout 300;
       server {
         listen 8080;
+        listen [::]:8080;
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -47,6 +47,7 @@ data:
       proxy_read_timeout 300;
       server {
         listen 8080;
+        listen [::]:8080;
     
         location = / {
           return 200 'OK';


### PR DESCRIPTION
This makes the nginx proxy listen on IPv6.

It is also possible to make nginx listen with a single listener directive, but I chose this approach because that's exactly how it was done in Loki: https://github.com/grafana/loki/blob/main/production/helm/loki/templates/_helpers.tpl (Search for listen).

I don't believe this warrants a changelog entry, as it only fixes one aspect of IPv6 compatibility.

#### What this PR does
This makes the nginx proxy listen on IPv6 in addition to IPv4.


#### Which issue(s) this PR fixes or relates to

Relates to #3743

#### Checklist

- [X] Tests updated
- [X] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`