### PR TITLE
Storage: remove signatureversionv2 from s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Storage: remove signatureversionv2 from s3. #6378
 * [CHANGE] Store-gateway: enable sparse index headers by default. Sparse index headers reduce the time to load an index header up to 90%. #6005
 * [CHANGE] Store-gateway: lazy-loading concurrency limit default value is now 4. #6004
 * [CHANGE] General: enabled `-log.buffered` by default. The `-log.buffered` has been deprecated and will be removed in Mimir 2.13. #6131

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -4445,7 +4445,7 @@ The s3_backend block configures the connection to Amazon S3 object storage backe
 [insecure: <boolean> | default = false]
 
 # (advanced) The signature version to use for authenticating against S3.
-# Supported values are: v4, v2.
+# Supported values are: v4.
 # CLI flag: -<prefix>.s3.signature-version
 [signature_version: <string> | default = "v4"]
 

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -71,7 +71,5 @@ func newS3Config(cfg Config) (s3.Config, error) {
 			MaxConnsPerHost:       cfg.HTTP.MaxConnsPerHost,
 			Transport:             cfg.HTTP.Transport,
 		},
-		// Enforce signature version 2 if CLI flag is set
-		SignatureV2: cfg.SignatureVersion == SignatureVersionV2,
 	}, nil
 }

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
+	// Signature Version 2 is being turned off (deprecated) in Amazon S3. Amazon S3 will then only accept API requests that are signed using Signature Version 4.
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingAWSSDK.html#UsingAWSSDK-sig2-deprecation
 	SignatureVersionV4 = "v4"
-	SignatureVersionV2 = "v2"
 
 	// SSEKMS config type constant to configure S3 server side encryption using KMS
 	// https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
@@ -36,7 +37,7 @@ const (
 )
 
 var (
-	supportedSignatureVersions     = []string{SignatureVersionV4, SignatureVersionV2}
+	supportedSignatureVersions     = []string{SignatureVersionV4}
 	supportedSSETypes              = []string{SSEKMS, SSES3}
 	supportedStorageClasses        = s3_service.ObjectStorageClass_Values()
 	errUnsupportedSignatureVersion = fmt.Errorf("unsupported signature version (supported values: %s)", strings.Join(supportedSignatureVersions, ", "))

--- a/pkg/storage/bucket/s3/config_test.go
+++ b/pkg/storage/bucket/s3/config_test.go
@@ -85,7 +85,7 @@ func TestConfig_Validate(t *testing.T) {
 		"should fail if invalid storage class is set": {
 			setup: func() *Config {
 				return &Config{
-					SignatureVersion: SignatureVersionV2,
+					SignatureVersion: SignatureVersionV4,
 					StorageClass:     "foo",
 				}
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Remove SignatureVersionv2 from the aws s3 api request authentication
S3 will stop accepting requests signed using SigV2 in all regions on June 24, 2019, any
requests signed using SigV2 made after this time will fail

Delete unnecessary v2 token swaps together

reference
https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingAWSSDK.html#UsingAWSSDK-sig2-deprecation
https://aws.amazon.com/blogs/aws/amazon-s3-update-sigv2-deprecation-period-extended-modified/

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
