### PR TITLE
Fix issue where successful streaming gRPC requests are incorrectly reported as cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [BUGFIX] Ingester: Don't cache context cancellation error when querying. #6446
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6469
 * [BUGFIX] All: fix issue where traces for some inter-component gRPC calls would incorrectly show the call as failing due to cancellation. #6470
+* [BUGFIX] Querier: correctly mark streaming requests that return no series from ingesters or store-gateways as successful, not cancelled, in metrics and traces. #6471
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [BUGFIX] Ingester: Don't cache context cancellation error when querying. #6446
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6469
 * [BUGFIX] All: fix issue where traces for some inter-component gRPC calls would incorrectly show the call as failing due to cancellation. #6470
-* [BUGFIX] Querier: correctly mark streaming requests that return no series from ingesters or store-gateways as successful, not cancelled, in metrics and traces. #6471
+* [BUGFIX] Querier: correctly mark streaming requests to ingesters or store-gateways as successful, not cancelled, in metrics and traces. #6471
 
 ### Mixin
 

--- a/integration/ingester_test.go
+++ b/integration/ingester_test.go
@@ -469,6 +469,27 @@ func TestIngesterQuerying(t *testing.T) {
 				},
 			},
 		},
+		"query that returns no results": {
+			// We have to push at least one sample to ensure that the tenant TSDB exists (otherwise the ingester takes a shortcut and returns early).
+			inSeries: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: "not_foobar",
+						},
+					},
+					Samples: []prompb.Sample{
+						{
+							Timestamp: queryStart.Add(-2 * time.Second).UnixMilli(),
+							Value:     100,
+						},
+					},
+				},
+			},
+			expectedQueryResult:          model.Matrix{},
+			expectedTimestampQueryResult: model.Matrix{},
+		},
 	}
 
 	for testName, tc := range testCases {
@@ -529,6 +550,32 @@ func TestIngesterQuerying(t *testing.T) {
 					result, err = client.QueryRange(timestampQuery, queryStart, queryEnd, queryStep)
 					require.NoError(t, err)
 					require.Equal(t, tc.expectedTimestampQueryResult, result)
+
+					queryRequestCount := func(status string) (float64, error) {
+						counts, err := querier.SumMetrics([]string{"cortex_ingester_client_request_duration_seconds"},
+							e2e.WithLabelMatchers(
+								labels.MustNewMatcher(labels.MatchEqual, "operation", "/cortex.Ingester/QueryStream"),
+								labels.MustNewMatcher(labels.MatchEqual, "status_code", status),
+							),
+							e2e.WithMetricCount,
+							e2e.SkipMissingMetrics,
+						)
+
+						if err != nil {
+							return 0, err
+						}
+
+						require.Len(t, counts, 1)
+						return counts[0], nil
+					}
+
+					successfulQueryRequests, err := queryRequestCount("2xx")
+					require.NoError(t, err)
+					require.Equal(t, 2.0, successfulQueryRequests) // 1 for first query request, 1 for timestamp query request
+
+					cancelledQueryRequests, err := queryRequestCount("cancel")
+					require.NoError(t, err)
+					require.Equal(t, 0.0, cancelledQueryRequests)
 				})
 			}
 		})

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1371,7 +1371,7 @@ func (d *Distributor) LabelNamesAndValues(ctx context.Context, matchers []*label
 		if err != nil {
 			return nil, err
 		}
-		defer stream.CloseSend() //nolint:errcheck
+		defer util.CloseAndExhaust[*ingester_client.LabelNamesAndValuesResponse](stream) //nolint:errcheck
 		return nil, merger.collectResponses(stream)
 	})
 	if err != nil {
@@ -1528,7 +1528,7 @@ func (d *Distributor) labelValuesCardinality(ctx context.Context, labelNames []m
 		if err != nil {
 			return struct{}{}, err
 		}
-		defer func() { _ = stream.CloseSend() }()
+		defer func() { _ = util.CloseAndExhaust[*ingester_client.LabelValuesCardinalityResponse](stream) }()
 
 		return struct{}{}, cardinalityConcurrentMap.processLabelValuesCardinalityMessages(desc.Zone, stream)
 	}, func(struct{}) {})

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -214,6 +214,13 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 					if err := stream.CloseSend(); err != nil {
 						level.Warn(log).Log("msg", "closing ingester client stream failed", "err", err)
 					}
+
+					// Exhaust the stream to ensure instrumentation middleware correctly observes the end of the stream, rather than reporting it as "context canceled".
+					for {
+						if _, err := stream.Recv(); err != nil {
+							break
+						}
+					}
 				}
 
 				cleanup()

--- a/pkg/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/frontend/v2/frontend_scheduler_worker.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerdiscovery"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
+	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/servicediscovery"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -282,7 +283,7 @@ func (w *frontendSchedulerWorker) runOne(ctx context.Context, client schedulerpb
 		}
 
 		loopErr = w.schedulerLoop(loop)
-		if closeErr := loop.CloseSend(); closeErr != nil {
+		if closeErr := util.CloseAndExhaust[*schedulerpb.SchedulerToFrontend](loop); closeErr != nil {
 			level.Debug(w.log).Log("msg", "failed to close frontend loop", "err", loopErr, "addr", w.schedulerAddr)
 		}
 

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -109,7 +109,7 @@ func (s *SeriesChunksStreamReader) readStream(log *spanlogger.SpanLogger) error 
 					return fmt.Errorf("expected to receive %v series, but got EOF after receiving %v series", s.expectedSeriesCount, totalSeries)
 				}
 
-				level.Debug(log).Log("msg", "finished streaming", "series", totalSeries, "chunks", totalChunks)
+				log.DebugLog("msg", "finished streaming", "series", totalSeries, "chunks", totalChunks)
 				return nil
 			}
 

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -59,7 +60,7 @@ func NewSeriesChunksStreamReader(client Ingester_QueryStreamClient, expectedSeri
 // Close cleans up all resources associated with this SeriesChunksStreamReader.
 // This method should only be called if StartBuffering is not called.
 func (s *SeriesChunksStreamReader) Close() {
-	if err := s.client.CloseSend(); err != nil {
+	if err := util.CloseAndExhaust[*QueryStreamResponse](s.client); err != nil {
 		level.Warn(s.log).Log("msg", "closing ingester client stream failed", "err", err)
 	}
 

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -331,7 +331,7 @@ func (s *storeGatewayStreamReader) GetChunks(seriesIndex uint64) (_ []storepb.Ag
 		// 1. If we receive more series than expected (likely due to a bug), or something else goes wrong after receiving the last series,
 		//    StartBuffering() will return an error. This method will then return it, which will bubble up to the PromQL engine and report
 		//    it, rather than it potentially being logged and missed.
-		// 2. It ensures the gPRC stream is cleaned up before the PromQL engine cancels the context used for the query. If the context
+		// 2. It ensures the gRPC stream is cleaned up before the PromQL engine cancels the context used for the query. If the context
 		//    is cancelled before the gRPC stream's Recv() returns EOF, this can result in misleading context cancellation errors being
 		//    logged and included in metrics and traces, when in fact the call succeeded.
 		if err := <-s.errorChan; err != nil {

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/series"
 	"github.com/grafana/mimir/pkg/storegateway/storegatewaypb"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -151,7 +152,7 @@ func newStoreGatewayStreamReader(client storegatewaypb.StoreGateway_SeriesClient
 // Close cleans up all resources associated with this storeGatewayStreamReader.
 // This method should only be called if StartBuffering is not called.
 func (s *storeGatewayStreamReader) Close() {
-	if err := s.client.CloseSend(); err != nil {
+	if err := util.CloseAndExhaust[*storepb.SeriesResponse](s.client); err != nil {
 		level.Warn(s.log).Log("msg", "closing store-gateway client stream failed", "err", err)
 	}
 }

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -307,25 +307,9 @@ func (s *storeGatewayStreamReader) GetChunks(seriesIndex uint64) (_ []storepb.Ag
 	}()
 
 	if len(s.chunksBatch) == 0 {
-		chks, channelOpen := <-s.seriesChunksChan
-
-		if !channelOpen {
-			// If there's an error, report it.
-			select {
-			case err, haveError := <-s.errorChan:
-				if haveError {
-					if _, ok := err.(validation.LimitError); ok {
-						return nil, err
-					}
-					return nil, errors.Wrapf(err, "attempted to read series at index %v from store-gateway chunks stream, but the stream has failed", seriesIndex)
-				}
-			default:
-			}
-
-			return nil, fmt.Errorf("attempted to read series at index %v from store-gateway chunks stream, but the stream has already been exhausted (was expecting %v series)", seriesIndex, s.expectedSeriesCount)
+		if err := s.readNextBatch(seriesIndex); err != nil {
+			return nil, err
 		}
-
-		s.chunksBatch = chks.Series
 	}
 
 	chks := s.chunksBatch[0]
@@ -339,7 +323,46 @@ func (s *storeGatewayStreamReader) GetChunks(seriesIndex uint64) (_ []storepb.Ag
 		return nil, fmt.Errorf("attempted to read series at index %v from store-gateway chunks stream, but the stream has series with index %v", seriesIndex, chks.SeriesIndex)
 	}
 
+	if int(seriesIndex) == s.expectedSeriesCount-1 {
+		// This is the last series we expect to receive. Wait for StartBuffering() to exit (which is signalled by returning an error or
+		// closing errorChan).
+		//
+		// This ensures two things:
+		// 1. If we receive more series than expected (likely due to a bug), or something else goes wrong after receiving the last series,
+		//    StartBuffering() will return an error. This method will then return it, which will bubble up to the PromQL engine and report
+		//    it, rather than it potentially being logged and missed.
+		// 2. It ensures the gPRC stream is cleaned up before the PromQL engine cancels the context used for the query. If the context
+		//    is cancelled before the gRPC stream's Recv() returns EOF, this can result in misleading context cancellation errors being
+		//    logged and included in metrics and traces, when in fact the call succeeded.
+		if err := <-s.errorChan; err != nil {
+			return nil, fmt.Errorf("attempted to read series at index %v from store-gateway chunks stream, but the stream has failed: %w", seriesIndex, err)
+		}
+	}
+
 	return chks.Chunks, nil
+}
+
+func (s *storeGatewayStreamReader) readNextBatch(seriesIndex uint64) error {
+	chks, channelOpen := <-s.seriesChunksChan
+
+	if !channelOpen {
+		// If there's an error, report it.
+		select {
+		case err, haveError := <-s.errorChan:
+			if haveError {
+				if _, ok := err.(validation.LimitError); ok {
+					return err
+				}
+				return errors.Wrapf(err, "attempted to read series at index %v from store-gateway chunks stream, but the stream has failed", seriesIndex)
+			}
+		default:
+		}
+
+		return fmt.Errorf("attempted to read series at index %v from store-gateway chunks stream, but the stream has already been exhausted (was expecting %v series)", seriesIndex, s.expectedSeriesCount)
+	}
+
+	s.chunksBatch = chks.Series
+	return nil
 }
 
 // EstimateChunkCount returns an estimate of the number of chunks this stream reader will return.

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -898,8 +898,8 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(ctx context.Context, sp *stor
 	// Wait until all client requests complete.
 	if err := g.Wait(); err != nil {
 		for _, stream := range streams {
-			if err := stream.CloseSend(); err != nil {
-				level.Warn(q.logger).Log("msg", "closing storegateway client stream failed", "err", err)
+			if err := util.CloseAndExhaust[*storepb.SeriesResponse](stream); err != nil {
+				level.Warn(q.logger).Log("msg", "closing store-gateway client stream failed", "err", err)
 			}
 		}
 		return nil, nil, nil, nil, nil, err

--- a/pkg/util/grpc.go
+++ b/pkg/util/grpc.go
@@ -8,17 +8,16 @@ type Stream[T any] interface {
 }
 
 func CloseAndExhaust[T any](stream Stream[T]) error {
-	if err := stream.CloseSend(); err != nil {
+	err := stream.CloseSend()
+	if err != nil {
 		return err
 	}
 
 	// Exhaust the stream to ensure:
 	// - the gRPC library can release any resources associated with the stream (see https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream)
 	// - instrumentation middleware correctly observes the end of the stream, rather than reporting it as "context canceled"
-	for {
-		if _, err := stream.Recv(); err != nil {
-			break
-		}
+	for err == nil {
+		_, err = stream.Recv()
 	}
 
 	return nil

--- a/pkg/util/grpc.go
+++ b/pkg/util/grpc.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package util
+
+type Stream[T any] interface {
+	CloseSend() error
+	Recv() (T, error)
+}
+
+func CloseAndExhaust[T any](stream Stream[T]) error {
+	if err := stream.CloseSend(); err != nil {
+		return err
+	}
+
+	// Exhaust the stream to ensure:
+	// - the gRPC library can release any resources associated with the stream (see https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream)
+	// - instrumentation middleware correctly observes the end of the stream, rather than reporting it as "context canceled"
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### What this PR does

This PR fixes multiple related issues:
* It fixes the issue where query requests that stream chunks but return no series are reported as cancelled rather than successful in traces and metrics reported by queriers ([77c191d](https://github.com/grafana/mimir/pull/6471/commits/77c191da45439fee37f77deaf8611c3e117ed86d))
* It also fixes a similar issue as above for other server streaming gRPC calls ([ae15605](https://github.com/grafana/mimir/pull/6471/commits/ae15605d94ad5c747c4590c7acdf5d1be50bf189))
* It fixes the issue where query requests that stream chunks and have some series are reported as cancelled ([5f6d927](https://github.com/grafana/mimir/pull/6471/commits/5f6d927ca20292103d07606cace8a41e623a30e3) for streaming from ingesters, [91fd892](https://github.com/grafana/mimir/pull/6471/commits/91fd8920e33ef791fc8aaf8111ea5e890d13e20d) for streaming from store-gateways)

[4453e0a](https://github.com/grafana/mimir/pull/6471/commits/4453e0a1f73d5cffe065ed8533bae08aa9f461bb) separately refactors the ingester stream reader (`SeriesChunksStreamReader`) to follow the same structure as the store-gateway stream reader (`storeGatewayStreamReader`).

I'd suggest reviewing each commit individually.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
