### PR TITLE
Improve logging and errors when using ingester and store-gateway chunks streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [ENHANCEMENT] Ingester: use the `PostingsForMatchers()` in-memory cache for label values queries with matchers too. #6151
 * [ENHANCEMENT] Ingester / store-gateway: optimized regex matchers. #6168 #6250
 * [ENHANCEMENT] Distributor: Include ingester IDs in circuit breaker related metrics and logs. #6206
+* [ENHANCEMENT] Querier: improve errors and logging when streaming chunks from ingesters and store-gateways. #6194
 * [BUGFIX] Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. #6032
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -169,12 +169,12 @@ func (s *SeriesChunksStreamReader) GetChunks(seriesIndex uint64) ([]Chunk, error
 					if _, ok := err.(validation.LimitError); ok {
 						return nil, err
 					}
-					return nil, fmt.Errorf("attempted to read series at index %v from stream, but the stream has failed: %w", seriesIndex, err)
+					return nil, fmt.Errorf("attempted to read series at index %v from ingester chunks stream, but the stream has failed: %w", seriesIndex, err)
 				}
 			default:
 			}
 
-			return nil, fmt.Errorf("attempted to read series at index %v from stream, but the stream has already been exhausted", seriesIndex)
+			return nil, fmt.Errorf("attempted to read series at index %v from ingester chunks stream, but the stream has already been exhausted (was expecting %v series)", seriesIndex, s.expectedSeriesCount)
 		}
 
 		s.seriesBatch = batch
@@ -190,7 +190,7 @@ func (s *SeriesChunksStreamReader) GetChunks(seriesIndex uint64) ([]Chunk, error
 	}
 
 	if series.SeriesIndex != seriesIndex {
-		return nil, fmt.Errorf("attempted to read series at index %v from stream, but the stream has series with index %v", seriesIndex, series.SeriesIndex)
+		return nil, fmt.Errorf("attempted to read series at index %v from ingester chunks stream, but the stream has series with index %v", seriesIndex, series.SeriesIndex)
 	}
 
 	return series.Chunks, nil

--- a/pkg/ingester/client/streaming_test.go
+++ b/pkg/ingester/client/streaming_test.go
@@ -153,7 +153,7 @@ func TestSeriesChunksStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 
 	s, err := reader.GetChunks(1)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 1 from stream, but the stream has series with index 0")
+	require.EqualError(t, err, "attempted to read series at index 1 from ingester chunks stream, but the stream has series with index 0")
 }
 
 func TestSeriesChunksStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
@@ -175,7 +175,7 @@ func TestSeriesChunksStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 
 	s, err = reader.GetChunks(1)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 1 from stream, but the stream has already been exhausted")
+	require.EqualError(t, err, "attempted to read series at index 1 from ingester chunks stream, but the stream has already been exhausted (was expecting 1 series)")
 }
 
 func TestSeriesChunksStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) {
@@ -199,7 +199,7 @@ func TestSeriesChunksStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 
 	s, err = reader.GetChunks(1)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 1 from stream, but the stream has failed: expected to receive 3 series, but got EOF after receiving 1 series")
+	require.EqualError(t, err, "attempted to read series at index 1 from ingester chunks stream, but the stream has failed: expected to receive 3 series, but got EOF after receiving 1 series")
 
 	require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed after failure")
 	require.True(t, cleanedUp.Load(), "expected cleanup function to be called")
@@ -223,7 +223,7 @@ func TestSeriesChunksStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 
 	s, err := reader.GetChunks(0)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 0 from stream, but the stream has failed: expected to receive only 1 series, but received at least 3 series")
+	require.EqualError(t, err, "attempted to read series at index 0 from ingester chunks stream, but the stream has failed: expected to receive only 1 series, but received at least 3 series")
 
 	require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed after receiving more series than expected")
 	require.True(t, cleanedUp.Load(), "expected cleanup function to be called")

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -301,12 +301,12 @@ func (s *storeGatewayStreamReader) GetChunks(seriesIndex uint64) ([]storepb.Aggr
 					if _, ok := err.(validation.LimitError); ok {
 						return nil, err
 					}
-					return nil, errors.Wrapf(err, "attempted to read series at index %v from stream, but the stream has failed", seriesIndex)
+					return nil, errors.Wrapf(err, "attempted to read series at index %v from store-gateway chunks stream, but the stream has failed", seriesIndex)
 				}
 			default:
 			}
 
-			return nil, fmt.Errorf("attempted to read series at index %v from stream, but the stream has already been exhausted", seriesIndex)
+			return nil, fmt.Errorf("attempted to read series at index %v from store-gateway chunks stream, but the stream has already been exhausted (was expecting %v series)", seriesIndex, s.expectedSeriesCount)
 		}
 
 		s.chunksBatch = chks.Series
@@ -320,7 +320,7 @@ func (s *storeGatewayStreamReader) GetChunks(seriesIndex uint64) ([]storepb.Aggr
 	}
 
 	if chks.SeriesIndex != seriesIndex {
-		return nil, fmt.Errorf("attempted to read series at index %v from stream, but the stream has series with index %v", seriesIndex, chks.SeriesIndex)
+		return nil, fmt.Errorf("attempted to read series at index %v from store-gateway chunks stream, but the stream has series with index %v", seriesIndex, chks.SeriesIndex)
 	}
 
 	return chks.Chunks, nil

--- a/pkg/querier/block_streaming_test.go
+++ b/pkg/querier/block_streaming_test.go
@@ -407,7 +407,7 @@ func TestStoreGatewayStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 
 	s, err := reader.GetChunks(1)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 1 from stream, but the stream has series with index 0")
+	require.EqualError(t, err, "attempted to read series at index 1 from store-gateway chunks stream, but the stream has series with index 0")
 }
 
 func TestStoreGatewayStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
@@ -426,7 +426,7 @@ func TestStoreGatewayStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 
 	s, err = reader.GetChunks(1)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 1 from stream, but the stream has already been exhausted")
+	require.EqualError(t, err, "attempted to read series at index 1 from store-gateway chunks stream, but the stream has already been exhausted (was expecting 1 series)")
 }
 
 func TestStoreGatewayStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) {
@@ -445,7 +445,7 @@ func TestStoreGatewayStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 
 	s, err = reader.GetChunks(1)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 1 from stream, but the stream has failed: expected to receive 3 series, but got EOF after receiving 1 series")
+	require.EqualError(t, err, "attempted to read series at index 1 from store-gateway chunks stream, but the stream has failed: expected to receive 3 series, but got EOF after receiving 1 series")
 
 	require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed after failure")
 }
@@ -466,7 +466,7 @@ func TestStoreGatewayStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 
 	s, err := reader.GetChunks(0)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 0 from stream, but the stream has failed: expected to receive only 1 series, but received at least 3 series")
+	require.EqualError(t, err, "attempted to read series at index 0 from store-gateway chunks stream, but the stream has failed: expected to receive only 1 series, but received at least 3 series")
 
 	require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed after receiving more series than expected")
 }

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -93,7 +93,7 @@ func TestStreamingChunkSeries_StreamReaderReturnsError(t *testing.T) {
 
 	iterator := series.Iterator(nil)
 	require.NotNil(t, iterator)
-	require.EqualError(t, iterator.Err(), "attempted to read series at index 0 from stream, but the stream has already been exhausted")
+	require.EqualError(t, iterator.Err(), "attempted to read series at index 0 from ingester chunks stream, but the stream has already been exhausted (was expecting 0 series)")
 }
 
 func TestStreamingChunkSeries_CreateIteratorTwice(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

This PR makes a number of small improvements to ingester and store-gateway chunks streaming:

* it differentiates between ingester and store-gateway chunks streaming in errors and log messages
* it adds the number of series expected to "stream exhausted" errors
* it logs errors encountered while reading chunks to the querier logs, rather than just attaching them to a trace span

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
