### PR TITLE
Distributor: Add OTLP handler benchmarks

### DIFF
--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package distributor
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+func BenchmarkOTLPHandler(b *testing.B) {
+	var samples []prompb.Sample
+	for i := 0; i < 1000; i++ {
+		ts := time.Date(2020, 4, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(i) * time.Second)
+		samples = append(samples, prompb.Sample{
+			Value:     1,
+			Timestamp: ts.UnixNano(),
+		})
+	}
+	sampleSeries := []prompb.TimeSeries{
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "foo"},
+			},
+			Samples: samples,
+			Histograms: []prompb.Histogram{
+				remote.HistogramToHistogramProto(1337, test.GenerateTestHistogram(1)),
+			},
+		},
+	}
+	// Sample metadata needs to correspond to every series in the sampleSeries
+	sampleMetadata := []mimirpb.MetricMetadata{
+		{
+			Help: "metric_help",
+			Unit: "metric_unit",
+		},
+	}
+	exportReq := TimeseriesToOTLPRequest(sampleSeries, sampleMetadata)
+
+	pushFunc := func(ctx context.Context, pushReq *Request) error {
+		if _, err := pushReq.WriteRequest(); err != nil {
+			return err
+		}
+
+		pushReq.CleanUp()
+		return nil
+	}
+	limits, err := validation.NewOverrides(
+		validation.Limits{},
+		validation.NewMockTenantLimits(map[string]*validation.Limits{}),
+	)
+	require.NoError(b, err)
+	handler := OTLPHandler(100000, nil, false, true, limits, RetryConfig{}, prometheus.NewPedanticRegistry(), pushFunc, log.NewNopLogger())
+
+	b.Run("protobuf", func(b *testing.B) {
+		req := createOTLPProtoRequest(b, exportReq, false)
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			require.Equal(b, http.StatusOK, resp.Code)
+			req.Body.(*reusableReader).Reset()
+		}
+	})
+
+	b.Run("JSON", func(b *testing.B) {
+		req := createOTLPJSONRequest(b, exportReq, false)
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			require.Equal(b, http.StatusOK, resp.Code)
+			req.Body.(*reusableReader).Reset()
+		}
+	})
+}
+
+func createOTLPProtoRequest(tb testing.TB, metricRequest pmetricotlp.ExportRequest, compress bool) *http.Request {
+	tb.Helper()
+
+	body, err := metricRequest.MarshalProto()
+	require.NoError(tb, err)
+
+	return createOTLPRequest(tb, body, compress, "application/x-protobuf")
+}
+
+func createOTLPJSONRequest(tb testing.TB, metricRequest pmetricotlp.ExportRequest, compress bool) *http.Request {
+	tb.Helper()
+
+	body, err := metricRequest.MarshalJSON()
+	require.NoError(tb, err)
+
+	return createOTLPRequest(tb, body, compress, "application/json")
+}
+
+func createOTLPRequest(tb testing.TB, body []byte, compress bool, contentType string) *http.Request {
+	tb.Helper()
+
+	if compress {
+		var b bytes.Buffer
+		gz := gzip.NewWriter(&b)
+		_, err := gz.Write(body)
+		require.NoError(tb, err)
+		require.NoError(tb, gz.Close())
+
+		body = b.Bytes()
+	}
+
+	// reusableReader is suitable for benchmarks
+	req, err := http.NewRequest("POST", "http://localhost/", newReusableReader(body))
+	require.NoError(tb, err)
+	// Since http.NewRequest will deduce content length only from known io.Reader implementations,
+	// define it ourselves
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Content-Type", contentType)
+	const tenantID = "test"
+	req.Header.Set("X-Scope-OrgID", tenantID)
+	ctx := user.InjectOrgID(context.Background(), tenantID)
+	req = req.WithContext(ctx)
+	if compress {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
+
+	return req
+}
+
+type reusableReader struct {
+	*bytes.Reader
+	raw []byte
+}
+
+func newReusableReader(raw []byte) *reusableReader {
+	return &reusableReader{
+		Reader: bytes.NewReader(raw),
+		raw:    raw,
+	}
+}
+
+func (r *reusableReader) Close() error {
+	return nil
+}
+
+func (r *reusableReader) Reset() {
+	r.Reader.Reset(r.raw)
+}
+
+var _ io.ReadCloser = &reusableReader{}

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/httpgrpc/server"
 	"github.com/grafana/dskit/middleware"
-	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
@@ -127,12 +126,12 @@ func TestHandlerOTLPPush(t *testing.T) {
 			Unit: "metric_unit",
 		},
 	}
-	samplesVerifierFunc := func(ctx context.Context, pushReq *Request) error {
+	samplesVerifierFunc := func(t *testing.T, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		series := request.Timeseries
-		assert.Len(t, series, 1)
+		require.Len(t, series, 1)
 
 		samples := series[0].Samples
 		assert.Equal(t, 1, len(samples))
@@ -150,15 +149,15 @@ func TestHandlerOTLPPush(t *testing.T) {
 		return nil
 	}
 
-	samplesVerifierFuncDisabledMetadataIngest := func(ctx context.Context, pushReq *Request) error {
+	samplesVerifierFuncDisabledMetadataIngest := func(t *testing.T, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		series := request.Timeseries
 		assert.Len(t, series, 1)
 
 		samples := series[0].Samples
-		assert.Equal(t, 1, len(samples))
+		require.Equal(t, 1, len(samples))
 		assert.Equal(t, float64(1), samples[0].Value)
 		assert.Equal(t, "__name__", series[0].Labels[0].Name)
 		assert.Equal(t, "foo", series[0].Labels[0].Value)
@@ -179,7 +178,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 		encoding    string
 		maxMsgSize  int
 
-		verifyFunc                PushFunc
+		verifyFunc                func(*testing.T, *Request) error
 		responseCode              int
 		errMessage                string
 		enableOtelMetadataStorage bool
@@ -218,7 +217,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			maxMsgSize:  30,
 			series:      sampleSeries,
 			metadata:    sampleMetadata,
-			verifyFunc: func(ctx context.Context, pushReq *Request) error {
+			verifyFunc: func(t *testing.T, pushReq *Request) error {
 				_, err := pushReq.WriteRequest()
 				return err
 			},
@@ -231,7 +230,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			maxMsgSize: 100000,
 			series:     sampleSeries,
 			metadata:   sampleMetadata,
-			verifyFunc: func(ctx context.Context, pushReq *Request) error {
+			verifyFunc: func(t *testing.T, pushReq *Request) error {
 				_, err := pushReq.WriteRequest()
 				return err
 			},
@@ -257,12 +256,12 @@ func TestHandlerOTLPPush(t *testing.T) {
 					Unit: "metric_unit",
 				},
 			},
-			verifyFunc: func(ctx context.Context, pushReq *Request) error {
+			verifyFunc: func(t *testing.T, pushReq *Request) error {
 				request, err := pushReq.WriteRequest()
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				series := request.Timeseries
-				assert.Len(t, series, 1)
+				require.Len(t, series, 1)
 
 				histograms := series[0].Histograms
 				assert.Equal(t, 1, len(histograms))
@@ -284,7 +283,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exportReq := TimeseriesToOTLPRequest(tt.series, tt.metadata)
-			req := createOTLPRequest(t, exportReq, tt.compression)
+			req := createOTLPProtoRequest(t, exportReq, tt.compression)
 			if tt.encoding != "" {
 				req.Header.Set("Content-Encoding", tt.encoding)
 			}
@@ -294,7 +293,11 @@ func TestHandlerOTLPPush(t *testing.T) {
 				validation.NewMockTenantLimits(map[string]*validation.Limits{}),
 			)
 			require.NoError(t, err)
-			handler := OTLPHandler(tt.maxMsgSize, nil, false, tt.enableOtelMetadataStorage, limits, RetryConfig{}, nil, tt.verifyFunc, log.NewNopLogger())
+			pusher := func(ctx context.Context, pushReq *Request) error {
+				t.Helper()
+				return tt.verifyFunc(t, pushReq)
+			}
+			handler := OTLPHandler(tt.maxMsgSize, nil, false, tt.enableOtelMetadataStorage, limits, RetryConfig{}, nil, pusher, log.NewNopLogger())
 
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
@@ -353,7 +356,7 @@ func TestHandler_otlpDroppedMetricsPanic(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	req := createOTLPRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), false)
+	req := createOTLPProtoRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), false)
 	resp := httptest.NewRecorder()
 	handler := OTLPHandler(100000, nil, false, true, limits, RetryConfig{}, nil, func(ctx context.Context, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
@@ -399,7 +402,7 @@ func TestHandler_otlpDroppedMetricsPanic2(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	req := createOTLPRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), false)
+	req := createOTLPProtoRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), false)
 	resp := httptest.NewRecorder()
 	handler := OTLPHandler(100000, nil, false, true, limits, RetryConfig{}, nil, func(ctx context.Context, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
@@ -425,7 +428,7 @@ func TestHandler_otlpDroppedMetricsPanic2(t *testing.T) {
 	datapoint3.BucketCounts().FromRaw([]uint64{10, 20, 30, 40, 50})
 	attributes.CopyTo(datapoint3.Attributes())
 
-	req = createOTLPRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), false)
+	req = createOTLPProtoRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), false)
 	resp = httptest.NewRecorder()
 	handler = OTLPHandler(100000, nil, false, true, limits, RetryConfig{}, nil, func(ctx context.Context, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
@@ -440,7 +443,7 @@ func TestHandler_otlpDroppedMetricsPanic2(t *testing.T) {
 }
 
 func TestHandler_otlpWriteRequestTooBigWithCompression(t *testing.T) {
-	// createOTLPRequest will create a request which is BIGGER with compression (37 vs 58 bytes).
+	// createOTLPProtoRequest will create a request which is BIGGER with compression (37 vs 58 bytes).
 	// Hence creating a dummy request.
 	var b bytes.Buffer
 	gz := gzip.NewWriter(&b)
@@ -626,41 +629,6 @@ func createRequest(t testing.TB, protobuf []byte) *http.Request {
 	req.Header.Add("Content-Encoding", "snappy")
 	req.Header.Set("Content-Type", "application/x-protobuf")
 	req.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
-	return req
-}
-
-func createOTLPRequest(t testing.TB, metricRequest pmetricotlp.ExportRequest, compress bool) *http.Request {
-	t.Helper()
-
-	rawBytes, err := metricRequest.MarshalProto()
-	require.NoError(t, err)
-
-	body := rawBytes
-
-	if compress {
-		var b bytes.Buffer
-		gz := gzip.NewWriter(&b)
-		_, err := gz.Write(rawBytes)
-		require.NoError(t, err)
-		require.NoError(t, gz.Close())
-
-		body = b.Bytes()
-	}
-
-	req, err := http.NewRequest("POST", "http://localhost/", bytes.NewReader(body))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/x-protobuf")
-	req.Header.Set("X-Scope-OrgID", "test")
-
-	// We need this for testing dropped metrics codepath which requires
-	// tenantID to be present.
-	_, ctx, err := tenant.ExtractTenantIDFromHTTPRequest(req)
-	require.NoError(t, err)
-	req = req.WithContext(ctx)
-
-	if compress {
-		req.Header.Set("Content-Encoding", "gzip")
-	}
 	return req
 }
 


### PR DESCRIPTION
#### What this PR does
Add benchmarks for `distributor.OTLPHandler`. Also fixing an issue in the tests, which is that verifier functions currently don't take the sub-test's `testing.T` argument, but instead the parent's. This becomes obvious when verifier functions fail, as the test runtime complains. Also use `require.NoError` instead of `assert.NoError` to avoid panics on unexpected errors.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
