### PR TITLE
Retry query when encountering monotonicity bug

### DIFF
--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -157,7 +157,8 @@ func (s *querySharding) Do(ctx context.Context, r Request) (Response, error) {
 	res := qry.Exec(ctx)
 	for _, anno := range res.Warnings {
 		// Rerun this without query sharding in the event the sharded version results in this monotonicity bug.
-		if errors.Is(annotations.ExtractAnnoError(anno), annotations.HistogramQuantileForcedMonotonicityInfo) {
+		if errors.Is(anno, annotations.HistogramQuantileForcedMonotonicityInfo) {
+			level.Warn(log).Log("msg", "retrying query without sharding to fix monotonicity bug", "original", r.GetQuery())
 			return s.next.Do(ctx, r)
 		}
 	}

--- a/vendor/github.com/prometheus/prometheus/util/annotations/annotations.go
+++ b/vendor/github.com/prometheus/prometheus/util/annotations/annotations.go
@@ -122,6 +122,10 @@ func (e annoErr) Error() string {
 	return fmt.Sprintf("%s (%s)", e.Err, e.PositionRange.StartPosInput(e.Query, 0))
 }
 
+func (e annoErr) Unwrap() error {
+	return e.Err
+}
+
 // NewInvalidQuantileWarning is used when the user specifies an invalid quantile
 // value, i.e. a float that is outside the range [0, 1] or NaN.
 func NewInvalidQuantileWarning(q float64, pos posrange.PositionRange) annoErr {


### PR DESCRIPTION
#### What this PR does

Currently Mimir has a [bug](https://raintank-corp.slack.com/archives/C9KL8THCY/p1697642615621789) that sometimes occurs when summing (or other aggregation) the classic histogram (separate series per bucket) input into histogram_quantile, when query sharding on the input results in reduced precision which is normally insignificant, but may result in non-monotonicity in the histogram buckets. As histogram_quantile assumes bucket monotonicity and gives wrong results when this assumption is violated, this PR fixes it by retrying the query without sharding in such cases so that the input is monotonic and does not trigger the bug.

Example showing the histogram_quantile input (summed results) at a single timestamp (bucket, value):
Non-sharded version (monotonic)
```
le=1 6454661.3014166197
le=5 8339611.2001912938
le=10 14118319.2444762159
le=25 14130031.5272856522
le=50 46001270.3030008152
le=64 46008473.8585563600
le=80 46008473.8585563600
le=100 46008473.8585563600
le=250 46008473.8585563600
le=1000 46008473.8585563600
le=+Inf 46008473.8585563600
```
Sharded version (non-monotonic -> bug)
```
le=1 6454661.3014166225
le=5 8339611.2001912957
le=10 14118319.2444762159
le=25 14130031.5272856504
le=50 46001270.3030008227
le=64 46008473.8585563824
le=80 46008473.8585563898
le=100 46008473.8585563824 (lower than prev)
le=250 46008473.8585563824
le=1000 46008473.8585563898
le=+Inf 46008473.8585563824 (lower than prev)
```

Current lint failure is because https://github.com/prometheus/prometheus/pull/13039 needs to be upstreamed first.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`