### PR TITLE
Track cortex_query_frontend_enqueue_duration_seconds metric even when query-scheduler is in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [ENHANCEMENT] Ingester: exported summary `cortex_ingester_inflight_push_requests_summary` tracking total number of inflight requests in percentile buckets. #5845
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879
-* [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request when not using the query-scheduler. #5879
+* [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879 #6087
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
 * [ENHANCEMENT] Implement support for `limit`, `limit_per_metric` and `metric` parameters for `<Prometheus HTTP prefix>/api/v1/metadata` endpoint. #5890

--- a/pkg/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/frontend/v2/frontend_scheduler_worker.go
@@ -376,10 +376,8 @@ func (w *frontendSchedulerWorker) enqueueRequest(loop schedulerpb.SchedulerForFr
 	defer spanLogger.Span.Finish()
 
 	// Keep track of how long it takes to enqueue a request end-to-end.
-	start := time.Now()
-	defer func() {
-		w.enqueueDuration.Observe(time.Since(start).Seconds())
-	}()
+	durationTimer := prometheus.NewTimer(w.enqueueDuration)
+	defer durationTimer.ObserveDuration()
 
 	err := loop.Send(&schedulerpb.FrontendToScheduler{
 		Type:            schedulerpb.ENQUEUE,


### PR DESCRIPTION
#### What this PR does
I'm investigating some query performance and I noticed we don't have any metric to see how long it takes to enqueue requests in the query-frontend when query-scheduler is in use. Im this PR I propose to track `cortex_query_frontend_enqueue_duration_seconds` also when query-scheduler is in use, so that we can track the enqueuing latency end-to-end.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
