### PR TITLE
Allow no changes for mimir release tech docs

### DIFF
--- a/.github/workflows/publish-technical-documentation-release-mimir.yml
+++ b/.github/workflows/publish-technical-documentation-release-mimir.yml
@@ -73,3 +73,5 @@ jobs:
         source_folder: "docs/sources/mimir"
         # Append ".x" to target to produce a v<major>.<minor>.x directory.
         target_folder: "content/docs/mimir/${{ steps.target.outputs.target }}.x"
+        # Patch releases may not have any new tehcnical documentation.
+        allow_no_changes: true


### PR DESCRIPTION
#### What this PR does

Patch releases may not have any changes for technical docs, this is okay, we don't want the workflow to fail because of that.

#### Which issue(s) this PR fixes or relates to

Ref: https://github.com/grafana/mimir/issues/5849

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
