### PR TITLE
Renovate: Enable go mod tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
     ],
     "prHourlyLimit": 1,
     "baseBranches": ["main", "release-2.10", "release-2.9"],
+    "postUpdateOptions": [
+      "gomodTidy",
+    ],
     "packageRules": [
       {
         "matchBaseBranches": ["release-2.10","release-2.9"],


### PR DESCRIPTION
#### What this PR does
Enable `go mod tidy` in Renovate PRs to update Go dependencies. Should fix our current problem of these PRs not updating go.sum.

See [documentation](https://docs.renovatebot.com/configuration-options/#postupdateoptions) on the option.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
