### PR TITLE
Support $rate_interval when parsing Query during dashboards analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 
 ### Mimirtool
 
+* [ENHANCEMENT] Analyze Grafana: Improve support for variables in range. #6657
 * [BUGFIX] Fix out of bounds error on export with large timespans and/or series count. #5700
 * [BUGFIX] Fix the issue where `--read-timeout` was applied to the entire `mimirtool analyze grafana` invocation rather than to individual Grafana API calls. #5915
 * [BUGFIX] Fix incorrect remote-read path joining for `mimirtool remote-read` commands on Windows. #6009


### PR DESCRIPTION
Grafana support several Global variables but also allow users to define an `interval` templated variable. When using mimirtool on such case we might have the following error:

```
"query=histogram_quantile(0.70, sum by (le) (rate(rpc_server_duration_milliseconds_bucket{rpc_method=~\"$gRPC_method\", job=\"$job\"}[$rate_interval]))): 1:124: parse error: missing unit character in duration",
```

This commit add support for more user define variables matching the global ones.

See: https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#global-variables

We have the following global variables that are out of the scope of dashboards analysis:
* $__dashboard
* $__from and $__to
* $__name
* $__org
* $__user
* $timeFilter or $__timeFilter
* $__timezone

However those are interesting:
* $__interval --> can be overridden by $interval
* $__interval_ms --> can be overridden by $interval
* $__range --> not addressed by this PR, should we?
* $__rate_interval --> can be overridden by $rate_interval
* $__rate_interval_ms --> can be overridden by $rate_interval

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
