### PR TITLE
ruler: fix TestRulerMetricsForInvalidQueriesAndNoFetchedSeries

### DIFF
--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -732,7 +732,6 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 		addNewRuleAndWait(groupName4, expression4, false)
 
 		// Ensure that samples were not returned.
-
 		require.Less(t, 0, getLastEvalSamples())
 
 		// Ensure that the metric for no fetched series was not incremented.

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -762,7 +762,7 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 		require.Zero(t, getLastEvalSamples())
 
 		// Ensure that the metric for no fetched series was incremented.
-		require.Greater(t, getZeroSeriesQueriesTotal(), zeroSeriesQueries)
+		require.Less(t, zeroSeriesQueries, getZeroSeriesQueriesTotal())
 	})
 
 	// Now let's stop ingester, and recheck metrics. This should increase cortex_ruler_queries_failed_total failures.

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -708,6 +708,7 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 
 		// Ensure that samples were returned.
 		require.Less(t, 0, getLastEvalSamples())
+
 		// Ensure that the metric for no fetched series was not incremented.
 		require.Equal(t, zeroSeriesQueries, getZeroSeriesQueriesTotal())
 

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -749,7 +749,7 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 		require.Zero(t, getLastEvalSamples())
 
 		// Ensure that the metric for no fetched series was incremented.
-		require.Greater(t, getZeroSeriesQueriesTotal(), zeroSeriesQueries)
+		require.Less(t, zeroSeriesQueries, getZeroSeriesQueriesTotal())
 
 		deleteRuleAndWait(groupName5)
 		zeroSeriesQueries = getZeroSeriesQueriesTotal()

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -719,7 +719,7 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 		addNewRuleAndWait(groupName3, expression3, false)
 
 		// Ensure that samples were returned.
-		require.Zero(t, getLastEvalSamples())
+		require.Less(t, 0, getLastEvalSamples())
 
 		// Ensure that the metric for no fetched series was not incremented.
 		require.Equal(t, zeroSeriesQueries, getZeroSeriesQueriesTotal())

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -699,6 +699,7 @@ func TestRulerMetricsForInvalidQueriesAndNoFetchedSeries(t *testing.T) {
 
 		// Ensure that the metric for no fetched series was not incremented.
 		require.Zero(t, getZeroSeriesQueriesTotal())
+
 		deleteRuleAndWait(groupName)
 		zeroSeriesQueries := getZeroSeriesQueriesTotal()
 


### PR DESCRIPTION
instead of assuming that rules only evaluate once, use the increase in the counter to tell whether the query is with 0 series or not

In addition to that add another helper function for comparing cortex_prometheus_last_evaluation_samples
