### PR TITLE
mixin: use heatmap for per pod p99 latency

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -21093,12 +21093,12 @@ data:
                             "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval])))",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "",
+                            "legendFormat": "{{pod}}",
                             "legendLink": null
                          }
                       ],
                       "title": "Per pod p99 latency",
-                      "type": "timeseries"
+                      "type": "heatmap"
                    }
                 ],
                 "repeat": null,
@@ -21708,12 +21708,12 @@ data:
                             "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_querier_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((querier.*|cortex|mimir|mimir-read.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval])))",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "",
+                            "legendFormat": "{{pod}}",
                             "legendLink": null
                          }
                       ],
                       "title": "Per pod p99 latency",
-                      "type": "timeseries"
+                      "type": "heatmap"
                    }
                 ],
                 "repeat": null,
@@ -21947,12 +21947,12 @@ data:
                             "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", route=~\"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata\"}[$__rate_interval])))",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "",
+                            "legendFormat": "{{pod}}",
                             "legendLink": null
                          }
                       ],
                       "title": "Per pod p99 latency",
-                      "type": "timeseries"
+                      "type": "heatmap"
                    }
                 ],
                 "repeat": null,
@@ -22186,12 +22186,12 @@ data:
                             "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\", route=~\"/gatewaypb.StoreGateway/.*\"}[$__rate_interval])))",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "",
+                            "legendFormat": "{{pod}}",
                             "legendLink": null
                          }
                       ],
                       "title": "Per pod p99 latency",
-                      "type": "timeseries"
+                      "type": "heatmap"
                    }
                 ],
                 "repeat": null,
@@ -26521,12 +26521,12 @@ data:
                             "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-query-frontend.*))\", route=~\"/httpgrpc.HTTP/Handle|.*api_v1_query\"}[$__rate_interval])))",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "",
+                            "legendFormat": "{{pod}}",
                             "legendLink": null
                          }
                       ],
                       "title": "Per pod p99 latency",
-                      "type": "timeseries"
+                      "type": "heatmap"
                    }
                 ],
                 "repeat": null,
@@ -26946,12 +26946,12 @@ data:
                             "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_querier_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-querier.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval])))",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "",
+                            "legendFormat": "{{pod}}",
                             "legendLink": null
                          }
                       ],
                       "title": "Per pod p99 latency",
-                      "type": "timeseries"
+                      "type": "heatmap"
                    }
                 ],
                 "repeat": null,
@@ -40025,12 +40025,12 @@ data:
                             "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", route=~\"/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push|otlp_v1_metrics\"}[$__rate_interval])))",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "",
+                            "legendFormat": "{{pod}}",
                             "legendLink": null
                          }
                       ],
                       "title": "Per pod p99 latency",
-                      "type": "timeseries"
+                      "type": "heatmap"
                    }
                 ],
                 "repeat": null,
@@ -40265,12 +40265,12 @@ data:
                             "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", route=\"/cortex.Ingester/Push\"}[$__rate_interval])))",
                             "format": "time_series",
                             "intervalFactor": 2,
-                            "legendFormat": "",
+                            "legendFormat": "{{pod}}",
                             "legendLink": null
                          }
                       ],
                       "title": "Per pod p99 latency",
-                      "type": "timeseries"
+                      "type": "heatmap"
                    }
                 ],
                 "repeat": null,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -674,12 +674,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, instance) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per instance p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -1289,12 +1289,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, instance) (rate(cortex_querier_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((querier.*|cortex|mimir|mimir-read.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per instance p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -1528,12 +1528,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, instance) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", route=~\"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per instance p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -1767,12 +1767,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, instance) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\", route=~\"/gatewaypb.StoreGateway/.*\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per instance p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -366,12 +366,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, instance) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-query-frontend.*))\", route=~\"/httpgrpc.HTTP/Handle|.*api_v1_query\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per instance p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -791,12 +791,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, instance) (rate(cortex_querier_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-querier.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per instance p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -673,12 +673,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, instance) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", route=~\"/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push|otlp_v1_metrics\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per instance p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -913,12 +913,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, instance) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", route=\"/cortex.Ingester/Push\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per instance p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -674,12 +674,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per pod p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -1289,12 +1289,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_querier_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((querier.*|cortex|mimir|mimir-read.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per pod p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -1528,12 +1528,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", route=~\"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per pod p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -1767,12 +1767,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((store-gateway.*|cortex|mimir|mimir-backend.*))\", route=~\"/gatewaypb.StoreGateway/.*\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per pod p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -366,12 +366,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-query-frontend.*))\", route=~\"/httpgrpc.HTTP/Handle|.*api_v1_query\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per pod p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -791,12 +791,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_querier_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ruler-querier.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per pod p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -673,12 +673,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", route=~\"/distributor.Distributor/Push|/httpgrpc.*|api_(v1|prom)_push|otlp_v1_metrics\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per pod p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,
@@ -913,12 +913,12 @@
                         "expr": "histogram_quantile(0.99, sum by(le, pod) (rate(cortex_request_duration_seconds_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", route=\"/cortex.Ingester/Push\"}[$__rate_interval])))",
                         "format": "time_series",
                         "intervalFactor": 2,
-                        "legendFormat": "",
+                        "legendFormat": "{{pod}}",
                         "legendLink": null
                      }
                   ],
                   "title": "Per pod p99 latency",
-                  "type": "timeseries"
+                  "type": "heatmap"
                }
             ],
             "repeat": null,

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -664,6 +664,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ),
     ),
 
+  heatmapPanel():: { type: 'heatmap' },
+
   newStatPanel(queries, legends='', unit='percentunit', decimals=1, thresholds=[], instant=false, novalue='')::
     super.queryPanel(queries, legends) + {
       type: 'stat',

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -124,8 +124,9 @@ local filename = 'mimir-reads.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.gateway), $.queries.read_http_routes_regex], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.gateway), $.queries.read_http_routes_regex], '{{%s}}' % $._config.per_instance_label
         )
       )
     )
@@ -141,8 +142,9 @@ local filename = 'mimir-reads.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.query_frontend), $.queries.read_http_routes_regex], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.query_frontend), $.queries.read_http_routes_regex], '{{%s}}' % $._config.per_instance_label
         )
       )
     )
@@ -210,8 +212,9 @@ local filename = 'mimir-reads.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_querier_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.querier), $.queries.read_http_routes_regex], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_querier_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.querier), $.queries.read_http_routes_regex], '{{%s}}' % $._config.per_instance_label
         )
       )
     )
@@ -227,8 +230,9 @@ local filename = 'mimir-reads.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/cortex.Ingester/Query(Stream)?|/cortex.Ingester/MetricsForLabelMatchers|/cortex.Ingester/LabelValues|/cortex.Ingester/MetricsMetadata"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)], '{{%s}}' % $._config.per_instance_label
         )
       )
     )
@@ -244,8 +248,9 @@ local filename = 'mimir-reads.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/gatewaypb.StoreGateway/.*"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.store_gateway)], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/gatewaypb.StoreGateway/.*"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.store_gateway)], '{{%s}}' % $._config.per_instance_label
         )
       )
     )

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
@@ -64,8 +64,9 @@ local filename = 'mimir-remote-ruler-reads.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ruler_query_frontend), rulerRoutesRegex], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ruler_query_frontend), rulerRoutesRegex], '{{%s}}' % $._config.per_instance_label
         )
       )
     )
@@ -92,8 +93,9 @@ local filename = 'mimir-remote-ruler-reads.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_querier_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ruler_querier), $.queries.read_http_routes_regex], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_querier_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ruler_querier), $.queries.read_http_routes_regex], '{{%s}}' % $._config.per_instance_label
         )
       )
     )

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -115,8 +115,9 @@ local filename = 'mimir-writes.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.gateway), $.queries.write_http_routes_regex], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.gateway), $.queries.write_http_routes_regex], '{{%s}}' % $._config.per_instance_label
         )
       )
     )
@@ -156,8 +157,9 @@ local filename = 'mimir-writes.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/distributor.Distributor/Push|/httpgrpc.*|%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.distributor), $.queries.write_http_routes_regex], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route=~"/distributor.Distributor/Push|/httpgrpc.*|%s"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.distributor), $.queries.write_http_routes_regex], '{{%s}}' % $._config.per_instance_label
         )
       )
     )
@@ -198,8 +200,9 @@ local filename = 'mimir-writes.json';
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.heatmapPanel() +
         $.hiddenLegendQueryPanel(
-          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route="/cortex.Ingester/Push"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)], ''
+          'histogram_quantile(0.99, sum by(le, %s) (rate(cortex_request_duration_seconds_bucket{%s, route="/cortex.Ingester/Push"}[$__rate_interval])))' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)], '{{%s}}' % $._config.per_instance_label
         )
       )
     )


### PR DESCRIPTION
I was doing an investigation and looking at "Per pod p99 latency" panels when there are many pods becomes really noisy and difficult to tell whether only one pod has high latency or all of them. I'm proposing this change of per-pod latency panels to heatmaps to help with this.

The tradeoff is that exemplars are now in the way and on the same scale.

I'll leave this open for some time for more people to chime in.

### Before

<img width="1775" alt="Screenshot 2023-12-08 at 13 07 26" src="https://github.com/grafana/mimir/assets/21020035/820e98fd-aa16-448a-a164-d9e7b2785db2">
<img width="1773" alt="Screenshot 2023-12-08 at 13 04 35" src="https://github.com/grafana/mimir/assets/21020035/217f7208-a937-420b-b27b-c27135530d47">

### After
<img width="1784" alt="Screenshot 2023-12-08 at 13 04 01" src="https://github.com/grafana/mimir/assets/21020035/4eb6649d-38fd-48dc-8173-31650eef8354">
<img width="1778" alt="Screenshot 2023-12-08 at 13 04 12" src="https://github.com/grafana/mimir/assets/21020035/d27ad088-78d3-4597-9f6a-fa74d849ed7c">
