### PR TITLE
Jsonnet: Update memcached to 1.6.22-alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 * [ENHANCEMENT] Double the amount of rule groups for each user tier. #5897
 * [ENHANCEMENT] Set `maxUnavailable` to 0 for `distributor`, `overrides-exporter`, `querier`, `query-frontend`, `query-scheduler` `ruler-querier`, `ruler-query-frontend`, `ruler-query-scheduler` and `consul` deployments, to ensure they don't become completely unavailable during a rollout. #5924
 * [ENHANCEMENT] Update rollout-operator to `v0.8.3`. #6022 #6110 #6558
+* [ENHANCEMENT] Update memcached to `memcached:1.6.22-alpine`. #6585
 * [ENHANCEMENT] Store-gateway: replaced the following deprecated CLI flags: #6319
   * `-blocks-storage.bucket-store.index-header-lazy-loading-enabled` replaced with `-blocks-storage.bucket-store.index-header.lazy-loading-enabled`
   * `-blocks-storage.bucket-store.index-header-lazy-loading-idle-timeout` replaced with `-blocks-storage.bucket-store.index-header.lazy-loading-idle-timeout`

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1216,7 +1216,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1270,7 +1270,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1324,7 +1324,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1378,7 +1378,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1218,7 +1218,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1272,7 +1272,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1326,7 +1326,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1380,7 +1380,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -1217,7 +1217,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1271,7 +1271,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1325,7 +1325,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1379,7 +1379,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1563,7 +1563,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1617,7 +1617,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1671,7 +1671,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1725,7 +1725,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1563,7 +1563,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1617,7 +1617,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1671,7 +1671,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1725,7 +1725,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1587,7 +1587,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1641,7 +1641,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1695,7 +1695,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1749,7 +1749,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -2042,7 +2042,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2096,7 +2096,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2150,7 +2150,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2204,7 +2204,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1460,7 +1460,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1514,7 +1514,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1568,7 +1568,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1622,7 +1622,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -1020,7 +1020,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1074,7 +1074,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1128,7 +1128,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1182,7 +1182,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -966,7 +966,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1020,7 +1020,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1074,7 +1074,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1128,7 +1128,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -2090,7 +2090,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2144,7 +2144,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2198,7 +2198,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2252,7 +2252,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1221,7 +1221,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1275,7 +1275,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1329,7 +1329,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1383,7 +1383,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -966,7 +966,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1020,7 +1020,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1074,7 +1074,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1128,7 +1128,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1264,7 +1264,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1318,7 +1318,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1372,7 +1372,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1426,7 +1426,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1323,7 +1323,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1377,7 +1377,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1431,7 +1431,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1485,7 +1485,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1216,7 +1216,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1270,7 +1270,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1324,7 +1324,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1378,7 +1378,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1222,7 +1222,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1276,7 +1276,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1330,7 +1330,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1384,7 +1384,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1228,7 +1228,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1282,7 +1282,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1336,7 +1336,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1390,7 +1390,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1222,7 +1222,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1276,7 +1276,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1330,7 +1330,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1384,7 +1384,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1587,7 +1587,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1641,7 +1641,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1695,7 +1695,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1749,7 +1749,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1672,7 +1672,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1726,7 +1726,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1780,7 +1780,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1834,7 +1834,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1672,7 +1672,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1726,7 +1726,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1780,7 +1780,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1834,7 +1834,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1672,7 +1672,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1726,7 +1726,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1780,7 +1780,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1834,7 +1834,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1672,7 +1672,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1726,7 +1726,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1780,7 +1780,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1834,7 +1834,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1219,7 +1219,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1273,7 +1273,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1327,7 +1327,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1381,7 +1381,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1216,7 +1216,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1270,7 +1270,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1324,7 +1324,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1378,7 +1378,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -1279,7 +1279,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1356,7 +1356,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1433,7 +1433,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1510,7 +1510,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1706,7 +1706,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1760,7 +1760,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1814,7 +1814,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1868,7 +1868,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1864,7 +1864,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1918,7 +1918,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1972,7 +1972,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2026,7 +2026,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1706,7 +1706,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1760,7 +1760,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1814,7 +1814,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1868,7 +1868,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1597,7 +1597,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1651,7 +1651,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1705,7 +1705,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1759,7 +1759,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1628,7 +1628,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1682,7 +1682,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1736,7 +1736,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1790,7 +1790,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1247,7 +1247,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1301,7 +1301,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1355,7 +1355,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1409,7 +1409,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1235,7 +1235,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1289,7 +1289,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1343,7 +1343,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1397,7 +1397,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1221,7 +1221,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1275,7 +1275,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1329,7 +1329,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1383,7 +1383,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -668,7 +668,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -722,7 +722,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -776,7 +776,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -830,7 +830,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -669,7 +669,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -723,7 +723,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -777,7 +777,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -831,7 +831,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1570,7 +1570,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1624,7 +1624,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1678,7 +1678,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1732,7 +1732,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1568,7 +1568,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1622,7 +1622,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1676,7 +1676,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1730,7 +1730,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1225,7 +1225,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1279,7 +1279,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1333,7 +1333,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1387,7 +1387,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1226,7 +1226,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1280,7 +1280,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1334,7 +1334,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1388,7 +1388,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1226,7 +1226,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1280,7 +1280,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1334,7 +1334,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1388,7 +1388,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1216,7 +1216,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1270,7 +1270,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1324,7 +1324,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1378,7 +1378,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1221,7 +1221,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1275,7 +1275,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1329,7 +1329,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1383,7 +1383,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -870,7 +870,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -924,7 +924,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -978,7 +978,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1032,7 +1032,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.19-alpine
+        image: memcached:1.6.22-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -1,7 +1,7 @@
 {
   _images+:: {
     // Various third-party images.
-    memcached: 'memcached:1.6.19-alpine',
+    memcached: 'memcached:1.6.22-alpine',
     memcachedExporter: 'prom/memcached-exporter:v0.13.0',
 
     // Our services.


### PR DESCRIPTION
#### What this PR does

Updates the memcached image to `1.6.22-alpine` in Jsonnet. It was already automatically updated in Helm by https://github.com/grafana/mimir/pull/6455, but Jsonnet doesn't get these updates.

[Release Notes](https://github.com/memcached/memcached/wiki/ReleaseNotes)

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
