### PR TITLE
mimir-build-image: Upgrade to google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr9491-80f5778956
+LATEST_BUILD_IMAGE_TAG ?= pr6541-2edf665d50
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -48,7 +48,7 @@ RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers
 
 RUN GO111MODULE=on \
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \
-	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 && \
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0 && \
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 && \
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
 	go install github.com/fatih/faillint@v1.12.0 && \


### PR DESCRIPTION
#### What this PR does

Upgrade build image to google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0, since github.com/golang/protobuf/protoc-gen-go is deprecated.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
