### PR TITLE
Refactor distributor test preparation

### DIFF
--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -62,12 +62,14 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReac
 
 							// Prepare distributors.
 							ds, ingesters, reg := prepare(t, prepConfig{
-								numIngesters:             3,
-								happyIngesters:           3,
-								numDistributors:          1,
-								limits:                   limits,
-								preferStreamingChunks:    streamingEnabled,
-								minimizeIngesterRequests: minimizeIngesterRequests,
+								numIngesters:    3,
+								happyIngesters:  3,
+								numDistributors: 1,
+								limits:          limits,
+								configure: func(config *Config) {
+									config.PreferStreamingChunksFromIngesters = streamingEnabled
+									config.MinimizeIngesterRequests = minimizeIngesterRequests
+								},
 							})
 
 							// Push a number of series below the max chunks limit. Each series has 1 sample,
@@ -146,11 +148,13 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReac
 
 			// Prepare distributors.
 			ds, ingesters, reg := prepare(t, prepConfig{
-				numIngesters:             3,
-				happyIngesters:           3,
-				numDistributors:          1,
-				limits:                   limits,
-				minimizeIngesterRequests: minimizeIngesterRequests,
+				numIngesters:    3,
+				happyIngesters:  3,
+				numDistributors: 1,
+				limits:          limits,
+				configure: func(config *Config) {
+					config.MinimizeIngesterRequests = minimizeIngesterRequests
+				},
 			})
 
 			// Push a number of series below the max series limit.


### PR DESCRIPTION
#### What this PR does

Instead of adding more and more config fields to prepConfig, we now can pass a `configure(*Config)` function instead, that would set the desired fields.

This will make another PR I'm working on easier to review.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated
- [ ] ~Documentation added~
- [ ] ~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`~
