### PR TITLE
Move util to format LabelAdaptor string to mimirpb package 

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -968,7 +968,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 			testReplica:     "instance1234567890123456789012345678901234567890",
 			cluster:         "cluster0",
 			samples:         5,
-			expectedError:   status.New(codes.FailedPrecondition, fmt.Sprintf(labelValueTooLongMsgFormat, "instance1234567890123456789012345678901234567890", formatLabelSet(labelSetGenWithReplicaAndCluster("instance1234567890123456789012345678901234567890", "cluster0")(0)))),
+			expectedError:   status.New(codes.FailedPrecondition, fmt.Sprintf(labelValueTooLongMsgFormat, "instance1234567890123456789012345678901234567890", mimirpb.FromLabelAdaptersToString(labelSetGenWithReplicaAndCluster("instance1234567890123456789012345678901234567890", "cluster0")(0)))),
 			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.BAD_DATA},
 		},
 	} {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1383,17 +1383,17 @@ func TestDistributor_Push_ExemplarValidation(t *testing.T) {
 		},
 		"rejects exemplar with no labels": {
 			req:    makeWriteRequestExemplar([]string{model.MetricNameLabel, "test"}, 1000, []string{}),
-			errMsg: `received an exemplar with no valid labels, timestamp: 1000 series: {__name__="test"} labels: {}`,
+			errMsg: `received an exemplar with no valid labels, timestamp: 1000 series: test labels: {}`,
 			errID:  globalerror.ExemplarLabelsMissing,
 		},
 		"rejects exemplar with no timestamp": {
 			req:    makeWriteRequestExemplar([]string{model.MetricNameLabel, "test"}, 0, []string{"foo", "bar"}),
-			errMsg: `received an exemplar with no timestamp, timestamp: 0 series: {__name__="test"} labels: {foo="bar"}`,
+			errMsg: `received an exemplar with no timestamp, timestamp: 0 series: test labels: {foo="bar"}`,
 			errID:  globalerror.ExemplarTimestampInvalid,
 		},
 		"rejects exemplar with too long labelset": {
 			req:    makeWriteRequestExemplar([]string{model.MetricNameLabel, "test"}, 1000, []string{"foo", strings.Repeat("0", 126)}),
-			errMsg: fmt.Sprintf(`received an exemplar where the size of its combined labels exceeds the limit of 128 characters, timestamp: 1000 series: {__name__="test"} labels: {foo="%s"}`, strings.Repeat("0", 126)),
+			errMsg: fmt.Sprintf(`received an exemplar where the size of its combined labels exceeds the limit of 128 characters, timestamp: 1000 series: test labels: {foo="%s"}`, strings.Repeat("0", 126)),
 			errID:  globalerror.ExemplarLabelsTooLong,
 		},
 		"rejects exemplar with too many series labels": {
@@ -1474,7 +1474,7 @@ func TestDistributor_Push_HistogramValidation(t *testing.T) {
 			bucketLimit: 7,
 			errMsg:      "received a native histogram sample with too many buckets, timestamp",
 			errID:       globalerror.MaxNativeHistogramBuckets,
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(maxNativeHistogramBucketsMsgFormat, 1000, "{__name__=\"test\"}", 8, 7)),
+			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(maxNativeHistogramBucketsMsgFormat, 1000, "test", 8, 7)),
 		},
 	}
 
@@ -1779,7 +1779,7 @@ func TestDistributor_HistogramReduction(t *testing.T) {
 				limits.MaxNativeHistogramBuckets = 1
 			},
 			req:                makeWriteRequestHistogram([]string{model.MetricNameLabel, "test"}, 1000, hugeH),
-			expectedError:      fmt.Errorf("received a native histogram sample with too many buckets and cannot reduce, timestamp: 1000 series: {__name__=\"test\"}, buckets: 2, limit: 1 (not-reducible-native-histogram)"),
+			expectedError:      fmt.Errorf("received a native histogram sample with too many buckets and cannot reduce, timestamp: 1000 series: test, buckets: 2, limit: 1 (not-reducible-native-histogram)"),
 			expectedTimeSeries: []mimirpb.PreallocTimeseries{},
 		},
 	}
@@ -4579,7 +4579,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(now),
 				Value:       1,
 			}},
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(exemplarEmptyLabelsMsgFormat, now, labels.FromStrings(labels.MetricName, "testmetric", "foo", "bar"), "{}")),
+			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(exemplarEmptyLabelsMsgFormat, now, `testmetric{foo="bar"}`, "{}")),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -228,13 +228,13 @@ func validateSampleHistogram(m *sampleValidationMetrics, now model.Time, cfg sam
 		if bucketCount > bucketLimit {
 			if !cfg.ReduceNativeHistogramOverMaxBuckets(userID) {
 				m.maxNativeHistogramBuckets.WithLabelValues(userID, group).Inc()
-				return fmt.Errorf(maxNativeHistogramBucketsMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToLabels(ls).String(), bucketCount, bucketLimit)
+				return fmt.Errorf(maxNativeHistogramBucketsMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToString(ls), bucketCount, bucketLimit)
 			}
 			for {
 				bc, err := s.ReduceResolution()
 				if err != nil {
 					m.maxNativeHistogramBuckets.WithLabelValues(userID, group).Inc()
-					return fmt.Errorf(notReducibleNativeHistogramMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToLabels(ls).String(), bucketCount, bucketLimit)
+					return fmt.Errorf(notReducibleNativeHistogramMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToString(ls), bucketCount, bucketLimit)
 				}
 				if bc < bucketLimit {
 					break
@@ -251,12 +251,12 @@ func validateSampleHistogram(m *sampleValidationMetrics, now model.Time, cfg sam
 func validateExemplar(m *exemplarValidationMetrics, userID string, ls []mimirpb.LabelAdapter, e mimirpb.Exemplar) error {
 	if len(e.Labels) <= 0 {
 		m.labelsMissing.WithLabelValues(userID).Inc()
-		return fmt.Errorf(exemplarEmptyLabelsMsgFormat, e.TimestampMs, mimirpb.FromLabelAdaptersToLabels(ls).String(), mimirpb.FromLabelAdaptersToLabels([]mimirpb.LabelAdapter{}).String())
+		return fmt.Errorf(exemplarEmptyLabelsMsgFormat, e.TimestampMs, mimirpb.FromLabelAdaptersToString(ls), mimirpb.FromLabelAdaptersToString([]mimirpb.LabelAdapter{}))
 	}
 
 	if e.TimestampMs == 0 {
 		m.timestampInvalid.WithLabelValues(userID).Inc()
-		return fmt.Errorf(exemplarMissingTimestampMsgFormat, e.TimestampMs, mimirpb.FromLabelAdaptersToLabels(ls).String(), mimirpb.FromLabelAdaptersToLabels(e.Labels).String())
+		return fmt.Errorf(exemplarMissingTimestampMsgFormat, e.TimestampMs, mimirpb.FromLabelAdaptersToString(ls), mimirpb.FromLabelAdaptersToString(e.Labels))
 	}
 
 	// Exemplar label length does not include chars involved in text
@@ -278,12 +278,12 @@ func validateExemplar(m *exemplarValidationMetrics, userID string, ls []mimirpb.
 
 	if labelSetLen > ExemplarMaxLabelSetLength {
 		m.labelsTooLong.WithLabelValues(userID).Inc()
-		return fmt.Errorf(exemplarMaxLabelLengthMsgFormat, e.TimestampMs, mimirpb.FromLabelAdaptersToLabels(ls).String(), mimirpb.FromLabelAdaptersToLabels(e.Labels).String())
+		return fmt.Errorf(exemplarMaxLabelLengthMsgFormat, e.TimestampMs, mimirpb.FromLabelAdaptersToString(ls), mimirpb.FromLabelAdaptersToString(e.Labels))
 	}
 
 	if !foundValidLabel {
 		m.labelsBlank.WithLabelValues(userID).Inc()
-		return fmt.Errorf(exemplarEmptyLabelsMsgFormat, e.TimestampMs, mimirpb.FromLabelAdaptersToLabels(ls).String(), mimirpb.FromLabelAdaptersToLabels(e.Labels).String())
+		return fmt.Errorf(exemplarEmptyLabelsMsgFormat, e.TimestampMs, mimirpb.FromLabelAdaptersToString(ls), mimirpb.FromLabelAdaptersToString(e.Labels))
 	}
 
 	return nil

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -86,7 +86,7 @@ func TestValidateLabels(t *testing.T) {
 			fmt.Errorf(
 				invalidLabelMsgFormat,
 				"foo ",
-				formatLabelSet(
+				mimirpb.FromLabelAdaptersToString(
 					[]mimirpb.LabelAdapter{
 						{Name: model.MetricNameLabel, Value: "valid"},
 						{Name: "foo ", Value: "bar"},
@@ -105,7 +105,7 @@ func TestValidateLabels(t *testing.T) {
 			fmt.Errorf(
 				labelNameTooLongMsgFormat,
 				"this_is_a_really_really_long_name_that_should_cause_an_error",
-				formatLabelSet(
+				mimirpb.FromLabelAdaptersToString(
 					[]mimirpb.LabelAdapter{
 						{Name: model.MetricNameLabel, Value: "badLabelName"},
 						{Name: "this_is_a_really_really_long_name_that_should_cause_an_error", Value: "test_value_please_ignore"},
@@ -119,7 +119,7 @@ func TestValidateLabels(t *testing.T) {
 			fmt.Errorf(
 				labelValueTooLongMsgFormat,
 				"test_value_please_ignore_no_really_nothing_to_see_here",
-				formatLabelSet(
+				mimirpb.FromLabelAdaptersToString(
 					[]mimirpb.LabelAdapter{
 						{Name: model.MetricNameLabel, Value: "badLabelValue"},
 						{Name: "much_shorter_name", Value: "test_value_please_ignore_no_really_nothing_to_see_here"},
@@ -355,7 +355,7 @@ func TestValidateLabelDuplication(t *testing.T) {
 	expected := fmt.Errorf(
 		duplicateLabelMsgFormat,
 		model.MetricNameLabel,
-		formatLabelSet(
+		mimirpb.FromLabelAdaptersToString(
 			[]mimirpb.LabelAdapter{
 				{Name: model.MetricNameLabel, Value: "a"},
 				{Name: model.MetricNameLabel, Value: "b"},
@@ -372,7 +372,7 @@ func TestValidateLabelDuplication(t *testing.T) {
 	expected = fmt.Errorf(
 		duplicateLabelMsgFormat,
 		"a",
-		formatLabelSet(
+		mimirpb.FromLabelAdaptersToString(
 			[]mimirpb.LabelAdapter{
 				{Name: model.MetricNameLabel, Value: "a"},
 				{Name: "a", Value: "a"},

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -208,7 +208,7 @@ func newSampleError(errID globalerror.ID, errMsg string, timestamp model.Time, l
 		errID:     errID,
 		errMsg:    errMsg,
 		timestamp: timestamp,
-		series:    mimirpb.FromLabelAdaptersToLabels(labels).String(),
+		series:    mimirpb.FromLabelAdaptersToString(labels),
 	}
 }
 
@@ -268,8 +268,8 @@ func newExemplarError(errID globalerror.ID, errMsg string, timestamp model.Time,
 		errID:          errID,
 		errMsg:         errMsg,
 		timestamp:      timestamp,
-		seriesLabels:   mimirpb.FromLabelAdaptersToLabels(seriesLabels).String(),
-		exemplarLabels: mimirpb.FromLabelAdaptersToLabels(exemplarLabels).String(),
+		seriesLabels:   mimirpb.FromLabelAdaptersToString(seriesLabels),
+		exemplarLabels: mimirpb.FromLabelAdaptersToString(exemplarLabels),
 	}
 }
 
@@ -314,8 +314,8 @@ func newTSDBIngestExemplarErr(ingestErr error, timestamp model.Time, seriesLabel
 	return tsdbIngestExemplarErr{
 		originalErr:    ingestErr,
 		timestamp:      timestamp,
-		seriesLabels:   mimirpb.FromLabelAdaptersToLabels(seriesLabels).String(),
-		exemplarLabels: mimirpb.FromLabelAdaptersToLabels(exemplarLabels).String(),
+		seriesLabels:   mimirpb.FromLabelAdaptersToString(seriesLabels),
+		exemplarLabels: mimirpb.FromLabelAdaptersToString(exemplarLabels),
 	}
 }
 
@@ -388,10 +388,10 @@ type perMetricSeriesLimitReachedError struct {
 }
 
 // newPerMetricSeriesLimitReachedError creates a new perMetricMetadataLimitReachedError indicating that a per-metric series limit has been reached.
-func newPerMetricSeriesLimitReachedError(limit int, labels labels.Labels) perMetricSeriesLimitReachedError {
+func newPerMetricSeriesLimitReachedError(limit int, labels []mimirpb.LabelAdapter) perMetricSeriesLimitReachedError {
 	return perMetricSeriesLimitReachedError{
 		limit:  limit,
-		series: labels.String(),
+		series: mimirpb.FromLabelAdaptersToString(labels),
 	}
 }
 

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -225,7 +225,7 @@ func TestNewTSDBIngestExemplarErr(t *testing.T) {
 	exemplarsLabels := []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}
 	anotherErr := errors.New("another error")
 	err := newTSDBIngestExemplarErr(anotherErr, timestamp, seriesLabels, exemplarsLabels)
-	expectedErrMsg := fmt.Sprintf("err: %v. timestamp=1970-01-19T05:30:43.969Z, series={__name__=\"test\"}, exemplar={traceID=\"123\"}", anotherErr)
+	expectedErrMsg := fmt.Sprintf("err: %v. timestamp=1970-01-19T05:30:43.969Z, series=test, exemplar={traceID=\"123\"}", anotherErr)
 	require.Equal(t, expectedErrMsg, err.Error())
 	checkIngesterError(t, err, mimirpb.BAD_DATA, true)
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1086,7 +1086,7 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 		case globalerror.MaxSeriesPerMetric:
 			stats.perMetricSeriesLimitCount++
 			updateFirstPartial(i.errorSamplers.maxSeriesPerMetricLimitExceeded, func() softError {
-				return newPerMetricSeriesLimitReachedError(i.limiter.limits.MaxGlobalSeriesPerMetric(userID), mimirpb.FromLabelAdaptersToLabelsWithCopy(labels))
+				return newPerMetricSeriesLimitReachedError(i.limiter.limits.MaxGlobalSeriesPerMetric(userID), labels)
 			})
 			return true
 		}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -7454,7 +7454,7 @@ func TestIngesterMetricLimitExceeded(t *testing.T) {
 	testLimits := func() {
 		// Append two series, expect series-exceeded error.
 		_, err = ing.Push(ctx, mimirpb.ToWriteRequest([][]mimirpb.LabelAdapter{labels1, labels3}, []mimirpb.Sample{sample2, sample3}, nil, nil, mimirpb.API))
-		expectedErr := newErrorWithStatus(wrapOrAnnotateWithUser(newPerMetricSeriesLimitReachedError(ing.limiter.limits.MaxGlobalSeriesPerMetric(userID), mimirpb.FromLabelAdaptersToLabels(labels3)), userID), codes.FailedPrecondition)
+		expectedErr := newErrorWithStatus(wrapOrAnnotateWithUser(newPerMetricSeriesLimitReachedError(ing.limiter.limits.MaxGlobalSeriesPerMetric(userID), labels3), userID), codes.FailedPrecondition)
 		checkErrorWithStatus(t, err, expectedErr)
 
 		// Append two metadata for the same metric. Drop the second one, and expect no error since metadata is a best effort approach.
@@ -9627,7 +9627,7 @@ func TestIngester_SampledMetricLimitExceeded(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	expectedError := wrapOrAnnotateWithUser(ing.errorSamplers.maxSeriesPerUserLimitExceeded.WrapError(newPerMetricSeriesLimitReachedError(ing.limiter.limits.MaxGlobalSeriesPerMetric(userID), mimirpb.FromLabelAdaptersToLabels(metricLabelAdapters2))), userID)
+	expectedError := wrapOrAnnotateWithUser(ing.errorSamplers.maxSeriesPerUserLimitExceeded.WrapError(newPerMetricSeriesLimitReachedError(ing.limiter.limits.MaxGlobalSeriesPerMetric(userID), metricLabelAdapters2)), userID)
 	require.Error(t, expectedError)
 
 	// We push 2 times more than errorSampleRate series hitting the max-series-per-metric, i.e., 10 series in total.


### PR DESCRIPTION
#### What this PR does

Move util to format LabelAdaptor string to mimirpb package 

And call it from more places.

Note that some error strings change, because the metric name is pulled
to the front, e.g. `test{foo="bar"}` instead of `{__name__="test",foo="bar"}`.

#### Checklist

- [x] Tests updated.
- NA Documentation added.
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- NA [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
