### PR TITLE
storegateway: use slice ref in raw chunk reader

### DIFF
--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -166,7 +166,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesChunks, 
 			return errors.Wrap(err, "read chunk")
 		}
 
-		err = populateChunk(&(res[pIdx.seriesEntry].chks[pIdx.chunkEntry]), rawChunk(cb))
+		err = populateChunk(&(res[pIdx.seriesEntry].chks[pIdx.chunkEntry]), rawChunk{b: &cb})
 		if err != nil {
 			return errors.Wrap(err, "populate chunk")
 		}
@@ -229,26 +229,28 @@ type loadIdx struct {
 // rawChunk is a helper type that wraps a chunk's raw bytes and implements the chunkenc.Chunk
 // interface over it.
 // It is used to Store API responses which don't need to introspect and validate the chunk's contents.
-type rawChunk []byte
-
-func (b rawChunk) Encoding() chunkenc.Encoding {
-	return chunkenc.Encoding(b[0])
+type rawChunk struct {
+	b *[]byte
 }
 
-func (b rawChunk) Bytes() []byte {
-	return b[1:]
+func (c rawChunk) Encoding() chunkenc.Encoding {
+	return chunkenc.Encoding((*c.b)[0])
 }
-func (b rawChunk) Compact() {}
 
-func (b rawChunk) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
+func (c rawChunk) Bytes() []byte {
+	return (*c.b)[1:]
+}
+func (c rawChunk) Compact() {}
+
+func (c rawChunk) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
 	panic("invalid call")
 }
 
-func (b rawChunk) Appender() (chunkenc.Appender, error) {
+func (c rawChunk) Appender() (chunkenc.Appender, error) {
 	panic("invalid call")
 }
 
-func (b rawChunk) NumSamples() int {
+func (c rawChunk) NumSamples() int {
 	panic("invalid call")
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When taking a look at a profile corresponding to a `store-gateway` component in our ops cell, it is noticeable that roughly `~10%` of the total number of allocations occur within the `loadChunks` method itself.

![Screenshot 2023-10-02 at 13 20 10](https://github.com/grafana/mimir/assets/888899/207930c9-bd90-4d8f-8fab-16affe7b3967)


Upon inspecting the source code for that method in the profile view, it is observed that the majority of allocations occur within the invocation of the `populateChunk` function.

```
ROUTINE ======================== github.com/grafana/mimir/pkg/storegateway.(*bucketChunkReader).loadChunks in vendor/github.com/grafana/mimir/pkg/storegateway/bucket_chunk_reader.go
 108420870  270188166 (flat, cum) 21.48% of Total
       ...        ...
 108420870  215100349    169:		err = populateChunk(&(res[pIdx.seriesEntry].chks[pIdx.chunkEntry]), rawChunk(cb))
         .          .    170:		if err != nil {
         .          .    171:			return errors.Wrap(err, "populate chunk")
         .          .    172:		}
```
         
When doing the escape analysis, we confirm that the allocation is taking place when casting the byte slice to `rawChunk` type.

```
pkg/storegateway/bucket_chunk_reader.go:169:79: rawChunk(cb) escapes to heap
```

This is because the byte slice doesn’t fit within the interface value, and so we are forced to make a copy of the passed value and then move a reference to this new value into the interface.

To avoid this unnecessary behavior, this PR modifies the definition of `rawChunk` to hold a reference to a byte slice instead, thus avoiding the unnecessary allocations.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
