### PR TITLE
Fix issue where queries fail with "context canceled" when ingester or store-gateway fails healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451 #6469
 * [BUGFIX] All: fix issue where traces for some inter-component gRPC calls would incorrectly show the call as failing due to cancellation. #6470
 * [BUGFIX] Querier: correctly mark streaming requests to ingesters or store-gateways as successful, not cancelled, in metrics and traces. #6471 #6505
+* [BUGFIX] Querier: fix issue where queries fail with "context canceled" error when an ingester or store-gateway fails healthcheck while the query is in progress. #6550
 
 ### Mixin
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -312,7 +312,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 						result.streamingSeries.Series = append(result.streamingSeries.Series, batch...)
 					}
 
-					streamReader := ingester_client.NewSeriesChunksStreamReader(stream, streamingSeriesCount, queryLimiter, cleanup, d.log)
+					streamReader := ingester_client.NewSeriesChunksStreamReader(ctx, stream, streamingSeriesCount, queryLimiter, cleanup, d.log)
 					closeStream = false
 					result.streamingSeries.StreamReader = streamReader
 				}

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -35,6 +36,7 @@ type StreamingSeriesSource struct {
 // SeriesChunksStreamReader is responsible for managing the streaming of chunks from an ingester and buffering
 // chunks in memory until they are consumed by the PromQL engine.
 type SeriesChunksStreamReader struct {
+	ctx                 context.Context
 	client              Ingester_QueryStreamClient
 	expectedSeriesCount int
 	queryLimiter        *limiter.QueryLimiter
@@ -47,8 +49,9 @@ type SeriesChunksStreamReader struct {
 	seriesBatch     []QueryStreamSeriesChunks
 }
 
-func NewSeriesChunksStreamReader(client Ingester_QueryStreamClient, expectedSeriesCount int, queryLimiter *limiter.QueryLimiter, cleanup func(), log log.Logger) *SeriesChunksStreamReader {
+func NewSeriesChunksStreamReader(ctx context.Context, client Ingester_QueryStreamClient, expectedSeriesCount int, queryLimiter *limiter.QueryLimiter, cleanup func(), log log.Logger) *SeriesChunksStreamReader {
 	return &SeriesChunksStreamReader{
+		ctx:                 ctx,
 		client:              client,
 		expectedSeriesCount: expectedSeriesCount,
 		queryLimiter:        queryLimiter,
@@ -141,7 +144,7 @@ func (s *SeriesChunksStreamReader) readStream(log *spanlogger.SpanLogger) error 
 		}
 
 		select {
-		case <-s.client.Context().Done():
+		case <-s.ctx.Done():
 			// Why do we abort if the context is done?
 			// We want to make sure that this goroutine is never leaked.
 			// This goroutine could be leaked if nothing is reading from the buffer, but this method is still trying to send
@@ -149,7 +152,12 @@ func (s *SeriesChunksStreamReader) readStream(log *spanlogger.SpanLogger) error 
 			// So, here, we try to send the series to the buffer if we can, but if the context is cancelled, then we give up.
 			// This only works correctly if the context is cancelled when the query request is complete or cancelled,
 			// which is true at the time of writing.
-			return s.client.Context().Err()
+			//
+			// Note that we deliberately don't use the context from the gRPC client here: that context is cancelled when
+			// the stream's underlying ClientConn is closed, which can happen if the querier decides that the ingester is no
+			// longer healthy. If that happens, we want to return the more informative error we'll get from Recv() above, not
+			// a generic 'context canceled' error.
+			return s.ctx.Err()
 		case s.seriesBatchChan <- msg.StreamingSeriesChunks:
 			// Batch enqueued successfully, nothing else to do for this batch.
 		}

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -157,7 +157,7 @@ func (s *SeriesChunksStreamReader) readStream(log *spanlogger.SpanLogger) error 
 			// the stream's underlying ClientConn is closed, which can happen if the querier decides that the ingester is no
 			// longer healthy. If that happens, we want to return the more informative error we'll get from Recv() above, not
 			// a generic 'context canceled' error.
-			return s.ctx.Err()
+			return fmt.Errorf("aborted stream because query was cancelled: %w", context.Cause(s.ctx))
 		case s.seriesBatchChan <- msg.StreamingSeriesChunks:
 			// Batch enqueued successfully, nothing else to do for this batch.
 		}

--- a/pkg/ingester/client/streaming_test.go
+++ b/pkg/ingester/client/streaming_test.go
@@ -74,10 +74,11 @@ func TestSeriesChunksStreamReader_HappyPaths(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			mockClient := &mockQueryStreamClient{ctx: context.Background(), batches: testCase.batches}
+			ctx := context.Background()
+			mockClient := &mockQueryStreamClient{ctx: ctx, batches: testCase.batches}
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
-			reader := NewSeriesChunksStreamReader(mockClient, 5, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+			reader := NewSeriesChunksStreamReader(ctx, mockClient, 5, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 
 			for i, expected := range [][]Chunk{series0, series1, series2, series3, series4} {
@@ -95,7 +96,7 @@ func TestSeriesChunksStreamReader_HappyPaths(t *testing.T) {
 	}
 }
 
-func TestSeriesChunksStreamReader_AbortsWhenContextCancelled(t *testing.T) {
+func TestSeriesChunksStreamReader_AbortsWhenParentContextCancelled(t *testing.T) {
 	// Ensure that the buffering goroutine is not leaked after context cancellation.
 	test.VerifyNoLeak(t)
 
@@ -112,12 +113,13 @@ func TestSeriesChunksStreamReader_AbortsWhenContextCancelled(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
+	streamCtx := context.Background()
+	mockClient := &mockQueryStreamClient{ctx: streamCtx, batches: batches}
 	cleanedUp := atomic.NewBool(false)
 	cleanup := func() { cleanedUp.Store(true) }
 
-	reader := NewSeriesChunksStreamReader(mockClient, 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	parentCtx, cancel := context.WithCancel(context.Background())
+	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
 	cancel()
 	reader.StartBuffering()
 
@@ -135,7 +137,43 @@ func TestSeriesChunksStreamReader_AbortsWhenContextCancelled(t *testing.T) {
 		}
 	}
 
-	require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed after context cancelled")
+	require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed after parent context cancelled")
+	require.True(t, cleanedUp.Load(), "expected cleanup function to be called")
+}
+
+func TestSeriesChunksStreamReader_DoesNotAbortWhenStreamContextCancelled(t *testing.T) {
+	// Ensure that the buffering goroutine is not leaked after context cancellation.
+	test.VerifyNoLeak(t)
+
+	// Create multiple batches to ensure that the buffering goroutine becomes blocked waiting to send further chunks to GetChunks().
+	batches := [][]QueryStreamSeriesChunks{
+		{
+			{SeriesIndex: 0, Chunks: []Chunk{createTestChunk(t, 1000, 1.23)}},
+		},
+		{
+			{SeriesIndex: 1, Chunks: []Chunk{createTestChunk(t, 1000, 4.56)}},
+		},
+		{
+			{SeriesIndex: 2, Chunks: []Chunk{createTestChunk(t, 1000, 7.89)}},
+		},
+	}
+
+	streamCtx, cancel := context.WithCancel(context.Background())
+	mockClient := &mockQueryStreamClient{ctx: streamCtx, batches: batches}
+	cleanedUp := atomic.NewBool(false)
+	cleanup := func() { cleanedUp.Store(true) }
+
+	parentCtx := context.Background()
+	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	cancel()
+	reader.StartBuffering()
+
+	for i := 0; i < 3; i++ {
+		_, err := reader.GetChunks(uint64(i))
+		require.NoError(t, err, "expected GetChunks to not report context cancellation error from stream context")
+	}
+
+	require.True(t, mockClient.closed.Load(), "expected gRPC client to be closed after stream exhausted")
 	require.True(t, cleanedUp.Load(), "expected cleanup function to be called")
 }
 
@@ -146,9 +184,10 @@ func TestSeriesChunksStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 		},
 	}
 
-	mockClient := &mockQueryStreamClient{ctx: context.Background(), batches: batches}
+	ctx := context.Background()
+	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanup := func() {}
-	reader := NewSeriesChunksStreamReader(mockClient, 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	reader := NewSeriesChunksStreamReader(ctx, mockClient, 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
 	s, err := reader.GetChunks(1)
@@ -171,9 +210,10 @@ func TestSeriesChunksStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 		},
 	}
 
-	mockClient := &mockQueryStreamClient{ctx: context.Background(), batches: batches}
+	ctx := context.Background()
+	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanup := func() {}
-	reader := NewSeriesChunksStreamReader(mockClient, 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	reader := NewSeriesChunksStreamReader(ctx, mockClient, 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
 	s, err := reader.GetChunks(0)
@@ -200,11 +240,12 @@ func TestSeriesChunksStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 		},
 	}
 
-	mockClient := &mockQueryStreamClient{ctx: context.Background(), batches: batches}
+	ctx := context.Background()
+	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanedUp := atomic.NewBool(false)
 	cleanup := func() { cleanedUp.Store(true) }
 
-	reader := NewSeriesChunksStreamReader(mockClient, 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	reader := NewSeriesChunksStreamReader(ctx, mockClient, 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
 	s, err := reader.GetChunks(0)
@@ -248,11 +289,12 @@ func TestSeriesChunksStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 
 	for name, batches := range testCases {
 		t.Run(name, func(t *testing.T) {
-			mockClient := &mockQueryStreamClient{ctx: context.Background(), batches: batches}
+			ctx := context.Background()
+			mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
 
-			reader := NewSeriesChunksStreamReader(mockClient, 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+			reader := NewSeriesChunksStreamReader(ctx, mockClient, 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 
 			s, err := reader.GetChunks(0)
@@ -303,11 +345,12 @@ func TestSeriesChunksStreamReader_ChunksLimits(t *testing.T) {
 				},
 			}
 
-			mockClient := &mockQueryStreamClient{ctx: context.Background(), batches: batches}
+			ctx := context.Background()
+			mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
 			queryMetrics := stats.NewQueryMetrics(prometheus.NewPedanticRegistry())
-			reader := NewSeriesChunksStreamReader(mockClient, 1, limiter.NewQueryLimiter(0, testCase.maxChunkBytes, testCase.maxChunks, 0, queryMetrics), cleanup, log.NewNopLogger())
+			reader := NewSeriesChunksStreamReader(ctx, mockClient, 1, limiter.NewQueryLimiter(0, testCase.maxChunkBytes, testCase.maxChunks, 0, queryMetrics), cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 
 			_, err := reader.GetChunks(0)

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -3,6 +3,7 @@
 package querier
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -126,6 +127,7 @@ func (bqs *blockStreamingQuerierSeries) Iterator(reuse chunkenc.Iterator) chunke
 // storeGatewayStreamReader is responsible for managing the streaming of chunks from a storegateway and buffering
 // chunks in memory until they are consumed by the PromQL engine.
 type storeGatewayStreamReader struct {
+	ctx                 context.Context
 	client              storegatewaypb.StoreGateway_SeriesClient
 	expectedSeriesCount int
 	queryLimiter        *limiter.QueryLimiter
@@ -139,8 +141,9 @@ type storeGatewayStreamReader struct {
 	err                    error
 }
 
-func newStoreGatewayStreamReader(client storegatewaypb.StoreGateway_SeriesClient, expectedSeriesCount int, queryLimiter *limiter.QueryLimiter, stats *stats.Stats, log log.Logger) *storeGatewayStreamReader {
+func newStoreGatewayStreamReader(ctx context.Context, client storegatewaypb.StoreGateway_SeriesClient, expectedSeriesCount int, queryLimiter *limiter.QueryLimiter, stats *stats.Stats, log log.Logger) *storeGatewayStreamReader {
 	return &storeGatewayStreamReader{
+		ctx:                 ctx,
 		client:              client,
 		expectedSeriesCount: expectedSeriesCount,
 		queryLimiter:        queryLimiter,
@@ -266,7 +269,7 @@ func (s *storeGatewayStreamReader) readStream(log *spanlogger.SpanLogger) error 
 
 func (s *storeGatewayStreamReader) sendBatch(c *storepb.StreamingChunksBatch) error {
 	select {
-	case <-s.client.Context().Done():
+	case <-s.ctx.Done():
 		// Why do we abort if the context is done?
 		// We want to make sure that the StartBuffering goroutine is never leaked.
 		// This goroutine could be leaked if nothing is reading from the buffer, but this method is still trying to send
@@ -274,7 +277,12 @@ func (s *storeGatewayStreamReader) sendBatch(c *storepb.StreamingChunksBatch) er
 		// So, here, we try to send the series to the buffer if we can, but if the context is cancelled, then we give up.
 		// This only works correctly if the context is cancelled when the query request is complete or cancelled,
 		// which is true at the time of writing.
-		return s.client.Context().Err()
+		//
+		// Note that we deliberately don't use the context from the gRPC client here: that context is cancelled when
+		// the stream's underlying ClientConn is closed, which can happen if the querier decides that the store-gateway is no
+		// longer healthy. If that happens, we want to return the more informative error we'll get from Recv() above, not
+		// a generic 'context canceled' error.
+		return s.ctx.Err()
 	case s.seriesChunksChan <- c:
 		// Batch enqueued successfully, nothing else to do for this batch.
 		return nil
@@ -283,9 +291,9 @@ func (s *storeGatewayStreamReader) sendBatch(c *storepb.StreamingChunksBatch) er
 
 func (s *storeGatewayStreamReader) sendChunksEstimate(chunksEstimate uint64) error {
 	select {
-	case <-s.client.Context().Done():
+	case <-s.ctx.Done():
 		// We abort if the context is done for the same reason we do in sendBatch - to avoid leaking the StartBuffering goroutine.
-		return s.client.Context().Err()
+		return s.ctx.Err()
 	case s.chunkCountEstimateChan <- int(chunksEstimate):
 		return nil
 	}

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -873,7 +873,7 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(ctx context.Context, sp *stor
 			} else if len(myStreamingSeries) > 0 {
 				// FetchedChunks and FetchedChunkBytes are added by the SeriesChunksStreamReader.
 				reqStats.AddFetchedSeries(uint64(len(myStreamingSeries)))
-				streamReader = newStoreGatewayStreamReader(stream, len(myStreamingSeries), queryLimiter, reqStats, q.logger)
+				streamReader = newStoreGatewayStreamReader(reqCtx, stream, len(myStreamingSeries), queryLimiter, reqStats, q.logger)
 				level.Debug(log).Log("msg", "received streaming series from store-gateway",
 					"instance", c.RemoteAddress(),
 					"fetched series", len(myStreamingSeries),

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -140,14 +140,15 @@ func createTestStreamReader(batches ...[]client.QueryStreamSeriesChunks) *client
 		seriesCount += len(batch)
 	}
 
+	ctx := context.Background()
 	mockClient := &mockQueryStreamClient{
-		ctx:     context.Background(),
+		ctx:     ctx,
 		batches: batches,
 	}
 
 	cleanup := func() {}
 
-	reader := client.NewSeriesChunksStreamReader(mockClient, seriesCount, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	reader := client.NewSeriesChunksStreamReader(ctx, mockClient, seriesCount, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
 	return reader


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where queries can fail with an unhelpful error message like `canceled: attempted to read series at index 0 from ingester chunks stream, but the stream has failed: context canceled`.

This occurs when streaming chunks is enabled and the ingester or store-gateway connection is closed and removed from the pool when the ingester or store-gateway fails its healthcheck. 

With the fix in this PR, queries will still fail in this scenario, but they'll fail with a slightly more descriptive error message (`grpc: the client connection is closing`). There does not seem to be an easy way to include a clearer error message here without complicating the code further.

##### Why do queries fail with a `context canceled` error message when a ingester or store-gateway fails its healthcheck? 
When that happens, the querier closes the connection for the ingester or store-gateway ([source](https://github.com/grafana/mimir/blob/7fbf8af80cfc3c496268faba45d3c5cbb86c75d6/vendor/github.com/grafana/dskit/ring/client/pool.go#L165)), which cancels the context associated with that connection ([source](https://github.com/grafana/mimir/blob/790c6ee0e699b5fedc15cd904cc315c8c5a66796/vendor/google.golang.org/grpc/clientconn.go#L1252)), which in turn cancels the context associated with the gRPC stream ([source](https://github.com/grafana/mimir/blob/badb73d84f094db154d1e146c1d0a3a57b0b3880/vendor/google.golang.org/grpc/stream.go#L392)). 

This context from the gRPC stream is what the stream reader's buffering goroutine uses to detect when it should abort ([ingesters](https://github.com/grafana/mimir/blob/851872b65bb85f584950341fdf556da782eaf4b7/pkg/ingester/client/streaming.go#L144), [store-gateways](https://github.com/grafana/mimir/blob/851872b65bb85f584950341fdf556da782eaf4b7/pkg/querier/block_streaming.go#L269)), rather than the context associated with the incoming query request. So it just returns the context cancellation error, rather than the slightly more informative error we'd get if we tried to call a method on the stream later on.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
