### PR TITLE
Give build image GitHub workflow permission to push commits

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -15,7 +15,8 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # Allow pushing to the GitHub repo for collaborators, forks should remain read-only
+      contents: write
       # Allow PR modification for collaborators, forks should remain read-only
       pull-requests: write
     steps:
@@ -107,7 +108,7 @@ jobs:
             git config --global user.name "${{ github.event.pull_request.user.login }}"
             git add Makefile
             git commit -m "Update build image version to ${{ steps.compute_hash.outputs.tag }}"
-            git push
+            git push origin HEAD
           fi 
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
#### What this PR does

Give "Build and Push mimir-build-image" GitHub workflow permission to push commits, since the current permission set isn't enough. See [example](https://github.com/grafana/mimir/actions/runs/6527802011/job/17723123228) of build that failed due to inability to push commit to PR head branch.

From reading the [reference documentation](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) on GitHub job permissions, I conclude that `contents: write` is necessary (upgrading from `contents: read`).

Also giving the commit push command an explicit branch to push to and from (`HEAD`), so we don't have to rely on the correct tracking branch.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
