### PR TITLE
WIP: track ingester inflight push requests before unmarshalling the request and interceptors

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -253,11 +253,14 @@ type Ingester interface {
 	UserRegistryHandler(http.ResponseWriter, *http.Request)
 	TenantsHandler(http.ResponseWriter, *http.Request)
 	TenantTSDBHandler(http.ResponseWriter, *http.Request)
+
+	StartPushRequest() error
+	FinishPushRequest()
 }
 
 // RegisterIngester registers the ingester HTTP and gRPC services.
 func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
-	client.RegisterIngesterServer(a.server.GRPC, i)
+	client.RegisterIngesterServerWithLimitsTracking(a.server.GRPC, i)
 
 	a.indexPage.AddLinks(dangerousWeight, "Dangerous", []IndexPageLink{
 		{Dangerous: true, Desc: "Trigger a flush of data from ingester to storage", Path: "/ingester/flush"},

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -260,7 +260,7 @@ type Ingester interface {
 
 // RegisterIngester registers the ingester HTTP and gRPC services.
 func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config) {
-	client.RegisterIngesterServerWithLimitsTracking(a.server.GRPC, i)
+	client.RegisterIngesterServerRequestTracking(a.server.GRPC, i)
 
 	a.indexPage.AddLinks(dangerousWeight, "Dangerous", []IndexPageLink{
 		{Dangerous: true, Desc: "Trigger a flush of data from ingester to storage", Path: "/ingester/flush"},

--- a/pkg/ingester/client/ingester_grpc.go
+++ b/pkg/ingester/client/ingester_grpc.go
@@ -13,7 +13,7 @@ type IngesterServerRequestTracking interface {
 	FinishPushRequest()
 }
 
-func RegisterIngesterServerWithLimitsTracking(s *grpc.Server, srv IngesterServerRequestTracking) {
+func RegisterIngesterServerRequestTracking(s *grpc.Server, srv IngesterServerRequestTracking) {
 	var desc grpc.ServiceDesc
 	desc = _Ingester_serviceDesc
 

--- a/pkg/ingester/client/ingester_grpc.go
+++ b/pkg/ingester/client/ingester_grpc.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+type IngesterServerWithInstanceLimits interface {
+	IngesterServer
+
+	StartPushRequest() error
+	FinishPushRequest()
+}
+
+func RegisterIngesterServerWithLimitsTracking(s *grpc.Server, srv IngesterServerWithInstanceLimits) {
+	var desc grpc.ServiceDesc
+	desc = _Ingester_serviceDesc
+
+	for ix, m := range _Ingester_serviceDesc.Methods {
+		if m.MethodName == "Push" {
+			_Ingester_serviceDesc.Methods[ix].Handler = _IngesterPushHandlerWithLimitsTracking
+		}
+	}
+
+	s.RegisterService(&desc, srv)
+}
+
+func _IngesterPushHandlerWithLimitsTracking(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	srvil := srv.(IngesterServerWithInstanceLimits)
+
+	err := srvil.StartPushRequest()
+	if err != nil {
+		return nil, err
+	}
+	defer srvil.FinishPushRequest()
+
+	return _Ingester_Push_Handler(srv, ctx, dec, interceptor)
+}

--- a/pkg/ingester/client/ingester_grpc.go
+++ b/pkg/ingester/client/ingester_grpc.go
@@ -6,14 +6,14 @@ import (
 	"google.golang.org/grpc"
 )
 
-type IngesterServerWithInstanceLimits interface {
+type IngesterServerRequestTracking interface {
 	IngesterServer
 
 	StartPushRequest() error
 	FinishPushRequest()
 }
 
-func RegisterIngesterServerWithLimitsTracking(s *grpc.Server, srv IngesterServerWithInstanceLimits) {
+func RegisterIngesterServerWithLimitsTracking(s *grpc.Server, srv IngesterServerRequestTracking) {
 	var desc grpc.ServiceDesc
 	desc = _Ingester_serviceDesc
 
@@ -27,7 +27,7 @@ func RegisterIngesterServerWithLimitsTracking(s *grpc.Server, srv IngesterServer
 }
 
 func _IngesterPushHandlerWithLimitsTracking(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	srvil := srv.(IngesterServerWithInstanceLimits)
+	srvil := srv.(IngesterServerRequestTracking)
 
 	err := srvil.StartPushRequest()
 	if err != nil {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -719,6 +719,44 @@ type pushStats struct {
 	perMetricSeriesLimitCount int
 }
 
+// StartPushRequest checks if ingester can start push request, and increments relevant counters.
+// All errors must be convertible to gRPC status code.
+func (i *Ingester) StartPushRequest() error {
+	if err := i.checkRunning(); err != nil {
+		return err
+	}
+
+	inflight := i.inflightPushRequests.Inc()
+	decreaseInDefer := true
+	defer func() {
+		if decreaseInDefer {
+			i.inflightPushRequests.Dec()
+		}
+	}()
+
+	il := i.getInstanceLimits()
+	if il != nil && il.MaxInflightPushRequests > 0 {
+		if inflight > il.MaxInflightPushRequests {
+			i.metrics.rejected.WithLabelValues(reasonIngesterMaxInflightPushRequests).Inc()
+			return errMaxInflightRequestsReached
+		}
+	}
+
+	if il != nil && il.MaxIngestionRate > 0 {
+		if rate := i.ingestionRate.Rate(); rate >= il.MaxIngestionRate {
+			i.metrics.rejected.WithLabelValues(reasonIngesterMaxIngestionRate).Inc()
+			return errMaxIngestionRateReached
+		}
+	}
+
+	decreaseInDefer = false
+	return nil
+}
+
+func (i *Ingester) FinishPushRequest() {
+	i.inflightPushRequests.Dec()
+}
+
 // PushWithCleanup is the Push() implementation for blocks storage and takes a WriteRequest and adds it to the TSDB head.
 func (i *Ingester) PushWithCleanup(ctx context.Context, pushReq *push.Request) (*mimirpb.WriteResponse, error) {
 	// NOTE: because we use `unsafe` in deserialisation, we must not
@@ -729,28 +767,9 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, pushReq *push.Request) (
 		return nil, util_log.DoNotLogError{Err: err}
 	}
 
-	// We will report *this* request in the error too.
-	inflight := i.inflightPushRequests.Inc()
-	defer i.inflightPushRequests.Dec()
-
-	il := i.getInstanceLimits()
-	if il != nil && il.MaxInflightPushRequests > 0 {
-		if inflight > il.MaxInflightPushRequests {
-			i.metrics.rejected.WithLabelValues(reasonIngesterMaxInflightPushRequests).Inc()
-			return nil, errMaxInflightRequestsReached
-		}
-	}
-
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	if il != nil && il.MaxIngestionRate > 0 {
-		if rate := i.ingestionRate.Rate(); rate >= il.MaxIngestionRate {
-			i.metrics.rejected.WithLabelValues(reasonIngesterMaxIngestionRate).Inc()
-			return nil, errMaxIngestionRateReached
-		}
 	}
 
 	req, err := pushReq.WriteRequest()

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -185,6 +185,14 @@ func (i *ActivityTrackerWrapper) TenantTSDBHandler(w http.ResponseWriter, r *htt
 	i.ing.TenantTSDBHandler(w, r)
 }
 
+func (i *ActivityTrackerWrapper) StartPushRequest() error {
+	return i.ing.StartPushRequest()
+}
+
+func (i *ActivityTrackerWrapper) FinishPushRequest() {
+	i.ing.FinishPushRequest()
+}
+
 func requestActivity(ctx context.Context, name string, req interface{}) string {
 	userID, _ := tenant.TenantID(ctx)
 	traceID, _ := tracing.ExtractSampledTraceID(ctx)


### PR DESCRIPTION
#### What this PR does

This PR wraps generated gRPC `_Ingester_Push_Handler` by code that starts/stops tracking of push request. This allows us to track request even before `WriteRequest` is unmarshalled or before any interceptor is called.

To be tested, unit tests are not updated yet.

#### Which issue(s) this PR fixes or relates to

Related to
- https://github.com/grafana/mimir/pull/5921
- https://github.com/grafana/mimir/pull/5958

Integrating all these PRs together will need bit of extra work.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
