### PR TITLE
feat(alertmanager): support loki alerts GeneratorURL in template functions

### DIFF
--- a/pkg/alertmanager/alertmanager_template_test.go
+++ b/pkg/alertmanager/alertmanager_template_test.go
@@ -44,17 +44,17 @@ func Test_withCustomFunctions(t *testing.T) {
 					GeneratorURL: "http://localhost:9090?foo=bar",
 				},
 			},
-			template:    `{{ queryFormGeneratorURL (index .Alerts 0).GeneratorURL }}`,
+			template:    `{{ queryFromGeneratorURL (index .Alerts 0).GeneratorURL }}`,
 			expectError: true,
 		},
 		{
 			name: "error on URL decoding query in GeneratorURL",
 			alerts: template.Alerts{
 				template.Alert{
-					GeneratorURL: "http://localhost:9090?g0.expr=up{foo=bar}",
+					GeneratorURL: "http://localhost:9090?expr=up{foo=bar}",
 				},
 			},
-			template:    `{{ queryFormGeneratorURL (index .Alerts 0).GeneratorURL }}`,
+			template:    `{{ queryFromGeneratorURL (index .Alerts 0).GeneratorURL }}`,
 			expectError: true,
 		},
 		{
@@ -76,6 +76,16 @@ func Test_withCustomFunctions(t *testing.T) {
 			},
 			template: `{{ grafanaExploreURL "https://foo.bar" "test_datasoruce" "now-12h" "now" (queryFromGeneratorURL (index .Alerts 0).GeneratorURL) }}`,
 			result:   `https://foo.bar/explore?left=` + url.QueryEscape(`{"range":{"from":"now-12h","to":"now"},"queries":[{"datasource":{"type":"prometheus","uid":"test_datasoruce"},"expr":"up{foo!=\"bar\"}","instant":false,"range":true,"refId":"A"}]}`),
+		},
+		{
+			name: "Generate Grafana Explore URL from GeneratorURL query from loki",
+			alerts: template.Alerts{
+				template.Alert{
+					GeneratorURL: `/explore?left={"queries":[{"datasource":{"type":"loki","uid":"loki"},"expr":"up{foo!=\"bar\"}","queryType":"range"}]}`,
+				},
+			},
+			template: `{{ grafanaExploreURL "http://localhost:9090" "test_datasource" "now-12h" "now" (queryFromGeneratorURL (index .Alerts 0).GeneratorURL) }}`,
+			result:   `http://localhost:9090/explore?left=%7B%22range%22%3A%7B%22from%22%3A%22now-12h%22%2C%22to%22%3A%22now%22%7D%2C%22queries%22%3A%5B%7B%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22loki%22%7D%2C%22expr%22%3A%22up%7Bfoo%21%3D%5C%22bar%5C%22%7D%22%2C%22instant%22%3Afalse%2C%22range%22%3Atrue%2C%22refId%22%3A%22A%22%7D%5D%7D`,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Hello,

We used mimir (v2.10.0) and loki (2.9.1), and the loki ruler is configured to send alerts to mimir alertmanager.

In my mimir alertmanager logs, we got this error since the loki upgrade to 2.9.1:

```
Oct 05 09:28:39 mimiralert01.example.com mimir[2867549]: {"caller":"dispatch.go:352","component":"dispatcher","err":"test_preprod_receiver/pagerduty[0]: notify retry canceled due to unrecoverable error after 1 attempts: \"grafana_link\": failed to template \"{{ grafanaExploreURL \\\"https://my-grafana.example.com\\\" \\\"prometheus\\\" \\\"now-1h\\\" \\\"now\\\" (queryFromGeneratorURL (index .Alerts 0).GeneratorURL) }}\": template: :1:105: executing \"\" at <queryFromGeneratorURL (index .Alerts 0).GeneratorURL>: error calling queryFromGeneratorURL: query not found in the generator URL","insight":"true","level":"error","msg":"Notify for alerts failed","num_alerts":1,"ts":"2023-10-05T09:28:39.164215296Z","user":"test"}
```

Before the PR https://github.com/grafana/loki/pull/8500 the loki GeneratorURL was starting with `/graph?g0.expr` and now it is `/explore?left=`, so now we got an error for loki alerts, caused by https://github.com/grafana/mimir/blob/main/pkg/alertmanager/alertmanager_template.go#L68


I would like to extend the mimir alertmanager templating function for `grafanaExploreURL` and `queryFromGeneratorURL` and support the generator url from loki. But I'm not sure that my implementation is the good way, as we can be confused with the alertmanager template function usage like:

```
grafana_link = "{{ grafanaExploreURL \"https://my-grafana.example.com\" \"prometheus\" \"now-1h\" \"now\" (queryFromGeneratorURL (index .Alerts 0).GeneratorURL) }}
```

As it mean that all grafana link will be use the prometheus datasource, except for alerts coming from loki.

Any helps appreciated.

@FUSAKLA as you did a good work with theses functions, maybe you can have a look ?

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
