### PR TITLE
Return any previous error if a chunks stream fails but the PromQL engine continues returning series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 * [ENHANCEMENT] Querier: Add `cortex_querier_federation_exemplar_tenants_queried` and `cortex_querier_federation_tenants_queried` metrics to track the number of tenants queried by multi-tenant queries. #6374 #6409
 * [ENHANCEMENT] All: added an experimental `-server.grpc.num-workers` flag that configures the number of long-living workers used to process gRPC requests. This could decrease the CPU usage by reducing the number of stack allocations. #6311
 * [ENHANCEMENT] All: improved IPv6 support by using the proper host:port formatting. #6311
-* [ENHANCEMENT] Querier: always return error encountered during chunks streaming, rather than `the stream has already been exhausted`. #6345
+* [ENHANCEMENT] Querier: always return error encountered during chunks streaming, rather than `the stream has already been exhausted`. #6345 #6433
 * [ENHANCEMENT] Query-frontend: add `instance_enable_ipv6` to support IPv6. #6111
 * [ENHANCEMENT] Store-gateway: return same detailed error messages as queriers when chunks or series limits are reached. #6347
 * [ENHANCEMENT] Querier: reduce memory consumed for queries that hit store-gateways. #6348

--- a/pkg/ingester/client/streaming_test.go
+++ b/pkg/ingester/client/streaming_test.go
@@ -153,7 +153,14 @@ func TestSeriesChunksStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 
 	s, err := reader.GetChunks(1)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 1 from ingester chunks stream, but the stream has series with index 0")
+	expectedError := "attempted to read series at index 1 from ingester chunks stream, but the stream has series with index 0"
+	require.EqualError(t, err, expectedError)
+
+	// Ensure we continue to return the error, even for subsequent calls to GetChunks.
+	_, err = reader.GetChunks(2)
+	require.EqualError(t, err, "attempted to read series at index 2 from ingester chunks stream, but the stream previously failed and returned an error: "+expectedError)
+	_, err = reader.GetChunks(3)
+	require.EqualError(t, err, "attempted to read series at index 3 from ingester chunks stream, but the stream previously failed and returned an error: "+expectedError)
 }
 
 func TestSeriesChunksStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
@@ -175,7 +182,14 @@ func TestSeriesChunksStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 
 	s, err = reader.GetChunks(1)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 1 from ingester chunks stream, but the stream has already been exhausted (was expecting 1 series)")
+	expectedError := "attempted to read series at index 1 from ingester chunks stream, but the stream has already been exhausted (was expecting 1 series)"
+	require.EqualError(t, err, expectedError)
+
+	// Ensure we continue to return the error, even for subsequent calls to GetChunks.
+	_, err = reader.GetChunks(2)
+	require.EqualError(t, err, "attempted to read series at index 2 from ingester chunks stream, but the stream previously failed and returned an error: "+expectedError)
+	_, err = reader.GetChunks(3)
+	require.EqualError(t, err, "attempted to read series at index 3 from ingester chunks stream, but the stream previously failed and returned an error: "+expectedError)
 }
 
 func TestSeriesChunksStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) {
@@ -199,10 +213,17 @@ func TestSeriesChunksStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 
 	s, err = reader.GetChunks(1)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 1 from ingester chunks stream, but the stream has failed: expected to receive 3 series, but got EOF after receiving 1 series")
+	expectedError := "attempted to read series at index 1 from ingester chunks stream, but the stream has failed: expected to receive 3 series, but got EOF after receiving 1 series"
+	require.EqualError(t, err, expectedError)
 
 	require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed after failure")
 	require.True(t, cleanedUp.Load(), "expected cleanup function to be called")
+
+	// Ensure we continue to return the error, even for subsequent calls to GetChunks.
+	_, err = reader.GetChunks(2)
+	require.EqualError(t, err, "attempted to read series at index 2 from ingester chunks stream, but the stream previously failed and returned an error: "+expectedError)
+	_, err = reader.GetChunks(3)
+	require.EqualError(t, err, "attempted to read series at index 3 from ingester chunks stream, but the stream previously failed and returned an error: "+expectedError)
 }
 
 func TestSeriesChunksStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
@@ -223,10 +244,17 @@ func TestSeriesChunksStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 
 	s, err := reader.GetChunks(0)
 	require.Nil(t, s)
-	require.EqualError(t, err, "attempted to read series at index 0 from ingester chunks stream, but the stream has failed: expected to receive only 1 series, but received at least 3 series")
+	expectedError := "attempted to read series at index 0 from ingester chunks stream, but the stream has failed: expected to receive only 1 series, but received at least 3 series"
+	require.EqualError(t, err, expectedError)
 
 	require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed after receiving more series than expected")
 	require.True(t, cleanedUp.Load(), "expected cleanup function to be called")
+
+	// Ensure we continue to return the error, even for subsequent calls to GetChunks.
+	_, err = reader.GetChunks(1)
+	require.EqualError(t, err, "attempted to read series at index 1 from ingester chunks stream, but the stream previously failed and returned an error: "+expectedError)
+	_, err = reader.GetChunks(2)
+	require.EqualError(t, err, "attempted to read series at index 2 from ingester chunks stream, but the stream previously failed and returned an error: "+expectedError)
 }
 
 func TestSeriesChunksStreamReader_ChunksLimits(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

This PR addresses some [post-merge feedback](https://github.com/grafana/mimir/pull/6345/files#r1363891539) from @pracucci on #6345.

#### Which issue(s) this PR fixes or relates to

#6345

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
