### PR TITLE
fix interface conversion mismatch in query-scheduler

### DIFF
--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -281,13 +281,13 @@ func (q *RequestQueue) tryDispatchRequestToQuerier(broker *queueBroker, call *ne
 	} else {
 		// should never error; any item previously in the queue already passed validation
 		err := broker.enqueueRequestFront(req)
-		level.Error(q.log).Log(
-			"msg", "failed to re-enqueue query request after dequeue",
-			"err", err, "tenant", tenantID, "querier", call.querierID,
-		)
-
+		if err != nil {
+			level.Error(q.log).Log(
+				"msg", "failed to re-enqueue query request after dequeue",
+				"err", err, "tenant", tenantID, "querier", call.querierID,
+			)
+		}
 	}
-
 	return true
 }
 

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -229,7 +229,12 @@ func (q *RequestQueue) dispatcherLoop() {
 //
 // If request is successfully enqueued, successFn is called before any querier can receive the request.
 func (q *RequestQueue) enqueueRequestToBroker(broker *queueBroker, r requestToEnqueue) error {
-	err := broker.enqueueRequestBack(r)
+	tr := tenantRequest{
+		tenantID:    r.tenantID,
+		req:         r.req,
+		maxQueriers: r.maxQueriers,
+	}
+	err := broker.enqueueRequestBack(&tr)
 	if err != nil {
 		if errors.Is(err, ErrTooManyRequests) {
 			q.discardedRequests.WithLabelValues(string(r.tenantID)).Inc()
@@ -265,7 +270,7 @@ func (q *RequestQueue) tryDispatchRequestToQuerier(broker *queueBroker, call *ne
 	}
 
 	reqForQuerier := nextRequestForQuerier{
-		req:           req,
+		req:           req.req,
 		lastUserIndex: call.lastUserIndex,
 		err:           nil,
 	}
@@ -274,10 +279,8 @@ func (q *RequestQueue) tryDispatchRequestToQuerier(broker *queueBroker, call *ne
 	if requestSent {
 		q.queueLength.WithLabelValues(string(tenantID)).Dec()
 	} else {
-		// re-casting to same type it was enqueued as; panic would indicate a bug
-		reqToEnqueue := req.(requestToEnqueue)
 		// should never error; any item previously in the queue already passed validation
-		err := broker.enqueueRequestFront(reqToEnqueue)
+		err := broker.enqueueRequestFront(req)
 		level.Error(q.log).Log(
 			"msg", "failed to re-enqueue query request after dequeue",
 			"err", err, "tenant", tenantID, "querier", call.querierID,


### PR DESCRIPTION
#### What this PR does

fixes mistake in 0446fab466cff4cd8f1ea69177ad825cc2cef844 where the item placed in the queue was a `queue.requestToEnqueue.req`, which is interface type `queue.Request` masking concrete type `*scheduler.schedulerRequest`.

Then when dequeuing, we received `queue.Request`. If the `queue.Request` failed to be sent to a dispatcher, we would re-enqueue it at the front. But the cast to `queue.requestToEnqueue` would fail, as the we only had the inner type `queue.Request`, not the larger `queue.requestToEnqueue`.

this caused panic message:

```
panic: interface conversion: queue.Request is *scheduler.schedulerRequest, not queue.requestToEnqueue

goroutine 1886 [running]:
github.com/grafana/mimir/pkg/scheduler/queue.(*RequestQueue).tryDispatchRequestToQuerier(0xc001ea8c00, 0xc0022c1ec0, 0xc00197fbc0)
	/Users/marco/workspace/src/github.com/grafana/mimir/pkg/scheduler/queue/queue.go:278 +0x765
github.com/grafana/mimir/pkg/scheduler/queue.(*RequestQueue).dispatcherLoop(0xc001ea8c00)
	/Users/marco/workspace/src/github.com/grafana/mimir/pkg/scheduler/queue/queue.go:200 +0x6aa
created by github.com/grafana/mimir/pkg/scheduler/queue.(*RequestQueue).starting in goroutine 1883
	/Users/marco/workspace/src/github.com/grafana/mimir/pkg/scheduler/queue/queue.go:135 +0x85
[truncated]
```

The fix is to enqueue the entire object, not just the inner request.

Instead of sticking with `queue.requestToEnqueue`, I have new type `queue.tenantRequest` which just takes the relevant parts of `queue.requestToEnqueue`; stripping out the `successFn` and `processed` channel, which are artifacts of scheduler orchestration control flow higher in the stack.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
