### PR TITLE
Get rid of a redundant nil check in pushSamplesToAppender()

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1232,9 +1232,6 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 
 					// Error adding exemplar
 					updateFirstPartial(nil, func() softError {
-						if err == nil {
-							return nil
-						}
 						return newTSDBIngestExemplarErr(err, model.Time(ex.TimestampMs), ts.Labels, ex.Labels)
 					})
 					stats.failedExemplarsCount++


### PR DESCRIPTION
#### What this PR does
This PR just removes a redundant nil [recently introduced](https://github.com/grafana/mimir/pull/6324/files#diff-e1032332627c413a3010c66b54b22b6e9835cf152fa339e40cf0b11204f7241fR1229-R1231) in `Ingester.pushSamplesToAppender()`.