### PR TITLE
Always report query result to query-frontend, even when cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 * [BUGFIX] Querier: correctly mark streaming requests to ingesters or store-gateways as successful, not cancelled, in metrics and traces. #6471 #6505
 * [BUGFIX] Querier: fix issue where queries fail with "context canceled" error when an ingester or store-gateway fails healthcheck while the query is in progress. #6550
 * [BUGFIX] Tracing: When creating an OpenTelemetry tracing span, add it to the context for later retrieval. #6614
+* [BUGFIX] Querier: always report query results to query-frontends, even when cancelled, to ensure query-frontends don't wait for results that will otherwise never arrive. #6703
 
 ### Mixin
 

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -224,8 +224,12 @@ func (sp *schedulerProcessor) runRequest(ctx context.Context, logger log.Logger,
 		if err != nil {
 			break
 		}
+
+		// Even if this query has been cancelled, we still want to tell the frontend about it, otherwise the frontend will wait for a result until it times out.
+		frontendCtx := context.WithoutCancel(ctx)
+
 		// Response is empty and uninteresting.
-		_, err = c.(frontendv2pb.FrontendForQuerierClient).QueryResult(ctx, &frontendv2pb.QueryResultRequest{
+		_, err = c.(frontendv2pb.FrontendForQuerierClient).QueryResult(frontendCtx, &frontendv2pb.QueryResultRequest{
 			QueryID:      queryID,
 			HttpResponse: response,
 			Stats:        stats,

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -4,6 +4,8 @@ package worker
 
 import (
 	"context"
+	"math"
+	"net"
 	"testing"
 	"time"
 
@@ -21,13 +23,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
 )
 
 func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 	t.Run("should immediately return if worker context is canceled and there's no inflight query", func(t *testing.T) {
-		sp, loopClient, requestHandler := prepareSchedulerProcessor()
+		sp, loopClient, requestHandler, _ := prepareSchedulerProcessor(t)
 
 		workerCtx, workerCancel := context.WithCancel(context.Background())
 
@@ -53,7 +56,7 @@ func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 	})
 
 	t.Run("should wait until inflight query execution is completed before returning when worker context is canceled", func(t *testing.T) {
-		sp, loopClient, requestHandler := prepareSchedulerProcessor()
+		sp, loopClient, requestHandler, frontend := prepareSchedulerProcessor(t)
 
 		recvCount := atomic.NewInt64(0)
 
@@ -63,7 +66,7 @@ func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 				return &schedulerpb.SchedulerToQuerier{
 					QueryID:         1,
 					HttpRequest:     nil,
-					FrontendAddress: "127.0.0.2",
+					FrontendAddress: frontend.addr,
 					UserID:          "user-1",
 				}, nil
 			default:
@@ -97,10 +100,63 @@ func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 		// and then to send the query result.
 		loopClient.AssertNumberOfCalls(t, "Send", 2)
 		loopClient.AssertCalled(t, "Send", &schedulerpb.QuerierToScheduler{QuerierID: "test-querier-id"})
+
+		require.Equal(t, 1, int(frontend.queryResultCalls.Load()), "expected frontend to be informed of query result exactly once")
 	})
 
-	t.Run("should not log an error when the query-scheduler is terminates while waiting for the next query to run", func(t *testing.T) {
-		sp, loopClient, requestHandler := prepareSchedulerProcessor()
+	t.Run("should report query result to frontend even if query is cancelled", func(t *testing.T) {
+		sp, loopClient, requestHandler, frontend := prepareSchedulerProcessor(t)
+
+		recvCount := atomic.NewInt64(0)
+		queryEvaluationBegun := make(chan struct{})
+
+		loopClient.On("Recv").Return(func() (*schedulerpb.SchedulerToQuerier, error) {
+			switch recvCount.Inc() {
+			case 1:
+				return &schedulerpb.SchedulerToQuerier{
+					QueryID:         1,
+					HttpRequest:     nil,
+					FrontendAddress: frontend.addr,
+					UserID:          "user-1",
+				}, nil
+			default:
+				// Wait until query execution has begun, then simulate the scheduler shutting down.
+				<-queryEvaluationBegun
+				return nil, schedulerpb.ErrSchedulerIsNotRunning
+			}
+		})
+
+		requestHandler.On("Handle", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(context.Context)
+
+			// Trigger the shutdown of the scheduler.
+			close(queryEvaluationBegun)
+
+			// Wait for our context to be cancelled before continuing.
+			select {
+			case <-ctx.Done():
+				// Nothing more to do.
+			case <-time.After(time.Second):
+				require.Fail(t, "expected query execution context to be cancelled when scheduler shut down")
+			}
+		}).Return(&httpgrpc.HTTPResponse{}, nil)
+
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+
+		// processQueriesOnSingleStream() blocks and retries until its context is cancelled, so run it in the background.
+		go func() {
+			sp.processQueriesOnSingleStream(workerCtx, nil, "127.0.0.1")
+		}()
+
+		require.Eventually(t, func() bool {
+			return frontend.queryResultCalls.Load() == 1
+		}, time.Second, 10*time.Millisecond, "expected frontend to be informed of query result exactly once")
+
+		workerCancel()
+	})
+
+	t.Run("should not log an error when the query-scheduler is terminated while waiting for the next query to run", func(t *testing.T) {
+		sp, loopClient, requestHandler, _ := prepareSchedulerProcessor(t)
 
 		// Override the logger to capture the logs.
 		logs := &concurrency.SyncBuffer{}
@@ -128,7 +184,7 @@ func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 
 func TestSchedulerProcessor_QueryTime(t *testing.T) {
 	runTest := func(t *testing.T, statsEnabled bool) {
-		fp, processClient, requestHandler := prepareSchedulerProcessor()
+		fp, processClient, requestHandler, frontend := prepareSchedulerProcessor(t)
 
 		recvCount := atomic.NewInt64(0)
 		queueTime := 3 * time.Second
@@ -139,7 +195,7 @@ func TestSchedulerProcessor_QueryTime(t *testing.T) {
 				return &schedulerpb.SchedulerToQuerier{
 					QueryID:         1,
 					HttpRequest:     nil,
-					FrontendAddress: "127.0.0.2",
+					FrontendAddress: frontend.addr,
 					UserID:          "user-1",
 					StatsEnabled:    statsEnabled,
 					QueueTimeNanos:  queueTime.Nanoseconds(),
@@ -170,6 +226,8 @@ func TestSchedulerProcessor_QueryTime(t *testing.T) {
 		// We expect Send() to be called twice: first to send the querier ID to scheduler
 		// and then to send the query result.
 		processClient.AssertNumberOfCalls(t, "Send", 2)
+
+		require.Equal(t, 1, int(frontend.queryResultCalls.Load()), "expected frontend to be informed of query result exactly once")
 	}
 
 	t.Run("query stats enabled should record queue time", func(t *testing.T) {
@@ -198,7 +256,7 @@ func TestCreateSchedulerProcessor(t *testing.T) {
 	assert.Equal(t, conf, sp.grpcConfig)
 }
 
-func prepareSchedulerProcessor() (*schedulerProcessor, *querierLoopClientMock, *requestHandlerMock) {
+func prepareSchedulerProcessor(t *testing.T) (*schedulerProcessor, *querierLoopClientMock, *requestHandlerMock, *frontendForQuerierMockServer) {
 	var querierLoopCtx context.Context
 
 	loopClient := &querierLoopClientMock{}
@@ -218,8 +276,19 @@ func prepareSchedulerProcessor() (*schedulerProcessor, *querierLoopClientMock, *
 	sp.schedulerClientFactory = func(_ *grpc.ClientConn) schedulerpb.SchedulerForQuerierClient {
 		return schedulerClient
 	}
+	sp.grpcConfig.MaxSendMsgSize = math.MaxInt
 
-	return sp, loopClient, requestHandler
+	frontendForQuerierMock := &frontendForQuerierMockServer{}
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	frontendForQuerierMock.addr = lis.Addr().String()
+
+	grpcServer := grpc.NewServer()
+	frontendv2pb.RegisterFrontendForQuerierServer(grpcServer, frontendForQuerierMock)
+	go func() { require.NoError(t, grpcServer.Serve(lis)) }()
+	t.Cleanup(grpcServer.Stop)
+
+	return sp, loopClient, requestHandler, frontendForQuerierMock
 }
 
 type schedulerForQuerierClientMock struct {
@@ -299,4 +368,15 @@ type requestHandlerMock struct {
 func (m *requestHandlerMock) Handle(ctx context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
 	args := m.Called(ctx, req)
 	return args.Get(0).(*httpgrpc.HTTPResponse), args.Error(1)
+}
+
+type frontendForQuerierMockServer struct {
+	addr             string
+	queryResultCalls atomic.Int64
+}
+
+func (f *frontendForQuerierMockServer) QueryResult(context.Context, *frontendv2pb.QueryResultRequest) (*frontendv2pb.QueryResultResponse, error) {
+	f.queryResultCalls.Inc()
+
+	return &frontendv2pb.QueryResultResponse{}, nil
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where queriers can fail to send query results to query-frontends if the query is cancelled for some reason. This manifests as query-frontends timing out waiting for query results.

This can happen in two scenarios:

* the query-scheduler dies or the query-frontend cancels the query, causing the gRPC stream between the querier and the query-scheduler to be closed and triggering cancellation of the query
* there's a race between when the querier cancels the contexts for processors for schedulers that are shutting down [here](https://github.com/grafana/mimir/blob/14e4b3eea2c67a44da1d8aa90c53d12299006398/pkg/querier/worker/processor_manager.go#L87-L90) and when the querier cancels the execution context created in `newExecutionContext` [here](https://github.com/grafana/mimir/blob/3a401cacc822fa25f542d45cb431248e05502610/pkg/querier/worker/util.go#L51) - it's possible that this happens:
  - `querierLoop` receives a query
  - `newExecutionContext` observes that `workerCtx` is cancelled and `inflightQuery` is `false` and cancels the execution context
  - `querierLoop` then sets `inflightQuery` to `true` and begins executing the query, which quickly fails because the context has been cancelled

https://github.com/grafana/mimir/pull/6706 fixes the second issue, but until that issue is fixed, this PR will at least mitigate the impact of that issue: the querier will report the query as cancelled and the query-frontend can retry the query, rather than the query-frontend simply timing out.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
