### PR TITLE
Remove deprecated configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Grafana Mimir
 
+* [CHANGE] The following deprecated configurations have been removed: #6673
+  * `-querier.query-ingesters-within`
+  * `-querier.iterators`
+  * `-querier.batch-iterators`
+  * `-blocks-storage.bucket-store.max-chunk-pool-bytes`
+  * `-blocks-storage.bucket-store.chunk-pool-min-bucket-size-bytes`
+  * `-blocks-storage.bucket-store.chunk-pool-max-bucket-size-bytes`
+  * `-blocks-storage.bucket-store.bucket-index.enabled`
 * [CHANGE] Querier: Split worker GRPC config into separate client configs for the frontend and scheduler to allow TLS to be configured correctly when specifying the `tls_server_name`. The GRPC config specified under `-querier.frontend-client.*` will no longer apply to the scheduler client, and will need to be set explicitly under `-querier.scheduler-client.*`. #6445 #6573
 * [CHANGE] Store-gateway: enable sparse index headers by default. Sparse index headers reduce the time to load an index header up to 90%. #6005
 * [CHANGE] Store-gateway: lazy-loading concurrency limit default value is now 4. #6004

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8120,39 +8120,6 @@
             },
             {
               "kind": "field",
-              "name": "max_chunk_pool_bytes",
-              "required": false,
-              "desc": "Max size - in bytes - of a chunks pool, used to reduce memory allocations. The pool is shared across all tenants. 0 to disable the limit.",
-              "fieldValue": null,
-              "fieldDefaultValue": 2147483648,
-              "fieldFlag": "blocks-storage.bucket-store.max-chunk-pool-bytes",
-              "fieldType": "int",
-              "fieldCategory": "deprecated"
-            },
-            {
-              "kind": "field",
-              "name": "chunk_pool_min_bucket_size_bytes",
-              "required": false,
-              "desc": "Size - in bytes - of the smallest chunks pool bucket.",
-              "fieldValue": null,
-              "fieldDefaultValue": 16000,
-              "fieldFlag": "blocks-storage.bucket-store.chunk-pool-min-bucket-size-bytes",
-              "fieldType": "int",
-              "fieldCategory": "deprecated"
-            },
-            {
-              "kind": "field",
-              "name": "chunk_pool_max_bucket_size_bytes",
-              "required": false,
-              "desc": "Size - in bytes - of the largest chunks pool bucket.",
-              "fieldValue": null,
-              "fieldDefaultValue": 50000000,
-              "fieldFlag": "blocks-storage.bucket-store.chunk-pool-max-bucket-size-bytes",
-              "fieldType": "int",
-              "fieldCategory": "deprecated"
-            },
-            {
-              "kind": "field",
               "name": "series_hash_cache_max_size_bytes",
               "required": false,
               "desc": "Max size - in bytes - of the in-memory series hash cache. The cache is shared across all tenants and it's used only when query sharding is enabled.",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1660,28 +1660,6 @@
       "blockEntries": [
         {
           "kind": "field",
-          "name": "iterators",
-          "required": false,
-          "desc": "Use iterators to execute query, as opposed to fully materialising the series in memory.",
-          "fieldValue": null,
-          "fieldDefaultValue": false,
-          "fieldFlag": "querier.iterators",
-          "fieldType": "boolean",
-          "fieldCategory": "deprecated"
-        },
-        {
-          "kind": "field",
-          "name": "batch_iterators",
-          "required": false,
-          "desc": "Use batch iterators to execute query, as opposed to fully materialising the series in memory.  Takes precedent over the -querier.iterators flag.",
-          "fieldValue": null,
-          "fieldDefaultValue": true,
-          "fieldFlag": "querier.batch-iterators",
-          "fieldType": "boolean",
-          "fieldCategory": "deprecated"
-        },
-        {
-          "kind": "field",
           "name": "query_store_after",
           "required": false,
           "desc": "The time after which a metric should be queried from storage and not just ingesters. 0 means all queries are sent to store. If this option is enabled, the time range of the query sent to the store-gateway will be manipulated to ensure the query end is not more recent than 'now - query-store-after'.",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8061,17 +8061,6 @@
               "blockEntries": [
                 {
                   "kind": "field",
-                  "name": "enabled",
-                  "required": false,
-                  "desc": "If enabled, queriers and store-gateways discover blocks by reading a bucket index (created and updated by the compactor) instead of periodically scanning the bucket.",
-                  "fieldValue": null,
-                  "fieldDefaultValue": true,
-                  "fieldFlag": "blocks-storage.bucket-store.bucket-index.enabled",
-                  "fieldType": "boolean",
-                  "fieldCategory": "deprecated"
-                },
-                {
-                  "kind": "field",
                   "name": "update_on_error_interval",
                   "required": false,
                   "desc": "How frequently a bucket index, which previously failed to load, should be tried to load again. This option is used only by querier.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -303,10 +303,6 @@ Usage of ./cmd/mimir/mimir:
     	The maximum allowed age of a bucket index (last updated) before queries start failing because the bucket index is too old. The bucket index is periodically updated by the compactor, and this check is enforced in the querier (at query time). (default 1h0m0s)
   -blocks-storage.bucket-store.bucket-index.update-on-error-interval duration
     	How frequently a bucket index, which previously failed to load, should be tried to load again. This option is used only by querier. (default 1m0s)
-  -blocks-storage.bucket-store.chunk-pool-max-bucket-size-bytes int
-    	[deprecated] Size - in bytes - of the largest chunks pool bucket. (default 50000000)
-  -blocks-storage.bucket-store.chunk-pool-min-bucket-size-bytes int
-    	[deprecated] Size - in bytes - of the smallest chunks pool bucket. (default 16000)
   -blocks-storage.bucket-store.chunks-cache.attributes-in-memory-max-items int
     	Maximum number of object attribute items to keep in a first level in-memory LRU cache. Metadata will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache. (default 50000)
   -blocks-storage.bucket-store.chunks-cache.attributes-ttl duration
@@ -527,8 +523,6 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] If enabled, store-gateway will persist a sparse version of the index-header to disk on construction and load sparse index-headers from disk instead of the whole index-header. (default true)
   -blocks-storage.bucket-store.index-header.verify-on-load
     	If true, verify the checksum of index headers upon loading them (either on startup or lazily when lazy loading is enabled). Setting to true helps detect disk corruption at the cost of slowing down index header loading.
-  -blocks-storage.bucket-store.max-chunk-pool-bytes uint
-    	[deprecated] Max size - in bytes - of a chunks pool, used to reduce memory allocations. The pool is shared across all tenants. 0 to disable the limit. (default 2147483648)
   -blocks-storage.bucket-store.max-concurrent int
     	Max number of concurrent queries to execute against the long-term storage. The limit is shared across all tenants. (default 100)
   -blocks-storage.bucket-store.meta-sync-concurrency int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -295,8 +295,6 @@ Usage of ./cmd/mimir/mimir:
     	This option controls how many series to fetch per batch. The batch size must be greater than 0. (default 5000)
   -blocks-storage.bucket-store.block-sync-concurrency int
     	Maximum number of concurrent blocks synching per tenant. (default 20)
-  -blocks-storage.bucket-store.bucket-index.enabled
-    	[deprecated] If enabled, queriers and store-gateways discover blocks by reading a bucket index (created and updated by the compactor) instead of periodically scanning the bucket. (default true)
   -blocks-storage.bucket-store.bucket-index.idle-timeout duration
     	How long a unused bucket index should be cached. Once this timeout expires, the unused bucket index is removed from the in-memory cache. This option is used only by querier. (default 1h0m0s)
   -blocks-storage.bucket-store.bucket-index.max-stale-period duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1611,8 +1611,6 @@ Usage of ./cmd/mimir/mimir:
     	Minimum time to wait for ring stability at startup, if set to positive value. Set to 0 to disable.
   -print.config
     	Print the config and exit.
-  -querier.batch-iterators
-    	[deprecated] Use batch iterators to execute query, as opposed to fully materialising the series in memory.  Takes precedent over the -querier.iterators flag. (default true)
   -querier.cardinality-analysis-enabled
     	Enables endpoints used for cardinality analysis.
   -querier.default-evaluation-interval duration
@@ -1667,8 +1665,6 @@ Usage of ./cmd/mimir/mimir:
     	Override the expected name on the server certificate.
   -querier.id string
     	Querier ID, sent to the query-frontend to identify requests from the same querier. Defaults to hostname.
-  -querier.iterators
-    	[deprecated] Use iterators to execute query, as opposed to fully materialising the series in memory.
   -querier.label-names-and-values-results-max-size-bytes int
     	Maximum size in bytes of distinct label names and values. When querier receives response from ingester, it merges the response with responses from other ingesters. This maximum size limit is applied to the merged(distinct) results. If the limit is reached, an error is returned. (default 419430400)
   -querier.label-values-max-cardinality-label-names-per-request int

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -3538,12 +3538,6 @@ bucket_store:
   [ignore_deletion_mark_delay: <duration> | default = 1h]
 
   bucket_index:
-    # (deprecated) If enabled, queriers and store-gateways discover blocks by
-    # reading a bucket index (created and updated by the compactor) instead of
-    # periodically scanning the bucket.
-    # CLI flag: -blocks-storage.bucket-store.bucket-index.enabled
-    [enabled: <boolean> | default = true]
-
     # (advanced) How frequently a bucket index, which previously failed to load,
     # should be tried to load again. This option is used only by querier.
     # CLI flag: -blocks-storage.bucket-store.bucket-index.update-on-error-interval

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -1168,17 +1168,6 @@ instance_limits:
 The `querier` block configures the querier.
 
 ```yaml
-# (deprecated) Use iterators to execute query, as opposed to fully materialising
-# the series in memory.
-# CLI flag: -querier.iterators
-[iterators: <boolean> | default = false]
-
-# (deprecated) Use batch iterators to execute query, as opposed to fully
-# materialising the series in memory.  Takes precedent over the
-# -querier.iterators flag.
-# CLI flag: -querier.batch-iterators
-[batch_iterators: <boolean> | default = true]
-
 # (advanced) The time after which a metric should be queried from storage and
 # not just ingesters. 0 means all queries are sent to store. If this option is
 # enabled, the time range of the query sent to the store-gateway will be

--- a/docs/sources/mimir/references/configuration-parameters/index.md
+++ b/docs/sources/mimir/references/configuration-parameters/index.md
@@ -3570,19 +3570,6 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.ignore-blocks-within
   [ignore_blocks_within: <duration> | default = 10h]
 
-  # (deprecated) Max size - in bytes - of a chunks pool, used to reduce memory
-  # allocations. The pool is shared across all tenants. 0 to disable the limit.
-  # CLI flag: -blocks-storage.bucket-store.max-chunk-pool-bytes
-  [max_chunk_pool_bytes: <int> | default = 2147483648]
-
-  # (deprecated) Size - in bytes - of the smallest chunks pool bucket.
-  # CLI flag: -blocks-storage.bucket-store.chunk-pool-min-bucket-size-bytes
-  [chunk_pool_min_bucket_size_bytes: <int> | default = 16000]
-
-  # (deprecated) Size - in bytes - of the largest chunks pool bucket.
-  # CLI flag: -blocks-storage.bucket-store.chunk-pool-max-bucket-size-bytes
-  [chunk_pool_max_bucket_size_bytes: <int> | default = 50000000]
-
   # (advanced) Max size - in bytes - of the in-memory series hash cache. The
   # cache is shared across all tenants and it's used only when query sharding is
   # enabled.

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -132,6 +132,10 @@ func runBackwardCompatibilityTest(t *testing.T, previousImage string, oldFlagsMa
 	// The distributor should have 512 tokens for the ingester ring and 1 for the distributor ring
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
 
+	// Start the compactor to have the bucket index created before querying.
+	compactor := e2emimir.NewCompactor("compactor", consul.NetworkHTTPEndpoint(), flags)
+	require.NoError(t, s.StartAndWaitReady(compactor))
+
 	checkQueries(t, consul, previousImage, flags, oldFlagsMapper, s, 1, instantQueryTest{
 		expr:           "series_1",
 		time:           series1Timestamp,

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -142,7 +142,6 @@ var (
 	BlocksStorageFlags = func() map[string]string {
 		return map[string]string{
 			"-blocks-storage.tsdb.block-ranges-period":          "1m",
-			"-blocks-storage.bucket-store.bucket-index.enabled": "false",
 			"-blocks-storage.bucket-store.ignore-blocks-within": "0",
 			"-blocks-storage.bucket-store.sync-interval":        "5s",
 			"-blocks-storage.tsdb.retention-period":             "5m",
@@ -192,8 +191,6 @@ blocks_storage:
 
   bucket_store:
     sync_interval: 5s
-    bucket_index:
-      enabled: false 
 
   s3:
     bucket_name:       mimir-blocks

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -38,7 +38,6 @@ func TestGettingStartedWithGossipedRing(t *testing.T) {
 	flags := map[string]string{
 		// decrease timeouts to make test faster. should still be fine with two instances only
 		"-ingester.ring.observe-period":                     "5s", // to avoid conflicts in tokens
-		"-blocks-storage.bucket-store.bucket-index.enabled": "false",
 		"-blocks-storage.bucket-store.sync-interval":        "1s", // sync continuously
 		"-blocks-storage.bucket-store.ignore-blocks-within": "0",
 		"-blocks-storage.backend":                           "s3",

--- a/integration/ingester_limits_test.go
+++ b/integration/ingester_limits_test.go
@@ -187,14 +187,13 @@ overrides:
 				require.NoError(t, copyFileToSharedDir(s, "docs/configurations/single-process-config-blocks.yaml", mimirConfigFile))
 
 				flags := map[string]string{
-					"-runtime-config.reload-period":                     "100ms",
-					"-blocks-storage.backend":                           "filesystem",
-					"-blocks-storage.filesystem.dir":                    "/tmp",
-					"-blocks-storage.storage-prefix":                    "blocks",
-					"-blocks-storage.bucket-store.bucket-index.enabled": "false",
-					"-ruler-storage.backend":                            "filesystem",
-					"-ruler-storage.local.directory":                    "/tmp", // Avoid warning "unable to list rules".
-					"-runtime-config.file":                              filepath.Join(e2e.ContainerSharedDir, overridesFile),
+					"-runtime-config.reload-period":  "100ms",
+					"-blocks-storage.backend":        "filesystem",
+					"-blocks-storage.filesystem.dir": "/tmp",
+					"-blocks-storage.storage-prefix": "blocks",
+					"-ruler-storage.backend":         "filesystem",
+					"-ruler-storage.local.directory": "/tmp", // Avoid warning "unable to list rules".
+					"-runtime-config.file":           filepath.Join(e2e.ContainerSharedDir, overridesFile),
 				}
 				cortex1 := e2emimir.NewSingleBinary("cortex-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 				require.NoError(t, s.StartAndWaitReady(cortex1))

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -364,8 +364,6 @@ func TestRulerSharding(t *testing.T) {
 		BlocksStorageFlags(),
 		RulerShardingFlags(consul.NetworkHTTPEndpoint()),
 		map[string]string{
-			// Enable the bucket index so we can skip the initial bucket scan.
-			"-blocks-storage.bucket-store.bucket-index.enabled": "true",
 			// Disable rule group limit
 			"-ruler.max-rule-groups-per-tenant": "0",
 		},
@@ -556,8 +554,6 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 		RulerFlags(),
 		BlocksStorageFlags(),
 		map[string]string{
-			// Enable the bucket index so we can skip the initial bucket scan.
-			"-blocks-storage.bucket-store.bucket-index.enabled": "true",
 			// Evaluate rules often, so that we don't need to wait for metrics to show up.
 			"-ruler.evaluation-interval": "2s",
 			"-ruler.poll-interval":       "2s",

--- a/operations/compare-helm-with-jsonnet/components/config/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/components/config/kustomization.yaml
@@ -115,8 +115,6 @@ patches:
         path: /config/store_gateway/sharding_ring/tokens_file_path
       - op: remove
         path: /config/store_gateway/sharding_ring/wait_stability_min_duration
-      - op: remove
-        path: /config/blocks_storage/bucket_store/max_chunk_pool_bytes
 
   - target:
       kind: MimirConfig

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [CHANGE] Remove deprecated configuration parameter `blocks_storage.bucket_store.max_chunk_pool_bytes`. #6673
 * [CHANGE] Reduce `-server.grpc-max-concurrent-streams` from 1000 to 500 for ingester and to 100 for all components. #5666
 * [CHANGE] Changed default `clusterDomain` from `cluster.local` to `cluster.local.` to reduce the number of DNS lookups made by Mimir. #6389
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.9.2`. #6022 #6110 #6558

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -472,31 +472,6 @@ func TestConfig_ValidateLimits(t *testing.T) {
 	}
 }
 
-// Temporary behavior to keep supporting global query-ingesters-within flag for two Mimir versions
-// TODO: Remove in Mimir 2.11.0
-func TestQueryIngestersWithinGlobalConfigIsUsedInsteadOfDefaultLimitConfig(t *testing.T) {
-	dir := t.TempDir()
-
-	cfg := Config{}
-	flagext.DefaultValues(&cfg)
-
-	cfg.Querier.QueryIngestersWithin = 5 * time.Hour
-	cfg.Target = []string{Overrides}
-
-	cfg.RuntimeConfig.LoadPath = []string{filepath.Join(dir, "config.yaml")}
-
-	c, err := New(cfg, prometheus.NewPedanticRegistry())
-	require.NoError(t, err)
-
-	_, err = c.ModuleManager.InitModuleServices(cfg.Target...)
-	require.NoError(t, err)
-	defer c.Server.Stop()
-
-	duration := c.Overrides.QueryIngestersWithin("test")
-
-	require.Equal(t, 5*time.Hour, duration)
-}
-
 func TestConfig_validateFilesystemPaths(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/rules"
 	prom_storage "github.com/prometheus/prometheus/storage"
@@ -352,14 +351,6 @@ func (t *Mimir) initRuntimeConfig() (services.Service, error) {
 
 	loader := runtimeConfigLoader{validate: t.Cfg.ValidateLimits}
 	t.Cfg.RuntimeConfig.Loader = loader.load
-
-	// QueryIngestersWithin is moving from a global config that can in the querier yaml to a limit config
-	// We need to preserve the option in the querier yaml for two releases
-	// If the querier config is configured by the user, the default limit is overwritten
-	// TODO: Remove in Mimir 2.11.0
-	if t.Cfg.Querier.QueryIngestersWithin != querier.DefaultQuerierCfgQueryIngestersWithin {
-		t.Cfg.LimitsConfig.QueryIngestersWithin = model.Duration(t.Cfg.Querier.QueryIngestersWithin)
-	}
 
 	// DeprecatedCacheUnalignedRequests is moving from a global config that can in the frontend yaml to a limit config
 	// We need to preserve the option in the frontend yaml for two releases

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -209,27 +209,13 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 	bucketClient = cachingBucket
 
 	// Create the blocks finder.
-	var finder BlocksFinder
-	if storageCfg.BucketStore.BucketIndex.DeprecatedEnabled {
-		finder = NewBucketIndexBlocksFinder(BucketIndexBlocksFinderConfig{
-			IndexLoader: bucketindex.LoaderConfig{
-				CheckInterval:         time.Minute,
-				UpdateOnStaleInterval: storageCfg.BucketStore.SyncInterval,
-				UpdateOnErrorInterval: storageCfg.BucketStore.BucketIndex.UpdateOnErrorInterval,
-				IdleTimeout:           storageCfg.BucketStore.BucketIndex.IdleTimeout,
-			},
-			MaxStalePeriod:           storageCfg.BucketStore.BucketIndex.MaxStalePeriod,
-			IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksDelay,
-		}, bucketClient, limits, logger, reg)
-	} else {
-		finder = NewBucketScanBlocksFinder(BucketScanBlocksFinderConfig{
-			ScanInterval:             storageCfg.BucketStore.SyncInterval,
-			TenantsConcurrency:       storageCfg.BucketStore.TenantSyncConcurrency,
-			MetasConcurrency:         storageCfg.BucketStore.MetaSyncConcurrency,
-			CacheDir:                 storageCfg.BucketStore.SyncDir,
-			IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksDelay,
-		}, bucketClient, limits, logger, reg)
-	}
+	finder := NewBucketScanBlocksFinder(BucketScanBlocksFinderConfig{
+		ScanInterval:             storageCfg.BucketStore.SyncInterval,
+		TenantsConcurrency:       storageCfg.BucketStore.TenantSyncConcurrency,
+		MetasConcurrency:         storageCfg.BucketStore.MetaSyncConcurrency,
+		CacheDir:                 storageCfg.BucketStore.SyncDir,
+		IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksDelay,
+	}, bucketClient, limits, logger, reg)
 
 	storesRingCfg := gatewayCfg.ShardingRing.ToRingConfig()
 	storesRingBackend, err := kv.NewClient(

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -40,9 +40,8 @@ import (
 
 // Config contains the configuration require to create a querier
 type Config struct {
-	Iterators            bool          `yaml:"iterators" category:"deprecated"`                         // Deprecated: Deprecated in Mimir 2.9.0, remove in Mimir 2.11.0 (https://github.com/grafana/mimir/issues/5107)
-	BatchIterators       bool          `yaml:"batch_iterators" category:"deprecated"`                   // Deprecated: Deprecated in Mimir 2.9.0, remove in Mimir 2.11.0 (https://github.com/grafana/mimir/issues/5107)
-	QueryIngestersWithin time.Duration `yaml:"query_ingesters_within" category:"advanced" doc:"hidden"` // Deprecated: Deprecated in Mimir 2.9.0, remove in Mimir 2.11.0
+	Iterators      bool `yaml:"iterators" category:"deprecated"`       // Deprecated: Deprecated in Mimir 2.9.0, remove in Mimir 2.11.0 (https://github.com/grafana/mimir/issues/5107)
+	BatchIterators bool `yaml:"batch_iterators" category:"deprecated"` // Deprecated: Deprecated in Mimir 2.9.0, remove in Mimir 2.11.0 (https://github.com/grafana/mimir/issues/5107)
 
 	// QueryStoreAfter the time after which queries should also be sent to the store and not just ingesters.
 	QueryStoreAfter    time.Duration `yaml:"query_store_after" category:"advanced"`
@@ -97,11 +96,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	// Based on our testing, 256 series / ingester was a good balance between memory consumption and the CPU overhead of managing a batch of series.
 	f.Uint64Var(&cfg.StreamingChunksPerIngesterSeriesBufferSize, "querier.streaming-chunks-per-ingester-buffer-size", 256, "Number of series to buffer per ingester when streaming chunks from ingesters.")
 	f.Uint64Var(&cfg.StreamingChunksPerStoreGatewaySeriesBufferSize, "querier.streaming-chunks-per-store-gateway-buffer-size", 256, "Number of series to buffer per store-gateway when streaming chunks from store-gateways.")
-
-	// The querier.query-ingesters-within flag has been moved to the limits.go file
-	// We still need to set a default value for cfg.QueryIngestersWithin since we need to keep supporting the querier yaml field until Mimir 2.11.0
-	// TODO: Remove in Mimir 2.11.0
-	cfg.QueryIngestersWithin = DefaultQuerierCfgQueryIngestersWithin
 
 	cfg.EngineConfig.RegisterFlags(f)
 }

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -477,23 +477,18 @@ func (cfg *BucketStoreConfig) Validate(logger log.Logger) error {
 }
 
 type BucketIndexConfig struct {
-	DeprecatedEnabled     bool          `yaml:"enabled" category:"deprecated"` // Deprecated. TODO: Remove in Mimir 2.11.
 	UpdateOnErrorInterval time.Duration `yaml:"update_on_error_interval" category:"advanced"`
 	IdleTimeout           time.Duration `yaml:"idle_timeout" category:"advanced"`
 	MaxStalePeriod        time.Duration `yaml:"max_stale_period" category:"advanced"`
 }
 
 func (cfg *BucketIndexConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
-	f.BoolVar(&cfg.DeprecatedEnabled, prefix+"enabled", true, "If enabled, queriers and store-gateways discover blocks by reading a bucket index (created and updated by the compactor) instead of periodically scanning the bucket.")
 	f.DurationVar(&cfg.UpdateOnErrorInterval, prefix+"update-on-error-interval", time.Minute, "How frequently a bucket index, which previously failed to load, should be tried to load again. This option is used only by querier.")
 	f.DurationVar(&cfg.IdleTimeout, prefix+"idle-timeout", time.Hour, "How long a unused bucket index should be cached. Once this timeout expires, the unused bucket index is removed from the in-memory cache. This option is used only by querier.")
 	f.DurationVar(&cfg.MaxStalePeriod, prefix+"max-stale-period", time.Hour, "The maximum allowed age of a bucket index (last updated) before queries start failing because the bucket index is too old. The bucket index is periodically updated by the compactor, and this check is enforced in the querier (at query time).")
 }
 
 // Validate the config.
-func (cfg *BucketIndexConfig) Validate(logger log.Logger) error {
-	if !cfg.DeprecatedEnabled {
-		util.WarnDeprecatedConfig(bucketIndexFlagPrefix+"enabled", logger)
-	}
+func (cfg *BucketIndexConfig) Validate(_ log.Logger) error {
 	return nil
 }

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -79,12 +79,6 @@ const (
 	// posting list in the index. Each posting is 4 bytes (uint32) which are the offset of the series in the index file.
 	BytesPerPostingInAPostingList = 4
 
-	// ChunkPoolDefaultMinBucketSize is the default minimum bucket size (bytes) of the chunk pool.
-	ChunkPoolDefaultMinBucketSize = EstimatedMaxChunkSize // Deprecated. TODO: Remove in Mimir 2.11.
-
-	// ChunkPoolDefaultMaxBucketSize is the default maximum bucket size (bytes) of the chunk pool.
-	ChunkPoolDefaultMaxBucketSize = 50e6 // Deprecated. TODO: Remove in Mimir 2.11.
-
 	// DefaultPostingOffsetInMemorySampling represents default value for --store.index-header-posting-offsets-in-mem-sampling.
 	// 32 value is chosen as it's a good balance for common setups. Sampling that is not too large (too many CPU cycles) and
 	// not too small (too much memory).
@@ -102,9 +96,6 @@ const (
 
 	DefaultMaxTSDBOpeningConcurrencyOnStartup = 10
 
-	maxChunksBytesPoolFlag      = "blocks-storage.bucket-store.max-chunk-pool-bytes"
-	minBucketSizeBytesFlag      = "blocks-storage.bucket-store.chunk-pool-min-bucket-size-bytes"
-	maxBucketSizeBytesFlag      = "blocks-storage.bucket-store.chunk-pool-max-bucket-size-bytes"
 	seriesSelectionStrategyFlag = "blocks-storage.bucket-store.series-selection-strategy"
 	bucketIndexFlagPrefix       = "blocks-storage.bucket-store.bucket-index."
 )
@@ -388,11 +379,6 @@ type BucketStoreConfig struct {
 	BucketIndex              BucketIndexConfig   `yaml:"bucket_index"`
 	IgnoreBlocksWithin       time.Duration       `yaml:"ignore_blocks_within" category:"advanced"`
 
-	// Chunk pool.
-	DeprecatedMaxChunkPoolBytes           uint64 `yaml:"max_chunk_pool_bytes" category:"deprecated"`             // Deprecated. TODO: Remove in Mimir 2.11.
-	DeprecatedChunkPoolMinBucketSizeBytes int    `yaml:"chunk_pool_min_bucket_size_bytes" category:"deprecated"` // Deprecated. TODO: Remove in Mimir 2.11.
-	DeprecatedChunkPoolMaxBucketSizeBytes int    `yaml:"chunk_pool_max_bucket_size_bytes" category:"deprecated"` // Deprecated. TODO: Remove in Mimir 2.11.
-
 	// Series hash cache.
 	SeriesHashCacheMaxBytes uint64 `yaml:"series_hash_cache_max_size_bytes" category:"advanced"`
 
@@ -444,9 +430,6 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 
 	f.StringVar(&cfg.SyncDir, "blocks-storage.bucket-store.sync-dir", "./tsdb-sync/", "Directory to store synchronized TSDB index headers. This directory is not required to be persisted between restarts, but it's highly recommended in order to improve the store-gateway startup time.")
 	f.DurationVar(&cfg.SyncInterval, "blocks-storage.bucket-store.sync-interval", 15*time.Minute, "How frequently to scan the bucket, or to refresh the bucket index (if enabled), in order to look for changes (new blocks shipped by ingesters and blocks deleted by retention or compaction).")
-	f.Uint64Var(&cfg.DeprecatedMaxChunkPoolBytes, maxChunksBytesPoolFlag, uint64(2*units.Gibibyte), "Max size - in bytes - of a chunks pool, used to reduce memory allocations. The pool is shared across all tenants. 0 to disable the limit.")
-	f.IntVar(&cfg.DeprecatedChunkPoolMinBucketSizeBytes, minBucketSizeBytesFlag, ChunkPoolDefaultMinBucketSize, "Size - in bytes - of the smallest chunks pool bucket.")
-	f.IntVar(&cfg.DeprecatedChunkPoolMaxBucketSizeBytes, maxBucketSizeBytesFlag, ChunkPoolDefaultMaxBucketSize, "Size - in bytes - of the largest chunks pool bucket.")
 	f.Uint64Var(&cfg.SeriesHashCacheMaxBytes, "blocks-storage.bucket-store.series-hash-cache-max-size-bytes", uint64(1*units.Gibibyte), "Max size - in bytes - of the in-memory series hash cache. The cache is shared across all tenants and it's used only when query sharding is enabled.")
 	f.IntVar(&cfg.MaxConcurrent, "blocks-storage.bucket-store.max-concurrent", 100, "Max number of concurrent queries to execute against the long-term storage. The limit is shared across all tenants.")
 	f.IntVar(&cfg.TenantSyncConcurrency, "blocks-storage.bucket-store.tenant-sync-concurrency", 10, "Maximum number of concurrent tenants synching blocks.")
@@ -480,15 +463,6 @@ func (cfg *BucketStoreConfig) Validate(logger log.Logger) error {
 	}
 	if err := cfg.BucketIndex.Validate(logger); err != nil {
 		return errors.Wrap(err, "bucket-index configuration")
-	}
-	if cfg.DeprecatedMaxChunkPoolBytes != uint64(2*units.Gibibyte) {
-		util.WarnDeprecatedConfig(maxChunksBytesPoolFlag, logger)
-	}
-	if cfg.DeprecatedChunkPoolMinBucketSizeBytes != ChunkPoolDefaultMinBucketSize {
-		util.WarnDeprecatedConfig(minBucketSizeBytesFlag, logger)
-	}
-	if cfg.DeprecatedChunkPoolMaxBucketSizeBytes != ChunkPoolDefaultMaxBucketSize {
-		util.WarnDeprecatedConfig(maxBucketSizeBytesFlag, logger)
 	}
 	if !util.StringsContain(validSeriesSelectionStrategies, cfg.SeriesSelectionStrategyName) {
 		return errors.New("invalid series-selection-strategy, set one of " + strings.Join(validSeriesSelectionStrategies, ", "))

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -448,29 +448,20 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 	}
 
 	// Instantiate a different blocks metadata fetcher based on whether bucket index is enabled or not.
-	var fetcher block.MetadataFetcher
-	if u.cfg.BucketStore.BucketIndex.DeprecatedEnabled {
-		fetcher = NewBucketIndexMetadataFetcher(
-			userID,
-			u.bucket,
-			u.limits,
-			u.logger,
-			fetcherReg,
-			filters,
-		)
-	} else {
-		var err error
-		fetcher, err = block.NewMetaFetcher(
-			userLogger,
-			u.cfg.BucketStore.MetaSyncConcurrency,
-			userBkt,
-			u.syncDirForUser(userID), // The fetcher stores cached metas in the "meta-syncer/" sub directory
-			fetcherReg,
-			filters,
-		)
-		if err != nil {
-			return nil, err
-		}
+	var (
+		fetcher block.MetadataFetcher
+		err     error
+	)
+	fetcher, err = block.NewMetaFetcher(
+		userLogger,
+		u.cfg.BucketStore.MetaSyncConcurrency,
+		userBkt,
+		u.syncDirForUser(userID), // The fetcher stores cached metas in the "meta-syncer/" sub directory
+		fetcherReg,
+		filters,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	bucketStoreOpts := []BucketStoreOption{
@@ -480,7 +471,7 @@ func (u *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 		WithLazyLoadingGate(u.lazyLoadingGate),
 	}
 
-	bs, err := NewBucketStore(
+	bs, err = NewBucketStore(
 		userID,
 		userBkt,
 		fetcher,

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -573,7 +573,6 @@ func prepareStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
 
 	cfg := mimir_tsdb.BlocksStorageConfig{}
 	flagext.DefaultValues(&cfg)
-	cfg.BucketStore.BucketIndex.DeprecatedEnabled = false
 	cfg.BucketStore.SyncDir = tmpDir
 
 	return cfg


### PR DESCRIPTION
#### What this PR does

In preparation for release 2.11, this PR performs the scheduled removals of the following deprecated configuration parameters:

  * `-querier.query-ingesters-within`
  * `-querier.iterators`
  * `-querier.batch-iterators`
  * `-blocks-storage.bucket-store.max-chunk-pool-bytes`
  * `-blocks-storage.bucket-store.chunk-pool-min-bucket-size-bytes`
  * `-blocks-storage.bucket-store.chunk-pool-max-bucket-size-bytes`
  * `-blocks-storage.bucket-store.bucket-index.enabled`
 
I've separated each deprecation removal into its own commit so it might be easiest to review this PR one commit at a time.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/6670

#### Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`