### PR TITLE
querier: backoff retrying to send responses to query-frontend

### DIFF
--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -246,12 +246,12 @@ func (sp *schedulerProcessor) runRequest(ctx context.Context, logger log.Logger,
 		if err == nil {
 			break
 		}
-		level.Warn(logger).Log("msg", "retrying to notify frontend about finished query", "err", err, "frontend", frontendAddress, "retries", bof.NumRetries())
+		level.Warn(logger).Log("msg", "retrying to notify frontend about finished query", "err", err, "frontend", frontendAddress, "retries", bof.NumRetries(), "query_id", queryID)
 		bof.Wait()
 	}
 
 	if err != nil {
-		level.Error(logger).Log("msg", "error notifying frontend about finished query", "err", err, "frontend", frontendAddress)
+		level.Error(logger).Log("msg", "error notifying frontend about finished query", "err", err, "frontend", frontendAddress, "query_id", queryID)
 	}
 }
 

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -247,6 +247,7 @@ func (sp *schedulerProcessor) runRequest(ctx context.Context, logger log.Logger,
 			break
 		}
 		level.Warn(logger).Log("msg", "retrying to notify frontend about finished query", "err", err, "frontend", frontendAddress, "retries", bof.NumRetries(), "query_id", queryID)
+		sp.frontendPool.RemoveClient(c, frontendAddress)
 		bof.Wait()
 	}
 


### PR DESCRIPTION
### Background

The querier will try sending a query's response to a frontend. If the sending fails, then the querier will remove the connection from the pool and immediately try to establish a new one.

### Problem

When there are multiple queries, then the can remove each other's new connections which leads to a live lock until the retries expire. One reason why the sending can fail is that the client was cleaned up

### What this PR does

* make retrying less aggressive to make livelocks less likely, but also to give time to whatever was causing to error to recover
* don't remove the query-frontend connection from the pool; if the connection is indeed faulty, then the [client pool](https://github.com/grafana/mimir/blob/c4c33cfa5dee26772bb5934b9e8365db40800893/pkg/querier/worker/scheduler_processor.go#L72) will clean it up ([within 6 seconds](https://github.com/grafana/mimir/blob/c4c33cfa5dee26772bb5934b9e8365db40800893/pkg/querier/worker/scheduler_processor.go#L67-L69) of it "becoming" faulty)

### Note to reviewers

Another way to solve this is to remove a particular client instance from the pool as opposed to removing any client given an address.