### PR TITLE
Add logrotate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [ENHANCEMENT] Ruler: Fetch secrets used to configure TLS on the Alertmanager client from Vault when `-vault.enabled` is true. #5239
 * [ENHANCEMENT] Query-frontend: added query-sharding support for `group by` aggregation queries. #6024
 * [ENHANCEMENT] Fetch secrets used to configure server-side TLS from Vault when `-vault.enabled` is true. #6052.
+* [ENHANCEMENT] Packaging: add logrotate config file. #6142
 * [BUGFIX] Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. #6032
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100

--- a/packaging/nfpm/mimir/mimir.logrotate
+++ b/packaging/nfpm/mimir/mimir.logrotate
@@ -1,0 +1,10 @@
+/var/log/mimir/mimir.log {
+  compress
+  copytruncate
+  create 0600 root root
+  daily
+  missingok
+  nodelaycompress
+  notifempty
+  rotate 7
+}

--- a/packaging/nfpm/nfpm.jsonnet
+++ b/packaging/nfpm/nfpm.jsonnet
@@ -45,6 +45,11 @@ local overrides = {
         dst: '/etc/mimir/runtime_config.yml',
         type: 'config|noreplace',
       },
+      {
+        src: './dist/tmp/dependencies-%s-%s-%s/mimir.logrotate' % [name, packager, arch],
+        dst: '/etc/logrotate.d/mimir',
+        type: 'config|noreplace',
+      },
     ],
     scripts: {
       postinstall: './dist/tmp/dependencies-%s-%s-%s/postinstall.sh' % [name, packager, arch],


### PR DESCRIPTION
#### What this PR does
In case users decide to store Mimir's logs out of journald (e.g. `/var/log/mimir.log`), we want to be sure that Mimir's logs won't fill up the disk.
#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
