### PR TITLE
Chore: Make only member of team able to run build image workflow

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -18,8 +18,8 @@ jobs:
       contents: read
       # Allow PR modification for collaborators, forks should remain read-only
       pull-requests: write
-      # We want to allow running github actions for all contributors, but don't want all contributors to be able to 
-      # publish new build images just by sending the PR. Hence this change.
+    # We want to allow running github actions for all contributors, but don't want all contributors to be able to 
+    # publish new build images just by sending the PR. Hence this change.
     if: github.event.pull_request.author_association == 'MEMBER' || github.actor == 'renovate[bot]'
     steps:
       - name: Checkout Repository

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -18,6 +18,9 @@ jobs:
       contents: read
       # Allow PR modification for collaborators, forks should remain read-only
       pull-requests: write
+      # We want to allow running github actions for all contributors, but don't want all contributors to be able to 
+      # publish new build images just by sending the PR. Hence this change.
+    if: github.event.pull_request.author_association == 'MEMBER' || github.actor == 'renovate[bot]'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

In long term, we should check whether the workflow is initiated by a member, rather than solely confirming the author's membership status.

This modification is necessary in scenarios where an external contributor submits a PR to modify the mimir-build-image, even if the PR receives approval from a maintainer, the build image will not update automatically. In such instances, we would be required to either manually update the build image or have a member initiate the PR to ensure the update occurs.

To avoid this, we could check whether the workflow is triggered by a member, in order to able to  start the workflow manually

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
