### PR TITLE
Add option to show rejected requests on Mimir writes dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [ENHANCEMENT] Double the amount of rule groups for each user tier. #5897
 * [ENHANCEMENT] Set `maxUnavailable` to 0 for `distributor`, `overrides-exporter`, `querier`, `query-frontend`, `query-scheduler` `ruler-querier`, `ruler-query-frontend`, `ruler-query-scheduler` and `consul` deployments, to ensure they don't become completely unavailable during a rollout. #5924
 * [ENHANCEMENT] Update rollout-operator to `v0.8.1`. #6022 #6110
+* [ENHANCEMENT] Dashboards: Optionally show rejected requests on Mimir Writes dashboard. Useful when used together with "early request rejection". #6132
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,13 @@
 
 ### Mixin
 
+* [ENHANCEMENT] Dashboards: Optionally show rejected requests on Mimir Writes dashboard. Useful when used together with "early request rejection". #6132
+
 ### Jsonnet
 
 * [ENHANCEMENT] Double the amount of rule groups for each user tier. #5897
 * [ENHANCEMENT] Set `maxUnavailable` to 0 for `distributor`, `overrides-exporter`, `querier`, `query-frontend`, `query-scheduler` `ruler-querier`, `ruler-query-frontend`, `ruler-query-scheduler` and `consul` deployments, to ensure they don't become completely unavailable during a rollout. #5924
 * [ENHANCEMENT] Update rollout-operator to `v0.8.1`. #6022 #6110
-* [ENHANCEMENT] Dashboards: Optionally show rejected requests on Mimir Writes dashboard. Useful when used together with "early request rejection". #6132
 
 ### Mimirtool
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -39675,6 +39675,7 @@ data:
                       "dashLength": 10,
                       "dashes": false,
                       "datasource": "$datasource",
+                      "description": "### Requests / sec\nThe rate of successful, failed and rejected requests to ingester.\nRejected requests are requests that ingester fails to handle because of ingester instance limits (ingester-max-inflight-push-requests and ingester-max-ingestion-rate).\nWhen ingester is configured to use \"early\" request rejection, then rejected requests are NOT included in other metrics.\nWhen ingester is not configured to use \"early\" request rejection, then rejected requests are also counted as \"errors\".\n\n",
                       "fill": 10,
                       "id": 10,
                       "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -705,6 +705,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\nThe rate of successful, failed and rejected requests to ingester.\nRejected requests are requests that ingester fails to handle because of ingester instance limits (ingester-max-inflight-push-requests and ingester-max-ingestion-rate).\nWhen ingester is configured to use \"early\" request rejection, then rejected requests are NOT included in other metrics.\nWhen ingester is not configured to use \"early\" request rejection, then rejected requests are also counted as \"errors\".\n\n",
                   "fill": 10,
                   "id": 10,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -705,6 +705,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Requests / sec\nThe rate of successful, failed and rejected requests to ingester.\nRejected requests are requests that ingester fails to handle because of ingester instance limits (ingester-max-inflight-push-requests and ingester-max-ingestion-rate).\nWhen ingester is configured to use \"early\" request rejection, then rejected requests are NOT included in other metrics.\nWhen ingester is not configured to use \"early\" request rejection, then rejected requests are also counted as \"errors\".\n\n",
                   "fill": 10,
                   "id": 10,
                   "legend": {

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -645,5 +645,13 @@
 
     // Used to add additional services to dashboards that support it.
     extraServiceNames: [],
+
+    // When using rejecting inflight requests in ingesters early (using -ingester.limit-inflight-requests-using-grpc-method-limiter option),
+    // rejected requests will not count towards standard Mimir metrics like cortex_request_duration_seconds_count.
+    // Enabling this will make them visible on the dashboard again.
+    //
+    // Disabled by default, because when -ingester.limit-inflight-requests-using-grpc-method-limiter is not used (default), then rejected requests
+    // are already counted as failures.
+    show_rejected_requests_on_writes_dashboard: false,
   },
 }

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -142,6 +142,15 @@ local filename = 'mimir-writes.json';
       $.row('Ingester')
       .addPanel(
         $.panel('Requests / sec') +
+        $.panelDescription(
+          'Requests / sec',
+          |||
+            The rate of successful, failed and rejected requests to ingester.
+            Rejected requests are requests that ingester fails to handle because of ingester instance limits (ingester-max-inflight-push-requests and ingester-max-ingestion-rate).
+            When ingester is configured to use "early" request rejection, then rejected requests are NOT included in other metrics.
+            When ingester is not configured to use "early" request rejection, then rejected requests are also counted as "errors".
+          |||
+        ) +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester)) +
         if $._config.show_rejected_requests_on_writes_dashboard then {
           targets: [

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -142,7 +142,22 @@ local filename = 'mimir-writes.json';
       $.row('Ingester')
       .addPanel(
         $.panel('Requests / sec') +
-        $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester))
+        $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester)) +
+        if $._config.show_rejected_requests_on_writes_dashboard then {
+          targets: [
+            {
+              legendLink: null,
+              expr: 'sum (rate(cortex_ingester_instance_rejected_requests_total{%s, reason=~"ingester_max_inflight_push_requests|ingester_max_ingestion_rate"}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester)],
+              format: 'time_series',
+              intervalFactor: 2,
+              legendFormat: 'rejected',
+              refId: 'B',
+            },
+          ] + super.targets,
+          aliasColors+: {
+            rejected: '#EAB839',
+          },
+        } else {},
       )
       .addPanel(
         $.panel('Latency') +


### PR DESCRIPTION
#### What this PR does

When using `-ingester.limit-inflight-requests-using-grpc-method-limiter` option from PR https://github.com/grafana/mimir/pull/6073 and https://github.com/grafana/mimir/pull/5976, then requests rejected early don't count towards standard Mimir metrics like `cortex_request_duration_seconds_count`, and aren't visible on the dashboard.

This PR adds option to show rejected requests to Mimir Writes dashboard.

Without showing rejected requests:

<img width="536" alt="Screenshot 2023-09-25 at 17 54 13" src="https://github.com/grafana/mimir/assets/895919/f0f73e8a-1493-4bc7-91c7-2469bd0ab6fc">

With showing rejected requests:

<img width="536" alt="Screenshot 2023-09-25 at 17 53 50" src="https://github.com/grafana/mimir/assets/895919/9d2a8667-32c7-461a-a25e-883cf676f5fa">


#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
