### PR TITLE
continuous-test: Include comparison of all expected and actual values when any float sample does not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Mimir Continuous Test
 
+* [ENHANCEMENT] Include comparison of all expected and actual values when any float sample does not match. #6756
+
 ### Query-tee
 
 ### Documentation

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -418,7 +418,7 @@ func randTime(min, max time.Time) time.Time {
 }
 
 func formatExpectedAndActualValuesComparison(matrix model.Matrix, expectedSeries int, generateValue generateValueFunc) string {
-	const precision = 6
+	const precision = 4
 
 	builder := strings.Builder{}
 	builder.WriteString("Timestamp      Expected  Actual\n")

--- a/pkg/continuoustest/util_test.go
+++ b/pkg/continuoustest/util_test.go
@@ -337,9 +337,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 1,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  -0.913545  -0.913545
-1701142020000  -0.951057  -0.951057
-1701142030000  -0.978148  -0.978148
+1701142010000  -0.9135  -0.9135
+1701142020000  -0.9511  -0.9511
+1701142030000  -0.9781  -0.9781
 `,
 		},
 		"all values match, multiple expected series": {
@@ -350,9 +350,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 3,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  -2.740636  -2.740636
-1701142020000  -2.853170  -2.853170
-1701142030000  -2.934443  -2.934443
+1701142010000  -2.7406  -2.7406
+1701142020000  -2.8532  -2.8532
+1701142030000  -2.9344  -2.9344
 `,
 		},
 		"one value differs": {
@@ -363,9 +363,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 3,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  -2.740636  -2.740636
-1701142020000  -2.853170  -1.853170  (value differs!)
-1701142030000  -2.934443  -2.934443
+1701142010000  -2.7406  -2.7406
+1701142020000  -2.8532  -1.8532  (value differs!)
+1701142030000  -2.9344  -2.9344
 `,
 		},
 		"multiple values differ": {
@@ -376,9 +376,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 3,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  -2.740636  -2.740636
-1701142020000  -2.853170  -1.853170  (value differs!)
-1701142030000  -2.934443  -3.934443  (value differs!)
+1701142010000  -2.7406  -2.7406
+1701142020000  -2.8532  -1.8532  (value differs!)
+1701142030000  -2.9344  -3.9344  (value differs!)
 `,
 		},
 	}


### PR DESCRIPTION
#### What this PR does

This PR improves the output of continuous-test when a query returns unexpected results. If a float sample does not match the expected value, continuous-test will now include a dump of all expected and received values, to aid in debugging failures.

One downside of this change is that failure messages could potentially become huge. The default value for `-tests.write-read-series-test.max-query-age` is 7 days, and continuous-test will select a random query time range that selects anywhere up to everything from now until that value. If this happens, and the test fails, continuous-test will write an error with 30,240 samples (7 days' samples with a 20s step). Given this should be a rare situation, and failures should be a rare occurrence, and debugging failures is otherwise difficult, I think this is a reasonable trade-off, but I'm open to other ideas. (Perhaps we could limit the length of the output, or only include the details of samples around the failing one?)

I haven't made the same change for histogram samples as printing these values is more complex, but if this proves valuable, then this could be added in a future PR.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
