### PR TITLE
ingester: implement request size instance limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [ENHANCEMENT] Querier: clarify log messages and span events emitted while querying ingesters, and include both ingester name and address when relevant. #6381
 * [ENHANCEMENT] Memcached: introduce new experimental configuration parameters `-<prefix>.memcached.write-buffer-size-bytes` `-<prefix>.memcached.read-buffer-size-bytes` to customise the memcached client write and read buffer size (the buffer is allocated for each memcached connection). #6468
 * [ENHANCEMENT] Ingester, Distributor: added experimental support for rejecting push requests received via gRPC before reading them into memory, if ingester or distributor is unable to accept the request. This is activated by using `-ingester.limit-inflight-requests-using-grpc-method-limiter` for ingester, and `-distributor.limit-inflight-requests-using-grpc-method-limiter` for distributor. #5976 #6300
+* [ENHANCEMENT] Ingester: Add `-ingester.instance-limits.max-inflight-push-requests-bytes`. This limit protects the ingester against requests that together may cause an OOM.
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145
 * [BUGFIX] Ingester: prevent query logic from continuing to execute after queries are canceled. #6085

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2866,6 +2866,17 @@
               "fieldFlag": "ingester.instance-limits.max-inflight-push-requests",
               "fieldType": "int",
               "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "max_inflight_push_requests_bytes",
+              "required": false,
+              "desc": "The sum of the request sizes in bytes of inflight push requests that this ingester can handle. This limit is per-ingester, not per-tenant. Additional requests will be rejected. 0 = unlimited.",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "ingester.instance-limits.max-inflight-push-requests-bytes",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1293,6 +1293,8 @@ Usage of ./cmd/mimir/mimir:
     	Comma-separated list of metric names, for which the -ingester.max-global-series-per-metric limit will be ignored. Does not affect the -ingester.max-global-series-per-user limit.
   -ingester.instance-limits.max-inflight-push-requests int
     	Max inflight push requests that this ingester can handle (across all tenants). Additional requests will be rejected. 0 = unlimited. (default 30000)
+  -ingester.instance-limits.max-inflight-push-requests-bytes int
+    	The sum of the request sizes in bytes of inflight push requests that this ingester can handle. This limit is per-ingester, not per-tenant. Additional requests will be rejected. 0 = unlimited.
   -ingester.instance-limits.max-ingestion-rate float
     	Max ingestion rate (samples/sec) that ingester will accept. This limit is per-ingester, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.
   -ingester.instance-limits.max-series int

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1089,6 +1089,12 @@ instance_limits:
   # CLI flag: -ingester.instance-limits.max-inflight-push-requests
   [max_inflight_push_requests: <int> | default = 30000]
 
+  # (advanced) The sum of the request sizes in bytes of inflight push requests
+  # that this ingester can handle. This limit is per-ingester, not per-tenant.
+  # Additional requests will be rejected. 0 = unlimited.
+  # CLI flag: -ingester.instance-limits.max-inflight-push-requests-bytes
+  [max_inflight_push_requests_bytes: <int> | default = 0]
+
 # (advanced) Comma-separated list of metric names, for which the
 # -ingester.max-global-series-per-metric limit will be ignored. Does not affect
 # the -ingester.max-global-series-per-user limit.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -119,10 +119,11 @@ const (
 )
 
 var (
-	reasonIngesterMaxIngestionRate        = globalerror.IngesterMaxIngestionRate.LabelValue()
-	reasonIngesterMaxTenants              = globalerror.IngesterMaxTenants.LabelValue()
-	reasonIngesterMaxInMemorySeries       = globalerror.IngesterMaxInMemorySeries.LabelValue()
-	reasonIngesterMaxInflightPushRequests = globalerror.IngesterMaxInflightPushRequests.LabelValue()
+	reasonIngesterMaxIngestionRate             = globalerror.IngesterMaxIngestionRate.LabelValue()
+	reasonIngesterMaxTenants                   = globalerror.IngesterMaxTenants.LabelValue()
+	reasonIngesterMaxInMemorySeries            = globalerror.IngesterMaxInMemorySeries.LabelValue()
+	reasonIngesterMaxInflightPushRequests      = globalerror.IngesterMaxInflightPushRequests.LabelValue()
+	reasonIngesterMaxInflightPushRequestsBytes = globalerror.IngesterMaxInflightPushRequestsBytes.LabelValue()
 	// This is the closest fitting Prometheus API error code for requests rejected due to limiting.
 	tooBusyError = newErrorWithHTTPStatus(
 		errors.New(tooBusyErrorMsg),
@@ -283,8 +284,9 @@ type Ingester struct {
 	usersMetadata    map[string]*userMetricsMetadata
 
 	// Rate of pushed samples. Used to limit global samples push rate.
-	ingestionRate        *util_math.EwmaRate
-	inflightPushRequests atomic.Int64
+	ingestionRate             *util_math.EwmaRate
+	inflightPushRequests      atomic.Int64
+	inflightPushRequestsBytes atomic.Int64
 
 	// Anonymous usage statistics tracked by ingester.
 	memorySeriesStats                  *expvar.Int
@@ -347,7 +349,7 @@ func New(cfg Config, limits *validation.Overrides, activeGroupsCleanupService *u
 		return nil, err
 	}
 	i.ingestionRate = util_math.NewEWMARate(0.2, instanceIngestionRateTickInterval)
-	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetrics.Enabled, i.getInstanceLimits, i.ingestionRate, &i.inflightPushRequests)
+	i.metrics = newIngesterMetrics(registerer, cfg.ActiveSeriesMetrics.Enabled, i.getInstanceLimits, i.ingestionRate, &i.inflightPushRequests, &i.inflightPushRequestsBytes)
 	i.activeGroups = activeGroupsCleanupService
 
 	if registerer != nil {
@@ -407,7 +409,7 @@ func NewForFlusher(cfg Config, limits *validation.Overrides, registerer promethe
 	if err != nil {
 		return nil, err
 	}
-	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil, &i.inflightPushRequests)
+	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil, &i.inflightPushRequests, &i.inflightPushRequestsBytes)
 
 	i.shipperIngesterID = "flusher"
 
@@ -769,12 +771,17 @@ type pushStats struct {
 // In the first case, returned errors can be inspected/logged by middleware. Ingester.PushWithCleanup will wrap the error in util_log.DoNotLogError wrapper.
 //
 // In the second case, returned errors will not be logged, because request will not reach any middleware.
-func (i *Ingester) StartPushRequest() error {
+func (i *Ingester) StartPushRequest(requestSize int64) error {
 	if err := i.checkAvailable(); err != nil {
 		return err
 	}
 
 	inflight := i.inflightPushRequests.Inc()
+	inflightBytes := int64(0)
+	if requestSize > 0 {
+		inflightBytes = i.inflightPushRequestsBytes.Add(requestSize)
+	}
+
 	decreaseInflightInDefer := true
 	defer func() {
 		if decreaseInflightInDefer {
@@ -783,17 +790,22 @@ func (i *Ingester) StartPushRequest() error {
 	}()
 
 	il := i.getInstanceLimits()
-	if il != nil && il.MaxInflightPushRequests > 0 {
-		if inflight > il.MaxInflightPushRequests {
+	if il != nil {
+		if il.MaxInflightPushRequests > 0 && inflight > il.MaxInflightPushRequests {
 			i.metrics.rejected.WithLabelValues(reasonIngesterMaxInflightPushRequests).Inc()
 			return errMaxInflightRequestsReached
 		}
-	}
 
-	if il != nil && il.MaxIngestionRate > 0 {
-		if rate := i.ingestionRate.Rate(); rate >= il.MaxIngestionRate {
-			i.metrics.rejected.WithLabelValues(reasonIngesterMaxIngestionRate).Inc()
-			return errMaxIngestionRateReached
+		if il.MaxInflightPushRequestsBytes > 0 && inflightBytes > il.MaxInflightPushRequestsBytes {
+			i.metrics.rejected.WithLabelValues(reasonIngesterMaxInflightPushRequestsBytes).Inc()
+			return errMaxInflightRequestsBytesReached
+		}
+
+		if il.MaxIngestionRate > 0 {
+			if rate := i.ingestionRate.Rate(); rate >= il.MaxIngestionRate {
+				i.metrics.rejected.WithLabelValues(reasonIngesterMaxIngestionRate).Inc()
+				return errMaxIngestionRateReached
+			}
 		}
 	}
 
@@ -801,8 +813,11 @@ func (i *Ingester) StartPushRequest() error {
 	return nil
 }
 
-func (i *Ingester) FinishPushRequest() {
+func (i *Ingester) FinishPushRequest(requestSize int64) {
 	i.inflightPushRequests.Dec()
+	if requestSize > 0 {
+		i.inflightPushRequestsBytes.Sub(requestSize)
+	}
 }
 
 // PushWithCleanup is the Push() implementation for blocks storage and takes a WriteRequest and adds it to the TSDB head.
@@ -813,10 +828,11 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReques
 
 	// If we're using grpc handlers, we don't need to start/finish request here.
 	if !i.cfg.LimitInflightRequestsUsingGrpcMethodLimiter {
-		if err := i.StartPushRequest(); err != nil {
+		reqSize := int64(req.Size())
+		if err := i.StartPushRequest(reqSize); err != nil {
 			return util_log.DoNotLogError{Err: err}
 		}
-		defer i.FinishPushRequest()
+		defer i.FinishPushRequest(reqSize)
 	}
 
 	userID, err := tenant.TenantID(ctx)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -782,10 +782,10 @@ func (i *Ingester) StartPushRequest(requestSize int64) error {
 		inflightBytes = i.inflightPushRequestsBytes.Add(requestSize)
 	}
 
-	decreaseInflightInDefer := true
+	finishRequestInDefer := true
 	defer func() {
-		if decreaseInflightInDefer {
-			i.inflightPushRequests.Dec()
+		if finishRequestInDefer {
+			i.FinishPushRequest(requestSize)
 		}
 	}()
 
@@ -809,7 +809,7 @@ func (i *Ingester) StartPushRequest(requestSize int64) error {
 		}
 	}
 
-	decreaseInflightInDefer = false
+	finishRequestInDefer = false
 	return nil
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6130,9 +6130,11 @@ func TestIngester_instanceLimitsMetrics(t *testing.T) {
 	reg := prometheus.NewRegistry()
 
 	l := InstanceLimits{
-		MaxIngestionRate:   10,
-		MaxInMemoryTenants: 20,
-		MaxInMemorySeries:  30,
+		MaxIngestionRate:             10,
+		MaxInMemoryTenants:           20,
+		MaxInMemorySeries:            30,
+		MaxInflightPushRequests:      40,
+		MaxInflightPushRequestsBytes: 50,
 	}
 
 	cfg := defaultIngesterTestConfig(t)
@@ -6146,10 +6148,11 @@ func TestIngester_instanceLimitsMetrics(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_ingester_instance_limits Instance limits used by this ingester.
 		# TYPE cortex_ingester_instance_limits gauge
-		cortex_ingester_instance_limits{limit="max_inflight_push_requests"} 0
 		cortex_ingester_instance_limits{limit="max_ingestion_rate"} 10
 		cortex_ingester_instance_limits{limit="max_series"} 30
 		cortex_ingester_instance_limits{limit="max_tenants"} 20
+		cortex_ingester_instance_limits{limit="max_inflight_push_requests"} 40
+		cortex_ingester_instance_limits{limit="max_inflight_push_requests_bytes"} 50
 	`), "cortex_ingester_instance_limits"))
 
 	l.MaxInMemoryTenants = 1000
@@ -6158,10 +6161,11 @@ func TestIngester_instanceLimitsMetrics(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_ingester_instance_limits Instance limits used by this ingester.
 		# TYPE cortex_ingester_instance_limits gauge
-		cortex_ingester_instance_limits{limit="max_inflight_push_requests"} 0
 		cortex_ingester_instance_limits{limit="max_ingestion_rate"} 10
 		cortex_ingester_instance_limits{limit="max_series"} 2000
 		cortex_ingester_instance_limits{limit="max_tenants"} 1000
+		cortex_ingester_instance_limits{limit="max_inflight_push_requests"} 40
+		cortex_ingester_instance_limits{limit="max_inflight_push_requests_bytes"} 50
 	`), "cortex_ingester_instance_limits"))
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -6191,38 +6191,11 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 
 	startCh := make(chan struct{})
 
+	const targetRequestDuration = time.Second
+
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		const targetRequestDuration = time.Second
-
-		samples := 100000
-		series := 1
-
-		// Find right series&samples count to make sure that push takes given target duration.
-		for {
-			req := generateSamplesForLabel(labels.FromStrings(labels.MetricName, fmt.Sprintf("test-%d-%d", series, samples)), series, samples)
-
-			start := time.Now()
-			_, err := i.Push(ctx, req)
-			require.NoError(t, err)
-
-			elapsed := time.Since(start)
-			t.Log(series, samples, elapsed)
-			if elapsed > targetRequestDuration {
-				break
-			}
-
-			samples = int(float64(samples) * float64(targetRequestDuration/elapsed) * 1.5) // Adjust number of series to hit our targetRequestDuration push duration.
-			for samples >= int(time.Hour.Milliseconds()) {
-				// We generate one sample per millisecond, if we have more than an hour of samples TSDB will fail with "out of bounds".
-				// So we trade samples for series here.
-				samples /= 10
-				series *= 10
-			}
-		}
-
-		// Now repeat push with number of samples calibrated to our target request duration.
-		req := generateSamplesForLabel(labels.FromStrings(labels.MetricName, fmt.Sprintf("real-%d-%d", series, samples)), series, samples)
+		req := prepareRequestForTargetRequestDuration(t, ctx, i, targetRequestDuration)
 
 		// Signal that we're going to do the real push now.
 		close(startCh)
@@ -6232,6 +6205,8 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 	})
 
 	g.Go(func() error {
+		req := generateSamplesForLabel(labels.FromStrings(labels.MetricName, "testcase"), 1, 1024)
+
 		select {
 		case <-ctx.Done():
 		// failed to setup
@@ -6239,8 +6214,9 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 			// we can start the test.
 		}
 
-		time.Sleep(10 * time.Millisecond) // Give first goroutine a chance to start pushing...
-		req := generateSamplesForLabel(labels.FromStrings(labels.MetricName, "testcase"), 1, 1024)
+		test.Poll(t, targetRequestDuration/3, int64(1), func() interface{} {
+			return i.inflightPushRequests.Load()
+		})
 
 		_, err := i.Push(ctx, req)
 		require.ErrorIs(t, err, errMaxInflightRequestsReached)
@@ -6263,10 +6239,133 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 		# HELP cortex_ingester_instance_rejected_requests_total Requests rejected for hitting per-instance limits
 		# TYPE cortex_ingester_instance_rejected_requests_total counter
 		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_inflight_push_requests"} 1
+		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_inflight_push_requests_bytes"} 0
 		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_ingestion_rate"} 0
 		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_series"} 0
 		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_tenants"} 0
 	`), "cortex_ingester_instance_rejected_requests_total"))
+}
+
+func TestIngester_inflightPushRequestsBytes(t *testing.T) {
+	var limitsMx sync.Mutex
+	limits := InstanceLimits{MaxInflightPushRequestsBytes: 0}
+
+	// Create a mocked ingester
+	cfg := defaultIngesterTestConfig(t)
+	cfg.InstanceLimitsFn = func() *InstanceLimits {
+		limitsMx.Lock()
+		defer limitsMx.Unlock()
+
+		// Make a copy
+		il := limits
+		return &il
+	}
+
+	reg := prometheus.NewPedanticRegistry()
+	i, err := prepareIngesterWithBlocksStorage(t, cfg, reg)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
+	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
+
+	// Wait until the ingester is healthy
+	test.Poll(t, 100*time.Millisecond, 1, func() interface{} {
+		return i.lifecycler.HealthyInstancesCount()
+	})
+
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	startCh := make(chan struct{})
+
+	const targetRequestDuration = time.Second
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		req := prepareRequestForTargetRequestDuration(t, ctx, i, targetRequestDuration)
+
+		// Update instance limits
+		limitsMx.Lock()
+		limits.MaxInflightPushRequestsBytes = int64(req.Size())
+		limitsMx.Unlock()
+
+		// Signal that we're going to do the real push now.
+		close(startCh)
+
+		_, err := i.Push(ctx, req)
+		return err
+	})
+
+	g.Go(func() error {
+		req := generateSamplesForLabel(labels.FromStrings(labels.MetricName, "testcase"), 1, 1024)
+
+		select {
+		case <-ctx.Done():
+		// failed to setup
+		case <-startCh:
+			// we can start the test.
+		}
+
+		test.Poll(t, targetRequestDuration/3, int64(1), func() interface{} {
+			return i.inflightPushRequests.Load()
+		})
+
+		_, err := i.Push(ctx, req)
+		require.ErrorIs(t, err, errMaxInflightRequestsBytesReached)
+
+		var optional middleware.OptionalLogging
+		require.ErrorAs(t, err, &optional)
+		require.False(t, optional.ShouldLog(ctx, time.Duration(0)), "expected not to log via .ShouldLog()")
+
+		s, ok := status.FromError(err)
+		require.True(t, ok, "expected to be able to convert to gRPC status")
+		require.Equal(t, codes.Unavailable, s.Code())
+
+		return nil
+	})
+
+	require.NoError(t, g.Wait())
+
+	// Ensure the rejected request has been tracked in a metric.
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_ingester_instance_rejected_requests_total Requests rejected for hitting per-instance limits
+		# TYPE cortex_ingester_instance_rejected_requests_total counter
+		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_inflight_push_requests"} 0
+		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_inflight_push_requests_bytes"} 1
+		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_ingestion_rate"} 0
+		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_series"} 0
+		cortex_ingester_instance_rejected_requests_total{reason="ingester_max_tenants"} 0
+	`), "cortex_ingester_instance_rejected_requests_total"))
+}
+
+func prepareRequestForTargetRequestDuration(t *testing.T, ctx context.Context, i *Ingester, targetRequestDuration time.Duration) *mimirpb.WriteRequest {
+	samples := 100000
+	ser := 1
+
+	// Find right series&samples count to make sure that push takes given target duration.
+	for {
+		req := generateSamplesForLabel(labels.FromStrings(labels.MetricName, fmt.Sprintf("test-%d-%d", ser, samples)), ser, samples)
+
+		start := time.Now()
+		_, err := i.Push(ctx, req)
+		require.NoError(t, err)
+
+		elapsed := time.Since(start)
+		t.Log(ser, samples, elapsed)
+		if elapsed > targetRequestDuration {
+			break
+		}
+
+		samples = int(float64(samples) * float64(targetRequestDuration/elapsed) * 1.5) // Adjust number of series to hit our targetRequestDuration push duration.
+		for samples >= int(time.Hour.Milliseconds()) {
+			// We generate one sample per millisecond, if we have more than an hour of samples TSDB will fail with "out of bounds".
+			// So we trade samples for series here.
+			samples /= 10
+			ser *= 10
+		}
+	}
+
+	// Now repeat push with number of samples calibrated to our target request duration.
+	req := generateSamplesForLabel(labels.FromStrings(labels.MetricName, fmt.Sprintf("real-%d-%d", ser, samples)), ser, samples)
+	return req
 }
 
 func generateSamplesForLabel(baseLabels labels.Labels, series, samples int) *mimirpb.WriteRequest {

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -365,6 +365,7 @@ func newIngesterMetrics(
 	m.rejected.WithLabelValues(reasonIngesterMaxTenants)
 	m.rejected.WithLabelValues(reasonIngesterMaxInMemorySeries)
 	m.rejected.WithLabelValues(reasonIngesterMaxInflightPushRequests)
+	m.rejected.WithLabelValues(reasonIngesterMaxInflightPushRequestsBytes)
 
 	return m
 }

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -89,8 +89,7 @@ func TestUserMetricsMetadata(t *testing.T) {
 				prometheus.NewPedanticRegistry(),
 				true,
 				func() *InstanceLimits { return nil },
-				nil,
-				nil,
+				nil, nil, nil,
 			)
 
 			mm := newMetadataMap(limiter, metrics, errorSamplers, "test")
@@ -145,8 +144,7 @@ func TestUserMetricsMetadataRequest(t *testing.T) {
 		prometheus.NewPedanticRegistry(),
 		true,
 		func() *InstanceLimits { return nil },
-		nil,
-		nil,
+		nil, nil, nil,
 	)
 
 	mm := newMetadataMap(limiter, metrics, newIngesterErrSamplers(0), "test")

--- a/pkg/mimir/grpc_push_check_test.go
+++ b/pkg/mimir/grpc_push_check_test.go
@@ -43,9 +43,8 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 		})
 	})
 
-	t.Run("ingester push receiver", func(t *testing.T) {
+	t.Run("ingester push receiver, wrong method name", func(t *testing.T) {
 		m := &mockIngesterReceiver{}
-
 		l := newGrpcInflightMethodLimiter(func() ingesterPushReceiver { return m }, nil)
 
 		ctx, err := l.RPCCallStarting(context.Background(), "test", nil)
@@ -55,24 +54,82 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 		})
 		require.Equal(t, 0, m.startCalls)
 		require.Equal(t, 0, m.finishCalls)
+	})
 
-		ctx, err = l.RPCCallStarting(context.Background(), ingesterPushMethod, nil)
+	t.Run("ingester push receiver, check returns error", func(t *testing.T) {
+		m := &mockIngesterReceiver{}
+		l := newGrpcInflightMethodLimiter(func() ingesterPushReceiver { return m }, nil)
+
+		m.returnError = errors.New("hello there")
+		ctx, err := l.RPCCallStarting(context.Background(), ingesterPushMethod, nil)
+		require.Error(t, err)
+		_, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Nil(t, ctx.Value(pushTypeCtxKey)) // Original context expected in case of errors.
+	})
+
+	t.Run("ingester push receiver, without size", func(t *testing.T) {
+		m := &mockIngesterReceiver{}
+		l := newGrpcInflightMethodLimiter(func() ingesterPushReceiver { return m }, nil)
+
+		ctx, err := l.RPCCallStarting(context.Background(), ingesterPushMethod, nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, int64(0), m.startBytes)
 		require.Equal(t, 0, m.finishCalls)
+		require.Equal(t, int64(0), m.finishBytes)
 
 		require.NotPanics(t, func() {
 			l.RPCCallFinished(ctx)
 		})
 		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, int64(0), m.startBytes)
 		require.Equal(t, 1, m.finishCalls)
+		require.Equal(t, int64(0), m.finishBytes)
+	})
 
-		m.returnError = errors.New("hello there")
-		ctx, err = l.RPCCallStarting(context.Background(), ingesterPushMethod, nil)
-		require.Error(t, err)
-		_, ok := status.FromError(err)
-		require.True(t, ok)
-		require.Nil(t, ctx.Value(pushTypeCtxKey)) // Original context expected in case of errors.
+	t.Run("ingester push receiver, with size provided", func(t *testing.T) {
+		m := &mockIngesterReceiver{}
+		l := newGrpcInflightMethodLimiter(func() ingesterPushReceiver { return m }, nil)
+
+		ctx, err := l.RPCCallStarting(context.Background(), ingesterPushMethod, metadata.New(map[string]string{
+			grpcutil.MetadataMessageSize: "123456",
+		}))
+		require.NoError(t, err)
+		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, int64(123456), m.startBytes)
+		require.Equal(t, 0, m.finishCalls)
+		require.Equal(t, int64(0), m.finishBytes)
+
+		require.NotPanics(t, func() {
+			l.RPCCallFinished(ctx)
+		})
+		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, int64(123456), m.startBytes)
+		require.Equal(t, 1, m.finishCalls)
+		require.Equal(t, int64(123456), m.finishBytes)
+	})
+
+	t.Run("ingester push receiver, with wrong size", func(t *testing.T) {
+		m := &mockIngesterReceiver{}
+		l := newGrpcInflightMethodLimiter(func() ingesterPushReceiver { return m }, nil)
+
+		ctx, err := l.RPCCallStarting(context.Background(), ingesterPushMethod, metadata.New(map[string]string{
+			grpcutil.MetadataMessageSize: "wrong",
+		}))
+		require.NoError(t, err)
+		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, int64(0), m.startBytes)
+		require.Equal(t, 0, m.finishCalls)
+		require.Equal(t, int64(0), m.finishBytes)
+
+		require.NotPanics(t, func() {
+			l.RPCCallFinished(ctx)
+		})
+		require.Equal(t, 1, m.startCalls)
+		require.Equal(t, int64(0), m.startBytes)
+		require.Equal(t, 1, m.finishCalls)
+		require.Equal(t, int64(0), m.finishBytes)
 	})
 
 	t.Run("distributor push via httpgrpc", func(t *testing.T) {
@@ -167,17 +224,21 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 
 type mockIngesterReceiver struct {
 	startCalls  int
+	startBytes  int64
 	finishCalls int
+	finishBytes int64
 	returnError error
 }
 
-func (i *mockIngesterReceiver) StartPushRequest() error {
+func (i *mockIngesterReceiver) StartPushRequest(size int64) error {
 	i.startCalls++
+	i.startBytes += size
 	return i.returnError
 }
 
-func (i *mockIngesterReceiver) FinishPushRequest() {
+func (i *mockIngesterReceiver) FinishPushRequest(size int64) {
 	i.finishCalls++
+	i.finishBytes += size
 }
 
 type mockDistributorReceiver struct {

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -37,10 +37,11 @@ const (
 	DistributorMaxInflightPushRequests      ID = "distributor-max-inflight-push-requests"
 	DistributorMaxInflightPushRequestsBytes ID = "distributor-max-inflight-push-requests-bytes"
 
-	IngesterMaxIngestionRate        ID = "ingester-max-ingestion-rate"
-	IngesterMaxTenants              ID = "ingester-max-tenants"
-	IngesterMaxInMemorySeries       ID = "ingester-max-series"
-	IngesterMaxInflightPushRequests ID = "ingester-max-inflight-push-requests"
+	IngesterMaxIngestionRate             ID = "ingester-max-ingestion-rate"
+	IngesterMaxTenants                   ID = "ingester-max-tenants"
+	IngesterMaxInMemorySeries            ID = "ingester-max-series"
+	IngesterMaxInflightPushRequests      ID = "ingester-max-inflight-push-requests"
+	IngesterMaxInflightPushRequestsBytes ID = "ingester-max-inflight-push-requests-bytes"
 
 	ExemplarLabelsMissing    ID = "exemplar-labels-missing"
 	ExemplarLabelsTooLong    ID = "exemplar-labels-too-long"


### PR DESCRIPTION
#### What this PR does

This PR implements total request size instance limit. Works best in combination with `-ingester.limit-inflight-requests-using-grpc-method-limiter` flag, and distributors with https://github.com/grafana/mimir/pull/6490.

#### Which issue(s) this PR fixes or relates to

Previous attempt https://github.com/grafana/mimir/pull/5958, rejected because the check is not very effective when done from inside Push handler in ingester.

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
