### PR TITLE
store-gateway: reduce logging for not finding eager loading snapshot

### DIFF
--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -96,6 +96,14 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 				}
 			},
 		},
+		"pre-shutdown loaded blocks snapshot doesn't exist and eager-loading is enabled": {
+			lazyReaderEnabled:      true,
+			lazyReaderIdleTimeout:  time.Minute,
+			eagerLoadReaderEnabled: true,
+			initialSync:            true,
+			expectedLoadCountMetricBeforeLabelNamesCall: 0, // although eager loading is enabled, this test will not do eager loading because there is no snapshot file
+			expectedLoadCountMetricAfterLabelNamesCall:  1,
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Related to https://github.com/grafana/mimir/issues/4762

The existing logging can be noisy when the upgrade happens. This is because the eager loading snapshot file isn't found. This emits a log line for trying to read the file and then a log line for trying to delete it. This can be unnecessarily worrying especially when there are many tenants. This PR removes logging when the file isn't found and doesn't attempt deleting it.

It also removes the `tenant` log field since that's redundant with the user logger we're using.

```
ts=2023-09-25T19:57:41.797242382Z caller=reader_pool.go:104 level=warn user=123 msg="loading the list of index-headers from snapshot file failed; not eagerly loading index-headers for tenant" file=/data/tsdb/123/lazy-loaded.json err="open /data/tsdb/1054557/lazy-loaded.json: no such file or directory" tenant=123
ts=2023-09-25T19:57:41.79726468Z caller=reader_pool.go:110 level=warn user=123 msg="removing the lazy-loaded index-header snapshot failed" file=/data/tsdb/123/lazy-loaded.json err="remove /data/tsdb/1054557/lazy-loaded.json: no such file or directory"
```

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
