### PR TITLE
Fix helm build script when running out of build-image in a non-bash shell

### DIFF
--- a/operations/helm/scripts/build.sh
+++ b/operations/helm/scripts/build.sh
@@ -66,6 +66,7 @@ function generate_manifests() {
 
   # Get the pid of the subshell calling this function in a portable way.
   # Do not use BASHPID come some shells don't support it.
+  # shellcheck disable=SC2016
   PID=$(exec sh -c 'echo "$PPID"')
 
   echo ""

--- a/operations/helm/scripts/build.sh
+++ b/operations/helm/scripts/build.sh
@@ -65,7 +65,7 @@ function generate_manifests() {
   OUTPUT_DIR=$3
 
   # Get the pid of the subshell calling this function in a portable way.
-  # Do not use BASHPID come some shells don't support it.
+  # Do not use BASHPID because some shells don't support it.
   # shellcheck disable=SC2016
   PID=$(exec sh -c 'echo "$PPID"')
 

--- a/operations/helm/scripts/build.sh
+++ b/operations/helm/scripts/build.sh
@@ -64,6 +64,10 @@ function generate_manifests() {
   INTERMEDIATE_OUTPUT_DIR=$2
   OUTPUT_DIR=$3
 
+  # Get the pid of the subshell calling this function in a portable way.
+  # Do not use BASHPID come some shells don't support it.
+  PID=$(exec sh -c 'echo "$PPID"')
+
   echo ""
   echo "Templating $TEST_NAME"
   ARGS=("${TEST_NAME}" "${CHART_PATH}" "-f" "${FILEPATH}" "--output-dir" "${INTERMEDIATE_OUTPUT_DIR}" "--namespace" "citestns" "--set-string" "regoTestGenerateValues=true")
@@ -74,7 +78,7 @@ function generate_manifests() {
     ARGS+=("--set-string" "kubeVersionOverride=${DEFAULT_KUBE_VERSION}")
   fi
 
-  echo "Rendering helm test $TEST_NAME in PID $BASHPID: 'helm template ${ARGS[*]}'"
+  echo "Rendering helm test $TEST_NAME in PID $PID: 'helm template ${ARGS[*]}'"
   helm template "${ARGS[@]}" 1>/dev/null
   cp -r "${INTERMEDIATE_OUTPUT_DIR}" "${OUTPUT_DIR}"
   rm "${OUTPUT_DIR}/${CHART_NAME}/templates/values-for-rego-tests.yaml"


### PR DESCRIPTION
#### What this PR does

I tried to run `make BUILD_IN_CONTAINER=false build-helm-tests` because it's faster than running in the build image, but it failed on my machine because I'm using zsh instead of bash and `$BASHPID` is not defined (`set -u` at the beginning of the `build.sh` script causes to abort the script if it finds an usage of a non initialized variable). Googling it,[ I've found out here](https://unix.stackexchange.com/questions/484442/how-can-i-get-the-pid-of-a-subshell) that there may be an easy way to get the PID in a portable way, so I'm replacing it. This change fix it on my machine.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
