### PR TITLE
ring: Use `net.JoinHostPort` to support IPv6 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [ENHANCEMENT] Ruler: Fetch secrets used to configure TLS on the Alertmanager client from Vault when `-vault.enabled` is true. #5239
 * [ENHANCEMENT] Fetch secrets used to configure server-side TLS from Vault when `-vault.enabled` is true. #6052.
 * [BUGFIX] Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. #6032
+* [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 
 ### Mixin
 

--- a/pkg/alertmanager/alertmanager_ring.go
+++ b/pkg/alertmanager/alertmanager_ring.go
@@ -7,7 +7,8 @@ package alertmanager
 
 import (
 	"flag"
-	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -85,7 +86,7 @@ func (cfg *RingConfig) ToLifecyclerConfig(logger log.Logger) (ring.BasicLifecycl
 
 	return ring.BasicLifecyclerConfig{
 		ID:                  cfg.Common.InstanceID,
-		Addr:                fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:     cfg.Common.HeartbeatPeriod,
 		HeartbeatTimeout:    cfg.Common.HeartbeatTimeout,
 		TokensObservePeriod: 0,

--- a/pkg/compactor/compactor_ring.go
+++ b/pkg/compactor/compactor_ring.go
@@ -7,7 +7,8 @@ package compactor
 
 import (
 	"flag"
-	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -64,7 +65,7 @@ func (cfg *RingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLif
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              cfg.Common.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:                 cfg.Common.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.Common.HeartbeatTimeout,
 		TokensObservePeriod:             cfg.ObservePeriod,

--- a/pkg/distributor/distributor_ring.go
+++ b/pkg/distributor/distributor_ring.go
@@ -7,7 +7,8 @@ package distributor
 
 import (
 	"flag"
-	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring"
@@ -44,7 +45,7 @@ func (cfg *RingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLif
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              cfg.Common.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:                 cfg.Common.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.Common.HeartbeatTimeout,
 		TokensObservePeriod:             0,

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -10,7 +10,9 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
+	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -125,7 +127,7 @@ type enqueueResult struct {
 func NewFrontend(cfg Config, log log.Logger, reg prometheus.Registerer) (*Frontend, error) {
 	requestsCh := make(chan *frontendRequest)
 
-	schedulerWorkers, err := newFrontendSchedulerWorkers(cfg, fmt.Sprintf("%s:%d", cfg.Addr, cfg.Port), requestsCh, log, reg)
+	schedulerWorkers, err := newFrontendSchedulerWorkers(cfg, net.JoinHostPort(cfg.Addr, strconv.Itoa(cfg.Port)), requestsCh, log, reg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ruler/ruler_ring.go
+++ b/pkg/ruler/ruler_ring.go
@@ -7,7 +7,8 @@ package ruler
 
 import (
 	"flag"
-	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring"
@@ -70,7 +71,7 @@ func (cfg *RingConfig) ToLifecyclerConfig(logger log.Logger) (ring.BasicLifecycl
 
 	return ring.BasicLifecyclerConfig{
 		ID:                  cfg.Common.InstanceID,
-		Addr:                fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:     cfg.Common.HeartbeatPeriod,
 		HeartbeatTimeout:    cfg.Common.HeartbeatTimeout,
 		TokensObservePeriod: 0,

--- a/pkg/scheduler/schedulerdiscovery/ring.go
+++ b/pkg/scheduler/schedulerdiscovery/ring.go
@@ -4,8 +4,9 @@ package schedulerdiscovery
 
 import (
 	"flag"
-	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -91,7 +92,7 @@ func (cfg *RingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLif
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              cfg.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:                 cfg.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.HeartbeatTimeout,
 		TokensObservePeriod:             0,

--- a/pkg/scheduler/schedulerdiscovery/ring_test.go
+++ b/pkg/scheduler/schedulerdiscovery/ring_test.go
@@ -3,7 +3,6 @@
 package schedulerdiscovery
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -22,7 +21,7 @@ func TestRingConfig_DefaultConfigToBasicLifecyclerConfig(t *testing.T) {
 
 	expected := ring.BasicLifecyclerConfig{
 		ID:                              cfg.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", cfg.InstanceAddr, cfg.InstancePort),
+		Addr:                            "127.0.0.1:9095",
 		HeartbeatPeriod:                 cfg.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.HeartbeatTimeout,
 		TokensObservePeriod:             0,
@@ -61,4 +60,27 @@ func TestRingConfig_CustomConfigToBasicLifecyclerConfig(t *testing.T) {
 	actual, err := cfg.ToBasicLifecyclerConfig(log.NewNopLogger())
 	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
+}
+
+func TestRingConfig_AddressFamilies(t *testing.T) {
+	cfg := RingConfig{}
+	flagext.DefaultValues(&cfg)
+
+	t.Run("IPv4", func(t *testing.T) {
+		cfg.InstanceAddr = "1.2.3.4"
+		cfg.InstancePort = 10
+
+		actual, err := cfg.ToBasicLifecyclerConfig(log.NewNopLogger())
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.3.4:10", actual.Addr)
+	})
+
+	t.Run("IPv6", func(t *testing.T) {
+		cfg.InstanceAddr = "::1"
+		cfg.InstancePort = 10
+
+		actual, err := cfg.ToBasicLifecyclerConfig(log.NewNopLogger())
+		require.NoError(t, err)
+		assert.Equal(t, "[::1]:10", actual.Addr)
+	})
 }

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -8,7 +8,9 @@ package storegateway
 import (
 	"flag"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -157,7 +159,7 @@ func (cfg *RingConfig) ToLifecyclerConfig(logger log.Logger) (ring.BasicLifecycl
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              cfg.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		Zone:                            cfg.InstanceZone,
 		HeartbeatPeriod:                 cfg.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.HeartbeatTimeout,

--- a/pkg/util/validation/exporter/ring.go
+++ b/pkg/util/validation/exporter/ring.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -82,7 +84,7 @@ func (c *RingConfig) toBasicLifecyclerConfig(logger log.Logger) (ring.BasicLifec
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              c.Common.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:                 c.Common.HeartbeatPeriod,
 		HeartbeatTimeout:                c.Common.HeartbeatTimeout,
 		TokensObservePeriod:             0,


### PR DESCRIPTION
#### What this PR does

Fixes an issue when using IPv6 where IPv6 addresses are not properly joined with ports resulting in the ring attempting to incorrectly use `::1:7496` instead of the proper `[::1]:7496` notation.

With this change it's fully possible to use Mimir within an IPv6 only network.

#### Which issue(s) this PR fixes or relates to

Fixes #3743

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`

---

For those interested in trying this out, here is a shortened snippet of the configuration changes I needed to make in order to get IPv6 working.

```yaml
alertmanager:
  sharding_ring:
    instance_enable_ipv6: true
compactor:
  sharding_ring:
    instance_enable_ipv6: true
distributor:
  ring:
    instance_enable_ipv6: true
ingester:
  ring:
    instance_enable_ipv6: true
memberlist:
  bind_addr:
    - '::'
  bind_port: 7946
  cluster_label: mimir
query_scheduler:
  service_discovery_mode: ring
  ring:
    instance_enable_ipv6: true
ruler:
  ring:
    instance_enable_ipv6: true
store_gateway:
  sharding_ring:
    instance_enable_ipv6: true
overrides_exporter:
  ring:
    instance_enable_ipv6: true
```
