### PR TITLE
Ingester: Add alert MimirIngesterReachingInflightPushRequestLimit and runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [FEATURE] Vault: Added support for new Vault authentication methods: `AppRole`, `Kubernetes`, `UserPass` and `Token`. #6143
 * [FEATURE] Add experimental endpoint `/api/v1/cardinality/active_series` to return the set of active series for a given selector. #6536 #6619
+* [ENHANCEMENT] Add `MimirIngesterReachingInflightPushRequestLimit` alert and runbook. #6649
 * [ENHANCEMENT] Ingester: exported summary `cortex_ingester_inflight_push_requests_summary` tracking total number of inflight requests in percentile buckets. #5845
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879
 * [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. When query-scheduler is in use, the metric has the `scheduler_address` label to differentiate the enqueue duration by query-scheduler backend. #5879 #6087 #6120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 * [FEATURE] Query-frontend: add experimental support for query blocking. Queries are blocked on a per-tenant basis and is configured via the limit `blocked_queries`. #5609
 * [FEATURE] Vault: Added support for new Vault authentication methods: `AppRole`, `Kubernetes`, `UserPass` and `Token`. #6143
 * [FEATURE] Add experimental endpoint `/api/v1/cardinality/active_series` to return the set of active series for a given selector. #6536 #6619
-* [ENHANCEMENT] Add `MimirIngesterReachingInflightPushRequestLimit` alert and runbook. #6649
 * [ENHANCEMENT] Ingester: exported summary `cortex_ingester_inflight_push_requests_summary` tracking total number of inflight requests in percentile buckets. #5845
 * [ENHANCEMENT] Query-scheduler: add `cortex_query_scheduler_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. #5879
 * [ENHANCEMENT] Query-frontend: add `cortex_query_frontend_enqueue_duration_seconds` metric that records the time taken to enqueue or reject a query request. When query-scheduler is in use, the metric has the `scheduler_address` label to differentiate the enqueue duration by query-scheduler backend. #5879 #6087 #6120
@@ -87,6 +86,7 @@
 
 * [CHANGE] Dashboards: enabled reporting gRPC codes as `status_code` label in Mimir dashboards. In case of gRPC calls, the successful `status_code` label on `cortex_request_duration_seconds` and gRPC client request duration metrics has changed from 'success' and '2xx' to 'OK'. #6561
 * [CHANGE] Alerts: remove `MimirGossipMembersMismatch` alert and replace it with `MimirGossipMembersTooHigh` and `MimirGossipMembersTooLow` alerts that should have a higher signal-to-noise ratio. #6508
+* [ENHANCEMENT] Alerts: add `MimirIngesterReachingInflightPushRequestLimit` alert and runbook. #6649
 * [ENHANCEMENT] Dashboards: Optionally show rejected requests on Mimir Writes dashboard. Useful when used together with "early request rejection" in ingester and distributor. #6132 #6556
 * [ENHANCEMENT] Alerts: added a critical alert for `CompactorSkippedBlocksWithOutOfOrderChunks` when multiple blocks are affected. #6410
 * [ENHANCEMENT] Dashboards: Added the min-replicas for autoscaling dashboards. #6528

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -178,6 +178,33 @@ How to **fix** it:
 2. **Scale up distributors**<br />
    Scaling up distributors will lower the number of in-flight push requests per distributor.
 
+### MimirIngesterReachingInflightPushRequestLimit
+
+This alert fires when the `cortex_ingester_inflight_push_requests_summary` per ingester instance limit is enabled and the actual number of in-flight push requests is approaching the set limit. Once the limit is reached, push requests to the ingester will fail (5xx) or 429 for new requests, while existing in-flight push requests will continue to succeed.
+
+In case of **emergency**:
+
+- If the actual number of in-flight push requests is very close to or already at the set limit, then you can increase the limit via CLI flag or config to gain some time
+- Increasing the limit will increase the number of in-flight push requests which will increase ingesters' memory utilization. Please monitor the ingesters' memory utilization via the `Mimir / Writes Resources` dashboard
+
+How the limit is **configured**:
+
+- The limit can be configured either by the CLI flag (`-ingester.instance-limits.max-inflight-push-requests`) or in the config:
+  ```
+  ingester:
+    instance_limits:
+      max_inflight_push_requests: <int>
+  ```
+- These changes are applied with a ingester restart.
+- The configured limit can be queried via `cortex_ingester_instance_limits{limit="max_inflight_push_requests"})`
+
+How to **fix** it:
+
+1. **Temporarily increase the limit**<br />
+   If the actual number of in-flight push requests is very close to or already hit the limit.
+2. **Scale up ingesters**<br />
+   Scaling up ingesters will lower the number of in-flight push requests per ingester, but pay attention this could cause tenants to start discarding samples due to lowered local series limits. The bottom panes of the [dashboard](https://ops.grafana-ops.net/d/eb5ead36-a5cb-4f0b-88c3-a6548b5496e6/series-increase-review?orgId=1) could give you an idea whether the current limit is already close to limit. If any tenants are in danger, the PR to add ingesters should also temporarily increase the global series limit for those tenants to compensate ([example](https://github.com/grafana/deployment_tools/pull/95487)). Be sure to revert the temporary limits increases after the in-memory series for the tenants drop (usually after the next compaction).
+
 ### MimirRequestLatency
 
 This alert fires when a specific Mimir route is experiencing an high latency.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -316,6 +316,20 @@ spec:
       for: 5m
       labels:
         severity: critical
+    - alert: MimirIngesterReachingInflightPushRequestLimit
+      annotations:
+        message: |
+          Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its inflight push request limit.
+        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachinginflightpushrequestlimit
+      expr: |
+        (
+            (cortex_ingester_inflight_push_requests_summary{quantile="1.0"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
+            and ignoring (limit, quantile)
+            (cortex_ingester_instance_limits{limit="max_inflight_push_requests"} > 0)
+        ) > 0.8
+      for: 5m
+      labels:
+        severity: critical
   - name: mimir-rollout-alerts
     rules:
     - alert: MimirRolloutStuck

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -323,13 +323,13 @@ spec:
         runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachinginflightpushrequestlimit
       expr: |
         (
-            (cortex_ingester_inflight_push_requests_summary{quantile="1.0"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
+            (cortex_ingester_inflight_push_requests_summary{quantile="0.9"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
             and ignoring (limit, quantile)
             (cortex_ingester_instance_limits{limit="max_inflight_push_requests"} > 0)
         ) > 0.8
       for: 5m
       labels:
-        severity: critical
+        severity: warning
   - name: mimir-rollout-alerts
     rules:
     - alert: MimirRolloutStuck

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -304,6 +304,20 @@ groups:
     for: 5m
     labels:
       severity: critical
+  - alert: MimirIngesterReachingInflightPushRequestLimit
+    annotations:
+      message: |
+        Ingester {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its inflight push request limit.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachinginflightpushrequestlimit
+    expr: |
+      (
+          (cortex_ingester_inflight_push_requests_summary{quantile="1.0"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
+          and ignoring (limit, quantile)
+          (cortex_ingester_instance_limits{limit="max_inflight_push_requests"} > 0)
+      ) > 0.8
+    for: 5m
+    labels:
+      severity: critical
 - name: mimir-rollout-alerts
   rules:
   - alert: MimirRolloutStuck

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -311,13 +311,13 @@ groups:
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachinginflightpushrequestlimit
     expr: |
       (
-          (cortex_ingester_inflight_push_requests_summary{quantile="1.0"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
+          (cortex_ingester_inflight_push_requests_summary{quantile="0.9"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
           and ignoring (limit, quantile)
           (cortex_ingester_instance_limits{limit="max_inflight_push_requests"} > 0)
       ) > 0.8
     for: 5m
     labels:
-      severity: critical
+      severity: warning
 - name: mimir-rollout-alerts
   rules:
   - alert: MimirRolloutStuck

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -311,13 +311,13 @@ groups:
       runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachinginflightpushrequestlimit
     expr: |
       (
-          (cortex_ingester_inflight_push_requests_summary{quantile="1.0"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
+          (cortex_ingester_inflight_push_requests_summary{quantile="0.9"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
           and ignoring (limit, quantile)
           (cortex_ingester_instance_limits{limit="max_inflight_push_requests"} > 0)
       ) > 0.8
     for: 5m
     labels:
-      severity: critical
+      severity: warning
 - name: mimir-rollout-alerts
   rules:
   - alert: MimirRolloutStuck

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -304,6 +304,20 @@ groups:
     for: 5m
     labels:
       severity: critical
+  - alert: MimirIngesterReachingInflightPushRequestLimit
+    annotations:
+      message: |
+        Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its inflight push request limit.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachinginflightpushrequestlimit
+    expr: |
+      (
+          (cortex_ingester_inflight_push_requests_summary{quantile="1.0"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
+          and ignoring (limit, quantile)
+          (cortex_ingester_instance_limits{limit="max_inflight_push_requests"} > 0)
+      ) > 0.8
+    for: 5m
+    labels:
+      severity: critical
 - name: mimir-rollout-alerts
   rules:
   - alert: MimirRolloutStuck

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -466,6 +466,25 @@ local utils = import 'mixin-utils/utils.libsonnet';
             ||| % $._config,
           },
         },
+        {
+          alert: $.alertName('IngesterReachingInflightPushRequestLimit'),
+          expr: |||
+            (
+                (cortex_ingester_inflight_push_requests_summary{quantile="1.0"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
+                and ignoring (limit, quantile)
+                (cortex_ingester_instance_limits{limit="max_inflight_push_requests"} > 0)
+            ) > 0.8
+          |||,
+          'for': '5m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: |||
+              Ingester {{ $labels.%(per_job_label)s }}/%(alert_instance_variable)s has reached {{ $value | humanizePercentage }} of its inflight push request limit.
+            ||| % $._config,
+          },
+        },
       ],
     },
     {

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -470,14 +470,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('IngesterReachingInflightPushRequestLimit'),
           expr: |||
             (
-                (cortex_ingester_inflight_push_requests_summary{quantile="1.0"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
+                (cortex_ingester_inflight_push_requests_summary{quantile="0.9"} / ignoring(limit, quantile) cortex_ingester_instance_limits{limit="max_inflight_push_requests"})
                 and ignoring (limit, quantile)
                 (cortex_ingester_instance_limits{limit="max_inflight_push_requests"} > 0)
             ) > 0.8
           |||,
           'for': '5m',
           labels: {
-            severity: 'critical',
+            severity: 'warning',
           },
           annotations: {
             message: |||


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This is to add alert MimirIngesterReachingInflightPushRequestLimit requested by PIR, in order to warn that Ingester inflight push request is approaching per Ingester limit. The equation used is if any of Ingester has more than 10% of the time r/s is surpassing 0.8 * limit and the situation persist during 5 minutes, the warning would raise. To be honest this is not science, just trying to figure out something good enough and make sense.

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
