### PR TITLE
Distributor: improve context.Canceled and context.DeadlineExceeded handling

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3504,7 +3504,7 @@ func (i *mockIngester) Push(ctx context.Context, req *mimirpb.WriteRequest, _ ..
 	}
 
 	if i.timeOut {
-		return nil, context.DeadlineExceeded
+		return nil, status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
 	}
 
 	if len(req.Timeseries) > 0 && i.timeseries == nil {
@@ -4798,8 +4798,12 @@ func TestHandleIngesterPushError(t *testing.T) {
 			expectedOutputError: errors.Wrap(unavailableErr, outputErrorMsgPrefix),
 		},
 		"a context cancel error gives the same wrapped error": {
-			ingesterPushError:   context.Canceled,
+			ingesterPushError:   status.Error(codes.Canceled, context.Canceled.Error()),
 			expectedOutputError: errors.Wrap(context.Canceled, outputErrorMsgPrefix),
+		},
+		"a context deadline exceeded error gives the same wrapped error": {
+			ingesterPushError:   status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error()),
+			expectedOutputError: errors.Wrap(context.DeadlineExceeded, outputErrorMsgPrefix),
 		},
 	}
 

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -11,7 +11,8 @@ import (
 
 const (
 	// 529 is non-standard status code used by some services to signal that "The service is overloaded".
-	StatusServiceOverloaded = 529
+	StatusServiceOverloaded     = 529
+	deadlineExceededWrapMessage = "exceeded configured distributor remote timeout"
 )
 
 var (

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -162,6 +162,9 @@ func distributorPushErrorHTTPStatus(ctx context.Context, pushErr error, limits *
 // the resulting HTTP status is returned with status true. Otherwise, -1 and the status
 // false are returned.
 func toHTTPStatus(pushErr error, serviceOverloadErrorEnabled bool) (int, bool) {
+	if errors.Is(pushErr, context.DeadlineExceeded) {
+		return http.StatusInternalServerError, true
+	}
 	switch {
 	case errors.As(pushErr, &replicasDidNotMatchError{}):
 		return http.StatusAccepted, true


### PR DESCRIPTION
#### What this PR does
Errors `context.Canceled` and `context.DeadlineExceeded` returned by the ingester are not correctly handled by the distributor. Namely, when `Distributor.send()` calls `IngesterClient.Push()`, the returned errors are gRPC errors. That means that a gRPC error `err` corresponding to `context.Canceled` or `context.DeadlineExceeded` will contain gRPC code `codes.Canceled` or `codes.DeadlineExceeded`, and checks `errors.Is(err, context.Canceled)` or `errors.Is(err, context.DeadlineExceeded)` will not be successful.

As a consequence, in case of a `context.Canceled` in `Ingester.Push()`, the current log entry would be 
```
msg="push error" err="failed pushing to ingester: rpc error: code = Canceled desc = context canceled"
```
instead of the expected ([here](https://github.com/grafana/mimir/blob/da1f78951396ef754d8e0ea95da4ccae457db98f/pkg/distributor/push.go#L126-L130))
```
msg="push request canceled" err="failed pushing to ingester: context canceled"
```

Similarly, in case of a `context.DeadlineExceeded` in `Ingester.Push()`, the current log entry would be
```
msg="push error" err="failed pushing to ingester: rpc error: code = DeadlineExceeded desc = context deadline exceeded"
```
instead of the expected ([here](https://github.com/grafana/mimir/blob/da1f78951396ef754d8e0ea95da4ccae457db98f/pkg/distributor/distributor.go#L1193-L1195))
```
msg="push error" err="exceeded configured distributor remote timeout: failed pushing to ingester: context deadline exceeded"
```

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/6008

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
