### PR TITLE
Warn if query-scheduler queue contains requests while shutting down

### DIFF
--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -215,6 +215,14 @@ func (q *RequestQueue) dispatcherLoop() {
 				currentElement = currentElement.Next()
 			}
 
+			if !queueBroker.isEmpty() {
+				// This should never happen: unless all of the queriers have shut down themselves, they should remain connected
+				// until the RequestQueue service enters the stopped state (see Scheduler.QuerierLoop()), and so we won't
+				// stop the RequestQueue until we've drained all enqueued queries.
+				// But if this does happen, we want to know about it.
+				level.Warn(q.log).Log("msg", "shutting down dispatcher loop: have no connected querier workers, but request queue is not empty, so these requests will be abandoned")
+			}
+
 			// We are done.
 			close(q.stopCompleted)
 			return


### PR DESCRIPTION
#### What this PR does

This PR adds logging for a scenario that should never happen, but if it were to happen, query-schedulers would silently drop queries.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
