### PR TITLE
Change -log.buffered default to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [CHANGE] Store-gateway: enable sparse index headers by default. Sparse index headers reduce the time to load an index header up to 90%. #6005
 * [CHANGE] Store-gateway: lazy-loading concurrency limit default value is now 4. #6004
+* [CHANGE] General: enabled `-log.buffered` by default. The `-log.buffered` has been deprecated and will be removed in Mimir 2.13. #6131
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [ENHANCEMENT] Ingester: exported summary `cortex_ingester_inflight_push_requests_summary` tracking total number of inflight requests in percentile buckets. #5845
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1404,7 +1404,7 @@ Usage of ./cmd/mimir/mimir:
   -ingester.tsdb-config-update-period duration
     	[experimental] Period with which to update the per-tenant TSDB configuration. (default 15s)
   -log.buffered
-    	Use a buffered logger to reduce write contention. (default true)
+    	[deprecated] Use a buffered logger to reduce write contention. (default true)
   -log.format string
     	Output log messages in the given format. Valid formats: [logfmt, json] (default "logfmt")
   -log.level value

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1404,7 +1404,7 @@ Usage of ./cmd/mimir/mimir:
   -ingester.tsdb-config-update-period duration
     	[experimental] Period with which to update the per-tenant TSDB configuration. (default 15s)
   -log.buffered
-    	Use a buffered logger to reduce write contention.
+    	Use a buffered logger to reduce write contention. (default true)
   -log.format string
     	Output log messages in the given format. Valid formats: [logfmt, json] (default "logfmt")
   -log.level value

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -70,7 +70,7 @@ func (mf *mainFlags) registerFlags(fs *flag.FlagSet) {
 	fs.IntVar(&mf.ballastBytes, "mem-ballast-size-bytes", 0, "Size of memory ballast to allocate.")
 	fs.IntVar(&mf.mutexProfileFraction, "debug.mutex-profile-fraction", 0, "Fraction of mutex contention events that are reported in the mutex profile. On average 1/rate events are reported. 0 to disable.")
 	fs.IntVar(&mf.blockProfileRate, "debug.block-profile-rate", 0, "Fraction of goroutine blocking events that are reported in the blocking profile. 1 to include every blocking event in the profile, 0 to disable.")
-	fs.BoolVar(&mf.useBufferedLogger, "log.buffered", false, "Use a buffered logger to reduce write contention.")
+	fs.BoolVar(&mf.useBufferedLogger, "log.buffered", true, "Use a buffered logger to reduce write contention.")
 	fs.BoolVar(&mf.rateLimitedLogsEnabled, "log.rate-limit-enabled", false, "Use rate limited logger to reduce the number of logged messages per second.")
 	fs.Float64Var(&mf.rateLimitedLogsPerSecond, "log.rate-limit-logs-per-second", 10000, "Maximum number of messages per second to be logged.")
 	fs.IntVar(&mf.rateLimitedLogsPerSecondBurst, "log.rate-limit-logs-per-second-burst", 25000, "Burst size, i.e., maximum number of messages that can be logged in a second, temporarily exceeding the configured maximum logs per second.")

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -56,7 +56,7 @@ type mainFlags struct {
 	ballastBytes                  int     `category:"advanced"`
 	mutexProfileFraction          int     `category:"advanced"`
 	blockProfileRate              int     `category:"advanced"`
-	useBufferedLogger             bool    `category:"advanced"`
+	useBufferedLogger             bool    `category:"deprecated"` // Deprecated: deprecated in Mimir 2.11, remove it in 2.13.
 	rateLimitedLogsEnabled        bool    `category:"experimental"`
 	rateLimitedLogsPerSecond      float64 `category:"experimental"`
 	rateLimitedLogsPerSecondBurst int     `category:"experimental"`

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -155,3 +155,8 @@ The following features or configuration parameters are currently deprecated and 
   - `-blocks-storage.bucket-store.bucket-index.enabled`
 - Querier
   - `-querier.iterators` and `-querier.batch-iterators` (Mimir 2.11 onwards will always use `-querier.batch-iterators=true`)
+
+The following features or configuration parameters are currently deprecated and will be **removed in Mimir 2.13**:
+
+- Logging
+  - `-log.buffered`


### PR DESCRIPTION
#### What this PR does
We're running `-log.buffered=true` in production since few weeks and everything looks good. I propose to change the default to true, and also deprecate it, so that will be removed in 2 releases (plan is to always use the buffered logger).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
