### PR TITLE
Fix remote-read address joining in mimirtool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * [BUGFIX] Fix out of bounds error on export with large timespans and/or series count. #5700
 * [BUGFIX] Fix the issue where `--read-timeout` was applied to the entire `mimirtool analyze grafana` invocation rather than to individual Grafana API calls. #5915
+* [BUGFIX] Fix incorrect remote-read path joining for `mimirtool remote-read` commands on Windows. #6009
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -188,10 +188,12 @@ func (c *RemoteReadCommand) readClient() (remote.ReadClient, error) {
 		return nil, err
 	}
 
-	addressURL.Path = filepath.Join(
-		addressURL.Path,
-		c.remoteReadPath,
-	)
+	remoteReadPathURL, err := url.Parse(c.remoteReadPath)
+	if err != nil {
+		return nil, err
+	}
+
+	addressURL = addressURL.ResolveReference(remoteReadPathURL)
 
 	// build client
 	readClient, err := remote.NewReadClient("remote-read", &remote.ClientConfig{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

`filepath.Join` was used to join two part of a URL, resulting in encoded backslashes (`\` -> `%5C`) on Windows. This uses a more standard way of joining URLs.

#### Which issue(s) this PR fixes or relates to

Fixes #6009.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
