### PR TITLE
Continue returning previous error message if a chunks stream fails but the PromQL engine continues consuming series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [ENHANCEMENT] Querier: improve errors and logging when streaming chunks from ingesters and store-gateways. #6194 #6309
 * [ENHANCEMENT] All: added an experimental `-server.grpc.num-workers` flag that configures the number of long-living workers used to process gRPC requests. This could decrease the CPU usage by reducing the number of stack allocations. #6311
 * [ENHANCEMENT] All: improved IPv6 support by using the proper host:port formatting. #6311
+* [ENHANCEMENT] Querier: always return error encountered during chunks streaming, rather than `the stream has already been exhausted`. #6345
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145
 * [BUGFIX] Ingester: prevent query logic from continuing to execute after queries are canceled. #6085

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -42,6 +42,7 @@ type SeriesChunksStreamReader struct {
 
 	seriesBatchChan chan []QueryStreamSeriesChunks
 	errorChan       chan error
+	err             error
 	seriesBatch     []QueryStreamSeriesChunks
 }
 
@@ -160,6 +161,14 @@ func (s *SeriesChunksStreamReader) StartBuffering() {
 // GetChunks returns the chunks for the series with index seriesIndex.
 // This method must be called with monotonically increasing values of seriesIndex.
 func (s *SeriesChunksStreamReader) GetChunks(seriesIndex uint64) ([]Chunk, error) {
+	if s.err != nil {
+		// Why not just return s.err?
+		// GetChunks should not be called once it has previously returned an error.
+		// However, if this does not hold true, this may indicate a bug somewhere else (see https://github.com/grafana/mimir-prometheus/pull/540 for an example).
+		// So it's valuable to return a slightly different error to indicate that something's not quite right if GetChunks is called after it's previously returned an error.
+		return nil, fmt.Errorf("attempted to read series at index %v from ingester chunks stream, but the stream previously failed and returned an error: %w", seriesIndex, s.err)
+	}
+
 	if len(s.seriesBatch) == 0 {
 		batch, channelOpen := <-s.seriesBatchChan
 
@@ -168,6 +177,7 @@ func (s *SeriesChunksStreamReader) GetChunks(seriesIndex uint64) ([]Chunk, error
 			select {
 			case err, haveError := <-s.errorChan:
 				if haveError {
+					s.err = err
 					if _, ok := err.(validation.LimitError); ok {
 						return nil, err
 					}

--- a/pkg/ingester/client/streaming_test.go
+++ b/pkg/ingester/client/streaming_test.go
@@ -277,6 +277,14 @@ func TestSeriesChunksStreamReader_ChunksLimits(t *testing.T) {
 
 			require.Eventually(t, mockClient.closed.Load, time.Second, 10*time.Millisecond, "expected gRPC client to be closed")
 			require.True(t, cleanedUp.Load(), "expected cleanup function to be called")
+
+			if testCase.expectedError != "" {
+				// Ensure we continue to return the error, even for subsequent calls to GetChunks.
+				_, err := reader.GetChunks(1)
+				require.EqualError(t, err, "attempted to read series at index 1 from ingester chunks stream, but the stream previously failed and returned an error: "+testCase.expectedError)
+				_, err = reader.GetChunks(2)
+				require.EqualError(t, err, "attempted to read series at index 2 from ingester chunks stream, but the stream previously failed and returned an error: "+testCase.expectedError)
+			}
 		})
 	}
 }

--- a/pkg/querier/block_streaming_test.go
+++ b/pkg/querier/block_streaming_test.go
@@ -520,6 +520,14 @@ func TestStoreGatewayStreamReader_ChunksLimits(t *testing.T) {
 			}
 
 			require.Eventually(t, mockClient.closed.Load, time.Second, 10*time.Millisecond, "expected gRPC client to be closed")
+
+			if testCase.expectedError != "" {
+				// Ensure we continue to return the error, even for subsequent calls to GetChunks.
+				_, err := reader.GetChunks(1)
+				require.EqualError(t, err, "attempted to read series at index 1 from store-gateway chunks stream, but the stream previously failed and returned an error: "+testCase.expectedError)
+				_, err = reader.GetChunks(2)
+				require.EqualError(t, err, "attempted to read series at index 2 from store-gateway chunks stream, but the stream previously failed and returned an error: "+testCase.expectedError)
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes the issue where a query executed with either form of chunks streaming enabled can fail with a `attempted to read series at index XXX from stream, but the stream has already been exhausted` error if streaming chunks fails for some reason (eg. hitting a limit), and the PromQL engine continues consuming series, ignoring the error when it is initially returned.

This _shouldn't_ happen (the PromQL engine should stop after the first failure), but https://github.com/grafana/mimir-prometheus/pull/540 is an example of a case where this didn't hold true.

This PR won't fix the issue of the PromQL engine not stopping, but it does improve the user experience to include the original error, rather than the generic `stream has already been exhausted` error.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
