### PR TITLE
Add new internal alert on metric to track ruler queries with zero fetched series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [ENHANCEMENT] Add connection-string option, `-<prefix>.azure.connection-string`, for Azure Blob Storage. #6487
 * [ENHANCEMENT] Ingester: Add `-ingester.instance-limits.max-inflight-push-requests-bytes`. This limit protects the ingester against requests that together may cause an OOM. #6492
 * [ENHANCEMENT] Ingester: add new per-tenant `cortex_ingester_local_limits` metric to expose the calculated local per-tenant limits seen at each ingester. Exports the local per-tenant series limit with label `{limit="max_global_series_per_user"}` #6403
+* [ENHANCEMENT] Add new internal alert on `cortex_ruler_queries_zero_fetched_series_total` and update runbook. #6546
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145
 * [BUGFIX] Ingester: prevent query logic from continuing to execute after queries are canceled. #6085

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -371,6 +371,15 @@ How to **investigate**:
   - **High latency**
     - Check the `Mimir / Remote ruler reads resources` dashboard to see if CPU or Memory usage increased unexpectedly
 
+### MimirRulerZeroFetchedSeriesQueries
+
+This alert fires when the per-tenant `cortex_ruler_queries_zero_fetched_series_total` counter goes up significantly, meaning that there are rules with queries that fetched no series, indicating that there could be late data affecting the rules, which could potentially result in alerts not firing when they should.
+
+How to **investigate**:
+
+- Search the logs for `{cluster="<CLUSTER>", namespace="<NAMESPACE>", container="ruler"} |= `query stats`|=`user=<USER>`|=`fetched_series_count=0`` to find the affected query.
+- Alternatively, search `{cluster="<CLUSTER>", namespace="<NAMESPACE>", container="ruler-query-frontend"} |= `query stats`|=`user=<USER>`|=`fetched_series_count=0`|=`response_size_bytes=4``. This is not the one that is used by the metric, but contains more info for investigation.
+
 ### MimirIngesterHasNotShippedBlocks
 
 This alert fires when a Mimir ingester is not uploading any block to the long-term storage. An ingester is expected to upload a block to the storage every block range period (defaults to 2h) and if a longer time elapse since the last successful upload it means something is not working correctly.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -485,6 +485,16 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: MimirRulerZeroFetchedSeriesQueries
+      annotations:
+        message: |
+          Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} have {{ printf "%.2f" $value }}% occurrences of queries fetching zero series, meaning the data could be late and potentially preventing alerts from firing.
+        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerzerofetchedseriesqueries
+      expr: |
+        sum by(cluster, namespace) (rate(cortex_ruler_queries_zero_fetched_series_total[1m])) > 0
+      for: 5m
+      labels:
+        severity: warning
   - name: gossip_alerts
     rules:
     - alert: MimirGossipMembersMismatch

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -463,6 +463,16 @@ groups:
     for: 5m
     labels:
       severity: warning
+  - alert: MimirRulerZeroFetchedSeriesQueries
+    annotations:
+      message: |
+        Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} have {{ printf "%.2f" $value }}% occurrences of queries fetching zero series, meaning the data could be late and potentially preventing alerts from firing.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerzerofetchedseriesqueries
+    expr: |
+      sum by(cluster, namespace) (rate(cortex_ruler_queries_zero_fetched_series_total[1m])) > 0
+    for: 5m
+    labels:
+      severity: warning
 - name: gossip_alerts
   rules:
   - alert: MimirGossipMembersMismatch

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -473,6 +473,16 @@ groups:
     for: 5m
     labels:
       severity: warning
+  - alert: MimirRulerZeroFetchedSeriesQueries
+    annotations:
+      message: |
+        Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} have {{ printf "%.2f" $value }}% occurrences of queries fetching zero series, meaning the data could be late and potentially preventing alerts from firing.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerzerofetchedseriesqueries
+    expr: |
+      sum by(cluster, namespace) (rate(cortex_ruler_queries_zero_fetched_series_total[1m])) > 0
+    for: 5m
+    labels:
+      severity: warning
 - name: gossip_alerts
   rules:
   - alert: MimirGossipMembersMismatch

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -692,6 +692,21 @@ local utils = import 'mixin-utils/utils.libsonnet';
             ||| % $._config,
           },
         },
+        {
+          alert: $.alertName('RulerZeroFetchedSeriesQueries'),
+          expr: |||
+            sum by(%(alert_aggregation_labels)s) (rate(cortex_ruler_queries_zero_fetched_series_total[1m])) > 0
+          ||| % $._config,
+          'for': '5m',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: |||
+              %(product)s rulers in %(alert_aggregation_variables)s have {{ printf "%%.2f" $value }}%% occurrences of queries fetching zero series, meaning the data could be late and potentially preventing alerts from firing.
+            ||| % $._config,
+          },
+        },
       ],
     },
     {


### PR DESCRIPTION
#### What this PR does

See title. This will be a warning for now for testing, meant to alert us if we have late data that may affect rules so we can look into them and try to fix any issues.

Leave as draft for now because it looks like it'll spam a lot of alerts, better to work on the current examples first.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2237

#### Checklist

- [ ] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`