### PR TITLE
Distributor: improve wrapping of gRPC errors returned by the ingester

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1277,6 +1277,12 @@ func handleIngesterPushError(err error) error {
 		// Wrap HTTP gRPC error with more explanatory message.
 		return httpgrpc.Errorf(int(resp.Code), "failed pushing to ingester: %s", resp.Body)
 	}
+	stat, ok := status.FromError(err)
+	if ok {
+		st := stat.Proto()
+		st.Message = fmt.Sprintf("failed pushing to ingester: %s", st.Message)
+		return status.ErrorProto(st)
+	}
 	return errors.Wrap(err, "failed pushing to ingester")
 }
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4785,10 +4785,10 @@ func TestHandleIngesterPushError(t *testing.T) {
 	outputErrorMsgPrefix := "failed pushing to ingester"
 	userID := "test"
 	errWithUserID := fmt.Errorf("user=%s: %s", userID, testErrorMsg)
-	unavailableErr := status.New(codes.Unavailable, testErrorMsg).Err()
 	test := map[string]struct {
 		ingesterPushError   error
 		expectedOutputError error
+		checkDetails        bool
 	}{
 		"no error gives no error": {
 			ingesterPushError:   nil,
@@ -4797,18 +4797,21 @@ func TestHandleIngesterPushError(t *testing.T) {
 		"a 4xx HTTP gRPC error gives a 4xx HTTP gRPC error": {
 			ingesterPushError:   httpgrpc.Errorf(http.StatusBadRequest, testErrorMsg),
 			expectedOutputError: httpgrpc.Errorf(http.StatusBadRequest, "%s: %s", outputErrorMsgPrefix, testErrorMsg),
+			checkDetails:        true,
 		},
 		"a 5xx HTTP gRPC error gives a 5xx HTTP gRPC error": {
 			ingesterPushError:   httpgrpc.Errorf(http.StatusServiceUnavailable, testErrorMsg),
 			expectedOutputError: httpgrpc.Errorf(http.StatusServiceUnavailable, "%s: %s", outputErrorMsgPrefix, testErrorMsg),
+			checkDetails:        true,
 		},
 		"a random ingester error without status gives the same wrapped error": {
 			ingesterPushError:   errWithUserID,
 			expectedOutputError: errors.Wrap(errWithUserID, outputErrorMsgPrefix),
 		},
-		"a gRPC unavailable error gives the same wrapped error": {
-			ingesterPushError:   unavailableErr,
-			expectedOutputError: errors.Wrap(unavailableErr, outputErrorMsgPrefix),
+		"a gRPC unavailable error gives a gRPC unavailable error with a wrapped message": {
+			ingesterPushError:   createGRPCErrorWithDetails(t, codes.Unavailable, testErrorMsg, mimirpb.INVALID),
+			expectedOutputError: createGRPCErrorWithDetails(t, codes.Unavailable, fmt.Sprintf("%s: %s", outputErrorMsgPrefix, testErrorMsg), mimirpb.INVALID),
+			checkDetails:        true,
 		},
 		"a context cancel error gives the same wrapped error": {
 			ingesterPushError:   context.Canceled,
@@ -4816,13 +4819,27 @@ func TestHandleIngesterPushError(t *testing.T) {
 		},
 	}
 
-	for _, testData := range test {
-		err := handleIngesterPushError(testData.ingesterPushError)
-		if testData.expectedOutputError == nil {
-			require.NoError(t, err)
-		} else {
-			require.ErrorContains(t, err, testData.expectedOutputError.Error())
-		}
+	for testName, testData := range test {
+		t.Run(testName, func(t *testing.T) {
+			err := handleIngesterPushError(testData.ingesterPushError)
+			if testData.expectedOutputError == nil {
+				require.NoError(t, err)
+			} else {
+				if testData.checkDetails {
+					expectedStat, ok := status.FromError(testData.expectedOutputError)
+					require.True(t, ok)
+
+					stat, ok := status.FromError(err)
+					require.True(t, ok)
+
+					require.Equal(t, expectedStat.Code(), stat.Code())
+					require.Equal(t, expectedStat.Message(), stat.Message())
+					require.Equal(t, expectedStat.Details(), stat.Details())
+				} else {
+					require.Errorf(t, err, testData.expectedOutputError.Error())
+				}
+			}
+		})
 	}
 }
 
@@ -4923,4 +4940,11 @@ func checkGRPCError(t *testing.T, expectedStatus *status.Status, expectedDetails
 		require.True(t, ok)
 		require.Equal(t, expectedDetails, errorDetails)
 	}
+}
+
+func createGRPCErrorWithDetails(t *testing.T, code codes.Code, message string, cause mimirpb.ErrorCause) error {
+	stat := status.New(code, message)
+	statWithDetails, err := stat.WithDetails(&mimirpb.WriteErrorDetails{Cause: cause})
+	require.NoError(t, err)
+	return statWithDetails.Err()
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes a regression introduced by https://github.com/grafana/mimir/pull/6416, where we replaced usages of `grpc/status` with `gogo/status` for ingester's gRPC error creation. 
Namely, if an error created by `gogo`'s `status.Error()` is wrapped (for example by using `errors.Wrap()` or `fmt.Errorf("...%w...")`, the resulting error is not recognized by `status.FromError()`. In the case of grpc's `status.Error()` this was not the case, i.e., even wrapped errors were recognized by `grpc`'s `status.FromError()`. 
Therefore, the only place where ingester errors are wrapped (`Distributor.handleIngesterPushError()`) must be updated in such a way that even the wrapped gRPC errors coming from the ingester preserve their type and semantics.

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/6008

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
