### PR TITLE
Update docs for VSCode Go import settings for Mimir

### DIFF
--- a/docs/internal/contributing/vscode-goimports-settings.json
+++ b/docs/internal/contributing/vscode-goimports-settings.json
@@ -1,16 +1,12 @@
 {
     "settings": {
         "go.formatTool": "goimports",
-        "go.formatFlags": [
-            "-local",
-            "github.com/grafana/mimir"
-        ],
-        "go.languageServerExperimentalFeatures": {
-            "format": false
+        "gopls": {
+            "formatting.local": "github.com/grafana/mimir"
         },
         "[go]": {
             "editor.codeActionsOnSave": {
-                "source.organizeImports": false
+                "source.organizeImports": true
             }
         },
         "editor.formatOnSave": true


### PR DESCRIPTION
File was a bit out of date and format flags were not taking effect. Updating based on latest settings.
