### PR TITLE
Return a clearer message when a query-frontend receives a request after it has stopped, and return HTTP 503 rather than 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * [ENHANCEMENT] Query-frontend: include length of query, time since the earliest and latest points of a query, time since the earliest and latest points of a query, cached/uncached bytes in "query stats" logs. Time parameters (start/end/time) are always formatted as RFC3339 now. #6473 #6477
 * [ENHANCEMENT] Distributor: added support for reducing the resolution of native histogram samples upon ingestion if the sample has too many buckets compared to `-validation.max-native-histogram-buckets`. This is enabled by default and can be turned off by setting `-validation.reduce-native-histogram-over-max-buckets` to `false`. #6535
 * [ENHANCEMENT] Distributor: Include source IPs in OTLP push handler logs. #6652
+* [ENHANCEMENT] Query-frontend: return clearer error message when a query request is received while shutting down. #6675
 * [BUGFIX] Distributor: return server overload error in the event of exceeding the ingestion rate limit. #6549
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -152,7 +152,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	f.mtx.Lock()
 	if f.stopped {
 		f.mtx.Unlock()
-		writeError(w, fmt.Errorf("frontend not running"))
+		http.Error(w, "frontend stopped", http.StatusServiceUnavailable)
 		return
 	}
 	f.inflightRequests++


### PR DESCRIPTION
#### What this PR does

This PR improves the error returned by query-frontends when they receive a query request while shutting down.

In particular, the error message is now clearer, and the HTTP status code will be 503 (service unavailable) rather than 500.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated
- [n/a] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
