### PR TITLE
Jsonnet: add node_affinity_matchers setting support for every Mimir component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,28 @@
 ### Jsonnet
 
 * [CHANGE] Querier: Increase `JAEGER_REPORTER_MAX_QUEUE_SIZE` from 1000 to 5000, to avoid dropping tracing spans. #6764
-* [FEATURE] Distributor: added `distributor_node_affinity_matchers` setting support. #6782
+* [FEATURE] Added support for the following root-level settings to configure the list of matchers to apply to node affinity: #6782 #6829
+  * `alertmanager_node_affinity_matchers`
+  * `compactor_node_affinity_matchers`
+  * `distributor_node_affinity_matchers`
+  * `ingester_node_affinity_matchers`
+  * `ingester_zone_a_node_affinity_matchers`
+  * `ingester_zone_b_node_affinity_matchers`
+  * `ingester_zone_c_node_affinity_matchers`
+  * `overrides_exporter_node_affinity_matchers`
+  * `querier_node_affinity_matchers`
+  * `query_frontend_node_affinity_matchers`
+  * `query_scheduler_node_affinity_matchers`
+  * `ruler_node_affinity_matchers`
+  * `ruler_node_affinity_matchers`
+  * `ruler_querier_node_affinity_matchers`
+  * `ruler_query_frontend_node_affinity_matchers`
+  * `ruler_query_scheduler_node_affinity_matchers`
+  * `store_gateway_node_affinity_matchers`
+  * `store_gateway_node_affinity_matchers`
+  * `store_gateway_zone_a_node_affinity_matchers`
+  * `store_gateway_zone_b_node_affinity_matchers`
+  * `store_gateway_zone_c_node_affinity_matchers`
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@
   * `ingester_zone_a_node_affinity_matchers`
   * `ingester_zone_b_node_affinity_matchers`
   * `ingester_zone_c_node_affinity_matchers`
+  * `mimir_backend_node_affinity_matchers`
+  * `mimir_backend_zone_a_node_affinity_matchers`
+  * `mimir_backend_zone_b_node_affinity_matchers`
+  * `mimir_backend_zone_c_node_affinity_matchers`
+  * `mimir_read_node_affinity_matchers`
+  * `mimir_write_node_affinity_matchers`
+  * `mimir_write_zone_a_node_affinity_matchers`
+  * `mimir_write_zone_b_node_affinity_matchers`
+  * `mimir_write_zone_c_node_affinity_matchers`
   * `overrides_exporter_node_affinity_matchers`
   * `querier_node_affinity_matchers`
   * `query_frontend_node_affinity_matchers`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [FEATURE] Added support for the following root-level settings to configure the list of matchers to apply to node affinity: #6782 #6829
   * `alertmanager_node_affinity_matchers`
   * `compactor_node_affinity_matchers`
+  * `continuous_test_node_affinity_matchers`
   * `distributor_node_affinity_matchers`
   * `ingester_node_affinity_matchers`
   * `ingester_zone_a_node_affinity_matchers`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
   * `querier_node_affinity_matchers`
   * `query_frontend_node_affinity_matchers`
   * `query_scheduler_node_affinity_matchers`
+  * `rollout_operator_node_affinity_matchers`
   * `ruler_node_affinity_matchers`
   * `ruler_node_affinity_matchers`
   * `ruler_querier_node_affinity_matchers`

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -538,6 +538,20 @@ spec:
         gossip_ring_member: "true"
         name: querier
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values:
+                - us-east-1
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-1a
+                - us-east-1b
       containers:
       - args:
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
@@ -634,6 +648,20 @@ spec:
       labels:
         name: query-frontend
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values:
+                - us-east-1
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-1a
+                - us-east-1b
       containers:
       - args:
         - -query-frontend.cache-results=true
@@ -710,6 +738,19 @@ spec:
         name: query-scheduler
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values:
+                - us-east-1
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-1a
+                - us-east-1b
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -774,6 +815,20 @@ spec:
         gossip_ring_member: "true"
         name: compactor
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values:
+                - us-east-1
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-1a
+                - us-east-1b
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
@@ -875,6 +930,19 @@ spec:
         name: ingester
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values:
+                - us-east-1
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-1a
+                - us-east-1b
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1206,6 +1274,19 @@ spec:
         name: store-gateway
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values:
+                - us-east-1
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-1a
+                - us-east-1b
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/operations/mimir-tests/test-node-selector-and-affinity.jsonnet
+++ b/operations/mimir-tests/test-node-selector-and-affinity.jsonnet
@@ -13,8 +13,19 @@ mimir {
     },
   },
 
-  distributor_node_affinity_matchers:: [
+  local nodeAffinityMatchers = [
     { key: 'topology.kubernetes.io/region', operator: 'In', values: ['us-east-1'] },
     { key: 'topology.kubernetes.io/zone', operator: 'In', values: ['us-east-1a', 'us-east-1b'] },
   ],
+
+  alertmanager_node_affinity_matchers:: nodeAffinityMatchers,
+  compactor_node_affinity_matchers:: nodeAffinityMatchers,
+  distributor_node_affinity_matchers:: nodeAffinityMatchers,
+  ingester_node_affinity_matchers:: nodeAffinityMatchers,
+  overrides_exporter_node_affinity_matchers:: nodeAffinityMatchers,
+  querier_node_affinity_matchers:: nodeAffinityMatchers,
+  query_frontend_node_affinity_matchers:: nodeAffinityMatchers,
+  query_scheduler_node_affinity_matchers:: nodeAffinityMatchers,
+  ruler_node_affinity_matchers:: nodeAffinityMatchers,
+  store_gateway_node_affinity_matchers:: nodeAffinityMatchers,
 }

--- a/operations/mimir/alertmanager.libsonnet
+++ b/operations/mimir/alertmanager.libsonnet
@@ -53,6 +53,8 @@
 
   alertmanager_env_map:: {},
 
+  alertmanager_node_affinity_matchers:: [],
+
   alertmanager_container::
     if $._config.alertmanager_enabled then
       container.new('alertmanager', $._images.alertmanager) +
@@ -77,6 +79,7 @@
   alertmanager_statefulset:
     if $._config.is_microservices_deployment_mode && $._config.alertmanager_enabled then
       $.newMimirStatefulSet('alertmanager', $._config.alertmanager.replicas, $.alertmanager_container, $.alertmanager_pvc, podManagementPolicy=null) +
+      $.newMimirNodeAffinityMatchers($.alertmanager_node_affinity_matchers) +
       statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +
       $.mimirVolumeMounts +
       statefulSet.mixin.spec.template.spec.withVolumesMixin(

--- a/operations/mimir/common.libsonnet
+++ b/operations/mimir/common.libsonnet
@@ -130,6 +130,16 @@
       topologySpreadConstraints.withMaxSkew(maxSkew),
     ),
 
+  newMimirNodeAffinityMatchers(nodeAffinityMatchers)::
+    local deployment = $.apps.v1.deployment;
+
+    if std.length(nodeAffinityMatchers) == 0 then {} else (
+      deployment.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.withNodeSelectorTerms(
+        local sorted = std.sort(nodeAffinityMatchers, function(x) x.key);
+        $.core.v1.nodeSelectorTerm.withMatchExpressions(sorted)
+      )
+    ),
+
   mimirVolumeMounts::
     $.util.volumeMounts(
       [$.util.volumeMountItem(name, $._config.configmaps[name]) for name in std.objectFieldsAll($._config.configmaps)]

--- a/operations/mimir/compactor.libsonnet
+++ b/operations/mimir/compactor.libsonnet
@@ -84,6 +84,8 @@
 
   compactor_env_map:: {},
 
+  compactor_node_affinity_matchers:: [],
+
   compactor_container::
     container.new('compactor', $._images.compactor) +
     container.withPorts($.compactor_ports) +
@@ -96,13 +98,14 @@
     $.util.readinessProbe +
     $.jaeger_mixin,
 
-  newCompactorStatefulSet(name, container)::
+  newCompactorStatefulSet(name, container, nodeAffinityMatchers=[])::
     $.newMimirStatefulSet(name, 1, container, compactor_data_pvc) +
+    $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +
     $.mimirVolumeMounts,
 
   compactor_statefulset: if !$._config.is_microservices_deployment_mode then null else
-    $.newCompactorStatefulSet('compactor', $.compactor_container),
+    $.newCompactorStatefulSet('compactor', $.compactor_container, $.compactor_node_affinity_matchers),
 
   compactor_service: if !$._config.is_microservices_deployment_mode then null else
     local service = $.core.v1.service;

--- a/operations/mimir/continuous-test.libsonnet
+++ b/operations/mimir/continuous-test.libsonnet
@@ -20,6 +20,8 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     'tests.write-read-series-test.max-query-age': '48h',
   },
 
+  continuous_test_node_affinity_matchers:: [],
+
   continuous_test_container::
     container.new('continuous-test', $._images.continuous_test) +
     container.withArgsMixin(k.util.mapToFlags($.continuous_test_args)) +
@@ -32,6 +34,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
 
   continuous_test_deployment: if !$._config.continuous_test_enabled then null else
     deployment.new('continuous-test', 1, [$.continuous_test_container]) +
+    $.newMimirNodeAffinityMatchers($.continuous_test_node_affinity_matchers) +
     // It doesn't make sense to run multiple continuous-test instances at the same time.
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -67,14 +67,7 @@
     $.newMimirSpreadTopology(name, $._config.distributor_topology_spread_max_skew) +
     $.mimirVolumeMounts +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
-    (
-      if std.length(nodeAffinityMatchers) == 0 then {} else (
-        deployment.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.withNodeSelectorTerms(
-          local sorted = std.sort(nodeAffinityMatchers, function(x) x.key);
-          $.core.v1.nodeSelectorTerm.withMatchExpressions(sorted)
-        )
-      )
-    ) +
+    $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge('15%') +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0),
 

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -347,6 +347,8 @@
     'kubernetes.namespace': $._config.namespace,
   },
 
+  rollout_operator_node_affinity_matchers:: [],
+
   rollout_operator_container::
     container.new('rollout-operator', $._images.rollout_operator) +
     container.withArgsMixin($.util.mapToFlags($.rollout_operator_args)) +
@@ -366,7 +368,8 @@
     deployment.mixin.spec.template.spec.withServiceAccountName('rollout-operator') +
     // Ensure Kubernetes doesn't run 2 operators at the same time.
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge(0) +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1),
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
+    $.newMimirNodeAffinityMatchers($.rollout_operator_node_affinity_matchers),
 
   rollout_operator_role: if !rollout_operator_enabled then null else
     role.new('rollout-operator-role') +

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -82,6 +82,10 @@
   ingester_zone_b_env_map:: $.ingester_env_map,
   ingester_zone_c_env_map:: $.ingester_env_map,
 
+  ingester_zone_a_node_affinity_matchers:: $.ingester_node_affinity_matchers,
+  ingester_zone_b_node_affinity_matchers:: $.ingester_node_affinity_matchers,
+  ingester_zone_c_node_affinity_matchers:: $.ingester_node_affinity_matchers,
+
   newIngesterZoneContainer(zone, zone_args, envmap={})::
     $.ingester_container +
     container.withArgs($.util.mapToFlags(
@@ -92,10 +96,10 @@
     )) +
     (if std.length(envmap) > 0 then container.withEnvMap(std.prune(envmap)) else {}),
 
-  newIngesterZoneStatefulSet(zone, container)::
+  newIngesterZoneStatefulSet(zone, container, nodeAffinityMatchers=[])::
     local name = 'ingester-zone-%s' % zone;
 
-    self.newIngesterStatefulSet(name, container, with_anti_affinity=false) +
+    self.newIngesterStatefulSet(name, container, with_anti_affinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
     statefulSet.mixin.metadata.withLabels({ 'rollout-group': 'ingester' }) +
     statefulSet.mixin.metadata.withAnnotations({ 'rollout-max-unavailable': std.toString($._config.multi_zone_ingester_max_unavailable) }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: name, 'rollout-group': 'ingester' }) +
@@ -131,7 +135,7 @@
     self.newIngesterZoneContainer('a', $.ingester_zone_a_args, $.ingester_zone_a_env_map),
 
   ingester_zone_a_statefulset: if !multi_zone_ingesters_deployed then null else
-    self.newIngesterZoneStatefulSet('a', $.ingester_zone_a_container),
+    self.newIngesterZoneStatefulSet('a', $.ingester_zone_a_container, $.ingester_zone_a_node_affinity_matchers),
 
   ingester_zone_a_service: if !multi_zone_ingesters_deployed then null else
     $.newIngesterZoneService($.ingester_zone_a_statefulset),
@@ -140,7 +144,7 @@
     self.newIngesterZoneContainer('b', $.ingester_zone_b_args, $.ingester_zone_b_env_map),
 
   ingester_zone_b_statefulset: if !multi_zone_ingesters_deployed then null else
-    self.newIngesterZoneStatefulSet('b', $.ingester_zone_b_container),
+    self.newIngesterZoneStatefulSet('b', $.ingester_zone_b_container, $.ingester_zone_b_node_affinity_matchers),
 
   ingester_zone_b_service: if !multi_zone_ingesters_deployed then null else
     $.newIngesterZoneService($.ingester_zone_b_statefulset),
@@ -149,7 +153,7 @@
     self.newIngesterZoneContainer('c', $.ingester_zone_c_args, $.ingester_zone_c_env_map),
 
   ingester_zone_c_statefulset: if !multi_zone_ingesters_deployed then null else
-    self.newIngesterZoneStatefulSet('c', $.ingester_zone_c_container),
+    self.newIngesterZoneStatefulSet('c', $.ingester_zone_c_container, $.ingester_zone_c_node_affinity_matchers),
 
   ingester_zone_c_service: if !multi_zone_ingesters_deployed then null else
     $.newIngesterZoneService($.ingester_zone_c_statefulset),
@@ -203,6 +207,10 @@
   store_gateway_zone_b_env_map:: $.store_gateway_env_map,
   store_gateway_zone_c_env_map:: $.store_gateway_env_map,
 
+  store_gateway_zone_a_node_affinity_matchers:: $.store_gateway_node_affinity_matchers,
+  store_gateway_zone_b_node_affinity_matchers:: $.store_gateway_node_affinity_matchers,
+  store_gateway_zone_c_node_affinity_matchers:: $.store_gateway_node_affinity_matchers,
+
   newStoreGatewayZoneContainer(zone, zone_args, envmap={})::
     $.store_gateway_container +
     container.withArgs($.util.mapToFlags(
@@ -220,10 +228,10 @@
     )) +
     (if std.length(envmap) > 0 then container.withEnvMap(std.prune(envmap)) else {}),
 
-  newStoreGatewayZoneStatefulSet(zone, container)::
+  newStoreGatewayZoneStatefulSet(zone, container, nodeAffinityMatchers=[])::
     local name = 'store-gateway-zone-%s' % zone;
 
-    self.newStoreGatewayStatefulSet(name, container) +
+    self.newStoreGatewayStatefulSet(name, container, with_anti_affinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
     statefulSet.mixin.metadata.withLabels({ 'rollout-group': 'store-gateway' }) +
     statefulSet.mixin.metadata.withAnnotations({ 'rollout-max-unavailable': std.toString($._config.multi_zone_store_gateway_max_unavailable) }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: name, 'rollout-group': 'store-gateway' }) +
@@ -265,7 +273,7 @@
     self.newStoreGatewayZoneContainer('a', $.store_gateway_zone_a_args, $.store_gateway_zone_a_env_map),
 
   store_gateway_zone_a_statefulset: if !multi_zone_store_gateways_deployed then null else
-    (self + nonRetainablePVCs).newStoreGatewayZoneStatefulSet('a', $.store_gateway_zone_a_container),
+    (self + nonRetainablePVCs).newStoreGatewayZoneStatefulSet('a', $.store_gateway_zone_a_container, $.store_gateway_zone_a_node_affinity_matchers),
 
   store_gateway_zone_a_service: if !multi_zone_store_gateways_deployed then null else
     self.newStoreGatewayZoneService($.store_gateway_zone_a_statefulset),
@@ -274,7 +282,7 @@
     self.newStoreGatewayZoneContainer('b', $.store_gateway_zone_b_args, $.store_gateway_zone_b_env_map),
 
   store_gateway_zone_b_statefulset: if !multi_zone_store_gateways_deployed then null else
-    (self + nonRetainablePVCs).newStoreGatewayZoneStatefulSet('b', $.store_gateway_zone_b_container),
+    (self + nonRetainablePVCs).newStoreGatewayZoneStatefulSet('b', $.store_gateway_zone_b_container, $.store_gateway_zone_b_node_affinity_matchers),
 
   store_gateway_zone_b_service: if !multi_zone_store_gateways_deployed then null else
     self.newStoreGatewayZoneService($.store_gateway_zone_b_statefulset),
@@ -283,7 +291,7 @@
     self.newStoreGatewayZoneContainer('c', $.store_gateway_zone_c_args, $.store_gateway_zone_c_env_map),
 
   store_gateway_zone_c_statefulset: if !multi_zone_store_gateways_deployed then null else
-    (self + nonRetainablePVCs).newStoreGatewayZoneStatefulSet('c', $.store_gateway_zone_c_container),
+    (self + nonRetainablePVCs).newStoreGatewayZoneStatefulSet('c', $.store_gateway_zone_c_container, $.store_gateway_zone_c_node_affinity_matchers),
 
   store_gateway_zone_c_service: if !multi_zone_store_gateways_deployed then null else
     self.newStoreGatewayZoneService($.store_gateway_zone_c_statefulset),

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -38,6 +38,8 @@
 
   overrides_exporter_container_env_map:: {},
 
+  overrides_exporter_node_affinity_matchers:: [],
+
   local container = $.core.v1.container,
   overrides_exporter_container::
     container.new(name, $._images.overrides_exporter) +
@@ -53,6 +55,7 @@
   local deployment = $.apps.v1.deployment,
   overrides_exporter_deployment: if !$._config.overrides_exporter_enabled then null else
     deployment.new(name, 1, [$.overrides_exporter_container], { name: name }) +
+    $.newMimirNodeAffinityMatchers($.overrides_exporter_node_affinity_matchers) +
     $.mimirVolumeMounts +
     deployment.mixin.metadata.withLabels({ name: name }) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge('15%') +

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -31,21 +31,24 @@
 
   query_frontend_env_map:: {},
 
+  query_frontend_node_affinity_matchers:: [],
+
   query_frontend_container::
     self.newQueryFrontendContainer('query-frontend', $.query_frontend_args, $.query_frontend_env_map),
 
   local deployment = $.apps.v1.deployment,
 
-  newQueryFrontendDeployment(name, container)::
+  newQueryFrontendDeployment(name, container, nodeAffinityMatchers=[])::
     deployment.new(name, 2, [container]) +
     $.mimirVolumeMounts +
     $.newMimirSpreadTopology(name, $._config.query_frontend_topology_spread_max_skew) +
+    $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge('15%') +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0),
 
   query_frontend_deployment: if !$._config.is_microservices_deployment_mode then null else
-    self.newQueryFrontendDeployment('query-frontend', $.query_frontend_container),
+    self.newQueryFrontendDeployment('query-frontend', $.query_frontend_container, $.query_frontend_node_affinity_matchers),
 
   query_frontend_service: if !$._config.is_microservices_deployment_mode then null else
     $.util.serviceFor($.query_frontend_deployment, $._config.service_ignored_labels),

--- a/operations/mimir/query-scheduler.libsonnet
+++ b/operations/mimir/query-scheduler.libsonnet
@@ -33,11 +33,14 @@
 
   query_scheduler_env_map:: {},
 
+  query_scheduler_node_affinity_matchers:: [],
+
   query_scheduler_container::
     self.newQuerySchedulerContainer('query-scheduler', $.query_scheduler_args, $.query_scheduler_env_map),
 
-  newQuerySchedulerDeployment(name, container)::
+  newQuerySchedulerDeployment(name, container, nodeAffinityMatchers=[])::
     deployment.new(name, 2, [container]) +
+    $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     $.mimirVolumeMounts +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
     $.util.antiAffinity +
@@ -46,7 +49,7 @@
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0),
 
   query_scheduler_deployment: if !$._config.is_microservices_deployment_mode || !$._config.query_scheduler_enabled then {} else
-    self.newQuerySchedulerDeployment('query-scheduler', $.query_scheduler_container),
+    self.newQuerySchedulerDeployment('query-scheduler', $.query_scheduler_container, $.query_scheduler_node_affinity_matchers),
 
   query_scheduler_service: if !$._config.is_microservices_deployment_mode || !$._config.query_scheduler_enabled then {} else
     $.util.serviceFor($.query_scheduler_deployment, $._config.service_ignored_labels),

--- a/operations/mimir/read-write-deployment/backend.libsonnet
+++ b/operations/mimir/read-write-deployment/backend.libsonnet
@@ -40,6 +40,11 @@
   mimir_backend_zone_b_args:: $.store_gateway_zone_b_args {},
   mimir_backend_zone_c_args:: $.store_gateway_zone_c_args {},
 
+  mimir_backend_node_affinity_matchers:: [],
+  mimir_backend_zone_a_node_affinity_matchers:: $.mimir_backend_node_affinity_matchers,
+  mimir_backend_zone_b_node_affinity_matchers:: $.mimir_backend_node_affinity_matchers,
+  mimir_backend_zone_c_node_affinity_matchers:: $.mimir_backend_node_affinity_matchers,
+
   mimir_backend_ports::
     std.uniq(
       std.sort(
@@ -77,10 +82,11 @@
       }
     )),
 
-  newMimirBackendZoneStatefulset(zone, container)::
+  newMimirBackendZoneStatefulset(zone, container, nodeAffinityMatchers=[])::
     local name = 'mimir-backend-zone-%s' % zone;
 
     $.newMimirStatefulSet(name, 3, container, mimir_backend_data_pvc) +
+    $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     statefulSet.mixin.metadata.withLabels({ 'rollout-group': 'mimir-backend' }) +
     statefulSet.mixin.metadata.withAnnotations({ 'rollout-max-unavailable': std.toString($._config.mimir_backend_max_unavailable) }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: name, 'rollout-group': 'mimir-backend' }) +
@@ -123,13 +129,13 @@
     $.newMimirBackendZoneContainer('c', $.mimir_backend_zone_c_args),
 
   mimir_backend_zone_a_statefulset: if !$._config.is_read_write_deployment_mode then null else
-    $.newMimirBackendZoneStatefulset('a', $.mimir_backend_zone_a_container),
+    $.newMimirBackendZoneStatefulset('a', $.mimir_backend_zone_a_container, $.mimir_backend_zone_a_node_affinity_matchers),
 
   mimir_backend_zone_b_statefulset: if !$._config.is_read_write_deployment_mode then null else
-    $.newMimirBackendZoneStatefulset('b', $.mimir_backend_zone_b_container),
+    $.newMimirBackendZoneStatefulset('b', $.mimir_backend_zone_b_container, $.mimir_backend_zone_b_node_affinity_matchers),
 
   mimir_backend_zone_c_statefulset: if !$._config.is_read_write_deployment_mode then null else
-    $.newMimirBackendZoneStatefulset('c', $.mimir_backend_zone_c_container),
+    $.newMimirBackendZoneStatefulset('c', $.mimir_backend_zone_c_container, $.mimir_backend_zone_c_node_affinity_matchers),
 
   mimir_backend_zone_a_service: if !$._config.is_read_write_deployment_mode then null else
     $.newMimirBackendZoneService($.mimir_backend_zone_a_statefulset),

--- a/operations/mimir/read-write-deployment/read.libsonnet
+++ b/operations/mimir/read-write-deployment/read.libsonnet
@@ -37,6 +37,8 @@
     GOMAXPROCS: null,
   },
 
+  mimir_read_node_affinity_matchers:: [],
+
   mimir_read_container:: if !$._config.is_read_write_deployment_mode then null else
     container.new('mimir-read', $._images.mimir_read) +
     container.withPorts($.mimir_read_ports) +
@@ -49,6 +51,7 @@
 
   mimir_read_deployment: if !$._config.is_read_write_deployment_mode then null else
     deployment.new('mimir-read', $._config.mimir_read_replicas, [$.mimir_read_container]) +
+    $.newMimirNodeAffinityMatchers($.mimir_read_node_affinity_matchers) +
     $.mimirVolumeMounts +
     $.newMimirSpreadTopology('mimir-read', $._config.mimir_read_topology_spread_max_skew) +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +

--- a/operations/mimir/read-write-deployment/write.libsonnet
+++ b/operations/mimir/read-write-deployment/write.libsonnet
@@ -30,6 +30,11 @@
   mimir_write_zone_b_args:: $.ingester_zone_b_args {},
   mimir_write_zone_c_args:: $.ingester_zone_c_args {},
 
+  mimir_write_node_affinity_matchers:: [],
+  mimir_write_zone_a_node_affinity_matchers:: $.mimir_write_node_affinity_matchers,
+  mimir_write_zone_b_node_affinity_matchers:: $.mimir_write_node_affinity_matchers,
+  mimir_write_zone_c_node_affinity_matchers:: $.mimir_write_node_affinity_matchers,
+
   mimir_write_ports::
     std.uniq(
       std.sort(
@@ -66,7 +71,7 @@
       },
     )),
 
-  newMimirWriteZoneStatefulset(zone, container)::
+  newMimirWriteZoneStatefulset(zone, container, nodeAffinityMatchers=[])::
     local name = 'mimir-write-zone-%s' % zone;
     local replicas = std.ceil($._config.mimir_write_replicas / 3);
 
@@ -113,13 +118,13 @@
     $.newMimirWriteZoneContainer('c', $.mimir_write_zone_c_args),
 
   mimir_write_zone_a_statefulset: if !$._config.is_read_write_deployment_mode then null else
-    $.newMimirWriteZoneStatefulset('a', $.mimir_write_zone_a_container),
+    $.newMimirWriteZoneStatefulset('a', $.mimir_write_zone_a_container, $.mimir_write_zone_a_node_affinity_matchers),
 
   mimir_write_zone_b_statefulset: if !$._config.is_read_write_deployment_mode then null else
-    $.newMimirWriteZoneStatefulset('b', $.mimir_write_zone_b_container),
+    $.newMimirWriteZoneStatefulset('b', $.mimir_write_zone_b_container, $.mimir_write_zone_b_node_affinity_matchers),
 
   mimir_write_zone_c_statefulset: if !$._config.is_read_write_deployment_mode then null else
-    $.newMimirWriteZoneStatefulset('c', $.mimir_write_zone_c_container),
+    $.newMimirWriteZoneStatefulset('c', $.mimir_write_zone_c_container, $.mimir_write_zone_c_node_affinity_matchers),
 
   mimir_write_zone_a_service: if !$._config.is_read_write_deployment_mode then null else
     $.newMimirWriteZoneService($.mimir_write_zone_a_statefulset),

--- a/operations/mimir/ruler-remote-evaluation.libsonnet
+++ b/operations/mimir/ruler-remote-evaluation.libsonnet
@@ -41,11 +41,13 @@
     GOMAXPROCS: null,
   },
 
+  ruler_querier_node_affinity_matchers:: $.querier_node_affinity_matchers,
+
   ruler_querier_container::
     $.newQuerierContainer('ruler-querier', $.ruler_querier_args, $.ruler_querier_env_map),
 
   ruler_querier_deployment: if !$._config.ruler_remote_evaluation_enabled then {} else
-    $.newQuerierDeployment('ruler-querier', $.ruler_querier_container),
+    $.newQuerierDeployment('ruler-querier', $.ruler_querier_container, $.ruler_querier_node_affinity_matchers),
 
   ruler_querier_service: if !$._config.ruler_remote_evaluation_enabled then {} else
     $.util.serviceFor($.ruler_querier_deployment, $._config.service_ignored_labels),
@@ -72,11 +74,13 @@
 
   ruler_query_frontend_env_map:: $.query_frontend_env_map,
 
+  ruler_query_frontend_node_affinity_matchers:: $.query_frontend_node_affinity_matchers,
+
   ruler_query_frontend_container::
     $.newQueryFrontendContainer('ruler-query-frontend', $.ruler_query_frontend_args, $.ruler_query_frontend_env_map),
 
   ruler_query_frontend_deployment: if !$._config.ruler_remote_evaluation_enabled then {} else
-    $.newQueryFrontendDeployment('ruler-query-frontend', $.ruler_query_frontend_container),
+    $.newQueryFrontendDeployment('ruler-query-frontend', $.ruler_query_frontend_container, $.ruler_query_frontend_node_affinity_matchers),
 
   ruler_query_frontend_service: if !$._config.ruler_remote_evaluation_enabled then {} else
     $.util.serviceFor($.ruler_query_frontend_deployment, $._config.service_ignored_labels) +
@@ -102,11 +106,13 @@
 
   ruler_query_scheduler_env_map:: $.query_scheduler_env_map,
 
+  ruler_query_scheduler_node_affinity_matchers:: $.query_scheduler_node_affinity_matchers,
+
   ruler_query_scheduler_container::
     $.newQuerySchedulerContainer(rulerQuerySchedulerName, $.ruler_query_scheduler_args, $.ruler_query_scheduler_env_map),
 
   ruler_query_scheduler_deployment: if !$._config.ruler_remote_evaluation_enabled then {} else
-    $.newQuerySchedulerDeployment(rulerQuerySchedulerName, $.ruler_query_scheduler_container),
+    $.newQuerySchedulerDeployment(rulerQuerySchedulerName, $.ruler_query_scheduler_container, $.ruler_query_scheduler_node_affinity_matchers),
 
   ruler_query_scheduler_service: if !$._config.ruler_remote_evaluation_enabled then {} else
     $.util.serviceFor($.ruler_query_scheduler_deployment, $._config.service_ignored_labels),

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -34,6 +34,8 @@
 
   ruler_env_map:: {},
 
+  ruler_node_affinity_matchers:: [],
+
   ruler_container::
     if $._config.ruler_enabled then
       container.new('ruler', $._images.ruler) +
@@ -52,6 +54,7 @@
     local name = 'ruler';
 
     deployment.new(name, 2, [$.ruler_container]) +
+    $.newMimirNodeAffinityMatchers($.ruler_node_affinity_matchers) +
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge('50%') +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0) +

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -63,6 +63,8 @@
     GOMEMLIMIT: std.toString(std.floor($.util.siToBytes($.store_gateway_container.resources.requests.memory))),
   },
 
+  store_gateway_node_affinity_matchers:: [],
+
   store_gateway_container::
     container.new('store-gateway', $._images.store_gateway) +
     container.withPorts($.store_gateway_ports) +
@@ -73,16 +75,20 @@
     $.util.readinessProbe +
     $.jaeger_mixin,
 
-  newStoreGatewayStatefulSet(name, container, with_anti_affinity=false)::
+  newStoreGatewayStatefulSet(name, container, with_anti_affinity=false, nodeAffinityMatchers=[])::
     $.newMimirStatefulSet(name, 3, container, store_gateway_data_pvc) +
+    $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +
     $.mimirVolumeMounts +
     (if with_anti_affinity then $.util.antiAffinity else {}),
 
   store_gateway_statefulset: if !$._config.is_microservices_deployment_mode then null else
-    self.newStoreGatewayStatefulSet('store-gateway',
-                                    $.store_gateway_container + (if std.length($.store_gateway_env_map) > 0 then container.withEnvMap(std.prune($.store_gateway_env_map)) else {}),
-                                    !$._config.store_gateway_allow_multiple_replicas_on_same_node),
+    self.newStoreGatewayStatefulSet(
+      'store-gateway',
+      $.store_gateway_container + (if std.length($.store_gateway_env_map) > 0 then container.withEnvMap(std.prune($.store_gateway_env_map)) else {}),
+      !$._config.store_gateway_allow_multiple_replicas_on_same_node,
+      $.store_gateway_node_affinity_matchers,
+    ),
 
   store_gateway_service: if !$._config.is_microservices_deployment_mode then null else
     $.util.serviceFor($.store_gateway_statefulset, $._config.service_ignored_labels),


### PR DESCRIPTION
#### What this PR does

This PR is a follow up of #6782. In #6782 I've introduced `distributor_node_affinity_matchers` and successfully use it at Grafana Labs to simplify the jsonnet setup. In this PR I'm doing the same for every other Mimir component.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
