### PR TITLE
Renovate: Ignore github.com/grafana/goautoneg

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
           "github.com/grafana/memberlist",
           "github.com/grafana/regexp",
           "github.com/colega/go-yaml-yaml",
-          "github.com/charleskorn/goautoneg",
+          "github.com/grafana/goautoneg",
           "github.com/grafana/opentracing-contrib-go-stdlib"
         ],
         "enabled": false


### PR DESCRIPTION
#### What this PR does
Configure Renovate to ignore github.com/grafana/goautoneg, since we are now using this instead of github.com/charleskorn/goautoneg. See `replace` directive in go.mod.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
