### PR TITLE
Update Vault Auth YAML fields to be consistent with CLI flags

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -9472,7 +9472,7 @@
             },
             {
               "kind": "block",
-              "name": "app_role",
+              "name": "approle",
               "required": false,
               "desc": "",
               "blockEntries": [
@@ -9580,7 +9580,7 @@
             },
             {
               "kind": "block",
-              "name": "user_pass",
+              "name": "userpass",
               "required": false,
               "desc": "",
               "blockEntries": [

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -239,7 +239,7 @@ vault:
     # CLI flag: -vault.auth.type
     [type: <string> | default = ""]
 
-    app_role:
+    approle:
       # (experimental) Role ID of the AppRole
       # CLI flag: -vault.auth.approle.role-id
       [role_id: <string> | default = ""]
@@ -279,7 +279,7 @@ vault:
       # CLI flag: -vault.auth.kubernetes.mount-path
       [mount_path: <string> | default = ""]
 
-    user_pass:
+    userpass:
       # (experimental) The userpass auth method username
       # CLI flag: -vault.auth.userpass.username
       [username: <string> | default = ""]

--- a/pkg/vault/auth.go
+++ b/pkg/vault/auth.go
@@ -36,9 +36,9 @@ type authMethod interface {
 type AuthConfig struct {
 	AuthType string `yaml:"type" category:"experimental"`
 
-	AuthAppRole    AuthAppRole    `yaml:"app_role,omitempty" category:"experimental"`
+	AuthAppRole    AuthAppRole    `yaml:"approle,omitempty" category:"experimental"`
 	AuthKubernetes AuthKubernetes `yaml:"kubernetes,omitempty" category:"experimental"`
-	AuthUserPass   AuthUserPass   `yaml:"user_pass,omitempty" category:"experimental"`
+	AuthUserPass   AuthUserPass   `yaml:"userpass,omitempty" category:"experimental"`
 	AuthToken      AuthToken      `yaml:"token,omitempty" category:"experimental"`
 }
 


### PR DESCRIPTION
YAML is `user_pass` and `app_role` whereas CLI flags are `userpass` and `approle` - updating so they are both consistent