### PR TITLE
Chore: Exclude Commit Update from Auto-Updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,11 @@
         "matchBaseBranches": ["release-2.10","release-2.9"],
         "packagePatterns": ["*"],
         "enabled": false
+      },
+      {
+        "packagePatterns": ["*"],
+        "matchCurrentVersion": "/^v\\d+.\\d+.\\d+-(\\d+\\.)?\\d{14}-[a-f0-9]+/",
+        "enabled": false
       }
     ],
     "branchPrefix": "deps-update/",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR addresses an issue where Renovate was overwriting specific commit replaces with the latest tag from the repository. This behavior could potentially lead to version fallbacks. To mitigate this, we are modifying Renovate to ignore updates related to commit replaces. 

See the test in my personal repo https://github.com/ying-jeanne/mimir/pull/80/files 
#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
