### PR TITLE
Track cortex_query_frontend_enqueue_duration_seconds by query-scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [ENHANCEMENT] Ingester: exported summary `cortex_ingester_inflight_push_requests_summary` tracking total number of inflight requests in percentile buckets. #5845
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879
-* [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879 #6087
-* [ENHANCEMENT] Store-gateway: add metric `cortex_bucket_store_blocks_loaded_by_duration` for counting the loaded number of blocks based on their duration. #6074 #6129
+* [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. When query-scheduler is in use, the metric has the `scheduler_address` label to differentiate the enqueue duration by query-scheduler backend. #5879 #6087 #6120
+* [ENHANCEMENT] Store-gateway: add metric `cortex_bucket_store_blocks_loaded_by_duration` for counting the loaded number of blocks based on their duration. #6074  #6129
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
 * [ENHANCEMENT] Implement support for `limit`, `limit_per_metric` and `metric` parameters for `<Prometheus HTTP prefix>/api/v1/metadata` endpoint. #5890

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	google.golang.org/api v0.142.0
+	google.golang.org/protobuf v1.31.0
 	sigs.k8s.io/kustomize/kyaml v0.14.3
 )
 
@@ -239,7 +240,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230803162519-f966b187b2e5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230913181813-007df8e322eb // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/telebot.v3 v3.1.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20230601164746-7562a1006961 // indirect

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -27,11 +27,13 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
 	"github.com/grafana/mimir/pkg/querier/stats"
@@ -165,7 +167,10 @@ func TestFrontend_ShouldTrackPerRequestMetrics(t *testing.T) {
 	// Assert on cortex_query_frontend_enqueue_duration_seconds.
 	metricsMap, err := metrics.NewMetricFamilyMapFromGatherer(reg)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(0), metricsMap.SumHistograms("cortex_query_frontend_enqueue_duration_seconds").Count())
+	require.NotEmpty(t, metricsMap["cortex_query_frontend_enqueue_duration_seconds"])
+	require.Len(t, metricsMap["cortex_query_frontend_enqueue_duration_seconds"].GetMetric(), 1)
+	assert.Equal(t, makeLabels("scheduler_address", f.cfg.SchedulerAddress), metricsMap["cortex_query_frontend_enqueue_duration_seconds"].GetMetric()[0].GetLabel())
+	assert.Equal(t, uint64(0), metricsMap["cortex_query_frontend_enqueue_duration_seconds"].GetMetric()[0].GetHistogram().GetSampleCount())
 
 	resp, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), userID), &httpgrpc.HTTPRequest{})
 	require.NoError(t, err)
@@ -183,17 +188,20 @@ func TestFrontend_ShouldTrackPerRequestMetrics(t *testing.T) {
 	// Assert on cortex_query_frontend_enqueue_duration_seconds.
 	metricsMap, err = metrics.NewMetricFamilyMapFromGatherer(reg)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1), metricsMap.SumHistograms("cortex_query_frontend_enqueue_duration_seconds").Count())
+	require.NotEmpty(t, metricsMap["cortex_query_frontend_enqueue_duration_seconds"])
+	require.Len(t, metricsMap["cortex_query_frontend_enqueue_duration_seconds"].GetMetric(), 1)
+	assert.Equal(t, makeLabels("scheduler_address", f.cfg.SchedulerAddress), metricsMap["cortex_query_frontend_enqueue_duration_seconds"].GetMetric()[0].GetLabel())
+	assert.Equal(t, uint64(1), metricsMap["cortex_query_frontend_enqueue_duration_seconds"].GetMetric()[0].GetHistogram().GetSampleCount())
 
 	// Manually remove the address, check that label is removed.
 	f.schedulerWorkers.InstanceRemoved(servicediscovery.Instance{Address: f.cfg.SchedulerAddress, InUse: true})
 	expectedMetrics = ``
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_query_frontend_workers_enqueued_requests_total"))
 
-	// Assert on cortex_query_frontend_enqueue_duration_seconds.
+	// Assert on cortex_query_frontend_enqueue_duration_seconds (ensure the series is removed).
 	metricsMap, err = metrics.NewMetricFamilyMapFromGatherer(reg)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1), metricsMap.SumHistograms("cortex_query_frontend_enqueue_duration_seconds").Count())
+	assert.Empty(t, metricsMap["cortex_query_frontend_enqueue_duration_seconds"])
 }
 
 func TestFrontendRetryEnqueue(t *testing.T) {
@@ -498,4 +506,17 @@ func checkStreamGoroutines() int {
 
 	goroutineStacks := string(buf[:stacklen])
 	return strings.Count(goroutineStacks, streamGoroutineStackFrameTrailer)
+}
+
+func makeLabels(namesAndValues ...string) []*dto.LabelPair {
+	out := []*dto.LabelPair(nil)
+
+	for i := 0; i+1 < len(namesAndValues); i = i + 2 {
+		out = append(out, &dto.LabelPair{
+			Name:  proto.String(namesAndValues[i]),
+			Value: proto.String(namesAndValues[i+1]),
+		})
+	}
+
+	return out
 }


### PR DESCRIPTION
#### What this PR does
This PR addresses a feedback received [here](https://github.com/grafana/mimir/pull/6087#pullrequestreview-1638980230). In this PR I proposes to track `cortex_query_frontend_enqueue_duration_seconds` by `query-scheduler` address, to have better visibility in case the slowdown is caused by a specific scheduler.

I've also took the opportunity to customise the `cortex_query_frontend_enqueue_duration_seconds` histogram buckets, to track 1ms latency too and removing any bucket bigger than 1s.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
