### PR TITLE
Upgrade to mimir-prometheus@d0d6240125f9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [BUGFIX] Querier: return actual error rather than `attempted to read series at index XXX from stream, but the stream has already been exhausted` (or even no error at all) when streaming chunks from ingesters or store-gateways is enabled and an error occurs while streaming chunks. #6346
 * [BUGFIX] Querier: reduce log volume when querying ingesters with zone-awareness enabled and one or more instances in a single zone unavailable. #6381
 * [BUGFIX] Querier: don't try to query further ingesters if ingester query request minimization is enabled and a query limit is reached as a result of the responses from the initial set of ingesters. #6402
+* [BUGFIX] Ingester: Don't cache context cancellation error when querying. #6446
 
 ### Mixin
 

--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231019100715-97933fb7d38e
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231020144705-d0d6240125f9
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/grafana/gomemcache v0.0.0-20230914135007-70d78eaabfe1 h1:MLYY2R60/74h
 github.com/grafana/gomemcache v0.0.0-20230914135007-70d78eaabfe1/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20231019100715-97933fb7d38e h1:tlVYEJDGD9e5Wk7ZYtjXtEJZXuWJqEF3Mb/+SqFiZ18=
-github.com/grafana/mimir-prometheus v0.0.0-20231019100715-97933fb7d38e/go.mod h1:bHUBXcO5vIkqWBAy86JlejQPQltETv9Cv5whKCeF2FM=
+github.com/grafana/mimir-prometheus v0.0.0-20231020144705-d0d6240125f9 h1:KVelZKI3FNeGvH9V3QYuXc7EGyc1AD7zsKanLqEdvaI=
+github.com/grafana/mimir-prometheus v0.0.0-20231020144705-d0d6240125f9/go.mod h1:bHUBXcO5vIkqWBAy86JlejQPQltETv9Cv5whKCeF2FM=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -884,7 +884,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231019100715-97933fb7d38e
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231020144705-d0d6240125f9
 ## explicit; go 1.20
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1466,7 +1466,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231019100715-97933fb7d38e
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231020144705-d0d6240125f9
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6


### PR DESCRIPTION
#### What this PR does
Upgrade to mimir-prometheus@d0d6240125f9, which brings in https://github.com/grafana/mimir-prometheus/pull/546, that fixes a bug affecting ingesters, where canceled queries may get cached (thus failing also consecutive requests, due to the poisoned cache entry).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
