### PR TITLE
query-scheduler multi dimension queueing data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   * `http.StatusServiceUnavailable` (503) and `codes.Unknown` are replaced with `codes.Internal`.
 * [CHANGE] Upgrade Node.js to v20. #6540
 * [CHANGE] Querier: `cortex_querier_blocks_consistency_checks_failed_total` is now incremented when a block couldn't be queried from any attempted store-gateway as opposed to incremented after each attempt. Also `cortex_querier_blocks_consistency_checks_total` is incremented once per query as opposed to once per attempt (with 3 attempts). #6590
+  [CHANGE] Query-Scheduler: introduce tree queue structure to support round-robin fairness across multiple queuing dimensions. #6533
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [FEATURE] Vault: Added support for new Vault authentication methods: `AppRole`, `Kubernetes`, `UserPass` and `Token`. #6143
 * [FEATURE] Add experimental endpoint `/api/v1/cardinality/active_series` to return the set of active series for a given selector. #6536 #6619

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@
   * `http.StatusServiceUnavailable` (503) and `codes.Unknown` are replaced with `codes.Internal`.
 * [CHANGE] Upgrade Node.js to v20. #6540
 * [CHANGE] Querier: `cortex_querier_blocks_consistency_checks_failed_total` is now incremented when a block couldn't be queried from any attempted store-gateway as opposed to incremented after each attempt. Also `cortex_querier_blocks_consistency_checks_total` is incremented once per query as opposed to once per attempt (with 3 attempts). #6590
-  [CHANGE] Query-Scheduler: introduce tree queue structure to support round-robin fairness across multiple queuing dimensions. #6533
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [FEATURE] Vault: Added support for new Vault authentication methods: `AppRole`, `Kubernetes`, `UserPass` and `Token`. #6143
 * [FEATURE] Add experimental endpoint `/api/v1/cardinality/active_series` to return the set of active series for a given selector. #6536 #6619

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -241,7 +241,6 @@ func (q *RequestQueue) enqueueRequestToBroker(broker *queueBroker, r requestToEn
 		}
 		return err
 	}
-
 	q.queueLength.WithLabelValues(string(r.tenantID)).Inc()
 
 	// Call the successFn here to ensure we call it before sending this request to a waiting querier.

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -193,7 +193,7 @@ func (q *RequestQueue) dispatcherLoop() {
 		if needToDispatchQueries {
 			currentElement := waitingGetNextRequestForQuerierCalls.Front()
 
-			for currentElement != nil && queueBroker.len() > 0 {
+			for currentElement != nil && !queueBroker.isEmpty() {
 				call := currentElement.Value.(*nextRequestForQuerierCall)
 				nextElement := currentElement.Next() // We have to capture the next element before calling Remove(), as Remove() clears it.
 
@@ -205,7 +205,7 @@ func (q *RequestQueue) dispatcherLoop() {
 			}
 		}
 
-		if stopping && (queueBroker.len() == 0 || q.connectedQuerierWorkers.Load() == 0) {
+		if stopping && (queueBroker.isEmpty() || q.connectedQuerierWorkers.Load() == 0) {
 			// Tell any waiting GetNextRequestForQuerier calls that nothing is coming.
 			currentElement := waitingGetNextRequestForQuerierCalls.Front()
 

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -261,9 +261,9 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 		maxQueriers: 0, // no sharding
 	}
 
-	require.Nil(t, queueBroker.tenantQueues["tenant-1"])
+	require.Nil(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"root", "tenant-1"}))
 	require.NoError(t, queueBroker.enqueueRequestBack(&tr))
-	require.Equal(t, queueBroker.tenantQueues["tenant-1"].requests.Len(), 1)
+	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"root", "tenant-1"}).isEmpty())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	call := &nextRequestForQuerierCall{
@@ -278,5 +278,5 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 	// indicating not to re-submit a request for nextRequestForQuerierCall for the querier
 	require.True(t, queue.tryDispatchRequestToQuerier(queueBroker, call))
 	// assert request was re-enqueued for tenant after failed send
-	require.Equal(t, queueBroker.tenantQueues["tenant-1"].requests.Len(), 1)
+	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"root", "tenant-1"}).isEmpty())
 }

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -261,9 +261,9 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 		req:      "request",
 	}
 
-	require.Nil(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"root", "tenant-1"}))
+	require.Nil(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"tenant-1"}))
 	require.NoError(t, queueBroker.enqueueRequestBack(&tr, tenantMaxQueriers))
-	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"root", "tenant-1"}).isEmpty())
+	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"tenant-1"}).isEmpty())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	call := &nextRequestForQuerierCall{
@@ -278,5 +278,5 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 	// indicating not to re-submit a request for nextRequestForQuerierCall for the querier
 	require.True(t, queue.tryDispatchRequestToQuerier(queueBroker, call))
 	// assert request was re-enqueued for tenant after failed send
-	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"root", "tenant-1"}).isEmpty())
+	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"tenant-1"}).isEmpty())
 }

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -263,7 +263,7 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 
 	require.Nil(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"tenant-1"}))
 	require.NoError(t, queueBroker.enqueueRequestBack(&tr, tenantMaxQueriers))
-	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"tenant-1"}).isEmpty())
+	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"tenant-1"}).IsEmpty())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	call := &nextRequestForQuerierCall{
@@ -278,5 +278,5 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 	// indicating not to re-submit a request for nextRequestForQuerierCall for the querier
 	require.True(t, queue.tryDispatchRequestToQuerier(queueBroker, call))
 	// assert request was re-enqueued for tenant after failed send
-	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"tenant-1"}).isEmpty())
+	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"tenant-1"}).IsEmpty())
 }

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -255,14 +255,14 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 	queueBroker := newQueueBroker(queue.maxOutstandingPerTenant, queue.forgetDelay)
 	queueBroker.addQuerierConnection(querierID)
 
+	tenantMaxQueriers := 0 // no sharding
 	tr := tenantRequest{
-		tenantID:    TenantID("tenant-1"),
-		req:         "request",
-		maxQueriers: 0, // no sharding
+		tenantID: TenantID("tenant-1"),
+		req:      "request",
 	}
 
 	require.Nil(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"root", "tenant-1"}))
-	require.NoError(t, queueBroker.enqueueRequestBack(&tr))
+	require.NoError(t, queueBroker.enqueueRequestBack(&tr, tenantMaxQueriers))
 	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"root", "tenant-1"}).isEmpty())
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -127,8 +127,8 @@ func newQueueBroker(maxTenantQueueSize int, forgetDelay time.Duration) *queueBro
 	}
 }
 
-func (qb *queueBroker) len() int {
-	return len(qb.tenantQueues)
+func (qb *queueBroker) isEmpty() bool {
+	return len(qb.tenantQueues) == 0
 }
 
 func (qb *queueBroker) enqueueRequestBack(request *tenantRequest) error {

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -123,7 +123,7 @@ func newQueueBroker(maxTenantQueueSize int, forgetDelay time.Duration) *queueBro
 }
 
 func (qb *queueBroker) isEmpty() bool {
-	return qb.tenantQueuesTree.isEmpty()
+	return qb.tenantQueuesTree.IsEmpty()
 }
 
 func (qb *queueBroker) enqueueRequestBack(request *tenantRequest, tenantMaxQueriers int) error {

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -161,7 +161,7 @@ func (qb *queueBroker) dequeueRequestForQuerier(lastTenantIndex int, querierID Q
 	}
 
 	queuePath := QueuePath{string(tenant.tenantID)}
-	_, queueElement := qb.tenantQueuesTree.DequeueByPath(queuePath)
+	queueElement := qb.tenantQueuesTree.DequeueByPath(queuePath)
 
 	queueNodeAfterDequeue := qb.tenantQueuesTree.getNode(queuePath)
 	if queueNodeAfterDequeue == nil {

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -132,7 +132,7 @@ func (qb *queueBroker) enqueueRequestBack(request *tenantRequest, tenantMaxQueri
 		return err
 	}
 
-	queuePath := QueuePath{qb.tenantQueuesTree.name, string(request.tenantID)}
+	queuePath := QueuePath{string(request.tenantID)}
 	return qb.tenantQueuesTree.EnqueueBackByPath(queuePath, request)
 }
 
@@ -147,7 +147,7 @@ func (qb *queueBroker) enqueueRequestFront(request *tenantRequest, tenantMaxQuer
 		return err
 	}
 
-	queuePath := QueuePath{qb.tenantQueuesTree.name, string(request.tenantID)}
+	queuePath := QueuePath{string(request.tenantID)}
 	return qb.tenantQueuesTree.EnqueueFrontByPath(queuePath, request)
 }
 
@@ -157,7 +157,7 @@ func (qb *queueBroker) dequeueRequestForQuerier(lastTenantIndex int, querierID Q
 		return nil, tenant, tenantIndex, err
 	}
 
-	queuePath := QueuePath{qb.tenantQueuesTree.name, string(tenant.tenantID)}
+	queuePath := QueuePath{string(tenant.tenantID)}
 	_, queueElement := qb.tenantQueuesTree.DequeueByPath(queuePath)
 
 	queueNodeAfterDequeue := qb.tenantQueuesTree.getNode(queuePath)

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -414,8 +414,9 @@ func getOrAdd(t *testing.T, qb *queueBroker, tenantID TenantID, maxQueriers int)
 	return addedQueue.localQueue
 }
 
+// getOrAddTenantQueue is a test utility, not intended for use by consumers of queueBroker
 func (qb *queueBroker) getOrAddTenantQueue(tenantID TenantID, maxQueriers int) (*TreeQueue, error) {
-	_, err := qb.tenantQuerierAssignments.getOrAddTenant(tenantID, maxQueriers)
+	err := qb.tenantQuerierAssignments.createOrUpdateTenant(tenantID, maxQueriers)
 	if err != nil {
 		return nil, err
 	}
@@ -424,6 +425,7 @@ func (qb *queueBroker) getOrAddTenantQueue(tenantID TenantID, maxQueriers int) (
 	return qb.tenantQueuesTree.getOrAddNode(queuePath)
 }
 
+// getQueue is a test utility, not intended for use by consumers of queueBroker
 func (qb *queueBroker) getQueue(tenantID TenantID) *TreeQueue {
 	tenant, err := qb.tenantQuerierAssignments.getTenant(tenantID)
 	if tenant == nil || err != nil {
@@ -435,6 +437,7 @@ func (qb *queueBroker) getQueue(tenantID TenantID) *TreeQueue {
 	return tenantQueue
 }
 
+// removeTenantQueue is a test utility, not intended for use by consumers of queueBroker
 func (qb *queueBroker) removeTenantQueue(tenantID TenantID) bool {
 	qb.tenantQuerierAssignments.removeTenant(tenantID)
 	queuePath := QueuePath{string(tenantID)}

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -202,7 +202,6 @@ func TestQueuesConsistency(t *testing.T) {
 				switch r.Int() % 6 {
 				case 0:
 					queue, err := qb.getOrAddTenantQueue(generateTenant(r), 3)
-					//queueTenant, err := qb.tenantQuerierAssignments.getOrAddTenant(generateTenant(r), 3)
 					assert.Nil(t, err)
 					assert.NotNil(t, queue)
 				case 1:
@@ -439,7 +438,7 @@ func (qb *queueBroker) getQueue(tenantID TenantID) *TreeQueue {
 
 func (qb *queueBroker) removeTenantQueue(tenantID TenantID) bool {
 	qb.tenantQuerierAssignments.removeTenant(tenantID)
-	queuePath := QueuePath{qb.tenantQueuesTree.name, string(tenantID)}
+	queuePath := QueuePath{string(tenantID)}
 	return qb.tenantQueuesTree.deleteNode(queuePath)
 }
 
@@ -462,7 +461,6 @@ func isConsistent(qb *queueBroker) error {
 
 	tenantCount := 0
 	for ix, tenantID := range qb.tenantQuerierAssignments.tenantIDOrder {
-		//tq := qb.tenantQueues[tenantID]
 		if tenantID != "" && qb.getQueue(tenantID) == nil {
 			return fmt.Errorf("tenant %s doesn't have queue", tenantID)
 		}
@@ -494,9 +492,10 @@ func isConsistent(qb *queueBroker) error {
 		}
 	}
 
-	//if tenantCount != len(qb.tenantQueues) {
-	//	return fmt.Errorf("inconsistent number of tenants list and tenant queues")
-	//}
+	tenantQueueCount := qb.tenantQueuesTree.NodeCount() - 1 // exclude root node
+	if tenantCount != tenantQueueCount {
+		return fmt.Errorf("inconsistent number of tenants list and tenant queues")
+	}
 
 	return nil
 }

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -422,7 +422,7 @@ func (qb *queueBroker) getOrAddTenantQueue(tenantID TenantID, maxQueriers int) (
 		return nil, err
 	}
 
-	queuePath := QueuePath{qb.tenantQueuesTree.name, string(tenantID)}
+	queuePath := QueuePath{string(tenantID)}
 	return qb.tenantQueuesTree.getOrAddNode(queuePath)
 }
 
@@ -432,7 +432,7 @@ func (qb *queueBroker) getQueue(tenantID TenantID) *TreeQueue {
 		return nil
 	}
 
-	queuePath := QueuePath{qb.tenantQueuesTree.name, string(tenantID)}
+	queuePath := QueuePath{string(tenantID)}
 	tenantQueue := qb.tenantQueuesTree.getNode(queuePath)
 	return tenantQueue
 }

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -37,7 +37,6 @@ func TestQueues(t *testing.T) {
 
 	// [one two]
 	qTwo := getOrAdd(t, qb, "two", 0)
-	assert.NotSame(t, qOne, qTwo)
 
 	lastTenantIndex = confirmOrderForQuerier(t, qb, "querier-1", lastTenantIndex, qTwo, qOne, qTwo, qOne)
 	confirmOrderForQuerier(t, qb, "querier-2", -1, qOne, qTwo, qOne)

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -92,7 +92,7 @@ func (q *TreeQueue) EnqueueBackByPath(childPath QueuePath, v any) error {
 		return err
 	}
 	if childQueue.LocalQueueLen()+1 > childQueue.maxQueueLen {
-		return ErrTooManyRequests
+		return ErrMaxQueueLengthExceeded
 	}
 
 	if childQueue.localQueue == nil {
@@ -169,7 +169,6 @@ func (q *TreeQueue) getOrAddNode(childPath QueuePath) (*TreeQueue, error) {
 	}
 
 	return childQueue.getOrAddNode(childPath[1:])
-
 }
 
 func (q *TreeQueue) getNode(childPath QueuePath) *TreeQueue {
@@ -287,3 +286,13 @@ func (q *TreeQueue) wrapIndex(increment bool) {
 		q.currentChildQueueIndex = localQueueIndex
 	}
 }
+
+type TreeQueueError struct {
+	msg string
+}
+
+func (e TreeQueueError) Error() string {
+	return e.msg
+}
+
+var ErrMaxQueueLengthExceeded = TreeQueueError{msg: "max queue length exceeded"}

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -148,8 +148,6 @@ func (q *TreeQueue) Dequeue() (QueuePath, any) {
 	initialLen := len(q.childQueueOrder)
 
 	for iters := 0; iters <= initialLen && v == nil; iters++ {
-		incrementQueueIndex := true
-
 		if q.index == localQueueIndex {
 			// dequeuing from local queue; either we have:
 			//  1. reached a leaf node, or
@@ -158,6 +156,7 @@ func (q *TreeQueue) Dequeue() (QueuePath, any) {
 				q.localQueue.Remove(elem)
 				v = elem.Value
 			}
+			q.wrapIndex(true)
 		} else {
 			// dequeuing from child queue node;
 			// pick the child node whose turn it is and recur
@@ -167,13 +166,11 @@ func (q *TreeQueue) Dequeue() (QueuePath, any) {
 
 			// perform cleanup if child node is empty after dequeuing recursively
 			if childQueue.isEmpty() {
-				delete(q.childQueueMap, childQueueName)
-				q.childQueueOrder = append(q.childQueueOrder[:q.index], q.childQueueOrder[q.index+1:]...)
-				// no need to increment; remainder of the slice has moved left to be under q.index
-				incrementQueueIndex = false
+				q.deleteNode(QueuePath{childQueueName})
+			} else {
+				q.wrapIndex(true)
 			}
 		}
-		q.wrapIndex(incrementQueueIndex)
 	}
 	if v == nil {
 		// don't report path when nothing was dequeued

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -9,15 +9,9 @@ import (
 )
 
 type QueuePath []string //nolint:revive
-type QueueIndex int
+type QueueIndex int     //nolint:revive
 
 const localQueueIndex = -1
-
-var removedQueueName = string([]byte{byte(0)})
-
-func isValidQueueName(name string) bool {
-	return !(name == removedQueueName)
-}
 
 // TreeQueue is a hierarchical queue implementation with an arbitrary amount of child queues.
 //
@@ -156,8 +150,8 @@ func (q *TreeQueue) DequeueByPath(path QueuePath) (QueuePath, any) {
 	}
 
 	dequeuedPathFromChild, v := childQueue.Dequeue()
-	// perform cleanup if child node is empty after dequeuing recursively
 
+	// perform cleanup if child node is empty after dequeuing recursively
 	if childQueue.isEmpty() {
 		delete(q.childQueueMap, childQueue.name)
 		directChildQueueName := dequeuedPathFromChild[0]
@@ -183,7 +177,7 @@ func (q *TreeQueue) Dequeue() (QueuePath, any) {
 	initialLen := len(q.childQueueOrder)
 
 	for iters := 0; iters <= initialLen && v == nil; iters++ {
-		increment := true
+		//increment := true
 
 		if q.index == localQueueIndex {
 			// dequeuing from local queue; either we have:
@@ -193,6 +187,7 @@ func (q *TreeQueue) Dequeue() (QueuePath, any) {
 				q.localQueue.Remove(elem)
 				v = elem.Value
 			}
+			q.wrapIndex(true)
 		} else {
 			// dequeuing from child queue node;
 			// pick the child node whose turn it is and recur
@@ -205,16 +200,43 @@ func (q *TreeQueue) Dequeue() (QueuePath, any) {
 				delete(q.childQueueMap, childQueueName)
 				q.childQueueOrder = append(q.childQueueOrder[:q.index], q.childQueueOrder[q.index+1:]...)
 				// no need to increment; remainder of the slice has moved left to be under q.index
-				increment = false
+				//increment = false
+				q.wrapIndex(false)
+			} else {
+				q.wrapIndex(true)
 			}
 		}
-		q.wrapIndex(increment)
+		//q.wrapIndex(increment)
 	}
 	if v == nil {
 		// don't report path when nothing was dequeued
 		return nil, nil
 	}
 	return append(QueuePath{q.name}, dequeuedPath...), v
+}
+
+func (q *TreeQueue) deleteNode(path QueuePath) bool {
+	if len(path) <= 1 {
+		// node cannot delete itself
+		return false
+	}
+
+	parentPath, childQueueName := path[:len(path)-1], path[len(path)-1]
+
+	parentNode := q.getNode(parentPath)
+	if parentNode == nil {
+		// not found
+		return false
+	}
+
+	delete(parentNode.childQueueMap, childQueueName)
+	for i, name := range parentNode.childQueueOrder {
+		if name == childQueueName {
+			parentNode.childQueueOrder = append(q.childQueueOrder[:i], q.childQueueOrder[i+1:]...)
+			parentNode.wrapIndex(false)
+		}
+	}
+	return true
 }
 
 func (q *TreeQueue) wrapIndex(increment bool) {

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -4,6 +4,7 @@ package queue
 
 import (
 	"container/list"
+	"errors"
 )
 
 type QueuePath []string //nolint:revive // disallows types beginning with package name
@@ -289,12 +290,4 @@ func (q *TreeQueue) wrapIndex(increment bool) {
 	}
 }
 
-type TreeQueueError struct {
-	msg string
-}
-
-func (e TreeQueueError) Error() string {
-	return e.msg
-}
-
-var ErrMaxQueueLengthExceeded = TreeQueueError{msg: "max queue length exceeded"}
+var ErrMaxQueueLengthExceeded = errors.New("max queue length exceeded")

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -167,7 +167,7 @@ func (q *TreeQueue) DequeueByPath(childPath QueuePath) (QueuePath, any) {
 		// guard against slicing into nil path
 		return nil, nil
 	}
-	return append(childPath, dequeuedPathFromChild[1:]...), v
+	return append(QueuePath{q.name}, append(childPath, dequeuedPathFromChild[1:]...)...), v
 }
 
 func (q *TreeQueue) Dequeue() (QueuePath, any) {

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -141,10 +141,10 @@ func (q *TreeQueue) getNode(path QueuePath) *TreeQueue {
 
 	if childQueue, ok := q.childQueueMap[childPath[0]]; ok {
 		return childQueue.getNode(childPath)
-	} else {
-		// no child node matches next path segment
-		return nil
 	}
+
+	// no child node matches next path segment
+	return nil
 }
 
 func (q *TreeQueue) DequeueByPath(path QueuePath) (QueuePath, any) {

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -6,8 +6,8 @@ import (
 	"container/list"
 )
 
-type QueuePath []string //nolint:revive
-type QueueIndex int     //nolint:revive
+type QueuePath []string //nolint:revive // disallows types beginning with package name
+type QueueIndex int     //nolint:revive // disallows types beginning with package name
 
 const localQueueIndex = -1
 
@@ -57,6 +57,7 @@ func (q *TreeQueue) IsEmpty() bool {
 	return q.LocalQueueLen() == 0 && len(q.childQueueMap) == 0
 }
 
+// NodeCount counts the TreeQueue node and all its children, recursively.
 func (q *TreeQueue) NodeCount() int {
 	count := 1 // count self
 	for _, childQueue := range q.childQueueMap {
@@ -65,6 +66,7 @@ func (q *TreeQueue) NodeCount() int {
 	return count
 }
 
+// ItemCount counts the queue items in the TreeQueue node and in all its children, recursively.
 func (q *TreeQueue) ItemCount() int {
 	count := q.LocalQueueLen() // count self
 	for _, childQueue := range q.childQueueMap {

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -1,0 +1,194 @@
+package queue
+
+import (
+	"container/list"
+
+	"github.com/pkg/errors"
+)
+
+type QueuePath []string //nolint:revive
+type QueueIndex int
+
+const localQueueIndex = -1
+
+var removedQueueName = string([]byte{byte(0)})
+
+func isValidQueueName(name string) bool {
+	return !(name == removedQueueName)
+}
+
+// TreeQueue is a hierarchical queue implementation with an arbitrary amount of child queues.
+//
+// TreeQueue internally maintains round-robin fair queuing across all of its queue dimensions.
+// Each queuing dimension is modeled as a node in the tree, internally reachable through a QueuePath.
+//
+// The QueuePath is an ordered array of strings describing the path through the tree to the node,
+// which contains the FIFO local queue of all items enqueued for that queuing dimension.
+//
+// When dequeuing from a given node, the node will round-robin equally between dequeuing directly
+// from its own local queue and dequeuing recursively from its list of child TreeQueues.
+// No queue at a given level of the tree is dequeued from consecutively unless all others
+// at the same level of the tree are empty down to the leaf node.
+type TreeQueue struct {
+	// name of the tree node will be set to its segment of the queue path
+	name            string
+	localQueue      *list.List
+	index           int
+	childQueueOrder []string
+	childQueueMap   map[string]*TreeQueue
+}
+
+func NewTreeQueue(name string) *TreeQueue {
+	return &TreeQueue{
+		name:            name,
+		localQueue:      list.New(),
+		index:           localQueueIndex,
+		childQueueMap:   map[string]*TreeQueue{},
+		childQueueOrder: nil,
+	}
+}
+
+func (q *TreeQueue) isEmpty() bool {
+	// avoid recursion to make this a cheap operation
+	//
+	// Because we dereference empty child nodes during dequeuing,
+	// we assume that emptiness means there are no child nodes
+	// and nothing in this tree node's local queue.
+	//
+	// In reality a package member could attach empty child queues with getOrAddNode
+	// in order to get a functionally-empty tree that would report false for isEmpty.
+	// We assume this does not occur or is not relevant during normal operation.
+	return q.localQueue.Len() == 0 && len(q.childQueueMap) == 0
+}
+
+func (q *TreeQueue) EnqueueBackByPath(path QueuePath, v any) error {
+	if path[0] != q.name {
+		return errors.New("path must begin with root node name")
+	}
+	childQueue, err := q.getOrAddNode(path)
+	if err != nil {
+		return err
+	}
+	childQueue.localQueue.PushBack(v)
+	return nil
+}
+
+// getOrAddNode recursively adds queues based on given path
+func (q *TreeQueue) getOrAddNode(path QueuePath) (*TreeQueue, error) {
+	if len(path) == 0 {
+		// non-nil tree must have at least the path equal to the root name
+		// not a recursion case; only occurs if empty path provided to root node
+		return nil, nil
+	}
+
+	if path[0] != q.name {
+		return nil, errors.New("path must begin with this node name")
+	}
+
+	childPath := path[1:]
+	if len(childPath) == 0 {
+		// no path left to create; we have arrived
+		return q, nil
+	}
+
+	var childQueue *TreeQueue
+	var ok bool
+
+	if childQueue, ok = q.childQueueMap[childPath[0]]; !ok {
+		// no child node matches next path segment
+		// create next child before recurring
+		childQueue = NewTreeQueue(childPath[0])
+		// add new child queue to ordered list for round-robining
+		q.childQueueOrder = append(q.childQueueOrder, childQueue.name)
+		// attach new child queue to lookup map
+		q.childQueueMap[childPath[0]] = childQueue
+	}
+
+	return childQueue.getOrAddNode(childPath)
+
+}
+
+func (q *TreeQueue) getNode(path QueuePath) *TreeQueue {
+	if len(path) == 0 {
+		// non-nil tree must have at least the path equal to the root name
+		// not a recursion case; only occurs if empty path provided to root node
+		return nil
+	}
+
+	childPath := path[1:]
+	if len(childPath) == 0 {
+		// no path left to search for; we have arrived
+		return q
+	}
+
+	if childQueue, ok := q.childQueueMap[childPath[0]]; ok {
+		return childQueue.getNode(childPath)
+	} else {
+		// no child node matches next path segment
+		return nil
+	}
+}
+
+func (q *TreeQueue) DequeueByPath(path QueuePath) (QueuePath, any) {
+	childQueue := q.getNode(path)
+	if childQueue == nil {
+		return nil, nil
+	}
+
+	dequeuedPathFromChild, v := childQueue.Dequeue()
+
+	if v == nil {
+		// guard against slicing into nil path
+		return nil, nil
+	}
+	return append(path, dequeuedPathFromChild[1:]...), v
+}
+
+func (q *TreeQueue) Dequeue() (QueuePath, any) {
+	var dequeuedPath QueuePath
+	var v any
+	initialLen := len(q.childQueueOrder)
+
+	for iters := 0; iters <= initialLen && v == nil; iters++ {
+		increment := true
+
+		if q.index == localQueueIndex {
+			// dequeuing from local queue; either we have:
+			//  1. reached a leaf node, or
+			//  2. reached an inner node when it is the local queue's turn
+			if elem := q.localQueue.Front(); elem != nil {
+				q.localQueue.Remove(elem)
+				v = elem.Value
+			}
+		} else {
+			// dequeuing from child queue node;
+			// pick the child node whose turn it is and recur
+			childQueueName := q.childQueueOrder[q.index]
+			childQueue := q.childQueueMap[childQueueName]
+			dequeuedPath, v = childQueue.Dequeue()
+
+			// perform cleanup if child node is empty after dequeuing recursively
+			if childQueue.isEmpty() {
+				delete(q.childQueueMap, childQueueName)
+				q.childQueueOrder = append(q.childQueueOrder[:q.index], q.childQueueOrder[q.index+1:]...)
+				// no need to increment; remainder of the slice has moved left to be under q.index
+				increment = false
+			}
+		}
+		q.wrapIndex(increment)
+	}
+	if v == nil {
+		// don't report path when nothing was dequeued
+		return nil, nil
+	}
+	return append(QueuePath{q.name}, dequeuedPath...), v
+}
+
+func (q *TreeQueue) wrapIndex(increment bool) {
+	if increment {
+		q.index++
+	}
+	if q.index >= len(q.childQueueOrder) {
+		q.index = localQueueIndex
+	}
+}

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -128,17 +128,11 @@ func (q *TreeQueue) DequeueByPath(childPath QueuePath) (QueuePath, any) {
 
 	dequeuedPathFromChild, v := childQueue.Dequeue()
 
-	// perform cleanup if child node is empty after dequeuing recursively
 	if childQueue.isEmpty() {
-		delete(q.childQueueMap, childQueue.name)
-		directChildQueueName := dequeuedPathFromChild[0]
-		for i, name := range q.childQueueOrder {
-			if name == directChildQueueName {
-				q.childQueueOrder = append(q.childQueueOrder[:i], q.childQueueOrder[i+1:]...)
-				q.wrapIndex(false)
-			}
-		}
-
+		// child node will recursively clean up its own empty children during dequeue,
+		// but nodes cannot delete themselves; delete the empty child in order to
+		// maintain structural guarantees relied on to make isEmpty() non-recursive
+		q.deleteNode(childPath)
 	}
 
 	if v == nil {

--- a/pkg/scheduler/queue/tree_queue.go
+++ b/pkg/scheduler/queue/tree_queue.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package queue
 
 import (

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -13,97 +13,93 @@ import (
 
 const maxTestQueueLen = 8
 
-func TestTreeQueue(t *testing.T) {
+// TestDequeueBalancedTree checks dequeuing behavior from a balanced tree.
+//
+// Dequeuing from a balanced tree allows the test to have a simple looped structures
+// while running checks to ensure that round-robin order is respected.
+func TestDequeueBalancedTree(t *testing.T) {
+	firstDimensions := []string{"0", "1", "2"}
+	secondDimensions := []string{"a", "b", "c"}
+	itemsPerDimension := 5
+	root := makeBalancedTreeQueue(t, firstDimensions, secondDimensions, itemsPerDimension)
+	assert.NotNil(t, root)
 
-	root := NewTreeQueue("root", maxTestQueueLen) // creates path: root
+	count := 0
+	// tree queue will fairly dequeue from all levels of the tree
+	rotationsBeforeRepeat := len(firstDimensions) * len(secondDimensions)
+	// track dequeued paths to ensure round-robin dequeuing does not repeat before expected
+	dequeuedPathCache := make([]QueuePath, rotationsBeforeRepeat)
 
-	type queuePathItem struct {
-		path QueuePath
-		item any
-	}
+	for !root.IsEmpty() {
+		dequeuedPath, v := root.Dequeue()
+		assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	// note no queue at a given level is dequeued from twice in a row
-	// unless all others at the same level are empty down to the leaf node
-	queuePathItems := []queuePathItem{
-		{QueuePath{"root", "0"}, "root:0:val0"},
-		{QueuePath{"root", "1"}, "root:1:val0"},
-		{QueuePath{"root", "2"}, "root:2:val0"},
-		{QueuePath{"root", "1", "0"}, "root:1:0:val0"},
-		{QueuePath{"root", "2", "0"}, "root:2:0:val0"},
-		{QueuePath{"root", "1"}, "root:1:val1"},
-		{QueuePath{"root", "2", "1"}, "root:2:1:val0"},
-		{QueuePath{"root", "1", "0"}, "root:1:0:val1"},
-		{QueuePath{"root", "2", "0"}, "root:2:0:val1"},
-		{QueuePath{"root", "2", "1"}, "root:2:1:val1"},
-		{QueuePath{"root", "2", "1"}, "root:2:1:val2"},
-	}
-
-	// build tree by enqueueing in order
-	for _, pathItem := range queuePathItems {
-		childPath := pathItem.path[1:]
-		require.Nil(t, root.EnqueueBackByPath(childPath, pathItem.item))
-	}
-
-	// assert all expected child paths have been created; empty child path {} serves as root path
-	childQueuePaths := []QueuePath{
-		{}, {"0"}, {"1"}, {"1", "0"}, {"2"}, {"2", "0"}, {"2", "1"},
-	}
-	assert.Equal(t, len(childQueuePaths), root.NodeCount())
-	for _, childQueuePath := range childQueuePaths {
-		assert.NotNil(t, root.getNode(childQueuePath))
-	}
-
-	// check some nonexistent paths
-	assert.Nil(t, root.getNode(QueuePath{"3"}))
-	assert.Nil(t, root.getNode(QueuePath{"1", "1"}))
-	assert.Nil(t, root.getNode(QueuePath{"2", "2"}))
-
-	// queuePathItems, plus an extra item which will be enqueued during dequeueing
-	// note no queue at a given level is dequeued from twice in a row
-	// unless all others at the same level are empty down to the leaf node
-	expectedQueueOutput := []queuePathItem{
-		{QueuePath{"root", "0"}, "root:0:val0"}, // root:0:localQueue is done
-		{QueuePath{"root", "1"}, "root:1:val0"},
-		{QueuePath{"root", "2"}, "root:2:val0"}, // root:2:localQueue is done
-		{QueuePath{"root", "1", "0"}, "root:1:0:val0"},
-		{QueuePath{"root", "2", "0"}, "root:2:0:val0"},
-		{QueuePath{"root", "1"}, "root:1:val1"}, // root:1:localQueue is done
-		{QueuePath{"root", "2", "1"}, "root:2:1:val0"},
-		{QueuePath{"root", "1", "0"}, "root:1:0:val1"}, // root:1:0:localQueue is done; no other queues in root:1, so root:1 is done as well
-		{QueuePath{"root", "2", "0"}, "root:2:0:val1"}, // root:2:0:localQueue is done
-		{QueuePath{"root", "1", "0"}, "root:1:0:val2"}, // this was enqueued during dequeueing, which re-creates the deleted root:1 and its child root:1:0
-		{QueuePath{"root", "2", "1"}, "root:2:1:val1"}, // once again root:1:0:localQueue is done; no other queues in root:1, so root:1 is done as well
-		{QueuePath{"root", "2", "1"}, "root:2:1:val2"}, // root:2:1:localQueue is done; no other queues in root:2, so root:2 is done as well
-		// back up to root; its local queue is done and all childQueueOrder are done, so the full tree is done
-	}
-
-	var queueOutput []queuePathItem
-	for range expectedQueueOutput {
-		path, v := root.Dequeue()
-		if v == nil {
-			fmt.Println(path)
-			break
+		// assert dequeued path has not repeated before the expected number of rotations
+		for _, previousDequeuedPath := range dequeuedPathCache {
+			assert.NotEqual(t, previousDequeuedPath, dequeuedPath)
 		}
-		queueOutput = append(queueOutput, queuePathItem{path, v})
-		if v == "root:1:0:val1" {
-			// root:1 and all subqueues are completely exhausted;
-			// root:2 will be next in the rotation
-			// here we insert something new into root:1 to test that:
-			//  - the new root:1 insert does not jump the line in front of root:2
-			//  - root:2 will not be dequeued from twice in a row now that there is a item in root:1 again
-			require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val2"))
-		}
-	}
-	assert.Equal(t, expectedQueueOutput, queueOutput)
 
-	// Dequeue one more time;
-	path, v := root.Dequeue()
-	assert.Nil(t, v) // assert we get nil back,
-	assert.Nil(t, path)
-	assert.True(t, root.IsEmpty()) // assert nothing in local or child queues
+		dequeuedPathCache = append(dequeuedPathCache[1:], dequeuedPath)
+		count++
+	}
+
+	// count items enqueued to nodes at depth 1
+	expectedFirstDimensionCount := len(firstDimensions) * itemsPerDimension
+	// count items enqueued to nodes at depth 2
+	expectedSecondDimensionCount := len(firstDimensions) * len(secondDimensions) * itemsPerDimension
+
+	assert.Equal(t, expectedFirstDimensionCount+expectedSecondDimensionCount, count)
 }
 
-func TestDequeue(t *testing.T) {
+// TestDequeueBalancedTree checks dequeuing behavior by path from a balanced tree.
+//
+// Dequeuing from a balanced tree allows the test to have a simple looped structures
+// while running checks to ensure that round-robin order is respected.
+func TestDequeueByPathBalancedTree(t *testing.T) {
+	firstDimensions := []string{"0", "1", "2"}
+	secondDimensions := []string{"a", "b", "c"}
+	itemsPerDimension := 5
+	root := makeBalancedTreeQueue(t, firstDimensions, secondDimensions, itemsPerDimension)
+	assert.NotNil(t, root)
+
+	count := 0
+	// tree queue will fairly dequeue from all levels of the tree below the path provided;
+	// dequeuing by path skips the top level the tree and rotates only through the
+	// second-layer subtrees of the first layer node selected by the queue path
+	rotationsBeforeRepeat := len(secondDimensions)
+	// track dequeued paths to ensure round-robin dequeuing does not repeat before expected
+	dequeuedPathCache := make([]QueuePath, rotationsBeforeRepeat)
+
+	for _, firstDimName := range firstDimensions {
+		firstDimPath := QueuePath{firstDimName}
+		for root.getNode(firstDimPath) != nil {
+			dequeuedPath, v := root.DequeueByPath(firstDimPath)
+			assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+			// assert dequeued path has not repeated before the expected number of rotations
+			for _, previousDequeuedPath := range dequeuedPathCache {
+				assert.NotEqual(t, previousDequeuedPath, dequeuedPath)
+			}
+
+			dequeuedPathCache = append(dequeuedPathCache[1:], dequeuedPath)
+			count++
+		}
+	}
+
+	// count items enqueued to nodes at depth 1
+	expectedFirstDimensionCount := len(firstDimensions) * itemsPerDimension
+	// count items enqueued to nodes at depth 2
+	expectedSecondDimensionCount := len(firstDimensions) * len(secondDimensions) * itemsPerDimension
+
+	assert.Equal(t, expectedFirstDimensionCount+expectedSecondDimensionCount, count)
+}
+
+// TestDequeuePathUnbalancedTree checks dequeuing behavior from an unbalanced tree.
+//
+// Assertions are done one by one to illustrate and check the behaviors of dequeuing from
+// an unbalanced tree, where the same node will be dequeued from twice if the node remains
+// nonempty while its sibling nodes have been exhausted and deleted from the tree.
+func TestDequeueUnbalancedTree(t *testing.T) {
 	root := makeUnbalancedTreeQueue(t)
 
 	// dequeue from root until exhausted
@@ -179,7 +175,12 @@ func TestDequeue(t *testing.T) {
 	assert.True(t, root.IsEmpty())
 }
 
-func TestDequeuePath(t *testing.T) {
+// TestDequeueByPathUnbalancedTree checks dequeuing behavior from an unbalanced tree by path.
+//
+// Assertions are done one by one to illustrate and check the behaviors of dequeuing from
+// an unbalanced tree, where the same node will be dequeued from twice if the node remains
+// nonempty while its sibling nodes have been exhausted and deleted from the tree.
+func TestDequeueByPathUnbalancedTree(t *testing.T) {
 	root := makeUnbalancedTreeQueue(t)
 
 	// dequeue from root:2 until exhausted
@@ -337,6 +338,33 @@ func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 
 	// assert nothing in local or child queues
 	assert.True(t, root.IsEmpty())
+}
+
+func makeBalancedTreeQueue(t *testing.T, firstDimensions, secondDimensions []string, itemsPerDimensions int) *TreeQueue {
+	root := NewTreeQueue("root", maxTestQueueLen)
+	require.Equal(t, 1, root.NodeCount())
+	require.Equal(t, 0, root.ItemCount())
+
+	cache := map[string]struct{}{}
+
+	for _, firstDimName := range firstDimensions {
+		// insert first dimension local queue items
+		for k := 0; k < itemsPerDimensions; k++ {
+			childPath := QueuePath{firstDimName}
+			item := makeQueueItemForChildPath(root, childPath, cache)
+			require.NoError(t, root.EnqueueBackByPath(childPath, item))
+		}
+		for _, secondDimName := range secondDimensions {
+			// insert second dimension local queue items
+			for k := 0; k < itemsPerDimensions; k++ {
+				childPath := QueuePath{firstDimName, secondDimName}
+				item := makeQueueItemForChildPath(root, childPath, cache)
+				require.NoError(t, root.EnqueueBackByPath(childPath, item))
+			}
+		}
+	}
+
+	return root
 }
 
 func makeUnbalancedTreeQueue(t *testing.T) *TreeQueue {

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -1,0 +1,224 @@
+package queue
+
+import (
+	"container/list"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTreeQueue(t *testing.T) {
+
+	expectedTreeQueue := &TreeQueue{
+		name:            "root",
+		localQueue:      list.New(),
+		index:           -1,
+		childQueueOrder: []string{"0", "1", "2"},
+		childQueueMap: map[string]*TreeQueue{
+			"0": {
+				name:            "0",
+				localQueue:      list.New(),
+				index:           -1,
+				childQueueOrder: nil,
+				childQueueMap:   map[string]*TreeQueue{},
+			},
+			"1": {
+				name:            "1",
+				localQueue:      list.New(),
+				index:           -1,
+				childQueueOrder: []string{"0"},
+				childQueueMap: map[string]*TreeQueue{
+					"0": {
+						name:            "0",
+						localQueue:      list.New(),
+						index:           -1,
+						childQueueOrder: nil,
+						childQueueMap:   map[string]*TreeQueue{},
+					},
+				},
+			},
+			"2": {
+				name:            "2",
+				localQueue:      list.New(),
+				index:           -1,
+				childQueueOrder: []string{"0", "1"},
+				childQueueMap: map[string]*TreeQueue{
+					"0": {
+						name:            "0",
+						localQueue:      list.New(),
+						index:           -1,
+						childQueueOrder: nil,
+						childQueueMap:   map[string]*TreeQueue{},
+					},
+					"1": {
+						name:            "1",
+						localQueue:      list.New(),
+						index:           -1,
+						childQueueOrder: nil,
+						childQueueMap:   map[string]*TreeQueue{},
+					},
+				},
+			},
+		},
+	}
+
+	root := NewTreeQueue("root") // creates path: root
+
+	root.getOrAddNode([]string{"root", "0"})      // creates paths: root:0
+	root.getOrAddNode([]string{"root", "1", "0"}) // creates paths: root:1 and root:1:0
+	root.getOrAddNode([]string{"root", "2", "0"}) // creates paths: root:2 and root:2:0
+	root.getOrAddNode([]string{"root", "2", "1"}) // creates paths: root:2:1 only, as root:2 already exists
+
+	assert.Equal(t, expectedTreeQueue, root)
+
+	child := root.getNode(QueuePath{"root", "0"})
+	assert.NotNil(t, child)
+
+	child = root.getNode(QueuePath{"root", "1"})
+	assert.NotNil(t, child)
+
+	child = root.getNode(QueuePath{"root", "1", "0"})
+	assert.NotNil(t, child)
+
+	child = root.getNode([]string{"root", "2"})
+	assert.NotNil(t, child)
+
+	child = root.getNode(QueuePath{"root", "2", "0"})
+	assert.NotNil(t, child)
+
+	child = root.getNode(QueuePath{"root", "2", "1"})
+	assert.NotNil(t, child)
+
+	// nonexistent paths
+	child = root.getNode(QueuePath{"root", "3"})
+
+	assert.Nil(t, child)
+
+	child = root.getNode(QueuePath{"root", "1", "1"})
+
+	assert.Nil(t, child)
+
+	child = root.getNode(QueuePath{"root", "2", "2"})
+	assert.Nil(t, child)
+
+	// enqueue in order
+	root.EnqueueBackByPath([]string{"root", "0"}, "root:0:val0")
+	root.EnqueueBackByPath([]string{"root", "1"}, "root:1:val0")
+	root.EnqueueBackByPath([]string{"root", "1"}, "root:1:val1")
+	root.EnqueueBackByPath([]string{"root", "2"}, "root:2:val0")
+	root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val0")
+	root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val1")
+	root.EnqueueBackByPath([]string{"root", "2", "0"}, "root:2:0:val0")
+	root.EnqueueBackByPath([]string{"root", "2", "0"}, "root:2:0:val1")
+	root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val0")
+	root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val1")
+	root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val2")
+
+	// note no queue at a given level is dequeued from twice in a row
+	// unless all others at the same level are empty down to the leaf node
+	expectedQueueOutput := []any{
+		"root:0:val0", // root:0:localQueue is done
+		"root:1:val0",
+		"root:2:val0", // root:2:localQueue is done
+		"root:1:0:val0",
+		"root:2:0:val0",
+		"root:1:val1", // root:1:localQueue is done
+		"root:2:1:val0",
+		"root:1:0:val1", // root:1:0:localQueue is done; no other queues in root:1, so root:1 is done as well
+		"root:2:0:val1", // root:2:0 :localQueue is done
+		"root:1:0:val2", // this is enqueued during dequeueing
+		"root:2:1:val1",
+		"root:2:1:val2", // root:2:1:localQueue is done; no other queues in root:2, so root:2 is done as well
+		// back up to root; its local queue is done and all childQueueOrder are done, so the full tree is done
+	}
+
+	expectedQueuePaths := []QueuePath{
+		{"root", "0"},
+		{"root", "1"},
+		{"root", "2"},
+		{"root", "1", "0"},
+		{"root", "2", "0"},
+		{"root", "1"},
+		{"root", "2", "1"},
+		{"root", "1", "0"},
+		{"root", "2", "0"},
+		{"root", "1", "0"},
+		{"root", "2", "1"},
+		{"root", "2", "1"},
+	}
+
+	var queueOutput []any
+	var queuePaths []QueuePath
+	for range expectedQueueOutput {
+		path, v := root.Dequeue()
+		if v == nil {
+			fmt.Println(path)
+			break
+		}
+		queueOutput = append(queueOutput, v)
+		queuePaths = append(queuePaths, path)
+		if v == "root:1:0:val1" {
+			// root:1 and all subqueues are completely exhausted;
+			// root:2 will be next in the rotation
+			// here we insert something new into root:1 to test that:
+			//  - the new root:1 insert does not jump the line in front of root:2
+			//  - root:2 will not be dequeued from twice in a row now that there is a value in root:1 again
+			root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val2")
+		}
+	}
+	assert.Equal(t, expectedQueueOutput, queueOutput)
+	assert.Equal(t, expectedQueuePaths, queuePaths)
+
+	// Dequeue one more time;
+	path, v := root.Dequeue()
+	assert.Nil(t, v) // assert we get nil back,
+	assert.Nil(t, path)
+	assert.True(t, root.isEmpty()) // assert nothing in local or child queues
+}
+
+func TestDequeuePath(t *testing.T) {
+	root := NewTreeQueue("root")
+	root.EnqueueBackByPath(QueuePath{"root", "0"}, "root:0:val0")
+	root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val0")
+	root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val1")
+	root.EnqueueBackByPath(QueuePath{"root", "2"}, "root:2:val0")
+	root.EnqueueBackByPath(QueuePath{"root", "1", "0"}, "root:1:0:val0")
+	root.EnqueueBackByPath(QueuePath{"root", "1", "0"}, "root:1:0:val1")
+	root.EnqueueBackByPath(QueuePath{"root", "2", "0"}, "root:2:0:val0")
+	root.EnqueueBackByPath(QueuePath{"root", "2", "0"}, "root:2:0:val1")
+	root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val0")
+	root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val1")
+	root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val2")
+
+	path := QueuePath{"root", "2"}
+	dequeuedPath, v := root.DequeueByPath(path)
+	assert.Equal(t, "root:2:val0", v)
+	assert.Equal(t, path, dequeuedPath[:len(path)])
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:2:0:val0", v)
+	assert.Equal(t, path, dequeuedPath[:len(path)])
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:2:1:val0", v)
+	assert.Equal(t, path, dequeuedPath[:len(path)])
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:2:0:val1", v)
+	assert.Equal(t, path, dequeuedPath[:len(path)])
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:2:1:val1", v)
+	assert.Equal(t, path, dequeuedPath[:len(path)])
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:2:1:val2", v)
+	assert.Equal(t, path, dequeuedPath[:len(path)])
+
+	// root:2 is exhausted
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Nil(t, v)
+	assert.Nil(t, dequeuedPath)
+
+}

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +21,7 @@ func TestDequeueBalancedTree(t *testing.T) {
 	secondDimensions := []string{"a", "b", "c"}
 	itemsPerDimension := 5
 	root := makeBalancedTreeQueue(t, firstDimensions, secondDimensions, itemsPerDimension)
-	assert.NotNil(t, root)
+	require.NotNil(t, root)
 
 	count := 0
 	// tree queue will fairly dequeue from all levels of the tree
@@ -34,10 +33,8 @@ func TestDequeueBalancedTree(t *testing.T) {
 		v := root.Dequeue()
 		dequeuedPath := getChildPathFromQueueItem(v)
 
-		// assert dequeued path has not repeated before the expected number of rotations
-		for _, previousDequeuedPath := range dequeuedPathCache {
-			assert.NotEqual(t, previousDequeuedPath, dequeuedPath)
-		}
+		// require dequeued path has not repeated before the expected number of rotations
+		require.NotContains(t, dequeuedPathCache, dequeuedPath)
 
 		dequeuedPathCache = append(dequeuedPathCache[1:], dequeuedPath)
 		count++
@@ -48,10 +45,10 @@ func TestDequeueBalancedTree(t *testing.T) {
 	// count items enqueued to nodes at depth 2
 	expectedSecondDimensionCount := len(firstDimensions) * len(secondDimensions) * itemsPerDimension
 
-	assert.Equal(t, expectedFirstDimensionCount+expectedSecondDimensionCount, count)
+	require.Equal(t, expectedFirstDimensionCount+expectedSecondDimensionCount, count)
 }
 
-// TestDequeueBalancedTree checks dequeuing behavior by path from a balanced tree.
+// TestDequeueByPathBalancedTree checks dequeuing behavior by path from a balanced tree.
 //
 // Dequeuing from a balanced tree allows the test to have a simple looped structures
 // while running checks to ensure that round-robin order is respected.
@@ -60,7 +57,7 @@ func TestDequeueByPathBalancedTree(t *testing.T) {
 	secondDimensions := []string{"a", "b", "c"}
 	itemsPerDimension := 5
 	root := makeBalancedTreeQueue(t, firstDimensions, secondDimensions, itemsPerDimension)
-	assert.NotNil(t, root)
+	require.NotNil(t, root)
 
 	count := 0
 	// tree queue will fairly dequeue from all levels of the tree below the path provided;
@@ -76,10 +73,8 @@ func TestDequeueByPathBalancedTree(t *testing.T) {
 			v := root.DequeueByPath(firstDimPath)
 			dequeuedPath := getChildPathFromQueueItem(v)
 
-			// assert dequeued path has not repeated before the expected number of rotations
-			for _, previousDequeuedPath := range dequeuedPathCache {
-				assert.NotEqual(t, previousDequeuedPath, dequeuedPath)
-			}
+			// require dequeued path has not repeated before the expected number of rotations
+			require.NotContains(t, dequeuedPathCache, dequeuedPath)
 
 			dequeuedPathCache = append(dequeuedPathCache[1:], dequeuedPath)
 			count++
@@ -91,7 +86,7 @@ func TestDequeueByPathBalancedTree(t *testing.T) {
 	// count items enqueued to nodes at depth 2
 	expectedSecondDimensionCount := len(firstDimensions) * len(secondDimensions) * itemsPerDimension
 
-	assert.Equal(t, expectedFirstDimensionCount+expectedSecondDimensionCount, count)
+	require.Equal(t, expectedFirstDimensionCount+expectedSecondDimensionCount, count)
 }
 
 // TestDequeuePathUnbalancedTree checks dequeuing behavior from an unbalanced tree.
@@ -104,62 +99,62 @@ func TestDequeueUnbalancedTree(t *testing.T) {
 
 	// dequeue from root until exhausted
 	v := root.Dequeue()
-	assert.Equal(t, "root:0:val0", v)
+	require.Equal(t, "root:0:val0", v)
 
 	// root:0 and any subtrees are exhausted
 	path := QueuePath{"0"}
 	v = root.DequeueByPath(path)
-	assert.Nil(t, v)
+	require.Nil(t, v)
 	// root:0 was deleted
-	assert.Nil(t, root.getNode(path))
+	require.Nil(t, root.getNode(path))
 
 	v = root.Dequeue()
-	assert.Equal(t, "root:1:val0", v)
+	require.Equal(t, "root:1:val0", v)
 
 	v = root.Dequeue()
-	assert.Equal(t, "root:2:0:val0", v)
+	require.Equal(t, "root:2:0:val0", v)
 
 	v = root.Dequeue()
-	assert.Equal(t, "root:1:0:val0", v)
+	require.Equal(t, "root:1:0:val0", v)
 
 	v = root.Dequeue()
-	assert.Equal(t, "root:2:1:val0", v)
+	require.Equal(t, "root:2:1:val0", v)
 
 	v = root.Dequeue()
-	assert.Equal(t, "root:1:val1", v)
+	require.Equal(t, "root:1:val1", v)
 
 	v = root.Dequeue()
-	assert.Equal(t, "root:2:0:val1", v)
+	require.Equal(t, "root:2:0:val1", v)
 
 	v = root.Dequeue()
-	assert.Equal(t, "root:1:0:val1", v)
+	require.Equal(t, "root:1:0:val1", v)
 
 	// root:1 and any subtrees are exhausted
 	path = QueuePath{"1"}
 	v = root.DequeueByPath(path)
-	assert.Nil(t, v)
+	require.Nil(t, v)
 	// root:1 was deleted
-	assert.Nil(t, root.getNode(path))
+	require.Nil(t, root.getNode(path))
 
 	v = root.Dequeue()
-	assert.Equal(t, "root:2:1:val1", v)
+	require.Equal(t, "root:2:1:val1", v)
 
 	v = root.Dequeue()
-	assert.Equal(t, "root:2:1:val2", v)
+	require.Equal(t, "root:2:1:val2", v)
 
 	// root:2 and any subtrees are exhausted
 	path = QueuePath{"2"}
 	v = root.DequeueByPath(path)
-	assert.Nil(t, v)
+	require.Nil(t, v)
 	// root:2 was deleted
-	assert.Nil(t, root.getNode(path))
+	require.Nil(t, root.getNode(path))
 
 	// all items have been dequeued
-	assert.Equal(t, 0, root.ItemCount())
-	assert.Equal(t, 1, root.NodeCount())
+	require.Equal(t, 0, root.ItemCount())
+	require.Equal(t, 1, root.NodeCount())
 
-	// assert nothing in local or child queues
-	assert.True(t, root.IsEmpty())
+	// require nothing in local or child queues
+	require.True(t, root.IsEmpty())
 }
 
 // TestDequeueByPathUnbalancedTree checks dequeuing behavior from an unbalanced tree by path.
@@ -173,75 +168,75 @@ func TestDequeueByPathUnbalancedTree(t *testing.T) {
 	// dequeue from root:2 until exhausted
 	path := QueuePath{"2"}
 	v := root.DequeueByPath(path)
-	assert.Equal(t, "root:2:0:val0", v)
+	require.Equal(t, "root:2:0:val0", v)
 
 	v = root.DequeueByPath(path)
-	assert.Equal(t, "root:2:1:val0", v)
+	require.Equal(t, "root:2:1:val0", v)
 
 	v = root.DequeueByPath(path)
-	assert.Equal(t, "root:2:0:val1", v)
+	require.Equal(t, "root:2:0:val1", v)
 
 	v = root.DequeueByPath(path)
-	assert.Equal(t, "root:2:1:val1", v)
+	require.Equal(t, "root:2:1:val1", v)
 
 	v = root.DequeueByPath(path)
-	assert.Equal(t, "root:2:1:val2", v)
+	require.Equal(t, "root:2:1:val2", v)
 
 	// root:2 is exhausted;
 	v = root.DequeueByPath(path)
-	assert.Nil(t, v)
+	require.Nil(t, v)
 	// root:2 and its two children root:2:0 and root:2:1 were deleted
-	assert.Nil(t, root.getNode(path))
-	assert.Equal(t, 2, len(root.childQueueMap))
-	assert.Equal(t, 2, len(root.childQueueOrder))
-	assert.Equal(t, 4, root.NodeCount())
+	require.Nil(t, root.getNode(path))
+	require.Equal(t, 2, len(root.childQueueMap))
+	require.Equal(t, 2, len(root.childQueueOrder))
+	require.Equal(t, 4, root.NodeCount())
 	// 5 of 10 items were dequeued
-	assert.Equal(t, 5, root.ItemCount())
+	require.Equal(t, 5, root.ItemCount())
 
 	// dequeue from root:1 until exhausted
 	path = QueuePath{"1"}
 	v = root.DequeueByPath(path)
-	assert.Equal(t, "root:1:val0", v)
+	require.Equal(t, "root:1:val0", v)
 
 	v = root.DequeueByPath(path)
-	assert.Equal(t, "root:1:0:val0", v)
+	require.Equal(t, "root:1:0:val0", v)
 
 	v = root.DequeueByPath(path)
-	assert.Equal(t, "root:1:val1", v)
+	require.Equal(t, "root:1:val1", v)
 
 	v = root.DequeueByPath(path)
-	assert.Equal(t, "root:1:0:val1", v)
+	require.Equal(t, "root:1:0:val1", v)
 
 	// root:1 is exhausted;
 	v = root.DequeueByPath(path)
-	assert.Nil(t, v)
+	require.Nil(t, v)
 	// root:1 and its child root:1:0 were deleted
-	assert.Nil(t, root.getNode(path))
-	assert.Equal(t, 1, len(root.childQueueMap))
-	assert.Equal(t, 1, len(root.childQueueOrder))
-	assert.Equal(t, 2, root.NodeCount())
+	require.Nil(t, root.getNode(path))
+	require.Equal(t, 1, len(root.childQueueMap))
+	require.Equal(t, 1, len(root.childQueueOrder))
+	require.Equal(t, 2, root.NodeCount())
 	// 9 of 10 items have been dequeued
-	assert.Equal(t, 1, root.ItemCount())
+	require.Equal(t, 1, root.ItemCount())
 
 	// dequeue from root:0 until exhausted
 	path = QueuePath{"0"}
 	v = root.DequeueByPath(path)
-	assert.Equal(t, "root:0:val0", v)
+	require.Equal(t, "root:0:val0", v)
 
 	// root:0 is exhausted;
 	v = root.DequeueByPath(path)
-	assert.Nil(t, v)
+	require.Nil(t, v)
 	// root:0 was deleted
-	assert.Nil(t, root.getNode(path))
-	assert.Equal(t, 0, len(root.childQueueMap))
-	assert.Equal(t, 0, len(root.childQueueOrder))
-	assert.Equal(t, 1, root.NodeCount())
+	require.Nil(t, root.getNode(path))
+	require.Equal(t, 0, len(root.childQueueMap))
+	require.Equal(t, 0, len(root.childQueueOrder))
+	require.Equal(t, 1, root.NodeCount())
 	// 10 of 10 items have been dequeued
-	assert.Equal(t, 0, root.ItemCount())
-	assert.Equal(t, 1, root.NodeCount())
+	require.Equal(t, 0, root.ItemCount())
+	require.Equal(t, 1, root.NodeCount())
 
-	// assert nothing in local or child queues
-	assert.True(t, root.IsEmpty())
+	// require nothing in local or child queues
+	require.True(t, root.IsEmpty())
 }
 
 func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
@@ -261,69 +256,69 @@ func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 	item = makeQueueItemForChildPath(root, childPath, cache)
 	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 
-	// enqueue two items to path root:1
+	// enqueue two items to path root:2
 	childPath = QueuePath{"2"}
 	item = makeQueueItemForChildPath(root, childPath, cache)
 	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	item = makeQueueItemForChildPath(root, childPath, cache)
 	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 
-	assert.Equal(t, []string{"0", "1", "2"}, root.childQueueOrder)
+	require.Equal(t, []string{"0", "1", "2"}, root.childQueueOrder)
 
 	// dequeue first item
 	v := root.Dequeue()
 	dequeuedPath := getChildPathFromQueueItem(v)
-	assert.Equal(t, QueuePath{"0"}, dequeuedPath)
+	require.Equal(t, QueuePath{"0"}, dequeuedPath)
 
 	// dequeue second item; root:1 is now exhausted and deleted
 	v = root.Dequeue()
 	dequeuedPath = getChildPathFromQueueItem(v)
-	assert.Equal(t, QueuePath{"1"}, dequeuedPath)
-	assert.Nil(t, root.getNode(QueuePath{"1"}))
-	assert.Equal(t, []string{"0", "2"}, root.childQueueOrder)
+	require.Equal(t, QueuePath{"1"}, dequeuedPath)
+	require.Nil(t, root.getNode(QueuePath{"1"}))
+	require.Equal(t, []string{"0", "2"}, root.childQueueOrder)
 
 	// dequeue third item
 	v = root.Dequeue()
 	dequeuedPath = getChildPathFromQueueItem(v)
-	assert.Equal(t, QueuePath{"2"}, dequeuedPath)
+	require.Equal(t, QueuePath{"2"}, dequeuedPath)
 
 	// root:1 was previously exhausted; root:0, then root:2 will be next in the rotation
 	// here we insert something new into root:1 to test that it
 	// does not jump the line in front of root:0 or root:2
 	item = makeQueueItemForChildPath(root, QueuePath{"1"}, cache)
 	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1"}, item))
-	assert.NotNil(t, root.getNode(QueuePath{"1"}))
-	assert.Equal(t, []string{"0", "2", "1"}, root.childQueueOrder)
+	require.NotNil(t, root.getNode(QueuePath{"1"}))
+	require.Equal(t, []string{"0", "2", "1"}, root.childQueueOrder)
 
 	// dequeue fourth item; the newly-enqueued root:1 item
 	// has not jumped the line in front of root:0
 	v = root.Dequeue()
 	dequeuedPath = getChildPathFromQueueItem(v)
-	assert.Equal(t, QueuePath{"0"}, dequeuedPath)
+	require.Equal(t, QueuePath{"0"}, dequeuedPath)
 
 	// dequeue fifth item; the newly-enqueued root:1 item
 	// has not jumped the line in front of root:2
 	v = root.Dequeue()
 	dequeuedPath = getChildPathFromQueueItem(v)
-	assert.Equal(t, QueuePath{"2"}, dequeuedPath)
+	require.Equal(t, QueuePath{"2"}, dequeuedPath)
 
 	// dequeue sixth item; verifying the order 0->2->1 is being followed
 	v = root.Dequeue()
 	dequeuedPath = getChildPathFromQueueItem(v)
-	assert.Equal(t, QueuePath{"1"}, dequeuedPath)
+	require.Equal(t, QueuePath{"1"}, dequeuedPath)
 
 	// all items have been dequeued
-	assert.Equal(t, 0, root.ItemCount())
-	assert.Equal(t, 1, root.NodeCount())
+	require.Equal(t, 0, root.ItemCount())
+	require.Equal(t, 1, root.NodeCount())
 
-	// assert nothing in local or child queues
-	assert.True(t, root.IsEmpty())
+	// require nothing in local or child queues
+	require.True(t, root.IsEmpty())
 }
 
 func TestNodeCannotDeleteItself(t *testing.T) {
 	root := NewTreeQueue("root", maxTestQueueLen)
-	assert.False(t, root.deleteNode(QueuePath{}))
-	assert.NotNil(t, root)
+	require.False(t, root.deleteNode(QueuePath{}))
+	require.NotNil(t, root)
 }
 
 func makeBalancedTreeQueue(t *testing.T, firstDimensions, secondDimensions []string, itemsPerDimensions int) *TreeQueue {

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -8,16 +8,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const maxTestQueueLen = 8
+
 func TestTreeQueue(t *testing.T) {
 
 	expectedTreeQueue := &TreeQueue{
 		name:            "root",
+		maxQueueLen:     maxTestQueueLen,
 		localQueue:      list.New(),
 		index:           -1,
 		childQueueOrder: []string{"0", "1", "2"},
 		childQueueMap: map[string]*TreeQueue{
 			"0": {
 				name:            "0",
+				maxQueueLen:     maxTestQueueLen,
 				localQueue:      list.New(),
 				index:           -1,
 				childQueueOrder: nil,
@@ -25,12 +29,14 @@ func TestTreeQueue(t *testing.T) {
 			},
 			"1": {
 				name:            "1",
+				maxQueueLen:     maxTestQueueLen,
 				localQueue:      list.New(),
 				index:           -1,
 				childQueueOrder: []string{"0"},
 				childQueueMap: map[string]*TreeQueue{
 					"0": {
 						name:            "0",
+						maxQueueLen:     maxTestQueueLen,
 						localQueue:      list.New(),
 						index:           -1,
 						childQueueOrder: nil,
@@ -40,12 +46,14 @@ func TestTreeQueue(t *testing.T) {
 			},
 			"2": {
 				name:            "2",
+				maxQueueLen:     maxTestQueueLen,
 				localQueue:      list.New(),
 				index:           -1,
 				childQueueOrder: []string{"0", "1"},
 				childQueueMap: map[string]*TreeQueue{
 					"0": {
 						name:            "0",
+						maxQueueLen:     maxTestQueueLen,
 						localQueue:      list.New(),
 						index:           -1,
 						childQueueOrder: nil,
@@ -53,6 +61,7 @@ func TestTreeQueue(t *testing.T) {
 					},
 					"1": {
 						name:            "1",
+						maxQueueLen:     maxTestQueueLen,
 						localQueue:      list.New(),
 						index:           -1,
 						childQueueOrder: nil,
@@ -63,7 +72,7 @@ func TestTreeQueue(t *testing.T) {
 		},
 	}
 
-	root := NewTreeQueue("root") // creates path: root
+	root := NewTreeQueue("root", maxTestQueueLen) // creates path: root
 
 	root.getOrAddNode([]string{"root", "0"})      // creates paths: root:0
 	root.getOrAddNode([]string{"root", "1", "0"}) // creates paths: root:1 and root:1:0
@@ -178,7 +187,7 @@ func TestTreeQueue(t *testing.T) {
 }
 
 func TestDequeuePath(t *testing.T) {
-	root := NewTreeQueue("root")
+	root := NewTreeQueue("root", maxTestQueueLen)
 	root.EnqueueBackByPath(QueuePath{"root", "0"}, "root:0:val0")
 	root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val0")
 	root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val1")

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -340,6 +340,12 @@ func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 	assert.True(t, root.IsEmpty())
 }
 
+func TestNodeCannotDeleteItself(t *testing.T) {
+	root := NewTreeQueue("root", maxTestQueueLen)
+	assert.False(t, root.deleteNode(QueuePath{}))
+	assert.NotNil(t, root)
+}
+
 func makeBalancedTreeQueue(t *testing.T, firstDimensions, secondDimensions []string, itemsPerDimensions int) *TreeQueue {
 	root := NewTreeQueue("root", maxTestQueueLen)
 	require.Equal(t, 1, root.NodeCount())

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -77,55 +77,55 @@ func TestTreeQueue(t *testing.T) {
 
 	root := NewTreeQueue("root", maxTestQueueLen) // creates path: root
 
-	_, _ = root.getOrAddNode([]string{"root", "0"})      // creates paths: root:0
-	_, _ = root.getOrAddNode([]string{"root", "1", "0"}) // creates paths: root:1 and root:1:0
-	_, _ = root.getOrAddNode([]string{"root", "2", "0"}) // creates paths: root:2 and root:2:0
-	_, _ = root.getOrAddNode([]string{"root", "2", "1"}) // creates paths: root:2:1 only, as root:2 already exists
+	_, _ = root.getOrAddNode(QueuePath{"0"})      // creates paths: root:0
+	_, _ = root.getOrAddNode(QueuePath{"1", "0"}) // creates paths: root:1 and root:1:0
+	_, _ = root.getOrAddNode(QueuePath{"2", "0"}) // creates paths: root:2 and root:2:0
+	_, _ = root.getOrAddNode(QueuePath{"2", "1"}) // creates paths: root:2:1 only, as root:2 already exists
 
 	assert.Equal(t, expectedTreeQueue, root)
 
-	child := root.getNode(QueuePath{"root", "0"})
+	child := root.getNode(QueuePath{"0"})
 	assert.NotNil(t, child)
 
-	child = root.getNode(QueuePath{"root", "1"})
+	child = root.getNode(QueuePath{"1"})
 	assert.NotNil(t, child)
 
-	child = root.getNode(QueuePath{"root", "1", "0"})
+	child = root.getNode(QueuePath{"1", "0"})
 	assert.NotNil(t, child)
 
-	child = root.getNode([]string{"root", "2"})
+	child = root.getNode(QueuePath{"2"})
 	assert.NotNil(t, child)
 
-	child = root.getNode(QueuePath{"root", "2", "0"})
+	child = root.getNode(QueuePath{"2", "0"})
 	assert.NotNil(t, child)
 
-	child = root.getNode(QueuePath{"root", "2", "1"})
+	child = root.getNode(QueuePath{"2", "1"})
 	assert.NotNil(t, child)
 
 	// nonexistent paths
-	child = root.getNode(QueuePath{"root", "3"})
+	child = root.getNode(QueuePath{"3"})
 
 	assert.Nil(t, child)
 
-	child = root.getNode(QueuePath{"root", "1", "1"})
+	child = root.getNode(QueuePath{"1", "1"})
 
 	assert.Nil(t, child)
 
-	child = root.getNode(QueuePath{"root", "2", "2"})
+	child = root.getNode(QueuePath{"2", "2"})
 	assert.Nil(t, child)
 
 	// enqueue in order
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "0"}, "root:0:val0"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "1"}, "root:1:val0"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "1"}, "root:1:val1"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2"}, "root:2:val0"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val0"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val1"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "0"}, "root:2:0:val0"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "0"}, "root:2:0:val1"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val0"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val1"))
-	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val2"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"0"}, "root:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1"}, "root:1:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1"}, "root:1:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2"}, "root:2:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "0"}, "root:2:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "0"}, "root:2:0:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val2"))
 
 	// note no queue at a given level is dequeued from twice in a row
 	// unless all others at the same level are empty down to the leaf node
@@ -176,7 +176,7 @@ func TestTreeQueue(t *testing.T) {
 			// here we insert something new into root:1 to test that:
 			//  - the new root:1 insert does not jump the line in front of root:2
 			//  - root:2 will not be dequeued from twice in a row now that there is a value in root:1 again
-			require.NoError(t, root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val2"))
+			require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val2"))
 		}
 	}
 	assert.Equal(t, expectedQueueOutput, queueOutput)
@@ -191,19 +191,19 @@ func TestTreeQueue(t *testing.T) {
 
 func TestDequeuePath(t *testing.T) {
 	root := NewTreeQueue("root", maxTestQueueLen)
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "0"}, "root:0:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val1"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2"}, "root:2:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "1", "0"}, "root:1:0:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "1", "0"}, "root:1:0:val1"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "0"}, "root:2:0:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "0"}, "root:2:0:val1"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val1"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val2"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"0"}, "root:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1"}, "root:1:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1"}, "root:1:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2"}, "root:2:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "0"}, "root:2:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "0"}, "root:2:0:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val2"))
 
-	path := QueuePath{"root", "2"}
+	path := QueuePath{"2"}
 	dequeuedPath, v := root.DequeueByPath(path)
 	assert.Equal(t, "root:2:val0", v)
 	assert.Equal(t, path, dequeuedPath[:len(path)])

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -3,8 +3,8 @@
 package queue
 
 import (
-	"container/list"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,178 +15,256 @@ const maxTestQueueLen = 8
 
 func TestTreeQueue(t *testing.T) {
 
-	expectedTreeQueue := &TreeQueue{
-		name:            "root",
-		maxQueueLen:     maxTestQueueLen,
-		localQueue:      list.New(),
-		index:           -1,
-		childQueueOrder: []string{"0", "1", "2"},
-		childQueueMap: map[string]*TreeQueue{
-			"0": {
-				name:            "0",
-				maxQueueLen:     maxTestQueueLen,
-				localQueue:      list.New(),
-				index:           -1,
-				childQueueOrder: nil,
-				childQueueMap:   map[string]*TreeQueue{},
-			},
-			"1": {
-				name:            "1",
-				maxQueueLen:     maxTestQueueLen,
-				localQueue:      list.New(),
-				index:           -1,
-				childQueueOrder: []string{"0"},
-				childQueueMap: map[string]*TreeQueue{
-					"0": {
-						name:            "0",
-						maxQueueLen:     maxTestQueueLen,
-						localQueue:      list.New(),
-						index:           -1,
-						childQueueOrder: nil,
-						childQueueMap:   map[string]*TreeQueue{},
-					},
-				},
-			},
-			"2": {
-				name:            "2",
-				maxQueueLen:     maxTestQueueLen,
-				localQueue:      list.New(),
-				index:           -1,
-				childQueueOrder: []string{"0", "1"},
-				childQueueMap: map[string]*TreeQueue{
-					"0": {
-						name:            "0",
-						maxQueueLen:     maxTestQueueLen,
-						localQueue:      list.New(),
-						index:           -1,
-						childQueueOrder: nil,
-						childQueueMap:   map[string]*TreeQueue{},
-					},
-					"1": {
-						name:            "1",
-						maxQueueLen:     maxTestQueueLen,
-						localQueue:      list.New(),
-						index:           -1,
-						childQueueOrder: nil,
-						childQueueMap:   map[string]*TreeQueue{},
-					},
-				},
-			},
-		},
-	}
-
 	root := NewTreeQueue("root", maxTestQueueLen) // creates path: root
 
-	_, _ = root.getOrAddNode(QueuePath{"0"})      // creates paths: root:0
-	_, _ = root.getOrAddNode(QueuePath{"1", "0"}) // creates paths: root:1 and root:1:0
-	_, _ = root.getOrAddNode(QueuePath{"2", "0"}) // creates paths: root:2 and root:2:0
-	_, _ = root.getOrAddNode(QueuePath{"2", "1"}) // creates paths: root:2:1 only, as root:2 already exists
-
-	assert.Equal(t, expectedTreeQueue, root)
-
-	child := root.getNode(QueuePath{"0"})
-	assert.NotNil(t, child)
-
-	child = root.getNode(QueuePath{"1"})
-	assert.NotNil(t, child)
-
-	child = root.getNode(QueuePath{"1", "0"})
-	assert.NotNil(t, child)
-
-	child = root.getNode(QueuePath{"2"})
-	assert.NotNil(t, child)
-
-	child = root.getNode(QueuePath{"2", "0"})
-	assert.NotNil(t, child)
-
-	child = root.getNode(QueuePath{"2", "1"})
-	assert.NotNil(t, child)
-
-	// nonexistent paths
-	child = root.getNode(QueuePath{"3"})
-
-	assert.Nil(t, child)
-
-	child = root.getNode(QueuePath{"1", "1"})
-
-	assert.Nil(t, child)
-
-	child = root.getNode(QueuePath{"2", "2"})
-	assert.Nil(t, child)
-
-	// enqueue in order
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"0"}, "root:0:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1"}, "root:1:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1"}, "root:1:val1"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2"}, "root:2:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val1"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "0"}, "root:2:0:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "0"}, "root:2:0:val1"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val0"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val1"))
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val2"))
+	type queuePathItem struct {
+		path QueuePath
+		item any
+	}
 
 	// note no queue at a given level is dequeued from twice in a row
 	// unless all others at the same level are empty down to the leaf node
-	expectedQueueOutput := []any{
-		"root:0:val0", // root:0:localQueue is done
-		"root:1:val0",
-		"root:2:val0", // root:2:localQueue is done
-		"root:1:0:val0",
-		"root:2:0:val0",
-		"root:1:val1", // root:1:localQueue is done
-		"root:2:1:val0",
-		"root:1:0:val1", // root:1:0:localQueue is done; no other queues in root:1, so root:1 is done as well
-		"root:2:0:val1", // root:2:0 :localQueue is done
-		"root:1:0:val2", // this is enqueued during dequeueing
-		"root:2:1:val1",
-		"root:2:1:val2", // root:2:1:localQueue is done; no other queues in root:2, so root:2 is done as well
+	queuePathItems := []queuePathItem{
+		{QueuePath{"root", "0"}, "root:0:val0"},
+		{QueuePath{"root", "1"}, "root:1:val0"},
+		{QueuePath{"root", "2"}, "root:2:val0"},
+		{QueuePath{"root", "1", "0"}, "root:1:0:val0"},
+		{QueuePath{"root", "2", "0"}, "root:2:0:val0"},
+		{QueuePath{"root", "1"}, "root:1:val1"},
+		{QueuePath{"root", "2", "1"}, "root:2:1:val0"},
+		{QueuePath{"root", "1", "0"}, "root:1:0:val1"},
+		{QueuePath{"root", "2", "0"}, "root:2:0:val1"},
+		{QueuePath{"root", "2", "1"}, "root:2:1:val1"},
+		{QueuePath{"root", "2", "1"}, "root:2:1:val2"},
+	}
+
+	// build tree by enqueueing in order
+	for _, pathItem := range queuePathItems {
+		childPath := pathItem.path[1:]
+		require.Nil(t, root.EnqueueBackByPath(childPath, pathItem.item))
+	}
+
+	// assert all expected child paths have been created; empty child path {} serves as root path
+	childQueuePaths := []QueuePath{
+		{}, {"0"}, {"1"}, {"1", "0"}, {"2"}, {"2", "0"}, {"2", "1"},
+	}
+	assert.Equal(t, len(childQueuePaths), root.NodeCount())
+	for _, childQueuePath := range childQueuePaths {
+		assert.NotNil(t, root.getNode(childQueuePath))
+	}
+
+	// check some nonexistent paths
+	assert.Nil(t, root.getNode(QueuePath{"3"}))
+	assert.Nil(t, root.getNode(QueuePath{"1", "1"}))
+	assert.Nil(t, root.getNode(QueuePath{"2", "2"}))
+
+	// queuePathItems, plus an extra item which will be enqueued during dequeueing
+	// note no queue at a given level is dequeued from twice in a row
+	// unless all others at the same level are empty down to the leaf node
+	expectedQueueOutput := []queuePathItem{
+		{QueuePath{"root", "0"}, "root:0:val0"}, // root:0:localQueue is done
+		{QueuePath{"root", "1"}, "root:1:val0"},
+		{QueuePath{"root", "2"}, "root:2:val0"}, // root:2:localQueue is done
+		{QueuePath{"root", "1", "0"}, "root:1:0:val0"},
+		{QueuePath{"root", "2", "0"}, "root:2:0:val0"},
+		{QueuePath{"root", "1"}, "root:1:val1"}, // root:1:localQueue is done
+		{QueuePath{"root", "2", "1"}, "root:2:1:val0"},
+		{QueuePath{"root", "1", "0"}, "root:1:0:val1"}, // root:1:0:localQueue is done; no other queues in root:1, so root:1 is done as well
+		{QueuePath{"root", "2", "0"}, "root:2:0:val1"}, // root:2:0:localQueue is done
+		{QueuePath{"root", "1", "0"}, "root:1:0:val2"}, // this was enqueued during dequeueing, which re-creates the deleted root:1 and its child root:1:0
+		{QueuePath{"root", "2", "1"}, "root:2:1:val1"}, // once again root:1:0:localQueue is done; no other queues in root:1, so root:1 is done as well
+		{QueuePath{"root", "2", "1"}, "root:2:1:val2"}, // root:2:1:localQueue is done; no other queues in root:2, so root:2 is done as well
 		// back up to root; its local queue is done and all childQueueOrder are done, so the full tree is done
 	}
 
-	expectedQueuePaths := []QueuePath{
-		{"root", "0"},
-		{"root", "1"},
-		{"root", "2"},
-		{"root", "1", "0"},
-		{"root", "2", "0"},
-		{"root", "1"},
-		{"root", "2", "1"},
-		{"root", "1", "0"},
-		{"root", "2", "0"},
-		{"root", "1", "0"},
-		{"root", "2", "1"},
-		{"root", "2", "1"},
-	}
-
-	var queueOutput []any
-	var queuePaths []QueuePath
+	var queueOutput []queuePathItem
 	for range expectedQueueOutput {
 		path, v := root.Dequeue()
 		if v == nil {
 			fmt.Println(path)
 			break
 		}
-		queueOutput = append(queueOutput, v)
-		queuePaths = append(queuePaths, path)
+		queueOutput = append(queueOutput, queuePathItem{path, v})
 		if v == "root:1:0:val1" {
 			// root:1 and all subqueues are completely exhausted;
 			// root:2 will be next in the rotation
 			// here we insert something new into root:1 to test that:
 			//  - the new root:1 insert does not jump the line in front of root:2
-			//  - root:2 will not be dequeued from twice in a row now that there is a value in root:1 again
+			//  - root:2 will not be dequeued from twice in a row now that there is a item in root:1 again
 			require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val2"))
 		}
 	}
 	assert.Equal(t, expectedQueueOutput, queueOutput)
-	assert.Equal(t, expectedQueuePaths, queuePaths)
 
 	// Dequeue one more time;
 	path, v := root.Dequeue()
 	assert.Nil(t, v) // assert we get nil back,
 	assert.Nil(t, path)
 	assert.True(t, root.IsEmpty()) // assert nothing in local or child queues
+}
+
+func TestDequeue(t *testing.T) {
+	root := makeTreeQueue(t)
+
+	// dequeue from root until exhausted
+	dequeuedPath, v := root.Dequeue()
+	assert.Equal(t, "root:0:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	// root:0 and any subtrees are exhausted
+	path := QueuePath{"0"}
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Nil(t, v)
+	assert.Nil(t, dequeuedPath)
+	// root:0 was deleted
+	assert.Nil(t, root.getNode(path))
+
+	dequeuedPath, v = root.Dequeue()
+	assert.Equal(t, "root:1:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.Dequeue()
+	assert.Equal(t, "root:2:0:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.Dequeue()
+	assert.Equal(t, "root:1:0:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.Dequeue()
+	assert.Equal(t, "root:2:1:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.Dequeue()
+	assert.Equal(t, "root:1:val1", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.Dequeue()
+	assert.Equal(t, "root:2:0:val1", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.Dequeue()
+	assert.Equal(t, "root:1:0:val1", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	// root:1 and any subtrees are exhausted
+	path = QueuePath{"1"}
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Nil(t, v)
+	assert.Nil(t, dequeuedPath)
+	// root:1 was deleted
+	assert.Nil(t, root.getNode(path))
+
+	dequeuedPath, v = root.Dequeue()
+	assert.Equal(t, "root:2:1:val1", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.Dequeue()
+	assert.Equal(t, "root:2:1:val2", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	// root:2 and any subtrees are exhausted
+	path = QueuePath{"2"}
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Nil(t, v)
+	assert.Nil(t, dequeuedPath)
+	// root:2 was deleted
+	assert.Nil(t, root.getNode(path))
+
+	// all items have been dequeued
+	assert.Equal(t, 0, root.ItemCount())
+
+	// final state of root
+	assert.True(t, root.IsEmpty())
+}
+
+func TestDequeuePath(t *testing.T) {
+	root := makeTreeQueue(t)
+
+	// dequeue from root:2 until exhausted
+	path := QueuePath{"2"}
+	dequeuedPath, v := root.DequeueByPath(path)
+	assert.Equal(t, "root:2:0:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:2:1:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:2:0:val1", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:2:1:val1", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:2:1:val2", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	// root:2 is exhausted;
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Nil(t, v)
+	assert.Nil(t, dequeuedPath)
+	// root:2 and its two children root:2:0 and root:2:1 were deleted
+	assert.Nil(t, root.getNode(path))
+	assert.Equal(t, 2, len(root.childQueueMap))
+	assert.Equal(t, 2, len(root.childQueueOrder))
+	assert.Equal(t, 4, root.NodeCount())
+	// 5 of 10 items were dequeued
+	assert.Equal(t, 5, root.ItemCount())
+
+	// dequeue from root:1 until exhausted
+	path = QueuePath{"1"}
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:1:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:1:0:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:1:val1", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:1:0:val1", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	// root:1 is exhausted;
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Nil(t, v)
+	assert.Nil(t, dequeuedPath)
+	// root:1 and its child root:1:0 were deleted
+	assert.Nil(t, root.getNode(path))
+	assert.Equal(t, 1, len(root.childQueueMap))
+	assert.Equal(t, 1, len(root.childQueueOrder))
+	assert.Equal(t, 2, root.NodeCount())
+	// 9 of 10 items have been dequeued
+	assert.Equal(t, 1, root.ItemCount())
+
+	// dequeue from root:0 until exhausted
+	path = QueuePath{"0"}
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Equal(t, "root:0:val0", v)
+	assertDequeuedPathValueMatch(t, dequeuedPath, v)
+
+	// root:0 is exhausted;
+	dequeuedPath, v = root.DequeueByPath(path)
+	assert.Nil(t, v)
+	assert.Nil(t, dequeuedPath)
+	// root:0 was deleted
+	assert.Nil(t, root.getNode(path))
+	assert.Equal(t, 0, len(root.childQueueMap))
+	assert.Equal(t, 0, len(root.childQueueOrder))
+	assert.Equal(t, 1, root.NodeCount())
+	// 10 of 10 items have been dequeued
+	assert.Equal(t, 0, root.ItemCount())
+
+	// final state of root
+	assert.True(t, root.IsEmpty())
 }
 
 func makeTreeQueue(t *testing.T) *TreeQueue {
@@ -220,134 +298,103 @@ func makeTreeQueue(t *testing.T) *TreeQueue {
 	require.Equal(t, 1, root.NodeCount())
 	require.Equal(t, 0, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"0"}, "root:0:val0"))
+	cache := map[string]struct{}{}
+
+	// enqueue one item to root:0
+	childPath := QueuePath{"0"}
+	item := makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 2, root.NodeCount())
 	require.Equal(t, 1, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1"}, "root:1:val0"))
+	// enqueue two items to root:1
+	childPath = QueuePath{"1"}
+	item = makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 3, root.NodeCount())
 	require.Equal(t, 2, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1"}, "root:1:val1"))
+	item = makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 3, root.NodeCount())
 	require.Equal(t, 3, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val0"))
+	// enqueue two items to root:1:0
+	childPath = QueuePath{"1", "0"}
+	item = makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 4, root.NodeCount())
 	require.Equal(t, 4, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"1", "0"}, "root:1:0:val1"))
+	item = makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 4, root.NodeCount())
 	require.Equal(t, 5, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "0"}, "root:2:0:val0"))
+	// enqueue two items to root:2:0
+	childPath = QueuePath{"2", "0"}
+	item = makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 6, root.NodeCount())
 	require.Equal(t, 6, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "0"}, "root:2:0:val1"))
+	item = makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 6, root.NodeCount())
 	require.Equal(t, 7, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val0"))
+	// enqueue three items to root:2:1
+	childPath = QueuePath{"2", "1"}
+	item = makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 7, root.NodeCount())
 	require.Equal(t, 8, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val1"))
+	item = makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 7, root.NodeCount())
 	require.Equal(t, 9, root.ItemCount())
 
-	require.NoError(t, root.EnqueueBackByPath(QueuePath{"2", "1"}, "root:2:1:val2"))
+	item = makeQueueItemForChildPath(root, childPath, cache)
+	require.NoError(t, root.EnqueueBackByPath(childPath, item))
 	require.Equal(t, 7, root.NodeCount())
 	require.Equal(t, 10, root.ItemCount())
 
 	return root
 }
 
-func TestDequeuePath(t *testing.T) {
-	root := makeTreeQueue(t)
+// makeQueueItemForChildPath constructs a queue item to match its enqueued path
+// by joining the path components and appending an incrementing value for each path.
+//
+// e.g. for a tree named "root":
+//   - childQueuePath{"1", "0"}'s first item will be "root:1:0:val0"
+//   - childQueuePath{"1", "0"}'s second item will be "root:1:0:val1"
+func makeQueueItemForChildPath(
+	treeQueue *TreeQueue, childPath QueuePath, cache map[string]struct{},
+) string {
+	path := append(QueuePath{treeQueue.name}, childPath...)
 
-	// dequeue from root:2 until exhausted
-	path := QueuePath{"2"}
-	dequeuedPath, v := root.DequeueByPath(path)
-	assert.Equal(t, "root:2:0:val0", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
+	i := 0
+	for {
+		item := strings.Join(path, ":") + fmt.Sprintf(":val%d", i)
+		if _, ok := cache[item]; !ok {
+			cache[item] = struct{}{}
+			return item
+		}
+		i++
+	}
+}
 
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Equal(t, "root:2:1:val0", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
+// assertDequeuedPathValueMatch checks a dequeued item and its dequeued path
+// to ensure the item was dequeued from the expected node of the tree, based
+// on the item being generated to match its path via makeQueueItemForChildPath
+func assertDequeuedPathValueMatch(t *testing.T, dequeuedPath QueuePath, v any) {
+	itemPath := strings.Split(v.(string), ":")
+	itemPathPrefix := itemPath[:len(itemPath)-1] // strip value from the end
 
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Equal(t, "root:2:0:val1", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
+	require.Equal(t, len(dequeuedPath), len(itemPathPrefix))
 
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Equal(t, "root:2:1:val1", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
-
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Equal(t, "root:2:1:val2", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
-
-	// root:2 is exhausted;
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Nil(t, v)
-	assert.Nil(t, dequeuedPath)
-	// root:2 and its two children root:2:0 and root:2:1 were deleted
-	assert.Nil(t, root.getNode(path))
-	assert.Equal(t, 2, len(root.childQueueMap))
-	assert.Equal(t, 2, len(root.childQueueOrder))
-	assert.Equal(t, 4, root.NodeCount())
-	// 5 of 10 items were dequeued
-	assert.Equal(t, 5, root.ItemCount())
-
-	// dequeue from root:1 until exhausted
-	path = QueuePath{"1"}
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Equal(t, "root:1:val0", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
-
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Equal(t, "root:1:0:val0", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
-
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Equal(t, "root:1:val1", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
-
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Equal(t, "root:1:0:val1", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
-
-	// root:1 is exhausted;
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Nil(t, v)
-	assert.Nil(t, dequeuedPath)
-	// root:1 and its child root:1:0 were deleted
-	assert.Nil(t, root.getNode(path))
-	assert.Equal(t, 1, len(root.childQueueMap))
-	assert.Equal(t, 1, len(root.childQueueOrder))
-	assert.Equal(t, 2, root.NodeCount())
-	// 9 of 10 items have been dequeued
-	assert.Equal(t, 1, root.ItemCount())
-
-	// dequeue from root:0 until exhausted
-	path = QueuePath{"0"}
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Equal(t, "root:0:val0", v)
-	assert.Equal(t, path, dequeuedPath[:len(path)])
-
-	// root:0 is exhausted;
-	dequeuedPath, v = root.DequeueByPath(path)
-	assert.Nil(t, v)
-	assert.Nil(t, dequeuedPath)
-	// root:0 was deleted
-	assert.Nil(t, root.getNode(path))
-	assert.Equal(t, 0, len(root.childQueueMap))
-	assert.Equal(t, 0, len(root.childQueueOrder))
-	assert.Equal(t, 1, root.NodeCount())
-	// 10 of 10 items have been dequeued
-	assert.Equal(t, 0, root.ItemCount())
-
-	// final state of root
-	assert.True(t, root.IsEmpty())
+	for i, nodeName := range dequeuedPath {
+		require.Equal(t, nodeName, itemPathPrefix[i])
+	}
 }

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const maxTestQueueLen = 8
@@ -74,10 +75,10 @@ func TestTreeQueue(t *testing.T) {
 
 	root := NewTreeQueue("root", maxTestQueueLen) // creates path: root
 
-	root.getOrAddNode([]string{"root", "0"})      // creates paths: root:0
-	root.getOrAddNode([]string{"root", "1", "0"}) // creates paths: root:1 and root:1:0
-	root.getOrAddNode([]string{"root", "2", "0"}) // creates paths: root:2 and root:2:0
-	root.getOrAddNode([]string{"root", "2", "1"}) // creates paths: root:2:1 only, as root:2 already exists
+	_, _ = root.getOrAddNode([]string{"root", "0"})      // creates paths: root:0
+	_, _ = root.getOrAddNode([]string{"root", "1", "0"}) // creates paths: root:1 and root:1:0
+	_, _ = root.getOrAddNode([]string{"root", "2", "0"}) // creates paths: root:2 and root:2:0
+	_, _ = root.getOrAddNode([]string{"root", "2", "1"}) // creates paths: root:2:1 only, as root:2 already exists
 
 	assert.Equal(t, expectedTreeQueue, root)
 
@@ -112,17 +113,17 @@ func TestTreeQueue(t *testing.T) {
 	assert.Nil(t, child)
 
 	// enqueue in order
-	root.EnqueueBackByPath([]string{"root", "0"}, "root:0:val0")
-	root.EnqueueBackByPath([]string{"root", "1"}, "root:1:val0")
-	root.EnqueueBackByPath([]string{"root", "1"}, "root:1:val1")
-	root.EnqueueBackByPath([]string{"root", "2"}, "root:2:val0")
-	root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val0")
-	root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val1")
-	root.EnqueueBackByPath([]string{"root", "2", "0"}, "root:2:0:val0")
-	root.EnqueueBackByPath([]string{"root", "2", "0"}, "root:2:0:val1")
-	root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val0")
-	root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val1")
-	root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val2")
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "0"}, "root:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "1"}, "root:1:val0"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "1"}, "root:1:val1"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2"}, "root:2:val0"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val1"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "0"}, "root:2:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "0"}, "root:2:0:val1"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val0"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val1"))
+	require.NoError(t, root.EnqueueBackByPath([]string{"root", "2", "1"}, "root:2:1:val2"))
 
 	// note no queue at a given level is dequeued from twice in a row
 	// unless all others at the same level are empty down to the leaf node
@@ -173,7 +174,7 @@ func TestTreeQueue(t *testing.T) {
 			// here we insert something new into root:1 to test that:
 			//  - the new root:1 insert does not jump the line in front of root:2
 			//  - root:2 will not be dequeued from twice in a row now that there is a value in root:1 again
-			root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val2")
+			require.NoError(t, root.EnqueueBackByPath([]string{"root", "1", "0"}, "root:1:0:val2"))
 		}
 	}
 	assert.Equal(t, expectedQueueOutput, queueOutput)
@@ -188,17 +189,17 @@ func TestTreeQueue(t *testing.T) {
 
 func TestDequeuePath(t *testing.T) {
 	root := NewTreeQueue("root", maxTestQueueLen)
-	root.EnqueueBackByPath(QueuePath{"root", "0"}, "root:0:val0")
-	root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val0")
-	root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val1")
-	root.EnqueueBackByPath(QueuePath{"root", "2"}, "root:2:val0")
-	root.EnqueueBackByPath(QueuePath{"root", "1", "0"}, "root:1:0:val0")
-	root.EnqueueBackByPath(QueuePath{"root", "1", "0"}, "root:1:0:val1")
-	root.EnqueueBackByPath(QueuePath{"root", "2", "0"}, "root:2:0:val0")
-	root.EnqueueBackByPath(QueuePath{"root", "2", "0"}, "root:2:0:val1")
-	root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val0")
-	root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val1")
-	root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val2")
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "0"}, "root:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "1"}, "root:1:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2"}, "root:2:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "1", "0"}, "root:1:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "1", "0"}, "root:1:0:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "0"}, "root:2:0:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "0"}, "root:2:0:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val0"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val1"))
+	require.NoError(t, root.EnqueueBackByPath(QueuePath{"root", "2", "1"}, "root:2:1:val2"))
 
 	path := QueuePath{"root", "2"}
 	dequeuedPath, v := root.DequeueByPath(path)

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -31,8 +31,8 @@ func TestDequeueBalancedTree(t *testing.T) {
 	dequeuedPathCache := make([]QueuePath, rotationsBeforeRepeat)
 
 	for !root.IsEmpty() {
-		dequeuedPath, v := root.Dequeue()
-		assertDequeuedPathValueMatch(t, dequeuedPath, v)
+		v := root.Dequeue()
+		dequeuedPath := getChildPathFromQueueItem(v)
 
 		// assert dequeued path has not repeated before the expected number of rotations
 		for _, previousDequeuedPath := range dequeuedPathCache {
@@ -73,8 +73,8 @@ func TestDequeueByPathBalancedTree(t *testing.T) {
 	for _, firstDimName := range firstDimensions {
 		firstDimPath := QueuePath{firstDimName}
 		for root.getNode(firstDimPath) != nil {
-			dequeuedPath, v := root.DequeueByPath(firstDimPath)
-			assertDequeuedPathValueMatch(t, dequeuedPath, v)
+			v := root.DequeueByPath(firstDimPath)
+			dequeuedPath := getChildPathFromQueueItem(v)
 
 			// assert dequeued path has not repeated before the expected number of rotations
 			for _, previousDequeuedPath := range dequeuedPathCache {
@@ -103,67 +103,54 @@ func TestDequeueUnbalancedTree(t *testing.T) {
 	root := makeUnbalancedTreeQueue(t)
 
 	// dequeue from root until exhausted
-	dequeuedPath, v := root.Dequeue()
+	v := root.Dequeue()
 	assert.Equal(t, "root:0:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
 	// root:0 and any subtrees are exhausted
 	path := QueuePath{"0"}
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Nil(t, v)
-	assert.Nil(t, dequeuedPath)
 	// root:0 was deleted
 	assert.Nil(t, root.getNode(path))
 
-	dequeuedPath, v = root.Dequeue()
+	v = root.Dequeue()
 	assert.Equal(t, "root:1:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.Dequeue()
+	v = root.Dequeue()
 	assert.Equal(t, "root:2:0:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.Dequeue()
+	v = root.Dequeue()
 	assert.Equal(t, "root:1:0:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.Dequeue()
+	v = root.Dequeue()
 	assert.Equal(t, "root:2:1:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.Dequeue()
+	v = root.Dequeue()
 	assert.Equal(t, "root:1:val1", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.Dequeue()
+	v = root.Dequeue()
 	assert.Equal(t, "root:2:0:val1", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.Dequeue()
+	v = root.Dequeue()
 	assert.Equal(t, "root:1:0:val1", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
 	// root:1 and any subtrees are exhausted
 	path = QueuePath{"1"}
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Nil(t, v)
-	assert.Nil(t, dequeuedPath)
 	// root:1 was deleted
 	assert.Nil(t, root.getNode(path))
 
-	dequeuedPath, v = root.Dequeue()
+	v = root.Dequeue()
 	assert.Equal(t, "root:2:1:val1", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.Dequeue()
+	v = root.Dequeue()
 	assert.Equal(t, "root:2:1:val2", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
 	// root:2 and any subtrees are exhausted
 	path = QueuePath{"2"}
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Nil(t, v)
-	assert.Nil(t, dequeuedPath)
 	// root:2 was deleted
 	assert.Nil(t, root.getNode(path))
 
@@ -185,30 +172,24 @@ func TestDequeueByPathUnbalancedTree(t *testing.T) {
 
 	// dequeue from root:2 until exhausted
 	path := QueuePath{"2"}
-	dequeuedPath, v := root.DequeueByPath(path)
+	v := root.DequeueByPath(path)
 	assert.Equal(t, "root:2:0:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Equal(t, "root:2:1:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Equal(t, "root:2:0:val1", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Equal(t, "root:2:1:val1", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Equal(t, "root:2:1:val2", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
 	// root:2 is exhausted;
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Nil(t, v)
-	assert.Nil(t, dequeuedPath)
 	// root:2 and its two children root:2:0 and root:2:1 were deleted
 	assert.Nil(t, root.getNode(path))
 	assert.Equal(t, 2, len(root.childQueueMap))
@@ -219,26 +200,21 @@ func TestDequeueByPathUnbalancedTree(t *testing.T) {
 
 	// dequeue from root:1 until exhausted
 	path = QueuePath{"1"}
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Equal(t, "root:1:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Equal(t, "root:1:0:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Equal(t, "root:1:val1", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Equal(t, "root:1:0:val1", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
 	// root:1 is exhausted;
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Nil(t, v)
-	assert.Nil(t, dequeuedPath)
 	// root:1 and its child root:1:0 were deleted
 	assert.Nil(t, root.getNode(path))
 	assert.Equal(t, 1, len(root.childQueueMap))
@@ -249,14 +225,12 @@ func TestDequeueByPathUnbalancedTree(t *testing.T) {
 
 	// dequeue from root:0 until exhausted
 	path = QueuePath{"0"}
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Equal(t, "root:0:val0", v)
-	assertDequeuedPathValueMatch(t, dequeuedPath, v)
 
 	// root:0 is exhausted;
-	dequeuedPath, v = root.DequeueByPath(path)
+	v = root.DequeueByPath(path)
 	assert.Nil(t, v)
-	assert.Nil(t, dequeuedPath)
 	// root:0 was deleted
 	assert.Nil(t, root.getNode(path))
 	assert.Equal(t, 0, len(root.childQueueMap))
@@ -297,18 +271,21 @@ func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 	assert.Equal(t, []string{"0", "1", "2"}, root.childQueueOrder)
 
 	// dequeue first item
-	dequeuedPath, _ := root.Dequeue()
-	assert.Equal(t, QueuePath{"root", "0"}, dequeuedPath)
+	v := root.Dequeue()
+	dequeuedPath := getChildPathFromQueueItem(v)
+	assert.Equal(t, QueuePath{"0"}, dequeuedPath)
 
 	// dequeue second item; root:1 is now exhausted and deleted
-	dequeuedPath, _ = root.Dequeue()
-	assert.Equal(t, QueuePath{"root", "1"}, dequeuedPath)
+	v = root.Dequeue()
+	dequeuedPath = getChildPathFromQueueItem(v)
+	assert.Equal(t, QueuePath{"1"}, dequeuedPath)
 	assert.Nil(t, root.getNode(QueuePath{"1"}))
 	assert.Equal(t, []string{"0", "2"}, root.childQueueOrder)
 
 	// dequeue third item
-	dequeuedPath, _ = root.Dequeue()
-	assert.Equal(t, QueuePath{"root", "2"}, dequeuedPath)
+	v = root.Dequeue()
+	dequeuedPath = getChildPathFromQueueItem(v)
+	assert.Equal(t, QueuePath{"2"}, dequeuedPath)
 
 	// root:1 was previously exhausted; root:0, then root:2 will be next in the rotation
 	// here we insert something new into root:1 to test that it
@@ -320,17 +297,20 @@ func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 
 	// dequeue fourth item; the newly-enqueued root:1 item
 	// has not jumped the line in front of root:0
-	dequeuedPath, _ = root.Dequeue()
-	assert.Equal(t, QueuePath{"root", "0"}, dequeuedPath)
+	v = root.Dequeue()
+	dequeuedPath = getChildPathFromQueueItem(v)
+	assert.Equal(t, QueuePath{"0"}, dequeuedPath)
 
 	// dequeue fifth item; the newly-enqueued root:1 item
 	// has not jumped the line in front of root:2
-	dequeuedPath, _ = root.Dequeue()
-	assert.Equal(t, QueuePath{"root", "2"}, dequeuedPath)
+	v = root.Dequeue()
+	dequeuedPath = getChildPathFromQueueItem(v)
+	assert.Equal(t, QueuePath{"2"}, dequeuedPath)
 
 	// dequeue sixth item; verifying the order 0->2->1 is being followed
-	dequeuedPath, _ = root.Dequeue()
-	assert.Equal(t, QueuePath{"root", "1"}, dequeuedPath)
+	v = root.Dequeue()
+	dequeuedPath = getChildPathFromQueueItem(v)
+	assert.Equal(t, QueuePath{"1"}, dequeuedPath)
 
 	// all items have been dequeued
 	assert.Equal(t, 0, root.ItemCount())
@@ -491,16 +471,10 @@ func makeQueueItemForChildPath(
 	}
 }
 
-// assertDequeuedPathValueMatch checks a dequeued item and its dequeued path
-// to ensure the item was dequeued from the expected node of the tree, based
-// on the item being generated to match its path via makeQueueItemForChildPath
-func assertDequeuedPathValueMatch(t *testing.T, dequeuedPath QueuePath, v any) {
+// getChildPathFromQueueItem enables assertions on the queue path the item was dequeued from.
+// Assertions require that the queue item value was generated via makeQueueItemForChildPath.
+func getChildPathFromQueueItem(v any) QueuePath {
 	itemPath := strings.Split(v.(string), ":")
-	itemPathPrefix := itemPath[:len(itemPath)-1] // strip value from the end
-
-	require.Equal(t, len(dequeuedPath), len(itemPathPrefix))
-
-	for i, nodeName := range dequeuedPath {
-		require.Equal(t, nodeName, itemPathPrefix[i])
-	}
+	itemPathPrefix := itemPath[1 : len(itemPath)-1] // strip value from the end
+	return itemPathPrefix
 }

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package queue
 
 import (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR introduces the recursive, multi-dimensional TreeQueue data structure for the query scheduler queue.
 Previously introduced in Loki, this tree structure allows for fair round-robin dequeuing from arbitrarily-nested queue dimensions.

In this PR, we do _not_ implement the planned two-dimensional queuing, where we will queue requests by (tenant, query component) where query component is ingester, store-gateway, or both.
For now we just are doing a lift and shift from the existing data structure (just a mapping of tenant ID to a linked list queue) to an equivalent single-dimensional queue using a TreeQueue of depth 1, where the single queueing dimension. is still just the tenant ID

Subsequent PRs will introduce the second queueing dimension based on which components the query will hit.

TODO: changelog, but will hold for feedback

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
