### PR TITLE
store-gateway: remove chunks ranges

### DIFF
--- a/pkg/storegateway/bucket_chunk_reader_test.go
+++ b/pkg/storegateway/bucket_chunk_reader_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (g seriesChunkRefsRange) refAt(i int) chunks.ChunkRef {
-	return chunkRef(g.segmentFile, g.refs[i].segFileOffset)
+	return chunkRef(g.refs[i].segmentFile, g.refs[i].segFileOffset)
 }
 
 func TestBucketChunkReader_refetchChunks(t *testing.T) {

--- a/pkg/storegateway/bucket_chunk_reader_test.go
+++ b/pkg/storegateway/bucket_chunk_reader_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,10 +16,6 @@ import (
 	"github.com/grafana/mimir/pkg/util/pool"
 	"github.com/grafana/mimir/pkg/util/test"
 )
-
-func (g seriesChunkRefsRange) refAt(i int) chunks.ChunkRef {
-	return chunkRef(g.refs[i].segmentFile, g.refs[i].segFileOffset)
-}
 
 func TestBucketChunkReader_refetchChunks(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -71,16 +66,12 @@ func TestBucketChunkReader_refetchChunks(t *testing.T) {
 			chunkrModifiedLen := block.chunkReader(ctx)
 
 			for sIdx, seriesRef := range seriesRefs {
-				for _, r := range seriesRef.chunksRanges {
+				loadedChunksCorrectLen[sIdx].chks = append(loadedChunksCorrectLen[sIdx].chks, make([]storepb.AggrChunk, len(seriesRef.refs))...)
+				loadedChunksModifiedLen[sIdx].chks = append(loadedChunksModifiedLen[sIdx].chks, make([]storepb.AggrChunk, len(seriesRef.refs))...)
+				for _, r := range seriesRef.refs {
 					existingChunksNum := len(loadedChunksCorrectLen[sIdx].chks)
-
-					loadedChunksCorrectLen[sIdx].chks = append(loadedChunksCorrectLen[sIdx].chks, make([]storepb.AggrChunk, len(r.refs))...)
-					loadedChunksModifiedLen[sIdx].chks = append(loadedChunksModifiedLen[sIdx].chks, make([]storepb.AggrChunk, len(r.refs))...)
-
-					for cIdx, c := range r.refs {
-						assert.NoError(t, chunkrCorrectLen.addLoad(r.refAt(cIdx), sIdx, existingChunksNum+cIdx, c.length))
-						assert.NoError(t, chunkrModifiedLen.addLoad(r.refAt(cIdx), sIdx, existingChunksNum+cIdx, skewChunkLen(c.length)))
-					}
+					assert.NoError(t, chunkrCorrectLen.addLoad(r.storageRef(), sIdx, existingChunksNum, r.length))
+					assert.NoError(t, chunkrModifiedLen.addLoad(r.storageRef(), sIdx, existingChunksNum, skewChunkLen(r.length)))
 				}
 			}
 

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -763,12 +763,12 @@ func (l *bucketIndexLoadedSeries) addSeries(ref storage.SeriesRef, data []byte) 
 // Error is returned on decoding error or if the reference does not resolve to a known series.
 //
 // It's NOT safe to call this function concurrently with addSeries().
-func (l *bucketIndexLoadedSeries) unsafeLoadSeries(ref storage.SeriesRef, chks *[]chunks.Meta, strategy seriesIteratorStrategy, stats *queryStats, lsetPool *pool.SlabPool[symbolizedLabel]) (ok bool, _ []symbolizedLabel, err error) {
+func (l *bucketIndexLoadedSeries) unsafeLoadSeries(ref storage.SeriesRef, chks *[]chunks.Meta, skipChunks bool, stats *queryStats, lsetPool *pool.SlabPool[symbolizedLabel]) (ok bool, _ []symbolizedLabel, err error) {
 	b, ok := l.series[ref]
 	if !ok {
 		return false, nil, errors.Errorf("series %d not found", ref)
 	}
 	stats.seriesProcessed++
 	stats.seriesProcessedSizeSum += len(b)
-	return decodeSeries(b, lsetPool, chks, strategy)
+	return decodeSeries(b, lsetPool, chks, skipChunks)
 }

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -188,10 +188,9 @@ func newChunksPreloadingIterator(
 	refsIterator seriesChunkRefsSetIterator,
 	refsIteratorBatchSize int,
 	stats *safeQueryStats,
-	minT, maxT int64,
 ) seriesChunksSetIterator {
 	var iterator seriesChunksSetIterator
-	iterator = newLoadingSeriesChunksSetIterator(ctx, logger, userID, chunkReaders, refsIterator, refsIteratorBatchSize, stats, minT, maxT)
+	iterator = newLoadingSeriesChunksSetIterator(ctx, logger, userID, chunkReaders, refsIterator, refsIteratorBatchSize, stats)
 	iterator = newPreloadingAndStatsTrackingSetIterator[seriesChunksSet](ctx, 1, iterator, stats)
 	return iterator
 }
@@ -327,6 +326,7 @@ func newPreloadingAndStatsTrackingSetIterator[Set any](ctx context.Context, prel
 	})
 }
 
+// loadingSeriesChunksSetIterator loads the chunks of many series from many TSDB blocks.
 type loadingSeriesChunksSetIterator struct {
 	ctx           context.Context
 	logger        log.Logger
@@ -336,9 +336,8 @@ type loadingSeriesChunksSetIterator struct {
 	fromBatchSize int
 	stats         *safeQueryStats
 
-	current          seriesChunksSet
-	err              error
-	minTime, maxTime int64
+	current seriesChunksSet
+	err     error
 }
 
 func newLoadingSeriesChunksSetIterator(
@@ -349,8 +348,6 @@ func newLoadingSeriesChunksSetIterator(
 	from seriesChunkRefsSetIterator,
 	fromBatchSize int,
 	stats *safeQueryStats,
-	minT int64,
-	maxT int64,
 ) *loadingSeriesChunksSetIterator {
 	return &loadingSeriesChunksSetIterator{
 		ctx:           ctx,
@@ -360,8 +357,6 @@ func newLoadingSeriesChunksSetIterator(
 		from:          from,
 		fromBatchSize: fromBatchSize,
 		stats:         stats,
-		minTime:       minT,
-		maxTime:       maxT,
 	}
 }
 
@@ -411,25 +406,14 @@ func (c *loadingSeriesChunksSetIterator) Next() (retHasNext bool) {
 	c.chunkReaders.reset()
 	for sIdx, s := range nextUnloaded.series {
 		nextSet.series[sIdx].lset = s.lset
-		nextSet.series[sIdx].chks = nextSet.newSeriesAggrChunkSlice(s.numChunks())
-		seriesChunkIdx := 0
+		nextSet.series[sIdx].chks = nextSet.newSeriesAggrChunkSlice(len(s.refs))
+		initializeChunks(s.refs, nextSet.series[sIdx].chks)
 
-		for _, chunksRange := range s.chunksRanges {
-			rangeChunks := nextSet.series[sIdx].chks[seriesChunkIdx : seriesChunkIdx+len(chunksRange.refs)]
-			initializeChunks(chunksRange, rangeChunks)
-
-			for _, chunk := range chunksRange.refs {
-				if chunk.minTime > c.maxTime || chunk.maxTime < c.minTime {
-					// We don't need to overfetch chunks that we know are outside minT/maxT.
-					seriesChunkIdx++
-					continue
-				}
-				err := c.chunkReaders.addLoad(chunk.blockID, chunkRef(chunk.segmentFile, chunk.segFileOffset), sIdx, seriesChunkIdx, chunk.length)
-				if err != nil {
-					c.err = errors.Wrap(err, "preloading chunks")
-					return false
-				}
-				seriesChunkIdx++
+		for cIdx, chunk := range s.refs {
+			err := c.chunkReaders.addLoad(chunk.blockID, chunkRef(chunk.segmentFile, chunk.segFileOffset), sIdx, cIdx, chunk.length)
+			if err != nil {
+				c.err = errors.Wrap(err, "preloading chunks")
+				return false
 			}
 		}
 	}
@@ -440,13 +424,6 @@ func (c *loadingSeriesChunksSetIterator) Next() (retHasNext bool) {
 		return false
 	}
 	c.recordProcessedChunks(nextSet.series)
-
-	// We might have over-fetched some chunks that were outside minT/maxT because we fetch a whole
-	// range of chunks. After storing the chunks in the cache, we should throw away the chunks that are outside
-	// the requested time range.
-	for sIdx := range nextSet.series {
-		nextSet.series[sIdx].chks = removeChunksOutsideRange(nextSet.series[sIdx].chks, c.minTime, c.maxTime)
-	}
 	c.recordReturnedChunks(nextSet.series)
 
 	nextSet.chunksReleaser = chunksPool
@@ -454,29 +431,14 @@ func (c *loadingSeriesChunksSetIterator) Next() (retHasNext bool) {
 	return true
 }
 
-func initializeChunks(chunksRange seriesChunkRefsRange, chunks []storepb.AggrChunk) {
+func initializeChunks(refs []seriesChunkRef, chunks []storepb.AggrChunk) {
 	for cIdx := range chunks {
-		chunks[cIdx].MinTime = chunksRange.refs[cIdx].minTime
-		chunks[cIdx].MaxTime = chunksRange.refs[cIdx].maxTime
+		chunks[cIdx].MinTime = refs[cIdx].minTime
+		chunks[cIdx].MaxTime = refs[cIdx].maxTime
 		if chunks[cIdx].Raw == nil {
 			chunks[cIdx].Raw = &storepb.Chunk{}
 		}
 	}
-}
-
-func removeChunksOutsideRange(chks []storepb.AggrChunk, minT, maxT int64) []storepb.AggrChunk {
-	writeIdx := 0
-	for i, chk := range chks {
-		if chk.MaxTime < minT || chk.MinTime > maxT {
-			continue
-		}
-		if writeIdx != i {
-			chks[writeIdx] = chks[i]
-		}
-		writeIdx++
-	}
-
-	return chks[:writeIdx]
 }
 
 func (c *loadingSeriesChunksSetIterator) At() seriesChunksSet {

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -424,7 +424,7 @@ func (c *loadingSeriesChunksSetIterator) Next() (retHasNext bool) {
 					seriesChunkIdx++
 					continue
 				}
-				err := c.chunkReaders.addLoad(chunksRange.blockID, chunkRef(chunksRange.segmentFile, chunk.segFileOffset), sIdx, seriesChunkIdx, chunk.length)
+				err := c.chunkReaders.addLoad(chunk.blockID, chunkRef(chunk.segmentFile, chunk.segFileOffset), sIdx, seriesChunkIdx, chunk.length)
 				if err != nil {
 					c.err = errors.Wrap(err, "preloading chunks")
 					return false

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -489,13 +489,13 @@ func (b testBlock) toSeriesChunkRefsWithNRangesOverlapping(seriesIndex, numRange
 	ranges := make([]seriesChunkRefsRange, numRanges)
 	chunksPerRange := len(series.refs) / numRanges
 	for i := range ranges {
-		ranges[i].blockID = b.ulid
-		ranges[i].segmentFile = uint32(chunkSegmentFile(series.refs[i*chunksPerRange]))
 		for j := 0; j < chunksPerRange; j++ {
 			ranges[i].refs = append(ranges[i].refs, seriesChunkRef{
 				segFileOffset: chunkOffset(series.refs[i*chunksPerRange+j]),
 				minTime:       series.chks[i*chunksPerRange+j].MinTime,
 				maxTime:       series.chks[i*chunksPerRange+j].MaxTime,
+				blockID:       b.ulid,
+				segmentFile:   uint32(chunkSegmentFile(series.refs[i*chunksPerRange+j])),
 			})
 		}
 	}
@@ -506,6 +506,8 @@ func (b testBlock) toSeriesChunkRefsWithNRangesOverlapping(seriesIndex, numRange
 			segFileOffset: chunkOffset(series.refs[i]),
 			minTime:       series.chks[i].MinTime,
 			maxTime:       series.chks[i].MaxTime,
+			blockID:       b.ulid,
+			segmentFile:   uint32(chunkSegmentFile(series.refs[i])),
 		})
 	}
 

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -479,61 +479,24 @@ func (b testBlock) seriesChunks(seriesIdx int) seriesChunks {
 	}
 }
 
-func (b testBlock) toSeriesChunkRefsWithNRanges(seriesIndex, numRanges int) seriesChunkRefs {
-	return b.toSeriesChunkRefsWithNRangesOverlapping(seriesIndex, numRanges, 0, 100000)
-}
-
-func (b testBlock) toSeriesChunkRefsWithNRangesOverlapping(seriesIndex, numRanges int, minT, maxT int64) seriesChunkRefs {
+func (b testBlock) toSeriesChunkRefs(seriesIndex int) seriesChunkRefs {
 	series := b.series[seriesIndex]
 
-	ranges := make([]seriesChunkRefsRange, numRanges)
-	chunksPerRange := len(series.refs) / numRanges
-	for i := range ranges {
-		for j := 0; j < chunksPerRange; j++ {
-			ranges[i].refs = append(ranges[i].refs, seriesChunkRef{
-				segFileOffset: chunkOffset(series.refs[i*chunksPerRange+j]),
-				minTime:       series.chks[i*chunksPerRange+j].MinTime,
-				maxTime:       series.chks[i*chunksPerRange+j].MaxTime,
-				blockID:       b.ulid,
-				segmentFile:   uint32(chunkSegmentFile(series.refs[i*chunksPerRange+j])),
-			})
-		}
-	}
-
-	// Account for integer division (e.g. 10 chunks in 3 ranges)
-	for i := chunksPerRange * len(ranges); i < len(series.refs); i++ {
-		ranges[len(ranges)-1].refs = append(ranges[len(ranges)-1].refs, seriesChunkRef{
-			segFileOffset: chunkOffset(series.refs[i]),
-			minTime:       series.chks[i].MinTime,
-			maxTime:       series.chks[i].MaxTime,
+	chunkRefs := make([]seriesChunkRef, len(series.chks))
+	for i, c := range series.chks {
+		chunkRefs[i] = seriesChunkRef{
 			blockID:       b.ulid,
+			segFileOffset: chunkOffset(series.refs[i]),
 			segmentFile:   uint32(chunkSegmentFile(series.refs[i])),
-		})
-	}
-
-	for rIdx := 0; rIdx < len(ranges); {
-		someChunkOverlaps := false
-		for _, c := range ranges[rIdx].refs {
-			if c.minTime <= maxT && c.maxTime >= minT {
-				someChunkOverlaps = true
-				break
-			}
-		}
-		if !someChunkOverlaps {
-			ranges = append(ranges[:rIdx], ranges[rIdx+1:]...)
-		} else {
-			rIdx++
+			minTime:       c.MinTime,
+			maxTime:       c.MaxTime,
 		}
 	}
 
 	return seriesChunkRefs{
-		lset:         series.lset,
-		chunksRanges: ranges,
+		lset: series.lset,
+		refs: chunkRefs,
 	}
-}
-
-func (b testBlock) toSeriesChunkRefs(seriesIndex int) seriesChunkRefs {
-	return b.toSeriesChunkRefsWithNRanges(seriesIndex, 1)
 }
 
 func TestLoadingSeriesChunksSetIterator(t *testing.T) {
@@ -551,7 +514,6 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 		existingBlocks      []testBlock
 		setsToLoad          []seriesChunkRefsSet
 		expectedSets        []seriesChunksSet
-		minT, maxT          int64 // optional; if empty, select a wide time range
 		addLoadErr, loadErr error
 		expectedErr         string
 	}
@@ -565,30 +527,6 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 				},
 				expectedSets: []seriesChunksSet{
 					{series: []seriesChunks{block1.seriesChunks(0), block1.seriesChunks(1)}},
-				},
-			},
-		},
-		"loads single set from single block with multiple ranges": {
-			{
-				existingBlocks: []testBlock{block1},
-				setsToLoad: []seriesChunkRefsSet{
-					{series: []seriesChunkRefs{block1.toSeriesChunkRefsWithNRanges(0, 10), block1.toSeriesChunkRefsWithNRanges(1, 10)}},
-				},
-				expectedSets: []seriesChunksSet{
-					{series: []seriesChunks{block1.seriesChunks(0), block1.seriesChunks(1)}},
-				},
-			},
-		},
-		"loads single set from single block with multiple ranges with mint/maxt": {
-			{
-				existingBlocks: []testBlock{block1},
-				minT:           0,
-				maxT:           50,
-				setsToLoad: []seriesChunkRefsSet{
-					{series: []seriesChunkRefs{block1.toSeriesChunkRefsWithNRanges(0, 10), block1.toSeriesChunkRefsWithNRanges(1, 10)}},
-				},
-				expectedSets: []seriesChunksSet{
-					{series: []seriesChunks{block1.toSeriesChunksOverlapping(0, 0, 50), block1.toSeriesChunksOverlapping(1, 0, 50)}},
 				},
 			},
 		},
@@ -629,19 +567,6 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 				},
 			},
 		},
-		"loads multiple sets from multiple blocks with multiple ranges": {
-			{
-				existingBlocks: []testBlock{block1, block2},
-				setsToLoad: []seriesChunkRefsSet{
-					{series: []seriesChunkRefs{block1.toSeriesChunkRefsWithNRanges(0, 4), block1.toSeriesChunkRefsWithNRanges(1, 4)}},
-					{series: []seriesChunkRefs{block2.toSeriesChunkRefsWithNRanges(0, 4), block2.toSeriesChunkRefsWithNRanges(1, 4)}},
-				},
-				expectedSets: []seriesChunksSet{
-					{series: []seriesChunks{block1.seriesChunks(0), block1.seriesChunks(1)}},
-					{series: []seriesChunks{block2.seriesChunks(0), block2.seriesChunks(1)}},
-				},
-			},
-		},
 		"loads sets from multiple blocks mixed": {
 			{
 				existingBlocks: []testBlock{block1, block2},
@@ -661,7 +586,7 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 				setsToLoad: []seriesChunkRefsSet{
 					{series: func() []seriesChunkRefs {
 						series := block1.toSeriesChunkRefs(0)
-						series.chunksRanges = append(series.chunksRanges, block2.toSeriesChunkRefs(0).chunksRanges...)
+						series.refs = append(series.refs, block2.toSeriesChunkRefs(0).refs...)
 						return []seriesChunkRefs{series}
 					}()},
 				},
@@ -669,46 +594,6 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 					{series: func() []seriesChunks {
 						series := block1.seriesChunks(0)
 						series.chks = append(series.chks, block2.seriesChunks(0).chks...)
-						return []seriesChunks{series}
-					}()},
-				},
-			},
-		},
-		"loads series with chunks from different blocks and multiple ranges": {
-			{
-				existingBlocks: []testBlock{block1, block2},
-				setsToLoad: []seriesChunkRefsSet{
-					{series: func() []seriesChunkRefs {
-						series := block1.toSeriesChunkRefsWithNRanges(0, 3)
-						series.chunksRanges = append(series.chunksRanges, block2.toSeriesChunkRefsWithNRanges(0, 4).chunksRanges...)
-						return []seriesChunkRefs{series}
-					}()},
-				},
-				expectedSets: []seriesChunksSet{
-					{series: func() []seriesChunks {
-						series := block1.seriesChunks(0)
-						series.chks = append(series.chks, block2.seriesChunks(0).chks...)
-						return []seriesChunks{series}
-					}()},
-				},
-			},
-		},
-		"loads series with chunks from different blocks and multiple chunks within minT/maxT": {
-			{
-				existingBlocks: []testBlock{block1, block2},
-				minT:           0,
-				maxT:           10,
-				setsToLoad: []seriesChunkRefsSet{
-					{series: func() []seriesChunkRefs {
-						series := block1.toSeriesChunkRefsWithNRanges(0, 3)
-						series.chunksRanges = append(series.chunksRanges, block2.toSeriesChunkRefsWithNRanges(0, 4).chunksRanges...)
-						return []seriesChunkRefs{series}
-					}()},
-				},
-				expectedSets: []seriesChunksSet{
-					{series: func() []seriesChunks {
-						series := block1.toSeriesChunksOverlapping(0, 0, 10)
-						series.chks = append(series.chks, block2.toSeriesChunksOverlapping(0, 0, 10).chks...)
 						return []seriesChunks{series}
 					}()},
 				},
@@ -756,13 +641,9 @@ func TestLoadingSeriesChunksSetIterator(t *testing.T) {
 						readersMap[block.ulid] = newChunkReaderMockWithSeries(block.series, testCase.addLoadErr, testCase.loadErr)
 					}
 					readers := newChunkReaders(readersMap)
-					minT, maxT := testCase.minT, testCase.maxT
-					if minT == 0 && maxT == 0 {
-						minT, maxT = 0, 100000 // select everything by default
-					}
 
 					// Run test
-					set := newLoadingSeriesChunksSetIterator(context.Background(), log.NewNopLogger(), "tenant", *readers, newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...), 100, newSafeQueryStats(), minT, maxT)
+					set := newLoadingSeriesChunksSetIterator(context.Background(), log.NewNopLogger(), "tenant", *readers, newSliceSeriesChunkRefsSetIterator(nil, testCase.setsToLoad...), 100, newSafeQueryStats())
 					loadedSets := readAllSeriesChunksSets(set)
 
 					// Assertions
@@ -843,7 +724,7 @@ func BenchmarkLoadingSeriesChunksSetIterator(b *testing.B) {
 
 			for n := 0; n < b.N; n++ {
 				batchSize := numSeriesPerSet
-				it := newLoadingSeriesChunksSetIterator(context.Background(), log.NewNopLogger(), "tenant", *chunkReaders, newSliceSeriesChunkRefsSetIterator(nil, sets...), batchSize, stats, 0, 10000)
+				it := newLoadingSeriesChunksSetIterator(context.Background(), log.NewNopLogger(), "tenant", *chunkReaders, newSliceSeriesChunkRefsSetIterator(nil, sets...), batchSize, stats)
 
 				actualSeries := 0
 				actualChunks := 0

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/storegateway/indexcache"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
-	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/pool"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -119,8 +118,8 @@ func (b symbolizedSeriesChunkRefsSet) release() {
 }
 
 type symbolizedSeriesChunkRefs struct {
-	lset         []symbolizedLabel
-	chunksRanges []seriesChunkRefsRange
+	lset []symbolizedLabel
+	refs []seriesChunkRef
 }
 
 // newSeriesChunkRefsSet creates a new seriesChunkRefsSet with the given capacity.
@@ -165,76 +164,44 @@ func (b seriesChunkRefsSet) release() {
 
 // seriesChunkRefs holds a series with a list of chunk references.
 type seriesChunkRefs struct {
-	lset         labels.Labels
-	chunksRanges []seriesChunkRefsRange
-}
-
-func (s seriesChunkRefs) numChunks() (n int) {
-	for _, r := range s.chunksRanges {
-		n += len(r.refs)
-	}
-	return
-}
-
-// seriesChunkRefsRange contains chunks from the same block and the same segment file. They are ordered by their minTime
-type seriesChunkRefsRange struct {
+	lset labels.Labels
 	refs []seriesChunkRef
-}
-
-func (g seriesChunkRefsRange) firstRef() chunks.ChunkRef {
-	if len(g.refs) == 0 {
-		return 0
-	}
-	return chunkRef(g.refs[0].segmentFile, g.refs[0].segFileOffset)
-}
-
-func (g seriesChunkRefsRange) minTime() int64 {
-	if len(g.refs) == 0 {
-		return 0
-	}
-	// Since chunks in the groups are ordered by minTime, then we can just take the minTime of the first one.
-	return g.refs[0].minTime
-}
-
-func (g seriesChunkRefsRange) maxTime() int64 {
-	// Since chunks are only ordered by minTime, we have no guarantee for their maxTime, so we need to iterate all.
-	maxT := int64(math.MinInt64)
-	for _, c := range g.refs {
-		if c.maxTime > maxT {
-			maxT = c.maxTime
-		}
-	}
-	return maxT
-}
-
-func (g seriesChunkRefsRange) Compare(other seriesChunkRefsRange) int {
-	if g.minTime() < other.minTime() {
-		return -1
-	}
-	if g.minTime() > other.minTime() {
-		return 1
-	}
-	// Same min time.
-
-	if g.maxTime() < other.maxTime() {
-		return -1
-	}
-	if g.maxTime() > other.maxTime() {
-		return 1
-	}
-	return 0
 }
 
 // seriesChunkRef holds the reference to a chunk in a given block.
 type seriesChunkRef struct {
 	blockID     ulid.ULID
 	segmentFile uint32
-	// The order of these fields matters; having the uint32 on top makes the whole struct 24 bytes; in a different order the struct is 32B
+	// The order of these fields matters; having the uint32 on top allows to pack together the two uint32 fields
 	segFileOffset uint32
 	// length will be 0 when the length of the chunk isn't known
 	length uint32
 	// minTime and maxTime are inclusive
 	minTime, maxTime int64
+}
+
+// Compare returns > 0 if m should be before other when sorting seriesChunkRef,
+// 0 if they're equal or < 0 if m should be after other.
+func (r seriesChunkRef) Compare(other seriesChunkRef) int {
+	if r.minTime < other.minTime {
+		return 1
+	}
+	if r.minTime > other.minTime {
+		return -1
+	}
+
+	// Same min time.
+	if r.maxTime < other.maxTime {
+		return 1
+	}
+	if r.maxTime > other.maxTime {
+		return -1
+	}
+	return 0
+}
+
+func (r seriesChunkRef) storageRef() chunks.ChunkRef {
+	return chunkRef(r.segmentFile, r.segFileOffset)
 }
 
 // seriesChunkRefsIteratorImpl implements an iterator returning a sequence of seriesChunkRefs.
@@ -468,7 +435,7 @@ func (s *mergedSeriesChunkRefsSet) ensureItemAvailableToRead(curr *seriesChunkRe
 }
 
 // nextUniqueEntry returns the next unique entry from both a and b. If a.At() and b.At() have the same
-// label set, nextUniqueEntry merges their chunks ranges. The merged ranges are sorted by their MinTime and then by MaxTime.
+// label set, nextUniqueEntry merges their chunks refs. The merged refs are sorted by their MinTime and then by MaxTime.
 func (s *mergedSeriesChunkRefsSet) nextUniqueEntry(a, b *seriesChunkRefsIteratorImpl) (toReturn seriesChunkRefs, _ bool) {
 	if a.Done() && b.Done() {
 		return toReturn, false
@@ -483,9 +450,9 @@ func (s *mergedSeriesChunkRefsSet) nextUniqueEntry(a, b *seriesChunkRefsIterator
 	}
 
 	aAt := a.At()
-	lsetA, chksA := aAt.lset, aAt.chunksRanges
+	lsetA, chksA := aAt.lset, aAt.refs
 	bAt := b.At()
-	lsetB, chksB := bAt.lset, bAt.chunksRanges
+	lsetB, chksB := bAt.lset, bAt.refs
 
 	if d := labels.Compare(lsetA, lsetB); d > 0 {
 		toReturn = b.At()
@@ -497,15 +464,15 @@ func (s *mergedSeriesChunkRefsSet) nextUniqueEntry(a, b *seriesChunkRefsIterator
 		return toReturn, true
 	}
 
-	// Both a and b contains the same series. Go through all chunk ranges and concatenate them from both
-	// series sets. We best effortly assume chunk ranges are sorted by min time. This means that
-	// if the ranges overlap, then the resulting chunks will not be in min time order.
+	// Both a and b contains the same series. Go through all chunk refs and concatenate them from both
+	// series sets. We best effortly assume chunk refs are sorted by min time. This means that
+	// if the chunks overlap, then the resulting chunks will not be in min time order.
 	// This is ok since the series API doesn't require us to return sorted chunks.
 	toReturn.lset = lsetA
 
 	// Slice reuse is not generally safe with nested merge iterators.
 	// We err on the safe side and create a new slice.
-	toReturn.chunksRanges = make([]seriesChunkRefsRange, 0, len(chksA)+len(chksB))
+	toReturn.refs = make([]seriesChunkRef, 0, len(chksA)+len(chksB))
 
 	bChunksOffset := 0
 Outer:
@@ -513,22 +480,22 @@ Outer:
 		for {
 			if bChunksOffset >= len(chksB) {
 				// No more b chunks.
-				toReturn.chunksRanges = append(toReturn.chunksRanges, chksA[aChunksOffset:]...)
+				toReturn.refs = append(toReturn.refs, chksA[aChunksOffset:]...)
 				break Outer
 			}
 
 			if chksA[aChunksOffset].Compare(chksB[bChunksOffset]) < 0 {
-				toReturn.chunksRanges = append(toReturn.chunksRanges, chksA[aChunksOffset])
+				toReturn.refs = append(toReturn.refs, chksA[aChunksOffset])
 				break
 			}
 
-			toReturn.chunksRanges = append(toReturn.chunksRanges, chksB[bChunksOffset])
+			toReturn.refs = append(toReturn.refs, chksB[bChunksOffset])
 			bChunksOffset++
 		}
 	}
 
 	if bChunksOffset < len(chksB) {
-		toReturn.chunksRanges = append(toReturn.chunksRanges, chksB[bChunksOffset:]...)
+		toReturn.refs = append(toReturn.refs, chksB[bChunksOffset:]...)
 	}
 
 	a.Next()
@@ -639,7 +606,7 @@ func (s *deduplicatingSeriesChunkRefsSetIterator) Next() bool {
 
 		if labels.Equal(nextSet.series[i].lset, nextSeries.lset) {
 			// We don't need to ensure that chunks are in any particular order. The querier will sort the chunks for a single series.
-			nextSet.series[i].chunksRanges = append(nextSet.series[i].chunksRanges, nextSeries.chunksRanges...)
+			nextSet.series[i].refs = append(nextSet.series[i].refs, nextSeries.refs...)
 		} else {
 			i++
 			if i >= s.batchSize {
@@ -689,9 +656,7 @@ func (l *limitingSeriesChunkRefsSetIterator) Next() bool {
 
 	var totalChunks int
 	for _, s := range l.currentBatch.series {
-		for _, r := range s.chunksRanges {
-			totalChunks += len(r.refs)
-		}
+		totalChunks += len(s.refs)
 	}
 
 	err = l.chunksLimiter.Reserve(uint64(totalChunks))
@@ -876,10 +841,6 @@ func newLoadingSeriesChunkRefsSetIterator(
 	tenantID string,
 	logger log.Logger,
 ) *loadingSeriesChunkRefsSetIterator {
-	if strategy.isNoChunkRefsOnEntireBlock() {
-		minTime, maxTime = blockMeta.MinTime, blockMeta.MaxTime
-	}
-
 	return &loadingSeriesChunkRefsSetIterator{
 		ctx:                 ctx,
 		postingsSetIterator: postingsSetIterator,
@@ -953,7 +914,7 @@ func (s *loadingSeriesChunkRefsSetIterator) Next() bool {
 		s.err = err
 		return false
 	}
-	defer symbolizedSet.release() // We only retain the slices of chunk ranges from this set. These are still not pooled, and it's ok to retain them.
+	defer symbolizedSet.release() // We only retain the slices of chunk refs from this set. These are still not pooled, and it's ok to retain them.
 
 	nextSet, err := s.stringifiedSet(symbolizedSet)
 	if err != nil {
@@ -1011,8 +972,13 @@ func (s *loadingSeriesChunkRefsSetIterator) symbolizedSet(ctx context.Context, p
 				series.lset = nil // setting the labels to nil ends up skipping the series
 			}
 		case !s.strategy.isNoChunkRefs():
+			minTime, maxTime := s.minTime, s.maxTime
+			if !s.strategy.isOverlapMintMaxt() {
+				minTime, maxTime = math.MinInt64, math.MaxInt64
+			}
+
 			clampLastChunkLength(symbolizedSet.series, metas)
-			series.chunksRanges = metasToRanges(partitionChunks(metas, 1, 1), s.blockID, s.minTime, s.maxTime)
+			series.refs = metasToChunkRefs(metas, s.blockID, minTime, maxTime)
 		}
 		symbolizedSet.series = append(symbolizedSet.series, series)
 	}
@@ -1029,7 +995,7 @@ func (s *loadingSeriesChunkRefsSetIterator) stringifiedSet(symbolizedSet symboli
 	return s.multiLookupStringify(symbolizedSet)
 }
 
-// clampLastChunkLength checks the length of the last chunk in the last range of the last series.
+// clampLastChunkLength checks the length of the last chunk in the last series.
 // If the length of that chunk is larger than the difference with the first chunk ref in metas
 // then the length is clamped at that difference.
 // clampLastChunkLength assumes that the chunks are sorted by their refs
@@ -1039,13 +1005,12 @@ func clampLastChunkLength(series []symbolizedSeriesChunkRefs, nextSeriesChunkMet
 	if len(series) == 0 || len(nextSeriesChunkMetas) == 0 {
 		return
 	}
-	var lastSeriesRanges = series[len(series)-1].chunksRanges
-	if len(lastSeriesRanges) == 0 {
+	var lastSeriesRefs = series[len(series)-1].refs
+	if len(lastSeriesRefs) == 0 {
 		return
 	}
 	var (
-		lastRange       = lastSeriesRanges[len(lastSeriesRanges)-1]
-		lastSeriesChunk = lastRange.refs[len(lastRange.refs)-1]
+		lastSeriesChunk = lastSeriesRefs[len(lastSeriesRefs)-1]
 		firstRef        = nextSeriesChunkMetas[0].Ref
 	)
 
@@ -1056,12 +1021,12 @@ func clampLastChunkLength(series []symbolizedSeriesChunkRefs, nextSeriesChunkMet
 	diffWithNextChunk := chunkOffset(firstRef) - lastSeriesChunk.segFileOffset
 	// The diff should always be positive, but if for some reason it isn't (a bug?), we don't want to set length to a negative value.
 	if diffWithNextChunk > 0 && lastSeriesChunk.length > diffWithNextChunk {
-		lastRange.refs[len(lastRange.refs)-1].length = diffWithNextChunk
+		lastSeriesRefs[len(lastSeriesRefs)-1].length = diffWithNextChunk
 	}
 }
 
 // filterSeries filters out series that don't belong to this shard (if sharding is configured) or that don't have any
-// chunk ranges and skipChunks=false. Empty chunks ranges indicates that the series doesn't have any chunk ranges in the
+// chunk refs. Empty chunks ranges indicates that the series doesn't have any chunk ranges in the
 // requested time range. filterSeries expects that the number of series matches the number of postings.
 func (s *loadingSeriesChunkRefsSetIterator) filterSeries(set seriesChunkRefsSet, postings []storage.SeriesRef, stats *queryStats) seriesChunkRefsSet {
 	writeIdx := 0
@@ -1074,7 +1039,7 @@ func (s *loadingSeriesChunkRefsSetIterator) filterSeries(set seriesChunkRefsSet,
 			continue
 		}
 		// 2. The series doesn't have any chunks in the requested time range but the request required the chunks (i.e. !s.strategy.isNoChunkRefs()).
-		if !s.strategy.isNoChunkRefs() && len(series.chunksRanges) == 0 {
+		if !s.strategy.isNoChunkRefs() && len(series.refs) == 0 {
 			continue
 		}
 		// 3. The series doesn't belong to this shard.
@@ -1088,112 +1053,57 @@ func (s *loadingSeriesChunkRefsSetIterator) filterSeries(set seriesChunkRefsSet,
 	return set
 }
 
-// partitionChunks creates a slice of []chunks.Meta for each range of chunks within the same segment file.
-// The partitioning here should be fairly static and not depend on the actual Series() request because
-// the resulting ranges may be used for caching, and we want our cache entries to be reusable between requests.
-// partitionChunks tries to partition the metas into targetNumRanges ranges. If any of those ranges will have
-// less than minChunksPerRange metas, then partitionChunks will return less ranges than targetNumRanges.
-// Regardless of targetNumRanges and minChunksPerRange, partitionChunks will keep chunks from separate segment files
-// in separate partitions.
-func partitionChunks(chks []chunks.Meta, targetNumRanges, minChunksPerRange int) [][]chunks.Meta {
-	if len(chks) == 0 {
+// metasToChunkRefs converts metas to chunk refs. It excludes any chunks that do not overlap with minT and maxT.
+func metasToChunkRefs(metas []chunks.Meta, blockID ulid.ULID, minT, maxT int64) []seriesChunkRef {
+	numChunksOverlapping := 0
+	for _, m := range metas {
+		if m.OverlapsClosedInterval(minT, maxT) {
+			numChunksOverlapping++
+		}
+	}
+	if numChunksOverlapping == 0 {
 		return nil
 	}
-	chunksPerRange := util_math.Max(minChunksPerRange, len(chks)/targetNumRanges)
+	refs := make([]seriesChunkRef, 0, numChunksOverlapping)
 
-	ranges := make([][]chunks.Meta, 0, util_math.Min(targetNumRanges, len(chks)/chunksPerRange))
-
-	currentRangeFirstChunkIdx := 0
-	for i := range chks {
-		isDifferentSegmentFile := chunkSegmentFile(chks[currentRangeFirstChunkIdx].Ref) != chunkSegmentFile(chks[i].Ref)
-		currentRangeIsFull := i-currentRangeFirstChunkIdx >= chunksPerRange
-		atLastRange := len(ranges) == targetNumRanges-1
-
-		if isDifferentSegmentFile || (currentRangeIsFull && !atLastRange) {
-			ranges = append(ranges, chks[currentRangeFirstChunkIdx:i])
-			currentRangeFirstChunkIdx = i
-		}
-	}
-
-	ranges = append(ranges, chks[currentRangeFirstChunkIdx:])
-
-	return ranges
-}
-
-// metasToRanges converts partitioned metas to ranges of chunk refs. It excludes any ranges that do not have
-// at least one chunk which overlaps with minT and maxT
-func metasToRanges(partitions [][]chunks.Meta, blockID ulid.ULID, minT, maxT int64) []seriesChunkRefsRange {
-	someMetaOverlapsWithMinTMaxT := func(gr []chunks.Meta) bool {
-		for _, m := range gr {
-			if m.MinTime <= maxT && m.MaxTime >= minT {
-				return true
-			}
-		}
-		return false
-	}
-
-	rangesWithinTime := 0
-	for _, gr := range partitions {
-		if someMetaOverlapsWithMinTMaxT(gr) {
-			rangesWithinTime++
-		}
-	}
-	if rangesWithinTime == 0 {
-		return nil
-	}
-	ranges := make([]seriesChunkRefsRange, 0, rangesWithinTime)
-
-	for pIdx, partition := range partitions {
-		if !someMetaOverlapsWithMinTMaxT(partition) {
+	for mIdx, m := range metas {
+		if !m.OverlapsClosedInterval(minT, maxT) {
 			continue
 		}
-
-		chunkRefs := make([]seriesChunkRef, 0, len(partition))
-		for cIdx, c := range partition {
-			var chunkLen uint32
-			// We can only calculate the length of this chunk, if we know the ref of the next chunk
-			// and the two chunks are in the same segment file.
-			// We do that by taking the difference between the chunk references. This works since the chunk references are offsets in a file.
-			// If the chunks are in different segment files (unlikely, but possible),
-			// then this chunk ends at the end of the segment file, and we don't know how big the segment file is.
-			if nextRef, ok := nextChunkRef(partitions, pIdx, cIdx); ok && chunkSegmentFile(nextRef) == chunkSegmentFile(c.Ref) {
-				chunkLen = chunkOffset(nextRef) - chunkOffset(c.Ref)
-				if chunkLen > tsdb.EstimatedMaxChunkSize {
-					// Clamp the length in case chunks are scattered across a segment file. This should never happen,
-					// but if it does, we don't want to have an erroneously large length.
-					chunkLen = tsdb.EstimatedMaxChunkSize
-				}
-			} else {
+		var chunkLen uint32
+		// We can only calculate the length of this chunk, if we know the ref of the next chunk
+		// and the two chunks are in the same segment file.
+		// We do that by taking the difference between the chunk references. This works since the chunk references are offsets in a file.
+		// If the chunks are in different segment files (unlikely, but possible),
+		// then this chunk ends at the end of the segment file, and we don't know how big the segment file is.
+		if nextRef, ok := nextChunkRef(metas, mIdx); ok && chunkSegmentFile(nextRef) == chunkSegmentFile(m.Ref) {
+			chunkLen = chunkOffset(nextRef) - chunkOffset(m.Ref)
+			if chunkLen > tsdb.EstimatedMaxChunkSize {
+				// Clamp the length in case chunks are scattered across a segment file. This should never happen,
+				// but if it does, we don't want to have an erroneously large length.
 				chunkLen = tsdb.EstimatedMaxChunkSize
 			}
-			chunkRefs = append(chunkRefs, seriesChunkRef{
-				segFileOffset: chunkOffset(c.Ref),
-				minTime:       c.MinTime,
-				maxTime:       c.MaxTime,
-				length:        chunkLen,
-				blockID:       blockID,
-				segmentFile:   uint32(chunkSegmentFile(partition[0].Ref)),
-			})
+		} else {
+			chunkLen = tsdb.EstimatedMaxChunkSize
 		}
-
-		ranges = append(ranges, seriesChunkRefsRange{
-			// We have a guarantee that each meta in a partition will be from the same segment file; we can just take the segment file of the first chunk.
+		refs = append(refs, seriesChunkRef{
+			segFileOffset: chunkOffset(m.Ref),
+			minTime:       m.MinTime,
+			maxTime:       m.MaxTime,
+			length:        chunkLen,
+			blockID:       blockID,
 			// The cast to uint32 is safe because the segment file seq must fit in the first 32 bytes of the chunk ref
-			refs: chunkRefs,
+			segmentFile: uint32(chunkSegmentFile(m.Ref)),
 		})
 	}
-	return ranges
+	return refs
 }
 
-func nextChunkRef(metas [][]chunks.Meta, gIdx int, cIdx int) (chunks.ChunkRef, bool) {
-	if cIdx+1 >= len(metas[gIdx]) && gIdx+1 >= len(metas) {
+func nextChunkRef(metas []chunks.Meta, cIdx int) (chunks.ChunkRef, bool) {
+	if cIdx+1 >= len(metas) {
 		return 0, false
 	}
-
-	if cIdx+1 < len(metas[gIdx]) {
-		return metas[gIdx][cIdx+1].Ref, true
-	}
-	return metas[gIdx+1][0].Ref, true
+	return metas[cIdx+1].Ref, true
 }
 
 func (s *loadingSeriesChunkRefsSetIterator) At() seriesChunkRefsSet {
@@ -1206,7 +1116,7 @@ func (s *loadingSeriesChunkRefsSetIterator) Err() error {
 
 // loadSeries returns a for chunks. It is not safe to use the returned []chunks.Meta after calling loadSeries again
 func (s *loadingSeriesChunkRefsSetIterator) loadSeries(ref storage.SeriesRef, loadedSeries *bucketIndexLoadedSeries, stats *queryStats, lsetPool *pool.SlabPool[symbolizedLabel]) ([]symbolizedLabel, []chunks.Meta, error) {
-	ok, lbls, err := loadedSeries.unsafeLoadSeries(ref, &s.chunkMetasBuffer, s.strategy, stats, lsetPool)
+	ok, lbls, err := loadedSeries.unsafeLoadSeries(ref, &s.chunkMetasBuffer, s.strategy.isNoChunkRefsOnEntireBlock(), stats, lsetPool)
 	if !ok || err != nil {
 		return nil, nil, errors.Wrap(err, "loadSeries")
 	}
@@ -1258,8 +1168,8 @@ func (s *loadingSeriesChunkRefsSetIterator) singlePassStringify(symbolizedSet sy
 		}
 
 		set.series = append(set.series, seriesChunkRefs{
-			lset:         labelsBuilder.Labels(),
-			chunksRanges: series.chunksRanges,
+			lset: labelsBuilder.Labels(),
+			refs: series.refs,
 		})
 	}
 
@@ -1278,8 +1188,8 @@ func (s *loadingSeriesChunkRefsSetIterator) multiLookupStringify(symbolizedSet s
 		}
 
 		set.series = append(set.series, seriesChunkRefs{
-			lset:         lset,
-			chunksRanges: series.chunksRanges,
+			lset: lset,
+			refs: series.refs,
 		})
 	}
 	return set, nil

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -35,52 +35,28 @@ func init() {
 	seriesChunkRefsSetPool = &pool.TrackedPool{Parent: seriesChunkRefsSetPool}
 }
 
-func TestSeriesChunkRefsRange_Compare(t *testing.T) {
-	testCases := map[string]struct {
-		input    []seriesChunkRefsRange
-		expected []seriesChunkRefsRange
-	}{
-		"sorts ranges with single chunk": {
-			input: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6}}},
-			},
-			expected: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7}}},
-			},
-		},
-		"sorts ranges with multiple chunks": {
-			input: []seriesChunkRefsRange{
-				// max time of the whole range may not be the max time of the last chunk
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 7}, {blockID: ulid.MustNew(0, nil), minTime: 3, maxTime: 5}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 10}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(1, nil), minTime: 2, maxTime: 5}}},
-			},
-			expected: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 10}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(1, nil), minTime: 2, maxTime: 5}}},
-				{refs: []seriesChunkRef{{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 7}, {blockID: ulid.MustNew(0, nil), minTime: 3, maxTime: 5}}},
-			},
-		},
+func TestSeriesChunkRef_Compare(t *testing.T) {
+	input := []seriesChunkRef{
+		{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5},
+		{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5},
+		{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3},
+		{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7},
+		{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6},
 	}
 
-	for testName, testCase := range testCases {
-		t.Run(testName, func(t *testing.T) {
-			input, expected := testCase.input, testCase.expected
-			sort.Slice(input, func(i, j int) bool {
-				return input[i].Compare(input[j]) < 0
-			})
-
-			assert.Equal(t, expected, input)
-		})
+	expected := []seriesChunkRef{
+		{blockID: ulid.MustNew(2, nil), minTime: 1, maxTime: 3},
+		{blockID: ulid.MustNew(1, nil), minTime: 1, maxTime: 5},
+		{blockID: ulid.MustNew(0, nil), minTime: 2, maxTime: 5},
+		{blockID: ulid.MustNew(4, nil), minTime: 3, maxTime: 6},
+		{blockID: ulid.MustNew(3, nil), minTime: 4, maxTime: 7},
 	}
+
+	sort.Slice(input, func(i, j int) bool {
+		return input[i].Compare(input[j]) > 0
+	})
+
+	assert.Equal(t, expected, input)
 }
 
 func TestSeriesChunkRefsIterator(t *testing.T) {
@@ -106,9 +82,9 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 	t.Run("should iterate a set with some items", func(t *testing.T) {
 		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
 			series: []seriesChunkRefs{
-				{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}},
-				{lset: series2, chunksRanges: []seriesChunkRefsRange{c[2]}},
-				{lset: series3, chunksRanges: []seriesChunkRefsRange{c[3], c[4]}},
+				{lset: series1, refs: []seriesChunkRef{c[0], c[1]}},
+				{lset: series2, refs: []seriesChunkRef{c[2]}},
+				{lset: series3, refs: []seriesChunkRef{c[3], c[4]}},
 			},
 		})
 
@@ -116,15 +92,15 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 		require.Zero(t, it.At())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series1, refs: []seriesChunkRef{c[0], c[1]}}, it.At())
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series2, chunksRanges: []seriesChunkRefsRange{c[2]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series2, refs: []seriesChunkRef{c[2]}}, it.At())
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series3, chunksRanges: []seriesChunkRefsRange{c[3], c[4]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series3, refs: []seriesChunkRef{c[3], c[4]}}, it.At())
 		require.False(t, it.Done())
 
 		require.False(t, it.Next())
@@ -135,9 +111,9 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 	t.Run("should re-initialize the internal state on reset()", func(t *testing.T) {
 		it := newSeriesChunkRefsIterator(seriesChunkRefsSet{
 			series: []seriesChunkRefs{
-				{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}},
-				{lset: series2, chunksRanges: []seriesChunkRefsRange{c[2]}},
-				{lset: series3, chunksRanges: []seriesChunkRefsRange{c[3], c[4]}},
+				{lset: series1, refs: []seriesChunkRef{c[0], c[1]}},
+				{lset: series2, refs: []seriesChunkRef{c[2]}},
+				{lset: series3, refs: []seriesChunkRef{c[3], c[4]}},
 			},
 		})
 
@@ -145,29 +121,29 @@ func TestSeriesChunkRefsIterator(t *testing.T) {
 		require.Zero(t, it.At())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series1, refs: []seriesChunkRef{c[0], c[1]}}, it.At())
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series2, chunksRanges: []seriesChunkRefsRange{c[2]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series2, refs: []seriesChunkRef{c[2]}}, it.At())
 		require.False(t, it.Done())
 
 		// Reset.
 		it.reset(seriesChunkRefsSet{
 			series: []seriesChunkRefs{
-				{lset: series1, chunksRanges: []seriesChunkRefsRange{c[3]}},
-				{lset: series4, chunksRanges: []seriesChunkRefsRange{c[4]}},
+				{lset: series1, refs: []seriesChunkRef{c[3]}},
+				{lset: series4, refs: []seriesChunkRef{c[4]}},
 			},
 		})
 
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series1, chunksRanges: []seriesChunkRefsRange{c[3]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series1, refs: []seriesChunkRef{c[3]}}, it.At())
 		require.False(t, it.Done())
 
 		require.True(t, it.Next())
-		require.Equal(t, seriesChunkRefs{lset: series4, chunksRanges: []seriesChunkRefsRange{c[4]}}, it.At())
+		require.Equal(t, seriesChunkRefs{lset: series4, refs: []seriesChunkRef{c[4]}}, it.At())
 		require.False(t, it.Done())
 
 		require.False(t, it.Next())
@@ -195,58 +171,58 @@ func TestFlattenedSeriesChunkRefs(t *testing.T) {
 		"should iterate a set with multiple items": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
 				}}),
 			expected: []seriesChunkRefs{
-				{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-				{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+				{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+				{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
 			},
 		},
 		"should iterate multiple sets with multiple items each": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
 				}},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
+					{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}},
 				}},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
+					{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}},
 				}}),
 			expected: []seriesChunkRefs{
-				{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-				{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
-				{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
-				{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
-				{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
+				{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+				{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
+				{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}},
+				{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}},
+				{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}},
 			},
 		},
 		"should keep iterating on empty sets": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
 				}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
+					{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}},
 				}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
+					{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}},
 				}},
 				seriesChunkRefsSet{}),
 			expected: []seriesChunkRefs{
-				{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-				{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
-				{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
-				{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
-				{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
+				{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+				{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
+				{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}},
+				{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}},
+				{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}},
 			},
 		},
 	}
@@ -278,18 +254,18 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[1], c[2], c[3]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[1], c[2], c[3]}},
 				}},
 			},
 		},
@@ -297,19 +273,19 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[0]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[0]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[0], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[0], c[2], c[3]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[0], c[0], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[0], c[0], c[2], c[3]}},
 				}},
 			},
 		},
@@ -318,14 +294,14 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			set1:      emptySeriesChunkRefsSetIterator{},
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[1]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[1]}},
 				}},
 			},
 		},
@@ -333,12 +309,12 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[1]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0]}},
 				},
 			}),
 			expectedSets: nil, // We expect no returned sets because an error occurred while creating the first one.
@@ -348,12 +324,12 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[1]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0]}},
 				},
 			}),
 			expectedSets: nil, // We expect no returned sets because an error occurred while creating the first one.
@@ -363,15 +339,15 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: make([]seriesChunkRefsRange, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: make([]seriesChunkRefsRange, 1)},
+					{lset: labels.FromStrings("l1", "v1"), refs: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v2"), refs: make([]seriesChunkRef, 1)},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: make([]seriesChunkRefsRange, 1)},
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: make([]seriesChunkRefsRange, 1)},
-					{lset: labels.FromStrings("l1", "v4"), chunksRanges: make([]seriesChunkRefsRange, 1)},
+					{lset: labels.FromStrings("l1", "v2"), refs: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v3"), refs: make([]seriesChunkRef, 1)},
+					{lset: labels.FromStrings("l1", "v4"), refs: make([]seriesChunkRef, 1)},
 				},
 			}),
 			expectedSets: nil, // We expect no returned sets because an error occurred while creating the first one.
@@ -381,25 +357,25 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 1, // Use a batch size of 1 in this test so that we can see when the iteration stops.
 			set1: newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0]}},
+					{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[2]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[3]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[3]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0]}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[1]}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[2]}},
 				}},
 			},
 			expectedErr: "something went wrong",
@@ -408,17 +384,17 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1], c[3]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0], c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0], c[2]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0], c[1], c[2], c[3]}},
 				}},
 			},
 		},
@@ -426,17 +402,17 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0], c[3]}},
 				},
 			}),
 			set2: newSliceSeriesChunkRefsSetIterator(nil, seriesChunkRefsSet{
 				series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1], c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1], c[2]}},
 				},
 			}),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[0], c[1], c[2], c[3]}},
 				}},
 			},
 		},
@@ -444,103 +420,103 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 1,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}}}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}}}},
 				seriesChunkRefsSet{},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3], c[3]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3], c[3]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}}}},
 			},
 		},
 		"should keep iterating on empty underlying sets (batch size = 2)": {
 			batchSize: 2,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}}}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}}}},
 				seriesChunkRefsSet{},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3], c[3]}},
-					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
+					{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3], c[3]}},
+					{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
+					{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}},
 				}},
 			},
 		},
 		"should keep iterating on second set after first set is exhausted (batch size = 1)": {
 			batchSize: 1,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}}}},
 			},
 		},
 		"should keep iterating on second set after first set is exhausted (batch size = 100)": {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
-					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}},
+					{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}},
 				}},
 			},
 		},
@@ -548,43 +524,43 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 			batchSize: 1,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}}}},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
-				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}}}},
+				{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}}}},
 			},
 		},
 		"should keep iterating on first set after second set is exhausted (batch size = 100)": {
 			batchSize: 100,
 			set1: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}}}},
 				seriesChunkRefsSet{},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}}}},
 			),
 			set2: newSliceSeriesChunkRefsSetIterator(nil,
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}}}},
-				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}}}},
+				seriesChunkRefsSet{series: []seriesChunkRefs{{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}}}},
 			),
 			expectedSets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
-					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
+					{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}},
+					{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}},
 				}},
 			},
 		},
@@ -609,7 +585,7 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 				require.Len(t, sets[setIdx].series, len(expectedSet.series))
 				for expectedSeriesIdx, expectedSeries := range expectedSet.series {
 					assert.Equal(t, expectedSeries.lset, sets[setIdx].series[expectedSeriesIdx].lset)
-					assert.Equal(t, expectedSeries.chunksRanges, sets[setIdx].series[expectedSeriesIdx].chunksRanges)
+					assert.Equal(t, expectedSeries.refs, sets[setIdx].series[expectedSeriesIdx].refs)
 				}
 			}
 		})
@@ -787,8 +763,8 @@ func TestSeriesSetWithoutChunks(t *testing.T) {
 		"should iterate a set with multiple items": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
 				}}),
 			expectedSeries: []labels.Labels{
 				labels.FromStrings("l1", "v1"),
@@ -799,15 +775,15 @@ func TestSeriesSetWithoutChunks(t *testing.T) {
 		"should iterate multiple sets with multiple items each": {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
 				}},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
+					{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}},
 				}},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
+					{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}},
 				}}),
 			expectedSeries: []labels.Labels{
 				labels.FromStrings("l1", "v1"),
@@ -822,17 +798,17 @@ func TestSeriesSetWithoutChunks(t *testing.T) {
 			input: newSliceSeriesChunkRefsSetIterator(nil,
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: []seriesChunkRefsRange{c[1]}},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: []seriesChunkRefsRange{c[2]}},
+					{lset: labels.FromStrings("l1", "v1"), refs: []seriesChunkRef{c[1]}},
+					{lset: labels.FromStrings("l1", "v2"), refs: []seriesChunkRef{c[2]}},
 				}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v3"), chunksRanges: []seriesChunkRefsRange{c[3]}},
+					{lset: labels.FromStrings("l1", "v3"), refs: []seriesChunkRef{c[3]}},
 				}},
 				seriesChunkRefsSet{},
 				seriesChunkRefsSet{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v4"), chunksRanges: []seriesChunkRefsRange{c[4]}},
-					{lset: labels.FromStrings("l1", "v5"), chunksRanges: []seriesChunkRefsRange{c[5]}},
+					{lset: labels.FromStrings("l1", "v4"), refs: []seriesChunkRef{c[4]}},
+					{lset: labels.FromStrings("l1", "v5"), refs: []seriesChunkRef{c[5]}},
 				}},
 				seriesChunkRefsSet{}),
 			expectedSeries: []labels.Labels{
@@ -873,13 +849,13 @@ func TestDeduplicatingSeriesChunkRefsSetIterator(t *testing.T) {
 	series3 := labels.FromStrings("l1", "v3")
 	sourceSets := []seriesChunkRefsSet{
 		{series: []seriesChunkRefs{
-			{lset: series1, chunksRanges: []seriesChunkRefsRange{c[0], c[1]}},
-			{lset: series1, chunksRanges: []seriesChunkRefsRange{c[2], c[3], c[4]}},
+			{lset: series1, refs: []seriesChunkRef{c[0], c[1]}},
+			{lset: series1, refs: []seriesChunkRef{c[2], c[3], c[4]}},
 		}},
 		{series: []seriesChunkRefs{
-			{lset: series2, chunksRanges: []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}},
-			{lset: series3, chunksRanges: []seriesChunkRefsRange{c[0]}},
-			{lset: series3, chunksRanges: []seriesChunkRefsRange{c[1]}},
+			{lset: series2, refs: []seriesChunkRef{c[0], c[1], c[2], c[3]}},
+			{lset: series3, refs: []seriesChunkRef{c[0]}},
+			{lset: series3, refs: []seriesChunkRef{c[1]}},
 		}},
 	}
 
@@ -893,15 +869,15 @@ func TestDeduplicatingSeriesChunkRefsSetIterator(t *testing.T) {
 
 		require.Len(t, sets[0].series, 1)
 		assert.Equal(t, series1, sets[0].series[0].lset)
-		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].chunksRanges)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].refs)
 
 		require.Len(t, sets[1].series, 1)
 		assert.Equal(t, series2, sets[1].series[0].lset)
-		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}, sets[1].series[0].chunksRanges)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, sets[1].series[0].refs)
 
 		require.Len(t, sets[2].series, 1)
 		assert.Equal(t, series3, sets[2].series[0].lset)
-		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1]}, sets[2].series[0].chunksRanges)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, sets[2].series[0].refs)
 	})
 
 	t.Run("batch size: 2", func(t *testing.T) {
@@ -916,16 +892,16 @@ func TestDeduplicatingSeriesChunkRefsSetIterator(t *testing.T) {
 		require.Len(t, sets[0].series, 2)
 
 		assert.Equal(t, series1, sets[0].series[0].lset)
-		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].chunksRanges)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].refs)
 
 		assert.Equal(t, series2, sets[0].series[1].lset)
-		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}, sets[0].series[1].chunksRanges)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, sets[0].series[1].refs)
 
 		// Second batch.
 		require.Len(t, sets[1].series, 1)
 
 		assert.Equal(t, series3, sets[1].series[0].lset)
-		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1]}, sets[1].series[0].chunksRanges)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, sets[1].series[0].refs)
 	})
 
 	t.Run("batch size: 3", func(t *testing.T) {
@@ -938,23 +914,23 @@ func TestDeduplicatingSeriesChunkRefsSetIterator(t *testing.T) {
 		require.Len(t, sets[0].series, 3)
 
 		assert.Equal(t, series1, sets[0].series[0].lset)
-		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].chunksRanges)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3], c[4]}, sets[0].series[0].refs)
 
 		assert.Equal(t, series2, sets[0].series[1].lset)
-		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1], c[2], c[3]}, sets[0].series[1].chunksRanges)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1], c[2], c[3]}, sets[0].series[1].refs)
 
 		assert.Equal(t, series3, sets[0].series[2].lset)
-		assert.Equal(t, []seriesChunkRefsRange{c[0], c[1]}, sets[0].series[2].chunksRanges)
+		assert.Equal(t, []seriesChunkRef{c[0], c[1]}, sets[0].series[2].refs)
 	})
 }
 
 func TestDeduplicatingSeriesChunkRefsSetIterator_PropagatesErrors(t *testing.T) {
 	chainedSet := newDeduplicatingSeriesChunkRefsSetIterator(100, newSliceSeriesChunkRefsSetIterator(errors.New("something went wrong"), seriesChunkRefsSet{
 		series: []seriesChunkRefs{
-			{lset: labels.FromStrings("l1", "v1"), chunksRanges: make([]seriesChunkRefsRange, 1)},
-			{lset: labels.FromStrings("l1", "v1"), chunksRanges: make([]seriesChunkRefsRange, 1)},
-			{lset: labels.FromStrings("l1", "v2"), chunksRanges: make([]seriesChunkRefsRange, 1)},
-			{lset: labels.FromStrings("l1", "v2"), chunksRanges: make([]seriesChunkRefsRange, 1)},
+			{lset: labels.FromStrings("l1", "v1"), refs: make([]seriesChunkRef, 1)},
+			{lset: labels.FromStrings("l1", "v1"), refs: make([]seriesChunkRef, 1)},
+			{lset: labels.FromStrings("l1", "v2"), refs: make([]seriesChunkRef, 1)},
+			{lset: labels.FromStrings("l1", "v2"), refs: make([]seriesChunkRef, 1)},
 		},
 	}))
 
@@ -981,10 +957,10 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedSetsCount: 1,
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
 				}},
 			},
 		},
@@ -995,10 +971,10 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "exceeded chunks limit",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 2)},
-					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 3)},
-					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 4)},
+					{lset: labels.FromStrings("l1", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), refs: generateSeriesChunksRanges(blockID, 2)},
+					{lset: labels.FromStrings("l2", "v1"), refs: generateSeriesChunksRanges(blockID, 3)},
+					{lset: labels.FromStrings("l2", "v2"), refs: generateSeriesChunksRanges(blockID, 4)},
 				}},
 			},
 		},
@@ -1009,23 +985,12 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "exceeded chunks limit",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-				}},
-			},
-		},
-		"exceeds chunks limit with multiple chunks per range": {
-			seriesLimit:       2,
-			chunksLimit:       5,
-			expectedSetsCount: 0,
-			expectedErr:       "exceeded chunks limit",
-			sets: []seriesChunkRefsSet{
-				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRangesN(blockID, 2, 3)},
+					{lset: labels.FromStrings("l2", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
 				}},
 			},
 		},
@@ -1036,10 +1001,10 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "exceeded series limit",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
 				}},
 			},
 		},
@@ -1050,12 +1015,12 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "exceeded series limit",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
 				}},
 			},
 		},
@@ -1067,12 +1032,12 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedErr:       "something went wrong",
 			sets: []seriesChunkRefsSet{
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l1", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l1", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l1", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
 				}},
 				{series: []seriesChunkRefs{
-					{lset: labels.FromStrings("l2", "v1"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
-					{lset: labels.FromStrings("l2", "v2"), chunksRanges: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v1"), refs: generateSeriesChunksRanges(blockID, 1)},
+					{lset: labels.FromStrings("l2", "v2"), refs: generateSeriesChunksRanges(blockID, 1)},
 				}},
 			},
 		},
@@ -1461,24 +1426,20 @@ func assertSeriesChunkRefsSetsEqual(t testing.TB, blockID ulid.ULID, blockDir st
 			promChunks := storage.NewListChunkSeriesIterator(filterPromChunksByTime(queryPromSeriesChunkMetas(t, actualSeries.lset, promBlock), minT, maxT)...)
 			prevChunkRef, prevChunkLen := chunks.ChunkRef(0), uint64(0)
 
-			for k, actualChunksRange := range actualSeries.chunksRanges {
-				for l, actualChunk := range actualChunksRange.refs {
-					require.Truef(t, promChunks.Next(), "out of prometheus chunks; left %d chunks: %v", len(actualChunksRange.refs)-l, actualChunksRange.refs[l:])
-					promChunk := promChunks.At()
-					if l == 0 {
-						assert.Equal(t, promChunk.Ref, actualChunksRange.firstRef(), "prom minT [%d, %d, %d]", i, j, k)
-					}
-					assert.Equalf(t, blockID, actualChunk.blockID, "blockID [%d, %d, %d]", i, j, k)
-					assert.Equalf(t, promChunk.Ref, chunkRef(actualChunk.segmentFile, actualChunk.segFileOffset), "ref [%d, %d, %d, %d]", i, j, k, l)
-					assert.Equalf(t, promChunk.MinTime, actualChunk.minTime, "minT [%d, %d, %d, %d]", i, j, k, l)
-					assert.Equalf(t, promChunk.MaxTime, actualChunk.maxTime, "maxT [%d, %d, %d, %d]", i, j, k, l)
-					assert.LessOrEqualf(t, uint64(prevChunkRef)+prevChunkLen, uint64(promChunk.Ref),
-						"estimated length shouldn't extend into the next chunk [%d, %d, %d, %d]", i, j, k, l)
-					assert.LessOrEqualf(t, actualChunk.length, uint32(tsdb.EstimatedMaxChunkSize),
-						"chunks can be larger than 16KB, but the estimted length should be capped to 16KB to limit the impact of bugs in estimations [%d, %d, %d, %d]", i, j, k, l)
+			for k, actualChunk := range actualSeries.refs {
+				require.Truef(t, promChunks.Next(), "out of prometheus chunks; left %d chunks: %v", len(actualSeries.refs)-k, actualSeries.refs[k:])
+				promChunk := promChunks.At()
+				assert.Equal(t, promChunk.Ref, actualChunk.storageRef(), "prom chunk ref [%d, %d, %d]", i, j, k)
+				assert.Equalf(t, blockID, actualChunk.blockID, "blockID [%d, %d, %d]", i, j, k)
+				assert.Equalf(t, promChunk.Ref, chunkRef(actualChunk.segmentFile, actualChunk.segFileOffset), "ref [%d, %d, %d]", i, j, k)
+				assert.Equalf(t, promChunk.MinTime, actualChunk.minTime, "minT [%d, %d, %d]", i, j, k)
+				assert.Equalf(t, promChunk.MaxTime, actualChunk.maxTime, "maxT [%d, %d, %d]", i, j, k)
+				assert.LessOrEqualf(t, uint64(prevChunkRef)+prevChunkLen, uint64(promChunk.Ref),
+					"estimated length shouldn't extend into the next chunk [%d, %d, %d]", i, j, k)
+				assert.LessOrEqualf(t, actualChunk.length, uint32(tsdb.EstimatedMaxChunkSize),
+					"chunks can be larger than 16KB, but the estimted length should be capped to 16KB to limit the impact of bugs in estimations [%d, %d, %d]", i, j, k)
 
-					prevChunkRef, prevChunkLen = promChunk.Ref, uint64(actualChunk.length)
-				}
+				prevChunkRef, prevChunkLen = promChunk.Ref, uint64(actualChunk.length)
 			}
 			if !strategy.isNoChunkRefs() {
 				// There shouldn't be extra chunks returned by prometheus
@@ -1652,6 +1613,17 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 			minT:    500, maxT: 600, // The chunks for this timeseries are between 0 and 99 and 1000 and 1099
 			batchSize:      100,
 			expectedSeries: []seriesChunkRefsSet{},
+		},
+		"correctly selects series from larger blocks": {
+			matcher: labels.MustNewMatcher(labels.MatchRegexp, "a", "3"),
+			minT:    0, maxT: 600,
+			batchSize: 100,
+			expectedSeries: []seriesChunkRefsSet{
+				{series: []seriesChunkRefs{
+					{lset: labels.FromStrings("a", "3", "b", "1")},
+					{lset: labels.FromStrings("a", "3", "b", "2")},
+				}},
+			},
 		},
 	}
 
@@ -1874,331 +1846,111 @@ func BenchmarkOpenBlockSeriesChunkRefsSetsIterator(b *testing.B) {
 	}
 }
 
-func TestMetasToRanges(t *testing.T) {
+func TestMetasToChunkRefs(t *testing.T) {
 	blockID := ulid.MustNew(1, nil)
 	testCases := map[string]struct {
-		partitions     [][]chunks.Meta
+		partitions     []chunks.Meta
 		minT, maxT     int64
-		expectedRanges []seriesChunkRefsRange
+		expectedChunks []seriesChunkRef
 	}{
-		"returns no ranges if partitions cover minT/maxT, but no individual chunk overlaps with the range": {
+		"returns no refs if no individual chunk overlaps with the range": {
 			minT: 16,
 			maxT: 17,
-			partitions: [][]chunks.Meta{
-				{{Ref: chunkRef(1, 23), MinTime: 1, MaxTime: 15}, {Ref: chunkRef(1, 45), MinTime: 20, MaxTime: 27}},
-				{{Ref: chunkRef(1, 58), MinTime: 78, MaxTime: 90}, {Ref: chunkRef(1, 79), MinTime: 91, MaxTime: 105}},
+			partitions: []chunks.Meta{
+				{Ref: chunkRef(1, 23), MinTime: 1, MaxTime: 15},
+				{Ref: chunkRef(1, 45), MinTime: 20, MaxTime: 27},
+				{Ref: chunkRef(1, 58), MinTime: 78, MaxTime: 90},
+				{Ref: chunkRef(1, 79), MinTime: 91, MaxTime: 105},
 			},
-			expectedRanges: nil,
+			expectedChunks: nil,
 		},
-		"returns no ranges if no partitions cover minT/maxT": {
-			minT: 5,
-			maxT: 50,
-			partitions: [][]chunks.Meta{
-				{{Ref: chunkRef(1, 23), MinTime: 78, MaxTime: 90}, {Ref: chunkRef(1, 45), MinTime: 90, MaxTime: 100}},
-				{{Ref: chunkRef(1, 58), MinTime: 101, MaxTime: 120}},
-			},
-			expectedRanges: nil,
-		},
-		"returns all partitions": {
+		"returns all chunks": {
 			minT: 5,
 			maxT: 500,
-			partitions: [][]chunks.Meta{
-				{{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20}, {Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88}},
-				{{Ref: chunkRef(1, 23), MinTime: 90, MaxTime: 100}, {Ref: chunkRef(1, 45), MinTime: 101, MaxTime: 120}},
-				{{Ref: chunkRef(1, 58), MinTime: 130, MaxTime: 150}},
+			partitions: []chunks.Meta{
+				{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20},
+				{Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88},
+				{Ref: chunkRef(1, 23), MinTime: 90, MaxTime: 100},
+				{Ref: chunkRef(1, 45), MinTime: 101, MaxTime: 120},
+				{Ref: chunkRef(1, 58), MinTime: 130, MaxTime: 150},
 			},
-			expectedRanges: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 2, length: 8, minTime: 9, maxTime: 20}, {blockID: blockID, segmentFile: 1, segFileOffset: 10, length: 13, minTime: 50, maxTime: 88}}},
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 23, length: 22, minTime: 90, maxTime: 100}, {blockID: blockID, segmentFile: 1, segFileOffset: 45, length: 13, minTime: 101, maxTime: 120}}},
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 58, length: tsdb.EstimatedMaxChunkSize, minTime: 130, maxTime: 150}}},
-			},
-		},
-		"a single input partition": {
-			minT: 5,
-			maxT: 500,
-			partitions: [][]chunks.Meta{
-				{{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20}, {Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88}},
-			},
-			expectedRanges: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 2, length: 8, minTime: 9, maxTime: 20}, {blockID: blockID, segmentFile: 1, segFileOffset: 10, length: tsdb.EstimatedMaxChunkSize, minTime: 50, maxTime: 88}}},
+			expectedChunks: []seriesChunkRef{
+				{blockID: blockID, segmentFile: 1, segFileOffset: 2, length: 8, minTime: 9, maxTime: 20},
+				{blockID: blockID, segmentFile: 1, segFileOffset: 10, length: 13, minTime: 50, maxTime: 88},
+				{blockID: blockID, segmentFile: 1, segFileOffset: 23, length: 22, minTime: 90, maxTime: 100},
+				{blockID: blockID, segmentFile: 1, segFileOffset: 45, length: 13, minTime: 101, maxTime: 120},
+				{blockID: blockID, segmentFile: 1, segFileOffset: 58, length: tsdb.EstimatedMaxChunkSize, minTime: 130, maxTime: 150},
 			},
 		},
 		"doesn't estimate length of chunks when they are from different segment files": {
 			minT: 5,
 			maxT: 500,
-			partitions: [][]chunks.Meta{
-				{{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20}, {Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88}},
-				{{Ref: chunkRef(1, 23), MinTime: 90, MaxTime: 100}, {Ref: chunkRef(1, 45), MinTime: 101, MaxTime: 120}},
-				{{Ref: chunkRef(2, 4), MinTime: 130, MaxTime: 150}},
+			partitions: []chunks.Meta{
+				{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20},
+				{Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88},
+				{Ref: chunkRef(1, 23), MinTime: 90, MaxTime: 100},
+				{Ref: chunkRef(1, 45), MinTime: 101, MaxTime: 120},
+				{Ref: chunkRef(2, 4), MinTime: 130, MaxTime: 150},
 			},
-			expectedRanges: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 2, length: 8, minTime: 9, maxTime: 20}, {blockID: blockID, segmentFile: 1, segFileOffset: 10, length: 13, minTime: 50, maxTime: 88}}},
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 23, length: 22, minTime: 90, maxTime: 100}, {blockID: blockID, segmentFile: 1, segFileOffset: 45, length: tsdb.EstimatedMaxChunkSize, minTime: 101, maxTime: 120}}},
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 2, segFileOffset: 4, length: tsdb.EstimatedMaxChunkSize, minTime: 130, maxTime: 150}}},
+			expectedChunks: []seriesChunkRef{
+				{blockID: blockID, segmentFile: 1, segFileOffset: 2, length: 8, minTime: 9, maxTime: 20},
+				{blockID: blockID, segmentFile: 1, segFileOffset: 10, length: 13, minTime: 50, maxTime: 88},
+				{blockID: blockID, segmentFile: 1, segFileOffset: 23, length: 22, minTime: 90, maxTime: 100},
+				{blockID: blockID, segmentFile: 1, segFileOffset: 45, length: tsdb.EstimatedMaxChunkSize, minTime: 101, maxTime: 120},
+				{blockID: blockID, segmentFile: 2, segFileOffset: 4, length: tsdb.EstimatedMaxChunkSize, minTime: 130, maxTime: 150},
 			},
 		},
 		"clamps the length of a chunk if the diff to the next chunk is larger than 16KB": {
 			minT: 5,
 			maxT: 500,
-			partitions: [][]chunks.Meta{
-				{{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20}, {Ref: chunkRef(1, 100_000), MinTime: 50, MaxTime: 88}},
+			partitions: []chunks.Meta{
+				{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20},
+				{Ref: chunkRef(1, 100_000), MinTime: 50, MaxTime: 88},
 			},
-			expectedRanges: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 2, length: tsdb.EstimatedMaxChunkSize, minTime: 9, maxTime: 20}, {blockID: blockID, segmentFile: 1, segFileOffset: 100_000, length: tsdb.EstimatedMaxChunkSize, minTime: 50, maxTime: 88}}},
-			},
-		},
-		"returns some ranges when some partitions overlap with minT/maxT": {
-			minT: 100,
-			maxT: 140,
-			partitions: [][]chunks.Meta{
-				{{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20}, {Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88}},
-				{{Ref: chunkRef(1, 23), MinTime: 90, MaxTime: 100}, {Ref: chunkRef(1, 45), MinTime: 101, MaxTime: 120}},
-				{{Ref: chunkRef(1, 58), MinTime: 130, MaxTime: 150}},
-			},
-			expectedRanges: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 23, length: 22, minTime: 90, maxTime: 100}, {blockID: blockID, segmentFile: 1, segFileOffset: 45, length: 13, minTime: 101, maxTime: 120}}},
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 58, length: tsdb.EstimatedMaxChunkSize, minTime: 130, maxTime: 150}}},
+			expectedChunks: []seriesChunkRef{
+				{blockID: blockID, segmentFile: 1, segFileOffset: 2, length: tsdb.EstimatedMaxChunkSize, minTime: 9, maxTime: 20},
+				{blockID: blockID, segmentFile: 1, segFileOffset: 100_000, length: tsdb.EstimatedMaxChunkSize, minTime: 50, maxTime: 88},
 			},
 		},
-		"returns some ranges when some partitions overlap at the edge with with minT/maxT": {
+		"returns some chunks they overlap at the edge with minT/maxT": {
 			minT: 120,
 			maxT: 130,
-			partitions: [][]chunks.Meta{
-				{{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20}, {Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88}},
-				{{Ref: chunkRef(1, 23), MinTime: 90, MaxTime: 100}, {Ref: chunkRef(1, 45), MinTime: 101, MaxTime: 120}},
-				{{Ref: chunkRef(2, 4), MinTime: 130, MaxTime: 150}},
+			partitions: []chunks.Meta{
+				{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20},
+				{Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88},
+				{Ref: chunkRef(1, 23), MinTime: 90, MaxTime: 100},
+				{Ref: chunkRef(1, 45), MinTime: 101, MaxTime: 120},
+				{Ref: chunkRef(2, 4), MinTime: 130, MaxTime: 150},
 			},
-			expectedRanges: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 23, length: 22, minTime: 90, maxTime: 100}, {blockID: blockID, segmentFile: 1, segFileOffset: 45, length: tsdb.EstimatedMaxChunkSize, minTime: 101, maxTime: 120}}},
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 2, segFileOffset: 4, length: tsdb.EstimatedMaxChunkSize, minTime: 130, maxTime: 150}}},
+			expectedChunks: []seriesChunkRef{
+				{blockID: blockID, segmentFile: 1, segFileOffset: 45, length: tsdb.EstimatedMaxChunkSize, minTime: 101, maxTime: 120},
+				{blockID: blockID, segmentFile: 2, segFileOffset: 4, length: tsdb.EstimatedMaxChunkSize, minTime: 130, maxTime: 150},
 			},
 		},
-		"still estimates length using chunks that aren't returned in any range": {
+		"still estimates length using chunks that aren't returned": {
 			minT: 95,
 			maxT: 105,
-			partitions: [][]chunks.Meta{
-				{{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20}, {Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88}},
-				{{Ref: chunkRef(1, 23), MinTime: 90, MaxTime: 100}, {Ref: chunkRef(1, 45), MinTime: 101, MaxTime: 120}},
-				{{Ref: chunkRef(1, 57), MinTime: 121, MaxTime: 125}, {Ref: chunkRef(1, 78), MinTime: 126, MaxTime: 129}},
-				{{Ref: chunkRef(2, 4), MinTime: 130, MaxTime: 150}},
+			partitions: []chunks.Meta{
+				{Ref: chunkRef(1, 2), MinTime: 9, MaxTime: 20},
+				{Ref: chunkRef(1, 10), MinTime: 50, MaxTime: 88},
+				{Ref: chunkRef(1, 23), MinTime: 90, MaxTime: 100},
+				{Ref: chunkRef(1, 45), MinTime: 101, MaxTime: 120},
+				{Ref: chunkRef(1, 57), MinTime: 121, MaxTime: 125},
+				{Ref: chunkRef(1, 78), MinTime: 126, MaxTime: 129},
+				{Ref: chunkRef(2, 4), MinTime: 130, MaxTime: 150},
 			},
-			expectedRanges: []seriesChunkRefsRange{
-				{refs: []seriesChunkRef{{blockID: blockID, segmentFile: 1, segFileOffset: 23, length: 22, minTime: 90, maxTime: 100}, {blockID: blockID, segmentFile: 1, segFileOffset: 45, length: 12, minTime: 101, maxTime: 120}}},
+			expectedChunks: []seriesChunkRef{
+				{blockID: blockID, segmentFile: 1, segFileOffset: 23, length: 22, minTime: 90, maxTime: 100},
+				{blockID: blockID, segmentFile: 1, segFileOffset: 45, length: 12, minTime: 101, maxTime: 120},
 			},
 		},
 	}
 
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			actualRanges := metasToRanges(testCase.partitions, blockID, testCase.minT, testCase.maxT)
-			assert.Equal(t, testCase.expectedRanges, actualRanges)
-			assert.Equal(t, len(testCase.expectedRanges), cap(actualRanges)) // Assert that we've done the slice preallocation correctly. This won't always catch all incorrect or missing preallocations, but might catch some.
-		})
-	}
-}
-
-func TestPartitionChunks(t *testing.T) {
-	testCases := map[string]struct {
-		targetNumRanges, minChunksPerRange int
-		input                              []chunks.Meta
-		expectedPartitions                 [][]chunks.Meta
-	}{
-		"empty input chunks": {
-			targetNumRanges: 10, minChunksPerRange: 3,
-		},
-		"even distribution into partitions": {
-			targetNumRanges: 4, minChunksPerRange: 1,
-			input: []chunks.Meta{
-				{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-				{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-				{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-				{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-				{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-				{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-				{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-				{Ref: chunkRef(1, 8), MinTime: 15, MaxTime: 16},
-				{Ref: chunkRef(1, 9), MinTime: 17, MaxTime: 18},
-				{Ref: chunkRef(1, 10), MinTime: 19, MaxTime: 20},
-				{Ref: chunkRef(1, 11), MinTime: 21, MaxTime: 22},
-				{Ref: chunkRef(1, 12), MinTime: 23, MaxTime: 24},
-			},
-			expectedPartitions: [][]chunks.Meta{
-				{
-					{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-					{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-					{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-				},
-				{
-					{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-					{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-					{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-				},
-				{
-					{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-					{Ref: chunkRef(1, 8), MinTime: 15, MaxTime: 16},
-					{Ref: chunkRef(1, 9), MinTime: 17, MaxTime: 18},
-				},
-				{
-					{Ref: chunkRef(1, 10), MinTime: 19, MaxTime: 20},
-					{Ref: chunkRef(1, 11), MinTime: 21, MaxTime: 22},
-					{Ref: chunkRef(1, 12), MinTime: 23, MaxTime: 24},
-				},
-			},
-		},
-		"when number of chunks per range would be less than minChunksPerRange, then targetNumRanges isn't used": {
-			targetNumRanges: 3, minChunksPerRange: 4,
-			input: []chunks.Meta{
-				{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-				{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-				{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-				{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-				{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-				{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-				{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-				{Ref: chunkRef(1, 8), MinTime: 15, MaxTime: 16},
-				{Ref: chunkRef(1, 9), MinTime: 17, MaxTime: 18},
-				{Ref: chunkRef(1, 10), MinTime: 19, MaxTime: 20},
-				{Ref: chunkRef(1, 11), MinTime: 21, MaxTime: 22},
-				{Ref: chunkRef(1, 12), MinTime: 23, MaxTime: 24},
-			},
-			expectedPartitions: [][]chunks.Meta{
-				{
-					{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-					{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-					{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-					{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-				},
-				{
-					{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-					{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-					{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-					{Ref: chunkRef(1, 8), MinTime: 15, MaxTime: 16},
-				},
-				{
-					{Ref: chunkRef(1, 9), MinTime: 17, MaxTime: 18},
-					{Ref: chunkRef(1, 10), MinTime: 19, MaxTime: 20},
-					{Ref: chunkRef(1, 11), MinTime: 21, MaxTime: 22},
-					{Ref: chunkRef(1, 12), MinTime: 23, MaxTime: 24},
-				},
-			},
-		},
-		"remainder of division with targetNumRanges is put in the last range": {
-			targetNumRanges: 3, minChunksPerRange: 1,
-			input: []chunks.Meta{
-				{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-				{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-				{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-				{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-				{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-				{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-				{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-				{Ref: chunkRef(1, 8), MinTime: 15, MaxTime: 16},
-				{Ref: chunkRef(1, 9), MinTime: 17, MaxTime: 18},
-				{Ref: chunkRef(1, 10), MinTime: 19, MaxTime: 20},
-				{Ref: chunkRef(1, 11), MinTime: 21, MaxTime: 22},
-			},
-			expectedPartitions: [][]chunks.Meta{
-				{
-					{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-					{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-					{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-				},
-				{
-					{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-					{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-					{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-				},
-				{
-					{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-					{Ref: chunkRef(1, 8), MinTime: 15, MaxTime: 16},
-					{Ref: chunkRef(1, 9), MinTime: 17, MaxTime: 18},
-					{Ref: chunkRef(1, 10), MinTime: 19, MaxTime: 20},
-					{Ref: chunkRef(1, 11), MinTime: 21, MaxTime: 22},
-				},
-			},
-		},
-		"targetNumRanges can be exceeded when there are chunks from multiple segment files": {
-			targetNumRanges: 3, minChunksPerRange: 1,
-			input: []chunks.Meta{
-				{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-				{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-				{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-				{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-				{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-				{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-				{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-				{Ref: chunkRef(2, 1), MinTime: 15, MaxTime: 16},
-				{Ref: chunkRef(2, 2), MinTime: 17, MaxTime: 18},
-				{Ref: chunkRef(2, 3), MinTime: 19, MaxTime: 20},
-				{Ref: chunkRef(2, 4), MinTime: 21, MaxTime: 22},
-			},
-			expectedPartitions: [][]chunks.Meta{
-				{
-					{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-					{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-					{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-				},
-				{
-					{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-					{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-					{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-				},
-				{
-					// This is an unfortunate case where one chunk is on its own because the next chunk is in a different segment file.
-					{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-				},
-				{
-					{Ref: chunkRef(2, 1), MinTime: 15, MaxTime: 16},
-					{Ref: chunkRef(2, 2), MinTime: 17, MaxTime: 18},
-					{Ref: chunkRef(2, 3), MinTime: 19, MaxTime: 20},
-				},
-				{
-					{Ref: chunkRef(2, 4), MinTime: 21, MaxTime: 22},
-				},
-			},
-		},
-		"chunks from separate segment files get their own range even when below minChunksPerRange": {
-			targetNumRanges: 3, minChunksPerRange: 1,
-			input: []chunks.Meta{
-				{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-				{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-				{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-				{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-				{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-				{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-				{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-				{Ref: chunkRef(1, 8), MinTime: 15, MaxTime: 16},
-				{Ref: chunkRef(1, 9), MinTime: 17, MaxTime: 18},
-				{Ref: chunkRef(1, 10), MinTime: 19, MaxTime: 20},
-				{Ref: chunkRef(2, 1), MinTime: 21, MaxTime: 22},
-			},
-			expectedPartitions: [][]chunks.Meta{
-				{
-					{Ref: chunkRef(1, 1), MinTime: 1, MaxTime: 2},
-					{Ref: chunkRef(1, 2), MinTime: 3, MaxTime: 4},
-					{Ref: chunkRef(1, 3), MinTime: 5, MaxTime: 6},
-				},
-				{
-					{Ref: chunkRef(1, 4), MinTime: 7, MaxTime: 8},
-					{Ref: chunkRef(1, 5), MinTime: 9, MaxTime: 10},
-					{Ref: chunkRef(1, 6), MinTime: 11, MaxTime: 12},
-				},
-				{
-					{Ref: chunkRef(1, 7), MinTime: 13, MaxTime: 14},
-					{Ref: chunkRef(1, 8), MinTime: 15, MaxTime: 16},
-					{Ref: chunkRef(1, 9), MinTime: 17, MaxTime: 18},
-					{Ref: chunkRef(1, 10), MinTime: 19, MaxTime: 20},
-				},
-				{
-					{Ref: chunkRef(2, 1), MinTime: 21, MaxTime: 22},
-				},
-			},
-		},
-	}
-	for testName, testCase := range testCases {
-		t.Run(testName, func(t *testing.T) {
-			actualPartitions := partitionChunks(testCase.input, testCase.targetNumRanges, testCase.minChunksPerRange)
-			assert.Equal(t, testCase.expectedPartitions, actualPartitions)
+			actualRanges := metasToChunkRefs(testCase.partitions, blockID, testCase.minT, testCase.maxT)
+			assert.Equal(t, testCase.expectedChunks, actualRanges)
+			assert.Equal(t, len(testCase.expectedChunks), cap(actualRanges)) // Assert that we've done the slice preallocation correctly. This won't always catch all incorrect or missing preallocations, but might catch some.
 		})
 	}
 }
@@ -2621,30 +2373,20 @@ func (l *staticLimiter) Reserve(num uint64) error {
 	return nil
 }
 
-func generateSeriesChunksRanges(blockID ulid.ULID, numRanges int) []seriesChunkRefsRange {
-	return generateSeriesChunksRangesN(blockID, 1, numRanges)
-}
+func generateSeriesChunksRanges(blockID ulid.ULID, numRefs int) []seriesChunkRef {
+	refs := make([]seriesChunkRef, 0, numRefs)
 
-func generateSeriesChunksRangesN(blockID ulid.ULID, numChunksPerRange, numRanges int) []seriesChunkRefsRange {
-	chunksRanges := make([]seriesChunkRefsRange, 0, numRanges)
-
-	for i := 0; i < numRanges; i++ {
-		refs := make([]seriesChunkRef, numChunksPerRange)
-		for rIdx := range refs {
-			refs[rIdx] = seriesChunkRef{segFileOffset: 10 * uint32(i),
-				minTime:     int64(i),
-				maxTime:     int64(i),
-				length:      10,
-				blockID:     blockID,
-				segmentFile: 1,
-			}
-		}
-		chunksRanges = append(chunksRanges, seriesChunkRefsRange{
-			refs: refs,
+	for i := 0; i < numRefs; i++ {
+		refs = append(refs, seriesChunkRef{segFileOffset: 10 * uint32(i),
+			minTime:     int64(i),
+			maxTime:     int64(i),
+			length:      10,
+			blockID:     blockID,
+			segmentFile: 1,
 		})
 	}
 
-	return chunksRanges
+	return refs
 }
 
 func readAllSeriesChunkRefsSet(it seriesChunkRefsSetIterator) []seriesChunkRefsSet {


### PR DESCRIPTION
#### What this PR does

This is the next and final PR in removing fine-grained chunks caching from the store-gateway. Since we're no longer caching individual ranges of chunks we don't need to keep that abstraction in the code either. 

This removal also simplifies `loadingSeriesChunkRefsSetIterator`. The iterator no longer needs to partition chunks into ranges. It returns only chunks that fall within the requested minT/maxT.

In turn `loadingSeriesChunksSetIterator` no longer has to account for chunks that may fall outside of minT/maxT. I also took the liberty to consolidate the usage of `seriesIteratorStrategy` and update some outdated comments related to that.

This PR also adds back a test that was removed in https://github.com/grafana/mimir/pull/5877#issuecomment-1717677250

I didn't add a changelog entry because there shouldn't be any user- or operator-visible changes resulting from this PR.

#### Which issue(s) this PR fixes or relates to

Fixes #3939 

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
