### PR TITLE
Emit histogram for number of tenants queried by federation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [ENHANCEMENT] Ingester / store-gateway: optimized regex matchers. #6168 #6250
 * [ENHANCEMENT] Distributor: Include ingester IDs in circuit breaker related metrics and logs. #6206
 * [ENHANCEMENT] Querier: improve errors and logging when streaming chunks from ingesters and store-gateways. #6194 #6309
+* [ENHANCEMENT] Querier: Add `cortex_querier_federation_exemplar_tenants_queried` and `cortex_querier_federation_sample_tenants_queried` metrics to track the number of tenants queried by multi-tenant queries. #6374
 * [ENHANCEMENT] All: added an experimental `-server.grpc.num-workers` flag that configures the number of long-living workers used to process gRPC requests. This could decrease the CPU usage by reducing the number of stack allocations. #6311
 * [ENHANCEMENT] All: improved IPv6 support by using the proper host:port formatting. #6311
 * [ENHANCEMENT] Querier: always return error encountered during chunks streaming, rather than `the stream has already been exhausted`. #6345

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 * [ENHANCEMENT] Ingester / store-gateway: optimized regex matchers. #6168 #6250
 * [ENHANCEMENT] Distributor: Include ingester IDs in circuit breaker related metrics and logs. #6206
 * [ENHANCEMENT] Querier: improve errors and logging when streaming chunks from ingesters and store-gateways. #6194 #6309
-* [ENHANCEMENT] Querier: Add `cortex_querier_federation_exemplar_tenants_queried` and `cortex_querier_federation_sample_tenants_queried` metrics to track the number of tenants queried by multi-tenant queries. #6374
+* [ENHANCEMENT] Querier: Add `cortex_querier_federation_exemplar_tenants_queried` and `cortex_querier_federation_tenants_queried` metrics to track the number of tenants queried by multi-tenant queries. #6374
 * [ENHANCEMENT] All: added an experimental `-server.grpc.num-workers` flag that configures the number of long-living workers used to process gRPC requests. This could decrease the CPU usage by reducing the number of stack allocations. #6311
 * [ENHANCEMENT] All: improved IPv6 support by using the proper host:port formatting. #6311
 * [ENHANCEMENT] Querier: always return error encountered during chunks streaming, rather than `the stream has already been exhausted`. #6345

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -471,8 +471,8 @@ func (t *Mimir) initTenantFederation() (serv services.Service, err error) {
 		// single tenant. This allows for a less impactful enabling of tenant
 		// federation.
 		const bypassForSingleQuerier = true
-		t.QuerierQueryable = querier.NewSampleAndChunkQueryable(tenantfederation.NewQueryable(t.QuerierQueryable, bypassForSingleQuerier, t.Cfg.TenantFederation.MaxConcurrent, util_log.Logger))
-		t.ExemplarQueryable = tenantfederation.NewExemplarQueryable(t.ExemplarQueryable, bypassForSingleQuerier, t.Cfg.TenantFederation.MaxConcurrent, util_log.Logger)
+		t.QuerierQueryable = querier.NewSampleAndChunkQueryable(tenantfederation.NewQueryable(t.QuerierQueryable, bypassForSingleQuerier, t.Cfg.TenantFederation.MaxConcurrent, t.Registerer, util_log.Logger))
+		t.ExemplarQueryable = tenantfederation.NewExemplarQueryable(t.ExemplarQueryable, bypassForSingleQuerier, t.Cfg.TenantFederation.MaxConcurrent, t.Registerer, util_log.Logger)
 		t.MetadataSupplier = tenantfederation.NewMetadataSupplier(t.MetadataSupplier, t.Cfg.TenantFederation.MaxConcurrent, util_log.Logger)
 	}
 	return nil, nil
@@ -783,7 +783,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 			// This makes this label more consistent and hopefully less confusing to users.
 			const bypassForSingleQuerier = false
 
-			federatedQueryable = tenantfederation.NewQueryable(queryable, bypassForSingleQuerier, t.Cfg.TenantFederation.MaxConcurrent, util_log.Logger)
+			federatedQueryable = tenantfederation.NewQueryable(queryable, bypassForSingleQuerier, t.Cfg.TenantFederation.MaxConcurrent, t.Registerer, util_log.Logger)
 
 			regularQueryFunc := rules.EngineQueryFunc(eng, queryable)
 			federatedQueryFunc := rules.EngineQueryFunc(eng, federatedQueryable)

--- a/pkg/querier/tenantfederation/merge_exemplar_queryable.go
+++ b/pkg/querier/tenantfederation/merge_exemplar_queryable.go
@@ -10,6 +10,8 @@ import (
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -27,8 +29,8 @@ import (
 // By setting bypassWithSingleQuerier to true, tenant federation logic gets
 // bypassed if the request is only for a single tenant. The requests will also
 // not contain the pseudo series label __tenant_id__ in this case.
-func NewExemplarQueryable(upstream storage.ExemplarQueryable, bypassWithSingleQuerier bool, maxConcurrency int, logger log.Logger) storage.ExemplarQueryable {
-	return NewMergeExemplarQueryable(defaultTenantLabel, upstream, bypassWithSingleQuerier, maxConcurrency, logger)
+func NewExemplarQueryable(upstream storage.ExemplarQueryable, bypassWithSingleQuerier bool, maxConcurrency int, reg prometheus.Registerer, logger log.Logger) storage.ExemplarQueryable {
+	return NewMergeExemplarQueryable(defaultTenantLabel, upstream, bypassWithSingleQuerier, maxConcurrency, reg, logger)
 }
 
 // NewMergeExemplarQueryable returns an exemplar queryable that makes requests for
@@ -41,7 +43,7 @@ func NewExemplarQueryable(upstream storage.ExemplarQueryable, bypassWithSingleQu
 // By setting bypassWithSingleQuerier to true, tenant federation logic gets
 // bypassed if the request is only for a single tenant. The requests will also
 // not contain the pseudo series label `idLabelName` in this case.
-func NewMergeExemplarQueryable(idLabelName string, upstream storage.ExemplarQueryable, bypassWithSingleQuerier bool, maxConcurrency int, logger log.Logger) storage.ExemplarQueryable {
+func NewMergeExemplarQueryable(idLabelName string, upstream storage.ExemplarQueryable, bypassWithSingleQuerier bool, maxConcurrency int, reg prometheus.Registerer, logger log.Logger) storage.ExemplarQueryable {
 	return &mergeExemplarQueryable{
 		logger:                  logger,
 		idLabelName:             idLabelName,
@@ -49,6 +51,11 @@ func NewMergeExemplarQueryable(idLabelName string, upstream storage.ExemplarQuer
 		upstream:                upstream,
 		resolver:                tenant.NewMultiResolver(),
 		maxConcurrency:          maxConcurrency,
+		tenantsQueried: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_querier_federation_exemplar_tenants_queried",
+			Help:    "Number of tenants queried for a single exemplar query.",
+			Buckets: []float64{1, 2, 4, 8, 16, 32},
+		}),
 	}
 }
 
@@ -59,6 +66,7 @@ type mergeExemplarQueryable struct {
 	upstream                storage.ExemplarQueryable
 	resolver                tenant.Resolver
 	maxConcurrency          int
+	tenantsQueried          prometheus.Histogram
 }
 
 // tenantsAndQueriers returns a list of tenant IDs and corresponding queriers based on the context
@@ -89,6 +97,7 @@ func (m *mergeExemplarQueryable) ExemplarQuerier(ctx context.Context) (storage.E
 		return nil, err
 	}
 
+	m.tenantsQueried.Observe(float64(len(ids)))
 	// If desired and there is only a single querier, just return it directly instead
 	// of going through the federation querier. bypassWithSingleQuerier=true allows a
 	// bit less overhead when it's not needed while bypassWithSingleQuerier=false will

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -107,7 +107,7 @@ func NewMergeQueryable(idLabelName string, callbacks MergeQueryableCallbacks, by
 		bypassWithSingleID: bypassWithSingleID,
 		maxConcurrency:     maxConcurrency,
 		tenantsQueried: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "cortex_querier_federation_sample_tenants_queried",
+			Name:    "cortex_querier_federation_tenants_queried",
 			Help:    "Number of tenants queried for a single standard query.",
 			Buckets: []float64{1, 2, 4, 8, 16, 32},
 		}),

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -409,31 +409,31 @@ var (
 	}
 
 	expectSingleTenantsMetrics = `
-# HELP cortex_querier_federation_sample_tenants_queried Number of tenants queried for a single standard query.
-# TYPE cortex_querier_federation_sample_tenants_queried histogram
-cortex_querier_federation_sample_tenants_queried_bucket{le="1"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="2"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="4"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="8"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="16"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="32"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="+Inf"} 1
-cortex_querier_federation_sample_tenants_queried_sum 1
-cortex_querier_federation_sample_tenants_queried_count 1
+# HELP cortex_querier_federation_tenants_queried Number of tenants queried for a single standard query.
+# TYPE cortex_querier_federation_tenants_queried histogram
+cortex_querier_federation_tenants_queried_bucket{le="1"} 1
+cortex_querier_federation_tenants_queried_bucket{le="2"} 1
+cortex_querier_federation_tenants_queried_bucket{le="4"} 1
+cortex_querier_federation_tenants_queried_bucket{le="8"} 1
+cortex_querier_federation_tenants_queried_bucket{le="16"} 1
+cortex_querier_federation_tenants_queried_bucket{le="32"} 1
+cortex_querier_federation_tenants_queried_bucket{le="+Inf"} 1
+cortex_querier_federation_tenants_queried_sum 1
+cortex_querier_federation_tenants_queried_count 1
 `
 
 	expectThreeTenantsMetrics = `
-# HELP cortex_querier_federation_sample_tenants_queried Number of tenants queried for a single standard query.
-# TYPE cortex_querier_federation_sample_tenants_queried histogram
-cortex_querier_federation_sample_tenants_queried_bucket{le="1"} 0
-cortex_querier_federation_sample_tenants_queried_bucket{le="2"} 0
-cortex_querier_federation_sample_tenants_queried_bucket{le="4"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="8"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="16"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="32"} 1
-cortex_querier_federation_sample_tenants_queried_bucket{le="+Inf"} 1
-cortex_querier_federation_sample_tenants_queried_sum 3
-cortex_querier_federation_sample_tenants_queried_count 1
+# HELP cortex_querier_federation_tenants_queried Number of tenants queried for a single standard query.
+# TYPE cortex_querier_federation_tenants_queried histogram
+cortex_querier_federation_tenants_queried_bucket{le="1"} 0
+cortex_querier_federation_tenants_queried_bucket{le="2"} 0
+cortex_querier_federation_tenants_queried_bucket{le="4"} 1
+cortex_querier_federation_tenants_queried_bucket{le="8"} 1
+cortex_querier_federation_tenants_queried_bucket{le="16"} 1
+cortex_querier_federation_tenants_queried_bucket{le="32"} 1
+cortex_querier_federation_tenants_queried_bucket{le="+Inf"} 1
+cortex_querier_federation_tenants_queried_sum 3
+cortex_querier_federation_tenants_queried_count 1
 `
 )
 


### PR DESCRIPTION
#### What this PR does

Adds new histograms for the number of tenants queried by exemplar, label name, label value, instant, or range queries.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated
- [NA] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
