### PR TITLE
Export distributor.pushFunc because it is needed externally

### DIFF
--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -47,7 +47,7 @@ func OTLPHandler(
 	enableOtelMetadataStorage bool,
 	limits *validation.Overrides,
 	reg prometheus.Registerer,
-	push pushFunc,
+	push PushFunc,
 ) http.Handler {
 	discardedDueToOtelParseError := validation.DiscardedSamplesCounter(reg, otelParseError)
 

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -24,8 +24,8 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
-// pushFunc defines the type of the push. It is similar to http.HandlerFunc.
-type pushFunc func(ctx context.Context, req *Request) error
+// PushFunc defines the type of the push. It is similar to http.HandlerFunc.
+type PushFunc func(ctx context.Context, req *Request) error
 
 // parserFunc defines how to read the body the request from an HTTP request
 type parserFunc func(ctx context.Context, r *http.Request, maxSize int, buffer []byte, req *mimirpb.PreallocWriteRequest) ([]byte, error)
@@ -50,7 +50,7 @@ func Handler(
 	sourceIPs *middleware.SourceIPExtractor,
 	allowSkipLabelNameValidation bool,
 	limits *validation.Overrides,
-	push pushFunc,
+	push PushFunc,
 ) http.Handler {
 	return handler(maxRecvMsgSize, sourceIPs, allowSkipLabelNameValidation, limits, push, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, dst []byte, req *mimirpb.PreallocWriteRequest) ([]byte, error) {
 		res, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRecvMsgSize, dst, req, util.RawSnappy)
@@ -78,7 +78,7 @@ func handler(
 	sourceIPs *middleware.SourceIPExtractor,
 	allowSkipLabelNameValidation bool,
 	limits *validation.Overrides,
-	push pushFunc,
+	push PushFunc,
 	parser parserFunc,
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -154,7 +154,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 		encoding    string
 		maxMsgSize  int
 
-		verifyFunc                pushFunc
+		verifyFunc                PushFunc
 		responseCode              int
 		errMessage                string
 		enableOtelMetadataStorage bool
@@ -449,7 +449,7 @@ func TestHandler_EnsureSkipLabelNameValidationBehaviour(t *testing.T) {
 		allowSkipLabelNameValidation              bool
 		req                                       *http.Request
 		includeAllowSkiplabelNameValidationHeader bool
-		verifyReqHandler                          pushFunc
+		verifyReqHandler                          PushFunc
 		expectedStatusCode                        int
 	}{
 		{
@@ -554,7 +554,7 @@ func TestHandler_EnsureSkipLabelNameValidationBehaviour(t *testing.T) {
 	}
 }
 
-func verifyWritePushFunc(t *testing.T, expectSource mimirpb.WriteRequest_SourceEnum) pushFunc {
+func verifyWritePushFunc(t *testing.T, expectSource mimirpb.WriteRequest_SourceEnum) PushFunc {
 	t.Helper()
 	return func(ctx context.Context, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
@@ -569,7 +569,7 @@ func verifyWritePushFunc(t *testing.T, expectSource mimirpb.WriteRequest_SourceE
 	}
 }
 
-func readBodyPushFunc(t *testing.T) pushFunc {
+func readBodyPushFunc(t *testing.T) PushFunc {
 	t.Helper()
 	return func(ctx context.Context, req *Request) error {
 		_, err := req.WriteRequest()


### PR DESCRIPTION
#### What this PR does
One of the previous refactorings ([PR](https://github.com/grafana/mimir/pull/6356)) moved the content of the `util/push` package under the `distributor` package. That PR also un-exported the `push.Func` function by renaming it into `distributor.pushFunc`. 

This PR exports the `distributor.pushFunc` because it is needed by `backend-enterprise`.

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
