### PR TITLE
Jsonnet: rename with_anti_affinity to withAntiAffinity

### DIFF
--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -73,7 +73,7 @@
     pvc.mixin.spec.withStorageClassName($._config.ingester_data_disk_class) +
     pvc.mixin.metadata.withName('ingester-data'),
 
-  newIngesterStatefulSet(name, container, with_anti_affinity=true, nodeAffinityMatchers=[])::
+  newIngesterStatefulSet(name, container, withAntiAffinity=true, nodeAffinityMatchers=[])::
     local ingesterContainer = container + $.core.v1.container.withVolumeMountsMixin([
       volumeMount.new('ingester-data', '/data'),
     ]);
@@ -85,7 +85,7 @@
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(1200) +
     $.mimirVolumeMounts +
     $.util.podPriority('high') +
-    (if with_anti_affinity then $.util.antiAffinity else {}),
+    (if withAntiAffinity then $.util.antiAffinity else {}),
 
   ingester_statefulset: if !$._config.is_microservices_deployment_mode then null else
     self.newIngesterStatefulSet(

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -99,7 +99,7 @@
   newIngesterZoneStatefulSet(zone, container, nodeAffinityMatchers=[])::
     local name = 'ingester-zone-%s' % zone;
 
-    self.newIngesterStatefulSet(name, container, with_anti_affinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
+    self.newIngesterStatefulSet(name, container, withAntiAffinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
     statefulSet.mixin.metadata.withLabels({ 'rollout-group': 'ingester' }) +
     statefulSet.mixin.metadata.withAnnotations({ 'rollout-max-unavailable': std.toString($._config.multi_zone_ingester_max_unavailable) }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: name, 'rollout-group': 'ingester' }) +
@@ -231,7 +231,7 @@
   newStoreGatewayZoneStatefulSet(zone, container, nodeAffinityMatchers=[])::
     local name = 'store-gateway-zone-%s' % zone;
 
-    self.newStoreGatewayStatefulSet(name, container, with_anti_affinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
+    self.newStoreGatewayStatefulSet(name, container, withAntiAffinity=false, nodeAffinityMatchers=nodeAffinityMatchers) +
     statefulSet.mixin.metadata.withLabels({ 'rollout-group': 'store-gateway' }) +
     statefulSet.mixin.metadata.withAnnotations({ 'rollout-max-unavailable': std.toString($._config.multi_zone_store_gateway_max_unavailable) }) +
     statefulSet.mixin.spec.template.metadata.withLabels({ name: name, 'rollout-group': 'store-gateway' }) +

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -75,12 +75,12 @@
     $.util.readinessProbe +
     $.jaeger_mixin,
 
-  newStoreGatewayStatefulSet(name, container, with_anti_affinity=false, nodeAffinityMatchers=[])::
+  newStoreGatewayStatefulSet(name, container, withAntiAffinity=false, nodeAffinityMatchers=[])::
     $.newMimirStatefulSet(name, 3, container, store_gateway_data_pvc) +
     $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +
     $.mimirVolumeMounts +
-    (if with_anti_affinity then $.util.antiAffinity else {}),
+    (if withAntiAffinity then $.util.antiAffinity else {}),
 
   store_gateway_statefulset: if !$._config.is_microservices_deployment_mode then null else
     self.newStoreGatewayStatefulSet(


### PR DESCRIPTION
#### What this PR does

This PR addresses a [comment received here](https://github.com/grafana/mimir/pull/6829#discussion_r1415911977), suggesting to rename `with_anti_affinity` to `withAntiAffinity`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
