### PR TITLE
Patch r258 with PostingsForMatchersCache fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145
 * [BUGFIX] Ingester: prevent query logic from continuing to execute after queries are canceled. #6085
 * [BUGFIX] Ensure correct nesting of children of the `querier.Select` tracing span. #6085
+* [BUGFIX] Ingester: Don't cache context cancellation error when querying. #6486
 
 ### Mixin
 

--- a/go.mod
+++ b/go.mod
@@ -251,7 +251,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230929133245-5e1fe508c771
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231026075524-478c4325d169
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -555,8 +555,8 @@ github.com/grafana/gomemcache v0.0.0-20230914135007-70d78eaabfe1 h1:MLYY2R60/74h
 github.com/grafana/gomemcache v0.0.0-20230914135007-70d78eaabfe1/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20230929133245-5e1fe508c771 h1:YVKeiFLJUGG/kdx3sdkmz4kS6gw+5OVAIOJBHwKuaIk=
-github.com/grafana/mimir-prometheus v0.0.0-20230929133245-5e1fe508c771/go.mod h1:FS+VpDcgSX2unPDcuzLAH4+qdraB8f/Kwy73bYwxFJo=
+github.com/grafana/mimir-prometheus v0.0.0-20231026075524-478c4325d169 h1:WcnFfpmUVS0aQ98Dc6f2z+w1R6FyzuVDkowfeKDZp0k=
+github.com/grafana/mimir-prometheus v0.0.0-20231026075524-478c4325d169/go.mod h1:FS+VpDcgSX2unPDcuzLAH4+qdraB8f/Kwy73bYwxFJo=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -917,7 +917,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20230929133245-5e1fe508c771
+# github.com/prometheus/prometheus v1.8.2-0.20220620125440-d7e7b8e04b5e => github.com/grafana/mimir-prometheus v0.0.0-20231026075524-478c4325d169
 ## explicit; go 1.20
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1497,7 +1497,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20230929133245-5e1fe508c771
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231026075524-478c4325d169
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6


### PR DESCRIPTION
#### What this PR does
Patch r258 with `tsdb.PostingsForMatchersCache` [cache poisoning fix](https://github.com/grafana/mimir-prometheus/pull/546). Backport of https://github.com/grafana/mimir/pull/6446.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
