### PR TITLE
fix up bad merge giving compile errors

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -360,7 +360,6 @@ func TestMapPushErrorToErrorWithStatus(t *testing.T) {
 	originalErr := errors.New(originalMsg)
 	family := "testmetric"
 	labelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: family}, {Name: "foo", Value: "biz"}}
-	labels := mimirpb.FromLabelAdaptersToLabels(labelAdapters)
 	timestamp := model.Time(1)
 
 	testCases := map[string]struct {
@@ -529,7 +528,6 @@ func TestMapPushErrorToErrorWithHTTPOrGRPCStatus(t *testing.T) {
 	originalErr := errors.New(originalMsg)
 	family := "testmetric"
 	labelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: family}, {Name: "foo", Value: "biz"}}
-	labels := mimirpb.FromLabelAdaptersToLabels(labelAdapters)
 	timestamp := model.Time(1)
 
 	testCases := map[string]struct {


### PR DESCRIPTION
Two PRs each removed parts of the code, but when they were both merged we need to also remove declarations that are no longer needed.