### PR TITLE
mimirtool: Don't send template full path in 'alertmanager load'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [BUGFIX] Fix out of bounds error on export with large timespans and/or series count. #5700
 * [BUGFIX] Fix the issue where `--read-timeout` was applied to the entire `mimirtool analyze grafana` invocation rather than to individual Grafana API calls. #5915
 * [BUGFIX] Fix incorrect remote-read path joining for `mimirtool remote-read` commands on Windows. #6009
+* [BUGFIX] Fix template files full path being sent in `mimirtool alertmanager load` command. #6137
 
 ### Mimir Continuous Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * [BUGFIX] Fix out of bounds error on export with large timespans and/or series count. #5700
 * [BUGFIX] Fix the issue where `--read-timeout` was applied to the entire `mimirtool analyze grafana` invocation rather than to individual Grafana API calls. #5915
 * [BUGFIX] Fix incorrect remote-read path joining for `mimirtool remote-read` commands on Windows. #6009
-* [BUGFIX] Fix template files full path being sent in `mimirtool alertmanager load` command. #6137
+* [BUGFIX] Fix template files full path being sent in `mimirtool alertmanager load` command. #6138
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/commands/alerts_test.go
+++ b/pkg/mimirtool/commands/alerts_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestReadAlertmanagerConfigTemplates(t *testing.T) {
 	cmd := AlertmanagerCommand{
-		TemplateFiles: []string {
+		TemplateFiles: []string{
 			"./testdata/alertmanager_template.tmpl",
 		},
 	}
@@ -32,7 +32,7 @@ func TestReadAlertmanagerConfigTemplates(t *testing.T) {
 
 func TestReadAlertmanagerConfigTemplates_collidingNames(t *testing.T) {
 	cmd := AlertmanagerCommand{
-		TemplateFiles: []string {
+		TemplateFiles: []string{
 			"./testdata/alertmanager_template.tmpl",
 			"./testdata/otherdir/alertmanager_template.tmpl",
 		},

--- a/pkg/mimirtool/commands/alerts_test.go
+++ b/pkg/mimirtool/commands/alerts_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAlertmanagerConfigTemplates(t *testing.T) {
+	cmd := AlertmanagerCommand{
+		TemplateFiles: []string {
+			"./testdata/alertmanager_template.tmpl",
+		},
+	}
+
+	templates, err := cmd.readAlertManagerConfigTemplates()
+	require.NoError(t, err)
+
+	require.Len(t, templates, 1)
+
+	var keys []string
+	for k := range templates {
+		keys = append(keys, k)
+	}
+
+	assert.Equal(t, "alertmanager_template.tmpl", keys[0])
+	assert.NotEmpty(t, templates[keys[0]])
+}
+
+func TestReadAlertmanagerConfigTemplates_collidingNames(t *testing.T) {
+	cmd := AlertmanagerCommand{
+		TemplateFiles: []string {
+			"./testdata/alertmanager_template.tmpl",
+			"./testdata/otherdir/alertmanager_template.tmpl",
+		},
+	}
+
+	_, err := cmd.readAlertManagerConfigTemplates()
+	require.Error(t, err)
+}

--- a/pkg/mimirtool/commands/testdata/alertmanager_template.tmpl
+++ b/pkg/mimirtool/commands/testdata/alertmanager_template.tmpl
@@ -1,0 +1,14 @@
+{{ define "my_message" }}[{{ .CommonLabels.alertname }} | {{ .CommonLabels.customer }} | {{ .CommonLabels.environment }}]{{ end }}
+
+{{ define "my_description" }}
+{{ range .Alerts -}}
+Alertname: {{ .Labels.alertname }}
+Severity: {{ .Labels.severity }}
+
+Details:
+• Customer: {{ .Labels.customer }}
+• Environment: {{ .Labels.environment }}
+• Description: {{ .Annotations.description }}
+
+{{ end }}
+{{ end }}

--- a/pkg/mimirtool/commands/testdata/otherdir/alertmanager_template.tmpl
+++ b/pkg/mimirtool/commands/testdata/otherdir/alertmanager_template.tmpl
@@ -1,0 +1,14 @@
+{{ define "my_other_message" }}[{{ .CommonLabels.alertname }} | {{ .CommonLabels.customer }} | {{ .CommonLabels.environment }}]{{ end }}
+
+{{ define "my_other_description" }}
+{{ range .Alerts -}}
+Alertname: {{ .Labels.alertname }}
+Severity: {{ .Labels.severity }}
+
+Details:
+• Customer: {{ .Labels.customer }}
+• Environment: {{ .Labels.environment }}
+• Description: {{ .Annotations.description }}
+
+{{ end }}
+{{ end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Makes sure templates sent to Mimir via the `mimirtool alertmanager load` command don't contain the full path, but instead only file name.

#### Which issue(s) this PR fixes or relates to

Fixes #6137

#### Checklist

- [x] Tests updated
- ~~Documentation added~~ (N/A)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
