### PR TITLE
critical compactor alert for multiple out-of-order chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 * [ENHANCEMENT] Dashboards: Optionally show rejected requests on Mimir Writes dashboard. Useful when used together with "early request rejection". #6132
 * [BUGFIX] Alerts: fixed issue where `GossipMembersMismatch` warning message referred to per-instance labels that were not produced by the alert query. #6146
+* [ENHANCEMENT] Alerts: added a critical alert for `CompactorSkippedBlocksWithOutOfOrderChunks` when multiple blocks are affected. #6410
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -898,6 +898,16 @@ spec:
       for: 1m
       labels:
         severity: warning
+    - alert: MimirCompactorSkippedBlocksWithOutOfOrderChunks
+      annotations:
+        message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+          }} has found and ignored blocks with out of order chunks.
+        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorskippedblockswithoutoforderchunks
+      expr: |
+        increase(cortex_compactor_blocks_marked_for_no_compaction_total{reason="block-index-out-of-order-chunk"}[5m]) > 1
+      for: 30m
+      labels:
+        severity: critical
   - name: mimir_autoscaling
     rules:
     - alert: MimirAutoscalerNotActive

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -873,6 +873,16 @@ groups:
     for: 1m
     labels:
       severity: warning
+  - alert: MimirCompactorSkippedBlocksWithOutOfOrderChunks
+    annotations:
+      message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{
+        $labels.namespace }} has found and ignored blocks with out of order chunks.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorskippedblockswithoutoforderchunks
+    expr: |
+      increase(cortex_compactor_blocks_marked_for_no_compaction_total{reason="block-index-out-of-order-chunk"}[5m]) > 1
+    for: 30m
+    labels:
+      severity: critical
 - name: mimir_autoscaling
   rules:
   - alert: MimirAutoscalerNotActive

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -886,6 +886,16 @@ groups:
     for: 1m
     labels:
       severity: warning
+  - alert: MimirCompactorSkippedBlocksWithOutOfOrderChunks
+    annotations:
+      message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} has found and ignored blocks with out of order chunks.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorskippedblockswithoutoforderchunks
+    expr: |
+      increase(cortex_compactor_blocks_marked_for_no_compaction_total{reason="block-index-out-of-order-chunk"}[5m]) > 1
+    for: 30m
+    labels:
+      severity: critical
 - name: mimir_autoscaling
   rules:
   - alert: MimirAutoscalerNotActive

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -123,6 +123,21 @@
             message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has found and ignored blocks with out of order chunks.' % $._config,
           },
         },
+        {
+          // Alert if compactor has tried to compact blocks with out-of-order chunks.
+          // Any number greater than 1 over the last 30 minutes should be investigated quickly as it could start to impact the read path.
+          alert: $.alertName('CompactorSkippedBlocksWithOutOfOrderChunks'),
+          'for': '30m',
+          expr: |||
+            increase(cortex_compactor_blocks_marked_for_no_compaction_total{reason="block-index-out-of-order-chunk"}[5m]) > 1
+          |||,
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has found and ignored blocks with out of order chunks.' % $._config,
+          },
+        },
       ],
     },
   ],


### PR DESCRIPTION
#### What this PR does

This adds a `critical` version of the `CompactorSkippedBlocksWithOutOfOrderChunks` alert. The idea is that if many out-of-order chunks are preventing blocks from being compacted, eventually the read path could be impacted since store-gateways would have to handle more numerous, smaller blocks. The critical alert signals that the reason for the out-of-order chunks should be investigated before the read path is affected.

#### Which issue(s) this PR fixes or relates to

This PR would give critical alerts for issues like https://github.com/prometheus/prometheus/issues/12873

#### Checklist

- [N/A] Tests updated
- [X] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
