### PR TITLE
Enable sharding for `active_series` requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [ENHANCEMENT] Distributor: support disabling metric relabel rules per-tenant via the flag `-distributor.metric-relabeling-enabled` or associated YAML. #6970
 * [ENHANCEMENT] Distributor: `-distributor.remote-timeout` is now accounted from the first ingester push request being sent. #6972
 * [FEATURE] Introduce `-tenant-federation.max-tenants` option to limit the max number of tenants allowed for requests when federation is enabled. #6959
+* [ENHANCEMENT] Query-frontend: add experimental support for sharding active series queries via `-query-frontend.shard-active-series-queries`. #6784
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -3705,6 +3705,17 @@
         },
         {
           "kind": "field",
+          "name": "active_series_results_max_size_bytes",
+          "required": false,
+          "desc": "Maximum size of an active series request result shard in bytes. 0 to disable.",
+          "fieldValue": null,
+          "fieldDefaultValue": 419430400,
+          "fieldFlag": "querier.active-series-results-max-size-bytes",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "ruler_evaluation_delay_duration",
           "required": false,
           "desc": "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed.",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5630,6 +5630,17 @@
         },
         {
           "kind": "field",
+          "name": "shard_active_series_queries",
+          "required": false,
+          "desc": "True to enable sharding of active series queries.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.shard-active-series-queries",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "query_result_response_format",
           "required": false,
           "desc": "Format to use when retrieving query results from queriers. Supported values: json, protobuf",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1623,6 +1623,8 @@ Usage of ./cmd/mimir/mimir:
     	Minimum time to wait for ring stability at startup, if set to positive value. Set to 0 to disable.
   -print.config
     	Print the config and exit.
+  -querier.active-series-results-max-size-bytes int
+    	[experimental] Maximum size of an active series request result shard in bytes. 0 to disable. (default 419430400)
   -querier.cardinality-analysis-enabled
     	Enables endpoints used for cardinality analysis.
   -querier.default-evaluation-interval duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1993,6 +1993,8 @@ Usage of ./cmd/mimir/mimir:
     	How often to resolve the scheduler-address, in order to look for new query-scheduler instances. (default 10s)
   -query-frontend.scheduler-worker-concurrency int
     	Number of concurrent workers forwarding queries to single query-scheduler. (default 5)
+  -query-frontend.shard-active-series-queries
+    	[experimental] True to enable sharding of active series queries.
   -query-frontend.split-instant-queries-by-interval duration
     	[experimental] Split instant queries by an interval and execute in parallel. 0 to disable it.
   -query-frontend.split-queries-by-interval duration

--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -139,6 +139,7 @@ frontend:
   align_queries_with_step: true
   cache_results: true
   additional_query_queue_dimensions_enabled: true
+  shard_active_series_queries: true
 
   # Uncomment when using "dns" service discovery mode for query-scheduler.
   # scheduler_address: "query-scheduler:9011"

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -125,6 +125,7 @@ The following features are currently experimental:
   - Ingester query request minimisation (`-querier.minimize-ingester-requests`)
   - Limiting queries based on the estimated number of chunks that will be used (`-querier.max-estimated-fetched-chunks-per-query-multiplier`)
   - Max concurrency for tenant federated queries (`-tenant-federation.max-concurrent`)
+  - Maximum response size for active series queries (`-querier.active-series-results-max-size-bytes`)
 - Query-frontend
   - `-query-frontend.querier-forget-delay`
   - Instant query splitting (`-query-frontend.split-instant-queries-by-interval`)
@@ -133,6 +134,7 @@ The following features are currently experimental:
   - Query blocking on a per-tenant basis (configured with the limit `blocked_queries`)
   - Wait for the query-frontend to complete startup if a query request is received while it is starting up (`-query-frontend.not-running-timeout`)
   - Max number of tenants that may be queried at once (`-tenant-federation.max-tenants`)
+  - Sharding of active series queries (`-query-frontend.shard-active-series-queries`)
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
 - Store-gateway

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1490,6 +1490,10 @@ results_cache:
 # CLI flag: -query-frontend.query-sharding-target-series-per-shard
 [query_sharding_target_series_per_shard: <int> | default = 0]
 
+# (experimental) True to enable sharding of active series queries.
+# CLI flag: -query-frontend.shard-active-series-queries
+[shard_active_series_queries: <boolean> | default = false]
+
 # Format to use when retrieving query results from queriers. Supported values:
 # json, protobuf
 # CLI flag: -query-frontend.query-result-response-format

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3232,6 +3232,11 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -querier.label-values-max-cardinality-label-names-per-request
 [label_values_max_cardinality_label_names_per_request: <int> | default = 100]
 
+# (experimental) Maximum size of an active series request result shard in bytes.
+# 0 to disable.
+# CLI flag: -querier.active-series-results-max-size-bytes
+[active_series_results_max_size_bytes: <int> | default = 419430400]
+
 # Duration to delay the evaluation of rules to ensure the underlying metrics
 # have been pushed.
 # CLI flag: -ruler.evaluation-delay-duration

--- a/go.mod
+++ b/go.mod
@@ -192,7 +192,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
-	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/klauspost/compress v1.17.4
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -60,6 +60,7 @@ type Config struct {
 	ShardedQueries                   bool          `yaml:"parallelize_shardable_queries"`
 	DeprecatedCacheUnalignedRequests bool          `yaml:"cache_unaligned_requests" category:"advanced" doc:"hidden"` // Deprecated: Deprecated in Mimir 2.10.0, remove in Mimir 2.12.0 (https://github.com/grafana/mimir/issues/5253)
 	TargetSeriesPerShard             uint64        `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
+	ShardActiveSeriesQueries         bool          `yaml:"shard_active_series_queries" category:"experimental"`
 
 	// CacheKeyGenerator allows to inject a CacheKeyGenerator to use for generating cache keys.
 	// If nil, the querymiddleware package uses a DefaultCacheKeyGenerator with SplitQueriesByInterval.
@@ -77,6 +78,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ShardedQueries, "query-frontend.parallelize-shardable-queries", false, "True to enable query sharding.")
 	f.Uint64Var(&cfg.TargetSeriesPerShard, "query-frontend.query-sharding-target-series-per-shard", 0, "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.")
 	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatProtobuf, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
+	f.BoolVar(&cfg.ShardActiveSeriesQueries, "query-frontend.shard-active-series-queries", false, "True to enable sharding of active series queries.")
 	cfg.ResultsCacheConfig.RegisterFlags(f)
 
 	// The query-frontend.cache-unaligned-requests flag has been moved to the limits.go file
@@ -323,12 +325,17 @@ func newQueryTripperware(
 		// range and instant queries have more accurate logic for query details.
 		next = newQueryDetailsStartEndRoundTripper(next)
 		cardinality := next
+		activeSeries := next
 		labels := next
 
 		// Inject the cardinality and labels query cache roundtripper only if the query results cache is enabled.
 		if cfg.CacheResults {
 			cardinality = newCardinalityQueryCacheRoundTripper(c, cacheKeyGenerator, limits, cardinality, log, registerer)
 			labels = newLabelsQueryCacheRoundTripper(c, cacheKeyGenerator, limits, labels, log, registerer)
+		}
+
+		if cfg.ShardActiveSeriesQueries {
+			activeSeries = newShardActiveSeriesMiddleware(activeSeries, log)
 		}
 
 		return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -339,6 +346,8 @@ func newQueryTripperware(
 				return instant.RoundTrip(r)
 			case IsCardinalityQuery(r.URL.Path):
 				return cardinality.RoundTrip(r)
+			case IsActiveSeriesQuery(r.URL.Path):
+				return activeSeries.RoundTrip(r)
 			case IsLabelsQuery(r.URL.Path):
 				return labels.RoundTrip(r)
 			default:
@@ -411,12 +420,15 @@ func IsInstantQuery(path string) bool {
 
 func IsCardinalityQuery(path string) bool {
 	return strings.HasSuffix(path, cardinalityLabelNamesPathSuffix) ||
-		strings.HasSuffix(path, cardinalityLabelValuesPathSuffix) ||
-		strings.HasSuffix(path, cardinalityActiveSeriesPathSuffix)
+		strings.HasSuffix(path, cardinalityLabelValuesPathSuffix)
 }
 
 func IsLabelsQuery(path string) bool {
 	return strings.HasSuffix(path, labelNamesPathSuffix) || labelValuesPathSuffix.MatchString(path)
+}
+
+func IsActiveSeriesQuery(path string) bool {
+	return strings.HasSuffix(path, cardinalityActiveSeriesPathSuffix)
 }
 
 func defaultInstantQueryParamsRoundTripper(next http.RoundTripper) http.RoundTripper {

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -335,7 +335,7 @@ func newQueryTripperware(
 		}
 
 		if cfg.ShardActiveSeriesQueries {
-			activeSeries = newShardActiveSeriesMiddleware(activeSeries, log)
+			activeSeries = newShardActiveSeriesMiddleware(activeSeries, limits, log)
 		}
 
 		return RoundTripFunc(func(r *http.Request) (*http.Response, error) {

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -183,8 +183,10 @@ func doShardedRequests(ctx context.Context, upstreamRequests []*http.Request, ne
 				return fmt.Errorf("received unexpected response from upstream: status %d, body: %s", resp.StatusCode, string(body))
 			}
 
-			queryStats.Merge(partialStats)
 			resps[i] = resp
+
+			span.LogFields(otlog.Uint64("seriesCount", partialStats.LoadFetchedSeries()))
+			queryStats.Merge(partialStats)
 
 			return nil
 		})

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -191,7 +191,6 @@ func shardedSelector(shardCount, currentShard int, expr parser.Expr) (parser.Exp
 func (s *shardActiveSeriesMiddleware) mergeResponses(responses []*http.Response) *http.Response {
 	reader, writer := io.Pipe()
 
-	json = jsoniter.ConfigCompatibleWithStandardLibrary
 	items := make(chan any)
 
 	g := new(errgroup.Group)

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -106,10 +106,7 @@ func setShardCountFromHeader(origShardCount int, r *http.Request, spanLog *spanl
 			continue
 		}
 		if shards >= 0 {
-			spanLog.DebugLog(
-				"msg",
-				fmt.Sprintf("using shard count from header %s: %d", totalShardsControlHeader, shards),
-			)
+			spanLog.DebugLog("msg", fmt.Sprintf("using shard count from header %s: %d", totalShardsControlHeader, shards))
 			return int(shards)
 		}
 	}

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -240,8 +240,9 @@ func (s *shardActiveSeriesMiddleware) mergeResponses(ctx context.Context, respon
 		}
 		r := res
 		g.Go(func() error {
-			defer func(Body io.ReadCloser) {
-				_ = Body.Close()
+			defer func(body io.ReadCloser) {
+				_, _ = io.ReadAll(body)
+				_ = body.Close()
 			}(r.Body)
 
 			it := jsoniter.Parse(jsoniter.ConfigFastest, r.Body, 512)

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -122,11 +122,11 @@ func parseSelector(req *http.Request) (*parser.VectorSelector, error) {
 	}
 	parsed, err := parser.ParseExpr(valSelector)
 	if err != nil {
-		return nil, errors.New("invalid selector")
+		return nil, fmt.Errorf("invalid selector: %w", err)
 	}
 	selector, ok := parsed.(*parser.VectorSelector)
 	if !ok {
-		return nil, errors.New("invalid selector")
+		return nil, fmt.Errorf("invalid selector: %w", err)
 	}
 
 	return selector, nil

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/go-kit/log"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"golang.org/x/sync/errgroup"
+
+	apierror "github.com/grafana/mimir/pkg/api/error"
+	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/storage/sharding"
+	"github.com/grafana/mimir/pkg/util"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+type shardActiveSeriesMiddleware struct {
+	upstream http.RoundTripper
+	logger   log.Logger
+}
+
+func newShardActiveSeriesMiddleware(upstream http.RoundTripper, logger log.Logger) http.RoundTripper {
+	return &shardActiveSeriesMiddleware{
+		upstream: upstream,
+		logger:   logger,
+	}
+}
+
+func (s *shardActiveSeriesMiddleware) RoundTrip(r *http.Request) (*http.Response, error) {
+	const defaultNumShards = 1
+
+	ctx := r.Context()
+
+	spanLog, ctx := spanlogger.NewWithLogger(ctx, s.logger, "shardActiveSeries.RoundTrip")
+	defer spanLog.Finish()
+
+	numShards := setShardCountFromHeader(defaultNumShards, r, spanLog)
+
+	if numShards < 2 {
+		spanLog.DebugLog("msg", "query sharding disabled for request")
+		return s.upstream.RoundTrip(r)
+	}
+
+	values, err := util.ParseRequestFormWithoutConsumingBody(r)
+	if err != nil {
+		return nil, apierror.New(apierror.TypeBadData, err.Error())
+	}
+
+	parsed, err := parser.ParseExpr(values.Get("selector"))
+	if err != nil {
+		return nil, apierror.New(apierror.TypeBadData, err.Error())
+	}
+
+	selector, ok := parsed.(*parser.VectorSelector)
+	if !ok {
+		return nil, apierror.New(apierror.TypeBadData, "invalid selector")
+	}
+
+	spanLog.DebugLog(
+		"msg", "sharding active series query",
+		"shardCount", numShards, "selector", selector.String(),
+	)
+
+	reqs, err := buildShardedRequests(ctx, r, numShards, selector)
+	if err != nil {
+		return nil, apierror.New(apierror.TypeInternal, err.Error())
+	}
+
+	resp, err := doShardedRequests(ctx, reqs, s.upstream)
+	if err != nil {
+		return nil, apierror.New(apierror.TypeInternal, err.Error())
+	}
+
+	return s.mergeResponses(resp), nil
+}
+
+func setShardCountFromHeader(origShardCount int, r *http.Request, spanLog *spanlogger.SpanLogger) int {
+	for _, value := range r.Header.Values(totalShardsControlHeader) {
+		shards, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			continue
+		}
+		if shards > 0 {
+			spanLog.DebugLog(
+				"msg",
+				fmt.Sprintf("using shard count from header %s: %d", totalShardsControlHeader, shards),
+			)
+			return int(shards)
+		}
+	}
+	return origShardCount
+}
+
+func buildShardedRequests(ctx context.Context, req *http.Request, numRequests int, selector parser.Expr) ([]*http.Request, error) {
+	reqs := make([]*http.Request, numRequests)
+	for i := 0; i < numRequests; i++ {
+		reqs[i] = req.Clone(ctx)
+
+		sharded, err := shardedSelector(numRequests, i, selector)
+		if err != nil {
+			return nil, err
+		}
+
+		vals := url.Values{}
+		vals.Set("selector", sharded.String())
+
+		reqs[i].Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		reqs[i].Header.Del(totalShardsControlHeader)
+		reqs[i].Body = io.NopCloser(strings.NewReader(vals.Encode()))
+	}
+
+	return reqs, nil
+}
+
+func doShardedRequests(ctx context.Context, upstreamRequests []*http.Request, next http.RoundTripper) ([]*http.Response, error) {
+	mtx := sync.Mutex{}
+	var resps []*http.Response
+
+	g, ctx := errgroup.WithContext(ctx)
+	queryStats := stats.FromContext(ctx)
+	for _, req := range upstreamRequests {
+		r := req
+		g.Go(func() error {
+			partialStats, childCtx := stats.ContextWithEmptyStats(ctx)
+			partialStats.AddShardedQueries(1)
+
+			var span opentracing.Span
+			span, childCtx = opentracing.StartSpanFromContext(childCtx, "shardActiveSeries.doRequests")
+			defer span.Finish()
+
+			resp, err := next.RoundTrip(r.WithContext(childCtx))
+			if err != nil {
+				span.LogFields(otlog.Error(err))
+				return err
+			}
+
+			queryStats.Merge(partialStats)
+
+			mtx.Lock()
+			resps = append(resps, resp)
+			mtx.Unlock()
+
+			return nil
+		})
+	}
+
+	return resps, g.Wait()
+}
+
+func shardedSelector(shardCount, currentShard int, expr parser.Expr) (parser.Expr, error) {
+	originalSelector, ok := expr.(*parser.VectorSelector)
+	if !ok {
+		return nil, errors.New("invalid selector")
+	}
+
+	shardMatcher, err := labels.NewMatcher(
+		labels.MatchEqual, sharding.ShardLabel,
+		sharding.ShardSelector{ShardIndex: uint64(currentShard), ShardCount: uint64(shardCount)}.LabelValue(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parser.VectorSelector{
+		Name:          originalSelector.Name,
+		LabelMatchers: append([]*labels.Matcher{shardMatcher}, originalSelector.LabelMatchers...),
+	}, nil
+}
+
+func (s *shardActiveSeriesMiddleware) mergeResponses(responses []*http.Response) *http.Response {
+	reader, writer := io.Pipe()
+
+	json = jsoniter.ConfigCompatibleWithStandardLibrary
+	items := make(chan any)
+
+	g := new(errgroup.Group)
+	for _, res := range responses {
+		r := res
+		g.Go(func() error {
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(r.Body)
+
+			it := jsoniter.Parse(jsoniter.ConfigFastest, r.Body, 512)
+
+			field := it.ReadObject()
+			if field != "data" {
+				err := errors.New("expected data field at top level")
+				return err
+			}
+
+			if it.WhatIsNext() != jsoniter.ArrayValue {
+				err := errors.New("expected data field to contain an array")
+				return err
+			}
+
+			for it.ReadArray() {
+				items <- it.Read()
+			}
+
+			return it.Error
+		})
+	}
+
+	go s.writeMergedResponse(g, writer, items)
+
+	return &http.Response{Body: reader, StatusCode: http.StatusOK}
+}
+
+func (s *shardActiveSeriesMiddleware) writeMergedResponse(g *errgroup.Group, w io.WriteCloser, series chan any) {
+	defer func(w io.Closer) {
+		_ = w.Close()
+	}(w)
+
+	stream := jsoniter.NewStream(jsoniter.ConfigFastest, w, 512)
+	defer func(stream *jsoniter.Stream) {
+		_ = stream.Flush()
+	}(stream)
+
+	stream.WriteObjectStart()
+	stream.WriteObjectField("data")
+
+	stream.WriteArrayStart()
+
+	doneWriting := make(chan struct{})
+	go func() {
+		firstItem := true
+		for {
+			item, ok := <-series
+			if !ok {
+				doneWriting <- struct{}{}
+				return
+			}
+			if firstItem {
+				firstItem = false
+			} else {
+				stream.WriteMore()
+			}
+			stream.WriteVal(item)
+		}
+	}()
+
+	err := g.Wait()
+	close(series)
+	<-doneWriting
+
+	stream.WriteArrayEnd()
+
+	if err != nil {
+		stream.WriteMore()
+		stream.WriteObjectField("status")
+		stream.WriteString("error")
+		stream.WriteMore()
+		stream.WriteObjectField("error")
+		stream.WriteString(err.Error())
+	}
+
+	stream.WriteObjectEnd()
+}

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	apierror "github.com/grafana/mimir/pkg/api/error"
+	"github.com/grafana/mimir/pkg/cardinality"
+	"github.com/grafana/mimir/pkg/storage/sharding"
+)
+
+func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
+	const defaultShardCount = 3
+
+	validReq := func(shardCount int) func() *http.Request {
+		return func() *http.Request {
+			r := httptest.NewRequest("POST", "/active_series", strings.NewReader(`selector={__name__="metric"}`))
+			r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			r.Header.Add(totalShardsControlHeader, strconv.Itoa(shardCount))
+			return r
+		}
+	}
+
+	noError := func(t *testing.T, err error) bool {
+		return assert.NoError(t, err)
+	}
+
+	tests := []struct {
+		// Request parameters
+		name    string
+		request func() *http.Request
+
+		// Possible responses from upstream
+		validResponses  [][]labels.Labels
+		invalidResponse []byte
+		errorResponse   error
+
+		// Error expectations
+		checkResponseErr  func(t *testing.T, err error) (continueTest bool)
+		checkUnmarshalErr func(t *testing.T, err error) (continueTest bool)
+
+		// Expected result
+		expect             result
+		expectedShardCount int
+	}{
+		{
+			name: "no selector",
+
+			request: func() *http.Request {
+				request := httptest.NewRequest("GET", "/active_series", nil)
+				request.Header.Add(totalShardsControlHeader, strconv.Itoa(defaultShardCount))
+				return request
+			},
+			checkResponseErr: func(t *testing.T, err error) (cont bool) {
+				assert.True(t, apierror.IsNonRetryableAPIError(err))
+				return false
+			},
+		},
+		{
+			name: "invalid selector",
+
+			request: func() *http.Request {
+				v := &url.Values{}
+				v.Set("selector", "{invalid}")
+				r := httptest.NewRequest("GET", "/active_series", nil)
+				r.Header.Add(totalShardsControlHeader, strconv.Itoa(defaultShardCount))
+				r.URL.RawQuery = v.Encode()
+				return r
+			},
+			checkResponseErr: func(t *testing.T, err error) (cont bool) {
+				assert.True(t, apierror.IsNonRetryableAPIError(err))
+				return false
+			},
+		},
+		{
+			name:            "upstream response: invalid type for data field",
+			invalidResponse: []byte(`{"data": "unexpected"}`),
+			request:         validReq(defaultShardCount),
+
+			// We don't expect an error here because it only occurs later as the response is
+			// being streamed.
+			checkResponseErr: func(t *testing.T, err error) (continueTest bool) {
+				return assert.NoError(t, err)
+			},
+			expectedShardCount: 3,
+			expect:             result{Status: "error", Error: "expected data field to contain an array"},
+		},
+		{
+			name:            "upstream response: no data field",
+			invalidResponse: []byte(`{"unexpected": "response"}`),
+			request:         validReq(defaultShardCount),
+
+			// We don't expect an error here because it only occurs later as the response is
+			// being streamed.
+			checkResponseErr: func(t *testing.T, err error) (continueTest bool) {
+				return assert.NoError(t, err)
+			},
+			expectedShardCount: 3,
+			expect:             result{Status: "error", Error: "expected data field at top level"},
+		},
+		{
+			name:    "upstream response: error",
+			request: validReq(defaultShardCount),
+
+			errorResponse: errors.New("upstream error"),
+			checkResponseErr: func(t *testing.T, err error) (continueTest bool) {
+				assert.Error(t, err)
+				return false
+			},
+		},
+		{
+			name:    "happy path, 3 shards",
+			request: validReq(defaultShardCount),
+
+			validResponses: [][]labels.Labels{
+				{labels.FromStrings(labels.MetricName, "metric", "shard", "1")},
+				{labels.FromStrings(labels.MetricName, "metric", "shard", "2")},
+				{labels.FromStrings(labels.MetricName, "metric", "shard", "3")},
+			},
+			checkResponseErr: noError,
+			expect: result{
+				Data: []labels.Labels{
+					labels.FromStrings(labels.MetricName, "metric", "shard", "1"),
+					labels.FromStrings(labels.MetricName, "metric", "shard", "2"),
+					labels.FromStrings(labels.MetricName, "metric", "shard", "3"),
+				},
+			},
+		},
+		{
+			name:    "no sharding, request passed through",
+			request: validReq(1),
+
+			validResponses:   [][]labels.Labels{{labels.FromStrings(labels.MetricName, "metric")}},
+			checkResponseErr: noError,
+			expect:           result{Data: []labels.Labels{labels.FromStrings(labels.MetricName, "metric")}},
+		},
+		{
+			name:    "handles empty shards",
+			request: validReq(6),
+			validResponses: [][]labels.Labels{
+				{labels.FromStrings(labels.MetricName, "metric", "shard", "1")},
+				{},
+				{},
+				{},
+				{},
+				{},
+			},
+			checkResponseErr: noError,
+			expect: result{
+				Data: []labels.Labels{
+					labels.FromStrings(labels.MetricName, "metric", "shard", "1"),
+				},
+			},
+			expectedShardCount: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Stub upstream with valid or invalid responses.
+			var requestCount atomic.Int32
+			upstream := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				defer func(Body io.ReadCloser) {
+					_ = Body.Close()
+				}(r.Body)
+
+				requestCount.Inc()
+
+				if tt.errorResponse != nil {
+					return nil, tt.errorResponse
+				}
+
+				if len(tt.invalidResponse) > 0 {
+					return &http.Response{Body: io.NopCloser(bytes.NewReader(tt.invalidResponse))}, nil
+				}
+
+				require.NoError(t, r.ParseForm())
+
+				req, err := cardinality.DecodeActiveSeriesRequestFromValues(r.Form)
+				require.NoError(t, err)
+
+				// Return requested shard.
+				shard, _, err := sharding.ShardFromMatchers(req.Matchers)
+				require.NoError(t, err)
+				// If no shard is requested, return the first response element
+				if shard == nil {
+					shard = &sharding.ShardSelector{ShardIndex: 0}
+				}
+				require.NotNil(t, tt.validResponses)
+				require.Greater(t, len(tt.validResponses), int(shard.ShardIndex))
+
+				resp, err := json.Marshal(result{Data: tt.validResponses[shard.ShardIndex]})
+				require.NoError(t, err)
+
+				return &http.Response{Body: io.NopCloser(bytes.NewReader(resp))}, nil
+			})
+
+			// Run the request through the middleware.
+			s := newShardActiveSeriesMiddleware(upstream, log.NewNopLogger())
+			resp, err := s.RoundTrip(tt.request().WithContext(user.InjectOrgID(tt.request().Context(), "test")))
+			if !tt.checkResponseErr(t, err) {
+				return
+			}
+
+			assert.GreaterOrEqual(t, 200, resp.StatusCode)
+
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(resp.Body)
+
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+
+			var res result
+			err = json.Unmarshal(body, &res)
+			require.NoError(t, err)
+
+			// Check that the response contains the expected data.
+			assert.ElementsMatch(t, tt.expect.Data, res.Data)
+			assert.Equal(t, tt.expect.Status, res.Status)
+			assert.Contains(t, res.Error, tt.expect.Error)
+
+			// Check that the request was split into the expected number of shards.
+			var expectedCount int
+			if tt.expectedShardCount > 0 {
+				expectedCount = tt.expectedShardCount
+			} else {
+				expectedCount = len(tt.expect.Data)
+			}
+			assert.Equal(t, int32(expectedCount), requestCount.Load())
+		})
+	}
+}
+
+type result struct {
+	Data   []labels.Labels `json:"data"`
+	Status string          `json:"status,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -328,6 +328,89 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 	}
 }
 
+func Test_shardActiveSeriesMiddleware_RoundTrip_ResponseBodyStreamed(t *testing.T) {
+	// This value needs to be set at least as large as the buffer size used by the
+	// actual code for this test to make sense.
+	const bufferSize = 512
+	const shardCount = 2
+
+	// Stub upstream with two responses that are larger than the buffer size and
+	// retain a reference to the response bodies. The responses use a custom body
+	// type that counts the number of bytes read, so we can assert on that later in
+	// the test.
+	var upstreamResponseBodies [shardCount]*bodyReadBytesCounter
+	var responseSize [shardCount]int
+	upstream := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		// Extract requested shard index
+		require.NoError(t, r.ParseForm())
+		req, err := cardinality.DecodeActiveSeriesRequestFromValues(r.Form)
+		require.NoError(t, err)
+		shard, _, err := sharding.ShardFromMatchers(req.Matchers)
+		require.NoError(t, err)
+		require.NotNil(t, shard, "this test requires a shard to be requested")
+
+		// Make sure the response body is big enough to not be buffered entirely.
+		response := fmt.Sprintf(fmt.Sprintf(`{"data": [{"__name__": "metric-%%%dd"}]}`, bufferSize), shard.ShardIndex)
+		body := &bodyReadBytesCounter{body: io.NopCloser(strings.NewReader(response))}
+		upstreamResponseBodies[shard.ShardIndex] = body
+		responseSize[shard.ShardIndex] = len(response)
+
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	})
+
+	s := newShardActiveSeriesMiddleware(
+		upstream,
+		mockLimits{maxShardedQueries: shardCount, totalShards: shardCount},
+		log.NewNopLogger(),
+	)
+
+	r := httptest.NewRequest("POST", "/active_series", strings.NewReader(`selector={__name__=~"metric-.*"}`))
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := s.RoundTrip(r.WithContext(user.InjectOrgID(r.Context(), "test")))
+	require.NoError(t, err)
+	defer func(body io.ReadCloser) {
+		_, _ = io.ReadAll(body)
+		_ = body.Close()
+	}(resp.Body)
+
+	// Check that upstream responses have been read only up to a max of the buffer size.
+	for _, body := range upstreamResponseBodies {
+		bytesRead := int(body.BytesRead())
+		require.GreaterOrEqual(t, bufferSize, bytesRead)
+	}
+
+	// Read and close the response body.
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	// Check that upstream responses have been fully read now.
+	for i, body := range upstreamResponseBodies {
+		bytesRead := int(body.BytesRead())
+		assert.Equal(t, responseSize[i], bytesRead)
+	}
+}
+
+// bodyReadBytesCounter is a wrapper around a response body that counts the number of bytes read from it.
+type bodyReadBytesCounter struct {
+	body      io.ReadCloser
+	bytesRead atomic.Uint64
+}
+
+func (b *bodyReadBytesCounter) Read(p []byte) (n int, err error) {
+	read, err := b.body.Read(p)
+	b.bytesRead.Add(uint64(read))
+	return read, err
+}
+
+func (b *bodyReadBytesCounter) Close() error {
+	return b.body.Close()
+}
+
+func (b *bodyReadBytesCounter) BytesRead() uint64 {
+	return b.bytesRead.Load()
+}
+
 type result struct {
 	Data   []labels.Labels `json:"data"`
 	Status string          `json:"status,omitempty"`

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -330,7 +330,7 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 
 func Test_shardActiveSeriesMiddleware_RoundTrip_ResponseBodyStreamed(t *testing.T) {
 	// This value needs to be set at least as large as the buffer size used by the
-	// actual code for this test to make sense.
+	// implementation for this test to make sense.
 	const bufferSize = 512
 	const shardCount = 2
 
@@ -350,7 +350,7 @@ func Test_shardActiveSeriesMiddleware_RoundTrip_ResponseBodyStreamed(t *testing.
 		require.NotNil(t, shard, "this test requires a shard to be requested")
 
 		// Make sure the response body is big enough to not be buffered entirely.
-		response := fmt.Sprintf(fmt.Sprintf(`{"data": [{"__name__": "metric-%%%dd"}]}`, bufferSize), shard.ShardIndex)
+		response := fmt.Sprintf(fmt.Sprintf(`{"data": [{"__name__": "metric-%%0%dd"}]}`, bufferSize), shard.ShardIndex)
 		body := &bodyReadBytesCounter{body: io.NopCloser(strings.NewReader(response))}
 		upstreamResponseBodies[shard.ShardIndex] = body
 		responseSize[shard.ShardIndex] = len(response)

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -196,7 +196,7 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 				}
 
 				if len(tt.invalidResponse) > 0 {
-					return &http.Response{Body: io.NopCloser(bytes.NewReader(tt.invalidResponse))}, nil
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(tt.invalidResponse))}, nil
 				}
 
 				require.NoError(t, r.ParseForm())
@@ -217,7 +217,7 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 				resp, err := json.Marshal(result{Data: tt.validResponses[shard.ShardIndex]})
 				require.NoError(t, err)
 
-				return &http.Response{Body: io.NopCloser(bytes.NewReader(resp))}, nil
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(resp))}, nil
 			})
 
 			// Run the request through the middleware.

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -23,7 +23,6 @@ import (
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/cardinality"
-	"github.com/grafana/mimir/pkg/distributor"
 	"github.com/grafana/mimir/pkg/storage/sharding"
 )
 
@@ -134,11 +133,11 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 		{
 			name:           "upstream response: response too large",
 			request:        validReq,
-			responseStatus: http.StatusBadRequest,
-			responseBody:   distributor.ErrResponseTooLarge.Error(),
+			responseStatus: http.StatusRequestEntityTooLarge,
+			responseBody:   "",
 
 			checkResponseErr: func(t *testing.T, err error) (continueTest bool) {
-				assert.Contains(t, err.Error(), distributor.ErrResponseTooLarge.Error())
+				assert.Contains(t, err.Error(), errShardCountTooLow.Error())
 				return false
 			},
 		},

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
+	"github.com/klauspost/compress/s2"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
@@ -276,7 +277,11 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 				_ = Body.Close()
 			}(resp.Body)
 
-			body, err := io.ReadAll(resp.Body)
+			var br io.Reader = resp.Body
+			if resp.Header.Get("Content-Encoding") == "x-snappy-framed" {
+				br = s2.NewReader(br)
+			}
+			body, err := io.ReadAll(br)
 			assert.NoError(t, err)
 
 			var res result

--- a/pkg/querier/cardinality_analysis_handler.go
+++ b/pkg/querier/cardinality_analysis_handler.go
@@ -105,7 +105,7 @@ func ActiveSeriesCardinalityHandler(d Distributor, limits *validation.Overrides)
 		res, err := d.ActiveSeries(ctx, req.Matchers)
 		if err != nil {
 			if errors.Is(err, distributor.ErrResponseTooLarge) {
-				http.Error(w, err.Error(), http.StatusBadRequest)
+				http.Error(w, "response shard exceeds size limit, retry with an increased shard count", http.StatusBadRequest)
 				return
 			}
 			respondFromError(err, w)

--- a/pkg/querier/cardinality_analysis_handler.go
+++ b/pkg/querier/cardinality_analysis_handler.go
@@ -105,7 +105,10 @@ func ActiveSeriesCardinalityHandler(d Distributor, limits *validation.Overrides)
 		res, err := d.ActiveSeries(ctx, req.Matchers)
 		if err != nil {
 			if errors.Is(err, distributor.ErrResponseTooLarge) {
-				http.Error(w, fmt.Errorf("%w: try increasing the requested shard count", err).Error(), http.StatusBadRequest)
+				// http.StatusRequestEntityTooLarge (413) is about the request (not the response)
+				// body size, but it's the closest we have, and we're using the same status code
+				// in the query scheduler to express the same error condition.
+				http.Error(w, fmt.Errorf("%w: try increasing the requested shard count", err).Error(), http.StatusRequestEntityTooLarge)
 				return
 			}
 			respondFromError(err, w)

--- a/pkg/querier/cardinality_analysis_handler.go
+++ b/pkg/querier/cardinality_analysis_handler.go
@@ -105,7 +105,7 @@ func ActiveSeriesCardinalityHandler(d Distributor, limits *validation.Overrides)
 		res, err := d.ActiveSeries(ctx, req.Matchers)
 		if err != nil {
 			if errors.Is(err, distributor.ErrResponseTooLarge) {
-				http.Error(w, "response shard exceeds size limit, retry with an increased shard count", http.StatusBadRequest)
+				http.Error(w, fmt.Errorf("%w: try increasing the requested shard count", err).Error(), http.StatusBadRequest)
 				return
 			}
 			respondFromError(err, w)

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -163,6 +163,7 @@ type Limits struct {
 	CardinalityAnalysisEnabled                    bool `yaml:"cardinality_analysis_enabled" json:"cardinality_analysis_enabled"`
 	LabelNamesAndValuesResultsMaxSizeBytes        int  `yaml:"label_names_and_values_results_max_size_bytes" json:"label_names_and_values_results_max_size_bytes"`
 	LabelValuesMaxCardinalityLabelNamesPerRequest int  `yaml:"label_values_max_cardinality_label_names_per_request" json:"label_values_max_cardinality_label_names_per_request"`
+	ActiveSeriesResultsMaxSizeBytes               int  `yaml:"active_series_results_max_size_bytes" json:"active_series_results_max_size_bytes" category:"experimental"`
 
 	// Ruler defaults and limits.
 	RulerEvaluationDelay                 model.Duration `yaml:"ruler_evaluation_delay_duration" json:"ruler_evaluation_delay_duration"`
@@ -261,6 +262,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 14, "Maximum number of split (by time) or partial (by shard) queries that will be scheduled in parallel by the query-frontend for a single input query. This limit is introduced to have a fairer query scheduling and avoid a single query over a large time range saturating all available queriers.")
 	f.Var(&l.MaxLabelsQueryLength, "store.max-labels-query-length", "Limit the time range (end - start time) of series, label names and values queries. This limit is enforced in the querier. If the requested time range is outside the allowed range, the request will not fail but will be manipulated to only query data within the allowed time range. 0 to disable.")
 	f.IntVar(&l.LabelNamesAndValuesResultsMaxSizeBytes, "querier.label-names-and-values-results-max-size-bytes", 400*1024*1024, "Maximum size in bytes of distinct label names and values. When querier receives response from ingester, it merges the response with responses from other ingesters. This maximum size limit is applied to the merged(distinct) results. If the limit is reached, an error is returned.")
+	f.IntVar(&l.ActiveSeriesResultsMaxSizeBytes, "querier.active-series-results-max-size-bytes", 400*1024*1024, "Maximum size of an active series request result shard in bytes. 0 to disable.")
 	f.BoolVar(&l.CardinalityAnalysisEnabled, "querier.cardinality-analysis-enabled", false, "Enables endpoints used for cardinality analysis.")
 	f.IntVar(&l.LabelValuesMaxCardinalityLabelNamesPerRequest, "querier.label-values-max-cardinality-label-names-per-request", 100, "Maximum number of label names allowed to be queried in a single /api/v1/cardinality/label_values API call.")
 	_ = l.MaxCacheFreshness.Set("1m")
@@ -457,6 +459,10 @@ func (o *Overrides) IngestionRate(userID string) float64 {
 // LabelNamesAndValuesResultsMaxSizeBytes returns the maximum size in bytes of distinct label names and values
 func (o *Overrides) LabelNamesAndValuesResultsMaxSizeBytes(userID string) int {
 	return o.getOverridesForUser(userID).LabelNamesAndValuesResultsMaxSizeBytes
+}
+
+func (o *Overrides) ActiveSeriesResultsMaxSizeBytes(userID string) int {
+	return o.getOverridesForUser(userID).ActiveSeriesResultsMaxSizeBytes
 }
 
 func (o *Overrides) CardinalityAnalysisEnabled(userID string) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

To build a response for an `/active_series` request, queriers need to hold the full series set in memory for deduplication. For selectors that return a large set of series this can consume a lot of memory, as allocations are proportional to the size of the set.

This PR allows sharding these requests in the frontend such that each querier only needs to bring part of the series set into memory for deduplication. The frontend then interleaves the partial responses into a single set that is returned back to the client. It also introduces a response size limit for active series responses in queriers to prevent unbounded allocation and OOMs.

This PR also introduces a dedicated roundtripper for active series requests to bypass the generic cache. Since this endpoint is supposed to return "fresh" data, setups with a large cache TTL config could yield outdated results if the cache is enabled and not manually bypassed for querying.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
