### PR TITLE
extend histogram cortex_distributor_sample_delay_seconds_bucket to track negative delays

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -321,6 +321,9 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 			Name: "cortex_distributor_sample_delay_seconds",
 			Help: "Number of seconds by which a sample came in late wrt wallclock.",
 			Buckets: []float64{
+				-60 * 1,      // 1 min early
+				-15,          // 15s early
+				-5,           // 5s early
 				30,           // 30s
 				60 * 1,       // 1 min
 				60 * 2,       // 2 min
@@ -626,9 +629,7 @@ func (d *Distributor) validateSeries(nowt time.Time, ts *mimirpb.PreallocTimeser
 	for _, s := range ts.Samples {
 
 		delta := now - model.Time(s.TimestampMs)
-		if delta > 0 {
-			d.sampleDelayHistogram.Observe(float64(delta) / 1000)
-		}
+		d.sampleDelayHistogram.Observe(float64(delta) / 1000)
 
 		if err := validateSample(d.sampleValidationMetrics, now, d.limits, userID, group, ts.Labels, s); err != nil {
 			return err
@@ -637,9 +638,7 @@ func (d *Distributor) validateSeries(nowt time.Time, ts *mimirpb.PreallocTimeser
 
 	for i, h := range ts.Histograms {
 		delta := now - model.Time(h.Timestamp)
-		if delta > 0 {
-			d.sampleDelayHistogram.Observe(float64(delta) / 1000)
-		}
+		d.sampleDelayHistogram.Observe(float64(delta) / 1000)
 
 		if err := validateSampleHistogram(d.sampleValidationMetrics, now, d.limits, userID, group, ts.Labels, &ts.Histograms[i]); err != nil {
 			return err

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -211,6 +211,9 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_sample_delay_seconds Number of seconds by which a sample came in late wrt wallclock.
 				# TYPE cortex_distributor_sample_delay_seconds histogram
+				cortex_distributor_sample_delay_seconds_bucket{le="-60"} 0
+				cortex_distributor_sample_delay_seconds_bucket{le="-15"} 0
+				cortex_distributor_sample_delay_seconds_bucket{le="-5"} 0
 				cortex_distributor_sample_delay_seconds_bucket{le="30"} 0
 				cortex_distributor_sample_delay_seconds_bucket{le="60"} 0
 				cortex_distributor_sample_delay_seconds_bucket{le="120"} 0
@@ -237,6 +240,9 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_sample_delay_seconds Number of seconds by which a sample came in late wrt wallclock.
 				# TYPE cortex_distributor_sample_delay_seconds histogram
+				cortex_distributor_sample_delay_seconds_bucket{le="-60"} 0
+				cortex_distributor_sample_delay_seconds_bucket{le="-15"} 0
+				cortex_distributor_sample_delay_seconds_bucket{le="-5"} 0
 				cortex_distributor_sample_delay_seconds_bucket{le="30"} 2
 				cortex_distributor_sample_delay_seconds_bucket{le="60"} 2
 				cortex_distributor_sample_delay_seconds_bucket{le="120"} 2
@@ -263,6 +269,9 @@ func TestDistributor_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_distributor_sample_delay_seconds Number of seconds by which a sample came in late wrt wallclock.
 				# TYPE cortex_distributor_sample_delay_seconds histogram
+				cortex_distributor_sample_delay_seconds_bucket{le="-60"} 0
+				cortex_distributor_sample_delay_seconds_bucket{le="-15"} 0
+				cortex_distributor_sample_delay_seconds_bucket{le="-5"} 0
 				cortex_distributor_sample_delay_seconds_bucket{le="30"} 0
 				cortex_distributor_sample_delay_seconds_bucket{le="60"} 0
 				cortex_distributor_sample_delay_seconds_bucket{le="120"} 0


### PR DESCRIPTION
We would like to track if there are users who send us samples with timestamps which are in the future, relative to wall clock time. 
This change doesn't need to be permanent, we can revert it in a few weeks from now. 