### PR TITLE
Make gh pr use PR number in build image publishing workflow

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -70,14 +70,13 @@ jobs:
         id: notification
         run: | 
           if [ ${{ steps.check_build.outputs.build }} == 'true' ]; then
-           gh pr comment $PR_URL --body "**Building new version of mimir-build-image**. After image is built and pushed to Docker Hub, \
+           gh pr comment ${{ github.event.pull_request.number }} --body "**Building new version of mimir-build-image**. After image is built and pushed to Docker Hub, \
            a new commit will automatically be added to this PR with new image version \\\`$IMAGE:$TAG\\\`. This can take up to 1 hour."
           else
             echo "This PR will not trigger a build of mimir-build-image"
-            gh pr comment $PR_URL --body "**Not building new version of mimir-build-image**. This PR modifies \\\`mimir-build-image/Dockerfile\\\`, but the image \\\`$IMAGE:$TAG\\\` already exists."
+            gh pr comment ${{ github.event.pull_request.number }} --body "**Not building new version of mimir-build-image**. This PR modifies \\\`mimir-build-image/Dockerfile\\\`, but the image \\\`$IMAGE:$TAG\\\` already exists."
           fi
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           TAG: ${{ steps.compute_hash.outputs.tag }}
           IMAGE: ${{ steps.prepare.outputs.image }}

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -70,13 +70,14 @@ jobs:
         id: notification
         run: | 
           if [ ${{ steps.check_build.outputs.build }} == 'true' ]; then
-           gh pr comment ${{ github.event.pull_request.number }} --body "**Building new version of mimir-build-image**. After image is built and pushed to Docker Hub, \
+           gh pr comment $PR_NUMBER --body "**Building new version of mimir-build-image**. After image is built and pushed to Docker Hub, \
            a new commit will automatically be added to this PR with new image version \\\`$IMAGE:$TAG\\\`. This can take up to 1 hour."
           else
             echo "This PR will not trigger a build of mimir-build-image"
-            gh pr comment ${{ github.event.pull_request.number }} --body "**Not building new version of mimir-build-image**. This PR modifies \\\`mimir-build-image/Dockerfile\\\`, but the image \\\`$IMAGE:$TAG\\\` already exists."
+            gh pr comment $PR_NUMBER --body "**Not building new version of mimir-build-image**. This PR modifies \\\`mimir-build-image/Dockerfile\\\`, but the image \\\`$IMAGE:$TAG\\\` already exists."
           fi
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           TAG: ${{ steps.compute_hash.outputs.tag }}
           IMAGE: ${{ steps.prepare.outputs.image }}


### PR DESCRIPTION
#### What this PR does
In the GitHub workflow for publishing the Mimir build image, make `gh pr comment` use PR number instead of `$PR_URL`. I'm not even sure if `$PR_URL` is set, it could look as if it should be `$PR_NUMBER`, which is unused.

`gh pr comment` supports both PR numbers and PR URLs. A PR number is clearly the more straightforward option.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
