### PR TITLE
Fixes the source column of store-gateway http page

### DIFF
--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -101,7 +101,7 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		}
 		var sources []string
 		for _, pb := range m.Compaction.Sources {
-			sources = append(parents, pb.String())
+			sources = append(sources, pb.String())
 		}
 		var blockSplitID *uint32
 		if splitCount > 0 {


### PR DESCRIPTION
I was looking at my blocks and there was some duplicate source which is impossible. 

After some digging i found this hidden mistake in the append.