### PR TITLE
Chore: Set renovate PRs only on monday before 9am UTC timezone

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
       "gomodTidy"
     ],
     "schedule": ["before 9am on Monday"],
+    "vulnerabilityAlerts": {
+        "schedule": null
+    }
     "packageRules": [
       {
         "matchBaseBranches": ["release-2.10","release-2.9"],

--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,6 @@
     ],
     "branchPrefix": "deps-update/",
     "vulnerabilityAlerts": {
-      "schedule": null,
       "enabled": true,
       "labels": ["security-update"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,6 @@
       "gomodTidy"
     ],
     "schedule": ["before 9am on Monday"],
-    "vulnerabilityAlerts": {
-        "schedule": null
-    }
     "packageRules": [
       {
         "matchBaseBranches": ["release-2.10","release-2.9"],
@@ -31,6 +28,7 @@
     ],
     "branchPrefix": "deps-update/",
     "vulnerabilityAlerts": {
+      "schedule": null,
       "enabled": true,
       "labels": ["security-update"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,11 @@
     "extends": [
       "config:base"
     ],
-    "prHourlyLimit": 1,
     "baseBranches": ["main", "release-2.10", "release-2.9"],
     "postUpdateOptions": [
-      "gomodTidy",
+      "gomodTidy"
     ],
+    "schedule": ["before 9am on Monday"],
     "packageRules": [
       {
         "matchBaseBranches": ["release-2.10","release-2.9"],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Since we activate renovate, it updates dependency whenever new version released, it could be noisy, instead we do update only on every Monday before 9am. And security update would be anytime.  based on this thread https://github.com/renovatebot/renovate/issues/1567 and related doc https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
