### PR TITLE
Chore: Fix dependabot permission

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -68,6 +68,7 @@ jobs:
           fi
 
       - name: Add Comment to the PR
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
         id: notification
         run: | 
           if [ ${{ steps.check_build.outputs.build }} == 'true' ]; then
@@ -79,7 +80,7 @@ jobs:
           fi
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.compute_hash.outputs.tag }}
           IMAGE: ${{ steps.prepare.outputs.image }}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to
Following a recent update, Dependabot no longer possesses access to secrets, as indicated in this link: https://github.com/dependabot/dependabot-core/issues/3253. Consequently, one viable solution entails incorporating secrets into Dependabot. However, we are restricted to generate additional GitHub tokens due to GitHub's rate limiting on PATs. Alternatively, we can opt to employ "pull_request_target" instead of "pull_request" as another potential solution.

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
