### PR TITLE
Include more information in "context canceled" errors returned from chunks streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 * [ENHANCEMENT] Query-frontend: optionally wait for the frontend to complete startup if requests are received while the frontend is still starting. Disabled by default, set `-query-frontend.not-running-timeout` to a non-zero value to enable. #6621
 * [ENHANCEMENT] Distributor: Include source IPs in OTLP push handler logs. #6652
 * [ENHANCEMENT] Query-frontend: return clearer error message when a query request is received while shutting down. #6675
+* [ENHANCEMENT] Querier: return clearer error message when a query request is cancelled by the caller. #6697
 * [BUGFIX] Distributor: return server overload error in the event of exceeding the ingestion rate limit. #6549
 * [BUGFIX] Ring: Ensure network addresses used for component hash rings are formatted correctly when using IPv6. #6068
 * [BUGFIX] Query-scheduler: don't retain connections from queriers that have shut down, leading to gradually increasing enqueue latency over time. #6100 #6145

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -114,6 +114,11 @@ func (s *SeriesChunksStreamReader) readStream(log *spanlogger.SpanLogger) error 
 
 				log.DebugLog("msg", "finished streaming", "series", totalSeries, "chunks", totalChunks)
 				return nil
+			} else if errors.Is(err, context.Canceled) {
+				// If there's a more detailed cancellation reason available, return that.
+				if cause := context.Cause(s.ctx); cause != nil {
+					return fmt.Errorf("aborted stream because query was cancelled: %w", cause)
+				}
 			}
 
 			return err

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -195,6 +195,13 @@ func (s *storeGatewayStreamReader) readStream(log *spanlogger.SpanLogger) error 
 	totalChunks := 0
 
 	translateReceivedError := func(err error) error {
+		if errors.Is(err, context.Canceled) {
+			// If there's a more detailed cancellation reason available, return that.
+			if cause := context.Cause(s.ctx); cause != nil {
+				return fmt.Errorf("aborted stream because query was cancelled: %w", cause)
+			}
+		}
+
 		if !errors.Is(err, io.EOF) {
 			return err
 		}

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -7,6 +7,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -134,10 +135,12 @@ func (sp *schedulerProcessor) processQueriesOnSingleStream(workerCtx context.Con
 }
 
 // process loops processing requests on an established stream.
-func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_QuerierLoopClient, address string, inflightQuery *atomic.Bool) error {
+func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_QuerierLoopClient, address string, inflightQuery *atomic.Bool) (err error) {
 	// Build a child context so we can cancel a query when the stream is closed.
-	ctx, cancel := context.WithCancel(c.Context())
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(c.Context())
+	defer func() {
+		cancel(fmt.Errorf("context cancelled because query-scheduler loop in querier for query-scheduler %v terminated with error: %w", address, err))
+	}()
 
 	for {
 		request, err := c.Recv()
@@ -160,8 +163,8 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 			// on the context being cancelled to abort streaming and terminate a goroutine if the query is aborted. Requests that
 			// go direct to a querier's HTTP API have a context created and cancelled in a similar way by the Go runtime's
 			// net/http package.
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
+			ctx, cancel := context.WithCancelCause(ctx)
+			defer cancel(errors.New("context cancelled because query evaluation finished"))
 
 			// We need to inject user into context for sending response back.
 			ctx = user.InjectOrgID(ctx, request.UserID)

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
 	querier_stats "github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
+	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/httpgrpcutil"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )
@@ -139,7 +140,7 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 	// Build a child context so we can cancel a query when the stream is closed.
 	ctx, cancel := context.WithCancelCause(c.Context())
 	defer func() {
-		cancel(fmt.Errorf("context cancelled because query-scheduler loop in querier for query-scheduler %v terminated with error: %w", address, err))
+		cancel(util.NewCancellationErrorf("query-scheduler loop in querier for query-scheduler %v terminated with error: %w", address, err))
 	}()
 
 	for {
@@ -164,7 +165,7 @@ func (sp *schedulerProcessor) querierLoop(c schedulerpb.SchedulerForQuerier_Quer
 			// go direct to a querier's HTTP API have a context created and cancelled in a similar way by the Go runtime's
 			// net/http package.
 			ctx, cancel := context.WithCancelCause(ctx)
-			defer cancel(errors.New("context cancelled because query evaluation finished"))
+			defer cancel(util.NewCancellationError(errors.New("query evaluation finished")))
 
 			// We need to inject user into context for sending response back.
 			ctx = user.InjectOrgID(ctx, request.UserID)

--- a/pkg/util/cancellation.go
+++ b/pkg/util/cancellation.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package util
+
+import (
+	"context"
+	"fmt"
+)
+
+type cancellationError struct {
+	inner error
+}
+
+func NewCancellationError(err error) error {
+	return cancellationError{err}
+}
+
+func NewCancellationErrorf(format string, args ...any) error {
+	return NewCancellationError(fmt.Errorf(format, args...))
+}
+
+func (e cancellationError) Error() string {
+	return "context canceled: " + e.inner.Error()
+}
+
+func (e cancellationError) Is(err error) bool {
+	return err == context.Canceled
+}
+
+func (e cancellationError) Unwrap() error {
+	return e.inner
+}

--- a/pkg/util/cancellation_test.go
+++ b/pkg/util/cancellation_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancellationError(t *testing.T) {
+	directlyNestedErr := NewCancellationError(io.ErrNoProgress)
+	require.True(t, errors.Is(directlyNestedErr, context.Canceled))
+	require.True(t, errors.Is(directlyNestedErr, io.ErrNoProgress))
+	require.False(t, errors.Is(directlyNestedErr, io.EOF))
+
+	indirectlyNestedErr := NewCancellationError(fmt.Errorf("something went wrong: %w", io.ErrNoProgress))
+	require.True(t, errors.Is(indirectlyNestedErr, context.Canceled))
+	require.True(t, errors.Is(indirectlyNestedErr, io.ErrNoProgress))
+	require.False(t, errors.Is(directlyNestedErr, io.EOF))
+}


### PR DESCRIPTION
#### What this PR does

This PR improves the errors returned from chunks streaming when the query context is cancelled.

When the query is cancelled, the querier cancels the context used for the query. This is frequently reported as `attempted to read series at index xxx from ingester chunks stream, but the stream has failed: context canceled`, which makes it sound like an issue with streaming chunks. 

In reality, the issue is often that the context was cancelled due because the caller cancelled the query, so this PR makes that clearer.

This change is imperfect: the clearer error message will only be returned if the code that first observes the `context.Canceled` error inspects the context with `context.Cause(ctx)`. This is now true for the chunks streaming code, but there's no guarantee the chunks streaming code will be the first to observe the `context.Canceled` error.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
