### PR TITLE
ingester: fix TestUserMetricsMetadataRequest not compiling

### DIFF
--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -149,7 +149,7 @@ func TestUserMetricsMetadataRequest(t *testing.T) {
 		nil,
 	)
 
-	mm := newMetadataMap(limiter, metrics, "test")
+	mm := newMetadataMap(limiter, metrics, newIngesterErrSamplers(0), "test")
 
 	inputMetadata := []mimirpb.MetricMetadata{
 		{Type: mimirpb.COUNTER, MetricFamilyName: "test_metric_1", Help: "foo"},


### PR DESCRIPTION
#5890 was merged too late after running its last CI, so much that `main` had drifted and 5890 introduced a compilation error