### PR TITLE
query-frontend: inject query cache keys for LabelValues/Cardinality requests

### DIFF
--- a/pkg/frontend/querymiddleware/cardinality_query_cache.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache.go
@@ -23,12 +23,12 @@ const (
 	cardinalityActiveSeriesQueryCachePrefix = "ca:"
 )
 
-func newCardinalityQueryCacheRoundTripper(cache cache.Cache, splitter CacheKeyGenerator, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
+func newCardinalityQueryCacheRoundTripper(cache cache.Cache, generator CacheKeyGenerator, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
 	ttl := &cardinalityQueryTTL{
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, splitter.LabelValuesCardinality, ttl, next, logger, newResultsCacheMetrics("cardinality", reg))
+	return newGenericQueryCacheRoundTripper(cache, generator.LabelValuesCardinality, ttl, next, logger, newResultsCacheMetrics("cardinality", reg))
 }
 
 type cardinalityQueryTTL struct {

--- a/pkg/frontend/querymiddleware/cardinality_query_cache.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache.go
@@ -23,12 +23,12 @@ const (
 	cardinalityActiveSeriesQueryCachePrefix = "ca:"
 )
 
-func newCardinalityQueryCacheRoundTripper(cache cache.Cache, splitter CacheSplitter, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
+func newCardinalityQueryCacheRoundTripper(cache cache.Cache, splitter CacheKeyGenerator, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
 	ttl := &cardinalityQueryTTL{
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, splitter.GenerateLabelValuesCardinalityCacheKey, ttl, next, logger, newResultsCacheMetrics("cardinality", reg))
+	return newGenericQueryCacheRoundTripper(cache, splitter.LabelValuesCardinality, ttl, next, logger, newResultsCacheMetrics("cardinality", reg))
 }
 
 type cardinalityQueryTTL struct {
@@ -39,7 +39,7 @@ func (c *cardinalityQueryTTL) ttl(userID string) time.Duration {
 	return c.limits.ResultsCacheTTLForCardinalityQuery(userID)
 }
 
-func (DefaultCacheSplitter) GenerateLabelValuesCardinalityCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error) {
+func (DefaultCacheSplitter) LabelValuesCardinality(ctx context.Context, path string, values url.Values) (*GenericQueryCacheKey, error) {
 	switch {
 	case strings.HasSuffix(path, cardinalityLabelNamesPathSuffix):
 		parsed, err := cardinality.DecodeLabelNamesRequestFromValues(values)

--- a/pkg/frontend/querymiddleware/cardinality_query_cache.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache.go
@@ -28,7 +28,7 @@ func newCardinalityQueryCacheRoundTripper(cache cache.Cache, splitter CacheSplit
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, splitter.LabelValuesCardinalityCacheKey, ttl, next, logger, newResultsCacheMetrics("cardinality", reg))
+	return newGenericQueryCacheRoundTripper(cache, splitter.GenerateLabelValuesCardinalityCacheKey, ttl, next, logger, newResultsCacheMetrics("cardinality", reg))
 }
 
 type cardinalityQueryTTL struct {
@@ -39,7 +39,7 @@ func (c *cardinalityQueryTTL) ttl(userID string) time.Duration {
 	return c.limits.ResultsCacheTTLForCardinalityQuery(userID)
 }
 
-func (DefaultCacheSplitter) LabelValuesCardinalityCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error) {
+func (DefaultCacheSplitter) GenerateLabelValuesCardinalityCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error) {
 	switch {
 	case strings.HasSuffix(path, cardinalityLabelNamesPathSuffix):
 		parsed, err := cardinality.DecodeLabelNamesRequestFromValues(values)

--- a/pkg/frontend/querymiddleware/cardinality_query_cache.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache.go
@@ -39,7 +39,7 @@ func (c *cardinalityQueryTTL) ttl(userID string) time.Duration {
 	return c.limits.ResultsCacheTTLForCardinalityQuery(userID)
 }
 
-func (DefaultCacheSplitter) LabelValuesCardinality(ctx context.Context, path string, values url.Values) (*GenericQueryCacheKey, error) {
+func (DefaultCacheKeyGenerator) LabelValuesCardinality(_ context.Context, path string, values url.Values) (*GenericQueryCacheKey, error) {
 	switch {
 	case strings.HasSuffix(path, cardinalityLabelNamesPathSuffix):
 		parsed, err := cardinality.DecodeLabelNamesRequestFromValues(values)

--- a/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
@@ -72,7 +72,7 @@ func TestCardinalityQueryCache_RoundTrip_WithTenantFederation(t *testing.T) {
 			cacheBackend := cache.NewInstrumentedMockCache()
 			limits := multiTenantMockLimits{byTenant: testData.limits}
 
-			rt := newCardinalityQueryCacheRoundTripper(cacheBackend, limits, downstream, testutil.NewLogger(t), nil)
+			rt := newCardinalityQueryCacheRoundTripper(cacheBackend, DefaultCacheSplitter(0), limits, downstream, testutil.NewLogger(t), nil)
 			res, err := rt.RoundTrip(req)
 			require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
@@ -72,7 +72,7 @@ func TestCardinalityQueryCache_RoundTrip_WithTenantFederation(t *testing.T) {
 			cacheBackend := cache.NewInstrumentedMockCache()
 			limits := multiTenantMockLimits{byTenant: testData.limits}
 
-			rt := newCardinalityQueryCacheRoundTripper(cacheBackend, DefaultCacheSplitter{}, limits, downstream, testutil.NewLogger(t), nil)
+			rt := newCardinalityQueryCacheRoundTripper(cacheBackend, DefaultCacheKeyGenerator{}, limits, downstream, testutil.NewLogger(t), nil)
 			res, err := rt.RoundTrip(req)
 			require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
@@ -72,7 +72,7 @@ func TestCardinalityQueryCache_RoundTrip_WithTenantFederation(t *testing.T) {
 			cacheBackend := cache.NewInstrumentedMockCache()
 			limits := multiTenantMockLimits{byTenant: testData.limits}
 
-			rt := newCardinalityQueryCacheRoundTripper(cacheBackend, DefaultCacheSplitter(0), limits, downstream, testutil.NewLogger(t), nil)
+			rt := newCardinalityQueryCacheRoundTripper(cacheBackend, DefaultCacheSplitter{}, limits, downstream, testutil.NewLogger(t), nil)
 			res, err := rt.RoundTrip(req)
 			require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/cardinality_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 )
 
-func Test_cardinalityEstimateBucket_GenerateCacheKey_keyFormat(t *testing.T) {
+func Test_cardinalityEstimateBucket_QueryRequest_keyFormat(t *testing.T) {
 	requestTime := parseTimeRFC3339(t, "2023-01-09T03:24:12Z")
 	hoursSinceEpoch := util.TimeToMillis(requestTime) / time.Hour.Milliseconds()
 	daysSinceEpoch := hoursSinceEpoch / 24
@@ -241,7 +241,7 @@ func Test_cardinalityEstimation_Do(t *testing.T) {
 
 }
 
-func Test_cardinalityEstimateBucket_GenerateCacheKey_requestEquality(t *testing.T) {
+func Test_cardinalityEstimateBucket_QueryRequest_requestEquality(t *testing.T) {
 	rangeQuery := &PrometheusRangeQueryRequest{
 		Start: util.TimeToMillis(parseTimeRFC3339(t, "2023-01-31T09:00:00Z")),
 		End:   util.TimeToMillis(parseTimeRFC3339(t, "2023-01-31T10:00:00Z")),

--- a/pkg/frontend/querymiddleware/generic_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache_test.go
@@ -226,7 +226,7 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 						initialStoreCallsCount := cacheBackend.CountStoreCalls()
 
 						reg := prometheus.NewPedanticRegistry()
-						rt := newRoundTripper(cacheBackend, DefaultCacheSplitter(0), limits, downstream, testutil.NewLogger(t), reg)
+						rt := newRoundTripper(cacheBackend, DefaultCacheSplitter{}, limits, downstream, testutil.NewLogger(t), reg)
 						res, err := rt.RoundTrip(req)
 						require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/generic_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type newGenericQueryCacheFunc func(cache cache.Cache, splitter CacheSplitter, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper
+type newGenericQueryCacheFunc func(cache cache.Cache, splitter CacheKeyGenerator, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper
 
 type testGenericQueryCacheRequestType struct {
 	reqPath        string

--- a/pkg/frontend/querymiddleware/generic_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache_test.go
@@ -226,7 +226,7 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 						initialStoreCallsCount := cacheBackend.CountStoreCalls()
 
 						reg := prometheus.NewPedanticRegistry()
-						rt := newRoundTripper(cacheBackend, DefaultCacheSplitter{}, limits, downstream, testutil.NewLogger(t), reg)
+						rt := newRoundTripper(cacheBackend, DefaultCacheKeyGenerator{}, limits, downstream, testutil.NewLogger(t), reg)
 						res, err := rt.RoundTrip(req)
 						require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/generic_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type newGenericQueryCacheFunc func(cache cache.Cache, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper
+type newGenericQueryCacheFunc func(cache cache.Cache, splitter CacheSplitter, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper
 
 type testGenericQueryCacheRequestType struct {
 	reqPath        string
@@ -226,7 +226,7 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 						initialStoreCallsCount := cacheBackend.CountStoreCalls()
 
 						reg := prometheus.NewPedanticRegistry()
-						rt := newRoundTripper(cacheBackend, limits, downstream, testutil.NewLogger(t), reg)
+						rt := newRoundTripper(cacheBackend, DefaultCacheSplitter(0), limits, downstream, testutil.NewLogger(t), reg)
 						res, err := rt.RoundTrip(req)
 						require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -34,7 +34,7 @@ func newLabelsQueryCacheRoundTripper(cache cache.Cache, cacheSplitter CacheSplit
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, cacheSplitter.LabelValuesCacheKey, ttl, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
+	return newGenericQueryCacheRoundTripper(cache, cacheSplitter.GenerateLabelValuesCacheKey, ttl, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
 }
 
 type labelsQueryTTL struct {
@@ -45,7 +45,7 @@ func (c *labelsQueryTTL) ttl(userID string) time.Duration {
 	return c.limits.ResultsCacheTTLForLabelsQuery(userID)
 }
 
-func (DefaultCacheSplitter) LabelValuesCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error) {
+func (DefaultCacheSplitter) GenerateLabelValuesCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error) {
 	var (
 		cacheKeyPrefix string
 		labelName      string

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -29,12 +29,12 @@ const (
 	stringParamSeparator = rune(0)
 )
 
-func newLabelsQueryCacheRoundTripper(cache cache.Cache, cacheSplitter CacheSplitter, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
+func newLabelsQueryCacheRoundTripper(cache cache.Cache, cacheSplitter CacheKeyGenerator, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
 	ttl := &labelsQueryTTL{
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, cacheSplitter.GenerateLabelValuesCacheKey, ttl, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
+	return newGenericQueryCacheRoundTripper(cache, cacheSplitter.LabelValues, ttl, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
 }
 
 type labelsQueryTTL struct {
@@ -45,7 +45,7 @@ func (c *labelsQueryTTL) ttl(userID string) time.Duration {
 	return c.limits.ResultsCacheTTLForLabelsQuery(userID)
 }
 
-func (DefaultCacheSplitter) GenerateLabelValuesCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error) {
+func (DefaultCacheSplitter) LabelValues(ctx context.Context, path string, values url.Values) (*GenericQueryCacheKey, error) {
 	var (
 		cacheKeyPrefix string
 		labelName      string

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -29,12 +29,12 @@ const (
 	stringParamSeparator = rune(0)
 )
 
-func newLabelsQueryCacheRoundTripper(cache cache.Cache, cacheSplitter CacheKeyGenerator, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
+func newLabelsQueryCacheRoundTripper(cache cache.Cache, generator CacheKeyGenerator, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
 	ttl := &labelsQueryTTL{
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, cacheSplitter.LabelValues, ttl, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
+	return newGenericQueryCacheRoundTripper(cache, generator.LabelValues, ttl, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
 }
 
 type labelsQueryTTL struct {

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -45,7 +45,7 @@ func (c *labelsQueryTTL) ttl(userID string) time.Duration {
 	return c.limits.ResultsCacheTTLForLabelsQuery(userID)
 }
 
-func (DefaultCacheSplitter) LabelValues(ctx context.Context, path string, values url.Values) (*GenericQueryCacheKey, error) {
+func (DefaultCacheKeyGenerator) LabelValues(_ context.Context, path string, values url.Values) (*GenericQueryCacheKey, error) {
 	var (
 		cacheKeyPrefix string
 		labelName      string

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -3,6 +3,7 @@
 package querymiddleware
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -28,23 +29,23 @@ const (
 	stringParamSeparator = rune(0)
 )
 
-func newLabelsQueryCacheRoundTripper(cache cache.Cache, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
-	delegate := &labelsQueryCache{
+func newLabelsQueryCacheRoundTripper(cache cache.Cache, cacheSplitter CacheSplitter, limits Limits, next http.RoundTripper, logger log.Logger, reg prometheus.Registerer) http.RoundTripper {
+	ttl := &labelsQueryTTL{
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, delegate, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
+	return newGenericQueryCacheRoundTripper(cache, cacheSplitter.LabelValuesCacheKey, ttl, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
 }
 
-type labelsQueryCache struct {
+type labelsQueryTTL struct {
 	limits Limits
 }
 
-func (c *labelsQueryCache) getTTL(userID string) time.Duration {
+func (c *labelsQueryTTL) ttl(userID string) time.Duration {
 	return c.limits.ResultsCacheTTLForLabelsQuery(userID)
 }
 
-func (c *labelsQueryCache) parseRequest(path string, values url.Values) (*genericQueryRequest, error) {
+func (DefaultCacheSplitter) LabelValuesCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error) {
 	var (
 		cacheKeyPrefix string
 		labelName      string
@@ -78,9 +79,9 @@ func (c *labelsQueryCache) parseRequest(path string, values url.Values) (*generi
 		return nil, err
 	}
 
-	return &genericQueryRequest{
-		cacheKey:       generateLabelsQueryRequestCacheKey(startTime, endTime, labelName, matcherSets),
-		cacheKeyPrefix: cacheKeyPrefix,
+	return &GenericQueryCacheKey{
+		CacheKey:       generateLabelsQueryRequestCacheKey(startTime, endTime, labelName, matcherSets),
+		CacheKeyPrefix: cacheKeyPrefix,
 	}, nil
 }
 

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -144,7 +144,7 @@ func TestDefaultCacheSplitter_LabelValuesCacheKey(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			for requestTypeName, requestTypeData := range requestTypes {
 				t.Run(requestTypeName, func(t *testing.T) {
-					c := DefaultCacheSplitter(0)
+					c := DefaultCacheSplitter{}
 					actual, err := c.GenerateLabelValuesCacheKey(context.Background(), "user-1", requestTypeData.requestPath, testData.params)
 					require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -3,6 +3,7 @@
 package querymiddleware
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -33,6 +34,7 @@ func TestLabelsQueryCache_RoundTrip(t *testing.T) {
 	})
 }
 
+// TODO dimitarvdimitrov rename
 func TestLabelsQueryCache_parseRequest(t *testing.T) {
 	const labelName = "test"
 
@@ -143,16 +145,16 @@ func TestLabelsQueryCache_parseRequest(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			for requestTypeName, requestTypeData := range requestTypes {
 				t.Run(requestTypeName, func(t *testing.T) {
-					c := &labelsQueryCache{}
-					actual, err := c.parseRequest(requestTypeData.requestPath, testData.params)
+					c := DefaultCacheSplitter(0)
+					actual, err := c.LabelValuesCacheKey(context.Background(), "user-1", requestTypeData.requestPath, testData.params)
 					require.NoError(t, err)
 
-					assert.Equal(t, requestTypeData.expectedCacheKeyPrefix, actual.cacheKeyPrefix)
+					assert.Equal(t, requestTypeData.expectedCacheKeyPrefix, actual.CacheKeyPrefix)
 
 					if requestTypeData.expectedCacheKeyWithLabelName {
-						assert.Equal(t, testData.expectedCacheKeyWithLabelName, actual.cacheKey)
+						assert.Equal(t, testData.expectedCacheKeyWithLabelName, actual.CacheKey)
 					} else {
-						assert.Equal(t, testData.expectedCacheKeyWithoutLabelName, actual.cacheKey)
+						assert.Equal(t, testData.expectedCacheKeyWithoutLabelName, actual.CacheKey)
 					}
 				})
 			}

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -34,8 +34,7 @@ func TestLabelsQueryCache_RoundTrip(t *testing.T) {
 	})
 }
 
-// TODO dimitarvdimitrov rename
-func TestLabelsQueryCache_parseRequest(t *testing.T) {
+func TestDefaultCacheSplitter_LabelValuesCacheKey(t *testing.T) {
 	const labelName = "test"
 
 	tests := map[string]struct {

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -34,7 +34,7 @@ func TestLabelsQueryCache_RoundTrip(t *testing.T) {
 	})
 }
 
-func TestDefaultCacheSplitter_LabelValuesCacheKey(t *testing.T) {
+func TestDefaultCacheKeyGenerator_LabelValuesCacheKey(t *testing.T) {
 	const labelName = "test"
 
 	tests := map[string]struct {

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -145,7 +145,7 @@ func TestDefaultCacheSplitter_LabelValuesCacheKey(t *testing.T) {
 			for requestTypeName, requestTypeData := range requestTypes {
 				t.Run(requestTypeName, func(t *testing.T) {
 					c := DefaultCacheSplitter{}
-					actual, err := c.GenerateLabelValuesCacheKey(context.Background(), "user-1", requestTypeData.requestPath, testData.params)
+					actual, err := c.LabelValues(context.Background(), requestTypeData.requestPath, testData.params)
 					require.NoError(t, err)
 
 					assert.Equal(t, requestTypeData.expectedCacheKeyPrefix, actual.CacheKeyPrefix)

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -145,7 +145,7 @@ func TestDefaultCacheSplitter_LabelValuesCacheKey(t *testing.T) {
 			for requestTypeName, requestTypeData := range requestTypes {
 				t.Run(requestTypeName, func(t *testing.T) {
 					c := DefaultCacheSplitter(0)
-					actual, err := c.LabelValuesCacheKey(context.Background(), "user-1", requestTypeData.requestPath, testData.params)
+					actual, err := c.GenerateLabelValuesCacheKey(context.Background(), "user-1", requestTypeData.requestPath, testData.params)
 					require.NoError(t, err)
 
 					assert.Equal(t, requestTypeData.expectedCacheKeyPrefix, actual.CacheKeyPrefix)

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -144,7 +144,7 @@ func TestDefaultCacheSplitter_LabelValuesCacheKey(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			for requestTypeName, requestTypeData := range requestTypes {
 				t.Run(requestTypeName, func(t *testing.T) {
-					c := DefaultCacheSplitter{}
+					c := DefaultCacheKeyGenerator{}
 					actual, err := c.LabelValues(context.Background(), requestTypeData.requestPath, testData.params)
 					require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -184,8 +184,8 @@ func (PrometheusResponseExtractor) ResponseWithoutHeaders(resp Response) Respons
 // consumers who wish to implement their own strategies.
 type CacheSplitter interface {
 	GenerateCacheKey(ctx context.Context, userID string, r Request) string
-	LabelValuesCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error)
-	LabelValuesCardinalityCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error)
+	GenerateLabelValuesCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error)
+	GenerateLabelValuesCardinalityCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error)
 }
 
 // DefaultCacheSplitter is a utility for using a constant split interval when determining cache keys

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -188,12 +188,14 @@ type CacheSplitter interface {
 	GenerateLabelValuesCardinalityCacheKey(ctx context.Context, userID, path string, values url.Values) (*GenericQueryCacheKey, error)
 }
 
-// DefaultCacheSplitter is a utility for using a constant split interval when determining cache keys
-type DefaultCacheSplitter time.Duration
+type DefaultCacheSplitter struct {
+	// Interval is a constant split interval when determining cache keys
+	Interval time.Duration
+}
 
 // GenerateCacheKey generates a cache key based on the userID, Request and interval.
 func (t DefaultCacheSplitter) GenerateCacheKey(_ context.Context, userID string, r Request) string {
-	startInterval := r.GetStart() / time.Duration(t).Milliseconds()
+	startInterval := r.GetStart() / t.Interval.Milliseconds()
 	stepOffset := r.GetStart() % r.GetStep()
 
 	// Use original format for step-aligned request, so that we can use existing cached results for such requests.

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -193,13 +193,13 @@ type CacheKeyGenerator interface {
 	LabelValuesCardinality(ctx context.Context, path string, values url.Values) (*GenericQueryCacheKey, error)
 }
 
-type DefaultCacheSplitter struct {
-	// Interval is a constant split interval when determining cache keys
+type DefaultCacheKeyGenerator struct {
+	// Interval is a constant split interval when determining cache keys for QueryRequest.
 	Interval time.Duration
 }
 
 // QueryRequest generates a cache key based on the userID, Request and interval.
-func (t DefaultCacheSplitter) QueryRequest(_ context.Context, userID string, r Request) string {
+func (t DefaultCacheKeyGenerator) QueryRequest(_ context.Context, userID string, r Request) string {
 	startInterval := r.GetStart() / t.Interval.Milliseconds()
 	stepOffset := r.GetStart() % r.GetStep()
 

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -575,7 +575,7 @@ func TestConstSplitter_generateCacheKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s - %s", tt.name, tt.interval), func(t *testing.T) {
-			if got := ConstSplitter(tt.interval).GenerateCacheKey(ctx, "fake", tt.r); got != tt.want {
+			if got := DefaultCacheSplitter(tt.interval).GenerateCacheKey(ctx, "fake", tt.r); got != tt.want {
 				t.Errorf("generateKey() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -552,7 +552,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 	}
 }
 
-func TestDefaultSplitter_GenerateCacheKey(t *testing.T) {
+func TestDefaultSplitter_QueryRequest(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
@@ -575,7 +575,7 @@ func TestDefaultSplitter_GenerateCacheKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s - %s", tt.name, tt.interval), func(t *testing.T) {
-			if got := (DefaultCacheSplitter{tt.interval}).GenerateCacheKey(ctx, "fake", tt.r); got != tt.want {
+			if got := (DefaultCacheSplitter{tt.interval}).QueryRequest(ctx, "fake", tt.r); got != tt.want {
 				t.Errorf("generateKey() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -575,7 +575,7 @@ func TestDefaultSplitter_QueryRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s - %s", tt.name, tt.interval), func(t *testing.T) {
-			if got := (DefaultCacheSplitter{tt.interval}).QueryRequest(ctx, "fake", tt.r); got != tt.want {
+			if got := (DefaultCacheKeyGenerator{tt.interval}).QueryRequest(ctx, "fake", tt.r); got != tt.want {
 				t.Errorf("generateKey() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -552,7 +552,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 	}
 }
 
-func TestConstSplitter_generateCacheKey(t *testing.T) {
+func TestDefaultSplitter_GenerateCacheKey(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
@@ -575,7 +575,7 @@ func TestConstSplitter_generateCacheKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s - %s", tt.name, tt.interval), func(t *testing.T) {
-			if got := DefaultCacheSplitter(tt.interval).GenerateCacheKey(ctx, "fake", tt.r); got != tt.want {
+			if got := (DefaultCacheSplitter{tt.interval}).GenerateCacheKey(ctx, "fake", tt.r); got != tt.want {
 				t.Errorf("generateKey() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -235,14 +235,14 @@ func newQueryTripperware(
 	}
 
 	cacheSplitter := cfg.CacheSplitter
+	if cacheSplitter == nil {
+		cacheSplitter = DefaultCacheSplitter(cfg.SplitQueriesByInterval)
+	}
+
 	// Inject the middleware to split requests by interval + results cache (if at least one of the two is enabled).
 	if cfg.SplitQueriesByInterval > 0 || cfg.CacheResults {
 		shouldCache := func(r Request) bool {
 			return !r.GetOptions().CacheDisabled
-		}
-
-		if cacheSplitter == nil {
-			cacheSplitter = DefaultCacheSplitter(cfg.SplitQueriesByInterval)
 		}
 
 		queryRangeMiddleware = append(queryRangeMiddleware, newInstrumentMiddleware("split_by_interval_and_results_cache", metrics), newSplitAndCacheMiddleware(

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -236,7 +236,7 @@ func newQueryTripperware(
 
 	cacheSplitter := cfg.CacheSplitter
 	if cacheSplitter == nil {
-		cacheSplitter = DefaultCacheSplitter(cfg.SplitQueriesByInterval)
+		cacheSplitter = DefaultCacheSplitter{Interval: cfg.SplitQueriesByInterval}
 	}
 
 	// Inject the middleware to split requests by interval + results cache (if at least one of the two is enabled).

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -63,7 +63,7 @@ type Config struct {
 
 	// CacheSplitter allows to inject a CacheSplitter to use for generating cache keys.
 	// If nil, the querymiddleware package uses a DefaultCacheSplitter with SplitQueriesByInterval.
-	CacheSplitter CacheSplitter `yaml:"-"`
+	CacheSplitter CacheKeyGenerator `yaml:"-"`
 
 	QueryResultResponseFormat string `yaml:"query_result_response_format"`
 }

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -61,9 +61,9 @@ type Config struct {
 	DeprecatedCacheUnalignedRequests bool          `yaml:"cache_unaligned_requests" category:"advanced" doc:"hidden"` // Deprecated: Deprecated in Mimir 2.10.0, remove in Mimir 2.12.0 (https://github.com/grafana/mimir/issues/5253)
 	TargetSeriesPerShard             uint64        `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
 
-	// CacheSplitter allows to inject a CacheSplitter to use for generating cache keys.
-	// If nil, the querymiddleware package uses a DefaultCacheSplitter with SplitQueriesByInterval.
-	CacheSplitter CacheKeyGenerator `yaml:"-"`
+	// CacheKeyGenerator allows to inject a CacheKeyGenerator to use for generating cache keys.
+	// If nil, the querymiddleware package uses a DefaultCacheKeyGenerator with SplitQueriesByInterval.
+	CacheKeyGenerator CacheKeyGenerator `yaml:"-"`
 
 	QueryResultResponseFormat string `yaml:"query_result_response_format"`
 }
@@ -234,9 +234,9 @@ func newQueryTripperware(
 		c = cache.NewCompression(cfg.ResultsCacheConfig.Compression, c, log)
 	}
 
-	cacheSplitter := cfg.CacheSplitter
-	if cacheSplitter == nil {
-		cacheSplitter = DefaultCacheSplitter{Interval: cfg.SplitQueriesByInterval}
+	cacheKeyGenerator := cfg.CacheKeyGenerator
+	if cacheKeyGenerator == nil {
+		cacheKeyGenerator = DefaultCacheKeyGenerator{Interval: cfg.SplitQueriesByInterval}
 	}
 
 	// Inject the middleware to split requests by interval + results cache (if at least one of the two is enabled).
@@ -252,7 +252,7 @@ func newQueryTripperware(
 			limits,
 			codec,
 			c,
-			cacheSplitter,
+			cacheKeyGenerator,
 			cacheExtractor,
 			shouldCache,
 			log,
@@ -327,8 +327,8 @@ func newQueryTripperware(
 
 		// Inject the cardinality and labels query cache roundtripper only if the query results cache is enabled.
 		if cfg.CacheResults {
-			cardinality = newCardinalityQueryCacheRoundTripper(c, cacheSplitter, limits, cardinality, log, registerer)
-			labels = newLabelsQueryCacheRoundTripper(c, cacheSplitter, limits, labels, log, registerer)
+			cardinality = newCardinalityQueryCacheRoundTripper(c, cacheKeyGenerator, limits, cardinality, log, registerer)
+			labels = newLabelsQueryCacheRoundTripper(c, cacheKeyGenerator, limits, labels, log, registerer)
 		}
 
 		return RoundTripFunc(func(r *http.Request) (*http.Response, error) {

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -92,7 +92,7 @@ type splitAndCacheMiddleware struct {
 	// Results caching.
 	cacheEnabled   bool
 	cache          cache.Cache
-	splitter       CacheSplitter
+	splitter       CacheKeyGenerator
 	extractor      Extractor
 	shouldCacheReq shouldCacheFn
 
@@ -108,7 +108,7 @@ func newSplitAndCacheMiddleware(
 	limits Limits,
 	merger Merger,
 	cache cache.Cache,
-	splitter CacheSplitter,
+	splitter CacheKeyGenerator,
 	extractor Extractor,
 	shouldCacheReq shouldCacheFn,
 	logger log.Logger,
@@ -170,7 +170,7 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req Request) (Response
 				continue
 			}
 
-			splitReq.cacheKey = s.splitter.GenerateCacheKey(ctx, tenant.JoinTenantIDs(tenantIDs), splitReq.orig)
+			splitReq.cacheKey = s.splitter.QueryRequest(ctx, tenant.JoinTenantIDs(tenantIDs), splitReq.orig)
 			lookupKeys = append(lookupKeys, splitReq.cacheKey)
 			lookupReqs = append(lookupReqs, splitReq)
 		}

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -244,7 +244,7 @@ func TestSplitAndCacheMiddleware_ResultsCache(t *testing.T) {
 		mockLimits{maxCacheFreshness: 10 * time.Minute, resultsCacheTTL: resultsCacheTTL, resultsCacheOutOfOrderWindowTTL: resultsCacheLowerTTL},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheSplitter{Interval: day},
+		DefaultCacheKeyGenerator{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -376,7 +376,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotLookupCacheIfStepIsNotAli
 		mockLimits{maxCacheFreshness: 10 * time.Minute},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheSplitter{Interval: day},
+		DefaultCacheKeyGenerator{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -492,7 +492,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_EnabledCachingOfStepUnalignedReque
 		limits,
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheSplitter{Interval: day},
+		DefaultCacheKeyGenerator{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -643,7 +643,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			cacheBackend := cache.NewMockCache()
-			cacheSplitter := DefaultCacheSplitter{Interval: day}
+			cacheSplitter := DefaultCacheKeyGenerator{Interval: day}
 			reg := prometheus.NewPedanticRegistry()
 
 			mw := newSplitAndCacheMiddleware(
@@ -864,7 +864,7 @@ func TestSplitAndCacheMiddleware_ResultsCacheFuzzy(t *testing.T) {
 					},
 					newTestPrometheusCodec(),
 					cache.NewMockCache(),
-					DefaultCacheSplitter{Interval: day},
+					DefaultCacheKeyGenerator{Interval: day},
 					PrometheusResponseExtractor{},
 					resultsCacheAlwaysEnabled,
 					log.NewNopLogger(),
@@ -1134,7 +1134,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), userID)
 			cacheBackend := cache.NewInstrumentedMockCache()
-			cacheSplitter := DefaultCacheSplitter{Interval: day}
+			cacheSplitter := DefaultCacheKeyGenerator{Interval: day}
 
 			mw := newSplitAndCacheMiddleware(
 				false, // No splitting.
@@ -1192,7 +1192,7 @@ func TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents(t *testing.T) {
 		},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheSplitter{Interval: day},
+		DefaultCacheKeyGenerator{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -1273,7 +1273,7 @@ func TestSplitAndCacheMiddleware_WrapMultipleTimes(t *testing.T) {
 		mockLimits{},
 		newTestPrometheusCodec(),
 		cache.NewMockCache(),
-		DefaultCacheSplitter{Interval: day},
+		DefaultCacheKeyGenerator{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -696,7 +696,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 			require.Equal(t, testData.downstreamResponse, resp)
 
 			// Check if the response was cached.
-			cacheKey := cacheHashKey(cacheSplitter.GenerateCacheKey(ctx, userID, req))
+			cacheKey := cacheHashKey(cacheSplitter.QueryRequest(ctx, userID, req))
 			found := cacheBackend.Fetch(ctx, []string{cacheKey})
 
 			if len(testData.expectedCachedResponses) == 0 {
@@ -1154,7 +1154,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 			mw.currentTime = func() time.Time { return time.UnixMilli(now) }
 
 			// Store all extents fixtures in the cache.
-			cacheKey := cacheSplitter.GenerateCacheKey(ctx, userID, testData.req)
+			cacheKey := cacheSplitter.QueryRequest(ctx, userID, testData.req)
 			mw.storeCacheExtents(cacheKey, []string{userID}, testData.cachedExtents)
 
 			// Run the request.

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -244,7 +244,7 @@ func TestSplitAndCacheMiddleware_ResultsCache(t *testing.T) {
 		mockLimits{maxCacheFreshness: 10 * time.Minute, resultsCacheTTL: resultsCacheTTL, resultsCacheOutOfOrderWindowTTL: resultsCacheLowerTTL},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		ConstSplitter(day),
+		DefaultCacheSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -376,7 +376,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotLookupCacheIfStepIsNotAli
 		mockLimits{maxCacheFreshness: 10 * time.Minute},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		ConstSplitter(day),
+		DefaultCacheSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -492,7 +492,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_EnabledCachingOfStepUnalignedReque
 		limits,
 		newTestPrometheusCodec(),
 		cacheBackend,
-		ConstSplitter(day),
+		DefaultCacheSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -643,7 +643,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			cacheBackend := cache.NewMockCache()
-			cacheSplitter := ConstSplitter(day)
+			cacheSplitter := DefaultCacheSplitter(day)
 			reg := prometheus.NewPedanticRegistry()
 
 			mw := newSplitAndCacheMiddleware(
@@ -864,7 +864,7 @@ func TestSplitAndCacheMiddleware_ResultsCacheFuzzy(t *testing.T) {
 					},
 					newTestPrometheusCodec(),
 					cache.NewMockCache(),
-					ConstSplitter(day),
+					DefaultCacheSplitter(day),
 					PrometheusResponseExtractor{},
 					resultsCacheAlwaysEnabled,
 					log.NewNopLogger(),
@@ -1134,7 +1134,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), userID)
 			cacheBackend := cache.NewInstrumentedMockCache()
-			cacheSplitter := ConstSplitter(day)
+			cacheSplitter := DefaultCacheSplitter(day)
 
 			mw := newSplitAndCacheMiddleware(
 				false, // No splitting.
@@ -1192,7 +1192,7 @@ func TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents(t *testing.T) {
 		},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		ConstSplitter(day),
+		DefaultCacheSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -1273,7 +1273,7 @@ func TestSplitAndCacheMiddleware_WrapMultipleTimes(t *testing.T) {
 		mockLimits{},
 		newTestPrometheusCodec(),
 		cache.NewMockCache(),
-		ConstSplitter(day),
+		DefaultCacheSplitter(day),
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -244,7 +244,7 @@ func TestSplitAndCacheMiddleware_ResultsCache(t *testing.T) {
 		mockLimits{maxCacheFreshness: 10 * time.Minute, resultsCacheTTL: resultsCacheTTL, resultsCacheOutOfOrderWindowTTL: resultsCacheLowerTTL},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheSplitter(day),
+		DefaultCacheSplitter{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -376,7 +376,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotLookupCacheIfStepIsNotAli
 		mockLimits{maxCacheFreshness: 10 * time.Minute},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheSplitter(day),
+		DefaultCacheSplitter{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -492,7 +492,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_EnabledCachingOfStepUnalignedReque
 		limits,
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheSplitter(day),
+		DefaultCacheSplitter{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -643,7 +643,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			cacheBackend := cache.NewMockCache()
-			cacheSplitter := DefaultCacheSplitter(day)
+			cacheSplitter := DefaultCacheSplitter{Interval: day}
 			reg := prometheus.NewPedanticRegistry()
 
 			mw := newSplitAndCacheMiddleware(
@@ -864,7 +864,7 @@ func TestSplitAndCacheMiddleware_ResultsCacheFuzzy(t *testing.T) {
 					},
 					newTestPrometheusCodec(),
 					cache.NewMockCache(),
-					DefaultCacheSplitter(day),
+					DefaultCacheSplitter{Interval: day},
 					PrometheusResponseExtractor{},
 					resultsCacheAlwaysEnabled,
 					log.NewNopLogger(),
@@ -1134,7 +1134,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), userID)
 			cacheBackend := cache.NewInstrumentedMockCache()
-			cacheSplitter := DefaultCacheSplitter(day)
+			cacheSplitter := DefaultCacheSplitter{Interval: day}
 
 			mw := newSplitAndCacheMiddleware(
 				false, // No splitting.
@@ -1192,7 +1192,7 @@ func TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents(t *testing.T) {
 		},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheSplitter(day),
+		DefaultCacheSplitter{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -1273,7 +1273,7 @@ func TestSplitAndCacheMiddleware_WrapMultipleTimes(t *testing.T) {
 		mockLimits{},
 		newTestPrometheusCodec(),
 		cache.NewMockCache(),
-		DefaultCacheSplitter(day),
+		DefaultCacheSplitter{Interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -643,7 +643,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			cacheBackend := cache.NewMockCache()
-			cacheSplitter := DefaultCacheKeyGenerator{Interval: day}
+			keyGenerator := DefaultCacheKeyGenerator{Interval: day}
 			reg := prometheus.NewPedanticRegistry()
 
 			mw := newSplitAndCacheMiddleware(
@@ -653,7 +653,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 				mockLimits{maxCacheFreshness: maxCacheFreshness, resultsCacheTTL: resultsCacheTTL, resultsCacheOutOfOrderWindowTTL: resultsCacheLowerTTL},
 				newTestPrometheusCodec(),
 				cacheBackend,
-				cacheSplitter,
+				keyGenerator,
 				PrometheusResponseExtractor{},
 				resultsCacheAlwaysEnabled,
 				log.NewNopLogger(),
@@ -696,7 +696,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 			require.Equal(t, testData.downstreamResponse, resp)
 
 			// Check if the response was cached.
-			cacheKey := cacheHashKey(cacheSplitter.QueryRequest(ctx, userID, req))
+			cacheKey := cacheHashKey(keyGenerator.QueryRequest(ctx, userID, req))
 			found := cacheBackend.Fetch(ctx, []string{cacheKey})
 
 			if len(testData.expectedCachedResponses) == 0 {
@@ -1134,7 +1134,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), userID)
 			cacheBackend := cache.NewInstrumentedMockCache()
-			cacheSplitter := DefaultCacheKeyGenerator{Interval: day}
+			keyGenerator := DefaultCacheKeyGenerator{Interval: day}
 
 			mw := newSplitAndCacheMiddleware(
 				false, // No splitting.
@@ -1143,7 +1143,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 				mockLimits{resultsCacheTTL: resultsCacheTTL, resultsCacheOutOfOrderWindowTTL: resultsCacheLowerTTL},
 				newTestPrometheusCodec(),
 				cacheBackend,
-				cacheSplitter,
+				keyGenerator,
 				PrometheusResponseExtractor{},
 				resultsCacheAlwaysEnabled,
 				log.NewNopLogger(),
@@ -1154,7 +1154,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 			mw.currentTime = func() time.Time { return time.UnixMilli(now) }
 
 			// Store all extents fixtures in the cache.
-			cacheKey := cacheSplitter.QueryRequest(ctx, userID, testData.req)
+			cacheKey := keyGenerator.QueryRequest(ctx, userID, testData.req)
 			mw.storeCacheExtents(cacheKey, []string{userID}, testData.cachedExtents)
 
 			// Run the request.


### PR DESCRIPTION
This PR makes it possible for GEM to inject its own cache key generation. This required splitting up the existing `genericQueryDelegate`  into two interfaces

```go
type tenantCacheTTL interface {
	// ttl returns the cache TTL for the input userID.
	ttl(userID string) time.Duration
}
```

and extending `CacheSplitter` to include LabelValues and Cardinality cache items

```go
// CacheKeyGenerator generates cache keys. This is a useful interface for downstream
// consumers who wish to implement their own strategies.
type CacheKeyGenerator interface {
	// QueryRequest should generate a cache key based on the tenant ID and Request.
	QueryRequest(ctx context.Context, tenantID string, r Request) string

	// LabelValues should return a cache key for a label values request. The cache key does not need to contain the tenant ID.
	LabelValues(ctx context.Context, path string, values url.Values) (*GenericQueryCacheKey, error)

	// LabelValuesCardinality should return a cache key for a label values cardinality request. The cache key does not need to contain the tenant ID.
	LabelValuesCardinality(ctx context.Context, path string, values url.Values) (*GenericQueryCacheKey, error)
}
```
