### PR TITLE
Backport PR 6032 (don't retry rejected queries) to release 2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.10.1
+
+### Grafana Mimir
+
+* [BUGFIX] Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. #6032
+
 ## 2.10.0
 
 ### Grafana Mimir

--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -61,6 +61,8 @@ func (e *apiError) statusCode() int {
 		return http.StatusRequestEntityTooLarge
 	case TypeNotAcceptable:
 		return http.StatusNotAcceptable
+	case TypeUnavailable:
+		return http.StatusServiceUnavailable
 	}
 	return http.StatusInternalServerError
 }
@@ -120,11 +122,11 @@ func IsAPIError(err error) bool {
 func IsNonRetryableAPIError(err error) bool {
 	apiErr := &apiError{}
 	// Reasoning:
-	// TypeNone, TypeUnavailable and TypeNotFound are not used anywhere in Mimir or Prometheus;
-	// TypeTimeout, TypeTooManyRequests, TypeNotAcceptable we presume a retry of the same request will fail in the same way.
+	// TypeNone and TypeNotFound are not used anywhere in Mimir nor Prometheus;
+	// TypeTimeout, TypeTooManyRequests, TypeNotAcceptable, TypeUnavailable we presume a retry of the same request will fail in the same way.
 	// TypeCanceled means something wants us to stop.
 	// TypeExec, TypeBadData and TypeTooLargeEntry are caused by the input data.
-	// TypeInternal can be a 500 error e.g. from querier failing to contact storegateway.
+	// TypeInternal can be a 500 error e.g. from querier failing to contact store-gateway.
 
 	return errors.As(err, &apiErr) && apiErr.Type != TypeInternal
 }

--- a/pkg/api/error/error_test.go
+++ b/pkg/api/error/error_test.go
@@ -19,7 +19,9 @@ func TestAllPrometheusErrorTypeValues(t *testing.T) {
 		errorType := Type(prometheusErrorTypeString)
 		apiError := New(errorType, "").(*apiError)
 
-		if errorType == TypeInternal || errorType == TypeNone || errorType == TypeUnavailable {
+		if errorType == TypeUnavailable {
+			require.Equal(t, http.StatusServiceUnavailable, apiError.statusCode())
+		} else if errorType == TypeInternal || errorType == TypeNone {
 			require.Equal(t, http.StatusInternalServerError, apiError.statusCode())
 		} else {
 			// If this assertion fails, it probably means a new error type has been added to Prometheus' API.

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -258,6 +258,19 @@ func TestDecodeFailedResponse(t *testing.T) {
 		require.True(t, ok, "Error should have an HTTPResponse encoded")
 		require.Equal(t, int32(http.StatusRequestEntityTooLarge), resp.Code)
 	})
+
+	t.Run("service unavailable", func(t *testing.T) {
+		_, err := codec.DecodeResponse(context.Background(), &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(strings.NewReader("something failed")),
+		}, nil, log.NewNopLogger())
+		require.Error(t, err)
+
+		require.True(t, apierror.IsAPIError(err))
+		resp, ok := apierror.HTTPResponseFromError(err)
+		require.True(t, ok, "Error should have an HTTPResponse encoded")
+		require.Equal(t, int32(http.StatusServiceUnavailable), resp.Code)
+	})
 }
 
 func TestPrometheusCodec_DecodeResponse_ContentTypeHandling(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Backport #6032 (Query-frontend: Don't retry on HTTP 503 from ingester limiting) to release 2.10 branch. It was suggested by @colega during the Mimir community call that we include this fix in the 2.10 series, so it can be included in the next patch version.

TODO:

- [x] Test manually

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
