### PR TITLE
Query-scheduler: remove unnecessary cleanup after graceful querier shutdown notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * [ENHANCEMENT] Packaging: add logrotate config file. #6142
 * [BUGFIX] Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. #6032
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
-* [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100
+* [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145
 
 ### Mixin
 

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -153,11 +153,9 @@ func (q *RequestQueue) dispatcherLoop() {
 				queues.notifyQuerierShutdown(qe.querierID)
 				needToDispatchQueries = true
 
-				// Tell any waiting GetNextRequestForQuerier calls for this querier that nothing is coming.
-				// If the querier shuts down without notifying us, this is OK: we'll never mark it as shutting down, so we'll
-				// dispatch a query to GetNextRequestForQuerier and Scheduler.QuerierLoop will try to send the query to it
-				// later. This will fail because the connection is broken, and GetNextRequestForQuerier won't be called again.
-				q.cancelWaitingConnectionsForQuerier(qe.querierID, waitingQuerierConnections)
+				// We don't need to do any cleanup here in response to a graceful shutdown: next time we try to dispatch a query to
+				// this querier, getNextQueueForQuerier will return ErrQuerierShuttingDown and we'll remove the waiting
+				// GetNextRequestForQuerier call from our list.
 			case forgetDisconnected:
 				if queues.forgetDisconnectedQueriers(time.Now()) > 0 {
 					// Removing some queriers may have caused a resharding.
@@ -238,11 +236,11 @@ func (q *RequestQueue) handleEnqueueRequest(queues *queues, r enqueueRequest) er
 // dispatchRequestToQuerier finds and forwards a request to a querier, if a suitable request is available.
 // Returns true if this querier should be removed from the list of waiting queriers (eg. because a request has been forwarded to it), false otherwise.
 func (q *RequestQueue) dispatchRequestToQuerier(queues *queues, querierConn *querierConnection) bool {
-	// If this querier has told us it's shutting down, don't bother trying to find a query request for it.
-	// Terminate GetNextRequestForQuerier with an error now.
 	queue, userID, idx, err := queues.getNextQueueForQuerier(querierConn.lastUserIndex.last, querierConn.querierID)
 	if err != nil {
+		// If this querier has told us it's shutting down, terminate GetNextRequestForQuerier with an error now...
 		querierConn.sendError(err)
+		// ...and remove the waiting GetNextRequestForQuerier call from our list.
 		return true
 	}
 
@@ -274,22 +272,6 @@ func (q *RequestQueue) dispatchRequestToQuerier(queues *queues, querierConn *que
 	}
 
 	return true
-}
-
-func (q *RequestQueue) cancelWaitingConnectionsForQuerier(querierID string, waitingQuerierConnections *list.List) {
-	currentElement := waitingQuerierConnections.Front()
-
-	for currentElement != nil {
-		querierConn := currentElement.Value.(*querierConnection)
-		nextElement := currentElement.Next() // We have to capture the next element before calling Remove(), as Remove() clears it.
-
-		if querierConn.querierID == querierID {
-			querierConn.sendError(ErrQuerierShuttingDown)
-			waitingQuerierConnections.Remove(currentElement)
-		}
-
-		currentElement = nextElement
-	}
 }
 
 // EnqueueRequest puts the request into the queue. maxQueries is user-specific value that specifies how many queriers can

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -184,7 +184,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBe
 	assert.GreaterOrEqual(t, waitTime.Milliseconds(), forgetDelay.Milliseconds())
 }
 
-func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnAfterGracefulShutdownNotification(t *testing.T) {
+func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnAfterContextCancelled(t *testing.T) {
 	const forgetDelay = 3 * time.Second
 	const querierID = "querier-1"
 
@@ -193,26 +193,26 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnAfterGracefulShutdown
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
 
-	ctx := context.Background()
-	require.NoError(t, services.StartAndAwaitRunning(ctx, queue))
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), queue))
 	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(ctx, queue))
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), queue))
 	})
 
 	queue.RegisterQuerierConnection(querierID)
 	errChan := make(chan error)
+	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		_, _, err := queue.GetNextRequestForQuerier(context.Background(), FirstUser(), querierID)
+		_, _, err := queue.GetNextRequestForQuerier(ctx, FirstUser(), querierID)
 		errChan <- err
 	}()
 
 	time.Sleep(20 * time.Millisecond) // Wait for GetNextRequestForQuerier to be waiting for a query.
-	queue.NotifyQuerierShutdown(querierID)
+	cancel()
 
 	select {
 	case err := <-errChan:
-		require.EqualError(t, err, "querier has informed the scheduler it is shutting down")
+		require.Equal(t, context.Canceled, err)
 	case <-time.After(time.Second):
 		require.Fail(t, "gave up waiting for GetNextRequestForQuerierToReturn")
 	}

--- a/pkg/scheduler/queue/user_queues.go
+++ b/pkg/scheduler/queue/user_queues.go
@@ -148,6 +148,8 @@ func (q *queues) getOrAddQueue(userID string, maxQueriers int) *list.List {
 // Finds next queue for the querier. To support fair scheduling between users, client is expected
 // to pass last user index returned by this function as argument. If there was no previous
 // last user index, use -1.
+//
+// getNextQueueForQuerier returns an error if the querier has already notified this scheduler that it is shutting down.
 func (q *queues) getNextQueueForQuerier(lastUserIndex int, querierID string) (*list.List, string, int, error) {
 	uid := lastUserIndex
 


### PR DESCRIPTION
#### What this PR does

This PR addresses some post-merge feedback on #6100,  https://github.com/grafana/mimir/pull/6100#issuecomment-1736897602:

> But your response prompted another question. Since the context is cancelled promptly, then do we need the extra cleanup in `cancelWaitingConnectionsForQuerier`? For all pending querier connections in `waitingQuerierConnections` we'd eventually hit [this condition](https://github.com/grafana/mimir/blob/a6d8fea3f302996073cb3d7e2868a72d1db833be/pkg/scheduler/queue/queue.go#L243-L247) and then remove the connection from `waitingQuerierConnections`

#### Which issue(s) this PR fixes or relates to

#6100

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
