### PR TITLE
Ingester error handling: add related experimental CLI flags to about-…

### DIFF
--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -109,6 +109,7 @@ The following features are currently experimental:
     - `ingester.ring.token-generation-strategy`
     - `ingester.ring.spread-minimizing-zones`
     - `ingester.ring.spread-minimizing-join-ring-in-order`
+  - Allow ingester's `Push()` to return gRPC errors only: `-ingester.return-only-grpc-errors`.
 - Ingester client
   - Per-ingester circuit breaking based on requests timing out or hitting per-instance limits
     - `-ingester.client.circuit-breaker.enabled`


### PR DESCRIPTION
#### What this PR does

In #6443 an experimental CLI flag `-ingester.return-only-grpc-errors` has been introduced, but it hasn't been documented in `about-versioning.md`, which is done by this PR.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/6008

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
