### PR TITLE
chore: fix index out of range in metrics metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. All the discarded samples will still be tracked by the `cortex_discarded_samples_total` metric. #5584 #6014
 * [ENHANCEMENT] Ruler: Fetch secrets used to configure TLS on the Alertmanager client from Vault when `-vault.enabled` is true. #5239
 * [BUGFIX] Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. #6032
-* [BUGFIX] Distributor: fix index out of range introduced in experimental feature from #5693. #5957
+* [BUGFIX] Distributor: fix index out of range introduced in OTLP Metadata handling (from #5693). #5957
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. All the discarded samples will still be tracked by the `cortex_discarded_samples_total` metric. #5584 #6014
 * [ENHANCEMENT] Ruler: Fetch secrets used to configure TLS on the Alertmanager client from Vault when `-vault.enabled` is true. #5239
 * [BUGFIX] Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. #6032
+* [BUGFIX] Distributor: fix index out of range introduced in experimental feature from #5693. #5957
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
 * [ENHANCEMENT] Implement support for `limit`, `limit_per_metric` and `metric` parameters for `<Prometheus HTTP prefix>/api/v1/metadata` endpoint. #5890
-* [ENHANCEMENT] Distributor: add experimental support for storing metadata when ingesting metrics via OTLP. This makes metrics description and type available when ingesting metrics via OTLP. Enable with `-distributor.enable-otlp-metadata-storage=true`. #5693 #5957
+* [ENHANCEMENT] Distributor: add experimental support for storing metadata when ingesting metrics via OTLP. This makes metrics description and type available when ingesting metrics via OTLP. Enable with `-distributor.enable-otlp-metadata-storage=true`. #5693 #6035
 * [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. All the discarded samples will still be tracked by the `cortex_discarded_samples_total` metric. #5584 #6014
 * [ENHANCEMENT] Ruler: Fetch secrets used to configure TLS on the Alertmanager client from Vault when `-vault.enabled` is true. #5239
 * [BUGFIX] Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. #6032

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,10 @@
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
 * [ENHANCEMENT] Implement support for `limit`, `limit_per_metric` and `metric` parameters for `<Prometheus HTTP prefix>/api/v1/metadata` endpoint. #5890
-* [ENHANCEMENT] Distributor: add experimental support for storing metadata when ingesting metrics via OTLP. This makes metrics description and type available when ingesting metrics via OTLP. Enable with `-distributor.enable-otlp-metadata-storage=true`. #5693
+* [ENHANCEMENT] Distributor: add experimental support for storing metadata when ingesting metrics via OTLP. This makes metrics description and type available when ingesting metrics via OTLP. Enable with `-distributor.enable-otlp-metadata-storage=true`. #5693 #5957
 * [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. All the discarded samples will still be tracked by the `cortex_discarded_samples_total` metric. #5584 #6014
 * [ENHANCEMENT] Ruler: Fetch secrets used to configure TLS on the Alertmanager client from Vault when `-vault.enabled` is true. #5239
 * [BUGFIX] Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. #6032
-* [BUGFIX] Distributor: fix index out of range introduced in OTLP Metadata handling (from #5693). #5957
 
 ### Mixin
 

--- a/pkg/util/push/otel.go
+++ b/pkg/util/push/otel.go
@@ -187,14 +187,16 @@ func otelMetricsToMetadata(md pmetric.Metrics) []*mimirpb.MetricMetadata {
 
 	metadataLength := 0
 	for i := 0; i < resourceMetricsSlice.Len(); i++ {
-		metadataLength += resourceMetricsSlice.At(i).ScopeMetrics().Len()
+		scopeMetricsSlice := resourceMetricsSlice.At(i).ScopeMetrics()
+		for j := 0; j < scopeMetricsSlice.Len(); j++ {
+			metadataLength += scopeMetricsSlice.At(j).Metrics().Len()
+		}
 	}
+
 	var metadata = make([]*mimirpb.MetricMetadata, metadataLength)
 	var metaDataPos = 0
 	for i := 0; i < resourceMetricsSlice.Len(); i++ {
-		resourceMetrics := resourceMetricsSlice.At(i)
-		scopeMetricsSlice := resourceMetrics.ScopeMetrics()
-
+		scopeMetricsSlice := resourceMetricsSlice.At(i).ScopeMetrics()
 		for j := 0; j < scopeMetricsSlice.Len(); j++ {
 			scopeMetrics := scopeMetricsSlice.At(j)
 			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {

--- a/pkg/util/push/otel.go
+++ b/pkg/util/push/otel.go
@@ -193,8 +193,7 @@ func otelMetricsToMetadata(md pmetric.Metrics) []*mimirpb.MetricMetadata {
 		}
 	}
 
-	var metadata = make([]*mimirpb.MetricMetadata, metadataLength)
-	var metaDataPos = 0
+	var metadata = make([]*mimirpb.MetricMetadata, 0, metadataLength)
 	for i := 0; i < resourceMetricsSlice.Len(); i++ {
 		scopeMetricsSlice := resourceMetricsSlice.At(i).ScopeMetrics()
 		for j := 0; j < scopeMetricsSlice.Len(); j++ {
@@ -207,8 +206,7 @@ func otelMetricsToMetadata(md pmetric.Metrics) []*mimirpb.MetricMetadata {
 					Help:             metric.Description(),
 					Unit:             metric.Unit(),
 				}
-				metadata[metaDataPos] = &entry
-				metaDataPos++
+				metadata = append(metadata, &entry)
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Fixes index out of range introduced https://github.com/grafana/mimir/pull/5693/files#diff-eb47b1b5619b45185602515d8d5274a06451058d43aaa9c85c9fc1a7222635c3R189 due to bad assumptions around shape of the data.

#### Which issue(s) this PR fixes or relates to

Sample log of the panic caused by not making the pre-allocated not long enough.
```
2023/09/15 16:56:46 http: panic serving 10.30.101.227:60402: runtime error: index out of range [56] with length 56
goroutine 1267 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1868 +0xb9
panic({0x23c29a0?, 0xc001818288?})
	/usr/local/go/src/runtime/panic.go:920 +0x270
github.com/opentracing-contrib/go-stdlib/nethttp.MiddlewareFunc.func5.1()
	/go/src/github.com/grafana/mimir/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go:155 +0x175
panic({0x23c29a0?, 0xc001818288?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/grafana/mimir/pkg/util/push.otelMetricsToMetadata({0xc000bec910?})
	/go/src/github.com/grafana/mimir/pkg/util/push/otel.go:208 +0x24b
github.com/grafana/mimir/pkg/util/push.OTLPHandler.func1({0x2cccb00, 0xc001291590}, 0xc000ec1700, 0x6400000, {0x1b9bae5?, 0xc00063d180?, 0xc000158a20?}, 0xc000bb9b80)
	/go/src/github.com/grafana/mimir/pkg/util/push/otel.go:157 +0xea5
github.com/grafana/mimir/pkg/util/push.OTLPHandler.handler.func2.1()
	/go/src/github.com/grafana/mimir/pkg/util/push/push.go:90 +0xc5
github.com/grafana/mimir/pkg/util/push.(*Request).WriteRequest(0xc000f803f0)
	/go/src/github.com/grafana/mimir/pkg/util/push/request.go:46 +0x36
github.com/grafana/mimir/pkg/distributor.(*Distributor).limitsMiddleware-fm.(*Distributor).limitsMiddleware.func1({0x2cccb00, 0xc001291590}, 0xc000f803f0)
	/go/src/github.com/grafana/mimir/pkg/distributor/distributor.go:1070 +0x2fd
github.com/grafana/mimir/pkg/util/push.OTLPHandler.handler.func2({0x2cc5cc0, 0xc000bb9b00}, 0xc000ec1700)
	/go/src/github.com/grafana/mimir/pkg/util/push/push.go:118 +0x21a
net/http.HandlerFunc.ServeHTTP(0xc000ec1600?, {0x2cc5cc0?, 0xc000bb9b00?}, 0x40e46c?)
	/usr/local/go/src/net/http/server.go:2136 +0x29
github.com/grafana/dskit/middleware.glob..func1.1({0x2cc5cc0, 0xc000bb9b00}, 0xc000ec1600)
	/go/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/middleware/http_auth.go:21 +0x112
net/http.HandlerFunc.ServeHTTP(0x2cccb00?, {0x2cc5cc0?, 0xc000bb9b00?}, 0x418408?)
	/usr/local/go/src/net/http/server.go:2136 +0x29
github.com/grafana/dskit/middleware.HTTPGRPCTracer.Wrap-fm.HTTPGRPCTracer.Wrap.func1({0x2cc5cc0, 0xc000bb9b00}, 0xc000ec1600)
	/go/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/middleware/http_tracing.go:103 +0x84c
net/http.HandlerFunc.ServeHTTP(0xc000ec1500?, {0x2cc5cc0?, 0xc000bb9b00?}, 0x1?)
	/usr/local/go/src/net/http/server.go:2136 +0x29
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0008e09c0, {0x2cc5cc0, 0xc000bb9b00}, 0xc000ec1400)
	/go/src/github.com/grafana/mimir/vendor/github.com/gorilla/mux/mux.go:210 +0x1c5
github.com/grafana/dskit/middleware.(*Instrument).Wrap.Instrument.Wrap.func1.2({0x2cc5cc0?, 0xc000bb9b00?})
	/go/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/middleware/instrument.go:74 +0x33
github.com/felixge/httpsnoop.(*Metrics).CaptureMetrics(0xc001399a28, {0x7fd30394c0b0, 0xc000aaef00}, 0xc000e357c0)
	/go/src/github.com/grafana/mimir/vendor/github.com/felixge/httpsnoop/capture_metrics.go:84 +0x1db
github.com/felixge/httpsnoop.CaptureMetricsFn({0x7fd30394c0b0, 0xc000aaef00}, 0xc00008cc58?)
	/go/src/github.com/grafana/mimir/vendor/github.com/felixge/httpsnoop/capture_metrics.go:39 +0x4e
github.com/grafana/dskit/middleware.(*Instrument).Wrap.Instrument.Wrap.func1({0x7fd30394c0b0, 0xc000aaef00}, 0xc000ec1400)
	/go/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/middleware/instrument.go:73 +0x306
net/http.HandlerFunc.ServeHTTP(0x2cc4dc0?, {0x7fd30394c0b0?, 0xc000aaef00?}, 0xc0012913e0?)
	/usr/local/go/src/net/http/server.go:2136 +0x29
github.com/grafana/dskit/middleware.(*Log).Wrap.Log.Wrap.func1({0x2cc4dc0, 0xc000aaeea0}, 0xc000ec1400)
	/go/src/github.com/grafana/mimir/vendor/github.com/grafana/dskit/middleware/logging.go:88 +0x277
net/http.HandlerFunc.ServeHTTP(0x410745?, {0x2cc4dc0?, 0xc000aaeea0?}, 0xc000158a01?)
	/usr/local/go/src/net/http/server.go:2136 +0x29
github.com/opentracing-contrib/go-stdlib/nethttp.MiddlewareFunc.func5({0x2cc2540?, 0xc000198a80}, 0xc0007ba400)
	/go/src/github.com/grafana/mimir/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go:159 +0x4f7
net/http.HandlerFunc.ServeHTTP(0x410745?, {0x2cc2540?, 0xc000198a80?}, 0xc000198a01?)
	/usr/local/go/src/net/http/server.go:2136 +0x29
net/http.serverHandler.ServeHTTP({0x2cbbaf8?}, {0x2cc2540?, 0xc000198a80?}, 0x6?)
	/usr/local/go/src/net/http/server.go:2938 +0x8e
net/http.(*conn).serve(0xc000140630, {0x2cccb00, 0xc000f1c810})
	/usr/local/go/src/net/http/server.go:2009 +0x5f4
created by net/http.(*Server).Serve in goroutine 56
	/usr/local/go/src/net/http/server.go:3086 +0x5cb
```

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
