### PR TITLE
Get rid of util/push and distributor/distributorerror packages

### DIFF
--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -29,8 +29,8 @@ import (
 	"github.com/prometheus/prometheus/prompb" // OTLP protos are not compatible with gogo
 	yaml "gopkg.in/yaml.v3"
 
+	"github.com/grafana/mimir/pkg/distributor"
 	"github.com/grafana/mimir/pkg/mimirpb"
-	"github.com/grafana/mimir/pkg/util/push"
 )
 
 var ErrNotFound = errors.New("not found")
@@ -141,7 +141,7 @@ func (c *Client) Push(timeseries []prompb.TimeSeries) (*http.Response, error) {
 // PushOTLP the input timeseries to the remote endpoint in OTLP format
 func (c *Client) PushOTLP(timeseries []prompb.TimeSeries, metadata []mimirpb.MetricMetadata) (*http.Response, error) {
 	// Create write request
-	otlpRequest := push.TimeseriesToOTLPRequest(timeseries, metadata)
+	otlpRequest := distributor.TimeseriesToOTLPRequest(timeseries, metadata)
 
 	data, err := otlpRequest.MarshalProto()
 	if err != nil {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -32,6 +32,7 @@ import (
 	frontendv2 "github.com/grafana/mimir/pkg/frontend/v2"
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
 	"github.com/grafana/mimir/pkg/ingester/client"
+	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/ruler"
 	"github.com/grafana/mimir/pkg/scheduler"
@@ -40,7 +41,6 @@ import (
 	"github.com/grafana/mimir/pkg/storegateway/storegatewaypb"
 	"github.com/grafana/mimir/pkg/util/gziphandler"
 	util_log "github.com/grafana/mimir/pkg/util/log"
-	"github.com/grafana/mimir/pkg/util/push"
 	"github.com/grafana/mimir/pkg/util/validation"
 	"github.com/grafana/mimir/pkg/util/validation/exporter"
 )
@@ -231,8 +231,8 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc, userL
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config, reg prometheus.Registerer, limits *validation.Overrides) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	a.RegisterRoute("/api/v1/push", push.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, d.PushWithMiddlewares), true, false, "POST")
-	a.RegisterRoute("/otlp/v1/metrics", push.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, reg, d.PushWithMiddlewares), true, false, "POST")
+	a.RegisterRoute("/api/v1/push", distributor.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, d.PushWithMiddlewares), true, false, "POST")
+	a.RegisterRoute("/otlp/v1/metrics", distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, reg, d.PushWithMiddlewares), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},
@@ -252,7 +252,7 @@ type Ingester interface {
 	FlushHandler(http.ResponseWriter, *http.Request)
 	ShutdownHandler(http.ResponseWriter, *http.Request)
 	PrepareShutdownHandler(http.ResponseWriter, *http.Request)
-	PushWithCleanup(context.Context, *push.Request) error
+	PushWithCleanup(ctx context.Context, req *mimirpb.WriteRequest, cleanUp func()) error
 	UserRegistryHandler(http.ResponseWriter, *http.Request)
 	TenantsHandler(http.ResponseWriter, *http.Request)
 	TenantTSDBHandler(http.ResponseWriter, *http.Request)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -252,7 +252,7 @@ type Ingester interface {
 	FlushHandler(http.ResponseWriter, *http.Request)
 	ShutdownHandler(http.ResponseWriter, *http.Request)
 	PrepareShutdownHandler(http.ResponseWriter, *http.Request)
-	PushWithCleanup(ctx context.Context, req *mimirpb.WriteRequest, cleanUp func()) error
+	PushWithCleanup(context.Context, *mimirpb.WriteRequest, func()) error
 	UserRegistryHandler(http.ResponseWriter, *http.Request)
 	TenantsHandler(http.ResponseWriter, *http.Request)
 	TenantTSDBHandler(http.ResponseWriter, *http.Request)

--- a/pkg/continuoustest/otlp_writer.go
+++ b/pkg/continuoustest/otlp_writer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
 
-	"github.com/grafana/mimir/pkg/util/push"
+	"github.com/grafana/mimir/pkg/distributor"
 )
 
 type otlpHTTPWriter struct {
@@ -26,7 +26,7 @@ type otlpHTTPWriter struct {
 }
 
 func (pw *otlpHTTPWriter) sendWriteRequest(ctx context.Context, req *prompb.WriteRequest) (int, error) {
-	metricRequest := push.TimeseriesToOTLPRequest(req.Timeseries, nil)
+	metricRequest := distributor.TimeseriesToOTLPRequest(req.Timeseries, nil)
 	rawBytes, err := metricRequest.MarshalProto()
 	if err != nil {
 		return 0, err

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -724,12 +724,12 @@ func (d *Distributor) prePushHaDedupeMiddleware(next pushFunc) pushFunc {
 
 		removeReplica, err := d.checkSample(ctx, userID, cluster, replica)
 		if err != nil {
-			if errors.As(err, &ReplicasDidNotMatch{}) {
+			if errors.As(err, &replicasDidNotMatchError{}) {
 				// These samples have been deduped.
 				d.dedupedSamples.WithLabelValues(userID, cluster).Add(float64(numSamples))
 			}
 
-			if errors.As(err, &TooManyClusters{}) {
+			if errors.As(err, &tooManyClustersError{}) {
 				d.discardedSamplesTooManyHaClusters.WithLabelValues(userID, group).Add(float64(numSamples))
 			}
 
@@ -899,7 +899,7 @@ func (d *Distributor) prePushValidationMiddleware(next pushFunc) pushFunc {
 			if validationErr != nil {
 				if firstPartialErr == nil {
 					// The series are never retained by validationErr. This is guaranteed by the way the latter is built.
-					firstPartialErr = NewValidation(validationErr)
+					firstPartialErr = newValidationError(validationErr)
 				}
 				removeIndexes = append(removeIndexes, tsIdx)
 				continue
@@ -920,7 +920,7 @@ func (d *Distributor) prePushValidationMiddleware(next pushFunc) pushFunc {
 			if validationErr := cleanAndValidateMetadata(d.metadataValidationMetrics, d.limits, userID, m); validationErr != nil {
 				if firstPartialErr == nil {
 					// The series are never retained by validationErr. This is guaranteed by the way the latter is built.
-					firstPartialErr = NewValidation(validationErr)
+					firstPartialErr = newValidationError(validationErr)
 				}
 
 				removeIndexes = append(removeIndexes, mIdx)
@@ -942,7 +942,7 @@ func (d *Distributor) prePushValidationMiddleware(next pushFunc) pushFunc {
 			d.discardedSamplesRateLimited.WithLabelValues(userID, group).Add(float64(validatedSamples))
 			d.discardedExemplarsRateLimited.WithLabelValues(userID).Add(float64(validatedExemplars))
 			d.discardedMetadataRateLimited.WithLabelValues(userID).Add(float64(validatedMetadata))
-			return NewIngestionRateLimited(d.limits.IngestionRate(userID), d.limits.IngestionBurstSize(userID))
+			return newIngestionRateLimitedError(d.limits.IngestionRate(userID), d.limits.IngestionBurstSize(userID))
 		}
 
 		// totalN included samples, exemplars and metadata. Ingester follows this pattern when computing its ingestion rate.
@@ -1043,7 +1043,7 @@ func (d *Distributor) limitsMiddleware(next pushFunc) pushFunc {
 		if !d.requestRateLimiter.AllowN(now, userID, 1) {
 			d.discardedRequestsRateLimited.WithLabelValues(userID).Add(1)
 
-			return NewRequestRateLimited(d.limits.RequestRate(userID), d.limits.RequestBurstSize(userID))
+			return newRequestRateLimitedError(d.limits.RequestRate(userID), d.limits.RequestBurstSize(userID))
 		}
 
 		// Note that we don't enforce the per-user ingestion rate limit here since we need to apply validation

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -49,7 +49,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/cardinality"
-	"github.com/grafana/mimir/pkg/distributor/distributorerror"
 	"github.com/grafana/mimir/pkg/ingester"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -189,7 +188,7 @@ func TestDistributor_Push(t *testing.T) {
 			happyIngesters: 3,
 			samples:        samplesIn{num: 25, startTimestampMs: 123456789000},
 			metadata:       5,
-			expectedError:  httpgrpc.Errorf(http.StatusTooManyRequests, distributorerror.NewIngestionRateLimited(20, 20).Error()),
+			expectedError:  httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(20, 20).Error()),
 			metricNames:    []string{lastSeenTimestamp},
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
@@ -487,7 +486,7 @@ func TestDistributor_PushRequestRateLimiter(t *testing.T) {
 			pushes: []testPush{
 				{expectedError: nil},
 				{expectedError: nil},
-				{expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, distributorerror.NewRequestRateLimited(4, 2).Error())},
+				{expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewRequestRateLimited(4, 2).Error())},
 			},
 		},
 		"request limit is disabled when set to 0": {
@@ -508,7 +507,7 @@ func TestDistributor_PushRequestRateLimiter(t *testing.T) {
 				{expectedError: nil},
 				{expectedError: nil},
 				{expectedError: nil},
-				{expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, distributorerror.NewRequestRateLimited(2, 3).Error())},
+				{expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewRequestRateLimited(2, 3).Error())},
 			},
 		},
 		"request limit is reached return 529 when enable service overload error set to true": {
@@ -519,7 +518,7 @@ func TestDistributor_PushRequestRateLimiter(t *testing.T) {
 			pushes: []testPush{
 				{expectedError: nil},
 				{expectedError: nil},
-				{expectedError: httpgrpc.Errorf(distributorerror.StatusServiceOverloaded, distributorerror.NewRequestRateLimited(4, 2).Error())},
+				{expectedError: httpgrpc.Errorf(StatusServiceOverloaded, NewRequestRateLimited(4, 2).Error())},
 			},
 		},
 	}
@@ -580,10 +579,10 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			pushes: []testPush{
 				{samples: 2, expectedError: nil},
 				{samples: 1, expectedError: nil},
-				{samples: 2, metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, distributorerror.NewIngestionRateLimited(10, 5).Error())},
+				{samples: 2, metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 5).Error())},
 				{samples: 2, expectedError: nil},
-				{samples: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, distributorerror.NewIngestionRateLimited(10, 5).Error())},
-				{metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, distributorerror.NewIngestionRateLimited(10, 5).Error())},
+				{samples: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 5).Error())},
+				{metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 5).Error())},
 			},
 		},
 		"for each distributor, set an ingestion burst limit.": {
@@ -593,10 +592,10 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			pushes: []testPush{
 				{samples: 10, expectedError: nil},
 				{samples: 5, expectedError: nil},
-				{samples: 5, metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, distributorerror.NewIngestionRateLimited(10, 20).Error())},
+				{samples: 5, metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 20).Error())},
 				{samples: 5, expectedError: nil},
-				{samples: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, distributorerror.NewIngestionRateLimited(10, 20).Error())},
-				{metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, distributorerror.NewIngestionRateLimited(10, 20).Error())},
+				{samples: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 20).Error())},
+				{metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 20).Error())},
 			},
 		},
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -188,7 +188,7 @@ func TestDistributor_Push(t *testing.T) {
 			happyIngesters: 3,
 			samples:        samplesIn{num: 25, startTimestampMs: 123456789000},
 			metadata:       5,
-			expectedError:  httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(20, 20).Error()),
+			expectedError:  httpgrpc.Errorf(http.StatusTooManyRequests, newIngestionRateLimitedError(20, 20).Error()),
 			metricNames:    []string{lastSeenTimestamp},
 			expectedMetrics: `
 				# HELP cortex_distributor_latest_seen_sample_timestamp_seconds Unix timestamp of latest received sample per user.
@@ -486,7 +486,7 @@ func TestDistributor_PushRequestRateLimiter(t *testing.T) {
 			pushes: []testPush{
 				{expectedError: nil},
 				{expectedError: nil},
-				{expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewRequestRateLimited(4, 2).Error())},
+				{expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, newRequestRateLimitedError(4, 2).Error())},
 			},
 		},
 		"request limit is disabled when set to 0": {
@@ -507,7 +507,7 @@ func TestDistributor_PushRequestRateLimiter(t *testing.T) {
 				{expectedError: nil},
 				{expectedError: nil},
 				{expectedError: nil},
-				{expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewRequestRateLimited(2, 3).Error())},
+				{expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, newRequestRateLimitedError(2, 3).Error())},
 			},
 		},
 		"request limit is reached return 529 when enable service overload error set to true": {
@@ -518,7 +518,7 @@ func TestDistributor_PushRequestRateLimiter(t *testing.T) {
 			pushes: []testPush{
 				{expectedError: nil},
 				{expectedError: nil},
-				{expectedError: httpgrpc.Errorf(StatusServiceOverloaded, NewRequestRateLimited(4, 2).Error())},
+				{expectedError: httpgrpc.Errorf(StatusServiceOverloaded, newRequestRateLimitedError(4, 2).Error())},
 			},
 		},
 	}
@@ -579,10 +579,10 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			pushes: []testPush{
 				{samples: 2, expectedError: nil},
 				{samples: 1, expectedError: nil},
-				{samples: 2, metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 5).Error())},
+				{samples: 2, metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, newIngestionRateLimitedError(10, 5).Error())},
 				{samples: 2, expectedError: nil},
-				{samples: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 5).Error())},
-				{metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 5).Error())},
+				{samples: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, newIngestionRateLimitedError(10, 5).Error())},
+				{metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, newIngestionRateLimitedError(10, 5).Error())},
 			},
 		},
 		"for each distributor, set an ingestion burst limit.": {
@@ -592,10 +592,10 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			pushes: []testPush{
 				{samples: 10, expectedError: nil},
 				{samples: 5, expectedError: nil},
-				{samples: 5, metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 20).Error())},
+				{samples: 5, metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, newIngestionRateLimitedError(10, 20).Error())},
 				{samples: 5, expectedError: nil},
-				{samples: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 20).Error())},
-				{metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, NewIngestionRateLimited(10, 20).Error())},
+				{samples: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, newIngestionRateLimitedError(10, 20).Error())},
+				{metadata: 1, expectedError: httpgrpc.Errorf(http.StatusTooManyRequests, newIngestionRateLimitedError(10, 20).Error())},
 			},
 		},
 	}

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -33,81 +33,81 @@ var (
 	)
 )
 
-// ReplicasDidNotMatch is an error stating that replicas do not match.
-type ReplicasDidNotMatch struct {
+// replicasDidNotMatchError is an error stating that replicas do not match.
+type replicasDidNotMatchError struct {
 	replica, elected string
 }
 
-// NewReplicasDidNotMatch creates a ReplicasDidNotMatch error with the given parameters.
-func NewReplicasDidNotMatch(replica, elected string) ReplicasDidNotMatch {
-	return ReplicasDidNotMatch{
+// newReplicasDidNotMatchError creates a replicasDidNotMatchError error with the given parameters.
+func newReplicasDidNotMatchError(replica, elected string) replicasDidNotMatchError {
+	return replicasDidNotMatchError{
 		replica: replica,
 		elected: elected,
 	}
 }
 
-func (e ReplicasDidNotMatch) Error() string {
+func (e replicasDidNotMatchError) Error() string {
 	return fmt.Sprintf("replicas did not match, rejecting sample: replica=%s, elected=%s", e.replica, e.elected)
 }
 
-// TooManyClusters is an error stating that there are too many HA clusters.
-type TooManyClusters struct {
+// tooManyClustersError is an error stating that there are too many HA clusters.
+type tooManyClustersError struct {
 	limit int
 }
 
-// NewTooManyClusters creates a TooManyClusters error containing the given error message.
-func NewTooManyClusters(limit int) TooManyClusters {
-	return TooManyClusters{
+// newTooManyClustersError creates a tooManyClustersError error containing the given error message.
+func newTooManyClustersError(limit int) tooManyClustersError {
+	return tooManyClustersError{
 		limit: limit,
 	}
 }
 
-func (e TooManyClusters) Error() string {
+func (e tooManyClustersError) Error() string {
 	return fmt.Sprintf(tooManyClustersMsgFormat, e.limit)
 }
 
-// Validation is an error, used to represent all validation errors from the validation package.
-type Validation struct {
+// validationError is an error, used to represent all validation errors from the validation package.
+type validationError struct {
 	error
 }
 
-// NewValidation wraps the given error into a Validation error.
-func NewValidation(err error) Validation {
-	return Validation{error: err}
+// newValidationError wraps the given error into a validationError error.
+func newValidationError(err error) validationError {
+	return validationError{error: err}
 }
 
-// IngestionRateLimited is an error used to represent the ingestion rate limited error.
-type IngestionRateLimited struct {
+// ingestionRateLimitedError is an error used to represent the ingestion rate limited error.
+type ingestionRateLimitedError struct {
 	limit float64
 	burst int
 }
 
-// NewIngestionRateLimited creates a IngestionRateLimited error containing the given error message.
-func NewIngestionRateLimited(limit float64, burst int) IngestionRateLimited {
-	return IngestionRateLimited{
+// newIngestionRateLimitedError creates a ingestionRateLimitedError error containing the given error message.
+func newIngestionRateLimitedError(limit float64, burst int) ingestionRateLimitedError {
+	return ingestionRateLimitedError{
 		limit: limit,
 		burst: burst,
 	}
 }
 
-func (e IngestionRateLimited) Error() string {
+func (e ingestionRateLimitedError) Error() string {
 	return fmt.Sprintf(ingestionRateLimitedMsgFormat, e.limit, e.burst)
 }
 
-// RequestRateLimited is an error used to represent the request rate limited error.
-type RequestRateLimited struct {
+// requestRateLimitedError is an error used to represent the request rate limited error.
+type requestRateLimitedError struct {
 	limit float64
 	burst int
 }
 
-// NewRequestRateLimited creates a RequestRateLimited error containing the given error message.
-func NewRequestRateLimited(limit float64, burst int) RequestRateLimited {
-	return RequestRateLimited{
+// newRequestRateLimitedError creates a requestRateLimitedError error containing the given error message.
+func newRequestRateLimitedError(limit float64, burst int) requestRateLimitedError {
+	return requestRateLimitedError{
 		limit: limit,
 		burst: burst,
 	}
 }
 
-func (e RequestRateLimited) Error() string {
+func (e requestRateLimitedError) Error() string {
 	return fmt.Sprintf(requestRateLimitedMsgFormat, e.limit, e.burst)
 }

--- a/pkg/distributor/errors_test.go
+++ b/pkg/distributor/errors_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package distributorerror
+package distributor
 
 import (
 	"fmt"
@@ -209,7 +209,7 @@ func TestToHTTPStatusHandler(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		httpStatus, outcome := ToHTTPStatus(tc.err, tc.serviceOverloadErrorEnabled)
+		httpStatus, outcome := toHTTPStatus(tc.err, tc.serviceOverloadErrorEnabled)
 		require.Equal(t, tc.expectedHTTPStatus, httpStatus)
 		require.Equal(t, tc.expectedOutcome, outcome)
 	}

--- a/pkg/distributor/errors_test.go
+++ b/pkg/distributor/errors_test.go
@@ -17,95 +17,95 @@ import (
 func TestNewReplicasNotMatchError(t *testing.T) {
 	replica := "a"
 	elected := "b"
-	err := NewReplicasDidNotMatch(replica, elected)
+	err := newReplicasDidNotMatchError(replica, elected)
 	assert.Error(t, err)
 	expectedMsg := fmt.Sprintf("replicas did not match, rejecting sample: replica=%s, elected=%s", replica, elected)
 	assert.EqualError(t, err, expectedMsg)
 
-	anotherErr := NewReplicasDidNotMatch("c", "d")
+	anotherErr := newReplicasDidNotMatchError("c", "d")
 	assert.NotErrorIs(t, err, anotherErr)
 
-	assert.True(t, errors.As(err, &ReplicasDidNotMatch{}))
-	assert.False(t, errors.As(err, &TooManyClusters{}))
+	assert.True(t, errors.As(err, &replicasDidNotMatchError{}))
+	assert.False(t, errors.As(err, &tooManyClustersError{}))
 
 	wrappedErr := fmt.Errorf("wrapped %w", err)
 	assert.ErrorIs(t, wrappedErr, err)
-	assert.True(t, errors.As(wrappedErr, &ReplicasDidNotMatch{}))
+	assert.True(t, errors.As(wrappedErr, &replicasDidNotMatchError{}))
 }
 
 func TestNewTooManyClustersError(t *testing.T) {
 	limit := 10
-	err := NewTooManyClusters(limit)
+	err := newTooManyClustersError(limit)
 	expectedErrorMsg := fmt.Sprintf(tooManyClustersMsgFormat, limit)
 	assert.Error(t, err)
 	assert.EqualError(t, err, expectedErrorMsg)
 
-	anotherErr := NewTooManyClusters(20)
+	anotherErr := newTooManyClustersError(20)
 	assert.NotErrorIs(t, err, anotherErr)
 
-	assert.True(t, errors.As(err, &TooManyClusters{}))
-	assert.False(t, errors.As(err, &ReplicasDidNotMatch{}))
+	assert.True(t, errors.As(err, &tooManyClustersError{}))
+	assert.False(t, errors.As(err, &replicasDidNotMatchError{}))
 
 	wrappedErr := fmt.Errorf("wrapped %w", err)
 	assert.ErrorIs(t, wrappedErr, err)
-	assert.True(t, errors.As(wrappedErr, &TooManyClusters{}))
+	assert.True(t, errors.As(wrappedErr, &tooManyClustersError{}))
 }
 
 func TestNewValidationError(t *testing.T) {
 	validationMsg := "this is a validation error"
 	firstErr := errors.New(validationMsg)
 
-	err := NewValidation(firstErr)
+	err := newValidationError(firstErr)
 	assert.Error(t, err)
 	assert.EqualError(t, err, validationMsg)
 
-	anotherErr := NewValidation(errors.New("this is another validation error"))
+	anotherErr := newValidationError(errors.New("this is another validation error"))
 	assert.NotErrorIs(t, err, anotherErr)
 
-	assert.True(t, errors.As(err, &Validation{}))
-	assert.False(t, errors.As(err, &ReplicasDidNotMatch{}))
+	assert.True(t, errors.As(err, &validationError{}))
+	assert.False(t, errors.As(err, &replicasDidNotMatchError{}))
 
 	wrappedErr := fmt.Errorf("wrapped %w", err)
 	assert.ErrorIs(t, wrappedErr, err)
-	assert.True(t, errors.As(wrappedErr, &Validation{}))
+	assert.True(t, errors.As(wrappedErr, &validationError{}))
 }
 
 func TestNewIngestionRateError(t *testing.T) {
 	limit := 10.0
 	burst := 10
-	err := NewIngestionRateLimited(limit, burst)
+	err := newIngestionRateLimitedError(limit, burst)
 	expectedErrorMsg := fmt.Sprintf(ingestionRateLimitedMsgFormat, limit, burst)
 	assert.Error(t, err)
 	assert.EqualError(t, err, expectedErrorMsg)
 
-	anotherErr := NewIngestionRateLimited(20, 20)
+	anotherErr := newIngestionRateLimitedError(20, 20)
 	assert.NotErrorIs(t, err, anotherErr)
 
-	assert.True(t, errors.As(err, &IngestionRateLimited{}))
-	assert.False(t, errors.As(err, &ReplicasDidNotMatch{}))
+	assert.True(t, errors.As(err, &ingestionRateLimitedError{}))
+	assert.False(t, errors.As(err, &replicasDidNotMatchError{}))
 
 	wrappedErr := fmt.Errorf("wrapped %w", err)
 	assert.ErrorIs(t, wrappedErr, err)
-	assert.True(t, errors.As(wrappedErr, &IngestionRateLimited{}))
+	assert.True(t, errors.As(wrappedErr, &ingestionRateLimitedError{}))
 }
 
 func TestNewRequestRateError(t *testing.T) {
 	limit := 10.0
 	burst := 10
-	err := NewRequestRateLimited(limit, burst)
+	err := newRequestRateLimitedError(limit, burst)
 	expectedErrorMsg := fmt.Sprintf(requestRateLimitedMsgFormat, limit, burst)
 	assert.Error(t, err)
 	assert.EqualError(t, err, expectedErrorMsg)
 
-	anotherErr := NewRequestRateLimited(20, 20)
+	anotherErr := newRequestRateLimitedError(20, 20)
 	assert.NotErrorIs(t, err, anotherErr)
 
-	assert.True(t, errors.As(err, &RequestRateLimited{}))
-	assert.False(t, errors.As(err, &ReplicasDidNotMatch{}))
+	assert.True(t, errors.As(err, &requestRateLimitedError{}))
+	assert.False(t, errors.As(err, &replicasDidNotMatchError{}))
 
 	wrappedErr := fmt.Errorf("wrapped %w", err)
 	assert.ErrorIs(t, wrappedErr, err)
-	assert.True(t, errors.As(wrappedErr, &RequestRateLimited{}))
+	assert.True(t, errors.As(wrappedErr, &requestRateLimitedError{}))
 }
 
 func TestToHTTPStatusHandler(t *testing.T) {
@@ -131,77 +131,77 @@ func TestToHTTPStatusHandler(t *testing.T) {
 			expectedOutcome:    false,
 		},
 		{
-			name:               "a ReplicasDidNotMatch gets translated into 202, true",
-			err:                NewReplicasDidNotMatch("a", "b"),
+			name:               "a replicasDidNotMatchError gets translated into 202, true",
+			err:                newReplicasDidNotMatchError("a", "b"),
 			expectedHTTPStatus: http.StatusAccepted,
 			expectedOutcome:    true,
 		},
 		{
-			name:               "a DoNotLog error of a ReplicasDidNotMatch gets translated into 202, true",
-			err:                log.DoNotLogError{Err: NewReplicasDidNotMatch("a", "b")},
+			name:               "a DoNotLog error of a replicasDidNotMatchError gets translated into 202, true",
+			err:                log.DoNotLogError{Err: newReplicasDidNotMatchError("a", "b")},
 			expectedHTTPStatus: http.StatusAccepted,
 			expectedOutcome:    true,
 		},
 		{
-			name:               "a TooManyClusters gets translated into 400, true",
-			err:                NewTooManyClusters(10),
+			name:               "a tooManyClustersError gets translated into 400, true",
+			err:                newTooManyClustersError(10),
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedOutcome:    true,
 		},
 		{
-			name:               "a DoNotLog error of a TooManyClusters gets translated into 400, true",
-			err:                log.DoNotLogError{Err: NewTooManyClusters(10)},
+			name:               "a DoNotLog error of a tooManyClustersError gets translated into 400, true",
+			err:                log.DoNotLogError{Err: newTooManyClustersError(10)},
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedOutcome:    true,
 		},
 		{
-			name:               "a Validation gets translated into 400, true",
-			err:                NewValidation(originalErr),
+			name:               "a validationError gets translated into 400, true",
+			err:                newValidationError(originalErr),
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedOutcome:    true,
 		},
 		{
-			name:               "a DoNotLog error of a Validation gets translated into 400, true",
-			err:                log.DoNotLogError{Err: NewValidation(originalErr)},
+			name:               "a DoNotLog error of a validationError gets translated into 400, true",
+			err:                log.DoNotLogError{Err: newValidationError(originalErr)},
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedOutcome:    true,
 		},
 		{
-			name:               "an IngestionRateLimited gets translated into an HTTP 429",
-			err:                NewIngestionRateLimited(10, 10),
+			name:               "an ingestionRateLimitedError gets translated into an HTTP 429",
+			err:                newIngestionRateLimitedError(10, 10),
 			expectedHTTPStatus: http.StatusTooManyRequests,
 			expectedOutcome:    true,
 		},
 		{
-			name:               "a DoNotLog error of an IngestionRateLimited gets translated into an HTTP 429",
-			err:                log.DoNotLogError{Err: NewIngestionRateLimited(10, 10)},
+			name:               "a DoNotLog error of an ingestionRateLimitedError gets translated into an HTTP 429",
+			err:                log.DoNotLogError{Err: newIngestionRateLimitedError(10, 10)},
 			expectedHTTPStatus: http.StatusTooManyRequests,
 			expectedOutcome:    true,
 		},
 		{
-			name:                        "a RequestRateLimited with serviceOverloadErrorEnabled gets translated into an HTTP 529",
-			err:                         NewRequestRateLimited(10, 10),
+			name:                        "a requestRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529",
+			err:                         newRequestRateLimitedError(10, 10),
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
 			expectedOutcome:             true,
 		},
 		{
-			name:                        "a DoNotLog error of a RequestRateLimited with serviceOverloadErrorEnabled gets translated into an HTTP 529",
-			err:                         log.DoNotLogError{Err: NewRequestRateLimited(10, 10)},
+			name:                        "a DoNotLog error of a requestRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529",
+			err:                         log.DoNotLogError{Err: newRequestRateLimitedError(10, 10)},
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
 			expectedOutcome:             true,
 		},
 		{
-			name:                        "a RequestRateLimited without serviceOverloadErrorEnabled gets translated into an HTTP 429",
-			err:                         NewRequestRateLimited(10, 10),
+			name:                        "a requestRateLimitedError without serviceOverloadErrorEnabled gets translated into an HTTP 429",
+			err:                         newRequestRateLimitedError(10, 10),
 			serviceOverloadErrorEnabled: false,
 			expectedHTTPStatus:          http.StatusTooManyRequests,
 			expectedOutcome:             true,
 		},
 		{
-			name:                        "a DoNotLog error of a RequestRateLimited without serviceOverloadErrorEnabled gets translated into an HTTP 429",
-			err:                         log.DoNotLogError{Err: NewRequestRateLimited(10, 10)},
+			name:                        "a DoNotLog error of a requestRateLimitedError without serviceOverloadErrorEnabled gets translated into an HTTP 429",
+			err:                         log.DoNotLogError{Err: newRequestRateLimitedError(10, 10)},
 			serviceOverloadErrorEnabled: false,
 			expectedHTTPStatus:          http.StatusTooManyRequests,
 			expectedOutcome:             true,

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -423,7 +423,7 @@ func (h *haTracker) checkReplica(ctx context.Context, userID, cluster, replica s
 			// Sample received is from non-elected replica: record details and reject.
 			entry.nonElectedLastSeenReplica = replica
 			entry.nonElectedLastSeenTimestamp = timestamp.FromTime(now)
-			err = NewReplicasDidNotMatch(replica, entry.elected.Replica)
+			err = newReplicasDidNotMatchError(replica, entry.elected.Replica)
 		}
 		h.electedLock.Unlock()
 		return err
@@ -434,7 +434,7 @@ func (h *haTracker) checkReplica(ctx context.Context, userID, cluster, replica s
 	h.electedLock.Unlock()
 	// If we have reached the limit for number of clusters, error out now.
 	if limit := h.limits.MaxHAClusters(userID); limit > 0 && nClusters+1 > limit {
-		return NewTooManyClusters(limit)
+		return newTooManyClustersError(limit)
 	}
 
 	err := h.updateKVStore(ctx, userID, cluster, replica, now)

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -25,7 +25,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/timestamp"
 
-	"github.com/grafana/mimir/pkg/distributor/distributorerror"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util"
 )
@@ -424,7 +423,7 @@ func (h *haTracker) checkReplica(ctx context.Context, userID, cluster, replica s
 			// Sample received is from non-elected replica: record details and reject.
 			entry.nonElectedLastSeenReplica = replica
 			entry.nonElectedLastSeenTimestamp = timestamp.FromTime(now)
-			err = distributorerror.NewReplicasDidNotMatch(replica, entry.elected.Replica)
+			err = NewReplicasDidNotMatch(replica, entry.elected.Replica)
 		}
 		h.electedLock.Unlock()
 		return err
@@ -435,7 +434,7 @@ func (h *haTracker) checkReplica(ctx context.Context, userID, cluster, replica s
 	h.electedLock.Unlock()
 	// If we have reached the limit for number of clusters, error out now.
 	if limit := h.limits.MaxHAClusters(userID); limit > 0 && nClusters+1 > limit {
-		return distributorerror.NewTooManyClusters(limit)
+		return NewTooManyClusters(limit)
 	}
 
 	err := h.updateKVStore(ctx, userID, cluster, replica, now)

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/mimir/pkg/distributor/distributorerror"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )
@@ -602,7 +601,7 @@ func TestHAClustersLimit(t *testing.T) {
 	assert.NoError(t, t1.checkReplica(context.Background(), userID, "b", "b1", now))
 	waitForClustersUpdate(t, 2, t1, userID)
 
-	expectedErr := distributorerror.NewTooManyClusters(2)
+	expectedErr := NewTooManyClusters(2)
 	assert.EqualError(t, t1.checkReplica(context.Background(), userID, "c", "c1", now), expectedErr.Error())
 
 	// Move time forward, and make sure that checkReplica for existing cluster works fine.
@@ -628,7 +627,7 @@ func TestHAClustersLimit(t *testing.T) {
 	waitForClustersUpdate(t, 2, t1, userID)
 
 	// But yet another cluster doesn't.
-	expectedErr = distributorerror.NewTooManyClusters(2)
+	expectedErr = NewTooManyClusters(2)
 	assert.EqualError(t, t1.checkReplica(context.Background(), userID, "a", "a2", now), expectedErr.Error())
 
 	now = now.Add(5 * time.Second)

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -601,7 +601,7 @@ func TestHAClustersLimit(t *testing.T) {
 	assert.NoError(t, t1.checkReplica(context.Background(), userID, "b", "b1", now))
 	waitForClustersUpdate(t, 2, t1, userID)
 
-	expectedErr := NewTooManyClusters(2)
+	expectedErr := newTooManyClustersError(2)
 	assert.EqualError(t, t1.checkReplica(context.Background(), userID, "c", "c1", now), expectedErr.Error())
 
 	// Move time forward, and make sure that checkReplica for existing cluster works fine.
@@ -627,7 +627,7 @@ func TestHAClustersLimit(t *testing.T) {
 	waitForClustersUpdate(t, 2, t1, userID)
 
 	// But yet another cluster doesn't.
-	expectedErr = NewTooManyClusters(2)
+	expectedErr = newTooManyClustersError(2)
 	assert.EqualError(t, t1.checkReplica(context.Background(), userID, "a", "a2", now), expectedErr.Error())
 
 	now = now.Add(5 * time.Second)

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package push
+package distributor
 
 import (
 	"compress/gzip"
@@ -47,7 +47,7 @@ func OTLPHandler(
 	enableOtelMetadataStorage bool,
 	limits *validation.Overrides,
 	reg prometheus.Registerer,
-	push Func,
+	push pushFunc,
 ) http.Handler {
 	discardedDueToOtelParseError := validation.DiscardedSamplesCounter(reg, otelParseError)
 

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package push
+package distributor
 
 import (
 	"context"
@@ -25,8 +25,8 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
-// Func defines the type of the push. It is similar to http.HandlerFunc.
-type Func func(ctx context.Context, req *Request) error
+// pushFunc defines the type of the push. It is similar to http.HandlerFunc.
+type pushFunc func(ctx context.Context, req *Request) error
 
 // parserFunc defines how to read the body the request from an HTTP request
 type parserFunc func(ctx context.Context, r *http.Request, maxSize int, buffer []byte, req *mimirpb.PreallocWriteRequest) ([]byte, error)
@@ -51,7 +51,7 @@ func Handler(
 	sourceIPs *middleware.SourceIPExtractor,
 	allowSkipLabelNameValidation bool,
 	limits *validation.Overrides,
-	push Func,
+	push pushFunc,
 ) http.Handler {
 	return handler(maxRecvMsgSize, sourceIPs, allowSkipLabelNameValidation, limits, push, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, dst []byte, req *mimirpb.PreallocWriteRequest) ([]byte, error) {
 		res, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRecvMsgSize, dst, req, util.RawSnappy)
@@ -79,7 +79,7 @@ func handler(
 	sourceIPs *middleware.SourceIPExtractor,
 	allowSkipLabelNameValidation bool,
 	limits *validation.Overrides,
-	push Func,
+	push pushFunc,
 	parser parserFunc,
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -163,18 +163,18 @@ func distributorPushErrorHTTPStatus(ctx context.Context, pushErr error, limits *
 // false are returned.
 func toHTTPStatus(pushErr error, serviceOverloadErrorEnabled bool) (int, bool) {
 	switch {
-	case errors.As(pushErr, &ReplicasDidNotMatch{}):
+	case errors.As(pushErr, &replicasDidNotMatchError{}):
 		return http.StatusAccepted, true
-	case errors.As(pushErr, &TooManyClusters{}):
+	case errors.As(pushErr, &tooManyClustersError{}):
 		return http.StatusBadRequest, true
-	case errors.As(pushErr, &Validation{}):
+	case errors.As(pushErr, &validationError{}):
 		return http.StatusBadRequest, true
-	case errors.As(pushErr, &IngestionRateLimited{}):
+	case errors.As(pushErr, &ingestionRateLimitedError{}):
 		// Return a 429 here to tell the client it is going too fast.
 		// Client may discard the data or slow down and re-send.
 		// Prometheus v2.26 added a remote-write option 'retry_on_http_429'.
 		return http.StatusTooManyRequests, true
-	case errors.As(pushErr, &RequestRateLimited{}):
+	case errors.As(pushErr, &requestRateLimitedError{}):
 		// Return a 429 or a 529 here depending on configuration to tell the client it is going too fast.
 		// Client may discard the data or slow down and re-send.
 		// Prometheus v2.26 added a remote-write option 'retry_on_http_429'.

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package push
+package distributor
 
 import (
 	"bytes"
@@ -155,7 +155,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 		encoding    string
 		maxMsgSize  int
 
-		verifyFunc                Func
+		verifyFunc                pushFunc
 		responseCode              int
 		errMessage                string
 		enableOtelMetadataStorage bool
@@ -450,7 +450,7 @@ func TestHandler_EnsureSkipLabelNameValidationBehaviour(t *testing.T) {
 		allowSkipLabelNameValidation              bool
 		req                                       *http.Request
 		includeAllowSkiplabelNameValidationHeader bool
-		verifyReqHandler                          Func
+		verifyReqHandler                          pushFunc
 		expectedStatusCode                        int
 	}{
 		{
@@ -555,7 +555,7 @@ func TestHandler_EnsureSkipLabelNameValidationBehaviour(t *testing.T) {
 	}
 }
 
-func verifyWritePushFunc(t *testing.T, expectSource mimirpb.WriteRequest_SourceEnum) Func {
+func verifyWritePushFunc(t *testing.T, expectSource mimirpb.WriteRequest_SourceEnum) pushFunc {
 	t.Helper()
 	return func(ctx context.Context, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
@@ -570,7 +570,7 @@ func verifyWritePushFunc(t *testing.T, expectSource mimirpb.WriteRequest_SourceE
 	}
 }
 
-func readBodyPushFunc(t *testing.T) Func {
+func readBodyPushFunc(t *testing.T) pushFunc {
 	t.Helper()
 	return func(ctx context.Context, req *Request) error {
 		_, err := req.WriteRequest()

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -802,10 +802,10 @@ func TestHandler_DistributorPushErrorHTTPStatus(t *testing.T) {
 	userID := "user"
 	originalMsg := "this is an error"
 	originalErr := errors.New(originalMsg)
-	replicasNotMatchErr := NewReplicasDidNotMatch("a", "b")
-	tooManyClustersErr := NewTooManyClusters(10)
-	ingestionRateLimitedErr := NewIngestionRateLimited(10, 10)
-	requestRateLimitedErr := NewRequestRateLimited(10, 10)
+	replicasNotMatchErr := newReplicasDidNotMatchError("a", "b")
+	tooManyClustersErr := newTooManyClustersError(10)
+	ingestionRateLimitedErr := newIngestionRateLimitedError(10, 10)
+	requestRateLimitedErr := newRequestRateLimitedError(10, 10)
 	testCases := []struct {
 		name                        string
 		err                         error
@@ -824,37 +824,37 @@ func TestHandler_DistributorPushErrorHTTPStatus(t *testing.T) {
 			expectedHTTPStatus: http.StatusInternalServerError,
 		},
 		{
-			name:               "a ReplicasDidNotMatch gets translated into an HTTP 202",
+			name:               "a replicasDidNotMatchError gets translated into an HTTP 202",
 			err:                replicasNotMatchErr,
 			expectedHTTPStatus: http.StatusAccepted,
 			expectedErrorMsg:   replicasNotMatchErr.Error(),
 		},
 		{
-			name:               "a TooManyClusters gets translated into an HTTP 400",
+			name:               "a tooManyClustersError gets translated into an HTTP 400",
 			err:                tooManyClustersErr,
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedErrorMsg:   tooManyClustersErr.Error(),
 		},
 		{
-			name:               "a Validation gets translated into an HTTP 400",
-			err:                NewValidation(originalErr),
+			name:               "a validationError gets translated into an HTTP 400",
+			err:                newValidationError(originalErr),
 			expectedHTTPStatus: http.StatusBadRequest,
 		},
 		{
-			name:               "an IngestionRateLimited gets translated into an HTTP 429",
+			name:               "an ingestionRateLimitedError gets translated into an HTTP 429",
 			err:                ingestionRateLimitedErr,
 			expectedHTTPStatus: http.StatusTooManyRequests,
 			expectedErrorMsg:   ingestionRateLimitedErr.Error(),
 		},
 		{
-			name:                        "a RequestRateLimited with serviceOverloadErrorEnabled gets translated into an HTTP 529",
+			name:                        "a requestRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529",
 			err:                         requestRateLimitedErr,
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
 			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
 		{
-			name:                        "a RequestRateLimited without serviceOverloadErrorEnabled gets translated into an HTTP 429",
+			name:                        "a requestRateLimitedError without serviceOverloadErrorEnabled gets translated into an HTTP 429",
 			err:                         requestRateLimitedErr,
 			serviceOverloadErrorEnabled: false,
 			expectedHTTPStatus:          http.StatusTooManyRequests,

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -31,7 +31,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 
-	"github.com/grafana/mimir/pkg/distributor/distributorerror"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/test"
@@ -803,10 +802,10 @@ func TestHandler_DistributorPushErrorHTTPStatus(t *testing.T) {
 	userID := "user"
 	originalMsg := "this is an error"
 	originalErr := errors.New(originalMsg)
-	replicasNotMatchErr := distributorerror.NewReplicasDidNotMatch("a", "b")
-	tooManyClustersErr := distributorerror.NewTooManyClusters(10)
-	ingestionRateLimitedErr := distributorerror.NewIngestionRateLimited(10, 10)
-	requestRateLimitedErr := distributorerror.NewRequestRateLimited(10, 10)
+	replicasNotMatchErr := NewReplicasDidNotMatch("a", "b")
+	tooManyClustersErr := NewTooManyClusters(10)
+	ingestionRateLimitedErr := NewIngestionRateLimited(10, 10)
+	requestRateLimitedErr := NewRequestRateLimited(10, 10)
 	testCases := []struct {
 		name                        string
 		err                         error
@@ -838,7 +837,7 @@ func TestHandler_DistributorPushErrorHTTPStatus(t *testing.T) {
 		},
 		{
 			name:               "a Validation gets translated into an HTTP 400",
-			err:                distributorerror.NewValidation(originalErr),
+			err:                NewValidation(originalErr),
 			expectedHTTPStatus: http.StatusBadRequest,
 		},
 		{
@@ -851,7 +850,7 @@ func TestHandler_DistributorPushErrorHTTPStatus(t *testing.T) {
 			name:                        "a RequestRateLimited with serviceOverloadErrorEnabled gets translated into an HTTP 529",
 			err:                         requestRateLimitedErr,
 			serviceOverloadErrorEnabled: true,
-			expectedHTTPStatus:          distributorerror.StatusServiceOverloaded,
+			expectedHTTPStatus:          StatusServiceOverloaded,
 			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
 		{

--- a/pkg/distributor/request.go
+++ b/pkg/distributor/request.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package push
+package distributor
 
 import (
 	"fmt"

--- a/pkg/distributor/request_test.go
+++ b/pkg/distributor/request_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package push
+package distributor
 
 import (
 	"testing"

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/activitytracker"
-	"github.com/grafana/mimir/pkg/util/push"
 )
 
 // ActivityTrackerWrapper is a wrapper around Ingester that adds queries to activity tracker.
@@ -36,9 +35,9 @@ func (i *ActivityTrackerWrapper) Push(ctx context.Context, request *mimirpb.Writ
 	return i.ing.Push(ctx, request)
 }
 
-func (i *ActivityTrackerWrapper) PushWithCleanup(ctx context.Context, r *push.Request) error {
+func (i *ActivityTrackerWrapper) PushWithCleanup(ctx context.Context, r *mimirpb.WriteRequest, cleanUp func()) error {
 	// No tracking in PushWithCleanup
-	return i.ing.PushWithCleanup(ctx, r)
+	return i.ing.PushWithCleanup(ctx, r, cleanUp)
 }
 
 func (i *ActivityTrackerWrapper) QueryStream(request *client.QueryRequest, server client.Ingester_QueryStreamServer) error {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -68,7 +68,6 @@ import (
 	"github.com/grafana/mimir/pkg/usagestats"
 	"github.com/grafana/mimir/pkg/util"
 	util_math "github.com/grafana/mimir/pkg/util/math"
-	"github.com/grafana/mimir/pkg/util/push"
 	util_test "github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -1215,7 +1214,7 @@ func TestIngester_Push(t *testing.T) {
 			// Push timeseries
 			for idx, req := range testData.reqs {
 				// Push metrics to the ingester. Override the default cleanup method of mimirpb.ReuseSlice with a no-op one.
-				err := i.PushWithCleanup(ctx, push.NewParsedRequest(req))
+				err := i.PushWithCleanup(ctx, req, func() {})
 
 				// We expect no error on any request except the last one
 				// which may error (and in that case we assert on it)


### PR DESCRIPTION
#### What this PR does
This PR is another refactoring needed for improving of ingester's and distributor's error handling. The main changes are:
- the content of `util/push` has been moved under the `distributor` package: the reason for this is that the push interacts only with the distributor, so it makes sense to place the former in the `distributor` package.
- the distributor errors that are currently declared in the `distributorerror` package have been moved under the `distributor` package: the reason `distributorerror` was created was to prevent a circular dependency between `push` and `distributor` packages.

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/6008

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
