### PR TITLE
Mimirtool: add --output-dir to alertmanager get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 ### Mimirtool
 
 * [ENHANCEMENT] Analyze Prometheus: set tenant header. #6737
+* [ENHANCEMENT] Add argument `--output-dir` to `mimirtool alertmanager get` where the config and templates will be written to and can be loaded via `mimirtool alertmanager load` #6760
 * [BUGFIX] Analyze rule-file: .metricsUsed field wasn't populated. #6953
 
 ### Mimir Continuous Test

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -96,6 +96,17 @@ The following command shows the current Alertmanager configuration.
 mimirtool alertmanager get
 ```
 
+Alternatively, you can output the config and template files to a folder which can then be loaded back
+into alert manager at a later date. For example, the following command outputs the files to a folder called `am`
+
+```bash
+mimirtool alertmanager get --output-dir="am"
+```
+
+The config file is named `config.yaml` and the template files ends in `.tpl`, where each template is written
+out to its own file. Note that using the `--output-dir` flag only writes the output to files and no longer print
+the config to the console.
+
 #### Load Alertmanager configuration
 
 The following command loads an Alertmanager configuration to the Alertmanager instance.
@@ -127,6 +138,16 @@ receivers:
 {{ define "alert_customer_env_message" }}
   [{{ .CommonLabels.alertname }} | {{ .CommonLabels.customer }} | {{ .CommonLabels.environment }}]
 {{ end }}
+```
+
+The input to `[<template_files>...]` accepts wildcard, i.e. `*.tpl` will include all the template files ending
+in `.tpl`. If we have used the previous command of exporting the config and templates to a directory, they
+can be loaded
+
+```bash
+# assuming we have written the files out to the folder am
+# mimirtool alertmanager get --output-dir="am"
+mimirtool alertmanager load  am/config.yaml am/*.tpl
 ```
 
 #### Delete Alertmanager configuration

--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -39,6 +39,7 @@ type AlertmanagerCommand struct {
 	TemplateFiles          []string
 	DisableColor           bool
 	ValidateOnly           bool
+	OutputDir              string
 
 	cli *client.MimirClient
 }
@@ -72,6 +73,7 @@ func (a *AlertmanagerCommand) Register(app *kingpin.Application, envVars EnvVarN
 	// Get Alertmanager Configs Command
 	getAlertsCmd := alertCmd.Command("get", "Get the Alertmanager configuration that is currently in the Grafana Mimir Alertmanager.").Action(a.getConfig)
 	getAlertsCmd.Flag("disable-color", "disable colored output").BoolVar(&a.DisableColor)
+	getAlertsCmd.Flag("output-dir", "The directory where the config and templates will be written to and disables printing to console.").ExistingDirVar(&a.OutputDir)
 
 	deleteCmd := alertCmd.Command("delete", "Delete the Alertmanager configuration that is currently in the Grafana Mimir Alertmanager.").Action(a.deleteConfig)
 
@@ -109,9 +111,36 @@ func (a *AlertmanagerCommand) getConfig(_ *kingpin.ParseContext) error {
 		return err
 	}
 
-	p := printer.New(a.DisableColor)
+	if a.OutputDir == "" {
+		p := printer.New(a.DisableColor)
+		return p.PrintAlertmanagerConfig(cfg, templates)
+	}
+	return a.outputAlertManagerConfigTemplates(cfg, templates)
+}
 
-	return p.PrintAlertmanagerConfig(cfg, templates)
+func (a *AlertmanagerCommand) outputAlertManagerConfigTemplates(config string, templates map[string]string) error {
+	var baseDir string
+	var fileOutputLocation string
+	baseDir, err := filepath.Abs(a.OutputDir)
+	if err != nil {
+		return err
+	}
+	fileOutputLocation = filepath.Join(baseDir, "config.yaml")
+	log.Debugf("writing the config file to %s", fileOutputLocation)
+	err = os.WriteFile(fileOutputLocation, []byte(config), os.FileMode(0o600))
+	if err != nil {
+		return err
+	}
+
+	for fn, template := range templates {
+		fileOutputLocation = filepath.Join(baseDir, fn)
+		log.Debugf("writing the template file to %s", fileOutputLocation)
+		err = os.WriteFile(fileOutputLocation, []byte(template), os.FileMode(0o600))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (a *AlertmanagerCommand) readAlertManagerConfig() (string, map[string]string, error) {

--- a/pkg/mimirtool/commands/alerts_test.go
+++ b/pkg/mimirtool/commands/alerts_test.go
@@ -3,6 +3,7 @@
 package commands
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,4 +41,48 @@ func TestReadAlertmanagerConfigTemplates_collidingNames(t *testing.T) {
 
 	_, err := cmd.readAlertManagerConfigTemplates()
 	require.Error(t, err)
+}
+
+func TestReadAlertmanagerValidConfigFile(t *testing.T) {
+	cmd := AlertmanagerCommand{
+		AlertmanagerConfigFile: "./testdata/alertmanager_config.yaml",
+	}
+
+	_, _, err := cmd.readAlertManagerConfig()
+	require.NoError(t, err)
+}
+
+func TestLoadAlertmanagerConfigAndTemplateFile(t *testing.T) {
+	// creates a temp directory to persist the original config and templates to disk
+	dir := t.TempDir()
+	// reads the existing config and template to memory
+	cmd := AlertmanagerCommand{
+		AlertmanagerConfigFile: "./testdata/alertmanager_config.yaml",
+		TemplateFiles: []string{
+			"./testdata/alertmanager_template.tmpl",
+		},
+		OutputDir: dir,
+	}
+	originalCfg, originalTemplates, err := cmd.readAlertManagerConfig()
+	require.NoError(t, err)
+	// write the data to a temp directory and reads it again
+	err = cmd.outputAlertManagerConfigTemplates(originalCfg, originalTemplates)
+	require.NoError(t, err)
+	// loads the new files that has been written out from memory, load the new files and compare
+	cmdLoad := AlertmanagerCommand{
+		AlertmanagerConfigFile: filepath.Join(dir, "config.yaml"),
+		TemplateFiles: []string{
+			filepath.Join(dir, "alertmanager_template.tmpl"),
+		},
+	}
+	loadedCfg, loadedTemplates, err := cmdLoad.readAlertManagerConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, originalCfg, loadedCfg)
+	assert.Equal(t, len(originalTemplates), len(loadedTemplates))
+	for fileName, fileContent := range originalTemplates {
+		if assert.Contains(t, loadedTemplates, fileName) {
+			assert.Equal(t, loadedTemplates[fileName], fileContent)
+		}
+	}
 }

--- a/pkg/mimirtool/commands/testdata/alertmanager_config.yaml
+++ b/pkg/mimirtool/commands/testdata/alertmanager_config.yaml
@@ -1,0 +1,11 @@
+global:
+  smtp_smarthost: 'localhost:25'
+
+templates:
+  - 'alertmanager_template.tmpl'
+
+route:
+  receiver: default
+
+receivers:
+  - name: default


### PR DESCRIPTION
#### What this PR does

Seeking some direction from the maintainers and raising the PR for feedback.

We have encountered the same problem where getting the config synced for alert manager using `mimirtool` is quite cumbersome. Looking to fix the issue where the output of `mimirtool alertmanager get` cannot be used for `mimirtool alertmanager load` since the `get` command output a single file that contains both the config and the templates file. Furthermore, the output is not a valid yaml.

To be honest, I am not entirely sure what direction this should go hence this only contains a minimal working enhancement that works on my test setup. For example, 

```shell
# assuming the env variables MIMIR_ADDRESS, MIMIR_TENANT_ID, MIMIR_API_KEY exists and are correct
# build the binary locally, then create the config and template
./mimirtool alertmanager get --log.level="debug" --output-dir="am"
# and assuming that all the templates has file extension .tpl
./mimirtool alertmanager load am/config.yaml am/*.tpl
```

Some of the obvious caveat:
 * Name of the main config is not configurable and fixed as `config.yaml`.
 * When using the flag `--output-dir` the config/templates no longer print to screen.
 * The debug log may be slightly out of place for some people, but since there is only one field `fileName` per line I am not sure `WithFields` is sensible (bit of personal preference here).
 * The flag `--disable-color` is ignored (well, this is fine unless we want color in txt file...).

and there are probably some edge cases which I am not aware of :) .


#### Which issue(s) this PR fixes or relates to

Enhancement for #3241 

#### Checklist

- [x] Tests updated. - Not done because not sure about direction.
- [x] Documentation added. - N/A maybe?
- [ X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ X] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
