### PR TITLE
Increase scale down period for distributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * [CHANGE] Ingester: reduce `-server.grpc-max-concurrent-streams` to 500. #5666
 * [CHANGE] Changed default `_config.cluster_domain` from `cluster.local` to `cluster.local.` to reduce the number of DNS lookups made by Mimir. #6389
 * [CHANGE] Query-frontend: changed default `_config.autoscaling_query_frontend_cpu_target_utilization` from `1` to `0.75`. #6395
+* [CHANGE] Distributor: Increase HPA scale down period such that distributors are slower to scale down after autoscaling up. #6589
 * [FEATURE] Store-gateway: Allow automated zone-by-zone downscaling, that can be enabled via the `store_gateway_automated_downscale_enabled` flag. It is disabled by default. #6149
 * [FEATURE] Ingester: Allow to configure TSDB Head early compaction using the following `_config` parameters: #6181
   * `ingester_tsdb_head_early_compaction_enabled` (disabled by default)

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1976,7 +1976,7 @@ spec:
       behavior:
         scaleDown:
           policies:
-          - periodSeconds: 60
+          - periodSeconds: 600
             type: Percent
             value: 10
   maxReplicaCount: 30

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1976,7 +1976,7 @@ spec:
       behavior:
         scaleDown:
           policies:
-          - periodSeconds: 60
+          - periodSeconds: 600
             type: Percent
             value: 10
   maxReplicaCount: 30

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -389,6 +389,11 @@
       cpu_target_utilization=$._config.autoscaling_distributor_cpu_target_utilization,
       memory_target_utilization=$._config.autoscaling_distributor_memory_target_utilization,
       with_cortex_prefix=true,
+      // The write path tends to have a stable amount of traffic (it's not usually bursty) so it's
+      // fine to use a longer scale down period. This avoids scaling down too quickly because
+      // distributors were briefly using less CPU (like when circuit breaking or load shedding)
+      // and causing outages when full traffic returns.
+      scale_down_period=600,
     ),
 
   distributor_deployment: overrideSuperIfExists(


### PR DESCRIPTION
#### What this PR does

Increase the amount of time that distributors are scaled down over from 60 seconds to 600 seconds. This helps avoid scaling down too quickly when distributors are using less CPU than normal (such as when they are circuit breaking or load shedding).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated
- [ ] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
