### PR TITLE
WIP: Register httpgrpc.HTTP Service twice

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -117,6 +117,17 @@
           "fieldFlag": "http.prometheus-http-prefix",
           "fieldType": "string",
           "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
+          "name": "register_duplicate_httpgrpc_service",
+          "required": false,
+          "desc": "If true, HTTP-GRPC translation service will be registered under httpgrpc.HTTP2 service name.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "api.register-duplicate-httpgrpc-service",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -265,6 +265,8 @@ Usage of ./cmd/mimir/mimir:
     	How long should we store stateful data (notification logs and silences). For notification log entries, refers to how long should we keep entries before they expire and are deleted. For silences, refers to how long should tenants view silences after they expire and are deleted. (default 120h0m0s)
   -alertmanager.web.external-url string
     	The URL under which Alertmanager is externally reachable (eg. could be different than -http.alertmanager-http-prefix in case Alertmanager is served via a reverse proxy). This setting is used both to configure the internal requests router and to generate links in alert templates. If the external URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager, both the UI and API. (default http://localhost:8080/alertmanager)
+  -api.register-duplicate-httpgrpc-service
+    	[experimental] If true, HTTP-GRPC translation service will be registered under httpgrpc.HTTP2 service name.
   -api.skip-label-name-validation-header-enabled
     	Allows to skip label name validation via X-Mimir-SkipLabelNameValidation header on the http write path. Use with caution as it breaks PromQL. Allowing this for external clients allows any client to send invalid label names. After enabling it, requests with a specific HTTP header set to true will not have label names validated.
   -auth.multitenancy-enabled

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -154,6 +154,11 @@ api:
   # CLI flag: -http.prometheus-http-prefix
   [prometheus_http_prefix: <string> | default = "/prometheus"]
 
+  # (experimental) If true, HTTP-GRPC translation service will be registered
+  # under httpgrpc.HTTP2 service name.
+  # CLI flag: -api.register-duplicate-httpgrpc-service
+  [register_duplicate_httpgrpc_service: <boolean> | default = false]
+
 # The server block configures the HTTP and gRPC server of the launched
 # service(s).
 [server: <server>]


### PR DESCRIPTION
#### What this PR does

This PR adds optional second registration of `httpgrpc.HTTP` service into gRPC server (under the service name `httpgrpc.HTTP2`, to avoid conflict).

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
