### PR TITLE
r261: Update mimir-prometheus to 05b95612d

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231024143142-c2072c06b346
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231101152422-05b95612d2ec
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/grafana/gomemcache v0.0.0-20230914135007-70d78eaabfe1 h1:MLYY2R60/74h
 github.com/grafana/gomemcache v0.0.0-20230914135007-70d78eaabfe1/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20231024143142-c2072c06b346 h1:ZdCUyerfnGqHPELPftRQMwz/GsSMldZ7xy60MfNt+WE=
-github.com/grafana/mimir-prometheus v0.0.0-20231024143142-c2072c06b346/go.mod h1:bHUBXcO5vIkqWBAy86JlejQPQltETv9Cv5whKCeF2FM=
+github.com/grafana/mimir-prometheus v0.0.0-20231101152422-05b95612d2ec h1:xAbQC8h4U+XKZ9fQpCn6XPXDcTp9b3mL5BVsvShd4rs=
+github.com/grafana/mimir-prometheus v0.0.0-20231101152422-05b95612d2ec/go.mod h1:bHUBXcO5vIkqWBAy86JlejQPQltETv9Cv5whKCeF2FM=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -884,7 +884,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231024143142-c2072c06b346
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231101152422-05b95612d2ec
 ## explicit; go 1.20
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1466,7 +1466,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231024143142-c2072c06b346
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231101152422-05b95612d2ec
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6


### PR DESCRIPTION
Updates mimir-prometheus to https://github.com/grafana/mimir-prometheus/commit/05b95612d This includes the fix for the ring buffer https://github.com/grafana/mimir-prometheus/commit/4696b46dd (https://github.com/prometheus/prometheus/commit/4696b46dd) cherry-picked on top of the currently used mimir-prometheus revision https://github.com/grafana/mimir-prometheus/commit/c2072c06b346. The cherry-pick in mimir-prometheus is safe because the bug had been in prometheus for 6 months now.
