### PR TITLE
Renovate: Ignore opentracing-contrib/go-grpc fork

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,8 @@
           "github.com/grafana/regexp",
           "github.com/colega/go-yaml-yaml",
           "github.com/grafana/goautoneg",
-          "github.com/grafana/opentracing-contrib-go-stdlib"
+          "github.com/grafana/opentracing-contrib-go-stdlib",
+          "github.com/charleskorn/go-grpc",
         ],
         "enabled": false
       }


### PR DESCRIPTION
#### What this PR does
Make Renovate ignore @charleskorn's opentracing-contrib/go-grpc fork, since it should be pinned until further notice.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
