### PR TITLE
Improve distributor_test

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -4834,7 +4834,7 @@ func TestHandleIngesterPushError(t *testing.T) {
 			ingesterPushError:         createStatusWithDetails(t, codes.Unavailable, testErrorMsg, mimirpb.INVALID).Err(),
 			expectedIngesterPushError: newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, testErrorMsg, mimirpb.INVALID)),
 		},
-		"a DedlineExceeded gRPC ingester error an ingesterPushError with INVALID cause": {
+		"a DeadlineExceeded gRPC ingester error an ingesterPushError with INVALID cause": {
 			// This is how context.DeadlineExceeded error is translated into a gRPC error.
 			ingesterPushError:         status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error()),
 			expectedIngesterPushError: newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, context.DeadlineExceeded.Error(), mimirpb.INVALID)),

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -944,6 +944,11 @@ func TestHandler_ToHTTPStatus(t *testing.T) {
 			expectedHTTPStatus: http.StatusInternalServerError,
 			expectedErrorMsg:   fmt.Sprintf("%s: %s", failedPushingToIngesterMessage, originalMsg),
 		},
+		"an ingesterPushError obtained from a DeadlineExceeded coming from the ingester gets translated into an HTTP 500": {
+			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, context.DeadlineExceeded.Error(), mimirpb.INVALID)),
+			expectedHTTPStatus: http.StatusInternalServerError,
+			expectedErrorMsg:   fmt.Sprintf("%s: %s", failedPushingToIngesterMessage, context.DeadlineExceeded),
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does
This PR fixes a small bug that was found in `distributor_test`. Moreover, it verifies that the gRPC errors with code `codes.DeadlineExceeded` coming from the ingester are correctly translated by the distributor and the push_handler.

#### Checklist
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
