### PR TITLE
Get rid of errMaxSeriesPerMetricLimitExceeded and errMaxSeriesPerUserLimitExceeded

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -29,9 +29,6 @@ var (
 		safeToWrapError("the ingester is currently too busy to process queries, try again later"),
 		http.StatusServiceUnavailable,
 	)
-
-	errMaxSeriesPerMetricLimitExceeded = safeToWrapError("per-metric series limit exceeded")
-	errMaxSeriesPerUserLimitExceeded   = safeToWrapError("per-user series limit exceeded")
 )
 
 type safeToWrap interface {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1012,14 +1012,14 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 			})
 			return true
 
-		case errMaxSeriesPerUserLimitExceeded:
+		case globalerror.MaxSeriesPerUser:
 			stats.perUserSeriesLimitCount++
 			updateFirstPartial(func() error {
 				return i.errorSamplers.maxSeriesPerUserLimitExceeded.WrapError(formatMaxSeriesPerUserError(i.limiter.limits, userID))
 			})
 			return true
 
-		case errMaxSeriesPerMetricLimitExceeded:
+		case globalerror.MaxSeriesPerMetric:
 			stats.perMetricSeriesLimitCount++
 			updateFirstPartial(func() error {
 				return i.errorSamplers.maxSeriesPerMetricLimitExceeded.WrapError(formatMaxSeriesPerMetricError(i.limiter.limits, mimirpb.FromLabelAdaptersToLabelsWithCopy(labels), userID))

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
 	"github.com/grafana/mimir/pkg/util/extract"
+	"github.com/grafana/mimir/pkg/util/globalerror"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 )
 
@@ -274,7 +275,7 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 
 	// Total series limit.
 	if !u.limiter.IsWithinMaxSeriesPerUser(u.userID, int(u.Head().NumSeries())) {
-		return errMaxSeriesPerUserLimitExceeded
+		return globalerror.MaxSeriesPerUser
 	}
 
 	// Series per metric name limit.
@@ -283,7 +284,7 @@ func (u *userTSDB) PreCreation(metric labels.Labels) error {
 		return err
 	}
 	if !u.seriesInMetric.canAddSeriesFor(u.userID, metricName) {
-		return errMaxSeriesPerMetricLimitExceeded
+		return globalerror.MaxSeriesPerMetric
 	}
 
 	return nil


### PR DESCRIPTION
#### What this PR does
This PR gets rid of errors `errMaxSeriesPerMetricLimitExceeded` and `errMaxSeriesPerUserLimitExceeded`, which are redundant, and can be replaced with `globalerror.MaxSeriesPerMetric` and `globalerror.MaxSeriesPerUser`.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/1900, https://github.com/grafana/mimir/issues/6008

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
