### PR TITLE
Query ingesters in PENDING state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * [BUGFIX] Querier: fix issue where queries fail with "context canceled" error when an ingester or store-gateway fails healthcheck while the query is in progress. #6550
 * [BUGFIX] Tracing: When creating an OpenTelemetry tracing span, add it to the context for later retrieval. #6614
 * [BUGFIX] Querier: always report query results to query-frontends, even when cancelled, to ensure query-frontends don't wait for results that will otherwise never arrive. #6703
+* [BUGFIX] Querier: attempt to query ingesters in PENDING state, to reduce the likelihood that scaling up the number of ingesters in multiple zones simultaneously causes a read outage. #6726
 
 ### Mixin
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -34,7 +34,9 @@ import (
 var (
 	// readNoExtend is a ring.Operation that only selects instances marked as ring.ACTIVE.
 	// This should mirror the operation used when choosing ingesters to write series to (ring.WriteNoExtend).
-	readNoExtend = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
+	// We include ring.PENDING instances as well to ensure we don't miss any instances that have
+	// recently started and we may not have observed in the ring.ACTIVE state yet.
+	readNoExtend = ring.NewOp([]ring.InstanceState{ring.ACTIVE, ring.PENDING}, nil)
 )
 
 func (d *Distributor) QueryExemplars(ctx context.Context, from, to model.Time, matchers ...[]*labels.Matcher) (*ingester_client.ExemplarQueryResponse, error) {

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -36,6 +36,8 @@ var (
 	// This should mirror the operation used when choosing ingesters to write series to (ring.WriteNoExtend).
 	// We include ring.PENDING instances as well to ensure we don't miss any instances that have
 	// recently started and we may not have observed in the ring.ACTIVE state yet.
+	// In the case where an ingester has just started, queriers may have only observed the ingester in the PENDING state,
+	// but distributors may have observed the ingester in the ACTIVE state and started sending samples.
 	readNoExtend = ring.NewOp([]ring.InstanceState{ring.ACTIVE, ring.PENDING}, nil)
 )
 


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue introduced in https://github.com/grafana/mimir/pull/5342.

We shouldn't consider `PENDING` ingesters as unhealthy: in the case where new ingesters have just started due to a scale-up, we'll consider each zone with a `PENDING` ingester as unhealthy, and so if two zones have just scaled up and have `PENDING` ingesters, the query will fail.

Furthermore, we should attempt to query ingesters in the `PENDING` state: in the case where an ingester has just started, queriers may have only observed the ingester in the `PENDING` state, but distributors may have observed the ingester in the `ACTIVE` state and started sending samples, for example:

- New ingester in zone A starts, publishes `PENDING` state to ring
- Querier observes new ingester in `PENDING` state
- New ingester sets state to `ACTIVE`
- Distributor observes new ingester as `ACTIVE`
- Distributor writes sample to ingester in zones A, B and C, write to B fails due to transient network issue
- Querier initiates query, selects zones A and B for initial requests

If we don't query the new zone A ingester that the querier still thinks is `PENDING`, then we'll miss the sample that is only in zone A and C.

Note that the downside of this change is that queriers will attempt to query ingesters that are possibly still starting up, and may not be ready to receive requests. In this case, [hedging](https://github.com/grafana/mimir/pull/5368) will cause the querier to try other ingesters, if available, after at most 2s, or sooner if the connection to the ingester fails before hedging is triggered, and one of the following will happen:

* If ingesters in other zones are healthy, then the impact is simply increased latency. An improvement for this would be to prioritize querying zones where all ingesters are `ACTIVE`, but I will add this in a follow up PR (https://github.com/grafana/mimir/pull/6727)
* If ingesters in other zones are not healthy (eg. they're also still starting up), then the query will fail. However, this will be mitigated by the query-frontend retrying the query, which may succeed on a later attempt. This is unavoidable if we want to guarantee correct query results.

#### Which issue(s) this PR fixes or relates to

Related: https://github.com/grafana/mimir/pull/5342

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
