### PR TITLE
Fix broken `BenchmarkPrometheusCodec_DecodeResponse` benchmark

### DIFF
--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -732,6 +732,9 @@ func BenchmarkPrometheusCodec_DecodeResponse(b *testing.B) {
 			StatusCode:    200,
 			Body:          io.NopCloser(bytes.NewReader(encodedRes)),
 			ContentLength: int64(len(encodedRes)),
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
 		}, nil, log.NewNopLogger())
 		require.NoError(b, err)
 	}


### PR DESCRIPTION
#### What this PR does

This PR fixes the `BenchmarkPrometheusCodec_DecodeResponse` benchmark: it currently fails with a `unknown response content type ''` error.

This was likely broken in #4153.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
