### PR TITLE
distributor: check for inflight bytes before reading httpgrpc message without message size in metadata.

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1028,7 +1028,7 @@ type requestState struct {
 }
 
 func (d *Distributor) StartPushRequest(ctx context.Context, httpgrpcRequestSize int64) (context.Context, error) {
-	ctx, _, err := d.startPushRequest(ctx, httpgrpcRequestSize)
+	ctx, _, err := d.startPushRequest(ctx, true, httpgrpcRequestSize)
 	return ctx, err
 }
 
@@ -1043,7 +1043,7 @@ func (d *Distributor) StartPushRequest(ctx context.Context, httpgrpcRequestSize 
 // This method creates requestState object and stores it in the context.
 // This object describes which checks were already performed on the request,
 // and which component is responsible for doing a cleanup.
-func (d *Distributor) startPushRequest(ctx context.Context, httpgrpcRequestSize int64) (context.Context, *requestState, error) {
+func (d *Distributor) startPushRequest(ctx context.Context, checkInflightBytesForUnknownHttpgrpcRequestSize bool, httpgrpcRequestSize int64) (context.Context, *requestState, error) {
 	// If requestState is already in context, it means that StartPushRequest already ran for this request.
 	rs, alreadyInContext := ctx.Value(requestStateKey).(*requestState)
 	if alreadyInContext {
@@ -1077,7 +1077,16 @@ func (d *Distributor) startPushRequest(ctx context.Context, httpgrpcRequestSize 
 
 	// If we know the httpgrpcRequestSize, we can check it.
 	if httpgrpcRequestSize > 0 {
-		if err := d.checkHttpgrpcRequestSize(rs, httpgrpcRequestSize); err != nil {
+		rs.httpgrpcRequestSize = httpgrpcRequestSize
+		inflightBytes := d.inflightPushRequestsBytes.Add(httpgrpcRequestSize)
+
+		if err := d.checkInflightBytes(inflightBytes, false); err != nil {
+			return ctx, nil, err
+		}
+	} else if checkInflightBytesForUnknownHttpgrpcRequestSize {
+		// If we don't know httpgrpcRequestSize, we can at least check if distributor already has too many inflight bytes.
+		inflightBytes := d.inflightPushRequestsBytes.Load()
+		if err := d.checkInflightBytes(inflightBytes, true); err != nil {
 			return ctx, nil, err
 		}
 	}
@@ -1088,17 +1097,6 @@ func (d *Distributor) startPushRequest(ctx context.Context, httpgrpcRequestSize 
 	return ctx, rs, nil
 }
 
-func (d *Distributor) checkHttpgrpcRequestSize(rs *requestState, httpgrpcRequestSize int64) error {
-	// If httpgrpcRequestSize was already checked, don't check it again.
-	if rs.httpgrpcRequestSize > 0 {
-		return nil
-	}
-
-	rs.httpgrpcRequestSize = httpgrpcRequestSize
-	inflightBytes := d.inflightPushRequestsBytes.Add(httpgrpcRequestSize)
-	return d.checkInflightBytes(inflightBytes)
-}
-
 func (d *Distributor) checkWriteRequestSize(rs *requestState, writeRequestSize int64) error {
 	// If writeRequestSize was already checked, don't check it again.
 	if rs.writeRequestSize > 0 {
@@ -1107,15 +1105,17 @@ func (d *Distributor) checkWriteRequestSize(rs *requestState, writeRequestSize i
 
 	rs.writeRequestSize = writeRequestSize
 	inflightBytes := d.inflightPushRequestsBytes.Add(writeRequestSize)
-	return d.checkInflightBytes(inflightBytes)
+	return d.checkInflightBytes(inflightBytes, false)
 }
 
-func (d *Distributor) checkInflightBytes(inflightBytes int64) error {
+func (d *Distributor) checkInflightBytes(inflightBytes int64, rejectEqualInflightBytes bool) error {
 	il := d.getInstanceLimits()
 
-	if il.MaxInflightPushRequestsBytes > 0 && inflightBytes > int64(il.MaxInflightPushRequestsBytes) {
-		d.rejectedRequests.WithLabelValues(reasonDistributorMaxInflightPushRequestsBytes).Inc()
-		return errMaxInflightRequestsBytesReached
+	if il.MaxInflightPushRequestsBytes > 0 {
+		if (rejectEqualInflightBytes && inflightBytes >= int64(il.MaxInflightPushRequestsBytes)) || inflightBytes > int64(il.MaxInflightPushRequestsBytes) {
+			d.rejectedRequests.WithLabelValues(reasonDistributorMaxInflightPushRequestsBytes).Inc()
+			return errMaxInflightRequestsBytesReached
+		}
 	}
 	return nil
 }
@@ -1149,7 +1149,7 @@ func (d *Distributor) cleanupAfterPushFinished(rs *requestState) {
 func (d *Distributor) limitsMiddleware(next PushFunc) PushFunc {
 	return func(ctx context.Context, pushReq *Request) error {
 		// We don't know request size yet, will check it later.
-		ctx, rs, err := d.startPushRequest(ctx, -1)
+		ctx, rs, err := d.startPushRequest(ctx, false, -1)
 		if err != nil {
 			return middleware.DoNotLogError{Err: err}
 		}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -5081,11 +5081,30 @@ func TestStartFinishRequest(t *testing.T) {
 			expectedPushError:              errMaxInflightRequestsBytesReached,
 		},
 
-		"too many inflight bytes requests, external": {
+		"too many inflight bytes requests, external check, unknown httpgrpc size, under bytes limit": {
 			externalCheck:                  true,
+			httpgrpcRequestSize:            0,
 			inflightRequestsBeforePush:     1,
-			inflightRequestsSizeBeforePush: 2 * inflightBytesLimit,
-			expectedStartError:             nil, // httpgrpc request size is not set when calling StartPushRequest, so it's not checked.
+			inflightRequestsSizeBeforePush: inflightBytesLimit - 1,
+			expectedStartError:             nil,
+			expectedPushError:              errMaxInflightRequestsBytesReached,
+		},
+
+		"too many inflight bytes requests, external check, unknown httpgrpc size, at bytes limit": {
+			externalCheck:                  true,
+			httpgrpcRequestSize:            0,
+			inflightRequestsBeforePush:     1,
+			inflightRequestsSizeBeforePush: inflightBytesLimit,
+			expectedStartError:             errMaxInflightRequestsBytesReached,
+			expectedPushError:              errMaxInflightRequestsBytesReached,
+		},
+
+		"too many inflight bytes requests, external check, unknown httpgrpc size, over bytes limit": {
+			externalCheck:                  true,
+			httpgrpcRequestSize:            0,
+			inflightRequestsBeforePush:     1,
+			inflightRequestsSizeBeforePush: inflightBytesLimit + 1,
+			expectedStartError:             errMaxInflightRequestsBytesReached,
 			expectedPushError:              errMaxInflightRequestsBytesReached,
 		},
 


### PR DESCRIPTION
#### What this PR does

This is enhancement of #6300, this PR rejects push requests coming from httpgrpc if Distributor is already at inflight-bytes limit. Previously this check would be skipped if gRPC message did not pass request size.

This was pointed out for ingesters in https://github.com/grafana/mimir/pull/6492#discussion_r1374794024, and distributors had the same bug.

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
