### PR TITLE
Move error samplers from Limiter to Ingester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
 * [ENHANCEMENT] Go: updated to 1.21.1. #5955
-* [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times, but all the samples causing an error will be tracked by the `cortex_discarded_samples_total` counter. #5584
+* [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. All the discarded samples will still be tracked by the `cortex_discarded_samples_total` metric. #5584 #6014
 * [BUGFIX] Ingester: fix spurious `not found` errors on label values API during head compaction. #5957
 
 ### Mixin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
 * [ENHANCEMENT] Go: updated to 1.21.1. #5955
-* [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. #5584
+* [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times, but all the samples causing an error will be tracked by the `cortex_discarded_samples_total` counter. #5584
 * [BUGFIX] Ingester: fix spurious `not found` errors on label values API during head compaction. #5957
 
 ### Mixin

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -8516,7 +8516,7 @@ func TestIngester_SampledUserLimitExceeded(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	expectedError := wrapWithUser(ing.limiter.samplers.maxSeriesPerUserLimitExceeded.WrapError(formatMaxSeriesPerUserError(ing.limiter.limits, userID)), userID)
+	expectedError := wrapWithUser(ing.errorSamplers.maxSeriesPerUserLimitExceeded.WrapError(formatMaxSeriesPerUserError(ing.limiter.limits, userID)), userID)
 	require.Error(t, expectedError)
 
 	// We push series hitting the max series limit too old samples than 2 times more than errorSampleRate.
@@ -8603,7 +8603,7 @@ func TestIngester_SampledMetricLimitExceeded(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	expectedError := wrapWithUser(ing.limiter.samplers.maxSeriesPerUserLimitExceeded.WrapError(formatMaxSeriesPerMetricError(ing.limiter.limits, mimirpb.FromLabelAdaptersToLabels(metricLabelAdapters2), userID)), userID)
+	expectedError := wrapWithUser(ing.errorSamplers.maxSeriesPerUserLimitExceeded.WrapError(formatMaxSeriesPerMetricError(ing.limiter.limits, mimirpb.FromLabelAdaptersToLabels(metricLabelAdapters2), userID)), userID)
 	require.Error(t, expectedError)
 
 	// We push series hitting the max series limit too old samples than 2 times more than errorSampleRate.

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -36,7 +36,6 @@ type Limiter struct {
 	ring                 RingCount
 	replicationFactor    int
 	zoneAwarenessEnabled bool
-	samplers             ingesterErrSamplers
 }
 
 // NewLimiter makes a new in-memory series limiter
@@ -45,14 +44,12 @@ func NewLimiter(
 	ring RingCount,
 	replicationFactor int,
 	zoneAwarenessEnabled bool,
-	errorSampleRate int64,
 ) *Limiter {
 	return &Limiter{
 		limits:               limits,
 		ring:                 ring,
 		replicationFactor:    replicationFactor,
 		zoneAwarenessEnabled: zoneAwarenessEnabled,
-		samplers:             newIngesterErrSamplers(errorSampleRate),
 	}
 }
 

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -299,7 +299,7 @@ func runLimiterMaxFunctionTest(
 			overrides, err := validation.NewOverrides(limits, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(overrides, ring, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled, 0)
+			limiter := NewLimiter(overrides, ring, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled)
 			actual := runMaxFn(limiter)
 			assert.Equal(t, testData.expectedValue, actual)
 		})
@@ -352,7 +352,7 @@ func TestLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false, 0)
+			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false)
 			actual := limiter.IsWithinMaxSeriesPerMetric("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
@@ -405,7 +405,7 @@ func TestLimiter_AssertMaxMetadataPerMetric(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false, 0)
+			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false)
 			actual := limiter.IsWithinMaxMetadataPerMetric("test", testData.metadata)
 
 			assert.Equal(t, testData.expected, actual)
@@ -459,7 +459,7 @@ func TestLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false, 0)
+			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false)
 			actual := limiter.IsWithinMaxSeriesPerUser("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
@@ -513,7 +513,7 @@ func TestLimiter_AssertMaxMetricsWithMetadataPerUser(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false, 0)
+			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false)
 			actual := limiter.IsWithinMaxMetricsWithMetadataPerUser("test", testData.metadata)
 
 			assert.Equal(t, testData.expected, actual)

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -24,13 +24,16 @@ type userMetricsMetadata struct {
 
 	mtx              sync.RWMutex
 	metricToMetadata map[string]metricMetadataSet
+
+	errorSamplers ingesterErrSamplers
 }
 
-func newMetadataMap(l *Limiter, m *ingesterMetrics, userID string) *userMetricsMetadata {
+func newMetadataMap(l *Limiter, m *ingesterMetrics, errorSamplers ingesterErrSamplers, userID string) *userMetricsMetadata {
 	return &userMetricsMetadata{
 		metricToMetadata: map[string]metricMetadataSet{},
 		limiter:          l,
 		metrics:          m,
+		errorSamplers:    errorSamplers,
 		userID:           userID,
 	}
 }
@@ -47,7 +50,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 		// Verify that the user can create more metric metadata given we don't have a set for that metric name.
 		if !mm.limiter.IsWithinMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)) {
 			mm.metrics.discardedMetadataPerUserMetadataLimit.WithLabelValues(mm.userID).Inc()
-			return mm.limiter.samplers.maxMetadataPerUserLimitExceeded.WrapError(formatMaxMetadataPerUserError(mm.limiter.limits, mm.userID))
+			return mm.errorSamplers.maxMetadataPerUserLimitExceeded.WrapError(formatMaxMetadataPerUserError(mm.limiter.limits, mm.userID))
 		}
 		set = metricMetadataSet{}
 		mm.metricToMetadata[metric] = set
@@ -55,7 +58,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 
 	if !mm.limiter.IsWithinMaxMetadataPerMetric(mm.userID, len(set)) {
 		mm.metrics.discardedMetadataPerMetricMetadataLimit.WithLabelValues(mm.userID).Inc()
-		return mm.limiter.samplers.maxMetadataPerMetricLimitExceeded.WrapError(formatMaxMetadataPerMetricError(mm.limiter.limits, labels.FromStrings(labels.MetricName, metric), mm.userID))
+		return mm.errorSamplers.maxMetadataPerMetricLimitExceeded.WrapError(formatMaxMetadataPerMetricError(mm.limiter.limits, labels.FromStrings(labels.MetricName, metric), mm.userID))
 	}
 
 	// if we have seen this metadata before, it is a no-op and we don't need to change our metrics.

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -20,6 +20,8 @@ func TestUserMetricsMetadata(t *testing.T) {
 		errContains string
 	}
 
+	errorSamplers := newIngesterErrSamplers(0)
+
 	tests := map[string]struct {
 		maxMetadataPerUser   int
 		maxMetadataPerMetric int
@@ -81,7 +83,7 @@ func TestUserMetricsMetadata(t *testing.T) {
 				MaxGlobalMetadataPerMetric:          testData.maxMetadataPerMetric,
 			}, nil)
 			require.NoError(t, err)
-			limiter := NewLimiter(limits, ring, 1, false, 0)
+			limiter := NewLimiter(limits, ring, 1, false)
 
 			// Mock metrics
 			metrics := newIngesterMetrics(
@@ -92,7 +94,7 @@ func TestUserMetricsMetadata(t *testing.T) {
 				nil,
 			)
 
-			mm := newMetadataMap(limiter, metrics, "test")
+			mm := newMetadataMap(limiter, metrics, errorSamplers, "test")
 
 			// Attempt to add all metadata
 			for _, i := range testData.inputMetadata {


### PR DESCRIPTION
#### What this PR does
In PR https://github.com/grafana/mimir/pull/5584 we introduced sampled logging of errors. The logic of sampling is implented in  the `Sampler` struct. The samplers are currently stored in the `samplers` field of `Limiter`.

This PR moves the `samplers` field from `Limiter` to `Ingester` (and renames it to `errorSamplers`), which is a more appropriate place for storing them.

Moreover, it improves the already existing tests `TestIngester_SampledUserLimitExceeded` and `TestIngester_SampledMetricLimitExceeded` by ensuring that samples errors get tracked by the `cortex_discarded_samples_total` counter.

#### Which issue(s) this PR fixes or relates to
Relates to #1900, #5894

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
