### PR TITLE
Exclude vector queries from being counted in metric for rules with zero fetched series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [CHANGE] Ingester: Increase default value of `-blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes` and `-blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes` to 100 MiB (previous default value was 10 MiB). #6764
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766
+* [ENHANCEMENT] Ruler: exclude vector queries from being tracked in `cortex_ruler_queries_zero_fetched_series_total`. #6544
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766
@@ -80,7 +81,7 @@
 * [ENHANCEMENT] Store-gateway: add metric `cortex_bucket_store_blocks_loaded_by_duration` for counting the loaded number of blocks based on their duration. #6074  #6129
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
-* [ENHANCEMENT] Ruler: add new per-tenant `cortex_ruler_queries_zero_fetched_series_total` metric to track rules that fetched no series. #5925 #6544
+* [ENHANCEMENT] Ruler: add new per-tenant `cortex_ruler_queries_zero_fetched_series_total` metric to track rules that fetched no series. #5925
 * [ENHANCEMENT] Implement support for `limit`, `limit_per_metric` and `metric` parameters for `<Prometheus HTTP prefix>/api/v1/metadata` endpoint. #5890
 * [ENHANCEMENT] Distributor: add experimental support for storing metadata when ingesting metrics via OTLP. This makes metrics description and type available when ingesting metrics via OTLP. Enable with `-distributor.enable-otlp-metadata-storage=true`. #5693 #6035 #6254
 * [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. All the discarded samples will still be tracked by the `cortex_discarded_samples_total` metric. #5584 #6014

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
 * [ENHANCEMENT] Store-gateway: add metric `cortex_bucket_store_blocks_loaded_by_duration` for counting the loaded number of blocks based on their duration. #6074  #6129
 * [ENHANCEMENT] Expose `/sync/mutex/wait/total:seconds` Go runtime metric as `go_sync_mutex_wait_total_seconds_total` from all components. #5879
 * [ENHANCEMENT] Query-scheduler: improve latency with many concurrent queriers. #5880
-* [ENHANCEMENT] Ruler: add new per-tenant `cortex_ruler_queries_zero_fetched_series_total` metric to track rules that fetched no series. #5925
+* [ENHANCEMENT] Ruler: add new per-tenant `cortex_ruler_queries_zero_fetched_series_total` metric to track rules that fetched no series. #5925 #6544
 * [ENHANCEMENT] Implement support for `limit`, `limit_per_metric` and `metric` parameters for `<Prometheus HTTP prefix>/api/v1/metadata` endpoint. #5890
 * [ENHANCEMENT] Distributor: add experimental support for storing metadata when ingesting metrics via OTLP. This makes metrics description and type available when ingesting metrics via OTLP. Enable with `-distributor.enable-otlp-metadata-storage=true`. #5693 #6035 #6254
 * [ENHANCEMENT] Ingester: added support for sampling errors, which can be enabled by setting `-ingester.error-sample-rate`. This way each error will be logged once in the configured number of times. All the discarded samples will still be tracked by the `cortex_discarded_samples_total` metric. #5584 #6014

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -694,9 +694,57 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 
 		deleteRuleAndWait(groupName)
 
-		const groupName2 = "good_rule_with_no_fetched_series_and_no_samples"
-		const expression2 = `sum(metric{foo="10000"})`
+		const groupName2 = "good_rule_with_fetched_series_and_samples"
+		const expression2 = `sum(metric{foo=~"1|2"})`
 		addNewRuleAndWait(groupName2, expression2, false)
+
+		// Ensure that samples were returned.
+		sum, err = ruler.SumMetrics([]string{"cortex_prometheus_last_evaluation_samples"})
+		require.NoError(t, err)
+		require.Less(t, float64(0), sum[0])
+
+		// Ensure that the metric for no fetched series was not incremented.
+		sum, err = ruler.SumMetrics([]string{"cortex_ruler_queries_zero_fetched_series_total"})
+		require.NoError(t, err)
+		require.Equal(t, float64(0), sum[0])
+
+		deleteRuleAndWait(groupName2)
+
+		const groupName3 = "good_rule_with_no_series_selector"
+		const expression3 = `vector(1.2345)`
+		addNewRuleAndWait(groupName3, expression3, false)
+
+		// Ensure that samples were returned.
+		sum, err = ruler.SumMetrics([]string{"cortex_prometheus_last_evaluation_samples"})
+		require.NoError(t, err)
+		require.Less(t, float64(0), sum[0])
+
+		// Ensure that the metric for no fetched series was not incremented.
+		sum, err = ruler.SumMetrics([]string{"cortex_ruler_queries_zero_fetched_series_total"})
+		require.NoError(t, err)
+		require.Equal(t, float64(0), sum[0])
+
+		deleteRuleAndWait(groupName3)
+
+		const groupName4 = "good_rule_with_fetched_series_and_samples_and_non_series_selector"
+		const expression4 = `sum(metric{foo=~"1|2"}) + vector(1.2345)`
+		addNewRuleAndWait(groupName4, expression4, false)
+
+		// Ensure that samples were returned.
+		sum, err = ruler.SumMetrics([]string{"cortex_prometheus_last_evaluation_samples"})
+		require.NoError(t, err)
+		require.Less(t, float64(0), sum[0])
+
+		// Ensure that the metric for no fetched series was not incremented.
+		sum, err = ruler.SumMetrics([]string{"cortex_ruler_queries_zero_fetched_series_total"})
+		require.NoError(t, err)
+		require.Equal(t, float64(0), sum[0])
+
+		deleteRuleAndWait(groupName4)
+
+		const groupName5 = "good_rule_with_no_fetched_series_and_no_samples_and_non_series_selector"
+		const expression5 = `sum(metric{foo="10000"}) + vector(1.2345)`
+		addNewRuleAndWait(groupName5, expression5, false)
 
 		// Ensure that no samples were returned.
 		sum, err = ruler.SumMetrics([]string{"cortex_prometheus_last_evaluation_samples"})
@@ -707,6 +755,22 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 		sum, err = ruler.SumMetrics([]string{"cortex_ruler_queries_zero_fetched_series_total"})
 		require.NoError(t, err)
 		require.Equal(t, float64(1), sum[0])
+
+		deleteRuleAndWait(groupName5)
+
+		const groupName6 = "good_rule_with_no_fetched_series_and_no_samples"
+		const expression6 = `sum(metric{foo="10000"})`
+		addNewRuleAndWait(groupName6, expression6, false)
+
+		// Ensure that no samples were returned.
+		sum, err = ruler.SumMetrics([]string{"cortex_prometheus_last_evaluation_samples"})
+		require.NoError(t, err)
+		require.Equal(t, float64(0), sum[0])
+
+		// Ensure that the metric for no fetched series was incremented.
+		sum, err = ruler.SumMetrics([]string{"cortex_ruler_queries_zero_fetched_series_total"})
+		require.NoError(t, err)
+		require.Equal(t, float64(2), sum[0])
 	})
 
 	// Now let's stop ingester, and recheck metrics. This should increase cortex_ruler_queries_failed_total failures.

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -211,12 +211,12 @@ func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedS
 			queryTime.Add(wallTime.Seconds())
 			// Do not count queries with errors for zero fetched series, or queries
 			// with no selectors that are not meant to fetch any series.
-			var hasSelector bool
-			if expr, err := parser.ParseExpr(qs); err == nil {
-				hasSelector = len(parser.ExtractSelectors(expr)) > 0
-			}
-			if err == nil && numSeries == 0 && hasSelector {
-				zeroFetchedSeriesCount.Add(1)
+			if err == nil && numSeries == 0 {
+				if expr, err := parser.ParseExpr(qs); err == nil {
+					if len(parser.ExtractSelectors(expr)) > 0 {
+						zeroFetchedSeriesCount.Add(1)
+					}
+				}
 			}
 
 			// Log ruler query stats.

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -213,10 +213,7 @@ func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedS
 			// with no selectors that are not meant to fetch any series.
 			var hasSelector bool
 			if expr, err := parser.ParseExpr(qs); err == nil {
-				for range parser.ExtractSelectors(expr) {
-					hasSelector = true
-					break
-				}
+				hasSelector = len(parser.ExtractSelectors(expr)) > 0
 			}
 			if err == nil && numSeries == 0 && hasSelector {
 				zeroFetchedSeriesCount.Add(1)

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -354,21 +354,39 @@ func TestRecordAndReportRuleQueryMetrics(t *testing.T) {
 	}
 	qf := RecordAndReportRuleQueryMetrics(mockFunc, queryTime.WithLabelValues("userID"), zeroFetchedSeriesCount.WithLabelValues("userID"), log.NewNopLogger())
 
+	// Ensure we start with counters at 0.
+	require.LessOrEqual(t, float64(0), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
+	require.Equal(t, float64(0), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
+
+	// Increment zeroFetchedSeriesCount for non-existent series.
 	_, _ = qf(context.Background(), "test", time.Now())
 	require.LessOrEqual(t, float64(1), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
 	require.Equal(t, float64(1), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
 
-	_, _ = qf(context.Background(), "test", time.Now())
+	// Increment zeroFetchedSeriesCount for another non-existent series.
+	_, _ = qf(context.Background(), "test2", time.Now())
 	require.LessOrEqual(t, float64(2), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
 	require.Equal(t, float64(2), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
 
+	// Don't increment zeroFetchedSeriesCount for query without series selectors.
 	_, _ = qf(context.Background(), "vector(0.995)", time.Now())
-	require.LessOrEqual(t, float64(2), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
+	require.LessOrEqual(t, float64(3), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
 	require.Equal(t, float64(2), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
 
+	// Don't increment zeroFetchedSeriesCount for another query without series selectors.
 	_, _ = qf(context.Background(), "vector(2.4192e+15 / 1e+09)", time.Now())
-	require.LessOrEqual(t, float64(2), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
+	require.LessOrEqual(t, float64(4), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
 	require.Equal(t, float64(2), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
+
+	// Increment zeroFetchedSeriesCount for non-existent series even when combined with a non-series selector.
+	_, _ = qf(context.Background(), "test + vector(0.995)", time.Now())
+	require.LessOrEqual(t, float64(5), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
+	require.Equal(t, float64(3), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
+
+	// Don't increment zeroFetchedSeriesCount for queries with errors.
+	_, _ = qf(context.Background(), "rate(test)", time.Now())
+	require.LessOrEqual(t, float64(6), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
+	require.Equal(t, float64(3), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
 }
 
 // TestManagerFactory_CorrectQueryableUsed ensures that when evaluating a group with non-empty SourceTenants

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -361,6 +361,14 @@ func TestRecordAndReportRuleQueryMetrics(t *testing.T) {
 	_, _ = qf(context.Background(), "test", time.Now())
 	require.LessOrEqual(t, float64(2), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
 	require.Equal(t, float64(2), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
+
+	_, _ = qf(context.Background(), "vector(0.995)", time.Now())
+	require.LessOrEqual(t, float64(2), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
+	require.Equal(t, float64(2), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
+
+	_, _ = qf(context.Background(), "vector(2.4192e+15 / 1e+09)", time.Now())
+	require.LessOrEqual(t, float64(2), testutil.ToFloat64(queryTime.WithLabelValues("userID")))
+	require.Equal(t, float64(2), testutil.ToFloat64(zeroFetchedSeriesCount.WithLabelValues("userID")))
 }
 
 // TestManagerFactory_CorrectQueryableUsed ensures that when evaluating a group with non-empty SourceTenants


### PR DESCRIPTION
#### What this PR does

We have a counter metric that tracks rules with zero fetched series. This PR excludes queries that are just `vector(number)` from being counted in there, as those are not expected to fetch any series and are not an indication of late data that may affect the rules.

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/5925

#### Checklist

- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`