### PR TITLE
storegateway: Use prometheus.NewDesc in tests

### DIFF
--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -977,7 +977,7 @@ func numObservationsForSummaries(t *testing.T, summaryName string, metrics dskit
 		summaryData.AddSummary(metric.GetSummary())
 	}
 	m := &dto.Metric{}
-	require.NoError(t, summaryData.Metric(&prometheus.Desc{}).Write(m))
+	require.NoError(t, summaryData.Metric(prometheus.NewDesc("test", "", nil, nil)).Write(m))
 	return m.GetSummary().GetSampleCount()
 }
 
@@ -989,6 +989,6 @@ func numObservationsForHistogram(t *testing.T, histogramName string, metrics dsk
 		histogramData.AddHistogram(metric.GetHistogram())
 	}
 	m := &dto.Metric{}
-	require.NoError(t, histogramData.Metric(&prometheus.Desc{}).Write(m))
+	require.NoError(t, histogramData.Metric(prometheus.NewDesc("test", "", nil, nil)).Write(m))
 	return m.GetHistogram().GetSampleCount()
 }


### PR DESCRIPTION
#### What this PR does
In pkg/storegateway, make sure to use `prometheus.NewDesc` instead of instantiating `prometheus.Desc` directly, in tests. The reason is that with [prometheus/client_golang v1.17](https://github.com/grafana/mimir/pull/6192) these tests segfault, due to lacking (`prometheus.Desc`) initialization.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
