### PR TITLE
Make Ingester.Push() return pure gRPC errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,12 @@
 * [CHANGE] Ingester: `/ingester/push` HTTP endpoint has been removed. This endpoint was added for testing and troubleshooting, but was never documented or used for anything. #6299
 * [CHANGE] Experimental setting `-log.rate-limit-logs-per-second-burst` renamed to `-log.rate-limit-logs-burst-size`. #6230
 * [CHANGE] Distributor: instead of errors with HTTP status codes, `Push()` now returns errors with gRPC codes: #6377
-  * `replicasDidNotMatchError` is mapped to `codes.AlreadyExists` instead of `http.StatusAccepted` (202).
-  * `tooManyClustersError` and `validationError` are mapped to `codes.FailedPrecondition` instead of `http.BadRequest` (400).
-  * `ingestionRateLimitedError` is mapped to `codes.ResourceExhausted` instead of `http.StatusTooManyRequests` (429).
-  * `requestRateLimitedError` is mapped to `codes.Unavailable` or `codes.ResourceExhausted` instead of the non-standard `529` (The service is overloaded) or `http.StatusTooManyRequests` (429).
-* [CHANGE] Ingester: by setting the newly introduced experimental CLI flag `-ingester.grpc-errors-enabled` to true, `Push()` will return only gRPC errors. This feature changes the status codes of the following errors: #6443
-  * `sampleError`, `exemplarError`, `tsdbIngestExemplarErr`, `perUserSeriesLimitReachedError`, `perUserMetadataLimitReachedError`, `perMetricSeriesLimitReachedError`, `perMetricMetadataLimitReachedError` are mapped to `codes.FailedPrecondition` instead of `http.StatusBadRequest` (400).
-  * `tsdbUnavailableError` is mapped to `codes.Internal` instead of `http.StatusServiceUnavailable` (503).
-  *  all other errors which are not  `ingestionError`s are mapped to `codes.Internal` instead of `codes.Unknown`.
+  * `http.StatusAccepted` (202) code is replaced with `codes.AlreadyExists`.
+  * `http.BadRequest` (400) code is replaced with `codes.FailedPrecondition`.
+  * `http.StatusTooManyRequests` (429) and the non-standard `529` (The service is overloaded) codes are replaced with `codes.ResourceExhausted`.
+* [CHANGE] Ingester: by setting the newly introduced experimental CLI flag `-ingester.return-only-grpc-errors` to true, `Push()` will return only gRPC errors. This feature changes the following status codes: #6443
+  * `http.StatusBadRequest` (400) is replaced with `codes.FailedPrecondition`.
+  * `http.StatusServiceUnavailable` (503) and `codes.Unknown` are replaced with `codes.Internal`.
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [FEATURE] Vault: Added support for new Vault authentication methods: `AppRole`, `Kubernetes`, `UserPass` and `Token`. #6143
 * [FEATURE] Ingester: Experimental support for ignoring context cancellation when querying chunks, useful in ruling out the query engine's potential role in unexpected query cancellations. Enable with `-ingester.chunks-query-ignore-cancellation`. #6408

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@
   * `tooManyClustersError` and `validationError` are mapped to `codes.FailedPrecondition` instead of `http.BadRequest` (400).
   * `ingestionRateLimitedError` is mapped to `codes.ResourceExhausted` instead of `http.StatusTooManyRequests` (429).
   * `requestRateLimitedError` is mapped to `codes.Unavailable` or `codes.ResourceExhausted` instead of the non-standard `529` (The service is overloaded) or `http.StatusTooManyRequests` (429).
-* [CHANGE] Store-gateway: experimental "eager loading on startup" feature is now enabled by default. The feature is used only when store-gateway blocks lazy-loading is enabled. #6463
+* [CHANGE] Ingester: by setting the newly introduced experimental CLI flag `-ingester.grpc-errors-enabled` to true, `Push()` will return only gRPC errors. This feature changes the status codes of the following errors: #6443
+  * `sampleError`, `exemplarError`, `tsdbIngestExemplarErr`, `perUserSeriesLimitReachedError`, `perUserMetadataLimitReachedError`, `perMetricSeriesLimitReachedError`, `perMetricMetadataLimitReachedError` are mapped to `codes.FailedPrecondition` instead of `http.StatusBadRequest` (400).
+  * `tsdbUnavailableError` is mapped to `codes.Internal` instead of `http.StatusServiceUnavailable` (503).
+  *  all other errors which are not  `ingestionError`s are mapped to `codes.Internal` instead of `codes.Unknown`.
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [FEATURE] Vault: Added support for new Vault authentication methods: `AppRole`, `Kubernetes`, `UserPass` and `Token`. #6143
 * [FEATURE] Ingester: Experimental support for ignoring context cancellation when querying chunks, useful in ruling out the query engine's potential role in unexpected query cancellations. Enable with `-ingester.chunks-query-ignore-cancellation`. #6408

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2939,12 +2939,12 @@
         },
         {
           "kind": "field",
-          "name": "grpc_errors_enabled",
+          "name": "return_only_grpc_errors",
           "required": false,
           "desc": "When enabled only gRPC errors will be returned by the ingester.",
           "fieldValue": null,
           "fieldDefaultValue": false,
-          "fieldFlag": "ingester.grpc-errors-enabled",
+          "fieldFlag": "ingester.return-only-grpc-errors",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
         }

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2936,6 +2936,17 @@
           "fieldFlag": "ingester.chunks-query-ignore-cancellation",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "grpc_errors_enabled",
+          "required": false,
+          "desc": "When enabled only gRPC errors will be returned by the ingester.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "ingester.grpc-errors-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1275,8 +1275,6 @@ Usage of ./cmd/mimir/mimir:
     	Override the expected name on the server certificate.
   -ingester.error-sample-rate int
     	[experimental] Each error will be logged once in this many times. Use 0 to log all of them.
-  -ingester.grpc-errors-enabled
-    	[experimental] When enabled only gRPC errors will be returned by the ingester.
   -ingester.ignore-series-limit-for-metric-names string
     	Comma-separated list of metric names, for which the -ingester.max-global-series-per-metric limit will be ignored. Does not affect the -ingester.max-global-series-per-user limit.
   -ingester.instance-limits.max-inflight-push-requests int
@@ -1315,6 +1313,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] CPU utilization limit, as CPU cores, for CPU/memory utilization based read request limiting. Use 0 to disable it.
   -ingester.read-path-memory-utilization-limit uint
     	[experimental] Memory limit, in bytes, for CPU/memory utilization based read request limiting. Use 0 to disable it.
+  -ingester.return-only-grpc-errors
+    	[experimental] When enabled only gRPC errors will be returned by the ingester.
   -ingester.ring.consul.acl-token string
     	ACL Token used to interact with Consul.
   -ingester.ring.consul.cas-retry-delay duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1275,6 +1275,8 @@ Usage of ./cmd/mimir/mimir:
     	Override the expected name on the server certificate.
   -ingester.error-sample-rate int
     	[experimental] Each error will be logged once in this many times. Use 0 to log all of them.
+  -ingester.grpc-errors-enabled
+    	[experimental] When enabled only gRPC errors will be returned by the ingester.
   -ingester.ignore-series-limit-for-metric-names string
     	Comma-separated list of metric names, for which the -ingester.max-global-series-per-metric limit will be ignored. Does not affect the -ingester.max-global-series-per-user limit.
   -ingester.instance-limits.max-inflight-push-requests int

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1119,8 +1119,8 @@ instance_limits:
 [chunks_query_ignore_cancellation: <boolean> | default = false]
 
 # (experimental) When enabled only gRPC errors will be returned by the ingester.
-# CLI flag: -ingester.grpc-errors-enabled
-[grpc_errors_enabled: <boolean> | default = false]
+# CLI flag: -ingester.return-only-grpc-errors
+[return_only_grpc_errors: <boolean> | default = false]
 ```
 
 ### querier

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1117,6 +1117,10 @@ instance_limits:
 # (experimental) Ignore cancellation when querying chunks.
 # CLI flag: -ingester.chunks-query-ignore-cancellation
 [chunks_query_ignore_cancellation: <boolean> | default = false]
+
+# (experimental) When enabled only gRPC errors will be returned by the ingester.
+# CLI flag: -ingester.grpc-errors-enabled
+[grpc_errors_enabled: <boolean> | default = false]
 ```
 
 ### querier

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1101,12 +1101,6 @@ func (d *Distributor) handlePushError(ctx context.Context, pushErr error) error 
 	if ok {
 		return pushErr
 	}
-	// If pushErr is already a gRPC (for example returned by the ingester), we just propagate it.
-	// TODO this should be updated once the ingester error handling is improved.
-	_, ok = status.FromError(pushErr)
-	if ok {
-		return pushErr
-	}
 
 	serviceOverloadErrorEnabled := false
 	userID, err := tenant.TenantID(ctx)
@@ -1272,18 +1266,21 @@ func handleIngesterPushError(err error) error {
 	if err == nil {
 		return nil
 	}
+
+	// TODO This code is needed for backwards compatibility, since ingesters may still return
+	// errors created by httpgrpc.Errorf(). If pushErr is one of those errors, we just propagate
+	// it. This code should be removed once that creation is removed from the ingesters.
 	resp, ok := httpgrpc.HTTPResponseFromError(err)
 	if ok {
 		// Wrap HTTP gRPC error with more explanatory message.
-		return httpgrpc.Errorf(int(resp.Code), "failed pushing to ingester: %s", resp.Body)
+		return httpgrpc.Errorf(int(resp.Code), "%s: %s", failedPushingToIngesterMessage, resp.Body)
 	}
+
 	stat, ok := status.FromError(err)
 	if ok {
-		st := stat.Proto()
-		st.Message = fmt.Sprintf("failed pushing to ingester: %s", st.Message)
-		return status.ErrorProto(st)
+		return newIngesterPushError(stat)
 	}
-	return errors.Wrap(err, "failed pushing to ingester")
+	return errors.Wrap(err, failedPushingToIngesterMessage)
 }
 
 // forReplicationSet runs f, in parallel, for all ingesters in the input replication set.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1096,7 +1096,7 @@ func (d *Distributor) handlePushError(ctx context.Context, pushErr error) error 
 
 	// TODO This code is needed for backwards compatibility, since ingesters may still return
 	// errors created by httpgrpc.Errorf(). If pushErr is one of those errors, we just propagate
-	// it. This code should be removed once that creation is removed from the ingesters.
+	// it. This code should be removed in mimir 2.12.0.
 	_, ok := httpgrpc.HTTPResponseFromError(pushErr)
 	if ok {
 		return pushErr
@@ -1269,7 +1269,7 @@ func handleIngesterPushError(err error) error {
 
 	// TODO This code is needed for backwards compatibility, since ingesters may still return
 	// errors created by httpgrpc.Errorf(). If pushErr is one of those errors, we just propagate
-	// it. This code should be removed once that creation is removed from the ingesters.
+	// it. This code should be removed in mimir 2.12.0.
 	resp, ok := httpgrpc.HTTPResponseFromError(err)
 	if ok {
 		// Wrap HTTP gRPC error with more explanatory message.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4798,7 +4798,7 @@ func TestHandleIngesterPushError(t *testing.T) {
 	// other errors created by httpgrpc with the same code, and with
 	// a more explanatory message.
 	// TODO: this is needed for backwards compatibility and will be removed
-	// when httpgrpc is removed from the write path.
+	// in mimir 2.12.0.
 	httpgrpcTests := map[string]struct {
 		ingesterPushError error
 		expectedStatus    int32
@@ -4870,7 +4870,7 @@ func TestHandleIngesterPushError(t *testing.T) {
 			ingesterPushError: errWithUserID,
 			expectedError:     errors.Wrap(errWithUserID, outputErrorMsgPrefix),
 		},
-		"a context cancel error gives the same wrapped error": {
+		"a context canceled error gives the same wrapped error": {
 			ingesterPushError: context.Canceled,
 			expectedError:     errors.Wrap(errWithUserID, outputErrorMsgPrefix),
 		},

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -16,8 +16,9 @@ import (
 
 const (
 	// 529 is non-standard status code used by some services to signal that "The service is overloaded".
-	StatusServiceOverloaded     = 529
-	deadlineExceededWrapMessage = "exceeded configured distributor remote timeout"
+	StatusServiceOverloaded        = 529
+	deadlineExceededWrapMessage    = "exceeded configured distributor remote timeout"
+	failedPushingToIngesterMessage = "failed pushing to ingester"
 )
 
 var (
@@ -157,6 +158,37 @@ func (e requestRateLimitedError) errorCause() mimirpb.ErrorCause {
 
 // Ensure that requestRateLimitedError implements distributorError.
 var _ distributorError = requestRateLimitedError{}
+
+// ingesterPushError is an error used to represent a failed attempt to push to the ingester.
+type ingesterPushError struct {
+	message string
+	cause   mimirpb.ErrorCause
+}
+
+// newIngesterPushError creates a ingesterPushError error representing the given status object.
+func newIngesterPushError(stat *status.Status) ingesterPushError {
+	errorCause := mimirpb.INVALID
+	if len(stat.Details()) == 1 {
+		if errorDetails, ok := stat.Details()[0].(*mimirpb.WriteErrorDetails); ok {
+			errorCause = errorDetails.GetCause()
+		}
+	}
+	return ingesterPushError{
+		message: stat.Message(),
+		cause:   errorCause,
+	}
+}
+
+func (e ingesterPushError) Error() string {
+	return fmt.Sprintf("%s: %s", failedPushingToIngesterMessage, e.message)
+}
+
+func (e ingesterPushError) errorCause() mimirpb.ErrorCause {
+	return e.cause
+}
+
+// Ensure that ingesterPushError implements distributorError.
+var _ distributorError = ingesterPushError{}
 
 // toGRPCError converts the given error into an appropriate gRPC error.
 func toGRPCError(pushErr error, serviceOverloadErrorEnabled bool) error {

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -168,8 +168,9 @@ type ingesterPushError struct {
 // newIngesterPushError creates a ingesterPushError error representing the given status object.
 func newIngesterPushError(stat *status.Status) ingesterPushError {
 	errorCause := mimirpb.INVALID
-	if len(stat.Details()) == 1 {
-		if errorDetails, ok := stat.Details()[0].(*mimirpb.WriteErrorDetails); ok {
+	details := stat.Details()
+	if len(details) == 1 {
+		if errorDetails, ok := details[0].(*mimirpb.WriteErrorDetails); ok {
 			errorCause = errorDetails.GetCause()
 		}
 	}

--- a/pkg/distributor/errors_test.go
+++ b/pkg/distributor/errors_test.go
@@ -184,13 +184,13 @@ func TestToGRPCError(t *testing.T) {
 			expectedGRPCCode: codes.Internal,
 			expectedErrorMsg: originalMsg,
 		},
-		"a replicasDidNotMatchError gets translated into an AlreadyExists error with REPLICASE_DID_NOT_MATCH cause": {
+		"a replicasDidNotMatchError gets translated into an AlreadyExists error with REPLICAS_DID_NOT_MATCH cause": {
 			err:                  replicasDidNotMatchErr,
 			expectedGRPCCode:     codes.AlreadyExists,
 			expectedErrorMsg:     replicasDidNotMatchErr.Error(),
 			expectedErrorDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.REPLICAS_DID_NOT_MATCH},
 		},
-		"a DoNotLotError of a replicasDidNotMatchError gets translated into an AlreadyExists error with REPLICASE_DID_NOT_MATCH cause": {
+		"a DoNotLotError of a replicasDidNotMatchError gets translated into an AlreadyExists error with REPLICAS_DID_NOT_MATCH cause": {
 			err:                  log.DoNotLogError{Err: replicasDidNotMatchErr},
 			expectedGRPCCode:     codes.AlreadyExists,
 			expectedErrorMsg:     replicasDidNotMatchErr.Error(),

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -180,6 +180,8 @@ func toHTTPStatus(ctx context.Context, pushErr error, limits *validation.Overrid
 			return http.StatusAccepted
 		case mimirpb.TOO_MANY_CLUSTERS:
 			return http.StatusBadRequest
+		case mimirpb.TSDB_UNAVAILABLE:
+			return http.StatusServiceUnavailable
 		}
 	}
 

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/log"
@@ -806,103 +807,126 @@ func TestHandler_ToHTTPStatus(t *testing.T) {
 	tooManyClustersErr := newTooManyClustersError(10)
 	ingestionRateLimitedErr := newIngestionRateLimitedError(10, 10)
 	requestRateLimitedErr := newRequestRateLimitedError(10, 10)
-	testCases := []struct {
-		name                        string
+
+	type testStruct struct {
 		err                         error
 		serviceOverloadErrorEnabled bool
 		expectedHTTPStatus          int
 		expectedErrorMsg            string
-	}{
-		{
-			name:               "a generic error gets translated into a HTTP 500",
+	}
+	testCases := map[string]testStruct{
+		"a generic error gets translated into a HTTP 500": {
 			err:                originalErr,
 			expectedHTTPStatus: http.StatusInternalServerError,
 		},
-		{
-			name:               "a DoNotLog of a generic error gets translated into a HTTP 500",
+		"a DoNotLog of a generic error gets translated into a HTTP 500": {
 			err:                log.DoNotLogError{Err: originalErr},
 			expectedHTTPStatus: http.StatusInternalServerError,
 		},
-		{
-			name:               "a context.DeadlineExceeded gets translated into a HTTP 500",
+		"a context.DeadlineExceeded gets translated into a HTTP 500": {
 			err:                context.DeadlineExceeded,
 			expectedHTTPStatus: http.StatusInternalServerError,
 			expectedErrorMsg:   context.DeadlineExceeded.Error(),
 		},
-		{
-			name:               "a replicasDidNotMatchError gets translated into an HTTP 202",
+		"a replicasDidNotMatchError gets translated into an HTTP 202": {
 			err:                replicasNotMatchErr,
 			expectedHTTPStatus: http.StatusAccepted,
 			expectedErrorMsg:   replicasNotMatchErr.Error(),
 		},
-		{
-			name:               "a DoNotLogError of a replicasDidNotMatchError gets translated into an HTTP 202",
+		"a DoNotLogError of a replicasDidNotMatchError gets translated into an HTTP 202": {
 			err:                log.DoNotLogError{Err: replicasNotMatchErr},
 			expectedHTTPStatus: http.StatusAccepted,
 			expectedErrorMsg:   replicasNotMatchErr.Error(),
 		},
-		{
-			name:               "a tooManyClustersError gets translated into an HTTP 400",
+		"a tooManyClustersError gets translated into an HTTP 400": {
 			err:                tooManyClustersErr,
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedErrorMsg:   tooManyClustersErr.Error(),
 		},
-		{
-			name:               "a DoNotLogError of a tooManyClustersError gets translated into an HTTP 400",
+		"a DoNotLogError of a tooManyClustersError gets translated into an HTTP 400": {
 			err:                log.DoNotLogError{Err: tooManyClustersErr},
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedErrorMsg:   tooManyClustersErr.Error(),
 		},
-		{
-			name:               "a validationError gets translated into an HTTP 400",
+		"a validationError gets translated into an HTTP 400": {
 			err:                newValidationError(originalErr),
 			expectedHTTPStatus: http.StatusBadRequest,
 		},
-		{
-			name:               "a DoNotLogError of a validationError gets translated into an HTTP 400",
+		"a DoNotLogError of a validationError gets translated into an HTTP 400": {
 			err:                log.DoNotLogError{Err: newValidationError(originalErr)},
 			expectedHTTPStatus: http.StatusBadRequest,
 		},
-		{
-			name:               "an ingestionRateLimitedError gets translated into an HTTP 429",
+		"an ingestionRateLimitedError gets translated into an HTTP 429": {
 			err:                ingestionRateLimitedErr,
 			expectedHTTPStatus: http.StatusTooManyRequests,
 			expectedErrorMsg:   ingestionRateLimitedErr.Error(),
 		},
-		{
-			name:               "a DoNotLogError of an ingestionRateLimitedError gets translated into an HTTP 429",
+		"a DoNotLogError of an ingestionRateLimitedError gets translated into an HTTP 429": {
 			err:                log.DoNotLogError{Err: ingestionRateLimitedErr},
 			expectedHTTPStatus: http.StatusTooManyRequests,
 			expectedErrorMsg:   ingestionRateLimitedErr.Error(),
 		},
-		{
-			name:                        "a requestRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529",
+		"a requestRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529": {
 			err:                         requestRateLimitedErr,
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
 			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
-		{
-			name:                        "a DoNotLogError of a requestRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529",
+		"a DoNotLogError of a requestRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529": {
 			err:                         log.DoNotLogError{Err: requestRateLimitedErr},
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
 			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
-		{
-			name:                        "a requestRateLimitedError without serviceOverloadErrorEnabled gets translated into an HTTP 429",
+		"a requestRateLimitedError without serviceOverloadErrorEnabled gets translated into an HTTP 429": {
 			err:                         requestRateLimitedErr,
 			serviceOverloadErrorEnabled: false,
 			expectedHTTPStatus:          http.StatusTooManyRequests,
 			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
-		{
-			name:                        "a DoNotLogError of a requestRateLimitedError without serviceOverloadErrorEnabled gets translated into an HTTP 429",
+		"a DoNotLogError of a requestRateLimitedError without serviceOverloadErrorEnabled gets translated into an HTTP 429": {
 			err:                         log.DoNotLogError{Err: requestRateLimitedErr},
 			serviceOverloadErrorEnabled: false,
 			expectedHTTPStatus:          http.StatusTooManyRequests,
 			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
+	}
+
+	// We enrich testCases with the cases corresponding to ingesterPushErrors
+	// with all possible error causes, and ensure that all those errors, except
+	// the ones with mimirpb.BAD_DATA and mimirpb.TSDB_UNAVAILABLE causes will
+	// be translated into an HTTP status 500, while the former will be translated
+	// an HTTP 400 and an HTTP 503 respectively.
+	// Additionally, we enrich testCases with the same ingeseterPushError, but
+	// wrapped with log.DoNotLogError.
+	ingesterPushErrorCauses := map[string]mimirpb.ErrorCause{
+		"INVALID":             mimirpb.INVALID,
+		"BAD_DATA":            mimirpb.BAD_DATA,
+		"INSTANCE_LIMIT":      mimirpb.INSTANCE_LIMIT,
+		"SERVICE_UNAVAILABLE": mimirpb.SERVICE_UNAVAILABLE,
+		"TSDB_UNAVAILABLE":    mimirpb.TSDB_UNAVAILABLE,
+	}
+
+	for causeName, causeValue := range ingesterPushErrorCauses {
+		expectedHTTPStatus := http.StatusInternalServerError
+		if causeValue == mimirpb.BAD_DATA {
+			expectedHTTPStatus = http.StatusBadRequest
+		} else if causeValue == mimirpb.TSDB_UNAVAILABLE {
+			expectedHTTPStatus = http.StatusServiceUnavailable
+		}
+		name := fmt.Sprintf("an ingesterPushError with %s gets translated into an HTTP %d cause", causeName, expectedHTTPStatus)
+		testCases[name] = testStruct{
+			err:                newIngesterPushError(createGRPCErrorWithDetails(t, codes.Internal, originalMsg, causeValue)),
+			expectedHTTPStatus: expectedHTTPStatus,
+			expectedErrorMsg:   fmt.Sprintf("%s: %s", failedPushingToIngesterMessage, originalMsg),
+		}
+
+		name = fmt.Sprintf("a DoNotLogError of %s", name)
+		testCases[name] = testStruct{
+			err:                log.DoNotLogError{Err: newIngesterPushError(createGRPCErrorWithDetails(t, codes.Internal, originalMsg, causeValue))},
+			expectedHTTPStatus: expectedHTTPStatus,
+			expectedErrorMsg:   fmt.Sprintf("%s: %s", failedPushingToIngesterMessage, originalMsg),
+		}
 	}
 
 	for _, tc := range testCases {

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -74,7 +74,7 @@ func newErrorWithStatus(originalErr error, code codes.Code) errorWithStatus {
 // newErrorWithHTTPStatus creates a new errorWithStatus backed by the given error,
 // and containing the given HTTP status code.
 // TODO this is needed for backwards compatibility only and should be removed
-// once httpgrpc.Errorf() usages in ingester are removed.
+// in mimir 2.12.0.
 func newErrorWithHTTPStatus(err error, code int) errorWithStatus {
 	errWithHTTPStatus := httpgrpc.Errorf(code, err.Error())
 	stat, _ := status.FromError(errWithHTTPStatus)
@@ -556,9 +556,10 @@ func handlePushErrorWithGRPC(err error) error {
 	return newErrorWithStatus(wrappedErr, errCode)
 }
 
-// TODO this method is needed only for the backwards compatibility.
-// It will be removed once httpgrpc has been completely removed
-// from both distributor and ingester.
+// handlePushErrorWithHTTPGRPC maps ingesterError objects to an appropriate
+// errorWithStatus, which may contain both HTTP and gRPC error codes.
+// TODO this method is needed only for the backwards compatibility,
+// and should be removed in mimir 2.12.0.
 func handlePushErrorWithHTTPGRPC(err error) error {
 	var ingesterErr ingesterError
 	if errors.As(err, &ingesterErr) {

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -408,7 +408,7 @@ func TestHandlePushErrorWithGRPC(t *testing.T) {
 			expectedMessage: newTSDBUnavailableError("tsdb stopping").Error(),
 			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.TSDB_UNAVAILABLE},
 		},
-		"a wrapped instanceLimitReachedError gets translated into a non-loggable errorWithStatus Internal error with details": {
+		"a wrapped tsdbUnavailableError gets translated into a non-loggable errorWithStatus Internal error with details": {
 			err:             fmt.Errorf("wrapped: %w", newTSDBUnavailableError("tsdb stopping")),
 			expectedCode:    codes.Internal,
 			expectedMessage: fmt.Sprintf("wrapped: %s", newTSDBUnavailableError("tsdb stopping").Error()),
@@ -607,31 +607,59 @@ func TestHandlePushErrorWithHTTPGRPC(t *testing.T) {
 				http.StatusBadRequest,
 			),
 		},
-		"a perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+		"a perUserSeriesLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
 			err: newPerUserSeriesLimitReachedError(10),
 			expectedTranslation: newErrorWithHTTPStatus(
 				newPerUserSeriesLimitReachedError(10),
 				http.StatusBadRequest,
 			),
 		},
-		"a wrapped perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+		"a wrapped perUserSeriesLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
 			err: fmt.Errorf("wrapped: %w", newPerUserSeriesLimitReachedError(10)),
 			expectedTranslation: newErrorWithHTTPStatus(
 				fmt.Errorf("wrapped: %w", newPerUserSeriesLimitReachedError(10)),
 				http.StatusBadRequest,
 			),
 		},
-		"a perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+		"a perMetricSeriesLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
 			err: newPerMetricSeriesLimitReachedError(10, labels),
 			expectedTranslation: newErrorWithHTTPStatus(
 				newPerMetricSeriesLimitReachedError(10, labels),
 				http.StatusBadRequest,
 			),
 		},
-		"a wrapped perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+		"a wrapped perMetricSeriesLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
 			err: fmt.Errorf("wrapped: %w", newPerMetricSeriesLimitReachedError(10, labels)),
 			expectedTranslation: newErrorWithHTTPStatus(
 				fmt.Errorf("wrapped: %w", newPerMetricSeriesLimitReachedError(10, labels)),
+				http.StatusBadRequest,
+			),
+		},
+		"a perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+			err: newPerUserMetadataLimitReachedError(10),
+			expectedTranslation: newErrorWithHTTPStatus(
+				newPerUserMetadataLimitReachedError(10),
+				http.StatusBadRequest,
+			),
+		},
+		"a wrapped perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+			err: fmt.Errorf("wrapped: %w", newPerUserMetadataLimitReachedError(10)),
+			expectedTranslation: newErrorWithHTTPStatus(
+				fmt.Errorf("wrapped: %w", newPerUserMetadataLimitReachedError(10)),
+				http.StatusBadRequest,
+			),
+		},
+		"a perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+			err: newPerMetricMetadataLimitReachedError(10, labels),
+			expectedTranslation: newErrorWithHTTPStatus(
+				newPerMetricMetadataLimitReachedError(10, labels),
+				http.StatusBadRequest,
+			),
+		},
+		"a wrapped perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+			err: fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, labels)),
+			expectedTranslation: newErrorWithHTTPStatus(
+				fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, labels)),
 				http.StatusBadRequest,
 			),
 		},

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -348,136 +348,288 @@ func TestWrapOrAnnotateWithUser(t *testing.T) {
 	require.Equal(t, wrappingErr, errors.Unwrap(wrappedSafeErr))
 }
 
-func TestHandlePushError(t *testing.T) {
+func TestHandlePushErrorWithGRPC(t *testing.T) {
 	originalMsg := "this is an error"
 	originalErr := errors.New(originalMsg)
 	labelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "biz"}}
 	labels := mimirpb.FromLabelAdaptersToLabels(labelAdapters)
-
 	timestamp := model.Time(1)
-	testCases := []struct {
-		name                string
+
+	testCases := map[string]struct {
+		err                 error
+		doNotLogExpected    bool
+		expectedCode        codes.Code
+		expectedMessage     string
+		expectedDetails     *mimirpb.WriteErrorDetails
+		expectedTranslation error
+	}{
+		"a generic error gets translated into an Internal gRPC error without details": {
+			err:             originalErr,
+			expectedCode:    codes.Internal,
+			expectedMessage: originalMsg,
+			expectedDetails: nil,
+		},
+		"a DoNotLog of a generic error gets translated into an Internal gRPC error without details": {
+			err:              log.DoNotLogError{Err: originalErr},
+			expectedCode:     codes.Internal,
+			expectedMessage:  originalMsg,
+			expectedDetails:  nil,
+			doNotLogExpected: true,
+		},
+		"an unavailableError gets translated into an errorWithStatus Unavailable error with details": {
+			err:             newUnavailableError(services.Stopping),
+			expectedCode:    codes.Unavailable,
+			expectedMessage: newUnavailableError(services.Stopping).Error(),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.SERVICE_UNAVAILABLE},
+		},
+		"a wrapped unavailableError gets translated into a non-loggable errorWithStatus Unavailable error": {
+			err:             fmt.Errorf("wrapped: %w", newUnavailableError(services.Stopping)),
+			expectedCode:    codes.Unavailable,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newUnavailableError(services.Stopping).Error()),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.SERVICE_UNAVAILABLE},
+		},
+		"an instanceLimitReachedError gets translated into a non-loggable errorWithStatus Unavailable error with details": {
+			err:              newInstanceLimitReachedError("instance limit reached"),
+			expectedCode:     codes.Unavailable,
+			expectedMessage:  newInstanceLimitReachedError("instance limit reached").Error(),
+			expectedDetails:  &mimirpb.WriteErrorDetails{Cause: mimirpb.INSTANCE_LIMIT},
+			doNotLogExpected: true,
+		},
+		"a wrapped instanceLimitReachedError gets translated into a non-loggable errorWithStatus Unavailable error with details": {
+			err:              fmt.Errorf("wrapped: %w", newInstanceLimitReachedError("instance limit reached")),
+			expectedCode:     codes.Unavailable,
+			expectedMessage:  fmt.Sprintf("wrapped: %s", newInstanceLimitReachedError("instance limit reached").Error()),
+			expectedDetails:  &mimirpb.WriteErrorDetails{Cause: mimirpb.INSTANCE_LIMIT},
+			doNotLogExpected: true,
+		},
+		"a tsdbUnavailableError gets translated into an errorWithStatus Internal error with details": {
+			err:             newTSDBUnavailableError("tsdb stopping"),
+			expectedCode:    codes.Internal,
+			expectedMessage: newTSDBUnavailableError("tsdb stopping").Error(),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.TSDB_UNAVAILABLE},
+		},
+		"a wrapped instanceLimitReachedError gets translated into a non-loggable errorWithStatus Internal error with details": {
+			err:             fmt.Errorf("wrapped: %w", newTSDBUnavailableError("tsdb stopping")),
+			expectedCode:    codes.Internal,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newTSDBUnavailableError("tsdb stopping").Error()),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.TSDB_UNAVAILABLE},
+		},
+		"a sampleError gets translated into an errorWithStatus FailedPrecondition error with details": {
+			err:             newSampleError("id", "sample error", timestamp, labelAdapters),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: newSampleError("id", "sample error", timestamp, labelAdapters).Error(),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a wrapped sampleError gets translated into a non-loggable errorWithStatus FailedPrecondition error with details": {
+			err:             fmt.Errorf("wrapped: %w", newSampleError("id", "sample error", timestamp, labelAdapters)),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newSampleError("id", "sample error", timestamp, labelAdapters).Error()),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a exemplarError gets translated into an errorWithStatus FailedPrecondition error with details": {
+			err:             newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters).Error(),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a wrapped exemplarError gets translated into a non-loggable errorWithStatus FailedPrecondition error with details": {
+			err:             fmt.Errorf("wrapped: %w", newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters)),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters).Error()),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a tsdbIngestExemplarErr gets translated into an errorWithStatus FailedPrecondition error with details": {
+			err:             newTSDBIngestExemplarErr(originalErr, timestamp, labelAdapters, labelAdapters),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: newTSDBIngestExemplarErr(originalErr, timestamp, labelAdapters, labelAdapters).Error(),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a wrapped tsdbIngestExemplarErr gets translated into a non-loggable errorWithStatus FailedPrecondition error with details": {
+			err:             fmt.Errorf("wrapped: %w", newTSDBIngestExemplarErr(originalErr, timestamp, labelAdapters, labelAdapters)),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newTSDBIngestExemplarErr(originalErr, timestamp, labelAdapters, labelAdapters).Error()),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a perUserSeriesLimitReachedError gets translated into an errorWithStatus FailedPrecondition error with details": {
+			err:             newPerUserSeriesLimitReachedError(10),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: newPerUserSeriesLimitReachedError(10).Error(),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a wrapped perUserSeriesLimitReachedError gets translated into a non-loggable errorWithStatus FailedPrecondition error with details": {
+			err:             fmt.Errorf("wrapped: %w", newPerUserSeriesLimitReachedError(10)),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newPerUserSeriesLimitReachedError(10).Error()),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a perUserMetadataLimitReachedError gets translated into an errorWithStatus FailedPrecondition error with details": {
+			err:             newPerUserMetadataLimitReachedError(10),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: newPerUserMetadataLimitReachedError(10).Error(),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a wrapped perUserMetadataLimitReachedError gets translated into a non-loggable errorWithStatus FailedPrecondition error with details": {
+			err:             fmt.Errorf("wrapped: %w", newPerUserMetadataLimitReachedError(10)),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newPerUserMetadataLimitReachedError(10).Error()),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a perMetricSeriesLimitReachedError gets translated into an errorWithStatus FailedPrecondition error with details": {
+			err:             newPerMetricSeriesLimitReachedError(10, labels),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: newPerMetricSeriesLimitReachedError(10, labels).Error(),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a wrapped perMetricSeriesLimitReachedError gets translated into a non-loggable errorWithStatus FailedPrecondition error with details": {
+			err:             fmt.Errorf("wrapped: %w", newPerMetricSeriesLimitReachedError(10, labels)),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newPerMetricSeriesLimitReachedError(10, labels).Error()),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a perMetricMetadataLimitReachedError gets translated into an errorWithStatus FailedPrecondition error with details": {
+			err:             newPerMetricMetadataLimitReachedError(10, labels),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: newPerMetricMetadataLimitReachedError(10, labels).Error(),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+		"a wrapped perMetricMetadataLimitReachedError gets translated into a non-loggable errorWithStatus FailedPrecondition error with details": {
+			err:             fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, labels)),
+			expectedCode:    codes.FailedPrecondition,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newPerMetricMetadataLimitReachedError(10, labels).Error()),
+			expectedDetails: &mimirpb.WriteErrorDetails{Cause: mimirpb.BAD_DATA},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			handledErr := handlePushErrorWithGRPC(tc.err)
+			stat, ok := status.FromError(handledErr)
+			require.True(t, ok)
+			require.Equal(t, tc.expectedCode, stat.Code())
+			require.Equal(t, tc.expectedMessage, stat.Message())
+			checkErrorWithStatusDetails(t, stat.Details(), tc.expectedDetails)
+			if tc.doNotLogExpected {
+				var doNotLogError log.DoNotLogError
+				require.ErrorAs(t, handledErr, &doNotLogError)
+				require.False(t, doNotLogError.ShouldLog(context.Background(), 0))
+			}
+		})
+	}
+}
+
+func TestHandlePushErrorWithHTTPGRPC(t *testing.T) {
+	originalMsg := "this is an error"
+	originalErr := errors.New(originalMsg)
+	labelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "biz"}}
+	labels := mimirpb.FromLabelAdaptersToLabels(labelAdapters)
+	timestamp := model.Time(1)
+
+	testCases := map[string]struct {
 		err                 error
 		doNotLogExpected    bool
 		expectedTranslation error
 	}{
-		{
-			name:                "a generic error is not translated",
+		"a generic error is not translated": {
 			err:                 originalErr,
 			expectedTranslation: originalErr,
 		},
-		{
-			name:                "a DoNotLog error of a generic error is not translated",
+		"a DoNotLog error of a generic error is not translated": {
 			err:                 log.DoNotLogError{Err: originalErr},
 			expectedTranslation: log.DoNotLogError{Err: originalErr},
 			doNotLogExpected:    true,
 		},
-		{
-			name:                "an unavailableError gets translated into an errorWithStatus Unavailable error",
+		"an unavailableError gets translated into an errorWithStatus Unavailable error": {
 			err:                 newUnavailableError(services.Stopping),
 			expectedTranslation: newErrorWithStatus(newUnavailableError(services.Stopping), codes.Unavailable),
 		},
-		{
-			name: "a wrapped unavailableError gets translated into a non-loggable errorWithStatus Unavailable error",
-			err:  fmt.Errorf("wrapped: %w", newUnavailableError(services.Stopping)),
+		"a wrapped unavailableError gets translated into a non-loggable errorWithStatus Unavailable error": {
+			err: fmt.Errorf("wrapped: %w", newUnavailableError(services.Stopping)),
 			expectedTranslation: newErrorWithStatus(
 				fmt.Errorf("wrapped: %w", newUnavailableError(services.Stopping)),
 				codes.Unavailable,
 			),
 		},
-		{
-			name: "an instanceLimitReachedError gets translated into a non-loggable errorWithStatus Unavailable error",
-			err:  newInstanceLimitReachedError("instance limit reached"),
+		"an instanceLimitReachedError gets translated into a non-loggable errorWithStatus Unavailable error": {
+			err: newInstanceLimitReachedError("instance limit reached"),
 			expectedTranslation: newErrorWithStatus(
 				log.DoNotLogError{Err: newInstanceLimitReachedError("instance limit reached")},
 				codes.Unavailable,
 			),
 			doNotLogExpected: true,
 		},
-		{
-			name: "a wrapped instanceLimitReachedError gets translated into a non-loggable errorWithStatus Unavailable error",
-			err:  fmt.Errorf("wrapped: %w", newInstanceLimitReachedError("instance limit reached")),
+		"a wrapped instanceLimitReachedError gets translated into a non-loggable errorWithStatus Unavailable error": {
+			err: fmt.Errorf("wrapped: %w", newInstanceLimitReachedError("instance limit reached")),
 			expectedTranslation: newErrorWithStatus(
 				log.DoNotLogError{Err: fmt.Errorf("wrapped: %w", newInstanceLimitReachedError("instance limit reached"))},
 				codes.Unavailable,
 			),
 			doNotLogExpected: true,
 		},
-		{
-			name: "a tsdbUnavailableError gets translated into an errorWithHTTPStatus 503 error",
-			err:  newTSDBUnavailableError("tsdb stopping"),
+		"a tsdbUnavailableError gets translated into an errorWithHTTPStatus 503 error": {
+			err: newTSDBUnavailableError("tsdb stopping"),
 			expectedTranslation: newErrorWithHTTPStatus(
 				newTSDBUnavailableError("tsdb stopping"),
 				http.StatusServiceUnavailable,
 			),
 		},
-		{
-			name: "a wrapped tsdbUnavailableError gets translated into an errorWithHTTPStatus 503 error",
-			err:  fmt.Errorf("wrapped: %w", newTSDBUnavailableError("tsdb stopping")),
+		"a wrapped tsdbUnavailableError gets translated into an errorWithHTTPStatus 503 error": {
+			err: fmt.Errorf("wrapped: %w", newTSDBUnavailableError("tsdb stopping")),
 			expectedTranslation: newErrorWithHTTPStatus(
 				fmt.Errorf("wrapped: %w", newTSDBUnavailableError("tsdb stopping")),
 				http.StatusServiceUnavailable,
 			),
 		},
-		{
-			name: "a sampleError gets translated into an errorWithHTTPStatus 400 error",
-			err:  newSampleError("id", "sample error", timestamp, labelAdapters),
+		"a sampleError gets translated into an errorWithHTTPStatus 400 error": {
+			err: newSampleError("id", "sample error", timestamp, labelAdapters),
 			expectedTranslation: newErrorWithHTTPStatus(
 				newSampleError("id", "sample error", timestamp, labelAdapters),
 				http.StatusBadRequest,
 			),
 		},
-		{
-			name: "a wrapped exemplarError gets translated into an errorWithHTTPStatus 400 error",
-			err:  fmt.Errorf("wrapped: %w", newSampleError("id", "sample error", timestamp, labelAdapters)),
+		"a wrapped sample gets translated into an errorWithHTTPStatus 400 error": {
+			err: fmt.Errorf("wrapped: %w", newSampleError("id", "sample error", timestamp, labelAdapters)),
 			expectedTranslation: newErrorWithHTTPStatus(
 				fmt.Errorf("wrapped: %w", newSampleError("id", "sample error", timestamp, labelAdapters)),
 				http.StatusBadRequest,
 			),
 		},
-		{
-			name: "a exemplarError gets translated into an errorWithHTTPStatus 400 error",
-			err:  newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters),
+		"a exemplarError gets translated into an errorWithHTTPStatus 400 error": {
+			err: newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters),
 			expectedTranslation: newErrorWithHTTPStatus(
 				newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters),
 				http.StatusBadRequest,
 			),
 		},
-		{
-			name: "a wrapped exemplarError gets translated into an errorWithHTTPStatus 400 error",
-			err:  fmt.Errorf("wrapped: %w", newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters)),
+		"a wrapped exemplarError gets translated into an errorWithHTTPStatus 400 error": {
+			err: fmt.Errorf("wrapped: %w", newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters)),
 			expectedTranslation: newErrorWithHTTPStatus(
 				fmt.Errorf("wrapped: %w", newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters)),
 				http.StatusBadRequest,
 			),
 		},
-		{
-			name: "a perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error",
-			err:  newPerUserSeriesLimitReachedError(10),
+		"a perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+			err: newPerUserSeriesLimitReachedError(10),
 			expectedTranslation: newErrorWithHTTPStatus(
 				newPerUserSeriesLimitReachedError(10),
 				http.StatusBadRequest,
 			),
 		},
-		{
-			name: "a wrapped perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error",
-			err:  fmt.Errorf("wrapped: %w", newPerUserSeriesLimitReachedError(10)),
+		"a wrapped perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+			err: fmt.Errorf("wrapped: %w", newPerUserSeriesLimitReachedError(10)),
 			expectedTranslation: newErrorWithHTTPStatus(
 				fmt.Errorf("wrapped: %w", newPerUserSeriesLimitReachedError(10)),
 				http.StatusBadRequest,
 			),
 		},
-		{
-			name: "a perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error",
-			err:  newPerMetricSeriesLimitReachedError(10, labels),
+		"a perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+			err: newPerMetricSeriesLimitReachedError(10, labels),
 			expectedTranslation: newErrorWithHTTPStatus(
 				newPerMetricSeriesLimitReachedError(10, labels),
 				http.StatusBadRequest,
 			),
 		},
-		{
-			name: "a wrapped perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error",
-			err:  fmt.Errorf("wrapped: %w", newPerMetricSeriesLimitReachedError(10, labels)),
+		"a wrapped perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
+			err: fmt.Errorf("wrapped: %w", newPerMetricSeriesLimitReachedError(10, labels)),
 			expectedTranslation: newErrorWithHTTPStatus(
 				fmt.Errorf("wrapped: %w", newPerMetricSeriesLimitReachedError(10, labels)),
 				http.StatusBadRequest,
@@ -485,14 +637,16 @@ func TestHandlePushError(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		handledErr := handlePushError(tc.err)
-		require.Equal(t, tc.expectedTranslation, handledErr)
-		if tc.doNotLogExpected {
-			var doNotLogError log.DoNotLogError
-			require.ErrorAs(t, handledErr, &doNotLogError)
-			require.False(t, doNotLogError.ShouldLog(context.Background(), 0))
-		}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			handledErr := handlePushErrorWithHTTPGRPC(tc.err)
+			require.Equal(t, tc.expectedTranslation, handledErr)
+			if tc.doNotLogExpected {
+				var doNotLogError log.DoNotLogError
+				require.ErrorAs(t, handledErr, &doNotLogError)
+				require.False(t, doNotLogError.ShouldLog(context.Background(), 0))
+			}
+		})
 	}
 }
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -181,6 +181,8 @@ type Config struct {
 	ErrorSampleRate int64 `yaml:"error_sample_rate" json:"error_sample_rate" category:"experimental"`
 
 	ChunksQueryIgnoreCancellation bool `yaml:"chunks_query_ignore_cancellation" category:"experimental"`
+
+	GRPCErrorsEnabled bool `yaml:"grpc_errors_enabled" json:"grpc_errors_enabled" category:"experimental"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -200,6 +202,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.LimitInflightRequestsUsingGrpcMethodLimiter, "ingester.limit-inflight-requests-using-grpc-method-limiter", false, "Use experimental method of limiting push requests.")
 	f.Int64Var(&cfg.ErrorSampleRate, "ingester.error-sample-rate", 0, "Each error will be logged once in this many times. Use 0 to log all of them.")
 	f.BoolVar(&cfg.ChunksQueryIgnoreCancellation, "ingester.chunks-query-ignore-cancellation", false, "Ignore cancellation when querying chunks.")
+	f.BoolVar(&cfg.GRPCErrorsEnabled, "ingester.grpc-errors-enabled", false, "When enabled only gRPC errors will be returned by the ingester.")
 }
 
 func (cfg *Config) Validate() error {
@@ -3176,8 +3179,15 @@ func (i *Ingester) Push(ctx context.Context, req *mimirpb.WriteRequest) (*mimirp
 	if err == nil {
 		return &mimirpb.WriteResponse{}, nil
 	}
-	handledErr := handlePushError(err)
+	handledErr := i.handlePushError(err)
 	return nil, handledErr
+}
+
+func (i *Ingester) handlePushError(err error) error {
+	if i.cfg.GRPCErrorsEnabled {
+		return handlePushErrorWithGRPC(err)
+	}
+	return handlePushErrorWithHTTPGRPC(err)
 }
 
 // pushMetadata returns number of ingested metadata.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -182,7 +182,7 @@ type Config struct {
 
 	ChunksQueryIgnoreCancellation bool `yaml:"chunks_query_ignore_cancellation" category:"experimental"`
 
-	GRPCErrorsEnabled bool `yaml:"grpc_errors_enabled" json:"grpc_errors_enabled" category:"experimental"`
+	ReturnOnlyGRPCErrors bool `yaml:"return_only_grpc_errors" json:"return_only_grpc_errors" category:"experimental"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -202,7 +202,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.LimitInflightRequestsUsingGrpcMethodLimiter, "ingester.limit-inflight-requests-using-grpc-method-limiter", false, "Use experimental method of limiting push requests.")
 	f.Int64Var(&cfg.ErrorSampleRate, "ingester.error-sample-rate", 0, "Each error will be logged once in this many times. Use 0 to log all of them.")
 	f.BoolVar(&cfg.ChunksQueryIgnoreCancellation, "ingester.chunks-query-ignore-cancellation", false, "Ignore cancellation when querying chunks.")
-	f.BoolVar(&cfg.GRPCErrorsEnabled, "ingester.grpc-errors-enabled", false, "When enabled only gRPC errors will be returned by the ingester.")
+	f.BoolVar(&cfg.ReturnOnlyGRPCErrors, "ingester.return-only-grpc-errors", false, "When enabled only gRPC errors will be returned by the ingester.")
 }
 
 func (cfg *Config) Validate() error {
@@ -3184,7 +3184,7 @@ func (i *Ingester) Push(ctx context.Context, req *mimirpb.WriteRequest) (*mimirp
 }
 
 func (i *Ingester) handlePushError(err error) error {
-	if i.cfg.GRPCErrorsEnabled {
+	if i.cfg.ReturnOnlyGRPCErrors {
 		return handlePushErrorWithGRPC(err)
 	}
 	return handlePushErrorWithHTTPGRPC(err)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1193,7 +1193,7 @@ func TestIngester_Push(t *testing.T) {
 			cfg := defaultIngesterTestConfig(t)
 			cfg.IngesterRing.ReplicationFactor = 1
 			cfg.ActiveSeriesMetrics.Enabled = !testData.disableActiveSeries
-			cfg.GRPCErrorsEnabled = true
+			cfg.ReturnOnlyGRPCErrors = true
 			limits := defaultLimitsTestConfig()
 			limits.MaxGlobalExemplarsPerUser = testData.maxExemplars
 			limits.MaxGlobalMetricsWithMetadataPerUser = testData.maxMetadataPerUser
@@ -5666,7 +5666,7 @@ func TestIngesterWithShippingDisabledDeletesBlocksOnlyAfterRetentionExpires(t *t
 
 func TestIngesterPushErrorDuringForcedCompaction(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	cfg.GRPCErrorsEnabled = true
+	cfg.ReturnOnlyGRPCErrors = true
 	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
 	require.NoError(t, err)
 
@@ -6585,7 +6585,7 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 		// Set RF=1 here to ensure the series and metadata limits
 		// are actually set to 1 instead of 3.
 		cfg.IngesterRing.ReplicationFactor = 1
-		cfg.GRPCErrorsEnabled = true
+		cfg.ReturnOnlyGRPCErrors = true
 		ing, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, dataDir, nil)
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
@@ -6689,7 +6689,7 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 		// Set RF=1 here to ensure the series and metadata limits
 		// are actually set to 1 instead of 3.
 		cfg.IngesterRing.ReplicationFactor = 1
-		cfg.GRPCErrorsEnabled = true
+		cfg.ReturnOnlyGRPCErrors = true
 		ing, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, dataDir, nil)
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
@@ -8590,7 +8590,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			ingesterCfg := defaultIngesterTestConfig(t)
 			ingesterCfg.IngesterRing.ReplicationFactor = 1
 			ingesterCfg.ErrorSampleRate = int64(errorSampleRate)
-			ingesterCfg.GRPCErrorsEnabled = true
+			ingesterCfg.ReturnOnlyGRPCErrors = true
 			limits := defaultLimitsTestConfig()
 			limits.MaxGlobalExemplarsPerUser = testData.maxExemplars
 			limits.NativeHistogramsIngestionEnabled = testData.nativeHistograms

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -431,7 +431,7 @@ func TestIngester_Push(t *testing.T) {
 					mimirpb.API,
 				),
 			},
-			expectedErr: newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), userID), http.StatusBadRequest),
+			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), userID), codes.FailedPrecondition),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 10}}},
 			},
@@ -489,7 +489,7 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), userID), http.StatusBadRequest),
+			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), userID), codes.FailedPrecondition),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
 			},
@@ -548,7 +548,7 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), userID), http.StatusBadRequest),
+			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), userID), codes.FailedPrecondition),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
 			},
@@ -667,7 +667,7 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), userID), http.StatusBadRequest),
+			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), userID), codes.FailedPrecondition),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}, {Value: 3, Timestamp: 1575043969 + 1}}},
 			},
@@ -726,7 +726,7 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), userID), http.StatusBadRequest),
+			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), userID), codes.FailedPrecondition),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{
 					{Value: 1, Timestamp: model.Time(now.UnixMilli())},
@@ -782,7 +782,7 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), userID), http.StatusBadRequest),
+			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), userID), codes.FailedPrecondition),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Histograms: []model.SampleHistogramPair{
 					{Timestamp: model.Time(now.UnixMilli()), Histogram: mimirpb.FromHistogramToPromHistogram(util_test.GenerateTestGaugeHistogram(0))},
@@ -846,7 +846,7 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), userID), http.StatusBadRequest),
+			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), userID), codes.FailedPrecondition),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{
 					Metric: metricLabelSet,
@@ -920,7 +920,7 @@ func TestIngester_Push(t *testing.T) {
 					mimirpb.API,
 				),
 			},
-			expectedErr: newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), userID), http.StatusBadRequest),
+			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), userID), codes.FailedPrecondition),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
 			},
@@ -979,7 +979,7 @@ func TestIngester_Push(t *testing.T) {
 					},
 				},
 			},
-			expectedErr:              newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), userID), http.StatusBadRequest),
+			expectedErr:              newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), userID), codes.FailedPrecondition),
 			expectedIngested:         nil,
 			expectedMetadataIngested: nil,
 			additionalMetrics: []string{
@@ -1193,6 +1193,7 @@ func TestIngester_Push(t *testing.T) {
 			cfg := defaultIngesterTestConfig(t)
 			cfg.IngesterRing.ReplicationFactor = 1
 			cfg.ActiveSeriesMetrics.Enabled = !testData.disableActiveSeries
+			cfg.GRPCErrorsEnabled = true
 			limits := defaultLimitsTestConfig()
 			limits.MaxGlobalExemplarsPerUser = testData.maxExemplars
 			limits.MaxGlobalMetricsWithMetadataPerUser = testData.maxMetadataPerUser
@@ -1225,7 +1226,9 @@ func TestIngester_Push(t *testing.T) {
 						assert.NoError(t, err)
 					} else {
 						handledErr := i.handlePushError(err)
-						assert.Equal(t, testData.expectedErr, handledErr)
+						errWithStatus, ok := handledErr.(errorWithStatus)
+						assert.True(t, ok)
+						assert.True(t, errWithStatus.equals(testData.expectedErr))
 					}
 				}
 			}
@@ -5662,7 +5665,9 @@ func TestIngesterWithShippingDisabledDeletesBlocksOnlyAfterRetentionExpires(t *t
 }
 
 func TestIngesterPushErrorDuringForcedCompaction(t *testing.T) {
-	i, err := prepareIngesterWithBlocksStorage(t, defaultIngesterTestConfig(t), nil)
+	cfg := defaultIngesterTestConfig(t)
+	cfg.GRPCErrorsEnabled = true
+	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
@@ -5688,7 +5693,8 @@ func TestIngesterPushErrorDuringForcedCompaction(t *testing.T) {
 	req, _, _, _ := mockWriteRequest(t, labels.FromStrings(labels.MetricName, "test"), 0, util.TimeToMillis(time.Now()))
 	ctx := user.InjectOrgID(context.Background(), userID)
 	_, err = i.Push(ctx, req)
-	require.Equal(t, newErrorWithHTTPStatus(wrapOrAnnotateWithUser(errTSDBForcedCompaction, userID), http.StatusServiceUnavailable), err)
+	expectedErr := newErrorWithStatus(wrapOrAnnotateWithUser(errTSDBForcedCompaction, userID), codes.Internal)
+	checkErrorWithStatus(t, err, expectedErr)
 
 	// Ingestion is successful after a flush.
 	ok, _ = db.changeState(forceCompacting, active)
@@ -6579,6 +6585,7 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 		// Set RF=1 here to ensure the series and metadata limits
 		// are actually set to 1 instead of 3.
 		cfg.IngesterRing.ReplicationFactor = 1
+		cfg.GRPCErrorsEnabled = true
 		ing, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, dataDir, nil)
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
@@ -6622,10 +6629,8 @@ func TestIngesterUserLimitExceeded(t *testing.T) {
 	testLimits := func() {
 		// Append to two series, expect series-exceeded error.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest([][]mimirpb.LabelAdapter{labels1, labels3}, []mimirpb.Sample{sample2, sample3}, nil, nil, mimirpb.API))
-		stat, ok := status.FromError(err)
-		require.True(t, ok)
-		assert.Equal(t, http.StatusBadRequest, int(stat.Code()))
-		assert.Equal(t, wrapOrAnnotateWithUser(newPerUserSeriesLimitReachedError(ing.limiter.limits.MaxGlobalSeriesPerUser(userID)), userID).Error(), stat.Message())
+		expectedErr := newErrorWithStatus(wrapOrAnnotateWithUser(newPerUserSeriesLimitReachedError(ing.limiter.limits.MaxGlobalSeriesPerUser(userID)), userID), codes.FailedPrecondition)
+		checkErrorWithStatus(t, err, expectedErr)
 
 		// Append two metadata, expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))
@@ -6684,6 +6689,7 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 		// Set RF=1 here to ensure the series and metadata limits
 		// are actually set to 1 instead of 3.
 		cfg.IngesterRing.ReplicationFactor = 1
+		cfg.GRPCErrorsEnabled = true
 		ing, err := prepareIngesterWithBlocksStorageAndLimits(t, cfg, limits, dataDir, nil)
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
@@ -6727,10 +6733,8 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 	testLimits := func() {
 		// Append two series, expect series-exceeded error.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest([][]mimirpb.LabelAdapter{labels1, labels3}, []mimirpb.Sample{sample2, sample3}, nil, nil, mimirpb.API))
-		stat, ok := status.FromError(err)
-		require.True(t, ok)
-		assert.Equal(t, http.StatusBadRequest, int(stat.Code()))
-		assert.Equal(t, wrapOrAnnotateWithUser(newPerMetricSeriesLimitReachedError(ing.limiter.limits.MaxGlobalSeriesPerMetric(userID), mimirpb.FromLabelAdaptersToLabels(labels3)), userID).Error(), stat.Message())
+		expectedErr := newErrorWithStatus(wrapOrAnnotateWithUser(newPerMetricSeriesLimitReachedError(ing.limiter.limits.MaxGlobalSeriesPerMetric(userID), mimirpb.FromLabelAdaptersToLabels(labels3)), userID), codes.FailedPrecondition)
+		checkErrorWithStatus(t, err, expectedErr)
 
 		// Append two metadata for the same metric. Drop the second one, and expect no error since metadata is a best effort approach.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest(nil, nil, nil, []*mimirpb.MetricMetadata{metadata1, metadata2}, mimirpb.API))
@@ -8318,8 +8322,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				),
 			},
 			expectedErrs: []errorWithStatus{
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), users[0]), http.StatusBadRequest),
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), users[1]), http.StatusBadRequest),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), users[0]), codes.FailedPrecondition),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
 			expectedSampling: true,
 			expectedMetrics: `
@@ -8351,8 +8355,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				},
 			},
 			expectedErrs: []errorWithStatus{
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[0]), http.StatusBadRequest),
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[1]), http.StatusBadRequest),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
 			expectedSampling: true,
 			expectedMetrics: `
@@ -8385,8 +8389,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				},
 			},
 			expectedErrs: []errorWithStatus{
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), users[0]), http.StatusBadRequest),
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), users[1]), http.StatusBadRequest),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
 			expectedSampling: true,
 			expectedMetrics: `
@@ -8422,8 +8426,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				},
 			},
 			expectedErrs: []errorWithStatus{
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[0]), http.StatusBadRequest),
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[1]), http.StatusBadRequest),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
 			expectedSampling: true,
 			expectedMetrics: `
@@ -8456,8 +8460,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				},
 			},
 			expectedErrs: []errorWithStatus{
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[0]), http.StatusBadRequest),
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[1]), http.StatusBadRequest),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
 			expectedSampling: true,
 			expectedMetrics: `
@@ -8484,8 +8488,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				},
 			},
 			expectedErrs: []errorWithStatus{
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[0]), http.StatusBadRequest),
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[1]), http.StatusBadRequest),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
 			expectedSampling: true,
 			expectedMetrics: `
@@ -8515,8 +8519,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				},
 			},
 			expectedErrs: []errorWithStatus{
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), users[0]), http.StatusBadRequest),
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), users[1]), http.StatusBadRequest),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), users[0]), codes.FailedPrecondition),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), users[1]), codes.FailedPrecondition),
 			},
 			expectedSampling: false,
 		},
@@ -8538,8 +8542,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				),
 			},
 			expectedErrs: []errorWithStatus{
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[0]), http.StatusBadRequest),
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[1]), http.StatusBadRequest),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[0]), codes.FailedPrecondition),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
 			expectedSampling: true,
 			expectedMetrics: `
@@ -8572,8 +8576,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				},
 			},
 			expectedErrs: []errorWithStatus{
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), users[0]), http.StatusBadRequest),
-				newErrorWithHTTPStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), users[1]), http.StatusBadRequest),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), users[0]), codes.FailedPrecondition),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), users[1]), codes.FailedPrecondition),
 			},
 			expectedSampling: false,
 		},
@@ -8586,6 +8590,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			ingesterCfg := defaultIngesterTestConfig(t)
 			ingesterCfg.IngesterRing.ReplicationFactor = 1
 			ingesterCfg.ErrorSampleRate = int64(errorSampleRate)
+			ingesterCfg.GRPCErrorsEnabled = true
 			limits := defaultLimitsTestConfig()
 			limits.MaxGlobalExemplarsPerUser = testData.maxExemplars
 			limits.NativeHistogramsIngestionEnabled = testData.nativeHistograms
@@ -8990,4 +8995,11 @@ func TestIngester_lastUpdatedTimeIsNotInTheFuture(t *testing.T) {
 
 	// Verify that maxTime of TSDB is actually our future sample.
 	require.Equal(t, futureTS, db.db.Head().MaxTime())
+}
+
+func checkErrorWithStatus(t *testing.T, err error, expectedErr error) {
+	require.Error(t, err)
+	errWithStatus, ok := err.(errorWithStatus)
+	require.True(t, ok)
+	require.True(t, errWithStatus.equals(expectedErr))
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1224,7 +1224,7 @@ func TestIngester_Push(t *testing.T) {
 					if testData.expectedErr == nil {
 						assert.NoError(t, err)
 					} else {
-						handledErr := handlePushError(err)
+						handledErr := i.handlePushError(err)
 						assert.Equal(t, testData.expectedErr, handledErr)
 					}
 				}


### PR DESCRIPTION
### What this PR does ###
This PR introduces an experimental CLI flag `-ingester.return-grpc-errors-only` that, when set to `true` makes `Ingester.Push()` return errors with gRPC codes only. The default value is `false`, which means that in some cases, `Ingester.Push()` creates gRPC errors with HTTP status codes, by using `dskit`'s `httpgrpc` package. This corresponds to the semantics of `Ingester.Push()` before this PR, i.e., by default the present PR does not change the semantics of `Ingester.Push()`. At the bottom of this PR description there is a table showing how all possible errors encountered during `Ingester.Push()` are returned to the caller depending on the `-ingester.return-grpc-errors-only` value.

Additionally, the push handler and `Distributor.Push()` have been updated to handle both versions of the errors returned by `Ingester.Push()`, i.e., independently whether they are pure gRPC errors, or the errors created by `httpgrpc`:
- the semantics of the push handler remains the same as before this PR.
- there is a small change in the semantics of `Distributor.Push()` represented by the table at the bottom of this PR description.

#### Errors translated by `Ingester.Push()` depending on the `-ingester.return-grpc-errors-only` configuration ####

| error                                                                                                                                                                                                               | `-ingester.grpc-errors-enabled=false`                                                                        | `-ingester.grpc-errors-enabled=false`                                                                                                             |
|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
| `sampleError`<br>`exemplarError`<br>`tsdbIngestExemplarErr`<br>`perUserSeriesLimitReachedError`<br>`perUserMetadataLimitReachedError`<br>`perMetricSeriesLimitReachedError`<br>`perMetricMetadataLimitReachedError` | - created by: `httpgrpc.Errorf()`<br>- code: `http.StatusBadRequest`                                         | - created by: `status.New()`<br>- code: `codes.FailedPrecondition`<br>- cause: `mimirpb.BAD_DATA`                                                 |
| `tsdbUnavailableError`                                                                                                                                                                                              | - created by: `httpgrpc.Errorf()`<br>- code: `http.StatusServiceUnavailable`                                 | - created by: `status.New()`<br>- code: `codes.Internal`<br>- cause: `mimirpb.TSDB_UNAVAILABLE`                                                   |
| `unavailableError`                                                                                                                                                                                                  | - created by: `status.New()`<br>- code: `codes.Unavailable`<br>- remark: opens circuit breaker               | - created by: `status.New()`<br>- code: `codes.Unavailable`<br>- cause: `mimirpb.SERVICE_UNAVAILABLE`<br>- remark: opens circuit breaker          |
| `instanceLimitReachedError`                                                                                                                                                                                         | - created by: `status.New()`<br>- code: `codes.Unavailable`<br>- remark: non-loggable, opens circuit breaker | - created by: `status.New()`<br>- code: `codes.Unavailable`<br>- cause: `mimirpb.INSTANCE_LIMIT`<br>- remark: non-loggable, opens circuit breaker |
| other errors not implementing <br>`ingesterError` interface                                                                                                                                                         | - propagated by `Ingester.Push()`<br>- implicitly assigned `codes.Unknown` by gRPC                           | - created by: `status.New()`<br>- code: `codes.Internal`<br>- cause: `mimirpb.INVALID`                                                                         |

#### Ingester errors translated by `Distributor.Push()` ###
This table shows differences in handling all possible ingester (client) errors before and after this PR.

| error                                                                                                | Before this PR                                        | After this PR                                                                                                 |
|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
| `httpgrpc` error with <br>status `http.BadStatusRequest`<br>(caused by bad data)<br>Note: _possible only if `-ingester.return-grpc-errors-only=false`_                    | - created by: `httpgrpc.Errorf()`<br>- code: `http.StatusBadRequest`         | - created by: `status.New()`<br>- code: `codes.FailedPrecondition`<br>- cause: `mimirpb.BAD_DATA`                                     |
| gRPC error with `codes.FailedPrecondition`<br>(caused by bad data)<br>Note: _possible only if `-ingester.return-grpc-errors-only=true`_ | n/a                  | - created by: `status.New()`<br>- code: `codes.FailedPrecondition`<br>- cause: `mimirpb.BAD_DATA` |
| `httpgrpc` error with <br>status `http.StatusServiceUnavailable`<br>(caused by TSDB problems)<br>Note: _possible only if `-ingester.return-grpc-errors-only=false`_        | - created by: `httpgrpc.Errorf()`<br>- code: `http.StatusServiceUnavailable` | - created by: `status.New()`<br>- code: `codes.Internal`<br>- cause: `mimirpb.TSDB_UNAVAILABLE`                                       |
| gRPC error with `codes.Internal`<br>(caused by TSDB problems)<br>Note: _possible only if `-ingester.return-grpc-errors-only=true`_ | n/a                  | - created by: `status.New()`<br>- code: `codes.Internal`<br>- cause: `mimirpb.TSDB_UNAVAILABLE` |
| gRPC error with `codes.Unavailable`<br>(caused by instance limits or <br>an ingester in a bad state) | - created by: `status.New()`<br>- code: `codes.Unavailable`                  | - created by: `status.New()`<br>- code: `codes.Unavailable`<br>- cause: `mimirpb.INSTANCE_LIMIT` or <br>`mimirpb.SERVICE_UNAVAILABLE` |
| gRPC error with <br>`codes.Unknown`<br>(caused by any other problem)<br>Note: _possible only if `-ingester.return-grpc-errors-only=false`_                                 | - created by: `status.New()`<br>- code: `codes.Unknown`                      | - created by: `status.New()`<br>- code: `codes.Internal`<br>- cause: `mimirpb.INVALID`                                                |

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/6008.

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
