### PR TITLE
querier: track consistency check failures without retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   * `http.StatusBadRequest` (400) is replaced with `codes.FailedPrecondition`.
   * `http.StatusServiceUnavailable` (503) and `codes.Unknown` are replaced with `codes.Internal`.
 * [CHANGE] Upgrade Node.js to v20. #6540
+* [CHANGE] Querier: `cortex_querier_blocks_consistency_checks_failed_total` is now incremented when a block couldn't be queried from any attempted store-gateway as opposed to incremented after each attempt. Also `cortex_querier_blocks_consistency_checks_total` is incremented once per query as opposed to once per attempt (with 3 attempts). #6590
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [FEATURE] Vault: Added support for new Vault authentication methods: `AppRole`, `Kubernetes`, `UserPass` and `Token`. #6143
 * [ENHANCEMENT] Ingester: exported summary `cortex_ingester_inflight_push_requests_summary` tracking total number of inflight requests in percentile buckets. #5845

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -13807,6 +13807,7 @@ data:
                       "dashLength": 10,
                       "dashes": false,
                       "datasource": "$datasource",
+                      "description": "### Consistency checks failed\nRate of queries that had to run with consistency checks and those checks failed. A failed consistency check means that some of at least one block which had to be queried wasn't present in any of the store-gateways.\n\n",
                       "fill": 1,
                       "id": 18,
                       "legend": {
@@ -30167,6 +30168,7 @@ data:
                       "dashLength": 10,
                       "dashes": false,
                       "datasource": "$datasource",
+                      "description": "### Consistency checks failed\nRate of queries that had to run with consistency checks and those checks failed. A failed consistency check means that some of at least one block which had to be queried wasn't present in any of the store-gateways.\n\n",
                       "fill": 1,
                       "id": 15,
                       "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -1430,6 +1430,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Consistency checks failed\nRate of queries that had to run with consistency checks and those checks failed. A failed consistency check means that some of at least one block which had to be queried wasn't present in any of the store-gateways.\n\n",
                   "fill": 1,
                   "id": 18,
                   "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
@@ -1274,6 +1274,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Consistency checks failed\nRate of queries that had to run with consistency checks and those checks failed. A failed consistency check means that some of at least one block which had to be queried wasn't present in any of the store-gateways.\n\n",
                   "fill": 1,
                   "id": 15,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -1430,6 +1430,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Consistency checks failed\nRate of queries that had to run with consistency checks and those checks failed. A failed consistency check means that some of at least one block which had to be queried wasn't present in any of the store-gateways.\n\n",
                   "fill": 1,
                   "id": 18,
                   "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -1274,6 +1274,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
+                  "description": "### Consistency checks failed\nRate of queries that had to run with consistency checks and those checks failed. A failed consistency check means that some of at least one block which had to be queried wasn't present in any of the store-gateways.\n\n",
                   "fill": 1,
                   "id": 15,
                   "legend": {

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -181,7 +181,13 @@ local filename = 'mimir-queries.json';
       .addPanel(
         $.panel('Consistency checks failed') +
         $.failurePanel('sum(rate(cortex_querier_blocks_consistency_checks_failed_total{%s}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.querier), $.jobMatcher($._config.job_names.querier)], 'Failure Rate') +
-        { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) },
+        { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) } +
+        $.panelDescription(
+          'Consistency checks failed',
+          |||
+            Rate of queries that had to run with consistency checks and those checks failed. A failed consistency check means that some of at least one block which had to be queried wasn't present in any of the store-gateways.
+          |||
+        ),
       )
       .addPanel(
         $.panel('Rejected queries') +

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -137,7 +137,13 @@ local filename = 'mimir-ruler.json';
       .addPanel(
         $.panel('Consistency checks failed') +
         $.failurePanel('sum(rate(cortex_querier_blocks_consistency_checks_failed_total{%s}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ruler), $.jobMatcher($._config.job_names.ruler)], 'Failures / sec') +
-        { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) },
+        { yaxes: $.yaxes({ format: 'percentunit', max: 1 }) } +
+        $.panelDescription(
+          'Consistency checks failed',
+          |||
+            Rate of queries that had to run with consistency checks and those checks failed. A failed consistency check means that some of at least one block which had to be queried wasn't present in any of the store-gateways.
+          |||
+        ),
       )
     )
     .addRow(

--- a/pkg/querier/blocks_consistency_checker.go
+++ b/pkg/querier/blocks_consistency_checker.go
@@ -78,7 +78,7 @@ func (c *BlocksConsistency) NewTracker(knownBlocks bucketindex.Blocks, knownDele
 		checksFailed: c.checksFailed,
 		checksTotal:  c.checksTotal,
 		tracked:      blocksToTrack,
-		queried:      make(map[ulid.ULID]struct{}, len(knownBlocks)),
+		queried:      make(map[ulid.ULID]struct{}, len(blocksToTrack)),
 	}
 }
 

--- a/pkg/querier/blocks_consistency_checker.go
+++ b/pkg/querier/blocks_consistency_checker.go
@@ -33,7 +33,7 @@ func NewBlocksConsistency(uploadGracePeriod, deletionGracePeriod time.Duration, 
 		logger:              logger,
 		checksTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_querier_blocks_consistency_checks_total",
-			Help: "Total number of consistency checks run on queried blocks.",
+			Help: "Total number of queries that needed to run with consistency checks. A consistency check is required when querying blocks from store-gateways to make sure that all blocks are queried.",
 		}),
 		checksFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_querier_blocks_consistency_checks_failed_total",

--- a/pkg/querier/blocks_consistency_checker.go
+++ b/pkg/querier/blocks_consistency_checker.go
@@ -37,7 +37,7 @@ func NewBlocksConsistency(uploadGracePeriod, deletionGracePeriod time.Duration, 
 		}),
 		checksFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_querier_blocks_consistency_checks_failed_total",
-			Help: "Total number of consistency checks failed on queried blocks. A failed consistency check means that some of the block which had to be queried weren't present in any of the store-gateways.",
+			Help: "Total number of queries that failed consistency checks. A failed consistency check means that some of at least one block which had to be queried wasn't present in any of the store-gateways.",
 		}),
 	}
 }

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -610,6 +611,10 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(
 }
 
 func newStoreConsistencyCheckFailedError(remainingBlocks []ulid.ULID) error {
+	// Sort the blocks, so it's easier to test the error strings.
+	sort.Slice(remainingBlocks, func(i, j int) bool {
+		return remainingBlocks[i].Compare(remainingBlocks[j]) < 0
+	})
 	return fmt.Errorf("%v. The failed blocks are: %s", globalerror.StoreConsistencyCheckFailed.Message("failed to fetch some blocks"), strings.Join(convertULIDsToString(remainingBlocks), " "))
 }
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -862,7 +862,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 						maxT:        maxT,
 						finder:      finder,
 						stores:      stores,
-						consistency: NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
+						consistency: NewBlocksConsistency(0, 0, log.NewNopLogger(), nil),
 						logger:      log.NewNopLogger(),
 						metrics:     newBlocksStoreQueryableMetrics(reg),
 						limits:      testData.limits,
@@ -1016,7 +1016,7 @@ func TestBlocksStoreQuerier_Select_cancelledContext(t *testing.T) {
 				maxT:        maxT,
 				finder:      finder,
 				stores:      stores,
-				consistency: NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
+				consistency: NewBlocksConsistency(0, 0, log.NewNopLogger(), nil),
 				logger:      log.NewNopLogger(),
 				metrics:     newBlocksStoreQueryableMetrics(reg),
 				limits:      &blocksStoreLimitsMock{},
@@ -1516,7 +1516,7 @@ func TestBlocksStoreQuerier_Labels(t *testing.T) {
 					maxT:        maxT,
 					finder:      finder,
 					stores:      stores,
-					consistency: NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
+					consistency: NewBlocksConsistency(0, 0, log.NewNopLogger(), nil),
 					logger:      log.NewNopLogger(),
 					metrics:     newBlocksStoreQueryableMetrics(reg),
 					limits:      &blocksStoreLimitsMock{},
@@ -1587,7 +1587,7 @@ func TestBlocksStoreQuerier_Labels(t *testing.T) {
 					maxT:        maxT,
 					finder:      finder,
 					stores:      stores,
-					consistency: NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
+					consistency: NewBlocksConsistency(0, 0, log.NewNopLogger(), nil),
 					logger:      log.NewNopLogger(),
 					metrics:     newBlocksStoreQueryableMetrics(reg),
 					limits:      &blocksStoreLimitsMock{},
@@ -1661,7 +1661,7 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 				maxT:            testData.queryMaxT,
 				finder:          finder,
 				stores:          &blocksStoreSetMock{},
-				consistency:     NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
+				consistency:     NewBlocksConsistency(0, 0, log.NewNopLogger(), nil),
 				logger:          log.NewNopLogger(),
 				metrics:         newBlocksStoreQueryableMetrics(nil),
 				limits:          &blocksStoreLimitsMock{},
@@ -1735,7 +1735,7 @@ func TestBlocksStoreQuerier_MaxLabelsQueryRange(t *testing.T) {
 				maxT:        testData.queryMaxT,
 				finder:      finder,
 				stores:      &blocksStoreSetMock{},
-				consistency: NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
+				consistency: NewBlocksConsistency(0, 0, log.NewNopLogger(), nil),
 				logger:      log.NewNopLogger(),
 				metrics:     newBlocksStoreQueryableMetrics(nil),
 				limits: &blocksStoreLimitsMock{
@@ -1865,7 +1865,7 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 
 					// Instantiate the querier that will be executed to run the query.
 					logger := log.NewNopLogger()
-					queryable, err := NewBlocksStoreQueryable(stores, finder, NewBlocksConsistencyChecker(0, 0, logger, nil), &blocksStoreLimitsMock{}, 0, 0, logger, nil)
+					queryable, err := NewBlocksStoreQueryable(stores, finder, NewBlocksConsistency(0, 0, logger, nil), &blocksStoreLimitsMock{}, 0, 0, logger, nil)
 					require.NoError(t, err)
 					require.NoError(t, services.StartAndAwaitRunning(context.Background(), queryable))
 					defer services.StopAndAwaitTerminated(context.Background(), queryable) // nolint:errcheck


### PR DESCRIPTION
Consistency checks are currently tracked per attempt. For example, this means that if there were two attempts to fetch some blocks and the first was partially siccessful and the second fetched the missing blocks, then the ratio of failed checks will be 50%. This is misleading because the second check succeeded and the query overall was successful. We graph this ratio in Mimir / Queries.

### Note to reviewers

with this change I took the chance to refactor the consistency checker. One side effect of this change is that the upload and deletion marker grace periods will not be recalculated upon each retry. This means that if a request to the store-gateway takes long enough for a block to fall outside of the uploadGracePeriod, then that block won't be queried. The time between query-ingesters-within and query-stores after is 1h and upload-grace-period is 45m. So unless a request takes 15m, this shouldn't be a problem (assuming default values).

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
