### PR TITLE
Clarify grafana agent native histogram support

### DIFF
--- a/docs/sources/mimir/send/native-histograms/_index.md
+++ b/docs/sources/mimir/send/native-histograms/_index.md
@@ -149,7 +149,7 @@ Use the latest version of Prometheus or at least version 2.47.
 
 ## Scrape and send native histograms with Grafana Agent
 
-Use the latest version of the Grafana Agent in [Flow mode](/docs/agent/latest/flow/) or at least version 0.38.
+Use the latest version of the Grafana Agent in [Flow mode](/docs/agent/latest/flow/) (static mode support is coming soon).
 
 1. To enable scraping native histograms you need to enable the argument `enable_protobuf_negotiation` in the `prometheus.scrape` component:
 


### PR DESCRIPTION
Native histogram is only supported in flow mode currently; static mode support is coming soon.
I'm sending in this PR based on a recent conversation in the #agent slack channel with @tpaschalis. 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
