### PR TITLE
ingester client: context canceled is not an error

### DIFF
--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -94,6 +94,9 @@ func (s *SeriesChunksStreamReader) StartBuffering() {
 
 		if err := s.readStream(log); err != nil {
 			s.errorChan <- err
+			if errors.Is(err, context.Canceled) {
+				return
+			}
 			level.Error(log).Log("msg", "received error while streaming chunks from ingester", "err", err)
 			ext.Error.Set(log.Span, true)
 		}


### PR DESCRIPTION
#### What this PR does

Don't output this kind of message , which we tend to get by the hundred: 
```
ts=2023-12-04T11:58:07.821737148Z caller=spanlogger.go:109 method=SeriesChunksStreamReader.StartBuffering user=279486 level=error msg="received error while streaming chunks from ingester" err="context canceled"
```

Don't mark spans as errored either.

#### Checklist

- NA Tests updated.
- NA Documentation added.
- NA `CHANGELOG.md` updated
- NA [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
