### PR TITLE
Dynamic inflight request limit, based on specified max memory

### DIFF
--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -31,7 +31,7 @@ var (
 	errMaxTenantsReached               = newInstanceLimitError(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
 	errMaxInMemorySeriesReached        = newInstanceLimitError(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
 	errMaxInflightRequestsReached      = newInstanceLimitError(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
-	errMaxInflightRequestsBytesReached = newInstanceLimitError(globalerror.IngesterMaxInflightPushRequestsBytes.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed size of inflight push requests", maxInflightPushRequestsBytesFlag))
+	errMaxInflightRequestsBytesReached = newInstanceLimitError(globalerror.IngesterMaxInflightPushRequestsBytes.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight requests based on average request size", maxInflightPushRequestsBytesFlag))
 )
 
 type instanceLimitErr struct {
@@ -76,7 +76,7 @@ func (l *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&l.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
-	f.Int64Var(&l.MaxInflightPushRequestsBytes, maxInflightPushRequestsBytesFlag, 0, "Max total size of inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
+	f.Int64Var(&l.MaxInflightPushRequestsBytes, maxInflightPushRequestsBytesFlag, 0, "Max total size of inflight push requests that this ingester can handle. This value is used indirectly to dynamically adjust allowed number of inflight requests based on average request size. 0 = unlimited.")
 }
 
 // Sets default limit values for unmarshalling.

--- a/pkg/ingester/instance_limits.go
+++ b/pkg/ingester/instance_limits.go
@@ -18,18 +18,20 @@ import (
 )
 
 const (
-	maxIngestionRateFlag        = "ingester.instance-limits.max-ingestion-rate"
-	maxInMemoryTenantsFlag      = "ingester.instance-limits.max-tenants"
-	maxInMemorySeriesFlag       = "ingester.instance-limits.max-series"
-	maxInflightPushRequestsFlag = "ingester.instance-limits.max-inflight-push-requests"
+	maxIngestionRateFlag             = "ingester.instance-limits.max-ingestion-rate"
+	maxInMemoryTenantsFlag           = "ingester.instance-limits.max-tenants"
+	maxInMemorySeriesFlag            = "ingester.instance-limits.max-series"
+	maxInflightPushRequestsFlag      = "ingester.instance-limits.max-inflight-push-requests"
+	maxInflightPushRequestsBytesFlag = "ingester.instance-limits.max-inflight-push-requests-bytes"
 )
 
 // We don't include values in the messages for per-instance limits to avoid leaking Mimir cluster configuration to users.
 var (
-	errMaxIngestionRateReached    = newInstanceLimitError(globalerror.IngesterMaxIngestionRate.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
-	errMaxTenantsReached          = newInstanceLimitError(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
-	errMaxInMemorySeriesReached   = newInstanceLimitError(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
-	errMaxInflightRequestsReached = newInstanceLimitError(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxIngestionRateReached         = newInstanceLimitError(globalerror.IngesterMaxIngestionRate.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the samples ingestion rate limit", maxIngestionRateFlag))
+	errMaxTenantsReached               = newInstanceLimitError(globalerror.IngesterMaxTenants.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of tenants", maxInMemoryTenantsFlag))
+	errMaxInMemorySeriesReached        = newInstanceLimitError(globalerror.IngesterMaxInMemorySeries.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of in-memory series", maxInMemorySeriesFlag))
+	errMaxInflightRequestsReached      = newInstanceLimitError(globalerror.IngesterMaxInflightPushRequests.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed number of inflight push requests", maxInflightPushRequestsFlag))
+	errMaxInflightRequestsBytesReached = newInstanceLimitError(globalerror.IngesterMaxInflightPushRequestsBytes.MessageWithPerInstanceLimitConfig("the write request has been rejected because the ingester exceeded the allowed size of inflight push requests", maxInflightPushRequestsBytesFlag))
 )
 
 type instanceLimitErr struct {
@@ -62,10 +64,11 @@ func (e *instanceLimitErr) Error() string {
 // InstanceLimits describes limits used by ingester. Reaching any of these will result in Push method to return
 // (internal) error.
 type InstanceLimits struct {
-	MaxIngestionRate        float64 `yaml:"max_ingestion_rate" category:"advanced"`
-	MaxInMemoryTenants      int64   `yaml:"max_tenants" category:"advanced"`
-	MaxInMemorySeries       int64   `yaml:"max_series" category:"advanced"`
-	MaxInflightPushRequests int64   `yaml:"max_inflight_push_requests" category:"advanced"`
+	MaxIngestionRate             float64 `yaml:"max_ingestion_rate" category:"advanced"`
+	MaxInMemoryTenants           int64   `yaml:"max_tenants" category:"advanced"`
+	MaxInMemorySeries            int64   `yaml:"max_series" category:"advanced"`
+	MaxInflightPushRequests      int64   `yaml:"max_inflight_push_requests" category:"advanced"`
+	MaxInflightPushRequestsBytes int64   `yaml:"max_inflight_push_requests_bytes" category:"advanced"`
 }
 
 func (l *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
@@ -73,6 +76,7 @@ func (l *InstanceLimits) RegisterFlags(f *flag.FlagSet) {
 	f.Int64Var(&l.MaxInMemoryTenants, maxInMemoryTenantsFlag, 0, "Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInMemorySeries, maxInMemorySeriesFlag, 0, "Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.")
 	f.Int64Var(&l.MaxInflightPushRequests, maxInflightPushRequestsFlag, 30000, "Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
+	f.Int64Var(&l.MaxInflightPushRequestsBytes, maxInflightPushRequestsBytesFlag, 0, "Max total size of inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited.")
 }
 
 // Sets default limit values for unmarshalling.

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -84,14 +84,7 @@ func TestUserMetricsMetadata(t *testing.T) {
 			limiter := NewLimiter(limits, ring, 1, false)
 
 			// Mock metrics
-			metrics := newIngesterMetrics(
-				prometheus.NewPedanticRegistry(),
-				true,
-				func() *InstanceLimits { return nil },
-				nil,
-				nil,
-				nil,
-			)
+			metrics := newIngesterMetrics(prometheus.NewPedanticRegistry(), true, func() *InstanceLimits { return nil }, nil, nil, nil, nil)
 
 			mm := newMetadataMap(limiter, metrics, "test")
 

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -90,6 +90,7 @@ func TestUserMetricsMetadata(t *testing.T) {
 				func() *InstanceLimits { return nil },
 				nil,
 				nil,
+				nil,
 			)
 
 			mm := newMetadataMap(limiter, metrics, "test")

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -37,10 +37,11 @@ const (
 	DistributorMaxInflightPushRequests      ID = "distributor-max-inflight-push-requests"
 	DistributorMaxInflightPushRequestsBytes ID = "distributor-max-inflight-push-requests-bytes"
 
-	IngesterMaxIngestionRate        ID = "ingester-max-ingestion-rate"
-	IngesterMaxTenants              ID = "ingester-max-tenants"
-	IngesterMaxInMemorySeries       ID = "ingester-max-series"
-	IngesterMaxInflightPushRequests ID = "ingester-max-inflight-push-requests"
+	IngesterMaxIngestionRate             ID = "ingester-max-ingestion-rate"
+	IngesterMaxTenants                   ID = "ingester-max-tenants"
+	IngesterMaxInMemorySeries            ID = "ingester-max-series"
+	IngesterMaxInflightPushRequests      ID = "ingester-max-inflight-push-requests"
+	IngesterMaxInflightPushRequestsBytes ID = "ingester-max-inflight-push-requests-bytes"
 
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"


### PR DESCRIPTION
#### What this PR does

This PR is an alternative to https://github.com/grafana/mimir/pull/5958. 

The problem with limiting inflight requests by size is that we don't know the size until request is actually in memory. That may already be too late.

This PR tries to solve that problem by introducing "dynamic inflight request limit" (in number of requests), and monitoring sizes of recent push requests.
- Compute average request size based on push requests received in last 2 minutes
- Divide specified "total size of push requests" by average request size.
- Result is what we call "dynamic inflight requests" limit in this PR.

This dynamic inflight request limit is then used in place of standard inflight request limit.

Unfortunately during the load test where the standard inflight request limit was set to 30000 and `max_inflight_push_requests_bytes` (introduced in this PR) was set to 1 GiB, we have still seen almost 2 GiB of inflight requests in memory, so this didn't work very well.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
