### PR TITLE
Store-gateway: Add no-compact column on store-gateway/tenants admin UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Ingester: Increase default value of `-blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes` and `-blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes` to 100 MiB (previous default value was 10 MiB). #6764
+* [ENHANCEMENT] Store-gateway: add no-compact details column on store-gateway tenants admin UI. #6848
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766
 * [ENHANCEMENT] Distributor: improve efficiency of some errors #6785
 * [ENHANCEMENT] Ruler: exclude vector queries from being tracked in `cortex_ruler_queries_zero_fetched_series_total`. #6544

--- a/pkg/storage/tsdb/block/markers.go
+++ b/pkg/storage/tsdb/block/markers.go
@@ -44,6 +44,7 @@ var (
 
 type Marker interface {
 	markerFilename() string
+	GetID() ulid.ULID
 }
 
 // DeletionMark stores block id and when block was marked for deletion.
@@ -59,7 +60,8 @@ type DeletionMark struct {
 	DeletionTime int64 `json:"deletion_time"`
 }
 
-func (m *DeletionMark) markerFilename() string { return DeletionMarkFilename }
+func (d DeletionMark) GetID() ulid.ULID       { return d.ID }
+func (d DeletionMark) markerFilename() string { return DeletionMarkFilename }
 
 // NoCompactReason is a reason for a block to be excluded from compaction.
 type NoCompactReason string
@@ -90,7 +92,8 @@ type NoCompactMark struct {
 	Reason        NoCompactReason `json:"reason"`
 }
 
-func (n *NoCompactMark) markerFilename() string { return NoCompactMarkFilename }
+func (n NoCompactMark) GetID() ulid.ULID       { return n.ID }
+func (n NoCompactMark) markerFilename() string { return NoCompactMarkFilename }
 
 // ReadMarker reads the given mark file from <dir>/<marker filename>.json in bucket.
 // ReadMarker has a one-minute timeout for completing the read against the bucket.

--- a/pkg/storage/tsdb/block/markers.go
+++ b/pkg/storage/tsdb/block/markers.go
@@ -44,7 +44,7 @@ var (
 
 type Marker interface {
 	markerFilename() string
-	GetID() ulid.ULID
+	BlockULID() ulid.ULID
 }
 
 // DeletionMark stores block id and when block was marked for deletion.
@@ -60,7 +60,7 @@ type DeletionMark struct {
 	DeletionTime int64 `json:"deletion_time"`
 }
 
-func (d DeletionMark) GetID() ulid.ULID       { return d.ID }
+func (d DeletionMark) BlockULID() ulid.ULID   { return d.ID }
 func (d DeletionMark) markerFilename() string { return DeletionMarkFilename }
 
 // NoCompactReason is a reason for a block to be excluded from compaction.
@@ -92,7 +92,7 @@ type NoCompactMark struct {
 	Reason        NoCompactReason `json:"reason"`
 }
 
-func (n NoCompactMark) GetID() ulid.ULID       { return n.ID }
+func (n NoCompactMark) BlockULID() ulid.ULID   { return n.ID }
 func (n NoCompactMark) markerFilename() string { return NoCompactMarkFilename }
 
 // ReadMarker reads the given mark file from <dir>/<marker filename>.json in bucket.

--- a/pkg/storegateway/blocks.gohtml
+++ b/pkg/storegateway/blocks.gohtml
@@ -38,6 +38,7 @@
         <th>Samples</th>
         <th>Chunks</th>
         <th>Labels</th>
+        <th>No Compact</th>
         {{ if .ShowSources }}
         <th>Sources</th>{{ end }}
         {{ if .ShowParents }}
@@ -63,6 +64,12 @@
             <td>{{ .Stats.NumSamples }}</td>
             <td>{{ .Stats.NumChunks }}</td>
             <td>{{ .Labels }}</td>
+            <td>
+                {{ range $i, $source := .NoCompactDetails }}
+                    {{ if $i }}<br>{{ end }}
+                    {{ . }}
+                {{ end }}
+            </td>
             {{ if $page.ShowSources }}
                 <td>
                     {{ range $i, $source := .Sources }}

--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -36,19 +36,20 @@ type blocksPageContents struct {
 }
 
 type formattedBlockData struct {
-	ULID            string
-	ULIDTime        string
-	SplitID         *uint32
-	MinTime         string
-	MaxTime         string
-	Duration        string
-	DeletedTime     string
-	CompactionLevel int
-	BlockSize       string
-	Labels          string
-	Sources         []string
-	Parents         []string
-	Stats           prom_tsdb.BlockStats
+	ULID             string
+	ULIDTime         string
+	SplitID          *uint32
+	MinTime          string
+	MaxTime          string
+	Duration         string
+	DeletedTime      string
+	CompactionLevel  int
+	BlockSize        string
+	Labels           string
+	NoCompactDetails []string
+	Sources          []string
+	Parents          []string
+	Stats            prom_tsdb.BlockStats
 }
 
 type richMeta struct {
@@ -81,7 +82,7 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	metasMap, deletedTimes, err := listblocks.LoadMetaFilesAndDeletionMarkers(req.Context(), s.stores.bucket, tenantID, showDeleted, time.Time{})
+	metasMap, deleteMarkerDetails, noCompactMarkerDetails, err := listblocks.LoadMetaFilesAndMarkers(req.Context(), s.stores.bucket, tenantID, showDeleted, time.Time{})
 	if err != nil {
 		util.WriteTextResponse(w, fmt.Sprintf("Failed to read block metadata: %s", err))
 		return
@@ -92,7 +93,7 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 	richMetas := make([]richMeta, 0, len(metas))
 
 	for _, m := range metas {
-		if !showDeleted && !deletedTimes[m.ULID].IsZero() {
+		if !showDeleted && !deleteMarkerDetails[m.ULID].Time.IsZero() {
 			continue
 		}
 		var parents []string
@@ -109,24 +110,32 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 			blockSplitID = &bsc
 		}
 		lbls := labels.FromMap(m.Thanos.Labels)
+		noCompactDetails := []string{}
+		if val, ok := noCompactMarkerDetails[m.ULID]; ok {
+			noCompactDetails = []string{
+				fmt.Sprintf("Time: %s", formatTimeIfNotZero(val.Time.UTC(), time.RFC3339)),
+				fmt.Sprintf("Reason: %s", val.Reason),
+			}
+		}
 		formattedBlocks = append(formattedBlocks, formattedBlockData{
-			ULID:            m.ULID.String(),
-			ULIDTime:        util.TimeFromMillis(int64(m.ULID.Time())).UTC().Format(time.RFC3339),
-			SplitID:         blockSplitID,
-			MinTime:         util.TimeFromMillis(m.MinTime).UTC().Format(time.RFC3339),
-			MaxTime:         util.TimeFromMillis(m.MaxTime).UTC().Format(time.RFC3339),
-			Duration:        util.TimeFromMillis(m.MaxTime).Sub(util.TimeFromMillis(m.MinTime)).String(),
-			DeletedTime:     formatTimeIfNotZero(deletedTimes[m.ULID].UTC(), time.RFC3339),
-			CompactionLevel: m.Compaction.Level,
-			BlockSize:       listblocks.GetFormattedBlockSize(m),
-			Labels:          lbls.String(),
-			Sources:         sources,
-			Parents:         parents,
-			Stats:           m.Stats,
+			ULID:             m.ULID.String(),
+			ULIDTime:         util.TimeFromMillis(int64(m.ULID.Time())).UTC().Format(time.RFC3339),
+			SplitID:          blockSplitID,
+			MinTime:          util.TimeFromMillis(m.MinTime).UTC().Format(time.RFC3339),
+			MaxTime:          util.TimeFromMillis(m.MaxTime).UTC().Format(time.RFC3339),
+			Duration:         util.TimeFromMillis(m.MaxTime).Sub(util.TimeFromMillis(m.MinTime)).String(),
+			DeletedTime:      formatTimeIfNotZero(deleteMarkerDetails[m.ULID].Time.UTC(), time.RFC3339),
+			NoCompactDetails: noCompactDetails,
+			CompactionLevel:  m.Compaction.Level,
+			BlockSize:        listblocks.GetFormattedBlockSize(m),
+			Labels:           lbls.String(),
+			Sources:          sources,
+			Parents:          parents,
+			Stats:            m.Stats,
 		})
 		var deletedAt *int64
-		if dt, ok := deletedTimes[m.ULID]; ok {
-			deletedAtTime := dt.UnixMilli()
+		if dt, ok := deleteMarkerDetails[m.ULID]; ok {
+			deletedAtTime := dt.Time.UnixMilli()
 			deletedAt = &deletedAtTime
 		}
 		richMetas = append(richMetas, richMeta{

--- a/pkg/util/listblocks/listblocks.go
+++ b/pkg/util/listblocks/listblocks.go
@@ -107,7 +107,7 @@ func fetchMarkerDetails[MARKER_TYPE block.Marker](ctx context.Context, bkt objst
 		}
 
 		mu.Lock()
-		details[m.GetID()] = m
+		details[m.BlockULID()] = m
 		mu.Unlock()
 		return nil
 	})

--- a/tools/listblocks/main.go
+++ b/tools/listblocks/main.go
@@ -172,11 +172,10 @@ func printMetas(metas map[ulid.ULID]*block.Meta, deleteMarkerDetails map[ulid.UL
 		}
 
 		if cfg.showDeleted {
-			val, ok := deleteMarkerDetails[b.ULID]
-			if deleteMarkerDetails[b.ULID].DeletionTime == 0 || !ok {
+			if deleteMarkerDetails[b.ULID].DeletionTime == 0 {
 				fmt.Fprintf(tabber, "\t") // no deletion time.
 			} else {
-				fmt.Fprintf(tabber, "%v\t", time.Unix(val.DeletionTime, 0).UTC().Format(time.RFC3339))
+				fmt.Fprintf(tabber, "%v\t", time.Unix(deleteMarkerDetails[b.ULID].DeletionTime, 0).UTC().Format(time.RFC3339))
 			}
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR introduces a new filter 'no-compact' in the admin UI for block filtering. Currently, we have various filters available for markers, but this addition extends functionality by enabling the display of blocks marked with 'no-compact'. Subsequent PRs will build upon this enhancement to provide users with the capability to mark blocks directly through the UI instead of CLI.

Test in local, how it looks like on UI
<img width="1423" alt="Screenshot 2023-12-07 at 19 16 05" src="https://github.com/grafana/mimir/assets/74549700/9e70e422-c266-48e4-8993-19e0c6ccbfd3">


#### Which issue(s) this PR fixes or relates to


Fixes #<issue number>

#### Checklist

- na Tests updated.
- na Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- na [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
