### PR TITLE
Improve distributor's TestStartFinishRequest test.

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -5024,7 +5024,7 @@ func TestStartFinishRequest(t *testing.T) {
 		expectedInflightBytesKey    ctxType = "bytes"
 	)
 
-	// Pretend push went OK, make sure to call CleanUp.
+	// Pretend push went OK, make sure to call CleanUp. Also check for expected values of inflight requests and inflight request size.
 	finishPush := func(ctx context.Context, pushReq *Request) error {
 		defer pushReq.CleanUp()
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -5017,10 +5017,11 @@ func TestStartFinishRequest(t *testing.T) {
 		}
 	}
 
+	type ctxType string
 	const (
-		distributorKey              = "dist"
-		expectedInflightRequestsKey = "req"
-		expectedInflightBytesKey    = "bytes"
+		distributorKey              ctxType = "dist"
+		expectedInflightRequestsKey ctxType = "req"
+		expectedInflightBytesKey    ctxType = "bytes"
 	)
 
 	// Pretend push went OK, make sure to call CleanUp.


### PR DESCRIPTION
#### What this PR does

This PR improves `distributor.TestStartFinishRequest` a bit, to check for inflight bytes and size during request execution. This is to make sure that proper values are tracked during the request.

This is enhancement of #6300.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
