### PR TITLE
feat/add discovered metrics to metricsUsed

### DIFF
--- a/pkg/mimirtool/commands/analyse_dashboards.go
+++ b/pkg/mimirtool/commands/analyse_dashboards.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/prometheus/common/model"
 
 	"github.com/grafana/mimir/pkg/mimirtool/analyze"
 	"github.com/grafana/mimir/pkg/mimirtool/minisdk"
@@ -51,6 +53,14 @@ func AnalyzeDashboards(dashFilesList []string) (*analyze.MetricsInGrafana, error
 		}
 		analyze.ParseMetricsInBoard(output, board)
 	}
+
+	var metricsUsed model.LabelValues
+	for metric := range output.OverallMetrics {
+		metricsUsed = append(metricsUsed, model.LabelValue(metric))
+	}
+	sort.Sort(metricsUsed)
+	output.MetricsUsed = metricsUsed
+
 	return output, nil
 }
 


### PR DESCRIPTION
#### What this PR does

Synchonizes behavior output between `analyze dashboard` and `analyze grafana`. 

The `analyze dashboard` command did not populate the `metricsUsed` field with metrics discovered from local dashboards. The `analyze grafana`, however, did that. After looking at the code, it seems it was only missing the copy metrics to the `metricsUsed` fields.


#### Which issue(s) this PR fixes or relates to

I did not open an issue.

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
