### PR TITLE
docs: bump required agent version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,7 @@
 
 ### Documentation
 
-* [ENHANCEMENT] Document the concept of native histograms and how to send them to Mimir, migration path. #5956 #6488 #6539
+* [ENHANCEMENT] Document the concept of native histograms and how to send them to Mimir, migration path. #5956 #6488 #6539 #6752
 * [ENHANCEMENT] Document native histograms query and visualization. #6231
 
 ### Tools

--- a/docs/sources/mimir/send/native-histograms/_index.md
+++ b/docs/sources/mimir/send/native-histograms/_index.md
@@ -149,7 +149,7 @@ Use the latest version of Prometheus or at least version 2.47.
 
 ## Scrape and send native histograms with Grafana Agent
 
-Use the latest version of the Grafana Agent in [Flow mode](/docs/agent/latest/flow/) or at least version 0.37.3.
+Use the latest version of the Grafana Agent in [Flow mode](/docs/agent/latest/flow/) or at least version 0.38.
 
 1. To enable scraping native histograms you need to enable the argument `enable_protobuf_negotiation` in the `prometheus.scrape` component:
 


### PR DESCRIPTION
Due to https://github.com/grafana/agent/pull/5750
