### PR TITLE
Jsonnet: add newDistributorContainer() utility

### DIFF
--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -47,15 +47,18 @@
     ),
   },
 
-  distributor_container::
-    container.new('distributor', $._images.distributor) +
+  newDistributorContainer(name, args, envVarMap={})::
+    container.new(name, $._images.distributor) +
     container.withPorts($.distributor_ports) +
-    container.withArgsMixin($.util.mapToFlags($.distributor_args)) +
-    (if std.length($.distributor_env_map) > 0 then container.withEnvMap(std.prune($.distributor_env_map)) else {}) +
+    container.withArgsMixin($.util.mapToFlags(args)) +
+    (if std.length(envVarMap) > 0 then container.withEnvMap(std.prune(envVarMap)) else {}) +
     $.util.resourcesRequests('2', '2Gi') +
     $.util.resourcesLimits(null, '4Gi') +
     $.util.readinessProbe +
     $.jaeger_mixin,
+
+  distributor_container::
+    $.newDistributorContainer('distributor', $.distributor_args, $.distributor_env_map),
 
   newDistributorDeployment(name, container)::
     deployment.new(name, 3, [container]) +


### PR DESCRIPTION
#### What this PR does
Following up https://github.com/grafana/mimir/pull/6774, I just realised it would be easier if I would also have `newDistributorContainer()` utility, so I'm adding it in this PR.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
