### PR TITLE
Restrict GitHub build image workflow permissions

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -14,6 +14,10 @@ concurrency:
 jobs: 
   build_and_push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Allow PR modification for collaborators, forks should remain read-only
+      pull-requests: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
#### What this PR does
Modify GitHub workflow for publishing build image, so the job only has permission to read repo content and to modify the PR. It doesn't need any other GitHub permissions, so this increases security.

This will also give Dependabot permission to modify the PR, which it doesn't have previously (and breaks the workflow when executed for Dependabot PRs).

If you see [the documentation](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#defining-access-for-the-github_token-scopes), a GitHub workflow can specify non-default permissions for a job. Dependabot should have read-only permissions for the (automatic) GITHUB_TOKEN secret by default, but it should be possible to configure it to have specific write permissions. It should [not be possible](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#changing-the-permissions-in-a-forked-repository) to give forks write permissions, on the other hand (good!). This GitHub [blog post](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/) also explains that Dependabot can be given GitHub write permissions through workflow `permissions` configuration.

_I've tested the same change in a personal (public) repo, and it works as desired. I.e., Dependabot has the GitHub API permission to make PR modifications (comment), but forked repos do not_.

The change is not necessary any longer, as we've migrated from Dependabot to Renovate, but it still increases security by reducing the permission set.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
