### PR TITLE
Improve performance of labels comparison when querying store-gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [ENHANCEMENT] All: improved IPv6 support by using the proper host:port formatting. #6311
 * [ENHANCEMENT] Querier: always return error encountered during chunks streaming, rather than `the stream has already been exhausted`. #6345
 * [ENHANCEMENT] Query-frontend: add `instance_enable_ipv6` to support IPv6. #6111
+* [ENHANCEMENT] Querier: reduce memory consumed for queries that hit store-gateways. #6348
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145
 * [BUGFIX] Ingester: prevent query logic from continuing to execute after queries are canceled. #6085

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -62,7 +62,7 @@ func (bqss *blockQuerierSeriesSet) Next() bool {
 		return false
 	}
 
-	currLabels := mimirpb.FromLabelAdaptersToLabels(bqss.series[bqss.next].Labels)
+	currLabels := bqss.series[bqss.next].Labels
 	currChunks := bqss.series[bqss.next].Chunks
 
 	bqss.next++
@@ -70,12 +70,12 @@ func (bqss *blockQuerierSeriesSet) Next() bool {
 	// Merge chunks for current series. Chunks may come in multiple responses, but as soon
 	// as the response has chunks for a new series, we can stop searching. Series are sorted.
 	// See documentation for StoreClient.Series call for details.
-	for bqss.next < len(bqss.series) && labels.Compare(currLabels, mimirpb.FromLabelAdaptersToLabels(bqss.series[bqss.next].Labels)) == 0 {
+	for bqss.next < len(bqss.series) && mimirpb.CompareLabelAdapters(currLabels, bqss.series[bqss.next].Labels) == 0 {
 		currChunks = append(currChunks, bqss.series[bqss.next].Chunks...)
 		bqss.next++
 	}
 
-	bqss.currSeries = newBlockQuerierSeries(currLabels, currChunks)
+	bqss.currSeries = newBlockQuerierSeries(mimirpb.FromLabelAdaptersToLabels(currLabels), currChunks)
 	return true
 }
 

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -48,18 +48,18 @@ func (bqss *blockStreamingQuerierSeriesSet) Next() bool {
 		return false
 	}
 
-	currLabels := mimirpb.FromLabelAdaptersToLabels(bqss.series[bqss.nextSeriesIndex].Labels)
+	currLabels := bqss.series[bqss.nextSeriesIndex].Labels
 	seriesIdxStart := bqss.nextSeriesIndex // First series in this group. We might merge with more below.
 	bqss.nextSeriesIndex++
 
 	// Chunks may come in multiple responses, but as soon as the response has chunks for a new series,
 	// we can stop searching. Series are sorted. See documentation for StoreClient.Series call for details.
 	// The actually merging of chunks happens in the Iterator() call where chunks are fetched.
-	for bqss.nextSeriesIndex < len(bqss.series) && labels.Compare(currLabels, mimirpb.FromLabelAdaptersToLabels(bqss.series[bqss.nextSeriesIndex].Labels)) == 0 {
+	for bqss.nextSeriesIndex < len(bqss.series) && mimirpb.CompareLabelAdapters(currLabels, bqss.series[bqss.nextSeriesIndex].Labels) == 0 {
 		bqss.nextSeriesIndex++
 	}
 
-	bqss.currSeries = newBlockStreamingQuerierSeries(currLabels, seriesIdxStart, bqss.nextSeriesIndex-1, bqss.streamReader)
+	bqss.currSeries = newBlockStreamingQuerierSeries(mimirpb.FromLabelAdaptersToLabels(currLabels), seriesIdxStart, bqss.nextSeriesIndex-1, bqss.streamReader)
 	return true
 }
 


### PR DESCRIPTION
#### What this PR does

This PR applies https://github.com/grafana/mimir/pull/5836 to two additional places that could benefit from it.

This improves performance when using `stringlabels` (as Mimir does). Note that the existing benchmark includes iterating through all of the samples in the series, which is why there isn't a dramatic latency change in the results below:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/querier
                                    │ before.txt  │             after.txt             │
                                    │   sec/op    │   sec/op     vs base              │
_blockQuerierSeriesSet_iteration-10   812.2m ± 0%   814.8m ± 0%  +0.32% (p=0.009 n=6)

                                    │  before.txt  │             after.txt              │
                                    │     B/op     │     B/op      vs base              │
_blockQuerierSeriesSet_iteration-10   8.426Mi ± 0%   7.694Mi ± 0%  -8.69% (p=0.002 n=6)

                                    │ before.txt  │             after.txt             │
                                    │  allocs/op  │  allocs/op   vs base              │
_blockQuerierSeriesSet_iteration-10   256.0k ± 0%   240.0k ± 0%  -6.25% (p=0.002 n=6)
```



#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
