### PR TITLE
Remove backwards compatibility tests for >1y

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,18 +7,6 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"grafana/mimir:2.0.0": e2emimir.ChainFlagMappers(
-		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
-		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
-	),
-	"grafana/mimir:2.1.0": e2emimir.ChainFlagMappers(
-		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
-		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
-	),
-	"grafana/mimir:2.2.0": e2emimir.ChainFlagMappers(
-		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
-		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
-	),
 	"grafana/mimir:2.3.1": e2emimir.ChainFlagMappers(
 		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
 		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),


### PR DESCRIPTION
#### What this PR does

2.3.0 was released one year ago, so we're removing backwards compatibility tests for versions older than that.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
