### PR TITLE
Speed up some store-gateway tests

### DIFF
--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1081,8 +1081,8 @@ func appendTestSeries(series int) func(testing.TB, func() storage.Appender) {
 				addSeries(labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", "0_"+strconv.Itoa(n)+labelLongSuffix, "j", "bar", "r", "foo"))
 				addSeries(labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", "1_"+strconv.Itoa(n)+labelLongSuffix, "j", "bar", "s", "foo"))
 				addSeries(labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", "2_"+strconv.Itoa(n)+labelLongSuffix, "j", "foo", "t", "foo"))
-		}
-		assert.NoError(t, app.Commit())
+			}
+			assert.NoError(t, app.Commit())
 			app = appenderFactory()
 		}
 	}

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1037,6 +1037,7 @@ func uploadTestBlock(t testing.TB, tmpDir string, bkt objstore.Bucket, dataSetup
 	headOpts := tsdb.DefaultHeadOptions()
 	headOpts.ChunkDirRoot = tmpDir
 	headOpts.ChunkRange = 1000
+	headOpts.IsolationDisabled = true
 	h, err := tsdb.NewHead(nil, nil, nil, nil, headOpts, nil)
 	assert.NoError(t, err)
 	defer func() {

--- a/pkg/storegateway/postings_codec_test.go
+++ b/pkg/storegateway/postings_codec_test.go
@@ -41,7 +41,7 @@ func TestDiffVarintCodec(t *testing.T) {
 		assert.NoError(t, os.RemoveAll(chunksDir))
 	})
 
-	appendTestSeries(1e4)(t, h.Appender(context.Background()))
+	appendTestSeries(1e4)(t, func() storage.Appender { return h.Appender(context.Background()) })
 
 	idx, err := h.Index()
 	assert.NoError(t, err)
@@ -146,7 +146,7 @@ func TestDiffVarintMatchersCodec(t *testing.T) {
 		assert.NoError(t, os.RemoveAll(chunksDir))
 	})
 
-	appendTestSeries(1e4)(t, h.Appender(context.Background()))
+	appendTestSeries(1e4)(t, func() storage.Appender { return h.Appender(context.Background()) })
 
 	idx, err := h.Index()
 	assert.NoError(t, err)

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1077,12 +1077,15 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 	largerTestBlockFactory := prepareTestBlock(test.NewTB(t), func(t testing.TB, appenderFactory func() storage.Appender) {
 		for i := 0; i < largerTestBlockSeriesCount; i++ {
 			appender := appenderFactory()
+			lbls := labels.FromStrings("l1", fmt.Sprintf("v%d", i))
+			var ref storage.SeriesRef
 			const numSamples = 240 // Write enough samples to have two chunks per series
 			for j := 0; j < numSamples; j++ {
-				_, err := appender.Append(0, labels.FromStrings("l1", fmt.Sprintf("v%d", i)), int64(i*10+j), float64(j))
+				var err error
+				ref, err = appender.Append(ref, lbls, int64(i*10+j), float64(j))
 				assert.NoError(t, err)
-		}
-		assert.NoError(t, appender.Commit())
+			}
+			assert.NoError(t, appender.Commit())
 		}
 	})
 


### PR DESCRIPTION
#### What this PR does

See individual commits for more details.
* disable tsdb transaction isolation 
* commit appender periodically 
* reduce overhad from testify 
* re-use details when creating test block 

Before:
```
go test -count=1 -timeout=90s -run TestLoadingSeriesChunkRefsSetIterator ./pkg/storegateway/ 
ok      github.com/grafana/mimir/pkg/storegateway       28.387s
```
After:
```
go test -count=1 -timeout=90s -run TestLoadingSeriesChunkRefsSetIterator ./pkg/storegateway/ 
ok      github.com/grafana/mimir/pkg/storegateway       9.119s
```

#### Checklist

- [x] Tests updated
- NA Documentation added
- NA `CHANGELOG.md` updated
