### PR TITLE
Dedupe scaled object creation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,8 +299,10 @@
 * [ENHANCEMENT] Update rollout-operator to `v0.7.0`. #5718
 * [ENHANCEMENT] Increase the default rollout speed for store-gateway when lazy loading is disabled. #5823
 * [ENHANCEMENT] Add autoscaling on memory for ruler-queriers. #5739
+* [ENHANCEMENT] Deduplicate scaled object creation for most objects that scale on CPU and memory. #6411
 * [BUGFIX] Fix compilation when index, chunks or metadata caches are disabled. #5710
 * [BUGFIX] Autoscaling: treat OOMing containers as though they are using their full memory request. #5739
+* [BUGFIX] Autoscaling: if no containers are up, report 0 memory usage instead of no data. #6411
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1943,9 +1943,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="alertmanager",namespace="default"})
-            and
-            max by (pod) (up{container="alertmanager",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="alertmanager",namespace="default"})
+              and
+              max by (pod) (up{container="alertmanager",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1999,9 +2001,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
-            and
-            max by (pod) (up{container="distributor",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
+              and
+              max by (pod) (up{container="distributor",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2082,9 +2086,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="query-frontend",namespace="default"})
-            and
-            max by (pod) (up{container="query-frontend",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="query-frontend",namespace="default"})
+              and
+              max by (pod) (up{container="query-frontend",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2138,9 +2144,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
-            and
-            max by (pod) (up{container="ruler",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
+              and
+              max by (pod) (up{container="ruler",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2194,9 +2202,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="ruler-querier",namespace="default"})
-            and
-            max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="ruler-querier",namespace="default"})
+              and
+              max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2250,9 +2260,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
-            and
-            max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
+              and
+              max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1943,9 +1943,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="alertmanager",namespace="default"})
-            and
-            max by (pod) (up{container="alertmanager",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="alertmanager",namespace="default"})
+              and
+              max by (pod) (up{container="alertmanager",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1999,9 +2001,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
-            and
-            max by (pod) (up{container="distributor",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
+              and
+              max by (pod) (up{container="distributor",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2082,9 +2086,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="query-frontend",namespace="default"})
-            and
-            max by (pod) (up{container="query-frontend",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="query-frontend",namespace="default"})
+              and
+              max by (pod) (up{container="query-frontend",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2138,9 +2144,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
-            and
-            max by (pod) (up{container="ruler",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
+              and
+              max by (pod) (up{container="ruler",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2194,9 +2202,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="ruler-querier",namespace="default"})
-            and
-            max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="ruler-querier",namespace="default"})
+              and
+              max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2250,9 +2260,11 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
-            and
-            max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
+              and
+              max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
+            ) or vector(0)
           )[15m:]
         )
         +

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -199,9 +199,11 @@
   local memoryHPAQuery = |||
     max_over_time(
       sum(
-        sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"})
-        and
-        max by (pod) (up{container="%(container)s",namespace="%(namespace)s"}) > 0
+        (
+          sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"})
+          and
+          max by (pod) (up{container="%(container)s",namespace="%(namespace)s"}) > 0
+        ) or vector(0)
       )[15m:]
     )
     +

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -215,8 +215,7 @@
     )
   |||,
 
-
-  newQueryFrontendScaledObject(
+  newResourceScaledObject(
     name,
     cpu_requests,
     memory_requests,
@@ -224,24 +223,32 @@
     max_replicas,
     cpu_target_utilization,
     memory_target_utilization,
+    with_cortex_prefix=false,
+    weight=1,
+    scaledownPeriod=null,
   ):: self.newScaledObject(
     name, $._config.namespace, {
-      min_replica_count: min_replicas,
-      max_replica_count: max_replicas,
+      min_replica_count: replicasWithWeight(min_replicas, weight),
+      max_replica_count: replicasWithWeight(max_replicas, weight),
+
+      [if scaledownPeriod != null then 'scaledownPeriod']: scaledownPeriod,
+
       triggers: [
         {
-          metric_name: '%s_cpu_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
+          metric_name: '%s%s_cpu_hpa_%s' %
+                       ([if with_cortex_prefix then 'cortex_' else ''] + [std.strReplace(name, '-', '_'), $._config.namespace]),
 
-          query: cpuHPAQuery % {
+          query: metricWithWeight(cpuHPAQuery % {
             container: name,
             namespace: $._config.namespace,
-          },
+          }, weight),
 
           // Threshold is expected to be a string
           threshold: std.toString(std.floor(cpuToMilliCPUInt(cpu_requests) * cpu_target_utilization)),
         },
         {
-          metric_name: '%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
+          metric_name: '%s%s_memory_hpa_%s' %
+                       ([if with_cortex_prefix then 'cortex_' else ''] + [std.strReplace(name, '-', '_'), $._config.namespace]),
 
           query: memoryHPAQuery % {
             container: name,
@@ -310,7 +317,7 @@
   ),
 
   query_frontend_scaled_object: if !$._config.autoscaling_query_frontend_enabled then null else
-    $.newQueryFrontendScaledObject(
+    $.newResourceScaledObject(
       name='query-frontend',
       cpu_requests=$.query_frontend_container.resources.requests.cpu,
       memory_requests=$.query_frontend_container.resources.requests.memory,
@@ -319,6 +326,7 @@
       cpu_target_utilization=$._config.autoscaling_query_frontend_cpu_target_utilization,
       memory_target_utilization=$._config.autoscaling_query_frontend_memory_target_utilization,
     ),
+
   query_frontend_deployment: overrideSuperIfExists(
     'query_frontend_deployment',
     if $._config.autoscaling_query_frontend_enabled then $.removeReplicasFromSpec else
@@ -387,7 +395,7 @@
   ),
 
   ruler_query_frontend_scaled_object: if !$._config.autoscaling_ruler_query_frontend_enabled || !$._config.ruler_remote_evaluation_enabled then null else
-    $.newQueryFrontendScaledObject(
+    $.newResourceScaledObject(
       name='ruler-query-frontend',
       cpu_requests=$.ruler_query_frontend_container.resources.requests.cpu,
       memory_requests=$.ruler_query_frontend_container.resources.requests.memory,
@@ -396,6 +404,7 @@
       cpu_target_utilization=$._config.autoscaling_ruler_query_frontend_cpu_target_utilization,
       memory_target_utilization=$._config.autoscaling_ruler_query_frontend_memory_target_utilization,
     ),
+
   ruler_query_frontend_deployment: overrideSuperIfExists(
     'ruler_query_frontend_deployment',
     if $._config.autoscaling_ruler_query_frontend_enabled then $.removeReplicasFromSpec else
@@ -404,57 +413,16 @@
         {}
   ),
 
-  //
-  // Distributors
-  //
-
-  newDistributorScaledObject(
-    name,
-    distributor_cpu_requests,
-    distributor_memory_requests,
-    min_replicas,
-    max_replicas,
-    cpu_target_utilization,
-    memory_target_utilization,
-  ):: self.newScaledObject(name, $._config.namespace, {
-    min_replica_count: min_replicas,
-    max_replica_count: max_replicas,
-
-    triggers: [
-      {
-        metric_name: 'cortex_%s_cpu_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
-
-        query: cpuHPAQuery % {
-          container: name,
-          namespace: $._config.namespace,
-        },
-
-        // threshold is expected to be a string.
-        threshold: std.toString(std.floor(cpuToMilliCPUInt(distributor_cpu_requests) * cpu_target_utilization)),
-      },
-      {
-        metric_name: 'cortex_%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
-
-        query: memoryHPAQuery % {
-          container: name,
-          namespace: $._config.namespace,
-        },
-
-        // threshold is expected to be a string
-        threshold: std.toString(std.floor($.util.siToBytes(distributor_memory_requests) * memory_target_utilization)),
-      },
-    ],
-  }),
-
   distributor_scaled_object: if !$._config.autoscaling_distributor_enabled then null else
-    $.newDistributorScaledObject(
+    $.newResourceScaledObject(
       name='distributor',
-      distributor_cpu_requests=$.distributor_container.resources.requests.cpu,
-      distributor_memory_requests=$.distributor_container.resources.requests.memory,
+      cpu_requests=$.distributor_container.resources.requests.cpu,
+      memory_requests=$.distributor_container.resources.requests.memory,
       min_replicas=$._config.autoscaling_distributor_min_replicas,
       max_replicas=$._config.autoscaling_distributor_max_replicas,
       cpu_target_utilization=$._config.autoscaling_distributor_cpu_target_utilization,
       memory_target_utilization=$._config.autoscaling_distributor_memory_target_utilization,
+      with_cortex_prefix=true,
     ),
 
   distributor_deployment: overrideSuperIfExists(
@@ -462,46 +430,17 @@
     if !$._config.autoscaling_distributor_enabled then {} else $.removeReplicasFromSpec
   ),
 
-  // Ruler
-
-  local newRulerScaledObject(name) = self.newScaledObject(
-    name, $._config.namespace, {
-      min_replica_count: $._config.autoscaling_ruler_min_replicas,
-      max_replica_count: $._config.autoscaling_ruler_max_replicas,
-
-      // To guarantee rule evaluation without any omissions, it is imperative to avoid the frequent scaling up and down of the ruler.
-      // As a result, we have made the decision to set the scale down periodSeconds to 600.
-      scaledownPeriod: 600,
-
-      triggers: [
-        {
-          metric_name: '%s_cpu_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
-
-          query: cpuHPAQuery % {
-            container: name,
-            namespace: $._config.namespace,
-          },
-
-          // Threshold is expected to be a string
-          threshold: std.toString(std.floor(cpuToMilliCPUInt($.ruler_container.resources.requests.cpu) * $._config.autoscaling_ruler_cpu_target_utilization)),
-        },
-        {
-          metric_name: '%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
-
-          query: memoryHPAQuery % {
-            container: name,
-            namespace: $._config.namespace,
-          },
-
-          // Threshold is expected to be a string
-          threshold: std.toString(std.floor($.util.siToBytes($.ruler_container.resources.requests.memory) * $._config.autoscaling_ruler_memory_target_utilization)),
-        },
-      ],
-    },
-  ),
-
-  ruler_scaled_object: if !$._config.autoscaling_ruler_enabled then null else newRulerScaledObject(
+  ruler_scaled_object: if !$._config.autoscaling_ruler_enabled then null else $.newResourceScaledObject(
     name='ruler',
+    cpu_requests=$.ruler_container.resources.requests.cpu,
+    memory_requests=$.ruler_container.resources.requests.memory,
+    min_replicas=$._config.autoscaling_ruler_min_replicas,
+    max_replicas=$._config.autoscaling_ruler_max_replicas,
+    cpu_target_utilization=$._config.autoscaling_ruler_cpu_target_utilization,
+    memory_target_utilization=$._config.autoscaling_ruler_memory_target_utilization,
+    // To guarantee rule evaluation without any omissions, it is imperative to avoid the frequent scaling up and down of the ruler.
+    // As a result, we have made the decision to set the scale down periodSeconds to 600.
+    scaledownPeriod=600,
   ),
 
   ruler_deployment: overrideSuperIfExists(
@@ -513,57 +452,16 @@
   local overrideSuperIfExists(name, override) = if !( name in super) || super[name] == null || super[name] == {} then null else
     super[name] + override,
 
-  // Alertmanager
-
-  newAlertmanagerScaledObject(
-    name,
-    alertmanager_cpu_requests,
-    alertmanager_memory_requests,
-    min_replicas,
-    max_replicas,
-    cpu_target_utilization,
-    memory_target_utilization,
-  ):: self.newScaledObject(name, $._config.namespace, {
-    min_replica_count: min_replicas,
-    max_replica_count: max_replicas,
-
-    triggers: [
-      {
-        metric_name: 'cortex_%s_cpu_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
-
-        query: cpuHPAQuery % {
-          container: name,
-          namespace: $._config.namespace,
-        },
-
-        // Threshold is expected to be a string.
-        // Since alertmanager is very memory-intensive as opposed to cpu-intensive, we don't bother
-        // with the any target utilization calculation for cpu, to keep things simpler and cheaper.
-        threshold: std.toString(std.floor(cpuToMilliCPUInt(alertmanager_cpu_requests) * cpu_target_utilization)),
-      },
-      {
-        metric_name: 'cortex_%s_memory_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
-
-        query: memoryHPAQuery % {
-          container: name,
-          namespace: $._config.namespace,
-        },
-
-        // Threshold is expected to be a string.
-        threshold: std.toString(std.floor($.util.siToBytes(alertmanager_memory_requests) * memory_target_utilization)),
-      },
-    ],
-  }),
-
   alertmanager_scaled_object: if !$._config.autoscaling_alertmanager_enabled then null else
-    $.newAlertmanagerScaledObject(
+    $.newResourceScaledObject(
       name='alertmanager',
-      alertmanager_cpu_requests=$.alertmanager_container.resources.requests.cpu,
-      alertmanager_memory_requests=$.alertmanager_container.resources.requests.memory,
+      cpu_requests=$.alertmanager_container.resources.requests.cpu,
+      memory_requests=$.alertmanager_container.resources.requests.memory,
       min_replicas=$._config.autoscaling_alertmanager_min_replicas,
       max_replicas=$._config.autoscaling_alertmanager_max_replicas,
       cpu_target_utilization=$._config.autoscaling_alertmanager_cpu_target_utilization,
       memory_target_utilization=$._config.autoscaling_alertmanager_memory_target_utilization,
+      with_cortex_prefix=true,
     ) + {
       spec+: {
         scaleTargetRef+: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
There are several very similar `new<X>ScaledObject` functions. This PR should be a no-op which cleans up several of them, consolidating into one `newResourceScaledObject` for objects that scale on CPU and memory resources. I've left `newRulerQuerierScaledObject` alone even though it is scaled on CPU and memory because it has the most inconsistent metric naming convention.

This PR also introduces a small fix for `memoryHPAQuery`, which would previously report no data if no containers were up -- now it will report 0 instead.

#### Which issue(s) this PR fixes or relates to
https://github.com/grafana/mimir/pull/5739#pullrequestreview-1640779359

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
