### PR TITLE
Add unit test to compare histogram_quantile results with and without query sharding

### DIFF
--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -837,9 +837,8 @@ func TestQuerySharding_NonMonotonicHistogramBuckets(t *testing.T) {
 					sort.Sort(byLabels(shardedPrometheusRes.Data.Result))
 					approximatelyEquals(t, expectedPrometheusRes, shardedPrometheusRes)
 
-					// Ensure the bucket monotonicity has been fixed by PromQL engine.
-					require.Len(t, shardedPrometheusRes.GetWarnings(), 1)
-					assert.Contains(t, shardedPrometheusRes.Warnings, annotations.HistogramQuantileForcedMonotonicityInfo.Error())
+					// Ensure the warning about bucket monotonicity from PromQL engine is hidden.
+					require.Len(t, shardedPrometheusRes.GetWarnings(), 0)
 				})
 			}
 		})


### PR DESCRIPTION
#### What this PR does

Adds a unit test from https://github.com/grafana/mimir/pull/6504 to ensure that the results from `histogram_quantile` with and without query sharding have no significant differences. Before the fix in https://github.com/prometheus/prometheus/pull/13153 was vendored in https://github.com/grafana/mimir/pull/6766 , this unit test failed, now it passes.

Context: Mimir had a [bug](https://raintank-corp.slack.com/archives/C9KL8THCY/p1697642615621789) that sometimes occurs when summing (or other aggregation) the classic histogram (separate series per bucket) input into `histogram_quantile`, when query sharding on the input results in reduced precision which is normally insignificant, but may result in non-monotonicity in the histogram buckets.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`