### PR TITLE
Chore: Fix github workflow and let only member runs mimir-build-image

### DIFF
--- a/.github/workflows/member_pr.yml
+++ b/.github/workflows/member_pr.yml
@@ -1,0 +1,59 @@
+### .github/workflows/member_pr.yml
+### This workflow operates on the target branch, which is "main," ensuring that no pull request can alter the logic until it has been merged into the "main" branch.
+name: Membership check
+on:
+    # It's important to use "pull_request_target" here to prevent potentially malicious users from creating pull requests and bypassing the constraint.
+    pull_request_target:
+        types: [opened, synchronize]
+        paths:
+          - mimir-build-image/Dockerfile 
+        branches:
+          - main
+          - 'release-**'
+
+jobs:
+    check-membership:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Check out repository
+            uses: actions/checkout@v4
+          - name: Check user for team affiliation
+            id: teamAffiliation
+            run: |
+                # Encode the triggering actor's username for use in the GitHub API URL. Otherwise the user like renovate[bot] has encoding error
+                ENCODED_USERNAME=$(printf %s "${{ github.triggering_actor }}" | xxd -p -c 256 | tr -d '\n' | sed 's/\(..\)/%\1/g')
+                
+                # Define the GitHub API URL for checking team membership.
+                API_URL="https://api.github.com/orgs/grafana/teams/mimir-maintainers/members/$ENCODED_USERNAME"
+                
+                # Send a GET request to the GitHub API with proper authentication.
+                response=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: token ${{ secrets.GH_BOT_ACCESS_TOKEN }}" $API_URL)
+                
+                # Check the response and update the result in the GitHub output.
+                if [ -z "$response" ]; then
+                  echo "team_membership=error" >> $GITHUB_OUTPUT
+                else
+                  # Set the result as an environment variable based on the response code
+                  if [ "$response" -eq 204 ]; then
+                    echo "team_membership=true" >> $GITHUB_OUTPUT
+                  elif [ "$response" -eq 404 ]; then
+                    echo "team_membership=false" >> $GITHUB_OUTPUT
+                  else
+                    echo "team_membership=error" >> $GITHUB_OUTPUT
+                  fi
+                fi
+
+          - name: Add Comment to the PR
+            id: notification
+            if: ${{ steps.teamAffiliation.outputs.team_membership != 'true' }}
+            run: | 
+                gh pr comment $PR_NUMBER --body "Changing the Dockerfile for mimir-build-image requires approval from a mimir-maintainer. Please reach out to one of the mimir-maintainers to review your changes before proceeding."
+            env:
+                PR_NUMBER: ${{ github.event.pull_request.number }}
+                GITHUB_TOKEN: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+
+          - name: Stop workflow if user is no member
+            if: ${{ steps.teamAffiliation.outputs.team_membership != 'true' }}
+            run: |
+              echo "You have no rights to trigger this job."
+              exit 1

--- a/.github/workflows/member_pr.yml
+++ b/.github/workflows/member_pr.yml
@@ -1,6 +1,6 @@
 ### .github/workflows/member_pr.yml
 ### This workflow operates on the target branch, which is "main," ensuring that no pull request can alter the logic until it has been merged into the "main" branch.
-name: Membership check
+name: Build image membership check
 on:
     # It's important to use "pull_request_target" here to prevent potentially malicious users from creating pull requests and bypassing the constraint.
     pull_request_target:
@@ -20,7 +20,7 @@ jobs:
           - name: Check user for team affiliation
             id: teamAffiliation
             run: |
-                # Encode the triggering actor's username for use in the GitHub API URL. Otherwise the user like renovate[bot] has encoding error
+                # Encode the triggering actor's username for use in the GitHub API URL. Otherwise users like renovate[bot] get an encoding error
                 ENCODED_USERNAME=$(printf %s "${{ github.triggering_actor }}" | xxd -p -c 256 | tr -d '\n' | sed 's/\(..\)/%\1/g')
                 
                 # Define the GitHub API URL for checking team membership.
@@ -47,13 +47,13 @@ jobs:
             id: notification
             if: ${{ steps.teamAffiliation.outputs.team_membership != 'true' }}
             run: | 
-                gh pr comment $PR_NUMBER --body "Changing the Dockerfile for mimir-build-image requires approval from a mimir-maintainer. Please reach out to one of the mimir-maintainers to review your changes before proceeding."
+                gh pr comment $PR_NUMBER --body "Changing the Dockerfile for mimir-build-image requires approval from a Mimir maintainer. Please reach out to a member of the mimir-maintainers group to review your changes before proceeding."
             env:
                 PR_NUMBER: ${{ github.event.pull_request.number }}
                 GITHUB_TOKEN: ${{secrets.GH_BOT_ACCESS_TOKEN}}
 
-          - name: Stop workflow if user is no member
+          - name: Stop workflow if user is not a member
             if: ${{ steps.teamAffiliation.outputs.team_membership != 'true' }}
             run: |
-              echo "You have no rights to trigger this job."
+              echo "You lack permission to trigger this job."
               exit 1

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -1,6 +1,6 @@
 name: Build and Push mimir-build-image
 
-# configure trigger by the complete of member_pr workflow
+# trigger on completion of member_pr workflow
 on:
   workflow_run:
     workflows: ["Membership check"]

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -1,32 +1,36 @@
 name: Build and Push mimir-build-image
 
-# configure trigger by pull request
+# configure trigger by the complete of member_pr workflow
 on:
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - mimir-build-image/Dockerfile  
+  workflow_run:
+    workflows: ["Membership check"]
+    types: 
+      - completed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number }}
   cancel-in-progress: true
 
 jobs: 
   build_and_push:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       # Allow pushing to the GitHub repo for collaborators, forks should remain read-only
       contents: write
       # Allow PR modification for collaborators, forks should remain read-only
       pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Checkout Pull Request Branch
-        run: gh pr checkout ${{ github.event.pull_request.number }}
+        run: gh pr checkout ${{ env.PR_NUMBER }}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
@@ -56,7 +60,7 @@ jobs:
           current_hash=$(md5sum ${{ steps.prepare.outputs.path }} | awk '{print substr($1, 0, 10)}')
           echo "the file path is ${{ steps.prepare.outputs.path }}"
           echo "build tag is $current_hash"
-          tag="pr${{ github.event.pull_request.number }}-$current_hash"
+          tag="pr${{ env.PR_NUMBER }}-$current_hash"
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Check Should Build Image
@@ -82,7 +86,7 @@ jobs:
             gh pr comment $PR_NUMBER --body "**Not building new version of mimir-build-image**. This PR modifies \\\`mimir-build-image/Dockerfile\\\`, but the image \\\`$IMAGE:$TAG\\\` already exists."
           fi
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           TAG: ${{ steps.compute_hash.outputs.tag }}
           IMAGE: ${{ steps.prepare.outputs.image }}
@@ -116,8 +120,8 @@ jobs:
           else
             echo "Build Image Version is not up to date"
             sed -i "s/$MAIN_TAG/${{ steps.compute_hash.outputs.tag }}/g" Makefile
-            git config --global user.email "${{ github.event.pull_request.user.login }}@users.noreply.github.com"
-            git config --global user.name "${{ github.event.pull_request.user.login }}"
+            git config --global user.email "${{ github.triggering_actor }}@users.noreply.github.com"
+            git config --global user.name "${{ github.triggering_actor }}"
             git add Makefile
             git commit -m "Update build image version to ${{ steps.compute_hash.outputs.tag }}"
             git push origin HEAD


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR arises from the decision to disable builds for contributors outside of the Mimir organization. Every contributor's pipeline execution must now receive approval from a maintainer. This change was questioned by discussions in another PR.

What's the rationale behind this approach? It's rooted in an issue opened within the dependabot-core repository (https://github.com/dependabot/dependabot-core/issues/3253). I have implemented two workflows: one for membership checking, executed on `pull_request_target`, which ensures that it operates exclusively within the context of the target branch. This means that no modifications in the commit branch are considered until they are merged into the target main/release branch. Consequently, contributors cannot bypass the membership check. This behaviour has been tested on my personal repository (https://github.com/ying-jeanne/mimir/pull/107).

Additionally, if the PR creator is not a part of the Grafana organization, the CI will fail and no build starts, as demonstrated in my personal test (https://github.com/ying-jeanne/mimir/actions/runs/6659976149/job/18100191154?pr=85). However, re-running the job using the 'ying-jeanne' account resulted in success (https://github.com/ying-jeanne/mimir/actions/runs/6659976149?pr=85).

Note the second workflow is not part of CI success, It's worth noting that the `build mimir-build-image` workflow is adding comment to indicate a new build is ongoing and prompts them to wait. If this approach proves insufficient, we are open to further enhancements.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- na Tests updated
- na Documentation added
- na `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
