### PR TITLE
Azure: Don't serialize config, pass it directly to Thanos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	golang.org/x/sync v0.3.0
 	golang.org/x/time v0.3.0
 	google.golang.org/grpc v1.57.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/pkg/storage/bucket/azure/bucket_client.go
+++ b/pkg/storage/bucket/azure/bucket_client.go
@@ -7,17 +7,15 @@ package azure
 
 import (
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/azure"
-	yaml "gopkg.in/yaml.v3"
 )
 
 func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
-	return newBucketClient(cfg, name, logger, azure.NewBucket)
+	return newBucketClient(cfg, name, logger, azure.NewBucketWithConfig)
 }
 
-func newBucketClient(cfg Config, name string, logger log.Logger, factory func(log.Logger, []byte, string) (*azure.Bucket, error)) (objstore.Bucket, error) {
+func newBucketClient(cfg Config, name string, logger log.Logger, factory func(log.Logger, azure.Config, string) (*azure.Bucket, error)) (objstore.Bucket, error) {
 	// Start with default config to make sure that all parameters are set to sensible values, especially
 	// HTTP Config field.
 	bucketConfig := azure.DefaultConfig
@@ -32,12 +30,5 @@ func newBucketClient(cfg Config, name string, logger log.Logger, factory func(lo
 		bucketConfig.Endpoint = cfg.Endpoint
 	}
 
-	// Thanos currently doesn't support passing the config as is, but expects a YAML,
-	// so we're going to serialize it.
-	serialized, err := yaml.Marshal(bucketConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "serializing objstore Azure bucket config")
-	}
-
-	return factory(logger, serialized, name)
+	return factory(logger, bucketConfig, name)
 }

--- a/pkg/storage/bucket/azure/bucket_client_test.go
+++ b/pkg/storage/bucket/azure/bucket_client_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore/providers/azure"
-	"gopkg.in/yaml.v2"
 )
 
 func TestNewBucketClient(t *testing.T) {
@@ -41,7 +40,7 @@ func TestNewBucketClient(t *testing.T) {
 }
 
 // fakeFactory is a test utility to act as an azure.Bucket factory, but in reality verify the input config.
-func fakeFactory(t *testing.T, cfg Config) func(log.Logger, []byte, string) (*azure.Bucket, error) {
+func fakeFactory(t *testing.T, cfg Config) func(log.Logger, azure.Config, string) (*azure.Bucket, error) {
 	expCfg := azure.DefaultConfig
 	expCfg.StorageAccountName = cfg.StorageAccountName
 	expCfg.StorageAccountKey = cfg.StorageAccountKey.String()
@@ -52,11 +51,9 @@ func fakeFactory(t *testing.T, cfg Config) func(log.Logger, []byte, string) (*az
 		expCfg.Endpoint = cfg.Endpoint
 	}
 
-	return func(_ log.Logger, c []byte, _ string) (*azure.Bucket, error) {
+	return func(_ log.Logger, azCfg azure.Config, _ string) (*azure.Bucket, error) {
 		t.Helper()
 
-		var azCfg azure.Config
-		require.NoError(t, yaml.Unmarshal(c, &azCfg))
 		assert.Equal(t, expCfg, azCfg)
 
 		return &azure.Bucket{}, nil


### PR DESCRIPTION
#### What this PR does
Pass config directly to `github.com/thanos-io/objstore/providers/azure.NewBucketWithConfig` instead of serializing it and calling `github.com/thanos-io/objstore/providers/azure.NewBucket`. Just a simple refactoring, no practical changes.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
