### PR TITLE
Use hard-coded list of block durations in store-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * [ENHANCEMENT] Ingester: exported summary `cortex_ingester_inflight_push_requests_summary` tracking total number of inflight requests in percentile buckets. #5845
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879
 * [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879 #6087
-* [ENHANCEMENT] Store-gateway: add metric `cortex_bucket_store_blocks_loaded_by_duration` for counting the loaded number of blocks based on their duration. #6074
+* [ENHANCEMENT] Store-gateway: add metric `cortex_bucket_store_blocks_loaded_by_duration` for counting the loaded number of blocks based on their duration. #6074 #6129
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
 * [ENHANCEMENT] Implement support for `limit`, `limit_per_metric` and `metric` parameters for `<Prometheus HTTP prefix>/api/v1/metadata` endpoint. #5890

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -259,14 +259,14 @@ func (s *BucketStore) RemoveBlocksAndClose() error {
 }
 
 // Stats returns statistics about the BucketStore instance.
-func (s *BucketStore) Stats(durations tsdb.DurationList) BucketStoreStats {
+func (s *BucketStore) Stats(durations []time.Duration) BucketStoreStats {
 	s.blocksMx.RLock()
 	defer s.blocksMx.RUnlock()
 
 	return buildStoreStats(durations, s.blocks)
 }
 
-func buildStoreStats(durations tsdb.DurationList, blocks map[ulid.ULID]*bucketBlock) BucketStoreStats {
+func buildStoreStats(durations []time.Duration, blocks map[ulid.ULID]*bucketBlock) BucketStoreStats {
 	stats := BucketStoreStats{}
 	stats.BlocksLoaded = make(map[time.Duration]int)
 


### PR DESCRIPTION
#### What this PR does

Use a hard-coded list of durations instead of requiring the store-gateway to be aware of compactor-specific configuration.

#### Which issue(s) this PR fixes or relates to

Related #6074

#### Checklist

- [NA] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
