### PR TITLE
release: only list dependencies when they exist

### DIFF
--- a/packaging/nfpm/nfpm.sh
+++ b/packaging/nfpm/nfpm.sh
@@ -29,14 +29,17 @@ for name in metaconvert mimir-continuous-test mimir mimirtool query-tee ; do
 
             # Generate package dependencies using envsubst
             mkdir "${pkg_dependencies_path}"
-            for dependencie in $(ls packaging/nfpm/${name}); do
-                docker run --rm \
-                  -v "$(pwd)/packaging/nfpm/${name}:/work" \
-                  -v "$(pwd)/${pkg_dependencies_path}:/processed" \
-                  -e "OS_ENV_DIR=${os_env_dir}" \
-                  -it 'bhgedigital/envsubst' \
-                  sh -c "envsubst '\${OS_ENV_DIR}' < /work/${dependencie} > /processed/${dependencie}"
-            done
+
+            if [ -d "packaging/nfpm/${name}" ]; then
+              for dependencie in $(ls packaging/nfpm/${name}); do
+                  docker run --rm \
+                    -v "$(pwd)/packaging/nfpm/${name}:/work" \
+                    -v "$(pwd)/${pkg_dependencies_path}:/processed" \
+                    -e "OS_ENV_DIR=${os_env_dir}" \
+                    -it 'bhgedigital/envsubst' \
+                    sh -c "envsubst '\${OS_ENV_DIR}' < /work/${dependencie} > /processed/${dependencie}"
+              done
+            fi
 
             docker run --rm \
               -v  "$(pwd):/work:delegated,z" \


### PR DESCRIPTION
#### What this PR does

There's only one folder in packaging/nfpm/ which is `mimir`. `ls` complains if we try to list the non-existing folder, so let's check it before and remove the warning.

#### Which issue(s) this PR fixes or relates to

Improves the release process.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
