### PR TITLE
Dependencies: Group mimir-build-image dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,12 @@ updates:
     schedule:
       interval: "daily"
       time: "06:04"
+    groups:
+      mimir-build-image-update: 
+        update-types: 
+        - "minor"
+        - "patch"
+        - "major"
   - package-ecosystem: docker
     directory: /cmd/metaconvert/
     schedule:


### PR DESCRIPTION
Make the dependencies in mimir-build-image update in group
Activate group PRs on one dockerfile, this is fixed by dependabotcore, tested PR in fork: https://github.com/ying-jeanne/mimir/pull/47. Group all dockerfiles' update is still not working. 

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
