### PR TITLE
store-gateway: fix duration metrics

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -51,7 +51,6 @@ import (
 	streamindex "github.com/grafana/mimir/pkg/storegateway/indexheader/index"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 	"github.com/grafana/mimir/pkg/util"
-	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/pool"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -574,6 +573,11 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		reqBlockMatchers []*labels.Matcher
 	)
 	defer s.recordSeriesCallResult(stats)
+	defer func(requestStart time.Time) {
+		stats.update(func(stats *queryStats) {
+			stats.streamingSeriesAmbientTime += time.Since(requestStart)
+		})
+	}(time.Now())
 
 	if req.Hints != nil {
 		reqHints := &hintspb.SeriesRequestHints{}
@@ -713,18 +717,10 @@ func (s *BucketStore) sendStreamingSeriesLabelsAndStats(
 	var (
 		encodeDuration = time.Duration(0)
 		sendDuration   = time.Duration(0)
-		iterationBegin = time.Now()
 	)
 	defer stats.update(func(stats *queryStats) {
-		// The time spent iterating over the series set is the
-		// actual time spent fetching series and chunks, encoding and sending them to the client.
-		// We split the timings to have a better view over how time is spent.
-		// We do not update streamingSeriesFetchSeriesAndChunksDuration here because it will be updated when sending
-		// streaming chunks, that includes the series and chunks fetch duration for sending the streaming series.
 		stats.streamingSeriesEncodeResponseDuration += encodeDuration
 		stats.streamingSeriesSendResponseDuration += sendDuration
-		stats.streamingSeriesOtherDuration += time.Duration(util_math.Max(0, int64(time.Since(iterationBegin)-
-			stats.streamingSeriesFetchSeriesAndChunksDuration-encodeDuration-sendDuration)))
 	})
 
 	seriesBuffer := make([]*storepb.StreamingSeries, req.StreamingChunksBatchSize)
@@ -780,21 +776,14 @@ func (s *BucketStore) sendStreamingChunks(
 		encodeDuration           time.Duration
 		sendDuration             time.Duration
 		seriesCount, chunksCount int
-		iterationBegin           = time.Now()
 	)
 
 	defer stats.update(func(stats *queryStats) {
 		stats.mergedSeriesCount += seriesCount
 		stats.mergedChunksCount += chunksCount
 
-		// The time spent iterating over the series set is the
-		// actual time spent fetching series and chunks, encoding and sending them to the client.
-		// We split the timings to have a better view over how time is spent.
-		stats.streamingSeriesFetchSeriesAndChunksDuration += stats.streamingSeriesWaitBatchLoadedDuration
 		stats.streamingSeriesEncodeResponseDuration += encodeDuration
 		stats.streamingSeriesSendResponseDuration += sendDuration
-		stats.streamingSeriesOtherDuration += time.Duration(util_math.Max(0, int64(time.Since(iterationBegin)-
-			stats.streamingSeriesFetchSeriesAndChunksDuration-encodeDuration-sendDuration)))
 	})
 
 	var (
@@ -894,21 +883,14 @@ func (s *BucketStore) sendSeriesChunks(
 		encodeDuration           time.Duration
 		sendDuration             time.Duration
 		seriesCount, chunksCount int
-		iterationBegin           = time.Now()
 	)
 
 	defer stats.update(func(stats *queryStats) {
 		stats.mergedSeriesCount += seriesCount
 		stats.mergedChunksCount += chunksCount
 
-		// The time spent iterating over the series set is the
-		// actual time spent fetching series and chunks, encoding and sending them to the client.
-		// We split the timings to have a better view over how time is spent.
-		stats.streamingSeriesFetchSeriesAndChunksDuration += stats.streamingSeriesWaitBatchLoadedDuration
 		stats.streamingSeriesEncodeResponseDuration += encodeDuration
 		stats.streamingSeriesSendResponseDuration += sendDuration
-		stats.streamingSeriesOtherDuration += time.Duration(util_math.Max(0, int64(time.Since(iterationBegin)-
-			stats.streamingSeriesFetchSeriesAndChunksDuration-encodeDuration-sendDuration)))
 	})
 
 	for seriesSet.Next() {
@@ -942,16 +924,18 @@ func (s *BucketStore) sendMessage(typ string, srv storepb.Store_SeriesServer, ms
 	// We encode it ourselves into a PreparedMsg in order to measure the time it takes.
 	encodeBegin := time.Now()
 	pmsg := &grpc.PreparedMsg{}
-	if err := pmsg.Encode(srv, msg); err != nil {
+	err := pmsg.Encode(srv, msg)
+	*encodeDuration += time.Since(encodeBegin)
+	if err != nil {
 		return status.Error(codes.Internal, errors.Wrapf(err, "encode %s response", typ).Error())
 	}
-	*encodeDuration += time.Since(encodeBegin)
 
 	sendBegin := time.Now()
-	if err := srv.SendMsg(pmsg); err != nil {
+	err = srv.SendMsg(pmsg)
+	*sendDuration += time.Since(sendBegin)
+	if err != nil {
 		return status.Error(codes.Unknown, errors.Wrapf(err, "send %s response", typ).Error())
 	}
-	*sendDuration += time.Since(sendBegin)
 
 	return nil
 }
@@ -971,9 +955,14 @@ func (s *BucketStore) sendHints(srv storepb.Store_SeriesServer, resHints *hintsp
 }
 
 func (s *BucketStore) sendStats(srv storepb.Store_SeriesServer, stats *safeQueryStats) error {
+	var encodeDuration, sendDuration time.Duration
+	defer stats.update(func(stats *queryStats) {
+		stats.streamingSeriesSendResponseDuration += sendDuration
+		stats.streamingSeriesEncodeResponseDuration += encodeDuration
+	})
 	unsafeStats := stats.export()
-	if err := srv.Send(storepb.NewStatsResponse(unsafeStats.postingsTouchedSizeSum + unsafeStats.seriesProcessedSizeSum)); err != nil {
-		return status.Error(codes.Unknown, errors.Wrap(err, "sends series response stats").Error())
+	if err := s.sendMessage("series response stats", srv, storepb.NewStatsResponse(unsafeStats.postingsTouchedSizeSum+unsafeStats.seriesProcessedSizeSum), &encodeDuration, &sendDuration); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1237,12 +1226,16 @@ func (s *BucketStore) recordStreamingSeriesStats(stats *queryStats) {
 		s.metrics.streamingSeriesBatchPreloadingWaitDuration.Observe(stats.streamingSeriesWaitBatchLoadedDuration.Seconds())
 	}
 
-	s.metrics.streamingSeriesRefsFetchDuration.Observe(stats.streamingSeriesFetchRefsDuration.Seconds())
-
 	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("expand_postings").Observe(stats.streamingSeriesExpandPostingsDuration.Seconds())
-	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("fetch_series_and_chunks").Observe(stats.streamingSeriesFetchSeriesAndChunksDuration.Seconds())
-	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("other").Observe(stats.streamingSeriesOtherDuration.Seconds())
+	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("fetch_series_and_chunks").Observe(stats.streamingSeriesBatchLoadDuration.Seconds())
 	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("load_index_header").Observe(stats.streamingSeriesIndexHeaderLoadDuration.Seconds())
+
+	specializedTime := stats.streamingSeriesExpandPostingsDuration +
+		stats.streamingSeriesBatchLoadDuration +
+		stats.streamingSeriesIndexHeaderLoadDuration +
+		stats.streamingSeriesEncodeResponseDuration +
+		stats.streamingSeriesSendResponseDuration
+	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("other").Observe((stats.streamingSeriesAmbientTime - specializedTime).Seconds())
 }
 
 func (s *BucketStore) recordCachedPostingStats(stats *queryStats) {
@@ -1637,7 +1630,6 @@ func labelValuesFromSeries(ctx context.Context, labelName string, seriesPerBatch
 	if len(pendingMatchers) > 0 {
 		iterator = newFilteringSeriesChunkRefsSetIterator(pendingMatchers, iterator, stats)
 	}
-	iterator = seriesStreamingFetchRefsDurationIterator(iterator, stats)
 	seriesSet := newSeriesSetWithoutChunks(ctx, iterator, stats)
 
 	differentValues := make(map[string]struct{})

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1230,12 +1230,15 @@ func (s *BucketStore) recordStreamingSeriesStats(stats *queryStats) {
 	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("fetch_series_and_chunks").Observe(stats.streamingSeriesBatchLoadDuration.Seconds())
 	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("load_index_header").Observe(stats.streamingSeriesIndexHeaderLoadDuration.Seconds())
 
-	specializedTime := stats.streamingSeriesExpandPostingsDuration +
+	categorizedTime := stats.streamingSeriesExpandPostingsDuration +
 		stats.streamingSeriesBatchLoadDuration +
 		stats.streamingSeriesIndexHeaderLoadDuration +
 		stats.streamingSeriesEncodeResponseDuration +
 		stats.streamingSeriesSendResponseDuration
-	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("other").Observe((stats.streamingSeriesAmbientTime - specializedTime).Seconds())
+
+	// "other" time is any time we have spent according to the wall clock,
+	// that hasn't been recorded in any of the known categories.
+	s.metrics.streamingSeriesRequestDurationByStage.WithLabelValues("other").Observe((stats.streamingSeriesAmbientTime - categorizedTime).Seconds())
 }
 
 func (s *BucketStore) recordCachedPostingStats(stats *queryStats) {

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -460,7 +460,6 @@ func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSe
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_fetched", metrics, "data_type", "series"))
 
 		assert.NotZero(t, numObservationsForHistogram(t, "cortex_bucket_store_series_request_stage_duration_seconds", metrics))
-		assert.NotZero(t, numObservationsForHistogram(t, "cortex_bucket_store_series_refs_fetch_duration_seconds", metrics))
 	}
 	if numChunksPerSeries > 0 {
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_touched", metrics, "data_type", "chunks"))
@@ -688,7 +687,6 @@ func assertQueryStatsLabelNamesMetricsRecorded(t *testing.T, numLabelNames int, 
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_fetched", metrics, "data_type", "series"))
 
 		assert.NotZero(t, numObservationsForHistogram(t, "cortex_bucket_store_series_request_stage_duration_seconds", metrics))
-		assert.NotZero(t, numObservationsForHistogram(t, "cortex_bucket_store_series_refs_fetch_duration_seconds", metrics))
 	}
 }
 

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -38,7 +38,6 @@ type BucketStoreMetrics struct {
 	streamingSeriesRequestDurationByStage      *prometheus.HistogramVec
 	streamingSeriesBatchPreloadingLoadDuration prometheus.Histogram
 	streamingSeriesBatchPreloadingWaitDuration prometheus.Histogram
-	streamingSeriesRefsFetchDuration           prometheus.Histogram
 
 	cachedPostingsCompressions           *prometheus.CounterVec
 	cachedPostingsCompressionErrors      *prometheus.CounterVec
@@ -183,11 +182,6 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 	m.streamingSeriesBatchPreloadingWaitDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_bucket_store_series_batch_preloading_wait_duration_seconds",
 		Help:    "Time spent by store-gateway waiting until the next batch is loaded, once the store-gateway is ready to send it. This metric is tracked only if the request is split into 2+ batches.",
-		Buckets: durationBuckets,
-	})
-	m.streamingSeriesRefsFetchDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-		Name:    "cortex_bucket_store_series_refs_fetch_duration_seconds",
-		Help:    "Time spent by store-gateway to fetch series labels and chunk references for a single request.",
 		Buckets: durationBuckets,
 	})
 

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1436,7 +1436,6 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 						"cortex_bucket_store_series_request_stage_duration_seconds":         true,
 						"cortex_bucket_store_series_batch_preloading_load_duration_seconds": st.maxSeriesPerBatch < totalSeries, // Tracked only when a request is split in multiple batches.
 						"cortex_bucket_store_series_batch_preloading_wait_duration_seconds": st.maxSeriesPerBatch < totalSeries, // Tracked only when a request is split in multiple batches.
-						"cortex_bucket_store_series_refs_fetch_duration_seconds":            true,
 					}
 
 					metrics, err := dskit_metrics.NewMetricFamilyMapFromGatherer(reg)

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -750,7 +750,7 @@ func openBlockSeriesChunkRefsSetsIterator(
 		iterator = newFilteringSeriesChunkRefsSetIterator(pendingMatchers, iterator, stats)
 	}
 
-	return seriesStreamingFetchRefsDurationIterator(iterator, stats), nil
+	return iterator, nil
 }
 
 // reusedPostings is used to share the postings and matches across function calls for re-use
@@ -776,15 +776,6 @@ func (p *reusedPostingsAndMatchers) set(ps []storage.SeriesRef, matchers []*labe
 
 func (p *reusedPostingsAndMatchers) isSet() bool {
 	return p.filled
-}
-
-// seriesStreamingFetchRefsDurationIterator tracks the time spent loading series and chunk refs.
-func seriesStreamingFetchRefsDurationIterator(iterator seriesChunkRefsSetIterator, stats *safeQueryStats) genericIterator[seriesChunkRefsSet] {
-	return newNextDurationMeasuringIterator[seriesChunkRefsSet](iterator, func(duration time.Duration, _ bool) {
-		stats.update(func(stats *queryStats) {
-			stats.streamingSeriesFetchRefsDuration += duration
-		})
-	})
 }
 
 // seriesIteratorStrategy defines the strategy to use when loading the series and their chunk refs.

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -56,9 +56,6 @@ type queryStats struct {
 	mergedSeriesCount int
 	mergedChunksCount int
 
-	// The total time spent fetching series and chunk refs.
-	streamingSeriesFetchRefsDuration time.Duration
-
 	// The number of batches the Series() request has been split into.
 	streamingSeriesBatchCount int
 
@@ -70,12 +67,13 @@ type queryStats struct {
 	streamingSeriesWaitBatchLoadedDuration time.Duration
 
 	// The Series() request timing breakdown.
-	streamingSeriesExpandPostingsDuration       time.Duration
-	streamingSeriesFetchSeriesAndChunksDuration time.Duration
-	streamingSeriesEncodeResponseDuration       time.Duration
-	streamingSeriesSendResponseDuration         time.Duration
-	streamingSeriesOtherDuration                time.Duration
-	streamingSeriesIndexHeaderLoadDuration      time.Duration
+	streamingSeriesExpandPostingsDuration  time.Duration
+	streamingSeriesEncodeResponseDuration  time.Duration
+	streamingSeriesSendResponseDuration    time.Duration
+	streamingSeriesIndexHeaderLoadDuration time.Duration
+
+	// streamingSeriesAmbientTime is the total WAL time spent serving the request. It includes all other durations.
+	streamingSeriesAmbientTime time.Duration
 }
 
 func (s queryStats) merge(o *queryStats) *queryStats {
@@ -123,15 +121,13 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 	s.mergedSeriesCount += o.mergedSeriesCount
 	s.mergedChunksCount += o.mergedChunksCount
 
-	s.streamingSeriesFetchRefsDuration += o.streamingSeriesFetchRefsDuration
 	s.streamingSeriesBatchCount += o.streamingSeriesBatchCount
 	s.streamingSeriesBatchLoadDuration += o.streamingSeriesBatchLoadDuration
 	s.streamingSeriesWaitBatchLoadedDuration += o.streamingSeriesWaitBatchLoadedDuration
 	s.streamingSeriesExpandPostingsDuration += o.streamingSeriesExpandPostingsDuration
-	s.streamingSeriesFetchSeriesAndChunksDuration += o.streamingSeriesFetchSeriesAndChunksDuration
 	s.streamingSeriesEncodeResponseDuration += o.streamingSeriesEncodeResponseDuration
 	s.streamingSeriesSendResponseDuration += o.streamingSeriesSendResponseDuration
-	s.streamingSeriesOtherDuration += o.streamingSeriesOtherDuration
+	s.streamingSeriesAmbientTime += o.streamingSeriesAmbientTime
 
 	s.streamingSeriesIndexHeaderLoadDuration += o.streamingSeriesIndexHeaderLoadDuration
 

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -72,7 +72,7 @@ type queryStats struct {
 	streamingSeriesSendResponseDuration    time.Duration
 	streamingSeriesIndexHeaderLoadDuration time.Duration
 
-	// streamingSeriesAmbientTime is the total WAL time spent serving the request. It includes all other durations.
+	// streamingSeriesAmbientTime is the total wall clock time spent serving the request. It includes all other durations.
 	streamingSeriesAmbientTime time.Duration
 }
 


### PR DESCRIPTION

* don't double count streamingSeriesOtherDuration and streamingSeriesFetchSeriesAndChunksDuration when using querier<>store-gateway streaming
* replace streamingSeriesFetchSeriesAndChunksDuration with streamingSeriesWaitBatchLoadedDuration and only record it once
* remove cortex_bucket_store_series_refs_fetch_duration_seconds because it is tracking the time per block, not per request and isn't directly useful in diagnosing slow store-gateway requests; it is also not used in dashboards
* record send/encode duration for sending stats
* record send/encode duration even if sending/encoding fails
* calculate "other" time based on the total time of the request (for example now it includes reading the bucket index, waiting for the query gate)
