### PR TITLE
WIP: Track push inflight requests via grpc server handlers.

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2859,6 +2859,17 @@
           "fieldFlag": "ingester.log-utilization-based-limiter-cpu-samples",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "limit_inflight_requests_using_grpc_tap_handle",
+          "required": false,
+          "desc": "Use experimental method of limiting push requests",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "ingester.limit-inflight-requests-using-grpc-handlers",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1271,6 +1271,8 @@ Usage of ./cmd/mimir/mimir:
     	Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.
   -ingester.instance-limits.max-tenants int
     	Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.
+  -ingester.limit-inflight-requests-using-grpc-handlers
+    	[experimental] Use experimental method of limiting push requests
   -ingester.log-utilization-based-limiter-cpu-samples
     	[experimental] Enable logging of utilization based limiter CPU samples.
   -ingester.max-global-exemplars-per-user int

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1033,6 +1033,10 @@ instance_limits:
 # (experimental) Enable logging of utilization based limiter CPU samples.
 # CLI flag: -ingester.log-utilization-based-limiter-cpu-samples
 [log_utilization_based_limiter_cpu_samples: <boolean> | default = false]
+
+# (experimental) Use experimental method of limiting push requests
+# CLI flag: -ingester.limit-inflight-requests-using-grpc-handlers
+[limit_inflight_requests_using_grpc_tap_handle: <boolean> | default = false]
 ```
 
 ### querier

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -769,7 +769,7 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, pushReq *push.Request) (
 	// If we're using grpc handlers, we don't need to start/finish request here.
 	if !i.cfg.LimitInflightRequestsUsingGrpcTapHandle {
 		if err := i.StartPushRequest(); err != nil {
-			return nil, err
+			return nil, util_log.DoNotLogError{Err: err}
 		}
 		defer i.FinishPushRequest()
 	}

--- a/pkg/mimir/grpc_push_check.go
+++ b/pkg/mimir/grpc_push_check.go
@@ -1,0 +1,73 @@
+package mimir
+
+import (
+	"context"
+
+	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/tap"
+)
+
+type pushReceiver interface {
+	StartPushRequest() error
+	FinishPushRequest()
+}
+
+func newGrpcPushCheck(getIngester func() pushReceiver) *grpcPushCheck {
+	return &grpcPushCheck{getIngester: getIngester}
+}
+
+// grpcPushCheck implements gRPC TapHandle and gRPC stats.Handler.
+// grpcPushCheck can track push inflight requests, and reject requests before even reading them into memory.
+type grpcPushCheck struct {
+	getIngester func() pushReceiver
+}
+
+// Custom type to hide it from other packages.
+type grpcPushCheckContextKey int
+
+const (
+	pushRequestStartedKey grpcPushCheckContextKey = 1
+)
+
+// TapHandle is called after receiving grpc request and headers, but before reading any request data yet.
+// If we reject request here, it won't be counted towards any metrics (eg. dskit middleware).
+// If we accept request (not return error), eventually HandleRPC with stats.End notification will be called.
+func (g *grpcPushCheck) TapHandle(ctx context.Context, info *tap.Info) (context.Context, error) {
+	pushRequestStarted := false
+
+	var err error
+	if info.FullMethodName == "/cortex.Ingester/Push" {
+		ing := g.getIngester()
+		if ing != nil {
+			// All errors returned by StartPushRequest can be converted to gRPC status.Status.
+			err = ing.StartPushRequest()
+			if err == nil {
+				pushRequestStarted = true
+			}
+		}
+	}
+
+	ctx = context.WithValue(ctx, pushRequestStartedKey, pushRequestStarted)
+	return ctx, err
+}
+
+func (g *grpcPushCheck) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (g *grpcPushCheck) HandleRPC(ctx context.Context, rpcStats stats.RPCStats) {
+	// when request ends, and we started push request tracking for this request, finish it.
+	if _, ok := rpcStats.(*stats.End); ok {
+		if b, ok := ctx.Value(pushRequestStartedKey).(bool); ok && b {
+			g.getIngester().FinishPushRequest()
+		}
+	}
+}
+
+func (g *grpcPushCheck) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (g *grpcPushCheck) HandleConn(_ context.Context, _ stats.ConnStats) {
+	// Not interested.
+}

--- a/pkg/mimir/grpc_push_check.go
+++ b/pkg/mimir/grpc_push_check.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package mimir
 
 import (

--- a/pkg/mimir/grpc_push_check_test.go
+++ b/pkg/mimir/grpc_push_check_test.go
@@ -1,0 +1,130 @@
+package mimir
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/test"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+func TestGrpcPushCheck(t *testing.T) {
+	const limit = 3
+	ingServer := &ingesterServer{finishRequest: make(chan struct{}), inflightLimit: limit}
+
+	c := setupGrpcServerWithCheckAndClient(t, ingServer)
+
+	// start push requests in background goroutines
+	started := sync.WaitGroup{}
+	finished := sync.WaitGroup{}
+	for i := 0; i < limit; i++ {
+		started.Add(1)
+		finished.Add(1)
+
+		go func() {
+			started.Done()
+			defer finished.Done()
+
+			_, err := c.Push(context.Background(), &mimirpb.WriteRequest{})
+			require.NoError(t, err)
+		}()
+	}
+
+	// Wait until all goroutines start.
+	started.Wait()
+
+	// Wait until all requests are inflight.
+	test.Poll(t, 1*time.Second, int64(limit), func() interface{} {
+		return ingServer.inflight.Load()
+	})
+
+	// Try another request. This one should fail with too many inflight requests error.
+	_, err := c.Push(context.Background(), &mimirpb.WriteRequest{})
+	require.Error(t, err)
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Code(123), s.Code())
+	require.Equal(t, "too many requests", s.Message())
+
+	require.Equal(t, int64(limit), ingServer.inflight.Load())
+
+	// unblock all requests
+	for i := 0; i < limit; i++ {
+		ingServer.finishRequest <- struct{}{}
+	}
+	finished.Wait()
+
+	require.Equal(t, int64(0), ingServer.inflight.Load())
+
+	// unblock subsequent requests immediately
+	close(ingServer.finishRequest)
+
+	// another push request should succeed.
+	_, err = c.Push(context.Background(), &mimirpb.WriteRequest{})
+	require.NoError(t, err)
+}
+
+func setupGrpcServerWithCheckAndClient(t *testing.T, ingServer *ingesterServer) ingester_client.IngesterClient {
+	g := newGrpcPushCheck(func() pushReceiver {
+		return ingServer
+	})
+
+	server := grpc.NewServer(grpc.InTapHandle(g.TapHandle), grpc.StatsHandler(g))
+	ingester_client.RegisterIngesterServer(server, ingServer)
+
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	go func() {
+		_ = server.Serve(l)
+	}()
+
+	t.Cleanup(func() {
+		_ = l.Close()
+	})
+
+	cc, err := grpc.Dial(l.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = cc.Close()
+	})
+
+	return ingester_client.NewIngesterClient(cc)
+}
+
+type ingesterServer struct {
+	ingester_client.IngesterServer
+	inflightLimit int64
+	finishRequest chan struct{}
+	inflight      atomic.Int64
+}
+
+func (i *ingesterServer) Push(ctx context.Context, request *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
+	<-i.finishRequest
+	return &mimirpb.WriteResponse{}, nil
+}
+
+func (i *ingesterServer) StartPushRequest() error {
+	v := i.inflight.Inc()
+	if v > i.inflightLimit {
+		i.inflight.Dec()
+		return status.Error(123, "too many requests")
+	}
+	return nil
+}
+
+func (i *ingesterServer) FinishPushRequest() {
+	i.inflight.Dec()
+}

--- a/pkg/mimir/grpc_push_check_test.go
+++ b/pkg/mimir/grpc_push_check_test.go
@@ -111,7 +111,7 @@ type ingesterServer struct {
 	inflight      atomic.Int64
 }
 
-func (i *ingesterServer) Push(ctx context.Context, request *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
+func (i *ingesterServer) Push(_ context.Context, _ *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
 	<-i.finishRequest
 	return &mimirpb.WriteResponse{}, nil
 }

--- a/pkg/mimir/grpc_push_check_test.go
+++ b/pkg/mimir/grpc_push_check_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package mimir
 
 import (

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -221,22 +221,24 @@ func (t *Mimir) initSanityCheck() (services.Service, error) {
 }
 
 func (t *Mimir) initServer() (services.Service, error) {
-	// We can't inject t.Ingester directly, because it may not be set yet. However by the time when grpcPushCheck runs
-	// t.Ingester will be available. There's no race condition here, because gRPC server (service returned by this method, ie. initServer)
-	// is started only after t.Ingester is set in initIngester.
-	g := newGrpcPushCheck(func() pushReceiver {
-		// Return explicit nil, if there's no ingester. We don't want to return typed-nil as interface value.
-		if t.Ingester == nil {
-			return nil
-		}
-		return t.Ingester
-	})
+	if t.Cfg.Ingester.LimitInflightRequestsUsingGrpcTapHandle {
+		// We can't inject t.Ingester directly, because it may not be set yet. However by the time when grpcPushCheck runs
+		// t.Ingester will be available. There's no race condition here, because gRPC server (service returned by this method, ie. initServer)
+		// is started only after t.Ingester is set in initIngester.
+		g := newGrpcPushCheck(func() pushReceiver {
+			// Return explicit nil, if there's no ingester. We don't want to return typed-nil as interface value.
+			if t.Ingester == nil {
+				return nil
+			}
+			return t.Ingester
+		})
 
-	// Installing this allows us to reject push requests received via gRPC early -- before they are fully read into memory.
-	t.Cfg.Server.GRPCOptions = append(t.Cfg.Server.GRPCOptions,
-		grpc.InTapHandle(g.TapHandle),
-		grpc.StatsHandler(g),
-	)
+		// Installing this allows us to reject push requests received via gRPC early -- before they are fully read into memory.
+		t.Cfg.Server.GRPCOptions = append(t.Cfg.Server.GRPCOptions,
+			grpc.InTapHandle(g.TapHandle),
+			grpc.StatsHandler(g),
+		)
+	}
 
 	// Mimir handles signals on its own.
 	DisableSignalHandling(&t.Cfg.Server)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/prometheus/rules"
 	prom_storage "github.com/prometheus/prometheus/storage"
 	prom_remote "github.com/prometheus/prometheus/storage/remote"
+	"google.golang.org/grpc"
 
 	"github.com/grafana/mimir/pkg/alertmanager"
 	"github.com/grafana/mimir/pkg/alertmanager/alertstore"
@@ -220,6 +221,23 @@ func (t *Mimir) initSanityCheck() (services.Service, error) {
 }
 
 func (t *Mimir) initServer() (services.Service, error) {
+	// We can't inject t.Ingester directly, because it may not be set yet. However by the time when grpcPushCheck runs
+	// t.Ingester will be available. There's no race condition here, because gRPC server (service returned by this method, ie. initServer)
+	// is started only after t.Ingester is set in initIngester.
+	g := newGrpcPushCheck(func() pushReceiver {
+		// Return explicit nil, if there's no ingester. We don't want to return typed-nil as interface value.
+		if t.Ingester == nil {
+			return nil
+		}
+		return t.Ingester
+	})
+
+	// Installing this allows us to reject push requests received via gRPC early -- before they are fully read into memory.
+	t.Cfg.Server.GRPCOptions = append(t.Cfg.Server.GRPCOptions,
+		grpc.InTapHandle(g.TapHandle),
+		grpc.StatsHandler(g),
+	)
+
 	// Mimir handles signals on its own.
 	DisableSignalHandling(&t.Cfg.Server)
 	serv, err := server.New(t.Cfg.Server)


### PR DESCRIPTION
#### What this PR does

This PR moves tracking of inflight push requests to gRPC handlers. We install 1) tap handle and 2) stats handler, and they work together to check if another push request is allowed, and track number of ongoing push requests.

Tap handle is called as soon as request headers are received, but before request body is read into memory. At that point we can check and reject request early, or accept it and increase ongoing requests. At this point no interceptor or stats handler has run yet, so if we reject request, the only record of request will be in `cortex_ingester_instance_rejected_requests_total` metric.

If tap handle allows the request to proceed, only then stats handlers and interceptors are called. Stats handler is also called after request has finished -- that is where we decrease number of inflight requests again.

Big benefit of this change is that we can reject requests early, before they are read into memory. This protects the ingester from crashing when it receives many push requests.

Since we increase number of ongoing requests in Tap handle, **are we guaranteed that `StatsHandler` is called when each time when request finishes**?

Tap handle is called in `operateHeaders`:

https://github.com/grafana/mimir/blob/611e6baaa83a042bf5a1b441e8a2832906eaa880/vendor/google.golang.org/grpc/internal/transport/http2_server.go#L567-L632

If request is not rejected, eventually `handle` function is called at the end of `operateHeaders`. `handle` is really a function passed to `HandleStreams`:

https://github.com/grafana/mimir/blob/611e6baaa83a042bf5a1b441e8a2832906eaa880/vendor/google.golang.org/grpc/server.go#L969-L984

This function will either pass request to worker, or start new goroutine. Either way, processing of the request moves to `handleStream` method:

https://github.com/grafana/mimir/blob/611e6baaa83a042bf5a1b441e8a2832906eaa880/vendor/google.golang.org/grpc/server.go#L1707-L1770

This method can return early with error, without calling stats handler in several cases:
1) method name is malformed. This should not be a problem in our usage, as tap handle only increases inflight push requests for specific and correct method name.
2) when service is unknown. This should also not happen in our case, since tap handle requires Mimir ingester component to be initialized, and it registers itself into gRPC server.
3) if the method is unknown, request would be processed as streaming RCP, not unary. Our unit test covers this. (However in this case, stats handler is actually called).

Once processing moves to `processUnaryRPC` or `processStreamingRPC`, we are guaranteed that stats handlers are called when request is finished via `defer` statement. (Push requests are unary)


TODO:
- [x] make this feature optional, and revert back to previous way of tracking when new tracking is not enabled
- [x] update ingester unit tests (not needed for now, since this new limiting is disabled by default)
- [ ] add integration test checking for both ways of limiting push requests

#### Which issue(s) this PR fixes or relates to

Related to
- https://github.com/grafana/mimir/pull/5962
- https://github.com/grafana/mimir/pull/5921
- https://github.com/grafana/mimir/pull/5958

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
