### PR TITLE
Felix/active series encoding benchmark

### DIFF
--- a/pkg/querier/cardinality_analysis_handler_test.go
+++ b/pkg/querier/cardinality_analysis_handler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -855,7 +856,7 @@ func TestActiveSeriesCardinalityHandler(t *testing.T) {
 			bodyContent, err := io.ReadAll(body)
 			require.NoError(t, err)
 
-			resp := activeSeriesResponse{}
+			resp := v1.Response{}
 			err = json.Unmarshal(bodyContent, &resp)
 			require.NoError(t, err)
 			assert.Len(t, resp.Data, len(series))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This adds a benchmark for the querier's `ActiveSeriesHandler` and uses [json-iterator](https://pkg.go.dev/github.com/json-iterator/go#section-readme) to replace the standard library `encoding/json` to improve marshaling performance.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/querier
                                 │   stdjson    │              jsoniter              │
                                 │    sec/op    │   sec/op     vs base               │
ActiveSeriesHandler_ServeHTTP-10   987.62µ ± 0%   98.82µ ± 0%  -89.99% (p=0.002 n=6)

                                 │   stdjson    │              jsoniter               │
                                 │     B/op     │     B/op      vs base               │
ActiveSeriesHandler_ServeHTTP-10   965.7Ki ± 0%   148.8Ki ± 0%  -84.59% (p=0.002 n=6)

                                 │   stdjson    │             jsoniter              │
                                 │  allocs/op   │ allocs/op   vs base               │
ActiveSeriesHandler_ServeHTTP-10   13139.0 ± 0%   132.0 ± 0%  -99.00% (p=0.002 n=6)
```

#### Which issue(s) this PR fixes or relates to
n/a

#### Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
