### PR TITLE
ingester: simplify metadata limit error

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -420,24 +420,24 @@ var _ softError = perMetricSeriesLimitReachedError{}
 // perMetricMetadataLimitReachedError is an ingesterError indicating that a per-metric metadata limit has been reached.
 type perMetricMetadataLimitReachedError struct {
 	limit  int
-	series string
+	family string
 }
 
 // newPerMetricMetadataLimitReachedError creates a new perMetricMetadataLimitReachedError indicating that a per-metric metadata limit has been reached.
-func newPerMetricMetadataLimitReachedError(limit int, labels labels.Labels) perMetricMetadataLimitReachedError {
+func newPerMetricMetadataLimitReachedError(limit int, family string) perMetricMetadataLimitReachedError {
 	return perMetricMetadataLimitReachedError{
 		limit:  limit,
-		series: labels.String(),
+		family: family,
 	}
 }
 
 func (e perMetricMetadataLimitReachedError) Error() string {
-	return fmt.Sprintf("%s This is for series %s",
+	return fmt.Sprintf("%s This is for metric %s",
 		globalerror.MaxMetadataPerMetric.MessageWithPerTenantLimitConfig(
 			fmt.Sprintf("per-metric metadata limit of %d exceeded", e.limit),
 			validation.MaxMetadataPerMetricFlag,
 		),
-		e.series,
+		e.family,
 	)
 }
 

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -129,16 +129,14 @@ func TestNewPerMetricSeriesLimitError(t *testing.T) {
 
 func TestNewPerMetricMetadataLimitError(t *testing.T) {
 	limit := 100
-	labels := mimirpb.FromLabelAdaptersToLabels(
-		[]mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "biz"}},
-	)
-	err := newPerMetricMetadataLimitReachedError(limit, labels)
-	expectedErrMsg := fmt.Sprintf("%s This is for series %s",
+	family := "testmetric"
+	err := newPerMetricMetadataLimitReachedError(limit, family)
+	expectedErrMsg := fmt.Sprintf("%s This is for metric %s",
 		globalerror.MaxMetadataPerMetric.MessageWithPerTenantLimitConfig(
 			fmt.Sprintf("per-metric metadata limit of %d exceeded", limit),
 			validation.MaxMetadataPerMetricFlag,
 		),
-		labels.String(),
+		family,
 	)
 	require.Equal(t, expectedErrMsg, err.Error())
 	checkIngesterError(t, err, mimirpb.BAD_DATA, true)
@@ -362,7 +360,8 @@ func TestWrapOrAnnotateWithUser(t *testing.T) {
 func TestMapPushErrorToErrorWithStatus(t *testing.T) {
 	const originalMsg = "this is an error"
 	originalErr := errors.New(originalMsg)
-	labelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "biz"}}
+	family := "testmetric"
+	labelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: family}, {Name: "foo", Value: "biz"}}
 	labels := mimirpb.FromLabelAdaptersToLabels(labelAdapters)
 	timestamp := model.Time(1)
 
@@ -497,15 +496,15 @@ func TestMapPushErrorToErrorWithStatus(t *testing.T) {
 			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.BAD_DATA},
 		},
 		"a perMetricMetadataLimitReachedError gets translated into an errorWithStatus FailedPrecondition error with details": {
-			err:             newPerMetricMetadataLimitReachedError(10, labels),
+			err:             newPerMetricMetadataLimitReachedError(10, family),
 			expectedCode:    codes.FailedPrecondition,
-			expectedMessage: newPerMetricMetadataLimitReachedError(10, labels).Error(),
+			expectedMessage: newPerMetricMetadataLimitReachedError(10, family).Error(),
 			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.BAD_DATA},
 		},
 		"a wrapped perMetricMetadataLimitReachedError gets translated into an errorWithStatus FailedPrecondition error with details": {
-			err:             fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, labels)),
+			err:             fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, family)),
 			expectedCode:    codes.FailedPrecondition,
-			expectedMessage: fmt.Sprintf("wrapped: %s", newPerMetricMetadataLimitReachedError(10, labels).Error()),
+			expectedMessage: fmt.Sprintf("wrapped: %s", newPerMetricMetadataLimitReachedError(10, family).Error()),
 			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.BAD_DATA},
 		},
 	}
@@ -530,7 +529,8 @@ func TestMapPushErrorToErrorWithStatus(t *testing.T) {
 func TestMapPushErrorToErrorWithHTTPOrGRPCStatus(t *testing.T) {
 	const originalMsg = "this is an error"
 	originalErr := errors.New(originalMsg)
-	labelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "biz"}}
+	family := "testmetric"
+	labelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: family}, {Name: "foo", Value: "biz"}}
 	labels := mimirpb.FromLabelAdaptersToLabels(labelAdapters)
 	timestamp := model.Time(1)
 
@@ -660,16 +660,16 @@ func TestMapPushErrorToErrorWithHTTPOrGRPCStatus(t *testing.T) {
 			),
 		},
 		"a perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: newPerMetricMetadataLimitReachedError(10, labels),
+			err: newPerMetricMetadataLimitReachedError(10, family),
 			expectedTranslation: newErrorWithHTTPStatus(
-				newPerMetricMetadataLimitReachedError(10, labels),
+				newPerMetricMetadataLimitReachedError(10, family),
 				http.StatusBadRequest,
 			),
 		},
 		"a wrapped perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, labels)),
+			err: fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, family)),
 			expectedTranslation: newErrorWithHTTPStatus(
-				fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, labels)),
+				fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, family)),
 				http.StatusBadRequest,
 			),
 		},

--- a/pkg/ingester/user_metrics_metadata.go
+++ b/pkg/ingester/user_metrics_metadata.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/prometheus/model/labels"
-
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
@@ -59,7 +57,7 @@ func (mm *userMetricsMetadata) add(metric string, metadata *mimirpb.MetricMetada
 
 	if !mm.limiter.IsWithinMaxMetadataPerMetric(mm.userID, len(set)) {
 		mm.metrics.discardedMetadataPerMetricMetadataLimit.WithLabelValues(mm.userID).Inc()
-		return mm.errorSamplers.maxMetadataPerMetricLimitExceeded.WrapError(newPerMetricMetadataLimitReachedError(mm.limiter.limits.MaxGlobalMetadataPerMetric(mm.userID), labels.FromStrings(labels.MetricName, metric)))
+		return mm.errorSamplers.maxMetadataPerMetricLimitExceeded.WrapError(newPerMetricMetadataLimitReachedError(mm.limiter.limits.MaxGlobalMetadataPerMetric(mm.userID), metric))
 	}
 
 	// if we have seen this metadata before, it is a no-op and we don't need to change our metrics.


### PR DESCRIPTION
#### What this PR does

Metadata is per-family not per-series; simplify the code to generate an error on too much metadata.

Also correct it to say 'metric' not 'series'.

#### Checklist

- [x] Tests updated.
- NA Documentation added.
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- NA [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
