### PR TITLE
Fix link to 'migrating from Prometheus or Thanos' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Grafana Mimir is an open source software project that provides a scalable long-t
 
 If you're migrating to Grafana Mimir, refer to the following documents:
 
-- [Migrating from Thanos or Prometheus to Grafana Mimir](https://grafana.com/docs/mimir/latest/migrate/migrating-from-thanos-or-prometheus/).
-- [Migrating from Cortex to Grafana Mimir](https://grafana.com/docs/mimir/latest/migrate/migrate-from-cortex/)
+- [Migrating from Thanos or Prometheus to Grafana Mimir](https://grafana.com/docs/mimir/latest/set-up/migrate/migrate-from-thanos-or-prometheus/).
+- [Migrating from Cortex to Grafana Mimir](https://grafana.com/docs/mimir/latest/set-up/migrate/migrate-from-cortex/)
 
 ## Deploying Grafana Mimir
 

--- a/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
+++ b/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
@@ -2,6 +2,7 @@
 aliases:
   - migrating-from-thanos-or-prometheus/
   - ../../migrate/migrate-from-thanos-or-prometheus/
+  - ../../migrate/migrating-from-thanos-or-prometheus/
 description: Learn how to migrate from Thanos or Prometheus to Grafana Mimir.
 menuTitle: Migrate from Thanos or Prometheus
 title: Migrate from Thanos or Prometheus to Grafana Mimir


### PR DESCRIPTION
#### What this PR does

This PR:

* fixes the link to 'migrating from Thanos or Prometheus' in the readme (it previously 404ed)
* updates the link to 'migrating from Cortex' in the readme (it previously went to the old page, which had a redirect set up)
* adds an alias for the new 'migrating from Thanos or Prometheus' page from the old path

#### Which issue(s) this PR fixes or relates to

Fixes #6114

#### Checklist

- [n/a] Tests updated
- [x] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
