### PR TITLE
distributor: do inflight checks before reading request (for httpgrpc requests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [ENHANCEMENT] Querier: reduce memory consumed for queries that hit store-gateways. #6348
 * [ENHANCEMENT] Ruler: include corresponding trace ID with log messages associated with rule evaluation. #6379
 * [ENHANCEMENT] Querier: clarify log messages and span events emitted while querying ingesters, and include both ingester name and address when relevant. #6381
+* [ENHANCEMENT] Ingester, Distributor: added experimental support for rejecting push requests received via gRPC before reading them into memory, if ingester or distributor is unable to accept the request. This is activated by using `-ingester.limit-inflight-requests-using-grpc-method-limiter` for ingester, and `-distributor.limit-inflight-requests-using-grpc-method-limiter` for distributor. #5976 #6300
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145
 * [BUGFIX] Ingester: prevent query logic from continuing to execute after queries are canceled. #6085

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1563,6 +1563,17 @@
           "fieldFlag": "distributor.write-requests-buffer-pooling-enabled",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "limit_inflight_requests_using_grpc_method_limiter",
+          "required": false,
+          "desc": "Use experimental method of limiting push requests.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "distributor.limit-inflight-requests-using-grpc-method-limiter",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1117,6 +1117,8 @@ Usage of ./cmd/mimir/mimir:
     	The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.
   -distributor.instance-limits.max-ingestion-rate float
     	Max ingestion rate (samples/sec) that this distributor will accept. This limit is per-distributor, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.
+  -distributor.limit-inflight-requests-using-grpc-method-limiter
+    	[experimental] Use experimental method of limiting push requests.
   -distributor.max-recv-msg-size int
     	Max message size in bytes that the distributors will accept for incoming push requests to the remote write API. If exceeded, the request will be rejected. (default 104857600)
   -distributor.remote-timeout duration

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -145,6 +145,9 @@ The following features are currently experimental:
 - Timeseries Unmarshal caching optimization in distributor (`-timeseries-unmarshal-caching-optimization-enabled`)
 - Reusing buffers for marshalling write requests in distributors (`-distributor.write-requests-buffer-pooling-enabled`)
 - Using a worker pool for handling GRPC requests (`-server.grpc.num-workers`)
+- Limiting inflight requests to Distributor and Ingester via gRPC limiter:
+  - `-distributor.limit-inflight-requests-using-grpc-method-limiter`
+  - `-ingester.limit-inflight-requests-using-grpc-method-limiter`
 
 ## Deprecated features
 

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -882,6 +882,10 @@ instance_limits:
 # (experimental) Enable pooling of buffers used for marshaling write requests.
 # CLI flag: -distributor.write-requests-buffer-pooling-enabled
 [write_requests_buffer_pooling_enabled: <boolean> | default = false]
+
+# (experimental) Use experimental method of limiting push requests.
+# CLI flag: -distributor.limit-inflight-requests-using-grpc-method-limiter
+[limit_inflight_requests_using_grpc_method_limiter: <boolean> | default = false]
 ```
 
 ### ingester

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -227,12 +227,15 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc, userL
 	a.RegisterRoute("/api/v1/user_limits", userLimitsHandler, true, true, "GET")
 }
 
+const PrometheusPushEndpoint = "/api/v1/push"
+const OTLPPushEndpoint = "/otlp/v1/metrics"
+
 // RegisterDistributor registers the endpoints associated with the distributor.
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config, reg prometheus.Registerer, limits *validation.Overrides) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	a.RegisterRoute("/api/v1/push", distributor.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, d.PushWithMiddlewares), true, false, "POST")
-	a.RegisterRoute("/otlp/v1/metrics", distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, reg, d.PushWithMiddlewares), true, false, "POST")
+	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, d.PushWithMiddlewares), true, false, "POST")
+	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, reg, d.PushWithMiddlewares), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -39,8 +39,6 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/cardinality"
 	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
@@ -1035,13 +1033,8 @@ type requestState struct {
 //
 // This method creates requestState object and stores it in the context. This object describes which checks were already performed on the request,
 // and which component is responsible for doing a cleanup.
-//
-// This method returns errors with gRPC status code.
 func (d *Distributor) StartPushRequest(ctx context.Context, requestSize int64) (context.Context, error) {
 	ctx, _, err := d.startPushRequest(ctx, requestSize)
-	if err != nil {
-		return ctx, status.Error(codes.Unavailable, err.Error())
-	}
 	return ctx, err
 }
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -5049,23 +5049,23 @@ func TestStartFinishRequest(t *testing.T) {
 		"too many inflight requests": {
 			inflightRequestsBeforePush:     inflightLimit,
 			inflightRequestsSizeBeforePush: 0,
-			expectedStartSizeKnownError:    status.Error(codes.Unavailable, errMaxInflightRequestsReached.Error()),
-			expectedStartSizeUnknownError:  status.Error(codes.Unavailable, errMaxInflightRequestsReached.Error()),
+			expectedStartSizeKnownError:    errMaxInflightRequestsReached,
+			expectedStartSizeUnknownError:  errMaxInflightRequestsReached,
 			expectedPushError:              errMaxInflightRequestsReached,
 		},
 
 		"too many inflight bytes requests": {
 			inflightRequestsBeforePush:     1,
 			inflightRequestsSizeBeforePush: 2 * inflightBytesLimit,
-			expectedStartSizeKnownError:    status.Error(codes.Unavailable, errMaxInflightRequestsBytesReached.Error()),
+			expectedStartSizeKnownError:    errMaxInflightRequestsBytesReached,
 			expectedStartSizeUnknownError:  nil,
 			expectedPushError:              errMaxInflightRequestsBytesReached,
 		},
 
 		"high ingestion rate": {
 			addIngestionRateBeforePush:    100 * ingestionRateLimit,
-			expectedStartSizeKnownError:   status.Error(codes.Unavailable, errMaxIngestionRateReached.Error()),
-			expectedStartSizeUnknownError: status.Error(codes.Unavailable, errMaxIngestionRateReached.Error()),
+			expectedStartSizeKnownError:   errMaxIngestionRateReached,
+			expectedStartSizeUnknownError: errMaxIngestionRateReached,
 			expectedPushError:             errMaxIngestionRateReached,
 		},
 	}
@@ -5128,10 +5128,11 @@ func TestStartFinishRequest(t *testing.T) {
 						} else {
 							require.ErrorIs(t, err, expectedStartError)
 
-							// Verify that errors returned by StartPushRequest method are true gRPC status errors.
+							// Verify that errors returned by StartPushRequest method are NOT gRPC status errors.
+							// They will be converted to gRPC status by grpcInflightMethodLimiter.
 							require.Error(t, err)
 							_, ok := status.FromError(err)
-							require.True(t, ok)
+							require.False(t, ok)
 						}
 					}
 

--- a/pkg/mimir/grpc_push_check.go
+++ b/pkg/mimir/grpc_push_check.go
@@ -74,9 +74,9 @@ func (g *grpcInflightMethodLimiter) RPCCallStarting(ctx context.Context, methodN
 	if g.getDistributor != nil && methodName == httpgrpcHandleMethod {
 		// Let's check httpgrpc metadata, if present.
 		httpMethod := getSingleMetadata(md, httpgrpc.MetadataMethod)
-		httpUrl := getSingleMetadata(md, httpgrpc.MetadataURL)
+		httpURL := getSingleMetadata(md, httpgrpc.MetadataURL)
 
-		if httpMethod == http.MethodPost && (strings.HasSuffix(httpUrl, api.PrometheusPushEndpoint) || strings.HasSuffix(httpUrl, api.OTLPPushEndpoint)) {
+		if httpMethod == http.MethodPost && (strings.HasSuffix(httpURL, api.PrometheusPushEndpoint) || strings.HasSuffix(httpURL, api.OTLPPushEndpoint)) {
 			dist := g.getDistributor()
 			if dist == nil {
 				return ctx, errNoDistributor

--- a/pkg/mimir/grpc_push_check.go
+++ b/pkg/mimir/grpc_push_check.go
@@ -85,7 +85,7 @@ func (g *grpcInflightMethodLimiter) RPCCallStarting(ctx context.Context, methodN
 
 			ctx, err := dist.StartPushRequest(ctx, msgSize)
 			if err != nil {
-				return ctx, err
+				return ctx, status.Error(codes.Unavailable, err.Error())
 			}
 
 			return context.WithValue(ctx, pushTypeCtxKey, distributorPush), nil

--- a/pkg/mimir/grpc_push_check.go
+++ b/pkg/mimir/grpc_push_check.go
@@ -4,39 +4,57 @@ package mimir
 
 import (
 	"context"
+	"net/http"
+	"strconv"
 
+	"github.com/grafana/dskit/grpcutil"
+	"github.com/grafana/dskit/httpgrpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/grafana/mimir/pkg/api"
 )
 
-type pushReceiver interface {
+type ingesterPushReceiver interface {
 	StartPushRequest() error
 	FinishPushRequest()
 }
 
+// Interface exposed by Distributor.
+type distributorPushReceiver interface {
+	StartPushRequest(ctx context.Context, requestSize int64) (context.Context, error)
+	FinishPushRequest(ctx context.Context)
+}
+
 // getPushReceiver function must be constant -- return same value on each call.
-func newGrpcInflightMethodLimiter(getIngester func() pushReceiver) *grpcInflightMethodLimiter {
-	return &grpcInflightMethodLimiter{getIngester: getIngester}
+func newGrpcInflightMethodLimiter(getIngester func() ingesterPushReceiver, getDistributor func() distributorPushReceiver) *grpcInflightMethodLimiter {
+	return &grpcInflightMethodLimiter{getIngester: getIngester, getDistributor: getDistributor}
 }
 
 // grpcInflightMethodLimiter implements gRPC TapHandle and gRPC stats.Handler.
 type grpcInflightMethodLimiter struct {
-	getIngester func() pushReceiver
+	getIngester    func() ingesterPushReceiver
+	getDistributor func() distributorPushReceiver
 }
 
 type ctxKey int
 
 const (
-	ingesterPushStarted ctxKey = 1
+	pushTypeCtxKey ctxKey = 1
 
-	ingesterPushMethod string = "/cortex.Ingester/Push"
+	ingesterPush    = 1
+	distributorPush = 2
+
+	ingesterPushMethod   string = "/cortex.Ingester/Push"
+	httpgrpcHandleMethod string = "/httpgrpc.HTTP/Handle"
 )
 
 var errNoIngester = status.Error(codes.Unavailable, "no ingester")
+var errNoDistributor = status.Error(codes.Unavailable, "no distributor")
 
-func (g *grpcInflightMethodLimiter) RPCCallStarting(ctx context.Context, methodName string, _ metadata.MD) (context.Context, error) {
-	if methodName == ingesterPushMethod {
+func (g *grpcInflightMethodLimiter) RPCCallStarting(ctx context.Context, methodName string, md metadata.MD) (context.Context, error) {
+	if g.getIngester != nil && methodName == ingesterPushMethod {
 		ing := g.getIngester()
 		if ing == nil {
 			// We return error here, to make sure that RPCCallFinished doesn't get called for this RPC call.
@@ -48,13 +66,61 @@ func (g *grpcInflightMethodLimiter) RPCCallStarting(ctx context.Context, methodN
 			return ctx, status.Error(codes.Unavailable, err.Error())
 		}
 
-		return context.WithValue(ctx, ingesterPushStarted, true), nil
+		return context.WithValue(ctx, pushTypeCtxKey, ingesterPush), nil
 	}
+
+	if g.getDistributor != nil && methodName == httpgrpcHandleMethod {
+		// Let's check httpgrpc metadata, if present.
+		httpMethod := getSingleMetadata(md, httpgrpc.MetadataMethod)
+		httpUrl := getSingleMetadata(md, httpgrpc.MetadataURL)
+		msgSize := getMessageSize(md, grpcutil.MetadataMessageSize)
+
+		if httpMethod == http.MethodPost && (httpUrl == api.PrometheusPushEndpoint || httpUrl == api.OTLPPushEndpoint) {
+			dist := g.getDistributor()
+			if dist == nil {
+				return ctx, errNoDistributor
+			}
+
+			ctx, err := dist.StartPushRequest(ctx, msgSize)
+			if err != nil {
+				return ctx, err
+			}
+
+			return context.WithValue(ctx, pushTypeCtxKey, distributorPush), nil
+		}
+	}
+
 	return ctx, nil
 }
 
 func (g *grpcInflightMethodLimiter) RPCCallFinished(ctx context.Context) {
-	if v, ok := ctx.Value(ingesterPushStarted).(bool); ok && v {
-		g.getIngester().FinishPushRequest()
+	if pt, ok := ctx.Value(pushTypeCtxKey).(int); ok {
+		switch pt {
+		case ingesterPush:
+			g.getIngester().FinishPushRequest()
+
+		case distributorPush:
+			g.getDistributor().FinishPushRequest(ctx)
+		}
 	}
+}
+
+func getMessageSize(md metadata.MD, key string) int64 {
+	s := getSingleMetadata(md, key)
+	if s != "" {
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func getSingleMetadata(md metadata.MD, key string) string {
+	val := md[key]
+	l := len(val)
+	if l == 0 || l > 1 {
+		return ""
+	}
+	return val[0]
 }

--- a/pkg/mimir/grpc_push_check.go
+++ b/pkg/mimir/grpc_push_check.go
@@ -75,7 +75,6 @@ func (g *grpcInflightMethodLimiter) RPCCallStarting(ctx context.Context, methodN
 		// Let's check httpgrpc metadata, if present.
 		httpMethod := getSingleMetadata(md, httpgrpc.MetadataMethod)
 		httpUrl := getSingleMetadata(md, httpgrpc.MetadataURL)
-		msgSize := getMessageSize(md, grpcutil.MetadataMessageSize)
 
 		if httpMethod == http.MethodPost && (strings.HasSuffix(httpUrl, api.PrometheusPushEndpoint) || strings.HasSuffix(httpUrl, api.OTLPPushEndpoint)) {
 			dist := g.getDistributor()
@@ -83,7 +82,7 @@ func (g *grpcInflightMethodLimiter) RPCCallStarting(ctx context.Context, methodN
 				return ctx, errNoDistributor
 			}
 
-			ctx, err := dist.StartPushRequest(ctx, msgSize)
+			ctx, err := dist.StartPushRequest(ctx, getMessageSize(md, grpcutil.MetadataMessageSize))
 			if err != nil {
 				return ctx, status.Error(codes.Unavailable, err.Error())
 			}

--- a/pkg/mimir/grpc_push_check.go
+++ b/pkg/mimir/grpc_push_check.go
@@ -24,7 +24,7 @@ type ingesterPushReceiver interface {
 
 // Interface exposed by Distributor.
 type distributorPushReceiver interface {
-	StartPushRequest(ctx context.Context, requestSize int64) (context.Context, error)
+	StartPushRequest(ctx context.Context, httpgrpcRequestSize int64) (context.Context, error)
 	FinishPushRequest(ctx context.Context)
 }
 

--- a/pkg/mimir/grpc_push_check_test.go
+++ b/pkg/mimir/grpc_push_check_test.go
@@ -6,12 +6,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/dskit/grpcutil"
+	"github.com/grafana/dskit/httpgrpc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/mimir/pkg/api"
 )
 
 func TestGrpcInflightMethodLimiter(t *testing.T) {
-	t.Run("nil push receiver", func(t *testing.T) {
-		l := newGrpcInflightMethodLimiter(func() pushReceiver { return nil })
+	t.Run("nil ingester and distributor receiver", func(t *testing.T) {
+		l := newGrpcInflightMethodLimiter(func() ingesterPushReceiver { return nil }, func() distributorPushReceiver { return nil })
 
 		ctx, err := l.RPCCallStarting(context.Background(), "test", nil)
 		require.NoError(t, err)
@@ -21,16 +26,25 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 
 		ctx, err = l.RPCCallStarting(context.Background(), ingesterPushMethod, nil)
 		require.ErrorIs(t, err, errNoIngester)
+
+		ctx, err = l.RPCCallStarting(context.Background(), httpgrpcHandleMethod, metadata.Pairs(httpgrpc.MetadataMethod, "POST", httpgrpc.MetadataURL, api.PrometheusPushEndpoint))
+		require.ErrorIs(t, err, errNoDistributor)
+
 		require.Panics(t, func() {
-			// In practice, this will not be called, since l.RPCCallStarting(ingesterPushMethod) returns error.
-			l.RPCCallFinished(context.WithValue(ctx, ingesterPushStarted, true))
+			// In practice, this will not be called, since l.RPCCallStarting() for ingester push returns error if there's no ingester.
+			l.RPCCallFinished(context.WithValue(ctx, pushTypeCtxKey, ingesterPush))
+		})
+
+		require.Panics(t, func() {
+			// In practice, this will not be called, since l.RPCCallStarting() distributor push returns error if there's no distributor.
+			l.RPCCallFinished(context.WithValue(ctx, pushTypeCtxKey, distributorPush))
 		})
 	})
 
-	t.Run("push receiver, no error", func(t *testing.T) {
-		m := &mockPushReceiver{startErr: nil}
+	t.Run("ingester push receiver", func(t *testing.T) {
+		m := &mockIngesterReceiver{}
 
-		l := newGrpcInflightMethodLimiter(func() pushReceiver { return m })
+		l := newGrpcInflightMethodLimiter(func() ingesterPushReceiver { return m }, nil)
 
 		ctx, err := l.RPCCallStarting(context.Background(), "test", nil)
 		require.NoError(t, err)
@@ -51,20 +65,111 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 		require.Equal(t, 1, m.startCalls)
 		require.Equal(t, 1, m.finishCalls)
 	})
+
+	t.Run("distributor push via httpgrpc", func(t *testing.T) {
+		m := &mockDistributorReceiver{}
+
+		l := newGrpcInflightMethodLimiter(nil, func() distributorPushReceiver { return m })
+
+		ctx, err := l.RPCCallStarting(context.Background(), "test", nil)
+		require.NoError(t, err)
+		l.RPCCallFinished(ctx)
+		require.Equal(t, 0, m.startCalls)
+		require.Equal(t, 0, m.finishCalls)
+
+		ctx, err = l.RPCCallStarting(context.Background(), httpgrpcHandleMethod, metadata.New(map[string]string{
+			httpgrpc.MetadataMethod:      "POST",
+			httpgrpc.MetadataURL:         api.PrometheusPushEndpoint,
+			grpcutil.MetadataMessageSize: "123456",
+		}))
+		require.NoError(t, err)
+		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, 0, m.finishCalls)
+		require.Equal(t, int64(123456), m.lastRequestSize)
+
+		// calling finish with empty context does not do any Finish calls.
+		l.RPCCallFinished(context.Background())
+		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, 0, m.finishCalls)
+
+		l.RPCCallFinished(ctx)
+		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, 1, m.finishCalls)
+	})
+
+	t.Run("distributor push via httpgrpc, GET", func(t *testing.T) {
+		m := &mockDistributorReceiver{}
+
+		l := newGrpcInflightMethodLimiter(nil, func() distributorPushReceiver { return m })
+
+		_, err := l.RPCCallStarting(context.Background(), httpgrpcHandleMethod, metadata.New(map[string]string{
+			httpgrpc.MetadataMethod:      "GET",
+			httpgrpc.MetadataURL:         api.PrometheusPushEndpoint,
+			grpcutil.MetadataMessageSize: "123456",
+		}))
+		require.NoError(t, err)
+		require.Equal(t, 0, m.startCalls)
+		require.Equal(t, 0, m.finishCalls)
+		require.Equal(t, int64(0), m.lastRequestSize)
+	})
+
+	t.Run("distributor push via httpgrpc, /hello", func(t *testing.T) {
+		m := &mockDistributorReceiver{}
+		l := newGrpcInflightMethodLimiter(nil, func() distributorPushReceiver { return m })
+
+		_, err := l.RPCCallStarting(context.Background(), httpgrpcHandleMethod, metadata.New(map[string]string{
+			httpgrpc.MetadataMethod:      "POST",
+			httpgrpc.MetadataURL:         "/hello",
+			grpcutil.MetadataMessageSize: "123456",
+		}))
+		require.NoError(t, err)
+		require.Equal(t, 0, m.startCalls)
+		require.Equal(t, 0, m.finishCalls)
+		require.Equal(t, int64(0), m.lastRequestSize)
+	})
+
+	t.Run("distributor push via httpgrpc, wrong message size", func(t *testing.T) {
+		m := &mockDistributorReceiver{}
+		l := newGrpcInflightMethodLimiter(nil, func() distributorPushReceiver { return m })
+
+		_, err := l.RPCCallStarting(context.Background(), httpgrpcHandleMethod, metadata.New(map[string]string{
+			httpgrpc.MetadataMethod:      "POST",
+			httpgrpc.MetadataURL:         api.OTLPPushEndpoint,
+			grpcutil.MetadataMessageSize: "one-two-three",
+		}))
+		require.NoError(t, err)
+		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, 0, m.finishCalls)
+		require.Equal(t, int64(0), m.lastRequestSize)
+	})
 }
 
-type mockPushReceiver struct {
+type mockIngesterReceiver struct {
 	startCalls  int
 	finishCalls int
-
-	startErr error
 }
 
-func (i *mockPushReceiver) StartPushRequest() error {
+func (i *mockIngesterReceiver) StartPushRequest() error {
 	i.startCalls++
-	return i.startErr
+	return nil
 }
 
-func (i *mockPushReceiver) FinishPushRequest() {
+func (i *mockIngesterReceiver) FinishPushRequest() {
+	i.finishCalls++
+}
+
+type mockDistributorReceiver struct {
+	startCalls      int
+	finishCalls     int
+	lastRequestSize int64
+}
+
+func (i *mockDistributorReceiver) StartPushRequest(ctx context.Context, requestSize int64) (context.Context, error) {
+	i.startCalls++
+	i.lastRequestSize = requestSize
+	return ctx, nil
+}
+
+func (i *mockDistributorReceiver) FinishPushRequest(ctx context.Context) {
 	i.finishCalls++
 }

--- a/pkg/mimir/grpc_push_check_test.go
+++ b/pkg/mimir/grpc_push_check_test.go
@@ -193,6 +193,6 @@ func (i *mockDistributorReceiver) StartPushRequest(ctx context.Context, requestS
 	return ctx, i.returnError
 }
 
-func (i *mockDistributorReceiver) FinishPushRequest(ctx context.Context) {
+func (i *mockDistributorReceiver) FinishPushRequest(_ context.Context) {
 	i.finishCalls++
 }

--- a/pkg/mimir/grpc_push_check_test.go
+++ b/pkg/mimir/grpc_push_check_test.go
@@ -88,7 +88,7 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 
 		ctx, err = l.RPCCallStarting(context.Background(), httpgrpcHandleMethod, metadata.New(map[string]string{
 			httpgrpc.MetadataMethod:      "POST",
-			httpgrpc.MetadataURL:         api.PrometheusPushEndpoint,
+			httpgrpc.MetadataURL:         api.PrometheusPushEndpoint, // no prefix
 			grpcutil.MetadataMessageSize: "123456",
 		}))
 		require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 
 		_, err := l.RPCCallStarting(context.Background(), httpgrpcHandleMethod, metadata.New(map[string]string{
 			httpgrpc.MetadataMethod:      "GET",
-			httpgrpc.MetadataURL:         api.PrometheusPushEndpoint,
+			httpgrpc.MetadataURL:         "prefix" + api.PrometheusPushEndpoint,
 			grpcutil.MetadataMessageSize: "123456",
 		}))
 		require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 
 		_, err := l.RPCCallStarting(context.Background(), httpgrpcHandleMethod, metadata.New(map[string]string{
 			httpgrpc.MetadataMethod:      "POST",
-			httpgrpc.MetadataURL:         api.OTLPPushEndpoint,
+			httpgrpc.MetadataURL:         "prefix" + api.OTLPPushEndpoint,
 			grpcutil.MetadataMessageSize: "one-two-three",
 		}))
 		require.NoError(t, err)


### PR DESCRIPTION
#### What this PR does

This PR implements inflight checks in Distributor by using gRPC method limiter introduced in https://github.com/grafana/dskit/pull/377. This PR relies on unmerged dskit PR https://github.com/grafana/dskit/pull/392 (waiting for new gRPC-go release).

This PR also relies on clients passing the correct metadata headers for httpgrpc requests (using methods introduced in https://github.com/grafana/dskit/pull/391).

To be rebased on top of https://github.com/grafana/mimir/pull/6301, after it's merged.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
