### PR TITLE
WIP: Add limit for total size of concurrent requests in ingesters's memory, and reject additional requests.

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -120,10 +120,11 @@ const (
 )
 
 var (
-	reasonIngesterMaxIngestionRate        = globalerror.IngesterMaxIngestionRate.LabelValue()
-	reasonIngesterMaxTenants              = globalerror.IngesterMaxTenants.LabelValue()
-	reasonIngesterMaxInMemorySeries       = globalerror.IngesterMaxInMemorySeries.LabelValue()
-	reasonIngesterMaxInflightPushRequests = globalerror.IngesterMaxInflightPushRequests.LabelValue()
+	reasonIngesterMaxIngestionRate             = globalerror.IngesterMaxIngestionRate.LabelValue()
+	reasonIngesterMaxTenants                   = globalerror.IngesterMaxTenants.LabelValue()
+	reasonIngesterMaxInMemorySeries            = globalerror.IngesterMaxInMemorySeries.LabelValue()
+	reasonIngesterMaxInflightPushRequests      = globalerror.IngesterMaxInflightPushRequests.LabelValue()
+	reasonIngesterMaxInflightPushRequestsBytes = globalerror.IngesterMaxInflightPushRequestsBytes.LabelValue()
 )
 
 // BlocksUploader interface is used to have an easy way to mock it in tests.
@@ -263,8 +264,9 @@ type Ingester struct {
 	usersMetadata    map[string]*userMetricsMetadata
 
 	// Rate of pushed samples. Used to limit global samples push rate.
-	ingestionRate        *util_math.EwmaRate
-	inflightPushRequests atomic.Int64
+	ingestionRate             *util_math.EwmaRate
+	inflightPushRequests      atomic.Int64
+	inflightPushRequestsBytes atomic.Int64
 
 	// Anonymous usage statistics tracked by ingester.
 	memorySeriesStats                  *expvar.Int
@@ -323,7 +325,7 @@ func New(cfg Config, limits *validation.Overrides, activeGroupsCleanupService *u
 		return nil, err
 	}
 	i.ingestionRate = util_math.NewEWMARate(0.2, instanceIngestionRateTickInterval)
-	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetrics.Enabled, i.getInstanceLimits, i.ingestionRate, &i.inflightPushRequests)
+	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetrics.Enabled, i.getInstanceLimits, i.ingestionRate, &i.inflightPushRequests, &i.inflightPushRequestsBytes)
 	i.activeGroups = activeGroupsCleanupService
 
 	if registerer != nil {
@@ -382,7 +384,7 @@ func NewForFlusher(cfg Config, limits *validation.Overrides, registerer promethe
 	if err != nil {
 		return nil, err
 	}
-	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil, &i.inflightPushRequests)
+	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil, &i.inflightPushRequests, &i.inflightPushRequestsBytes)
 
 	i.shipperIngesterID = "flusher"
 
@@ -756,6 +758,17 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, pushReq *push.Request) (
 	req, err := pushReq.WriteRequest()
 	if err != nil {
 		return nil, err
+	}
+
+	requestSize := int64(req.Size()) // This can be expensive call. Check it in profiles.
+	totalRequestSize := i.inflightPushRequestsBytes.Add(requestSize)
+	defer i.inflightPushRequestsBytes.Sub(requestSize)
+
+	if il != nil && il.MaxInflightPushRequestsBytes > 0 {
+		if totalRequestSize > il.MaxInflightPushRequestsBytes {
+			i.metrics.rejected.WithLabelValues(reasonIngesterMaxInflightPushRequestsBytes).Inc()
+			return nil, errMaxInflightRequestsBytesReached
+		}
 	}
 
 	// Given metadata is a best-effort approach, and we don't halt on errors

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -18,18 +18,20 @@ import (
 )
 
 const (
-	maxIngestionRateFlag        = "ingester.instance-limits.max-ingestion-rate"
-	maxInMemoryTenantsFlag      = "ingester.instance-limits.max-tenants"
-	maxInMemorySeriesFlag       = "ingester.instance-limits.max-series"
-	maxInflightPushRequestsFlag = "ingester.instance-limits.max-inflight-push-requests"
+	maxIngestionRateFlag             = "ingester.instance-limits.max-ingestion-rate"
+	maxInMemoryTenantsFlag           = "ingester.instance-limits.max-tenants"
+	maxInMemorySeriesFlag            = "ingester.instance-limits.max-series"
+	maxInflightPushRequestsFlag      = "ingester.instance-limits.max-inflight-push-requests"
+	maxInflightPushRequestsBytesFlag = "ingester.instance-limits.max-inflight-push-requests-bytes"
 )
 
 // We don't include values in the messages for per-instance limits to avoid leaking Mimir cluster configuration to users.
 var (
-	errMaxIngestionRateReached    = newInstanceLimitError(globalerror.IngesterMaxIngestionRate.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
-	errMaxTenantsReached          = newInstanceLimitError(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
-	errMaxInMemorySeriesReached   = newInstanceLimitError(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
-	errMaxInflightRequestsReached = newInstanceLimitError(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxIngestionRateReached         = newInstanceLimitError(globalerror.IngesterMaxIngestionRate.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
+	errMaxTenantsReached               = newInstanceLimitError(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
+	errMaxInMemorySeriesReached        = newInstanceLimitError(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
+	errMaxInflightRequestsReached      = newInstanceLimitError(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxInflightRequestsBytesReached = newInstanceLimitError(globalerror.IngesterMaxInflightPushRequestsBytes.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed size of inflight push requests", maxInflightPushRequestsBytesFlag))
 )
 
 type instanceLimitErr struct {
@@ -62,10 +64,11 @@ func (e *instanceLimitErr) Error() string {
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return
 // (internal) error.
 type InstanceLimits struct {
-	MaxIngestionRate        float64 `yaml:"max_ingestion_rate" category:"advanced"`
-	MaxInMemoryTenants      int64   `yaml:"max_tenants" category:"advanced"`
-	MaxInMemorySeries       int64   `yaml:"max_series" category:"advanced"`
-	MaxInflightPushRequests int64   `yaml:"max_inflight_push_requests" category:"advanced"`
+	MaxIngestionRate             float64 `yaml:"max_ingestion_rate" category:"advanced"`
+	MaxInMemoryTenants           int64   `yaml:"max_tenants" category:"advanced"`
+	MaxInMemorySeries            int64   `yaml:"max_series" category:"advanced"`
+	MaxInflightPushRequests      int64   `yaml:"max_inflight_push_requests" category:"advanced"`
+	MaxInflightPushRequestsBytes int64   `yaml:"max_inflight_push_requests_bytes" category:"advanced"`
 }
 
 func (l *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
@@ -73,6 +76,7 @@ func (l *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&l.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
+	f.Int64Var(&l.MaxInflightPushRequestsBytes, maxInflightPushRequestsBytesFlag, 0, "Max total size of inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
 }
 
 // Sets default limit values for unmarshalling.

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -90,6 +90,7 @@ func TestUserMetricsMetadata(t *testing.T) {
 				func() *InstanceLimits { return nil },
 				nil,
 				nil,
+				nil,
 			)
 
 			mm := newMetadataMap(limiter, metrics, "test")

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -37,10 +37,11 @@ const (
 	DistributorMaxInflightPushRequests      ID = "distributor-max-inflight-push-requests"
 	DistributorMaxInflightPushRequestsBytes ID = "distributor-max-inflight-push-requests-bytes"
 
-	IngesterMaxIngestionRate        ID = "ingester-max-ingestion-rate"
-	IngesterMaxTenants              ID = "ingester-max-tenants"
-	IngesterMaxInMemorySeries       ID = "ingester-max-series"
-	IngesterMaxInflightPushRequests ID = "ingester-max-inflight-push-requests"
+	IngesterMaxIngestionRate             ID = "ingester-max-ingestion-rate"
+	IngesterMaxTenants                   ID = "ingester-max-tenants"
+	IngesterMaxInMemorySeries            ID = "ingester-max-series"
+	IngesterMaxInflightPushRequests      ID = "ingester-max-inflight-push-requests"
+	IngesterMaxInflightPushRequestsBytes ID = "ingester-max-inflight-push-requests-bytes"
 
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"


### PR DESCRIPTION
#### What this PR does

This PR adds `-ingester.instance-limits.max-inflight-push-requests-bytes` instance limit that rejects additional requests, if ingester is already handling requests that altogether have more specified size. This is similar to distributor's `-distributor.instance-limits.max-inflight-push-requests-bytes`.

This limit can work better than existing `-ingester.instance-limits.max-inflight-push-requests`, because "max inflight push requests" set to 1000 has different effect on memory if average request size is 1 KiB or 100 KiB.

One possible negative of this change is that ingester now spends extra cpu cycles computing request size. I'm going to test this PR with some workloads and see if this shows as a problem in the profiles. If so, we can easily move the computation to distributor, and pass the size in the WriteRequest.

I'm also going to test this in combination with https://github.com/grafana/mimir/pull/5921.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
