### PR TITLE
querier: minor internal cleanup

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -356,7 +356,10 @@ func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHin
 	sets := make(chan storage.SeriesSet, len(queriers))
 	for _, querier := range queriers {
 		go func(querier storage.Querier) {
-			sets <- querier.Select(ctx, true, sp, matchers...)
+			select {
+			case sets <- querier.Select(ctx, true, sp, matchers...):
+			case <-ctx.Done():
+			}
 		}(querier)
 	}
 


### PR DESCRIPTION
I noticed that the goroutine will block forever if the context is cancelled. This can cause a goroutine leak. I couldn't porive it was happening in clusters at Grafana Labs, but it's still a valid fix.
