### PR TITLE
Renovate: Enable only security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,12 @@
     "baseBranches": ["main", "release-2.10", "release-2.9"],
     "packageRules": [
       {
+        "enabled": false,
+        "groupName": "everything",
+        "matchPackagePatterns": ["*"],
+        "separateMajorMinor": false
+      },
+      {
         "matchBaseBranches": ["release-2.10","release-2.9"],
         "packagePatterns": ["*"],
         "enabled": false


### PR DESCRIPTION
#### What this PR does
I propose we enable only security updates for Renovate, since that's how we had configured Dependabot, and Renovate currently makes a lot of PRs to update dependencies.

I followed [this recipe](https://github.com/renovatebot/renovate/discussions/15490) to understand how to enable only security updates in Renovate.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
