### PR TITLE
[backport r263] Vendor update mimir-prometheus (#6579)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -249,7 +249,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231103061820-790cede0a18a
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231106160916-237a77b48340
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586 h1:/of8Z8taCPft
 github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20231103061820-790cede0a18a h1:ig5QuR9D4HFbexx0Tbfkx3Z3nlxCZ7JaAh+HxC++AVk=
-github.com/grafana/mimir-prometheus v0.0.0-20231103061820-790cede0a18a/go.mod h1:VIbTjmxRZbB1CvLd3TRKcrXU62bXesG4P24dmcugLbY=
+github.com/grafana/mimir-prometheus v0.0.0-20231106160916-237a77b48340 h1:fVwUQ/DflEdP0CRqMmrV9e06rS7YWPCCX0QQsxHtl0A=
+github.com/grafana/mimir-prometheus v0.0.0-20231106160916-237a77b48340/go.mod h1:VIbTjmxRZbB1CvLd3TRKcrXU62bXesG4P24dmcugLbY=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=

--- a/vendor/github.com/prometheus/prometheus/storage/merge.go
+++ b/vendor/github.com/prometheus/prometheus/storage/merge.go
@@ -895,9 +895,6 @@ func (c *concatenatingChunkIterator) Next() bool {
 		c.curr = c.iterators[c.idx].At()
 		return true
 	}
-	if c.iterators[c.idx].Err() != nil {
-		return false
-	}
 	c.idx++
 	return c.Next()
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -887,7 +887,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231103061820-790cede0a18a
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231106160916-237a77b48340
 ## explicit; go 1.20
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1469,7 +1469,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231103061820-790cede0a18a
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231106160916-237a77b48340
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6


### PR DESCRIPTION
For https://github.com/grafana/mimir-prometheus/pull/562
revert of https://github.com/grafana/mimir-prometheus/pull/549

Ref: #incident-2023-11-06-cortex-ops-01-block-to-the-future

Backport of #6579 

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>
(cherry picked from commit 4987dd5cda16668c0829e829b56ac82726004586)
