### PR TITLE
chore: add support for not setting replicas helm chart

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Reduce `-server.grpc-max-concurrent-streams` from 1000 to 500 for ingester and to 100 for all components. #5666
 * [CHANGE] Changed default `clusterDomain` from `cluster.local` to `cluster.local.` to reduce the number of DNS lookups made by Mimir. #6389
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.9.1`. #6022 #6110
+* [ENHANCEMENT] Add support for not setting replicas for distributor, querier, and query-frontend. #6373
 * [BUGFIX] Let the unified gatway/nginx config listen on IPv6 as well. Followup to #5948. #6204
 * [BUGFIX] Quote `checksum/config` when using external config. This allows setting `externalConfigVersion` to numeric values. #6407
 

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- toYaml .Values.distributor.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  {{- if .Values.distributor.replicas }}
   replicas: {{ .Values.distributor.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 6 }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -8,7 +8,6 @@ metadata:
     {{- toYaml .Values.distributor.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  # testy
   {{- if or (kindIs "float64" .Values.distributor.replicas) (.Values.distributor.replicas) }}
   replicas: {{ .Values.distributor.replicas }}
   {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.distributor.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  {{- if or (kindIs "float64" .Values.distributor.replicas) (.Values.distributor.replicas) }}
+  {{- if or (or (kindIs "int64" .Values.distributor.replicas) (kindIs "float64" .Values.distributor.replicas)) (.Values.distributor.replicas) }}
   replicas: {{ .Values.distributor.replicas }}
   {{- end }}
   selector:

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- toYaml .Values.distributor.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   {{- if or (or (kindIs "int64" .Values.distributor.replicas) (kindIs "float64" .Values.distributor.replicas)) (.Values.distributor.replicas) }}
   replicas: {{ .Values.distributor.replicas }}
   {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.distributor.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  {{- if .Values.distributor.replicas }}
+  {{- if kindIs "float64" .Values.distributor.replicas }}
   replicas: {{ .Values.distributor.replicas }}
   {{- end }}
   selector:

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -8,7 +8,8 @@ metadata:
     {{- toYaml .Values.distributor.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  {{- if kindIs "float64" .Values.distributor.replicas }}
+  # testy
+  {{- if or (kindIs "float64" .Values.distributor.replicas) (.Values.distributor.replicas) }}
   replicas: {{ .Values.distributor.replicas }}
   {{- end }}
   selector:

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -8,7 +8,10 @@ metadata:
     {{- toYaml .Values.querier.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  {{- if or (or (kindIs "int64" .Values.querier.replicas) (kindIs "float64" .Values.querier.replicas)) (.Values.querier.replicas) }}
   replicas: {{ .Values.querier.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" . "component" "querier" "memberlist" true) | nindent 6 }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,7 +8,10 @@ metadata:
     {{- toYaml .Values.query_frontend.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  {{- if or (or (kindIs "int64" .Values.query_frontend.replicas) (kindIs "float64" .Values.query_frontend.replicas)) (.Values.query_frontend.replicas) }}
   replicas: {{ .Values.query_frontend.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-frontend") | nindent 6 }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -697,6 +697,7 @@ alertmanager:
       storageClass: null
 
 distributor:
+  # Setting it to null will produce a deployment without replicas set, allowing you to use autoscaling with the deployment
   replicas: 1
 
   service:
@@ -1201,6 +1202,7 @@ querier:
   extraEnvFrom: []
 
 query_frontend:
+  # Setting it to null will produce a deployment without replicas set, allowing you to use autoscaling with the deployment
   replicas: 1
 
   service:
@@ -3247,6 +3249,7 @@ graphite:
   enabled: false
 
   querier:
+    # Setting it to null will produce a deployment without replicas set, allowing you to use autoscaling with the deployment
     replicas: 2
 
     schemasConfiguration:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 12
   selector:
     matchLabels:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 4
   selector:
     matchLabels:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 3
   selector:
     matchLabels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -12,6 +12,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -12,6 +12,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -12,6 +12,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 2
   selector:
     matchLabels:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -13,6 +13,7 @@ metadata:
     {}
   namespace: "citestns"
 spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Introduces support for not setting replicas, specifically so you can use autoscaling with components which are safe to autoscale.

As I mentioned here https://github.com/grafana/mimir/issues/3430#issuecomment-1753648322 I did some testing,

I started with
```
  {{- if ne .Values.distributor.replicas "null"  }}
  replicas: {{ .Values.distributor.replicas }}
  {{- end }}
```
but helm complains when it's not null:
```
Error: template: mimir-distributed/templates/distributor/distributor-dep.yaml:11:9: executing "mimir-distributed/templates/distributor/distributor-dep.yaml" at <ne .Values.distributor.replicas "null">: error calling ne: incompatible types for comparison
```
So I tried:
```
  {{- if .Values.distributor.replicas }}
  replicas: {{ .Values.distributor.replicas }}
  {{- end }}
```
when replicas is a number i.e. the default `1` it works.
When it's set to null the replicas is not set, good.
But when it's set to 0 it's also unset. Now this is not a common case imho but it would break.
Would that be okay or should I look for another way to do it?

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number> https://github.com/grafana/mimir/issues/3430#issuecomment-1755134227

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
