### PR TITLE
[release-2.10] Backport: Docs: fix link to self hosted mimir integrations (#6092)

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -12,7 +12,7 @@ weight: 60
 You can monitor Grafana Mimir or Grafana Enterprise Metrics itself, by collecting metrics and logs from Mimir or GEM that is running on a Kubernetes cluster. This is called _metamonitoring_.
 
 > **Note:** In Grafana, you can create dashboards and receive alerts about those metrics and logs. To set up dashboards and alerts,
-> see [Installing Grafana Mimir dashboards and alerts](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/monitor-grafana-mimir/installing-dashboards-and-alerts/) or [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/).
+> see [Installing Grafana Mimir dashboards and alerts](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/monitor-grafana-mimir/installing-dashboards-and-alerts/) or [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mimir/).
 
 Alternatively, to monitor the health of your system without using the Helm chart, see [Collect metrics and logs without the Helm chart](/docs/mimir/{{< param "mimir_docs_version" >}}/manage/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-without-the-helm-chart).
 
@@ -27,7 +27,7 @@ The Helm chart does not collect Prometheus node_exporter metrics;
 metrics from node_exporter must all have an instance label on them
 that has the same value as the instance label on Mimir metrics.
 For the list of necessary node_exporter metrics see the metrics
-prefixed with `node` in [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/#metrics).
+prefixed with `node` in [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mimir/#metrics).
 
 You can configure your collection of metrics and logs
 by using the [Grafana Agent operator](/docs/agent/latest/operator/).

--- a/docs/sources/mimir/manage/monitor-grafana-mimir/collecting-metrics-and-logs.md
+++ b/docs/sources/mimir/manage/monitor-grafana-mimir/collecting-metrics-and-logs.md
@@ -12,7 +12,7 @@ weight: 60
 
 You can collect logs and metrics from a Mimir or GEM cluster. To set up dashboards and alerts,
 see [Installing Grafana Mimir dashboards and alerts]({{< relref "./installing-dashboards-and-alerts" >}})
-or [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/integrations/integrations/integration-mimir/).
+or [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mimir/).
 
 It is easier and best to monitor a cluster if it was installed via the Grafana Mimir Helm chart.
 For more information, see the [documentation for the Grafana Mimir Helm chart](/docs/helm-charts/mimir-distributed/latest/).


### PR DESCRIPTION
This is cherry-picking https://github.com/grafana/mimir/commit/bddb996ca7fb19f74bfac8e90ed156af90f4afd7