### PR TITLE
Renovate: Fix rule for ignoring pinned modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
         "enabled": false
       },
       {
-        "packagePatterns": [
+        "matchPackageNames": [
           "github.com/grafana/mimir-prometheus",
           "github.com/grafana/memberlist",
           "github.com/grafana/regexp",


### PR DESCRIPTION
#### What this PR does
AFAICT, the Renovate rule for ignoring our pinned (via `replace` directives) Go modules is configured wrong. Reading the `packageRules` [documentation](https://docs.renovatebot.com/configuration-options/#packagerules), I don't find a single mention of `packagePatterns`. Instead I find [`matchPackagePaterns`](https://docs.renovatebot.com/configuration-options/#matchpackagepatterns) and [`matchPackageNames`](https://docs.renovatebot.com/configuration-options/#matchpackagenames). I suggest we use `matchPackageNames` since we don't use actual patterns, but full module names.

Please point out if I'm missing something :)

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
