### PR TITLE
AutoPilot GKE auto add ApiVersion

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -17,8 +17,8 @@ spec:
   serviceName: {{ template "mimir.fullname" . }}-compactor
   {{- if .Values.compactor.persistentVolume.enabled }}
   volumeClaimTemplates:
-      - apiVersion: v1	
-      kind: PersistentVolumeClaim	
+    - apiVersion: v1	
+      kind: PersistentVolumeClaim
       metadata:
         name: storage
         {{- if .Values.compactor.persistentVolume.annotations }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -17,7 +17,9 @@ spec:
   serviceName: {{ template "mimir.fullname" . }}-compactor
   {{- if .Values.compactor.persistentVolume.enabled }}
   volumeClaimTemplates:
-    - metadata:
+      - apiVersion: v1	
+      kind: PersistentVolumeClaim	
+      metadata:
         name: storage
         {{- if .Values.compactor.persistentVolume.annotations }}
         annotations:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -27,7 +27,9 @@ spec:
   serviceName: {{ template "mimir.fullname" . }}-ingester{{- if not .Values.enterprise.legacyLabels -}}-headless{{- end -}}
   {{- if .Values.ingester.persistentVolume.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1	
+      kind: PersistentVolumeClaim
+      metadata:
         name: storage
         {{- if .Values.ingester.persistentVolume.annotations }}
         annotations:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -27,7 +27,9 @@ spec:
   serviceName: {{ template "mimir.fullname" . }}-store-gateway{{- if not .Values.enterprise.legacyLabels -}}-headless{{- end -}}
   {{- if .Values.store_gateway.persistentVolume.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1	
+      kind: PersistentVolumeClaim	
+      metadata:
         name: storage
         {{- if .Values.store_gateway.persistentVolume.annotations }}
         annotations:


### PR DESCRIPTION
When using GKE Autopilot they automatically add 
    - apiVersion: v1	
      kind: PersistentVolumeClaim
and if you then use gitOPS it will constantly re-create the pod to match what it automatically added. This also works on standard (normal kubernetes clusters)

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adds apiVersion and kind to the volumeClaimTemplate

#### Which issue(s) this PR fixes or relates to
ArgoCD and Flux constantly re-deploy on GKE autopilot
Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
