### PR TITLE
Revert "chore(deps): update github.com/grafana/regexp digest to 6b5c0a4 (main) (#6223)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -266,7 +266,7 @@ replace github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-
 replace gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 
 // We are using our modified version of the upstream GO regexp (branch remotes/origin/speedup-golang-1.19.2)
-replace github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
+replace github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
 
 // Replace goautoneg with a fork until https://github.com/munnerz/goautoneg/pull/5 is merged
 replace github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-20230303030534-7248a2f4c9cc

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ github.com/grafana/mimir-prometheus v0.0.0-20231002103016-8c43257d393c h1:noZPQu
 github.com/grafana/mimir-prometheus v0.0.0-20231002103016-8c43257d393c/go.mod h1:FS+VpDcgSX2unPDcuzLAH4+qdraB8f/Kwy73bYwxFJo=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
-github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd h1:PpuIBO5P3e9hpqBD0O/HjhShYuM6XE0i/lbE6J94kww=
-github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
+github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
+github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=

--- a/vendor/github.com/grafana/regexp/README.md
+++ b/vendor/github.com/grafana/regexp/README.md
@@ -10,3 +10,10 @@ The `main` branch is non-optimised: switch over to [`speedup`](https://github.co
 ## Benchmarks:
 
 ![image](https://user-images.githubusercontent.com/8125524/152182951-856549ed-6044-4285-b799-69b31f598e32.png)
+
+## Links to upstream changes:
+* [regexp: allow patterns with no alternates to be one-pass](https://go-review.googlesource.com/c/go/+/353711)
+* [regexp: speed up onepass prefix check](https://go-review.googlesource.com/c/go/+/354909)
+* [regexp: handle prefix string with fold-case](https://go-review.googlesource.com/c/go/+/358756)
+* [regexp: avoid copying each instruction executed](https://go-review.googlesource.com/c/go/+/355789)
+* [regexp: allow prefix string anchored at beginning](https://go-review.googlesource.com/c/go/+/377294)

--- a/vendor/github.com/grafana/regexp/backtrack.go
+++ b/vendor/github.com/grafana/regexp/backtrack.go
@@ -15,8 +15,9 @@
 package regexp
 
 import (
-	"regexp/syntax"
 	"sync"
+
+	"github.com/grafana/regexp/syntax"
 )
 
 // A job is an entry on the backtracker's job stack. It holds
@@ -336,17 +337,7 @@ func (re *Regexp) backtrack(ib []byte, is string, pos int, ncap int, dstCap []in
 		// but we are not clearing visited between calls to TrySearch,
 		// so no work is duplicated and it ends up still being linear.
 		width := -1
-		for ; pos <= end && width != 0; pos += width {
-			if len(re.prefix) > 0 {
-				// Match requires literal prefix; fast search for it.
-				advance := i.index(re, pos)
-				if advance < 0 {
-					freeBitState(b)
-					return nil
-				}
-				pos += advance
-			}
-
+		for pos <= end && width != 0 {
 			if len(b.cap) > 0 {
 				b.cap[0] = pos
 			}
@@ -355,6 +346,17 @@ func (re *Regexp) backtrack(ib []byte, is string, pos int, ncap int, dstCap []in
 				goto Match
 			}
 			_, width = i.step(pos)
+			pos += width
+
+			if len(re.prefix) > 0 {
+				// Match requires literal prefix; fast search for next occurrence.
+				advance := i.index(re, pos)
+				if advance < 0 {
+					freeBitState(b)
+					return nil
+				}
+				pos += advance
+			}
 		}
 		freeBitState(b)
 		return nil

--- a/vendor/github.com/grafana/regexp/exec.go
+++ b/vendor/github.com/grafana/regexp/exec.go
@@ -6,8 +6,9 @@ package regexp
 
 import (
 	"io"
-	"regexp/syntax"
 	"sync"
+
+	"github.com/grafana/regexp/syntax"
 )
 
 // A queue is a 'sparse array' holding pending threads of execution.
@@ -204,6 +205,8 @@ func (m *machine) match(i input, pos int) bool {
 				// Have match; finished exploring alternatives.
 				break
 			}
+			// Note we don't check foldCase here, because Unicode folding is complicated;
+			// just let it fall through to EqualFold on the whole string.
 			if len(m.re.prefix) > 0 && r1 != m.re.prefixRune && i.canCheckPrefix() {
 				// Match requires literal prefix; fast search for it.
 				advance := i.index(m.re, pos)
@@ -401,45 +404,46 @@ func (re *Regexp) doOnePass(ir io.RuneReader, ib []byte, is string, pos, ncap in
 	}
 
 	m := newOnePassMachine()
+	matched := false
+	i, _ := m.inputs.init(ir, ib, is)
+
+	r, r1 := endOfText, endOfText
+	width, width1 := 0, 0
+	var flag lazyFlag
+	var pc int
+	var inst *onePassInst
+
+	// If there is a simple literal prefix, skip over it.
+	if pos == 0 && len(re.prefix) > 0 && i.canCheckPrefix() {
+		// Match requires literal prefix; fast search for it.
+		if !i.hasPrefix(re) {
+			goto Return
+		}
+		pos += len(re.prefix)
+		pc = int(re.prefixEnd)
+	} else {
+		pc = re.onepass.Start
+	}
+
 	if cap(m.matchcap) < ncap {
 		m.matchcap = make([]int, ncap)
 	} else {
 		m.matchcap = m.matchcap[:ncap]
 	}
 
-	matched := false
 	for i := range m.matchcap {
 		m.matchcap[i] = -1
 	}
 
-	i, _ := m.inputs.init(ir, ib, is)
-
-	r, r1 := endOfText, endOfText
-	width, width1 := 0, 0
 	r, width = i.step(pos)
-	if r != endOfText {
-		r1, width1 = i.step(pos + width)
-	}
-	var flag lazyFlag
 	if pos == 0 {
 		flag = newLazyFlag(-1, r)
 	} else {
 		flag = i.context(pos)
 	}
-	pc := re.onepass.Start
-	inst := &re.onepass.Inst[pc]
 	// If there is a simple literal prefix, skip over it.
-	if pos == 0 && flag.match(syntax.EmptyOp(inst.Arg)) &&
-		len(re.prefix) > 0 && i.canCheckPrefix() {
-		// Match requires literal prefix; fast search for it.
-		if !i.hasPrefix(re) {
-			goto Return
-		}
-		pos += len(re.prefix)
-		r, width = i.step(pos)
+	if r != endOfText {
 		r1, width1 = i.step(pos + width)
-		flag = i.context(pos)
-		pc = int(re.prefixEnd)
 	}
 	for {
 		inst = &re.onepass.Inst[pc]
@@ -526,6 +530,29 @@ func (re *Regexp) doExecute(r io.RuneReader, b []byte, s string, pos int, ncap i
 
 	if r == nil && len(b)+len(s) < re.minInputLen {
 		return nil
+	}
+
+	// Check prefix match before allocating data structures
+	if len(re.prefix) > 0 && r == nil {
+		if re.cond&syntax.EmptyBeginText != 0 { // anchored
+			if b != nil && !(&inputBytes{str: b[pos:]}).hasPrefix(re) {
+				return nil
+			}
+			if s != "" && !(&inputString{str: s[pos:]}).hasPrefix(re) {
+				return nil
+			}
+		} else { // non-anchored
+			var advance int
+			if b != nil {
+				advance = (&inputBytes{str: b}).index(re, pos)
+			} else {
+				advance = (&inputString{str: s}).index(re, pos)
+			}
+			if advance < 0 {
+				return nil
+			}
+			pos += advance
+		}
 	}
 
 	if re.onepass != nil {

--- a/vendor/github.com/grafana/regexp/onepass.go
+++ b/vendor/github.com/grafana/regexp/onepass.go
@@ -5,11 +5,12 @@
 package regexp
 
 import (
-	"regexp/syntax"
 	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/grafana/regexp/syntax"
 )
 
 // "One-pass" regexp execution.
@@ -38,10 +39,10 @@ type onePassInst struct {
 // is the entire match. Pc is the index of the last rune instruction
 // in the string. The OnePassPrefix skips over the mandatory
 // EmptyBeginText
-func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
+func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, foldCase bool, pc uint32) {
 	i := &p.Inst[p.Start]
 	if i.Op != syntax.InstEmptyWidth || (syntax.EmptyOp(i.Arg))&syntax.EmptyBeginText == 0 {
-		return "", i.Op == syntax.InstMatch, uint32(p.Start)
+		return "", i.Op == syntax.InstMatch, false, uint32(p.Start)
 	}
 	pc = i.Out
 	i = &p.Inst[pc]
@@ -51,12 +52,13 @@ func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
 	}
 	// Avoid allocation of buffer if prefix is empty.
 	if iop(i) != syntax.InstRune || len(i.Rune) != 1 {
-		return "", i.Op == syntax.InstMatch, uint32(p.Start)
+		return "", i.Op == syntax.InstMatch, false, uint32(p.Start)
 	}
 
+	foldCase = (syntax.Flags(i.Arg)&syntax.FoldCase != 0)
 	// Have prefix; gather characters.
 	var buf strings.Builder
-	for iop(i) == syntax.InstRune && len(i.Rune) == 1 && syntax.Flags(i.Arg)&syntax.FoldCase == 0 && i.Rune[0] != utf8.RuneError {
+	for iop(i) == syntax.InstRune && len(i.Rune) == 1 && (syntax.Flags(i.Arg)&syntax.FoldCase != 0) == foldCase && i.Rune[0] != utf8.RuneError {
 		buf.WriteRune(i.Rune[0])
 		pc, i = i.Out, &p.Inst[i.Out]
 	}
@@ -65,7 +67,7 @@ func onePassPrefix(p *syntax.Prog) (prefix string, complete bool, pc uint32) {
 		p.Inst[i.Out].Op == syntax.InstMatch {
 		complete = true
 	}
-	return buf.String(), complete, pc
+	return buf.String(), complete, foldCase, pc
 }
 
 // OnePassNext selects the next actionable state of the prog, based on the input character.
@@ -472,12 +474,20 @@ func compileOnePass(prog *syntax.Prog) (p *onePassProg) {
 		syntax.EmptyOp(prog.Inst[prog.Start].Arg)&syntax.EmptyBeginText != syntax.EmptyBeginText {
 		return nil
 	}
-	// every instruction leading to InstMatch must be EmptyEndText
+	hasAlt := false
+	for _, inst := range prog.Inst {
+		if inst.Op == syntax.InstAlt || inst.Op == syntax.InstAltMatch {
+			hasAlt = true
+			break
+		}
+	}
+	// If we have alternates, every instruction leading to InstMatch must be EmptyEndText.
+	// Also, any match on empty text must be $.
 	for _, inst := range prog.Inst {
 		opOut := prog.Inst[inst.Out].Op
 		switch inst.Op {
 		default:
-			if opOut == syntax.InstMatch {
+			if opOut == syntax.InstMatch && hasAlt {
 				return nil
 			}
 		case syntax.InstAlt, syntax.InstAltMatch:

--- a/vendor/github.com/grafana/regexp/regexp.go
+++ b/vendor/github.com/grafana/regexp/regexp.go
@@ -72,12 +72,13 @@ package regexp
 import (
 	"bytes"
 	"io"
-	"regexp/syntax"
 	"strconv"
 	"strings"
 	"sync"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/grafana/regexp/syntax"
 )
 
 // Regexp is the representation of a compiled regular expression.
@@ -94,6 +95,7 @@ type Regexp struct {
 	prefixBytes    []byte         // prefix, as a []byte
 	prefixRune     rune           // first rune in prefix
 	prefixEnd      uint32         // pc for last rune in prefix
+	prefixFoldCase bool           // check prefix case-insensitive
 	mpool          int            // pool for machines
 	matchcap       int            // size of recorded match lengths
 	prefixComplete bool           // prefix is the entire regexp
@@ -199,10 +201,10 @@ func compile(expr string, mode syntax.Flags, longest bool) (*Regexp, error) {
 		minInputLen: minInputLen(re),
 	}
 	if regexp.onepass == nil {
-		regexp.prefix, regexp.prefixComplete = prog.Prefix()
+		regexp.prefix, regexp.prefixComplete, regexp.prefixFoldCase = prog.PrefixAndCase()
 		regexp.maxBitStateLen = maxBitStateLen(prog)
 	} else {
-		regexp.prefix, regexp.prefixComplete, regexp.prefixEnd = onePassPrefix(prog)
+		regexp.prefix, regexp.prefixComplete, regexp.prefixFoldCase, regexp.prefixEnd = onePassPrefix(prog)
 	}
 	if regexp.prefix != "" {
 		// TODO(rsc): Remove this allocation by adding
@@ -404,10 +406,26 @@ func (i *inputString) canCheckPrefix() bool {
 }
 
 func (i *inputString) hasPrefix(re *Regexp) bool {
+	if re.prefixFoldCase {
+		n := len(re.prefix)
+		return len(i.str) >= n && strings.EqualFold(i.str[0:n], re.prefix)
+	}
 	return strings.HasPrefix(i.str, re.prefix)
 }
 
 func (i *inputString) index(re *Regexp, pos int) int {
+	if re.prefixFoldCase {
+		n := len(re.prefix)
+		// Brute-force compare at every position; could replace with sophisticated algo like strings.Index
+		for p := pos; p+n <= len(i.str); {
+			if strings.EqualFold(i.str[p:p+n], re.prefix) {
+				return p - pos
+			}
+			_, w := i.step(p)
+			p += w
+		}
+		return -1
+	}
 	return strings.Index(i.str[pos:], re.prefix)
 }
 
@@ -451,10 +469,26 @@ func (i *inputBytes) canCheckPrefix() bool {
 }
 
 func (i *inputBytes) hasPrefix(re *Regexp) bool {
+	if re.prefixFoldCase {
+		n := len(re.prefixBytes)
+		return len(i.str) >= n && bytes.EqualFold(i.str[0:n], re.prefixBytes)
+	}
 	return bytes.HasPrefix(i.str, re.prefixBytes)
 }
 
 func (i *inputBytes) index(re *Regexp, pos int) int {
+	if re.prefixFoldCase {
+		n := len(re.prefixBytes)
+		// Brute-force compare at every position; could replace with sophisticated algo like bytes.Index
+		for p := pos; p+n <= len(i.str); {
+			if bytes.EqualFold(i.str[p:p+n], re.prefixBytes) {
+				return p - pos
+			}
+			_, w := i.step(p)
+			p += w
+		}
+		return -1
+	}
 	return bytes.Index(i.str[pos:], re.prefixBytes)
 }
 

--- a/vendor/github.com/grafana/regexp/syntax/prog.go
+++ b/vendor/github.com/grafana/regexp/syntax/prog.go
@@ -146,20 +146,37 @@ func (i *Inst) op() InstOp {
 // regexp must start with. Complete is true if the prefix
 // is the entire match.
 func (p *Prog) Prefix() (prefix string, complete bool) {
-	i := p.skipNop(uint32(p.Start))
+	prefix, complete, foldCase := p.PrefixAndCase()
+	if foldCase {
+		return "", false
+	}
+	return prefix, complete
+}
+
+// Prefix returns a literal string that all matches for the
+// regexp must start with. Complete is true if the prefix
+// is the entire match. FoldCase is true if the string should
+// match in upper or lower case.
+func (p *Prog) PrefixAndCase() (prefix string, complete bool, foldCase bool) {
+	i := &p.Inst[p.Start]
+	// Skip any no-op, capturing or begin-text instructions
+	for i.Op == InstNop || i.Op == InstCapture || (i.Op == InstEmptyWidth && EmptyOp(i.Arg)&EmptyBeginText != 0) {
+		i = &p.Inst[i.Out]
+	}
 
 	// Avoid allocation of buffer if prefix is empty.
 	if i.op() != InstRune || len(i.Rune) != 1 {
-		return "", i.Op == InstMatch
+		return "", i.Op == InstMatch, false
 	}
 
 	// Have prefix; gather characters.
 	var buf strings.Builder
-	for i.op() == InstRune && len(i.Rune) == 1 && Flags(i.Arg)&FoldCase == 0 && i.Rune[0] != utf8.RuneError {
+	foldCase = (Flags(i.Arg)&FoldCase != 0)
+	for i.op() == InstRune && len(i.Rune) == 1 && (Flags(i.Arg)&FoldCase != 0) == foldCase && i.Rune[0] != utf8.RuneError {
 		buf.WriteRune(i.Rune[0])
 		i = p.skipNop(i.Out)
 	}
-	return buf.String(), i.Op == InstMatch
+	return buf.String(), i.Op == InstMatch, foldCase
 }
 
 // StartCond returns the leading empty-width conditions that must

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -623,7 +623,7 @@ github.com/grafana/e2e/images
 # github.com/grafana/gomemcache v0.0.0-20230914135007-70d78eaabfe1
 ## explicit; go 1.18
 github.com/grafana/gomemcache/memcache
-# github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd => github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
+# github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
 ## explicit; go 1.17
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
@@ -1500,6 +1500,6 @@ sigs.k8s.io/yaml
 # github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231002103016-8c43257d393c
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
-# github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
+# github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6
 # github.com/munnerz/goautoneg => github.com/charleskorn/goautoneg v0.0.0-20230303030534-7248a2f4c9cc
 # github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956


### PR DESCRIPTION
#### What this PR does

This reverts commit 88a5289fda1d938a9d4df33ab4bba81a1ab25f1f.

See [comment](https://github.com/grafana/mimir/pull/6223#issuecomment-1750831584) as to why.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
