### PR TITLE
Update aliases with comments for clarity and add missing aliases to fix 46 broken links in GEM docs

### DIFF
--- a/docs/sources/mimir/configure/about-anonymous-usage-statistics-reporting.md
+++ b/docs/sources/mimir/configure/about-anonymous-usage-statistics-reporting.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - ../operators-guide/configure/about-anonymous-usage-statistics-reporting/ # /docs/mimir/<MIMIR_VERSION>/operators-guide/configure/about-anonymous-usage-statistics-reporting/
 description: Learn about Grafana Mimir anonymous usage statistics reporting
 menuTitle: About anonymous usage statistics reporting
 title: About Grafana Mimir anonymous usage statistics reporting

--- a/docs/sources/mimir/configure/about-runtime-configuration.md
+++ b/docs/sources/mimir/configure/about-runtime-configuration.md
@@ -1,7 +1,8 @@
 ---
 aliases:
-  - ../configuring/about-runtime-configuration/
-  - ../operators-guide/configure/about-runtime-configuration/
+  - ../configuring/about-runtime-configuration/ # /docs/mimir/<MIMIR_VERSION>/configuring/about-runtime-configuration/
+  - ../operators-guide/configure/about-runtime-configuration/ # /docs/mimir/<MIMIR_VERSION>/operators-guide/configure/about-runtime-configuration/
+  - ../operators-guide/configuring/about-runtime-configuration/ # /docs/mimir/<MIMIR_VERSION>/operators-guide/configuring/about-runtime-configuration/
 description:
   Runtime configuration enables you to change a subset of configurations
   without restarting Grafana Mimir.


### PR DESCRIPTION
GEM documentation has links to the absolute paths referenced in the comments in this PR. With the aliases in place, Hugo creates redirects, fixing the links.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
