### PR TITLE
Refactoring: change the signature of push.Func function

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -32,7 +32,6 @@ import (
 	frontendv2 "github.com/grafana/mimir/pkg/frontend/v2"
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
 	"github.com/grafana/mimir/pkg/ingester/client"
-	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/ruler"
 	"github.com/grafana/mimir/pkg/scheduler"
@@ -252,7 +251,7 @@ type Ingester interface {
 	FlushHandler(http.ResponseWriter, *http.Request)
 	ShutdownHandler(http.ResponseWriter, *http.Request)
 	PrepareShutdownHandler(http.ResponseWriter, *http.Request)
-	PushWithCleanup(context.Context, *push.Request) (*mimirpb.WriteResponse, error)
+	PushWithCleanup(context.Context, *push.Request) error
 	UserRegistryHandler(http.ResponseWriter, *http.Request)
 	TenantsHandler(http.ResponseWriter, *http.Request)
 	TenantTSDBHandler(http.ResponseWriter, *http.Request)

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -36,7 +36,7 @@ func (i *ActivityTrackerWrapper) Push(ctx context.Context, request *mimirpb.Writ
 	return i.ing.Push(ctx, request)
 }
 
-func (i *ActivityTrackerWrapper) PushWithCleanup(ctx context.Context, r *push.Request) (*mimirpb.WriteResponse, error) {
+func (i *ActivityTrackerWrapper) PushWithCleanup(ctx context.Context, r *push.Request) error {
 	// No tracking in PushWithCleanup
 	return i.ing.PushWithCleanup(ctx, r)
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1215,7 +1215,7 @@ func TestIngester_Push(t *testing.T) {
 			// Push timeseries
 			for idx, req := range testData.reqs {
 				// Push metrics to the ingester. Override the default cleanup method of mimirpb.ReuseSlice with a no-op one.
-				_, err := i.PushWithCleanup(ctx, push.NewParsedRequest(req))
+				err := i.PushWithCleanup(ctx, push.NewParsedRequest(req))
 
 				// We expect no error on any request except the last one
 				// which may error (and in that case we assert on it)

--- a/pkg/util/push/push.go
+++ b/pkg/util/push/push.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Func defines the type of the push. It is similar to http.HandlerFunc.
-type Func func(ctx context.Context, req *Request) (*mimirpb.WriteResponse, error)
+type Func func(ctx context.Context, req *Request) error
 
 // parserFunc defines how to read the body the request from an HTTP request
 type parserFunc func(ctx context.Context, r *http.Request, maxSize int, buffer []byte, req *mimirpb.PreallocWriteRequest) ([]byte, error)
@@ -115,7 +115,7 @@ func handler(maxRecvMsgSize int,
 			return &req.WriteRequest, cleanup, nil
 		}
 		req := newRequest(supplier)
-		if _, err := push(ctx, req); err != nil {
+		if err := push(ctx, req); err != nil {
 			if errors.Is(err, context.Canceled) {
 				http.Error(w, err.Error(), statusClientClosedRequest)
 				level.Warn(logger).Log("msg", "push request canceled", "err", err)

--- a/pkg/util/push/push_test.go
+++ b/pkg/util/push/push_test.go
@@ -730,6 +730,12 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 		expectedHTTPStatus int
 	}{
 		{
+			name:               "no error during push gets translated into a HTTP 200",
+			parserError:        false,
+			err:                nil,
+			expectedHTTPStatus: http.StatusOK,
+		},
+		{
 			name:               "a generic error during request parsing gets an HTTP 400",
 			parserError:        true,
 			err:                fmt.Errorf("something went wrong during the request parsing"),


### PR DESCRIPTION
#### What this PR does
This PR changes the signature of the `push.Func` function from
```
type Func func(ctx context.Context, req *Request) (*mimirpb.WriteResponse(), error)
```
to
```
type Func func(ctx context.Context, req *Request) error
```
The main reason for this change is that all implementations of `push.Func()` actually return:
- `&mimirpb.WriteResponse()` in the case of no error, or 
- `nil` in the case of error.

This logic has been moved to the topmost callers of `push.Func()`, which are mostly `ingester.Push()` and `distributor.Push()`.

This refactoring is just a preliminary change needed for a bigger refactoring and improving of intester's and distributor's write path error handling.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/1900, https://github.com/grafana/mimir/issues/6008

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
