### PR TITLE
WIP: update build image with Go 1.20.10.

### DIFF
--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM registry.k8s.io/kustomize/kustomize:v5.1.1 as kustomize
 FROM alpine/helm:3.13.0 as helm
-FROM golang:1.21.3-bullseye
+FROM golang:1.20.10-bullseye
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"


### PR DESCRIPTION
#### What this PR does

Update build-image for use in `release-2.9` branch.

This PR is not intended for merging.