### PR TITLE
Upstream internal jsonnet changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Ingester: Increase default value of `-blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes` and `-blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes` to 100 MiB (defaults to 10 MiB). #6764
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766
@@ -15,7 +16,6 @@
 ### Jsonnet
 
 * [CHANGE] Querier: Increase `JAEGER_REPORTER_MAX_QUEUE_SIZE` from 1000 to 5000, to avoid dropping tracing spans. #6764
-* [CHANGE] Ingester: Increase value of `-blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes` and `-blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes` to 100 MiB (defaults to 10 MiB). #6764
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Grafana Mimir
 
-* [CHANGE] Ingester: Increase default value of `-blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes` and `-blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes` to 100 MiB (defaults to 10 MiB). #6764
+* [CHANGE] Ingester: Increase default value of `-blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes` and `-blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes` to 100 MiB (previous default value was 10 MiB). #6764
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@
 * [CHANGE] Changed default `_config.cluster_domain` from `cluster.local` to `cluster.local.` to reduce the number of DNS lookups made by Mimir. #6389
 * [CHANGE] Query-frontend: changed default `_config.autoscaling_query_frontend_cpu_target_utilization` from `1` to `0.75`. #6395
 * [CHANGE] Distributor: Increase HPA scale down period such that distributors are slower to scale down after autoscaling up. #6589
+* [CHANGE] Querier: Increase `JAEGER_REPORTER_MAX_QUEUE_SIZE` from 1000 to 5000, to avoid dropping tracing spans. #6764
 * [FEATURE] Store-gateway: Allow automated zone-by-zone downscaling, that can be enabled via the `store_gateway_automated_downscale_enabled` flag. It is disabled by default. #6149
 * [FEATURE] Ingester: Allow to configure TSDB Head early compaction using the following `_config` parameters: #6181
   * `ingester_tsdb_head_early_compaction_enabled` (disabled by default)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Jsonnet
 
+* [CHANGE] Querier: Increase `JAEGER_REPORTER_MAX_QUEUE_SIZE` from 1000 to 5000, to avoid dropping tracing spans. #6764
+* [CHANGE] Ingester: Increase value of `-blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes` and `-blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes` to 100 MiB (defaults to 10 MiB). #6764
+
 ### Mimirtool
 
 ### Mimir Continuous Test
@@ -157,7 +160,6 @@
 * [CHANGE] Changed default `_config.cluster_domain` from `cluster.local` to `cluster.local.` to reduce the number of DNS lookups made by Mimir. #6389
 * [CHANGE] Query-frontend: changed default `_config.autoscaling_query_frontend_cpu_target_utilization` from `1` to `0.75`. #6395
 * [CHANGE] Distributor: Increase HPA scale down period such that distributors are slower to scale down after autoscaling up. #6589
-* [CHANGE] Querier: Increase `JAEGER_REPORTER_MAX_QUEUE_SIZE` from 1000 to 5000, to avoid dropping tracing spans. #6764
 * [FEATURE] Store-gateway: Allow automated zone-by-zone downscaling, that can be enabled via the `store_gateway_automated_downscale_enabled` flag. It is disabled by default. #6149
 * [FEATURE] Ingester: Allow to configure TSDB Head early compaction using the following `_config` parameters: #6181
   * `ingester_tsdb_head_early_compaction_enabled` (disabled by default)

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8625,7 +8625,7 @@
               "required": false,
               "desc": "Maximum size in bytes of the cache for postings for matchers in the Head and OOOHead when TTL is greater than 0.",
               "fieldValue": null,
-              "fieldDefaultValue": 10485760,
+              "fieldDefaultValue": 104857600,
               "fieldFlag": "blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes",
               "fieldType": "int",
               "fieldCategory": "experimental"
@@ -8669,7 +8669,7 @@
               "required": false,
               "desc": "Maximum size in bytes of the cache for postings for matchers in each compacted block when TTL is greater than 0.",
               "fieldValue": null,
-              "fieldDefaultValue": 10485760,
+              "fieldDefaultValue": 104857600,
               "fieldFlag": "blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes",
               "fieldType": "int",
               "fieldCategory": "experimental"

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -752,7 +752,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.tsdb.block-postings-for-matchers-cache-force
     	[experimental] Force the cache to be used for postings for matchers in compacted blocks, even if it's not a concurrent (query-sharding) call.
   -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes int
-    	[experimental] Maximum size in bytes of the cache for postings for matchers in each compacted block when TTL is greater than 0. (default 10485760)
+    	[experimental] Maximum size in bytes of the cache for postings for matchers in each compacted block when TTL is greater than 0. (default 104857600)
   -blocks-storage.tsdb.block-postings-for-matchers-cache-size int
     	[deprecated] Maximum number of entries in the cache for postings for matchers in each compacted block when TTL is greater than 0. (default 100)
   -blocks-storage.tsdb.block-postings-for-matchers-cache-ttl duration
@@ -782,7 +782,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.tsdb.head-postings-for-matchers-cache-force
     	[experimental] Force the cache to be used for postings for matchers in the Head and OOOHead, even if it's not a concurrent (query-sharding) call.
   -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes int
-    	[experimental] Maximum size in bytes of the cache for postings for matchers in the Head and OOOHead when TTL is greater than 0. (default 10485760)
+    	[experimental] Maximum size in bytes of the cache for postings for matchers in the Head and OOOHead when TTL is greater than 0. (default 104857600)
   -blocks-storage.tsdb.head-postings-for-matchers-cache-size int
     	[deprecated] Maximum number of entries in the cache for postings for matchers in the Head and OOOHead when TTL is greater than 0. (default 100)
   -blocks-storage.tsdb.head-postings-for-matchers-cache-ttl duration

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3827,7 +3827,7 @@ tsdb:
   # (experimental) Maximum size in bytes of the cache for postings for matchers
   # in the Head and OOOHead when TTL is greater than 0.
   # CLI flag: -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes
-  [head_postings_for_matchers_cache_max_bytes: <int> | default = 10485760]
+  [head_postings_for_matchers_cache_max_bytes: <int> | default = 104857600]
 
   # (experimental) Force the cache to be used for postings for matchers in the
   # Head and OOOHead, even if it's not a concurrent (query-sharding) call.
@@ -3848,7 +3848,7 @@ tsdb:
   # (experimental) Maximum size in bytes of the cache for postings for matchers
   # in each compacted block when TTL is greater than 0.
   # CLI flag: -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes
-  [block_postings_for_matchers_cache_max_bytes: <int> | default = 10485760]
+  [block_postings_for_matchers_cache_max_bytes: <int> | default = 104857600]
 
   # (experimental) Force the cache to be used for postings for matchers in
   # compacted blocks, even if it's not a concurrent (query-sharding) call.

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1110,11 +1110,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1110,9 +1110,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -623,7 +623,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -623,7 +623,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1110,11 +1110,13 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.early-head-compaction-min-estimated-series-reduction-percentage=15
         - -blocks-storage.tsdb.early-head-compaction-min-in-memory-series=2000000
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1110,13 +1110,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.early-head-compaction-min-estimated-series-reduction-percentage=15
         - -blocks-storage.tsdb.early-head-compaction-min-in-memory-series=2000000
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -1111,9 +1111,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -624,7 +624,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -1111,11 +1111,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -738,7 +738,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1063,7 +1063,7 @@ spec:
         - -usage-stats.installation-mode=jsonnet
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: ruler-querier

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1456,9 +1456,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1456,11 +1456,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -738,7 +738,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1063,7 +1063,7 @@ spec:
         - -usage-stats.installation-mode=jsonnet
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: ruler-querier

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1456,9 +1456,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1456,11 +1456,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1484,11 +1484,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1484,9 +1484,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1008,7 +1008,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1709,11 +1709,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1825,11 +1823,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1941,11 +1937,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1709,9 +1709,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1823,9 +1825,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1937,9 +1941,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1175,7 +1175,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1357,11 +1357,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1357,9 +1357,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -977,7 +977,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -611,7 +611,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -914,11 +914,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -914,9 +914,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -860,9 +860,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -557,7 +557,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -860,11 +860,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1086,7 +1086,7 @@ spec:
         - -usage-stats.installation-mode=jsonnet
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: mimir-read
@@ -1185,7 +1185,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1745,9 +1745,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1863,9 +1865,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1981,9 +1985,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -2867,9 +2873,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -2997,9 +3005,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -3127,9 +3137,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1745,11 +1745,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1865,11 +1863,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1985,11 +1981,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -2873,11 +2867,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -3005,11 +2997,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -3137,11 +3127,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1110,11 +1110,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1110,9 +1110,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -623,7 +623,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -860,9 +860,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -557,7 +557,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -860,11 +860,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1153,9 +1153,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -636,7 +636,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1153,11 +1153,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1217,11 +1217,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=example-blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1217,9 +1217,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=example-blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -722,7 +722,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1110,11 +1110,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1110,9 +1110,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -623,7 +623,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1115,9 +1115,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1115,11 +1115,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -625,7 +625,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1120,9 +1120,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1120,11 +1120,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -627,7 +627,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1115,9 +1115,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1115,11 +1115,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -625,7 +625,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1484,11 +1484,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1484,9 +1484,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1008,7 +1008,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1061,7 +1061,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1563,9 +1563,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1563,11 +1563,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1061,7 +1061,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1563,9 +1563,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1563,11 +1563,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1061,7 +1061,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1563,9 +1563,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1563,11 +1563,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1061,7 +1061,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1563,9 +1563,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1563,11 +1563,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1113,11 +1113,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1113,9 +1113,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -626,7 +626,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1110,11 +1110,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1110,9 +1110,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -623,7 +623,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -1170,9 +1170,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -629,7 +629,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -1170,11 +1170,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1347,11 +1347,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1476,11 +1474,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1599,11 +1595,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -802,7 +802,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1347,9 +1347,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1474,9 +1476,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1595,9 +1599,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1404,9 +1404,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1520,9 +1522,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1638,9 +1642,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1756,9 +1762,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1404,11 +1404,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1522,11 +1520,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1642,11 +1638,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1762,11 +1756,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -870,7 +870,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1347,11 +1347,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1476,11 +1474,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1599,11 +1595,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -802,7 +802,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1347,9 +1347,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1474,9 +1476,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
@@ -1595,9 +1599,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1494,11 +1494,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1011,7 +1011,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1494,9 +1494,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -761,7 +761,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1108,7 +1108,7 @@ spec:
         - -usage-stats.installation-mode=jsonnet
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: ruler-querier

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1520,9 +1520,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1520,11 +1520,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -635,7 +635,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1140,11 +1140,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1140,9 +1140,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1128,11 +1128,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1128,9 +1128,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -630,7 +630,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1115,9 +1115,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -623,7 +623,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1115,11 +1115,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -1449,9 +1449,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1580,9 +1582,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1711,9 +1715,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -554,7 +554,7 @@ spec:
         - -usage-stats.installation-mode=jsonnet
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: mimir-read

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -1449,11 +1449,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1582,11 +1580,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1715,11 +1711,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -417,7 +417,7 @@ spec:
         - -usage-stats.installation-mode=jsonnet
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: mimir-read

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -1027,11 +1027,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1160,11 +1158,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1293,11 +1289,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -1027,9 +1027,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1158,9 +1160,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1289,9 +1293,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -1450,9 +1450,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1581,9 +1583,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1712,9 +1716,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -555,7 +555,7 @@ spec:
         - -usage-stats.installation-mode=jsonnet
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: mimir-read

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -1450,11 +1450,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1583,11 +1581,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3
@@ -1716,11 +1712,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1463,11 +1463,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1463,9 +1463,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -740,7 +740,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1068,7 +1068,7 @@ spec:
         - -usage-stats.installation-mode=jsonnet
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: ruler-querier

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1461,11 +1461,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -740,7 +740,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1066,7 +1066,7 @@ spec:
         - -usage-stats.installation-mode=jsonnet
         env:
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: ruler-querier

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1461,9 +1461,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1118,11 +1118,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1118,9 +1118,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -626,7 +626,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1119,9 +1119,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1119,11 +1119,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -626,7 +626,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1118,9 +1118,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.azure.container-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.azure.account-key=azure-account-key

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1118,11 +1118,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.azure.container-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.azure.account-key=azure-account-key

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -625,7 +625,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1110,11 +1110,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1110,9 +1110,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -623,7 +623,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
@@ -979,11 +979,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
@@ -495,7 +495,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
@@ -979,9 +979,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -624,7 +624,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1114,9 +1114,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1114,11 +1114,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.s3.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=s3

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -764,9 +764,11 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -764,11 +764,9 @@ spec:
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
-        - -blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes=104857600
         - -blocks-storage.tsdb.ship-interval=1m
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -526,7 +526,7 @@ spec:
         - name: GOMAXPROCS
           value: "5"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1024"
+          value: "5000"
         image: grafana/mimir:2.10.4
         imagePullPolicy: IfNotPresent
         name: querier

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -69,6 +69,7 @@
     storage_azure_account_key: error 'must specify Azure account key',
 
     jaeger_agent_host: null,
+    querier_jaeger_reporter_max_queue_size: 5000,
 
     // Allow to configure the alertmanager disk.
     alertmanager_data_disk_size: '100Gi',

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -69,7 +69,6 @@
     storage_azure_account_key: error 'must specify Azure account key',
 
     jaeger_agent_host: null,
-    querier_jaeger_reporter_max_queue_size: 5000,
 
     // Allow to configure the alertmanager disk.
     alertmanager_data_disk_size: '100Gi',

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -39,19 +39,6 @@
       // requested just because it spikes during the WAL replay. Therefore, the WAL replay
       // concurrency is chosen in such a way that it is always less than the current CPU request.
       'blocks-storage.tsdb.wal-replay-concurrency': std.max(1, std.floor($.util.parseCPU($.ingester_container.resources.requests.cpu) - 1)),
-
-      // This setting puts a cap on the per-TSDB head/block max PostingsForMatchers() cache size in bytes. This limit is
-      // *in addition* to the max size in items (default to 100 items).
-      //
-      // This increase is most useful on Mimir clusters with 1 tenant. If the tenant runs very high cardinality
-      // queries (e.g. a query touching 1M series / ingester) then with the default cache
-      // size of 10MB we may not be able to effectively use the cache.
-      //
-      // A single cached posting takes about 9 bytes in the cache, on average. The default max cache size as number of items
-      // is 100, so having a 100MB cache per-tenant for the TSDB Head means we can cache 100MB / 100 / 9 = 116k postings
-      // per cached entry on average.
-      'blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes': 100 * 1024 * 1024,
-      'blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes': 100 * 1024 * 1024,
     } + (
       // Optionally configure the TSDB head early compaction (only when enabled).
       if !$._config.ingester_tsdb_head_early_compaction_enabled then {} else {

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -39,6 +39,19 @@
       // requested just because it spikes during the WAL replay. Therefore, the WAL replay
       // concurrency is chosen in such a way that it is always less than the current CPU request.
       'blocks-storage.tsdb.wal-replay-concurrency': std.max(1, std.floor($.util.parseCPU($.ingester_container.resources.requests.cpu) - 1)),
+
+      // This setting puts a cap on the per-TSDB head/block max PostingsForMatchers() cache size in bytes. This limit is
+      // *in addition* to the max size in items (default to 100 items).
+      //
+      // This increase is most useful on Mimir clusters with 1 tenant. If the tenant runs very high cardinality
+      // queries (e.g. a query touching 1M series / ingester) then with the default cache
+      // size of 10MB we may not be able to effectively use the cache.
+      //
+      // A single cached posting takes about 9 bytes in the cache, on average. The default max cache size as number of items
+      // is 100, so having a 100MB cache per-tenant for the TSDB Head means we can cache 100MB / 100 / 9 = 116k postings
+      // per cached entry on average.
+      'blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes': 100 * 1024 * 1024,
+      'blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes': 100 * 1024 * 1024,
     } + (
       // Optionally configure the TSDB head early compaction (only when enabled).
       if !$._config.ingester_tsdb_head_early_compaction_enabled then {} else {

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -42,7 +42,7 @@
     $.util.resourcesLimits(null, '24Gi'),
 
   querier_env_map:: {
-    JAEGER_REPORTER_MAX_QUEUE_SIZE: '1024',  // Default is 100.
+    JAEGER_REPORTER_MAX_QUEUE_SIZE: std.toString($._config.querier_jaeger_reporter_max_queue_size),
 
     // Dynamically set GOMAXPROCS based on CPU request.
     GOMAXPROCS: std.toString(

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -42,7 +42,7 @@
     $.util.resourcesLimits(null, '24Gi'),
 
   querier_env_map:: {
-    JAEGER_REPORTER_MAX_QUEUE_SIZE: std.toString($._config.querier_jaeger_reporter_max_queue_size),
+    JAEGER_REPORTER_MAX_QUEUE_SIZE: '5000',
 
     // Dynamically set GOMAXPROCS based on CPU request.
     GOMAXPROCS: std.toString(

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -87,8 +87,8 @@ const (
 	// DefaultPostingsForMatchersCacheMaxBytes setting puts a limit cap on the per-TSDB head/block max PostingsForMatchers() cache size in bytes.
 	// This limit is *in addition* to the max size in items (default to 100 items).
 	//
-	// This increase is most useful on Mimir clusters with 1 tenant. If the tenant runs very high cardinality
-	// queries (e.g. a query touching 1M series / ingester) then with the default cache
+	// This value is most useful on Mimir clusters with 1 tenant. If the tenant runs very high cardinality
+	// queries (e.g. a query touching 1M series / ingester) then with the previous default cache
 	// size of 10MB we may not be able to effectively use the cache.
 	//
 	// A single cached posting takes about 9 bytes in the cache, on average. The default max cache size as number of items


### PR DESCRIPTION
#### What this PR does

This PR upstreams some of the changes that we use internally.

- Increase `JAEGER_REPORTER_MAX_QUEUE_SIZE` to 5000 to avoid dropping of spans

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
