### PR TITLE
Bump alpine/helm from 3.11.1 to 3.13.0 in /mimir-build-image

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
+        # Temporarily downgrade from v3, since it fails to authenticate (might need a Docker Hub personal access token instead of password)
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        # Temporarily downgrade from v3, since it fails to authenticate (might need a Docker Hub personal access token instead of password)
+        # Temporarily downgrade from v3, since it fails to authenticate
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr5960-facaa1c135
+LATEST_BUILD_IMAGE_TAG ?= pr6188-f9147daefa
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -4,7 +4,7 @@
 # Provenance-includes-copyright: The Cortex Authors.
 
 FROM k8s.gcr.io/kustomize/kustomize:v4.5.5 as kustomize
-FROM alpine/helm:3.11.1 as helm
+FROM alpine/helm:3.13.0 as helm
 FROM golang:1.21.1-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->
https://github.com/grafana/mimir/pull/6180/files update build-image failed because bug of docker/login-action@v3, there is a similar ticket opened in repo https://github.com/docker/login-action/issues/606, ~~fallback github action~~ downgrade to docker/login-action v2 to unblock docker image update.

See failed build https://github.com/grafana/mimir/pull/6180
#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
