### PR TITLE
Allow ingester.Push() to proceed on soft errors only

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -78,6 +78,14 @@ type ingesterError interface {
 	errorType() ingesterErrorType
 }
 
+// softError is a marker interface for the errors on which ingester.Push should not stop immediately.
+type softError interface {
+	error
+	soft()
+}
+
+type softErrorFunction func() softError
+
 // wrapOrAnnotateWithUser prepends the given userID to the given error.
 // If the given error matches one of the errors from this package, the
 // returned error retains a reference to the former.
@@ -113,6 +121,9 @@ func (e sampleError) Error() string {
 func (e sampleError) errorType() ingesterErrorType {
 	return badData
 }
+
+// sampleError implements the softError interface.
+func (e sampleError) soft() {}
 
 func newSampleError(errID globalerror.ID, errMsg string, timestamp model.Time, labels []mimirpb.LabelAdapter) sampleError {
 	return sampleError{
@@ -167,6 +178,9 @@ func (e exemplarError) errorType() ingesterErrorType {
 	return badData
 }
 
+// exemplarError implements the softError interface.
+func (e exemplarError) soft() {}
+
 func newExemplarError(errID globalerror.ID, errMsg string, timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) exemplarError {
 	return exemplarError{
 		errID:          errID,
@@ -207,7 +221,10 @@ func (e tsdbIngestExemplarErr) errorType() ingesterErrorType {
 	return badData
 }
 
-func newTSDBIngestExemplarErr(ingestErr error, timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) error {
+// tsdbIngestExemplarErr implements the softError interface.
+func (e tsdbIngestExemplarErr) soft() {}
+
+func newTSDBIngestExemplarErr(ingestErr error, timestamp model.Time, seriesLabels, exemplarLabels []mimirpb.LabelAdapter) tsdbIngestExemplarErr {
 	return tsdbIngestExemplarErr{
 		originalErr:    ingestErr,
 		timestamp:      timestamp,
@@ -240,6 +257,9 @@ func (e perUserSeriesLimitReachedError) errorType() ingesterErrorType {
 	return badData
 }
 
+// perUserSeriesLimitReachedError implements the softError interface.
+func (e perUserSeriesLimitReachedError) soft() {}
+
 // perUserMetadataLimitReachedError is an ingesterError indicating that a per-user metadata limit has been reached.
 type perUserMetadataLimitReachedError struct {
 	limit int
@@ -263,6 +283,9 @@ func (e perUserMetadataLimitReachedError) Error() string {
 func (e perUserMetadataLimitReachedError) errorType() ingesterErrorType {
 	return badData
 }
+
+// perUserMetadataLimitReachedError implements the softError interface.
+func (e perUserMetadataLimitReachedError) soft() {}
 
 // perMetricSeriesLimitReachedError is an ingesterError indicating that a per-metric series limit has been reached.
 type perMetricSeriesLimitReachedError struct {
@@ -293,6 +316,9 @@ func (e perMetricSeriesLimitReachedError) errorType() ingesterErrorType {
 	return badData
 }
 
+// perMetricSeriesLimitReachedError implements the softError interface.
+func (e perMetricSeriesLimitReachedError) soft() {}
+
 // perMetricMetadataLimitReachedError is an ingesterError indicating that a per-metric metadata limit has been reached.
 type perMetricMetadataLimitReachedError struct {
 	limit  int
@@ -321,6 +347,9 @@ func (e perMetricMetadataLimitReachedError) Error() string {
 func (e perMetricMetadataLimitReachedError) errorType() ingesterErrorType {
 	return badData
 }
+
+// perMetricMetadataLimitReachedError implements the softError interface.
+func (e perMetricMetadataLimitReachedError) soft() {}
 
 // unavailableError is an ingesterError indicating that the ingester is unavailable.
 type unavailableError struct {

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -32,12 +32,12 @@ func TestUnavailableError(t *testing.T) {
 	require.Error(t, err)
 	expectedMsg := fmt.Sprintf(integerUnavailableMsgFormat, state)
 	require.EqualError(t, err, expectedMsg)
-	checkIngesterError(t, err, unavailable)
+	checkIngesterError(t, err, unavailable, false)
 
 	wrappedErr := wrapOrAnnotateWithUser(err, userID)
 	require.ErrorIs(t, wrappedErr, err)
 	require.ErrorAs(t, wrappedErr, &unavailableError{})
-	checkIngesterError(t, wrappedErr, unavailable)
+	checkIngesterError(t, wrappedErr, unavailable, false)
 }
 
 func TestInstanceLimitReachedError(t *testing.T) {
@@ -45,12 +45,12 @@ func TestInstanceLimitReachedError(t *testing.T) {
 	err := newInstanceLimitReachedError(limitErrorMessage)
 	require.Error(t, err)
 	require.EqualError(t, err, limitErrorMessage)
-	checkIngesterError(t, err, instanceLimitReached)
+	checkIngesterError(t, err, instanceLimitReached, false)
 
 	wrappedErr := wrapOrAnnotateWithUser(err, userID)
 	require.ErrorIs(t, wrappedErr, err)
 	require.ErrorAs(t, wrappedErr, &instanceLimitReachedError{})
-	checkIngesterError(t, wrappedErr, instanceLimitReached)
+	checkIngesterError(t, wrappedErr, instanceLimitReached, false)
 }
 
 func TestNewTSDBUnavailableError(t *testing.T) {
@@ -58,7 +58,7 @@ func TestNewTSDBUnavailableError(t *testing.T) {
 	err := newTSDBUnavailableError(tsdbErrMsg)
 	require.Error(t, err)
 	require.EqualError(t, err, tsdbErrMsg)
-	checkIngesterError(t, err, tsdbUnavailable)
+	checkIngesterError(t, err, tsdbUnavailable, false)
 
 	wrappedErr := fmt.Errorf("wrapped: %w", err)
 	require.ErrorIs(t, wrappedErr, err)
@@ -67,7 +67,7 @@ func TestNewTSDBUnavailableError(t *testing.T) {
 	wrappedWithUserErr := wrapOrAnnotateWithUser(err, userID)
 	require.ErrorIs(t, wrappedWithUserErr, err)
 	require.ErrorAs(t, wrappedWithUserErr, &tsdbUnavailableError{})
-	checkIngesterError(t, wrappedErr, tsdbUnavailable)
+	checkIngesterError(t, wrappedErr, tsdbUnavailable, false)
 }
 
 func TestNewPerUserSeriesLimitError(t *testing.T) {
@@ -78,12 +78,12 @@ func TestNewPerUserSeriesLimitError(t *testing.T) {
 		validation.MaxSeriesPerUserFlag,
 	)
 	require.Equal(t, expectedErrMsg, err.Error())
-	checkIngesterError(t, err, badData)
+	checkIngesterError(t, err, badData, true)
 
 	wrappedErr := wrapOrAnnotateWithUser(err, userID)
 	require.ErrorIs(t, wrappedErr, err)
 	require.ErrorAs(t, wrappedErr, &perUserSeriesLimitReachedError{})
-	checkIngesterError(t, wrappedErr, badData)
+	checkIngesterError(t, wrappedErr, badData, true)
 }
 
 func TestNewPerUserMetadataLimitError(t *testing.T) {
@@ -94,12 +94,12 @@ func TestNewPerUserMetadataLimitError(t *testing.T) {
 		validation.MaxMetadataPerUserFlag,
 	)
 	require.Equal(t, expectedErrMsg, err.Error())
-	checkIngesterError(t, err, badData)
+	checkIngesterError(t, err, badData, true)
 
 	wrappedErr := wrapOrAnnotateWithUser(err, userID)
 	require.ErrorIs(t, wrappedErr, err)
 	require.ErrorAs(t, wrappedErr, &perUserMetadataLimitReachedError{})
-	checkIngesterError(t, wrappedErr, badData)
+	checkIngesterError(t, wrappedErr, badData, true)
 }
 
 func TestNewPerMetricSeriesLimitError(t *testing.T) {
@@ -116,12 +116,12 @@ func TestNewPerMetricSeriesLimitError(t *testing.T) {
 		labels.String(),
 	)
 	require.Equal(t, expectedErrMsg, err.Error())
-	checkIngesterError(t, err, badData)
+	checkIngesterError(t, err, badData, true)
 
 	wrappedErr := wrapOrAnnotateWithUser(err, userID)
 	require.ErrorIs(t, wrappedErr, err)
 	require.ErrorAs(t, wrappedErr, &perMetricSeriesLimitReachedError{})
-	checkIngesterError(t, wrappedErr, badData)
+	checkIngesterError(t, wrappedErr, badData, true)
 }
 
 func TestNewPerMetricMetadataLimitError(t *testing.T) {
@@ -138,12 +138,12 @@ func TestNewPerMetricMetadataLimitError(t *testing.T) {
 		labels.String(),
 	)
 	require.Equal(t, expectedErrMsg, err.Error())
-	checkIngesterError(t, err, badData)
+	checkIngesterError(t, err, badData, true)
 
 	wrappedErr := wrapOrAnnotateWithUser(err, userID)
 	require.ErrorIs(t, wrappedErr, err)
 	require.ErrorAs(t, wrappedErr, &perMetricMetadataLimitReachedError{})
-	checkIngesterError(t, wrappedErr, badData)
+	checkIngesterError(t, wrappedErr, badData, true)
 }
 
 func TestNewSampleError(t *testing.T) {
@@ -177,13 +177,13 @@ func TestNewSampleError(t *testing.T) {
 	for testName, tc := range tests {
 		t.Run(testName, func(t *testing.T) {
 			require.Equal(t, tc.expectedMsg, tc.err.Error())
-			checkIngesterError(t, tc.err, badData)
+			checkIngesterError(t, tc.err, badData, true)
 
 			wrappedErr := wrapOrAnnotateWithUser(tc.err, userID)
 			require.ErrorIs(t, wrappedErr, tc.err)
 			var sampleErr sampleError
 			require.ErrorAs(t, wrappedErr, &sampleErr)
-			checkIngesterError(t, wrappedErr, badData)
+			checkIngesterError(t, wrappedErr, badData, true)
 		})
 	}
 }
@@ -208,13 +208,13 @@ func TestNewExemplarError(t *testing.T) {
 	for testName, tc := range tests {
 		t.Run(testName, func(t *testing.T) {
 			require.Equal(t, tc.expectedMsg, tc.err.Error())
-			checkIngesterError(t, tc.err, badData)
+			checkIngesterError(t, tc.err, badData, true)
 
 			wrappedErr := wrapOrAnnotateWithUser(tc.err, userID)
 			require.ErrorIs(t, wrappedErr, tc.err)
 			var exemplarErr exemplarError
 			require.ErrorAs(t, wrappedErr, &exemplarErr)
-			checkIngesterError(t, wrappedErr, badData)
+			checkIngesterError(t, wrappedErr, badData, true)
 		})
 	}
 }
@@ -226,12 +226,12 @@ func TestNewTSDBIngestExemplarErr(t *testing.T) {
 	err := newTSDBIngestExemplarErr(anotherErr, timestamp, seriesLabels, exemplarsLabels)
 	expectedErrMsg := fmt.Sprintf("err: %v. timestamp=1970-01-19T05:30:43.969Z, series={__name__=\"test\"}, exemplar={traceID=\"123\"}", anotherErr)
 	require.Equal(t, expectedErrMsg, err.Error())
-	checkIngesterError(t, err, badData)
+	checkIngesterError(t, err, badData, true)
 
 	wrappedErr := wrapOrAnnotateWithUser(err, userID)
 	require.ErrorIs(t, wrappedErr, err)
 	require.ErrorAs(t, wrappedErr, &tsdbIngestExemplarErr{})
-	checkIngesterError(t, wrappedErr, badData)
+	checkIngesterError(t, wrappedErr, badData, true)
 }
 
 func TestErrorWithStatus(t *testing.T) {
@@ -282,8 +282,13 @@ func TestWrapOrAnnotateWithUser(t *testing.T) {
 	require.Equal(t, wrappingErr, errors.Unwrap(wrappedSafeErr))
 }
 
-func checkIngesterError(t *testing.T, err error, expectedType ingesterErrorType) {
+func checkIngesterError(t *testing.T, err error, expectedType ingesterErrorType, isSoft bool) {
 	var ingesterErr ingesterError
 	require.ErrorAs(t, err, &ingesterErr)
 	require.Equal(t, expectedType, ingesterErr.errorType())
+
+	if isSoft {
+		var softErr softError
+		require.ErrorAs(t, err, &softErr)
+	}
 }

--- a/pkg/ingester/instance_limits_test.go
+++ b/pkg/ingester/instance_limits_test.go
@@ -47,11 +47,11 @@ func TestInstanceLimitErr(t *testing.T) {
 		var instanceLimitErr instanceLimitReachedError
 		require.Error(t, instanceLimitErr)
 		require.ErrorAs(t, limitError, &instanceLimitErr)
-		checkIngesterError(t, limitError, instanceLimitReached)
+		checkIngesterError(t, limitError, instanceLimitReached, false)
 
 		wrappedWithUserErr := wrapOrAnnotateWithUser(limitError, userID)
 		require.Error(t, wrappedWithUserErr)
 		require.ErrorIs(t, wrappedWithUserErr, limitError)
-		checkIngesterError(t, wrappedWithUserErr, instanceLimitReached)
+		checkIngesterError(t, wrappedWithUserErr, instanceLimitReached, false)
 	}
 }


### PR DESCRIPTION
#### What this PR does
Ingester's `ingester.pushSamplesToAppender()`, called by `ingester.Push()`, appends samples and exemplars to the appender. The former distinguishes between:
- _soft errors_, which should allow `ingester.Push()` to continue its execution and to ingest all valid samples and exemplars, and to return the first encountered error only at the end, and 
- _other errors_, that should be returned immediately.

So far there was no precise way to determine which error is a soft error. This PR introduces `softError`, an interface that should be implemented by all the errors that shouldn't prevent `ingester.Push()` from going ahead. Only these errors will be considered as _soft errors_ by `pushSamplesToAppender()`.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/6008
#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
