### PR TITLE
[proposal] Flag query blocking proposal as accepted

### DIFF
--- a/docs/proposals/query-blocking.md
+++ b/docs/proposals/query-blocking.md
@@ -14,7 +14,7 @@ draft: true
 
 **Type:** Feature
 
-**Status:** Draft
+**Status:** Accepted
 
 **Related issues/PRs:**
 


### PR DESCRIPTION
#### What this PR does

This PR is a nit and only flag the query blocking proposal as accepted.
The related feature has been implemented via #5609 

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
