### PR TITLE
Enable -blocks-storage.bucket-store.index-header.eager-loading-startup-enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   * `tooManyClustersError` and `validationError` are mapped to `codes.FailedPrecondition` instead of `http.BadRequest` (400).
   * `ingestionRateLimitedError` is mapped to `codes.ResourceExhausted` instead of `http.StatusTooManyRequests` (429).
   * `requestRateLimitedError` is mapped to `codes.Unavailable` or `codes.ResourceExhausted` instead of the non-standard `529` (The service is overloaded) or `http.StatusTooManyRequests` (429).
-* [CHANGE] Store-gateway: the "eager loading on startup" feature is now marked as stable and enabled by default. The feature is used only when store-gateway blocks lazy-loading is enabled. #6463
+* [CHANGE] Store-gateway: experimental "eager loading on startup" feature is now enabled by default. The feature is used only when store-gateway blocks lazy-loading is enabled. #6463
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [FEATURE] Vault: Added support for new Vault authentication methods: `AppRole`, `Kubernetes`, `UserPass` and `Token`. #6143
 * [FEATURE] Ingester: Experimental support for ignoring context cancellation when querying chunks, useful in ruling out the query engine's potential role in unexpected query cancellations. Enable with `-ingester.chunks-query-ignore-cancellation`. #6408

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
 * [CHANGE] Ingester: `/ingester/push` HTTP endpoint has been removed. This endpoint was added for testing and troubleshooting, but was never documented or used for anything. #6299
 * [CHANGE] Experimental setting `-log.rate-limit-logs-per-second-burst` renamed to `-log.rate-limit-logs-burst-size`. #6230
 * [CHANGE] Distributor: instead of errors with HTTP status codes, `Push()` now returns errors with gRPC codes: #6377
-* * `replicasDidNotMatchError` is mapped to `codes.AlreadyExists` instead of `http.StatusAccepted` (202).
-* * `tooManyClustersError` and `validationError` are mapped to `codes.FailedPrecondition` instead of `http.BadRequest` (400).
-* * `ingestionRateLimitedError` is mapped to `codes.ResourceExhausted` instead of `http.StatusTooManyRequests` (429).
-* * `requestRateLimitedError` is mapped to `codes.Unavailable` or `codes.ResourceExhausted` instead of the non-standard `529` (The service is overloaded) or `http.StatusTooManyRequests` (429).
+  * `replicasDidNotMatchError` is mapped to `codes.AlreadyExists` instead of `http.StatusAccepted` (202).
+  * `tooManyClustersError` and `validationError` are mapped to `codes.FailedPrecondition` instead of `http.BadRequest` (400).
+  * `ingestionRateLimitedError` is mapped to `codes.ResourceExhausted` instead of `http.StatusTooManyRequests` (429).
+  * `requestRateLimitedError` is mapped to `codes.Unavailable` or `codes.ResourceExhausted` instead of the non-standard `529` (The service is overloaded) or `http.StatusTooManyRequests` (429).
+* [CHANGE] Store-gateway: the "eager loading on startup" feature is now marked as stable and enabled by default. The feature is used only when store-gateway blocks lazy-loading is enabled. #6463
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [FEATURE] Vault: Added support for new Vault authentication methods: `AppRole`, `Kubernetes`, `UserPass` and `Token`. #6143
 * [FEATURE] Ingester: Experimental support for ignoring context cancellation when querying chunks, useful in ruling out the query engine's potential role in unexpected query cancellations. Enable with `-ingester.chunks-query-ignore-cancellation`. #6408

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7762,12 +7762,12 @@
                   "kind": "field",
                   "name": "eager_loading_startup_enabled",
                   "required": false,
-                  "desc": "If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. It is not valid to enable this if index-header lazy loading is disabled.",
+                  "desc": "If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. Ignored if index-header lazy loading is disabled.",
                   "fieldValue": null,
-                  "fieldDefaultValue": false,
+                  "fieldDefaultValue": true,
                   "fieldFlag": "blocks-storage.bucket-store.index-header.eager-loading-startup-enabled",
                   "fieldType": "boolean",
-                  "fieldCategory": "experimental"
+                  "fieldCategory": "advanced"
                 },
                 {
                   "kind": "field",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7767,7 +7767,7 @@
                   "fieldDefaultValue": true,
                   "fieldFlag": "blocks-storage.bucket-store.index-header.eager-loading-startup-enabled",
                   "fieldType": "boolean",
-                  "fieldCategory": "advanced"
+                  "fieldCategory": "experimental"
                 },
                 {
                   "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -500,7 +500,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout duration
     	[deprecated] If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity. (default 1h0m0s)
   -blocks-storage.bucket-store.index-header.eager-loading-startup-enabled
-    	If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. Ignored if index-header lazy loading is disabled. (default true)
+    	[experimental] If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. Ignored if index-header lazy loading is disabled. (default true)
   -blocks-storage.bucket-store.index-header.lazy-loading-concurrency int
     	[experimental] Maximum number of concurrent index header loads across all tenants. If set to 0, concurrency is unlimited. (default 4)
   -blocks-storage.bucket-store.index-header.lazy-loading-enabled

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -500,7 +500,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout duration
     	[deprecated] If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity. (default 1h0m0s)
   -blocks-storage.bucket-store.index-header.eager-loading-startup-enabled
-    	[experimental] If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. It is not valid to enable this if index-header lazy loading is disabled.
+    	If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. Ignored if index-header lazy loading is disabled. (default true)
   -blocks-storage.bucket-store.index-header.lazy-loading-concurrency int
     	[experimental] Maximum number of concurrent index header loads across all tenants. If set to 0, concurrency is unlimited. (default 4)
   -blocks-storage.bucket-store.index-header.lazy-loading-enabled

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -3564,11 +3564,11 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.index-header.max-idle-file-handles
     [max_idle_file_handles: <int> | default = 1]
 
-    # (experimental) If enabled, store-gateway will periodically persist block
-    # IDs of lazy loaded index-headers and load them eagerly during startup. It
-    # is not valid to enable this if index-header lazy loading is disabled.
+    # (advanced) If enabled, store-gateway will periodically persist block IDs
+    # of lazy loaded index-headers and load them eagerly during startup. Ignored
+    # if index-header lazy loading is disabled.
     # CLI flag: -blocks-storage.bucket-store.index-header.eager-loading-startup-enabled
-    [eager_loading_startup_enabled: <boolean> | default = false]
+    [eager_loading_startup_enabled: <boolean> | default = true]
 
     # (advanced) If enabled, store-gateway will lazy load an index-header only
     # once required by a query.

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -3564,9 +3564,9 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.index-header.max-idle-file-handles
     [max_idle_file_handles: <int> | default = 1]
 
-    # (advanced) If enabled, store-gateway will periodically persist block IDs
-    # of lazy loaded index-headers and load them eagerly during startup. Ignored
-    # if index-header lazy loading is disabled.
+    # (experimental) If enabled, store-gateway will periodically persist block
+    # IDs of lazy loaded index-headers and load them eagerly during startup.
+    # Ignored if index-header lazy loading is disabled.
     # CLI flag: -blocks-storage.bucket-store.index-header.eager-loading-startup-enabled
     [eager_loading_startup_enabled: <boolean> | default = true]
 

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -25,8 +25,7 @@ const (
 var NotFoundRangeErr = errors.New("range not found") //nolint:revive
 
 var (
-	errEagerLoadingStartupEnabledLazyLoadDisabled = errors.New("invalid configuration: store-gateway index header eager-loading is enabled, but lazy-loading is disabled")
-	errInvalidIndexHeaderLazyLoadingConcurrency   = errors.New("invalid index-header lazy loading max concurrency; must be non-negative")
+	errInvalidIndexHeaderLazyLoadingConcurrency = errors.New("invalid index-header lazy loading max concurrency; must be non-negative")
 )
 
 // Reader is an interface allowing to read essential, minimal number of index fields from the small portion of index file called header.
@@ -64,7 +63,7 @@ type Reader interface {
 
 type Config struct {
 	MaxIdleFileHandles         uint `yaml:"max_idle_file_handles" category:"advanced"`
-	EagerLoadingStartupEnabled bool `yaml:"eager_loading_startup_enabled" category:"experimental"`
+	EagerLoadingStartupEnabled bool `yaml:"eager_loading_startup_enabled" category:"advanced"`
 	// Controls whether index-header lazy loading is enabled.
 	LazyLoadingEnabled     bool          `yaml:"lazy_loading_enabled" category:"advanced"`
 	LazyLoadingIdleTimeout time.Duration `yaml:"lazy_loading_idle_timeout" category:"advanced"`
@@ -82,15 +81,12 @@ func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.BoolVar(&cfg.LazyLoadingEnabled, prefix+"lazy-loading-enabled", DefaultIndexHeaderLazyLoadingEnabled, "If enabled, store-gateway will lazy load an index-header only once required by a query.")
 	f.DurationVar(&cfg.LazyLoadingIdleTimeout, prefix+"lazy-loading-idle-timeout", DefaultIndexHeaderLazyLoadingIdleTimeout, "If index-header lazy loading is enabled and this setting is > 0, the store-gateway will offload unused index-headers after 'idle timeout' inactivity.")
 	f.IntVar(&cfg.LazyLoadingConcurrency, prefix+"lazy-loading-concurrency", 4, "Maximum number of concurrent index header loads across all tenants. If set to 0, concurrency is unlimited.")
-	f.BoolVar(&cfg.EagerLoadingStartupEnabled, prefix+"eager-loading-startup-enabled", false, "If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. It is not valid to enable this if index-header lazy loading is disabled.")
+	f.BoolVar(&cfg.EagerLoadingStartupEnabled, prefix+"eager-loading-startup-enabled", true, "If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. Ignored if index-header lazy loading is disabled.")
 	f.BoolVar(&cfg.SparsePersistenceEnabled, prefix+"sparse-persistence-enabled", true, "If enabled, store-gateway will persist a sparse version of the index-header to disk on construction and load sparse index-headers from disk instead of the whole index-header.")
 	f.BoolVar(&cfg.VerifyOnLoad, prefix+"verify-on-load", false, "If true, verify the checksum of index headers upon loading them (either on startup or lazily when lazy loading is enabled). Setting to true helps detect disk corruption at the cost of slowing down index header loading.")
 }
 
 func (cfg *Config) Validate() error {
-	if !cfg.LazyLoadingEnabled && cfg.EagerLoadingStartupEnabled {
-		return errEagerLoadingStartupEnabledLazyLoadDisabled
-	}
 	if cfg.LazyLoadingConcurrency < 0 {
 		return errInvalidIndexHeaderLazyLoadingConcurrency
 	}

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -63,7 +63,7 @@ type Reader interface {
 
 type Config struct {
 	MaxIdleFileHandles         uint `yaml:"max_idle_file_handles" category:"advanced"`
-	EagerLoadingStartupEnabled bool `yaml:"eager_loading_startup_enabled" category:"advanced"`
+	EagerLoadingStartupEnabled bool `yaml:"eager_loading_startup_enabled" category:"experimental"`
 	// Controls whether index-header lazy loading is enabled.
 	LazyLoadingEnabled     bool          `yaml:"lazy_loading_enabled" category:"advanced"`
 	LazyLoadingIdleTimeout time.Duration `yaml:"lazy_loading_idle_timeout" category:"advanced"`

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -275,13 +275,6 @@ func TestConfig_Validate(t *testing.T) {
 		setup       func(*Config)
 		expectedErr error
 	}{
-		"should fail on invalid index-header eager loading in startup": {
-			setup: func(cfg *Config) {
-				cfg.EagerLoadingStartupEnabled = true
-				cfg.LazyLoadingEnabled = false
-			},
-			expectedErr: errEagerLoadingStartupEnabledLazyLoadDisabled,
-		},
 		"should fail on invalid index-header lazy loading max concurrency": {
 			setup: func(cfg *Config) {
 				cfg.LazyLoadingConcurrency = -1


### PR DESCRIPTION
#### What this PR does
We have `-blocks-storage.bucket-store.index-header.eager-loading-startup-enabled=true` enabled in production since few weeks at Grafana Labs and there's no known issue. I propose to enable it by default. To enable it by default without incurring into config validation errors if someone has lazy loading disabled, I've changed a bit the logic to simply ignore it when lazy loading is disabled, instead of returning an error.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
