### PR TITLE
alertmanager: improve docs for updating tenant configuration

### DIFF
--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -108,7 +108,7 @@ mimirtool alertmanager load <config_file> <template_files>...
 ##### Example
 
 ```bash
-mimirtool alertmanager load ./example_alertmanager_config.yaml example_alertmanager_template.tpl
+mimirtool alertmanager load ./example_alertmanager_config.yaml ./example_alertmanager_template.tpl
 ```
 
 `./example_alertmanager_config.yaml`:
@@ -121,7 +121,7 @@ receivers:
   - name: "example_receiver"
 ```
 
-`example_alertmanager_template.tpl`:
+`./example_alertmanager_template.tpl`:
 
 ```gotemplate
 {{ define "alert_customer_env_message" }}

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -108,7 +108,7 @@ mimirtool alertmanager load <config_file> <template_files>...
 ##### Example
 
 ```bash
-mimirtool alertmanager load ./example_alertmanager_config.yaml
+mimirtool alertmanager load ./example_alertmanager_config.yaml example_alertmanager_template.tpl
 ```
 
 `./example_alertmanager_config.yaml`:
@@ -119,6 +119,14 @@ route:
   group_by: ["example_groupby"]
 receivers:
   - name: "example_receiver"
+```
+
+`example_alertmanager_template.tpl`:
+
+```gotemplate
+{{ define "alert_customer_env_message" }}
+  [{{ .CommonLabels.alertname }} | {{ .CommonLabels.customer }} | {{ .CommonLabels.environment }}]
+{{ end }}
 ```
 
 #### Delete Alertmanager configuration

--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -976,9 +976,11 @@ Requires [authentication](#authentication).
 POST /api/v1/alerts
 ```
 
-Stores or updates the Alertmanager configuration for the authenticated tenant. The Alertmanager configuration is stored in the configured backend object storage.
+Stores or updates the Alertmanager configuration for the authenticated tenant. The Alertmanager configuration is stored in the configured backend object storage and shared between Alertmanager instances.
 
 This endpoint expects the Alertmanager **YAML** configuration in the request body and returns `201` on success.
+
+The names of the templates in `template_files` must be valid file names and not be relative or absolute paths. For example, both `/templates/my-template.tpl` and `./my-template.tpl` are invalid, whereas `my-template.tpl` is valid.
 
 This endpoint can be enabled and disabled via the `-alertmanager.enable-api` CLI flag (or its respective YAML config option).
 

--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -976,11 +976,11 @@ Requires [authentication](#authentication).
 POST /api/v1/alerts
 ```
 
-Stores or updates the Alertmanager configuration for the authenticated tenant. The Alertmanager configuration is stored in the configured backend object storage and shared between Alertmanager instances.
+Stores or updates the Alertmanager configuration for the authenticated tenant. The Alertmanager configuration is stored in the configured backend object storage.
 
 This endpoint expects the Alertmanager **YAML** configuration in the request body and returns `201` on success.
 
-The names of the templates in `template_files` must be valid file names and not be relative or absolute paths. For example, both `/templates/my-template.tpl` and `./my-template.tpl` are invalid, whereas `my-template.tpl` is valid.
+The names of the templates in `template_files` must be valid file names and not contain any path separators. For example, both `/templates/my-template.tpl` and `./my-template.tpl` are invalid, whereas `my-template.tpl` is valid.
 
 This endpoint can be enabled and disabled via the `-alertmanager.enable-api` CLI flag (or its respective YAML config option).
 

--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -75,7 +75,7 @@ func (a *AlertmanagerCommand) Register(app *kingpin.Application, envVars EnvVarN
 	deleteCmd := alertCmd.Command("delete", "Delete the Alertmanager configuration that is currently in the Grafana Mimir Alertmanager.").Action(a.deleteConfig)
 
 	loadalertCmd := alertCmd.Command("load", "Load Alertmanager tenant configuration and template files into Grafana Mimir.").Action(a.loadConfig)
-	loadalertCmd.Arg("config", "Alertmanager configuration to load").Required().StringVar(&a.AlertmanagerConfigFile)
+	loadalertCmd.Arg("config", "Alertmanager configuration file to load").Required().StringVar(&a.AlertmanagerConfigFile)
 	loadalertCmd.Arg("template-files", "The template files to load").ExistingFilesVar(&a.TemplateFiles)
 
 	for _, cmd := range []*kingpin.CmdClause{getAlertsCmd, deleteCmd, loadalertCmd} {


### PR DESCRIPTION
#### What this PR does

https://github.com/grafana/mimir/issues/6137 prompted me to document the behaviour of the `POST /api/v1/alerts` endpoint. This also adds an example of setting a template file via `mimirtool alertmanager load`, but now with a relative path allowed by the changes in https://github.com/grafana/mimir/pull/6138

#### Checklist

- [ ] ~~Tests updated~~
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
