### PR TITLE
Query-frontend worker: put back 'continue' removed in error

### DIFF
--- a/pkg/querier/worker/frontend_processor.go
+++ b/pkg/querier/worker/frontend_processor.go
@@ -88,6 +88,7 @@ func (fp *frontendProcessor) processQueriesOnSingleStream(workerCtx context.Cont
 			if !grpcutil.IsCanceled(err) {
 				level.Error(fp.log).Log("msg", "error processing requests", "address", address, "err", err)
 				backoff.Wait()
+				continue
 			}
 		}
 


### PR DESCRIPTION
This line was removed in #4648; I can only think it was due to a bad merge or similar.
Removing `continue` would mean we always reset the backoff after an error.

Note this file is only used if you are not using the query-frontend sheduler.
