### PR TITLE
Revert PR #6451

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 * [BUGFIX] Querier: reduce log volume when querying ingesters with zone-awareness enabled and one or more instances in a single zone unavailable. #6381
 * [BUGFIX] Querier: don't try to query further ingesters if ingester query request minimization is enabled and a query limit is reached as a result of the responses from the initial set of ingesters. #6402
 * [BUGFIX] Ingester: Don't cache context cancellation error when querying. #6446
-* [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451 #6469
+* [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6469
 * [BUGFIX] All: fix issue where traces for some inter-component gRPC calls would incorrectly show the call as failing due to cancellation. #6470
 * [BUGFIX] Querier: correctly mark streaming requests to ingesters or store-gateways as successful, not cancelled, in metrics and traces. #6471 #6505
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1769,11 +1769,6 @@ func (i *Ingester) executeSamplesQuery(ctx context.Context, db *userTSDB, from, 
 				return 0, 0, fmt.Errorf("unsupported value type: %v", valType)
 			}
 		}
-
-		if err := it.Err(); err != nil {
-			return 0, 0, err
-		}
-
 		numSamples += len(ts.Samples) + len(ts.Histograms)
 		numSeries++
 		tsSize := ts.Size()
@@ -1870,11 +1865,6 @@ func (i *Ingester) executeChunksQuery(ctx context.Context, db *userTSDB, from, t
 			ts.Chunks = append(ts.Chunks, ch)
 			numSamples += meta.Chunk.NumSamples()
 		}
-
-		if err := it.Err(); err != nil {
-			return 0, 0, err
-		}
-
 		numSeries++
 		tsSize := ts.Size()
 
@@ -2092,10 +2082,6 @@ func (i *Ingester) sendStreamingQueryChunks(allSeries *chunkSeriesNode, stream c
 
 				seriesChunks.Chunks = append(seriesChunks.Chunks, ch)
 				numSamples += meta.Chunk.NumSamples()
-			}
-
-			if err := it.Err(); err != nil {
-				return 0, 0, 0, err
 			}
 
 			numChunks += len(seriesChunks.Chunks)


### PR DESCRIPTION
This PR reverts "Check for errors when iterating through chunks or samples in response to a query (#6451)".

We think that combination of #6451 and #6469 introduced a bug, where queries executing during head compaction could fail with error when series is removed.

#### Checklist

- [na] Tests updated
- [na] Documentation added
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
