### PR TITLE
Upgrade r260 to mimir-prometheus@693f219a88e2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [BUGFIX] Ensure correct nesting of children of the `querier.Select` tracing span. #6085
 * [BUGFIX] Packaging: fix preremove script preventing upgrades on RHEL based OS. #6067
 * [BUGFIX] Querier: return actual error rather than `attempted to read series at index XXX from stream, but the stream has already been exhausted` (or even no error at all) when streaming chunks from ingesters or store-gateways is enabled and an error occurs while streaming chunks. #6346
+* [BUGFIX] Ingester: Don't cache context cancellation error when querying. #6461
 
 ### Mixin
 

--- a/go.mod
+++ b/go.mod
@@ -251,7 +251,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231012014731-f477e1b21cfd
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231023075231-693f219a88e2
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ github.com/grafana/gomemcache v0.0.0-20230914135007-70d78eaabfe1 h1:MLYY2R60/74h
 github.com/grafana/gomemcache v0.0.0-20230914135007-70d78eaabfe1/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20231012014731-f477e1b21cfd h1:LYjf99LSJ1Tr1FsypHbBoTDyx67Rs8pepN0VSSs9Enw=
-github.com/grafana/mimir-prometheus v0.0.0-20231012014731-f477e1b21cfd/go.mod h1:GikKWT3QqA+R3uYRd/RILJNNFxu0HejZYRLtXEF27tQ=
+github.com/grafana/mimir-prometheus v0.0.0-20231023075231-693f219a88e2 h1:hUm6Pp4HSNvqc1xS2S7dlBTkbMFBhtXxQ420Uqn99lc=
+github.com/grafana/mimir-prometheus v0.0.0-20231023075231-693f219a88e2/go.mod h1:GikKWT3QqA+R3uYRd/RILJNNFxu0HejZYRLtXEF27tQ=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -890,7 +890,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231012014731-f477e1b21cfd
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231023075231-693f219a88e2
 ## explicit; go 1.20
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1470,7 +1470,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231012014731-f477e1b21cfd
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231023075231-693f219a88e2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6


### PR DESCRIPTION
#### What this PR does
Upgrade r260's mimir-prometheus dependency to [693f219a88e224c96422be0e01aedfe14bfbfeab](https://github.com/grafana/mimir-prometheus/tree/693f219a88e224c96422be0e01aedfe14bfbfeab), which brings in https://github.com/grafana/mimir-prometheus/pull/546.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
