### PR TITLE
Add note about recreating pods to runbook for EtcdAllocatingTooMuchMemory alert

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -864,8 +864,8 @@ This can be triggered if there are too many HA dedupe keys in etcd. We saw this 
   },
 ```
 
-Note that you may need to recreate each etcd pod in order for this change to take effect. First, check that all etcd pods are running and healthy. Then delete one pod at a time
-and wait for it to be recreated and become healthy before repeating for the next pod until all pods have been recreated.
+Note that you may need to recreate each etcd pod in order for this change to take effect, as etcd-operator does not automatically recreate pods in response to changes like these.
+First, check that all etcd pods are running and healthy. Then delete one pod at a time and wait for it to be recreated and become healthy before repeating for the next pod until all pods have been recreated.
 
 ### MimirAlertmanagerSyncConfigsFailing
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -864,6 +864,9 @@ This can be triggered if there are too many HA dedupe keys in etcd. We saw this 
   },
 ```
 
+Note that you may need to recreate each etcd pod in order for this change to take effect. First, check that all etcd pods are running and healthy. Then delete one pod at a time
+and wait for it to be recreated and become healthy before repeating for the next pod until all pods have been recreated.
+
 ### MimirAlertmanagerSyncConfigsFailing
 
 How it **works**:


### PR DESCRIPTION
#### What this PR does

This PR improves the runbook for the `EtcdAllocatingTooMuchMemory` alert.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
