### PR TITLE
Update rollout-operator image to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 * [ENHANCEMENT] Double the amount of rule groups for each user tier. #5897
 * [ENHANCEMENT] Set `maxUnavailable` to 0 for `distributor`, `overrides-exporter`, `querier`, `query-frontend`, `query-scheduler` `ruler-querier`, `ruler-query-frontend`, `ruler-query-scheduler` and `consul` deployments, to ensure they don't become completely unavailable during a rollout. #5924
+* [ENHANCEMENT] Update rollout-operator to `v0.8.0`. #6022
 
 ### Mimirtool
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Update the `rollout-operator` subchart to `0.9.0`. #6022
+
 ## 5.1.0
 
 * [ENHANCEMENT] Make compactor podManagementPolicy configurable. #5902

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.2.8
 - name: rollout-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.8.0
-digest: sha256:580f4f22d63fa6c9e0295635d4b472d917b548ea9dd05164fa23a9cd24535cce
-generated: "2023-08-11T12:31:42.683128-04:00"
+  version: 0.9.0
+digest: sha256:c8cc620082c2a01ef1c5362726c43991b28785f0770886ea11c04a2ff6ec8c37
+generated: "2023-09-13T15:30:51.584039-04:00"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
   - name: rollout-operator
     alias: rollout_operator
     repository: https://grafana.github.io/helm-charts
-    version: 0.8.0
+    version: 0.9.0
     condition: rollout_operator.enabled

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -25,7 +25,7 @@ Kubernetes: `^1.20.0-0`
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.0.7 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.2.8 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.8.0 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.9.0 |
 
 # Contributing and releasing
 

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: enterprise-https-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: enterprise-https-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: enterprise-https-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: enterprise-https-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: gateway-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: gateway-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: gateway-nginx-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: gateway-nginx-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: large-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: large-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: openshift-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -40,7 +40,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: openshift-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: scheduler-name-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: scheduler-name-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: small-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: small-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-vault-agent-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.7.0"
+          image: "grafana/rollout-operator:v0.8.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-vault-agent-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.8.0
+    helm.sh/chart: rollout-operator-0.9.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.7.0"
+    app.kubernetes.io/version: "v0.8.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1373,7 +1373,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.7.0
+        image: grafana/rollout-operator:v0.8.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1401,7 +1401,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.7.0
+        image: grafana/rollout-operator:v0.8.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1002,7 +1002,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.7.0
+        image: grafana/rollout-operator:v0.8.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1070,7 +1070,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.7.0
+        image: grafana/rollout-operator:v0.8.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -617,7 +617,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.7.0
+        image: grafana/rollout-operator:v0.8.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -480,7 +480,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.7.0
+        image: grafana/rollout-operator:v0.8.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -618,7 +618,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.7.0
+        image: grafana/rollout-operator:v0.8.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -28,6 +28,6 @@
     mimir_backend: self.mimir,
 
     // See: https://github.com/grafana/rollout-operator
-    rollout_operator: 'grafana/rollout-operator:v0.7.0',
+    rollout_operator: 'grafana/rollout-operator:v0.8.0',
   },
 }


### PR DESCRIPTION
#### What this PR does

Updates the rollout-operator to [v0.8.0](https://github.com/grafana/rollout-operator/releases/tag/v0.8.0) in both Helm and Jsonnet.

#### Which issue(s) this PR fixes or relates to

Fixes: N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
