### PR TITLE
Update Go to 1.21.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.10.0-rc.2
+
+### Grafana Mimir
+
+* [ENHANCEMENT] Go: updated to 1.21.1. #5955
 
 ## 2.10.0-rc.1
 

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr5734-cf25a5b2b4
+LATEST_BUILD_IMAGE_TAG ?= pr5955-facaa1c135
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM k8s.gcr.io/kustomize/kustomize:v4.5.5 as kustomize
 FROM alpine/helm:3.11.1 as helm
-FROM golang:1.21.0-bullseye
+FROM golang:1.21.1-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"


### PR DESCRIPTION
Cherry-pick PR #5955 (Update of Go to 1.21.1) onto release-2.10 branch.
