### PR TITLE
r262 backport enqueue after dequeue interface conversion fix

### DIFF
--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -229,7 +229,12 @@ func (q *RequestQueue) dispatcherLoop() {
 //
 // If request is successfully enqueued, successFn is called before any querier can receive the request.
 func (q *RequestQueue) enqueueRequestToBroker(broker *queueBroker, r requestToEnqueue) error {
-	err := broker.enqueueRequestBack(r)
+	tr := tenantRequest{
+		tenantID:    r.tenantID,
+		req:         r.req,
+		maxQueriers: r.maxQueriers,
+	}
+	err := broker.enqueueRequestBack(&tr)
 	if err != nil {
 		if errors.Is(err, ErrTooManyRequests) {
 			q.discardedRequests.WithLabelValues(string(r.tenantID)).Inc()
@@ -265,7 +270,7 @@ func (q *RequestQueue) tryDispatchRequestToQuerier(broker *queueBroker, call *ne
 	}
 
 	reqForQuerier := nextRequestForQuerier{
-		req:           req,
+		req:           req.req,
 		lastUserIndex: call.lastUserIndex,
 		err:           nil,
 	}
@@ -274,17 +279,15 @@ func (q *RequestQueue) tryDispatchRequestToQuerier(broker *queueBroker, call *ne
 	if requestSent {
 		q.queueLength.WithLabelValues(string(tenantID)).Dec()
 	} else {
-		// re-casting to same type it was enqueued as; panic would indicate a bug
-		reqToEnqueue := req.(requestToEnqueue)
 		// should never error; any item previously in the queue already passed validation
-		err := broker.enqueueRequestFront(reqToEnqueue)
-		level.Error(q.log).Log(
-			"msg", "failed to re-enqueue query request after dequeue",
-			"err", err, "tenant", tenantID, "querier", call.querierID,
-		)
-
+		err := broker.enqueueRequestFront(req)
+		if err != nil {
+			level.Error(q.log).Log(
+				"msg", "failed to re-enqueue query request after dequeue",
+				"err", err, "tenant", tenantID, "querier", call.querierID,
+			)
+		}
 	}
-
 	return true
 }
 


### PR DESCRIPTION
* fix interface conversion mismatch in query-scheduler

* adding test case for re-enqueueing after disconnected querier

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
