### PR TITLE
Propose `promextra.CounterVec` / `promextra.GaugeVec` to reduce allocations

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -5200,7 +5200,7 @@ func TestIngesterCompactAndCloseIdleTSDB(t *testing.T) {
 		return len(i.tsdbs)
 	})
 
-	require.Greater(t, testutil.ToFloat64(i.metrics.idleTsdbChecks.WithLabelValues(string(tsdbIdleClosed))), float64(0))
+	require.Greater(t, testutil.ToFloat64(i.metrics.idleTsdbChecks.WithLabelValue(string(tsdbIdleClosed))), float64(0))
 	i.updateActiveSeries(time.Now())
 	require.Equal(t, int64(0), i.seriesCount.Load()) // Flushing removed all series from memory.
 

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -50,7 +50,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 	if !ok {
 		// Verify that the user can create more metric metadata given we don't have a set for that metric name.
 		if !mm.limiter.IsWithinMaxMetricsWithMetadataPerUser(mm.userID, len(mm.metricToMetadata)) {
-			mm.metrics.discardedMetadataPerUserMetadataLimit.WithLabelValues(mm.userID).Inc()
+			mm.metrics.discardedMetadataPerUserMetadataLimit.WithLabelValue(mm.userID).Inc()
 			return mm.errorSamplers.maxMetadataPerUserLimitExceeded.WrapError(formatMaxMetadataPerUserError(mm.limiter.limits, mm.userID))
 		}
 		set = metricMetadataSet{}
@@ -58,7 +58,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 	}
 
 	if !mm.limiter.IsWithinMaxMetadataPerMetric(mm.userID, len(set)) {
-		mm.metrics.discardedMetadataPerMetricMetadataLimit.WithLabelValues(mm.userID).Inc()
+		mm.metrics.discardedMetadataPerMetricMetadataLimit.WithLabelValue(mm.userID).Inc()
 		return mm.errorSamplers.maxMetadataPerMetricLimitExceeded.WrapError(formatMaxMetadataPerMetricError(mm.limiter.limits, labels.FromStrings(labels.MetricName, metric), mm.userID))
 	}
 
@@ -66,7 +66,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 	_, ok = set[*metadata]
 	if !ok {
 		mm.metrics.memMetadata.Inc()
-		mm.metrics.memMetadataCreatedTotal.WithLabelValues(mm.userID).Inc()
+		mm.metrics.memMetadataCreatedTotal.WithLabelValue(mm.userID).Inc()
 	}
 
 	mm.metricToMetadata[metric][*metadata] = time.Now()
@@ -87,7 +87,7 @@ func (mm *userMetricsMetadata) purge(deadline time.Time) {
 	}
 
 	mm.metrics.memMetadata.Sub(float64(deleted))
-	mm.metrics.memMetadataRemovedTotal.WithLabelValues(mm.userID).Add(float64(deleted))
+	mm.metrics.memMetadataRemovedTotal.WithLabelValue(mm.userID).Add(float64(deleted))
 }
 
 func (mm *userMetricsMetadata) toClientMetadata(req *client.MetricsMetadataRequest) []*mimirpb.MetricMetadata {

--- a/pkg/util/promextra/vec.go
+++ b/pkg/util/promextra/vec.go
@@ -1,0 +1,92 @@
+package promextra
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var pool = sync.Pool{New: func() any {
+	b := make([]string, 2)
+	return &b
+}}
+
+type CounterVec struct {
+	CounterVec *prometheus.CounterVec
+}
+
+func (vec CounterVec) WithLabelValue(val string) prometheus.Counter {
+	values := pool.Get().(*[]string)
+	defer pool.Put(values)
+
+	*values = append((*values)[:0], val)
+
+	return vec.CounterVec.WithLabelValues(*values...)
+}
+
+func (vec CounterVec) WithTwoLabelValues(val1, val2 string) prometheus.Counter {
+	values := pool.Get().(*[]string)
+	defer pool.Put(values)
+
+	*values = append((*values)[:0], val1, val2)
+
+	return vec.CounterVec.WithLabelValues(*values...)
+}
+
+func (vec CounterVec) DeleteLabelValue(val string) {
+	values := pool.Get().(*[]string)
+	defer pool.Put(values)
+
+	*values = append((*values)[:0], val)
+
+	vec.CounterVec.DeleteLabelValues(*values...)
+}
+
+func (vec CounterVec) DeleteTwoLabelValues(val1, val2 string) {
+	values := pool.Get().(*[]string)
+	defer pool.Put(values)
+
+	*values = append((*values)[:0], val1, val2)
+
+	vec.CounterVec.DeleteLabelValues(*values...)
+}
+
+type GaugeVec struct {
+	GaugeVec *prometheus.GaugeVec
+}
+
+func (vec GaugeVec) WithLabelValue(val string) prometheus.Gauge {
+	values := pool.Get().(*[]string)
+	defer pool.Put(values)
+
+	*values = append((*values)[:0], val)
+
+	return vec.GaugeVec.WithLabelValues(*values...)
+}
+
+func (vec GaugeVec) WithTwoLabelValues(val1, val2 string) prometheus.Gauge {
+	values := pool.Get().(*[]string)
+	defer pool.Put(values)
+
+	*values = append((*values)[:0], val1, val2)
+
+	return vec.GaugeVec.WithLabelValues(*values...)
+}
+
+func (vec GaugeVec) DeleteLabelValue(val string) {
+	values := pool.Get().(*[]string)
+	defer pool.Put(values)
+
+	*values = append((*values)[:0], val)
+
+	vec.GaugeVec.DeleteLabelValues(*values...)
+}
+
+func (vec GaugeVec) DeleteTwoLabelValues(val1, val2 string) {
+	values := pool.Get().(*[]string)
+	defer pool.Put(values)
+
+	*values = append((*values)[:0], val1, val2)
+
+	vec.GaugeVec.DeleteLabelValues(*values...)
+}

--- a/pkg/util/promextra/vec.go
+++ b/pkg/util/promextra/vec.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package promextra
 
 import (


### PR DESCRIPTION
#### What this PR does

Each time we call WithLabelValues(...) we have to allocate a slice for that single argument that is immediately thrown away.

These allocations can't be seen on the profiling because it's the caller, not the `WithLabelValues` who performs an allocation, so they're spread across the entire codebase.

I propose to replace that in our hot paths by a wrapper that would reuse that slice through a pool. I replaced the usages in `pkg/ingester/metrics.go` as an example. Other usages would be done in follow up PRs. Most of our usages only need to pass one or two labels, so I did just that.

I didn't embed `prometheus.CounterVec` on purpose: this way it's easier to refactor without missing calls unchanged. I'm also leaving that field exported on purpose, as some usages may still need to access other methods.

I didn't want to spend too much time on naming, I'm open for discussion on that `promvec.Counter` could be another alternative.

#### Which issue(s) this PR fixes or relates to

None, just passing by.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
