### PR TITLE
Get rid of /ingester/push endpoint

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -259,7 +259,7 @@ type Ingester interface {
 }
 
 // RegisterIngester registers the ingester HTTP and gRPC services.
-func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config, limits *validation.Overrides) {
+func (a *API) RegisterIngester(i Ingester) {
 	client.RegisterIngesterServer(a.server.GRPC, i)
 
 	a.indexPage.AddLinks(dangerousWeight, "Dangerous", []IndexPageLink{
@@ -270,7 +270,6 @@ func (a *API) RegisterIngester(i Ingester, pushConfig distributor.Config, limits
 	a.RegisterRoute("/ingester/flush", http.HandlerFunc(i.FlushHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/ingester/prepare-shutdown", http.HandlerFunc(i.PrepareShutdownHandler), false, true, "GET", "POST", "DELETE")
 	a.RegisterRoute("/ingester/shutdown", http.HandlerFunc(i.ShutdownHandler), false, true, "GET", "POST")
-	a.RegisterRoute("/ingester/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, i.PushWithCleanup), true, false, "POST") // For testing and debugging.
 	a.RegisterRoute("/ingester/tsdb_metrics", http.HandlerFunc(i.UserRegistryHandler), true, true, "GET")
 
 	a.indexPage.AddLinks(defaultWeight, "Ingester", []IndexPageLink{

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -629,7 +629,7 @@ func (t *Mimir) initIngester() (serv services.Service, err error) {
 	if t.ActivityTracker != nil {
 		ing = ingester.NewIngesterActivityTracker(t.Ingester, t.ActivityTracker)
 	}
-	t.API.RegisterIngester(ing, t.Cfg.Distributor, t.Overrides)
+	t.API.RegisterIngester(ing)
 	return nil, nil
 }
 


### PR DESCRIPTION
#### What this PR does

This PR gets rid of the `/ingester/push` endpoint. This endpoint was introduced for testing and debugging, and has not been used. Moreover, it is not a part of the [documented public API](https://grafana.com/docs/mimir/latest/references/http-api/). Therefore, it will be removed.

#### Which issue(s) this PR fixes or relates to

Related to Related to https://github.com/grafana/mimir/issues/1900, https://github.com/grafana/mimir/issues/6008

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
