### PR TITLE
OpenTelemetryTracerBridge.Start: Make returned context contain span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [BUGFIX] All: fix issue where traces for some inter-component gRPC calls would incorrectly show the call as failing due to cancellation. #6470
 * [BUGFIX] Querier: correctly mark streaming requests to ingesters or store-gateways as successful, not cancelled, in metrics and traces. #6471 #6505
 * [BUGFIX] Querier: fix issue where queries fail with "context canceled" error when an ingester or store-gateway fails healthcheck while the query is in progress. #6550
+* [BUGFIX] Tracing: When creating an OpenTelemetry tracing span, add it to the context for later retrieval. #6614
 
 ### Mixin
 

--- a/pkg/mimir/tracing.go
+++ b/pkg/mimir/tracing.go
@@ -117,7 +117,8 @@ func (t *OpenTelemetryTracerBridge) Start(ctx context.Context, spanName string, 
 	}
 
 	span, ctx := opentracing.StartSpanFromContextWithTracer(ctx, t.tracer, spanName, mappedOptions...)
-	return ctx, NewOpenTelemetrySpanBridge(span, t.provider)
+	otelSpan := NewOpenTelemetrySpanBridge(span, t.provider)
+	return trace.ContextWithSpan(ctx, otelSpan), otelSpan
 }
 
 type OpenTelemetrySpanBridge struct {

--- a/pkg/mimir/tracing_test.go
+++ b/pkg/mimir/tracing_test.go
@@ -3,6 +3,7 @@
 package mimir
 
 import (
+	"context"
 	crand "crypto/rand"
 	"encoding/binary"
 	"errors"
@@ -204,4 +205,13 @@ func (m *TracingSpanMock) LogEventWithPayload(event string, payload interface{})
 
 func (m *TracingSpanMock) Log(data opentracing.LogData) {
 	m.Called(data)
+}
+
+func TestOpenTelemetryTracerBridge_Start(t *testing.T) {
+	bridge := NewOpenTelemetryProviderBridge(opentracing.GlobalTracer())
+	tracer := bridge.Tracer("")
+	ctx, span := tracer.Start(context.Background(), "test")
+	ctxSpan := trace.SpanFromContext(ctx)
+
+	require.Same(t, span, ctxSpan, "returned context should contain span")
 }


### PR DESCRIPTION
#### What this PR does
I found that there's a bug in `OpenTelemetryTracerBridge.Start`, i.e. that the returned context doesn't contain a `go.opentelemetry.io/otel/trace.Span` although it should. This PR fixes it, and adds a test for it.

The practical effect of the bug is losing OpenTelemetry tracing events, e.g. in Prometheus, where code depends on fetching a span from the context (if no span is in the context, these events are discarded).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated
- [na] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
