### PR TITLE
Don't treat 2xx status codes as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,9 @@
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
 * [ENHANCEMENT] Implement support for `limit`, `limit_per_metric` and `metric` parameters for `<Prometheus HTTP prefix>/api/v1/metadata` endpoint. #5890
-* [ENHANCEMENT] Go: updated to 1.21.1. #5955
 * [ENHANCEMENT] Distributor: add experimental support for storing metadata when ingesting metrics via OTLP. This makes metrics description and type available when ingesting metrics via OTLP. Enable with `-distributor.enable-otlp-metadata-storage=true`. #5693
 * [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. All the discarded samples will still be tracked by the `cortex_discarded_samples_total` metric. #5584 #6014
 * [ENHANCEMENT] Ruler: Fetch secrets used to configure TLS on the Alertmanager client from Vault when `-vault.enabled` is true. #5239
-* [BUGFIX] Ingester: fix spurious `not found` errors on label values API during head compaction. #5957
 
 ### Mixin
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1264,7 +1264,7 @@ func handleIngesterPushError(err error) error {
 	stat, ok := status.FromError(err)
 	if ok {
 		statusCode := int(stat.Code())
-		if statusCode/100 == 2 || statusCode/100 == 4 || statusCode/100 == 5 {
+		if statusCode/100 == 4 || statusCode/100 == 5 {
 			return httpgrpc.Errorf(statusCode, "failed pushing to ingester: %s", stat.Message())
 		}
 	}


### PR DESCRIPTION
#### What this PR does
In https://github.com/grafana/mimir/pull/5979 status codes 2xx were, erroneously, treated as error codes. Although unrealistic, this cases should be removed.

Moreover, in https://github.com/grafana/mimir/pull/5584 some entries in CHANGELOG were, erroneously, duplicated. They are removed by this PR.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
