### PR TITLE
Log errors that trigger opening of a circuit breaker

### DIFF
--- a/pkg/ingester/client/circuitbreaker.go
+++ b/pkg/ingester/client/circuitbreaker.go
@@ -69,7 +69,13 @@ func NewCircuitBreaker(inst ring.InstanceDesc, cfg CircuitBreakerConfig, metrics
 			transitionHalfOpen.Inc()
 			level.Info(logger).Log("msg", "circuit breaker is half-open", "ingester", inst.Id, "previous", event.OldState, "current", event.NewState)
 		}).
-		HandleIf(func(r any, err error) bool { return isFailure(err) }).
+		HandleIf(func(r any, err error) bool {
+			isFail := isFailure(err)
+			if isFail {
+				level.Warn(logger).Log("msg", "circuit breaker detected a failing execution", "ingester", inst.Id, "err", err)
+			}
+			return isFail
+		}).
 		Build()
 
 	executor := failsafe.NewExecutor[any](breaker)


### PR DESCRIPTION
#### What this PR does
This PR introduces additional log messages showing all possible reasons for circuit breaker opening.
Before this PR the only message related to a circuit breaker opening logged by the distributor was:
```
caller=circuitbreaker.go level=info component=ingester-client msg="circuit breaker is open" ingester=<intester ID> previous=closed current=open
```
That message doesn't say anything about the failing executions that have caused the circuit breaker opening.
This PR changes the current behaviour by logging all the failing executions that are relevant for circuit breaker opening. 
For example, 
```
caller=circuitbreaker.go level=warn component=ingester-client msg="circuit breaker detected a failing execution" ingester=<ingester ID> err="rpc error: code = DeadlineExceeded desc = context deadline exceeded"
```
or
```
caller=circuitbreaker.go level=warn component=ingester-client msg="circuit breaker" ingester=<ingester ID> err="rpc error: code = Unavailable desc = ingester is unavailable (current state: Stopping)"
```

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
