### PR TITLE
Add option `distributor.ingestion-burst-factor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * [ENHANCEMENT] Query-frontend: return clearer error message when a query request is received while shutting down. #6675
 * [ENHANCEMENT] Querier: return clearer error message when a query request is cancelled by the caller. #6697
 * [ENHANCEMENT] Compactor: Mark corrupted blocks for no-compaction to avoid blocking compactor future runs. #6588
+* [ENHANCEMENT] Distributor: Added an experimental configuration option `distributor.ingestion-burst-factor` that overrides the `distributor.ingestion-burst-size` option if set. The `distributor.ingestion-burst-factor` is used to set the underlying ingestion rate limiter token bucket's burst size to a multiple of the per distributor `distributor.ingestion-rate-limit` and the `distributor.ingestion-burst-factor`. This is disabled by default. #
 * [BUGFIX] Distributor: return server overload error in the event of exceeding the ingestion rate limit. #6549
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@
 * [ENHANCEMENT] Query-frontend: return clearer error message when a query request is received while shutting down. #6675
 * [ENHANCEMENT] Querier: return clearer error message when a query request is cancelled by the caller. #6697
 * [ENHANCEMENT] Compactor: Mark corrupted blocks for no-compaction to avoid blocking compactor future runs. #6588
-* [ENHANCEMENT] Distributor: Added an experimental configuration option `distributor.ingestion-burst-factor` that overrides the `distributor.ingestion-burst-size` option if set. The `distributor.ingestion-burst-factor` is used to set the underlying ingestion rate limiter token bucket's burst size to a multiple of the per distributor `distributor.ingestion-rate-limit` and the `distributor.ingestion-burst-factor`. This is disabled by default. #
+* [ENHANCEMENT] Distributor: Added an experimental configuration option `distributor.ingestion-burst-factor` that overrides the `distributor.ingestion-burst-size` option if set. The `distributor.ingestion-burst-factor` is used to set the underlying ingestion rate limiter token bucket's burst size to a multiple of the per distributor `distributor.ingestion-rate-limit` and the `distributor.ingestion-burst-factor`. This is disabled by default. #6662
 * [BUGFIX] Distributor: return server overload error in the event of exceeding the ingestion rate limit. #6549
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3107,11 +3107,11 @@
           "kind": "field",
           "name": "ingestion_burst_factor",
           "required": false,
-          "desc": "Per-tenant burst factor which is the maximum burst size allowed as a multiple of the per-tenant ingestion rate. If this is set it will override the `ingestion-burst-size` option.",
+          "desc": "Per-tenant burst factor which is the maximum burst size allowed as a multiple of the per-tenant ingestion rate, this burst-factor must be greater than or equal to 1. If this is set it will override the ingestion-burst-size option.",
           "fieldValue": null,
           "fieldDefaultValue": 0,
           "fieldFlag": "distributor.ingestion-burst-factor",
-          "fieldType": "int",
+          "fieldType": "float",
           "fieldCategory": "experimental"
         },
         {

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3105,6 +3105,17 @@
         },
         {
           "kind": "field",
+          "name": "ingestion_burst_factor",
+          "required": false,
+          "desc": "Per-tenant burst factor which is the maximum burst size allowed as a multiple of the per-tenant ingestion rate. If this is set it will override the `ingestion-burst-size` option.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "distributor.ingestion-burst-factor",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "accept_ha_samples",
           "required": false,
           "desc": "Flag to enable, for all tenants, handling of samples with external labels identifying replicas in an HA Prometheus setup.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1127,8 +1127,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum jitter applied to the update timeout, in order to spread the HA heartbeats over time. (default 5s)
   -distributor.health-check-ingesters
     	Run a health check on each ingester client during periodic cleanup. (default true)
-  -distributor.ingestion-burst-factor int
-    	[experimental] Per-tenant burst factor which is the maximum burst size allowed as a multiple of the per-tenant ingestion rate. If this is set it will override the `ingestion-burst-size` option.
+  -distributor.ingestion-burst-factor float
+    	[experimental] Per-tenant burst factor which is the maximum burst size allowed as a multiple of the per-tenant ingestion rate, this burst-factor must be greater than or equal to 1. If this is set it will override the ingestion-burst-size option.
   -distributor.ingestion-burst-size int
     	Per-tenant allowed ingestion burst size (in number of samples). (default 200000)
   -distributor.ingestion-rate-limit float

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1127,6 +1127,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum jitter applied to the update timeout, in order to spread the HA heartbeats over time. (default 5s)
   -distributor.health-check-ingesters
     	Run a health check on each ingester client during periodic cleanup. (default true)
+  -distributor.ingestion-burst-factor int
+    	[experimental] Per-tenant burst factor which is the maximum burst size allowed as a multiple of the per-tenant ingestion rate. If this is set it will override the `ingestion-burst-size` option.
   -distributor.ingestion-burst-size int
     	Per-tenant allowed ingestion burst size (in number of samples). (default 200000)
   -distributor.ingestion-rate-limit float

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2868,6 +2868,12 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -distributor.ingestion-burst-size
 [ingestion_burst_size: <int> | default = 200000]
 
+# (experimental) Per-tenant burst factor which is the maximum burst size allowed
+# as a multiple of the per-tenant ingestion rate. If this is set it will
+# override the `ingestion-burst-size` option.
+# CLI flag: -distributor.ingestion-burst-factor
+[ingestion_burst_factor: <int> | default = 0]
+
 # Flag to enable, for all tenants, handling of samples with external labels
 # identifying replicas in an HA Prometheus setup.
 # CLI flag: -distributor.ha-tracker.enable-for-all-users

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -2869,10 +2869,11 @@ The `limits` block configures default and per-tenant limits imposed by component
 [ingestion_burst_size: <int> | default = 200000]
 
 # (experimental) Per-tenant burst factor which is the maximum burst size allowed
-# as a multiple of the per-tenant ingestion rate. If this is set it will
-# override the `ingestion-burst-size` option.
+# as a multiple of the per-tenant ingestion rate, this burst-factor must be
+# greater than or equal to 1. If this is set it will override the
+# ingestion-burst-size option.
 # CLI flag: -distributor.ingestion-burst-factor
-[ingestion_burst_factor: <int> | default = 0]
+[ingestion_burst_factor: <float> | default = 0]
 
 # Flag to enable, for all tenants, handling of samples with external labels
 # identifying replicas in an HA Prometheus setup.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -974,7 +974,7 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 
 			burstSize := d.limits.IngestionBurstSize(userID)
 			if d.limits.IngestionBurstFactor(userID) > 0 {
-				burstSize = int(d.limits.IngestionRate(userID)*d.limits.IngestionBurstFactor(userID))
+				burstSize = int(d.limits.IngestionRate(userID) * d.limits.IngestionBurstFactor(userID))
 			}
 			return newIngestionRateLimitedError(d.limits.IngestionRate(userID), burstSize)
 		}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -974,7 +974,7 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 
 			burstSize := d.limits.IngestionBurstSize(userID)
 			if d.limits.IngestionBurstFactor(userID) > 0 {
-				burstSize = int(d.limits.IngestionRate(userID))*d.limits.IngestionBurstFactor(userID)
+				burstSize = int(d.limits.IngestionRate(userID)*d.limits.IngestionBurstFactor(userID))
 			}
 			return newIngestionRateLimitedError(d.limits.IngestionRate(userID), burstSize)
 		}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -426,7 +426,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 
 		subservices = append(subservices, distributorsLifecycler, distributorsRing)
 		requestRateStrategy = newGlobalRateStrategy(newRequestRateStrategy(limits), d)
-		ingestionRateStrategy = newGlobalRateStrategy(newIngestionRateStrategy(limits), d)
+		ingestionRateStrategy = newGlobalRateStrategyWithBurstFactor(limits, d)
 	}
 
 	d.requestRateLimiter = limiter.NewRateLimiter(requestRateStrategy, 10*time.Second)
@@ -971,7 +971,12 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 			d.discardedSamplesRateLimited.WithLabelValues(userID, group).Add(float64(validatedSamples))
 			d.discardedExemplarsRateLimited.WithLabelValues(userID).Add(float64(validatedExemplars))
 			d.discardedMetadataRateLimited.WithLabelValues(userID).Add(float64(validatedMetadata))
-			return newIngestionRateLimitedError(d.limits.IngestionRate(userID), d.limits.IngestionBurstSize(userID))
+
+			burstSize := d.limits.IngestionBurstSize(userID)
+			if d.limits.IngestionBurstFactor(userID) > 0 {
+				burstSize = int(d.limits.IngestionRate(userID))*d.limits.IngestionBurstFactor(userID)
+			}
+			return newIngestionRateLimitedError(d.limits.IngestionRate(userID), burstSize)
 		}
 
 		// totalN included samples, exemplars and metadata. Ingester follows this pattern when computing its ingestion rate.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -679,7 +679,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 				{metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 40).Error())},
 			},
 		},
-		"Test burstFactor burst limit": {
+		"Test burstFactor burst limit in one burst": {
 			distributors:         2,
 			ingestionRate:        10,
 			ingestionBurstFactor: 2,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -633,7 +633,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 		distributors         int
 		ingestionRate        float64
 		ingestionBurstSize   int
-		ingestionBurstFactor int
+		ingestionBurstFactor float64
 		pushes               []testPush
 	}{
 		"evenly share the ingestion limit across distributors": {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -630,15 +630,17 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 
 	ctx := user.InjectOrgID(context.Background(), "user")
 	tests := map[string]struct {
-		distributors       int
-		ingestionRate      float64
-		ingestionBurstSize int
-		pushes             []testPush
+		distributors         int
+		ingestionRate        float64
+		ingestionBurstSize   int
+		ingestionBurstFactor int
+		pushes               []testPush
 	}{
 		"evenly share the ingestion limit across distributors": {
-			distributors:       2,
-			ingestionRate:      10,
-			ingestionBurstSize: 5,
+			distributors:         2,
+			ingestionRate:        10,
+			ingestionBurstSize:   5,
+			ingestionBurstFactor: 0,
 			pushes: []testPush{
 				{samples: 2, expectedError: nil},
 				{samples: 1, expectedError: nil},
@@ -649,9 +651,10 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			},
 		},
 		"for each distributor, set an ingestion burst limit.": {
-			distributors:       2,
-			ingestionRate:      10,
-			ingestionBurstSize: 20,
+			distributors:         2,
+			ingestionRate:        10,
+			ingestionBurstSize:   20,
+			ingestionBurstFactor: 0,
 			pushes: []testPush{
 				{samples: 10, expectedError: nil},
 				{samples: 5, expectedError: nil},
@@ -659,6 +662,32 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 				{samples: 5, expectedError: nil},
 				{samples: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 20).Error())},
 				{metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 20).Error())},
+			},
+		},
+		"evenly share the ingestion burst limit across distributors": {
+			distributors:         2,
+			ingestionRate:        10,
+			ingestionBurstFactor: 4,
+			// This is equivalent to the test above because the ingestion rate and burst are per distributor with the burst factor meaning the burst would be:
+			// (10 (ingest rate) / 2 (number of distributors)) * 4 (burst factor)= 20 burst per distributor
+			pushes: []testPush{
+				{samples: 10, expectedError: nil},
+				{samples: 5, expectedError: nil},
+				{samples: 5, metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 40).Error())},
+				{samples: 5, expectedError: nil},
+				{samples: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 40).Error())},
+				{metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 40).Error())},
+			},
+		},
+		"Test burstFactor burst limit": {
+			distributors:         2,
+			ingestionRate:        10,
+			ingestionBurstFactor: 2,
+			pushes: []testPush{
+				// Burst is 10 for the distributor (10/2)*2 = 10
+				{samples: 10, expectedError: nil},
+				// We've drained the pool so this should fail until the bucket re-fills in a few seconds
+				{samples: 1, metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 20).Error())},
 			},
 		},
 	}
@@ -673,6 +702,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			flagext.DefaultValues(limits)
 			limits.IngestionRate = testData.ingestionRate
 			limits.IngestionBurstSize = testData.ingestionBurstSize
+			limits.IngestionBurstFactor = testData.ingestionBurstFactor
 
 			// Start all expected distributors
 			distributors, _, _ := prepare(t, prepConfig{
@@ -682,16 +712,16 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 				limits:          limits,
 			})
 
-			// Push samples in multiple requests to the first distributor
+			// Push samples in multiple requests to only the first distributor
 			for _, push := range testData.pushes {
 				request := makeWriteRequest(0, push.samples, push.metadata, false, false)
 				response, err := distributors[0].Push(ctx, request)
 
 				if push.expectedError == nil {
-					assert.Equal(t, emptyResponse, response)
+					assert.Equal(t, emptyResponse, response, "Received error when a successful write was expected.")
 					assert.Nil(t, err)
 				} else {
-					assert.Nil(t, response)
+					assert.Nil(t, response, "Received successful write response when an error was expected.")
 					checkGRPCError(t, push.expectedError, expectedErrorDetails, err)
 				}
 			}

--- a/pkg/distributor/rate_strategy.go
+++ b/pkg/distributor/rate_strategy.go
@@ -54,9 +54,8 @@ func (s *globalIngestionStrategyWithBurstFactor) Burst(tenantID string) int {
 		} else {
 			return int(math.Ceil(burstByFactor))
 		}
-	} else {
-		return s.limits.IngestionBurstSize(tenantID)
 	}
+	return s.limits.IngestionBurstSize(tenantID)
 }
 
 type globalStrategy struct {

--- a/pkg/distributor/rate_strategy.go
+++ b/pkg/distributor/rate_strategy.go
@@ -43,9 +43,10 @@ func (s *globalIngestionStrategyWithBurstFactor) Limit(tenantID string) float64 
 }
 
 func (s *globalIngestionStrategyWithBurstFactor) Burst(tenantID string) int {
-	if s.limits.IngestionBurstFactor(tenantID) > 0 {
+	burstFactor := s.limits.IngestionBurstFactor(tenantID)
+	if burstFactor > 0 {
 		limit := s.Limit(tenantID)
-		burstByFactor := float64(s.limits.IngestionBurstFactor(tenantID)) * limit
+		burstByFactor := float64(burstFactor) * limit
 		// If the ingestion rate * burst factor is too large we want to set it to the max possible burst value
 		if burstByFactor >= math.MaxInt {
 			return math.MaxInt
@@ -116,29 +117,6 @@ func (s *requestRateStrategy) Burst(tenantID string) int {
 
 type ingestionRateStrategy struct {
 	limits *validation.Overrides
-}
-
-func newIngestionRateStrategy(limits *validation.Overrides) limiter.RateLimiterStrategy {
-	return &ingestionRateStrategy{
-		limits: limits,
-	}
-}
-
-func (s *ingestionRateStrategy) Limit(tenantID string) float64 {
-	return s.limits.IngestionRate(tenantID)
-}
-
-func (s *ingestionRateStrategy) Burst(tenantID string) int {
-	if s.limits.IngestionBurstFactor(tenantID) > 0 {
-		burstByFactor := float64(s.limits.IngestionBurstFactor(tenantID)) * s.limits.IngestionRate(tenantID)
-		// If the ingestion rate * burst factor is too large we want to set it to the max possible burst value
-		if burstByFactor >= math.MaxInt {
-			return math.MaxInt
-		} else {
-			return int(burstByFactor)
-		}
-	}
-	return s.limits.IngestionBurstSize(tenantID)
 }
 
 type infiniteStrategy struct{}

--- a/pkg/distributor/rate_strategy.go
+++ b/pkg/distributor/rate_strategy.go
@@ -51,9 +51,8 @@ func (s *globalIngestionStrategyWithBurstFactor) Burst(tenantID string) int {
 		// If the ingestion rate * burst factor is too large we want to set it to the max possible burst value
 		if burstByFactor >= math.MaxInt {
 			return math.MaxInt
-		} else {
-			return int(math.Ceil(burstByFactor))
 		}
+		return int(math.Ceil(burstByFactor))
 	}
 	return s.limits.IngestionBurstSize(tenantID)
 }

--- a/pkg/distributor/rate_strategy_test.go
+++ b/pkg/distributor/rate_strategy_test.go
@@ -70,6 +70,21 @@ func TestIngestionRateStrategy(t *testing.T) {
 		assert.Equal(t, strategy.Limit("test"), float64(math.MaxInt)/2)
 		assert.Equal(t, strategy.Burst("test"), math.MaxInt)
 	})
+	t.Run("Burst factor should be set to to max int if limit is rate.inf", func(t *testing.T) {
+		// Init limits overrides
+		overrides, err := validation.NewOverrides(validation.Limits{
+			IngestionRate:        math.MaxFloat64,
+			IngestionBurstFactor: 3,
+		}, nil)
+		require.NoError(t, err)
+
+		mockRing := newReadLifecyclerMock()
+		mockRing.On("HealthyInstancesCount").Return(2)
+
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing)
+		assert.Equal(t, strategy.Limit("test"), math.MaxFloat64)
+		assert.Equal(t, strategy.Burst("test"), math.MaxInt)
+	})
 }
 
 type readLifecyclerMock struct {

--- a/pkg/distributor/rate_strategy_test.go
+++ b/pkg/distributor/rate_strategy_test.go
@@ -6,6 +6,7 @@
 package distributor
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ func TestIngestionRateStrategy(t *testing.T) {
 		mockRing := newReadLifecyclerMock()
 		mockRing.On("HealthyInstancesCount").Return(2)
 
-		strategy := newGlobalRateStrategy(newIngestionRateStrategy(overrides), mockRing)
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing)
 		assert.Equal(t, strategy.Limit("test"), float64(500))
 		assert.Equal(t, strategy.Burst("test"), 10000)
 	})
@@ -38,6 +39,36 @@ func TestIngestionRateStrategy(t *testing.T) {
 
 		assert.Equal(t, strategy.Limit("test"), float64(rate.Inf))
 		assert.Equal(t, strategy.Burst("test"), 0)
+	})
+	t.Run("Burst factor should be 3x the per distributor limit", func(t *testing.T) {
+		// Init limits overrides
+		overrides, err := validation.NewOverrides(validation.Limits{
+			IngestionRate:        float64(1000),
+			IngestionBurstFactor: 3,
+		}, nil)
+		require.NoError(t, err)
+
+		mockRing := newReadLifecyclerMock()
+		mockRing.On("HealthyInstancesCount").Return(2)
+
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing)
+		assert.Equal(t, strategy.Limit("test"), float64(500))
+		assert.Equal(t, strategy.Burst("test"), 1500)
+	})
+	t.Run("Burst factor should be set to to max int if limit is too large", func(t *testing.T) {
+		// Init limits overrides
+		overrides, err := validation.NewOverrides(validation.Limits{
+			IngestionRate:        float64(math.MaxInt),
+			IngestionBurstFactor: 3,
+		}, nil)
+		require.NoError(t, err)
+
+		mockRing := newReadLifecyclerMock()
+		mockRing.On("HealthyInstancesCount").Return(2)
+
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing)
+		assert.Equal(t, strategy.Limit("test"), float64(math.MaxInt)/2)
+		assert.Equal(t, strategy.Burst("test"), math.MaxInt)
 	})
 }
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -49,6 +49,7 @@ const (
 	RequestBurstSizeFlag                     = "distributor.request-burst-size"
 	IngestionRateFlag                        = "distributor.ingestion-rate-limit"
 	IngestionBurstSizeFlag                   = "distributor.ingestion-burst-size"
+	IngestionBurstFactorFlag                 = "distributor.ingestion-burst-factor"
 	HATrackerMaxClustersFlag                 = "distributor.ha-tracker.max-clusters"
 	resultsCacheTTLFlag                      = "query-frontend.results-cache-ttl"
 	resultsCacheTTLForOutOfOrderWindowFlag   = "query-frontend.results-cache-ttl-for-out-of-order-time-window"
@@ -73,6 +74,7 @@ type Limits struct {
 	RequestBurstSize                            int                 `yaml:"request_burst_size" json:"request_burst_size"`
 	IngestionRate                               float64             `yaml:"ingestion_rate" json:"ingestion_rate"`
 	IngestionBurstSize                          int                 `yaml:"ingestion_burst_size" json:"ingestion_burst_size"`
+	IngestionBurstFactor                        int                 `yaml:"ingestion_burst_factor" json:"ingestion_burst_factor" category:"experimental"`
 	AcceptHASamples                             bool                `yaml:"accept_ha_samples" json:"accept_ha_samples"`
 	HAClusterLabel                              string              `yaml:"ha_cluster_label" json:"ha_cluster_label"`
 	HAReplicaLabel                              string              `yaml:"ha_replica_label" json:"ha_replica_label"`
@@ -197,6 +199,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.RequestBurstSize, RequestBurstSizeFlag, 0, "Per-tenant allowed push request burst size. 0 to disable.")
 	f.Float64Var(&l.IngestionRate, IngestionRateFlag, 10000, "Per-tenant ingestion rate limit in samples per second.")
 	f.IntVar(&l.IngestionBurstSize, IngestionBurstSizeFlag, 200000, "Per-tenant allowed ingestion burst size (in number of samples).")
+	f.IntVar(&l.IngestionBurstFactor, IngestionBurstFactorFlag, 0, "Per-tenant burst factor which is the maximum burst size allowed as a multiple of the per-tenant ingestion rate. If this is set it will override the `ingestion-burst-size` option.")
 	f.BoolVar(&l.AcceptHASamples, "distributor.ha-tracker.enable-for-all-users", false, "Flag to enable, for all tenants, handling of samples with external labels identifying replicas in an HA Prometheus setup.")
 	f.StringVar(&l.HAClusterLabel, "distributor.ha-tracker.cluster", "cluster", "Prometheus label to look for in samples to identify a Prometheus HA cluster.")
 	f.StringVar(&l.HAReplicaLabel, "distributor.ha-tracker.replica", "__replica__", "Prometheus label to look for in samples to identify a Prometheus HA replica.")
@@ -445,6 +448,10 @@ func (o *Overrides) LabelValuesMaxCardinalityLabelNamesPerRequest(userID string)
 // IngestionBurstSize returns the burst size for ingestion rate.
 func (o *Overrides) IngestionBurstSize(userID string) int {
 	return o.getOverridesForUser(userID).IngestionBurstSize
+}
+
+func (o *Overrides) IngestionBurstFactor(userID string) int{
+	return o.getOverridesForUser(userID).IngestionBurstFactor
 }
 
 // AcceptHASamples returns whether the distributor should track and accept samples from HA replicas for this user.

--- a/pkg/util/validation/user_limits_handler.go
+++ b/pkg/util/validation/user_limits_handler.go
@@ -17,7 +17,7 @@ type UserLimitsResponse struct {
 	// Write path limits
 	IngestionRate             float64 `json:"ingestion_rate"`
 	IngestionBurstSize        int     `json:"ingestion_burst_size"`
-	IngestionBurstFactor      int     `json:"ingestion_burst_factor"`
+	IngestionBurstFactor      float64 `json:"ingestion_burst_factor"`
 	MaxGlobalSeriesPerUser    int     `json:"max_global_series_per_user"`
 	MaxGlobalSeriesPerMetric  int     `json:"max_global_series_per_metric"`
 	MaxGlobalExemplarsPerUser int     `json:"max_global_exemplars_per_user"`

--- a/pkg/util/validation/user_limits_handler.go
+++ b/pkg/util/validation/user_limits_handler.go
@@ -17,6 +17,7 @@ type UserLimitsResponse struct {
 	// Write path limits
 	IngestionRate             float64 `json:"ingestion_rate"`
 	IngestionBurstSize        int     `json:"ingestion_burst_size"`
+	IngestionBurstFactor      int     `json:"ingestion_burst_factor"`
 	MaxGlobalSeriesPerUser    int     `json:"max_global_series_per_user"`
 	MaxGlobalSeriesPerMetric  int     `json:"max_global_series_per_metric"`
 	MaxGlobalExemplarsPerUser int     `json:"max_global_exemplars_per_user"`
@@ -51,6 +52,7 @@ func UserLimitsHandler(defaultLimits Limits, tenantLimits TenantLimits) http.Han
 			// Write path limits
 			IngestionRate:             userLimits.IngestionRate,
 			IngestionBurstSize:        userLimits.IngestionBurstSize,
+			IngestionBurstFactor:      userLimits.IngestionBurstFactor,
 			MaxGlobalSeriesPerUser:    userLimits.MaxGlobalSeriesPerUser,
 			MaxGlobalSeriesPerMetric:  userLimits.MaxGlobalSeriesPerMetric,
 			MaxGlobalExemplarsPerUser: userLimits.MaxGlobalExemplarsPerUser,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR is to add `distributor.ingestion-burst-factor`, when set it will override the `distributor.ingestion-burst-size`. When `distributor.ingestion-burst-factor` is set the burst size on the underlying token bucket for the ingest rate limiter to a multiple of the maximum ingestion rate a distributor can handle. This is to simplify setting the burst size to a multiple of the global rate limit. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [X] Tests updated
- [X] Documentation added
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
