### PR TITLE
Fix alias which needed to be updated after the page moved

### DIFF
--- a/docs/sources/mimir/set-up/migrate/_index.md
+++ b/docs/sources/mimir/set-up/migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - migration-guide/
-  - ../migrate/
+  - ../migration-guide/ # /docs/mimir/<MIMIR_VERSION>/migration-guide/
+  - ../migrate/ # /docs/mimir/<MIMIR_VERSION>/migrate/
 description: Refer to these guides when migrating to Grafana Mimir.
 menuTitle: Migrate
 title: Migrate to Grafana Mimir


### PR DESCRIPTION
Relative aliases do not remember where they came from.
I've added comments to explain the absolute path.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
