### PR TITLE
Helm/Jsonnet: update memcached-exporter to 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 * [BUGFIX] Fix panic during tsdb Commit #6766
 * [BUGFIX] tsdb/head: wlog exemplars after samples #6766
 * [BUGFIX] Ruler: fix issue where "failed to remotely evaluate query expression, will retry" messages are logged without context such as the trace ID and do not appear in trace events. #6789
-* [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
 
 ### Mixin
 
@@ -59,6 +58,7 @@
   * `store_gateway_zone_a_node_affinity_matchers`
   * `store_gateway_zone_b_node_affinity_matchers`
   * `store_gateway_zone_c_node_affinity_matchers`
+* [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [BUGFIX] Fix panic during tsdb Commit #6766
 * [BUGFIX] tsdb/head: wlog exemplars after samples #6766
 * [BUGFIX] Ruler: fix issue where "failed to remotely evaluate query expression, will retry" messages are logged without context such as the trace ID and do not appear in trace events. #6789
+* [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
 
 ### Mixin
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -38,7 +38,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Make Memcached connection limit configurable. #6715
 * [BUGFIX] Let the unified gatway/nginx config listen on IPv6 as well. Followup to #5948. #6204
 * [BUGFIX] Quote `checksum/config` when using external config. This allows setting `externalConfigVersion` to numeric values. #6407
-* [BUGFIX] Update memcached-exporter due to CVE-2023-39325. #6861
+* [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
 
 ## 5.1.3
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -35,9 +35,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Change the default timeout used for index-queries caches from `200ms` to `450ms`. #6786
 * [ENHANCEMENT] Update the `rollout-operator` subchart to `0.10.0`. #6022 #6110 #6558 #6681
 * [ENHANCEMENT] Add support for not setting replicas for distributor, querier, and query-frontend. #6373
+* [ENHANCEMENT] Make Memcached connection limit configurable. #6715
 * [BUGFIX] Let the unified gatway/nginx config listen on IPv6 as well. Followup to #5948. #6204
 * [BUGFIX] Quote `checksum/config` when using external config. This allows setting `externalConfigVersion` to numeric values. #6407
-* [ENHANCEMENT] Make Memcached connection limit configurable. #6715
+* [BUGFIX] Update memcached-exporter due to CVE-2023-39325.
 
 ## 5.1.3
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -38,7 +38,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Make Memcached connection limit configurable. #6715
 * [BUGFIX] Let the unified gatway/nginx config listen on IPv6 as well. Followup to #5948. #6204
 * [BUGFIX] Quote `checksum/config` when using external config. This allows setting `externalConfigVersion` to numeric values. #6407
-* [BUGFIX] Update memcached-exporter due to CVE-2023-39325.
+* [BUGFIX] Update memcached-exporter due to CVE-2023-39325. #6861
 
 ## 5.1.3
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1709,7 +1709,7 @@ memcachedExporter:
 
   image:
     repository: prom/memcached-exporter
-    tag: v0.13.0
+    tag: v0.14.1
     pullPolicy: IfNotPresent
 
   resources:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.13.0
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1230,7 +1230,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1284,7 +1284,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1338,7 +1338,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1392,7 +1392,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1232,7 +1232,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1286,7 +1286,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1340,7 +1340,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1394,7 +1394,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -1231,7 +1231,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1285,7 +1285,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1339,7 +1339,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1393,7 +1393,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1576,7 +1576,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1630,7 +1630,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1684,7 +1684,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1738,7 +1738,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1576,7 +1576,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1630,7 +1630,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1684,7 +1684,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1738,7 +1738,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1601,7 +1601,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1655,7 +1655,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1709,7 +1709,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1763,7 +1763,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -2056,7 +2056,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2110,7 +2110,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2164,7 +2164,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2218,7 +2218,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1474,7 +1474,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1528,7 +1528,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1582,7 +1582,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1636,7 +1636,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -1034,7 +1034,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1088,7 +1088,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1142,7 +1142,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1196,7 +1196,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -980,7 +980,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1034,7 +1034,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1088,7 +1088,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1142,7 +1142,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -2103,7 +2103,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2157,7 +2157,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2211,7 +2211,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2265,7 +2265,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1235,7 +1235,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1289,7 +1289,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1343,7 +1343,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1397,7 +1397,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -980,7 +980,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1034,7 +1034,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1088,7 +1088,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1142,7 +1142,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1278,7 +1278,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1332,7 +1332,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1386,7 +1386,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1440,7 +1440,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1337,7 +1337,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1391,7 +1391,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1445,7 +1445,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1499,7 +1499,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1230,7 +1230,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1284,7 +1284,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1338,7 +1338,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1392,7 +1392,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1236,7 +1236,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1290,7 +1290,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1344,7 +1344,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1398,7 +1398,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1242,7 +1242,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1296,7 +1296,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1350,7 +1350,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1404,7 +1404,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1236,7 +1236,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1290,7 +1290,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1344,7 +1344,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1398,7 +1398,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1601,7 +1601,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1655,7 +1655,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1709,7 +1709,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1763,7 +1763,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1686,7 +1686,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1740,7 +1740,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1794,7 +1794,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1848,7 +1848,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1686,7 +1686,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1740,7 +1740,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1794,7 +1794,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1848,7 +1848,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1686,7 +1686,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1740,7 +1740,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1794,7 +1794,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1848,7 +1848,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1686,7 +1686,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1740,7 +1740,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1794,7 +1794,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1848,7 +1848,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1233,7 +1233,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1287,7 +1287,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1341,7 +1341,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1395,7 +1395,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1230,7 +1230,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1284,7 +1284,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1338,7 +1338,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1392,7 +1392,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -1303,7 +1303,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1380,7 +1380,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1457,7 +1457,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1534,7 +1534,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1720,7 +1720,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1774,7 +1774,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1828,7 +1828,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1882,7 +1882,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1878,7 +1878,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1932,7 +1932,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1986,7 +1986,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2040,7 +2040,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1720,7 +1720,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1774,7 +1774,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1828,7 +1828,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1882,7 +1882,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -1074,7 +1074,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1130,7 +1130,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1186,7 +1186,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1242,7 +1242,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1611,7 +1611,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1665,7 +1665,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1719,7 +1719,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1773,7 +1773,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1641,7 +1641,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1695,7 +1695,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1749,7 +1749,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1803,7 +1803,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1261,7 +1261,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1315,7 +1315,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1369,7 +1369,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1423,7 +1423,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1249,7 +1249,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1303,7 +1303,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1357,7 +1357,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1411,7 +1411,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1235,7 +1235,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1289,7 +1289,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1343,7 +1343,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1397,7 +1397,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -682,7 +682,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -736,7 +736,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -790,7 +790,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -844,7 +844,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -683,7 +683,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -737,7 +737,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -791,7 +791,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -845,7 +845,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1583,7 +1583,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1637,7 +1637,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1691,7 +1691,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1745,7 +1745,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1581,7 +1581,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1635,7 +1635,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1689,7 +1689,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1743,7 +1743,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1239,7 +1239,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1293,7 +1293,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1347,7 +1347,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1401,7 +1401,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1240,7 +1240,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1294,7 +1294,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1348,7 +1348,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1402,7 +1402,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1240,7 +1240,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1294,7 +1294,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1348,7 +1348,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1402,7 +1402,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1230,7 +1230,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1284,7 +1284,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1338,7 +1338,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1392,7 +1392,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1235,7 +1235,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1289,7 +1289,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1343,7 +1343,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1397,7 +1397,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -884,7 +884,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -938,7 +938,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -992,7 +992,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1046,7 +1046,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.13.0
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -2,7 +2,7 @@
   _images+:: {
     // Various third-party images.
     memcached: 'memcached:1.6.22-alpine',
-    memcachedExporter: 'prom/memcached-exporter:v0.13.0',
+    memcachedExporter: 'prom/memcached-exporter:v0.14.1',
 
     // Our services.
     mimir: 'grafana/mimir:2.10.4',


### PR DESCRIPTION
#### What this PR does

Dependency update.
Changelog: 0.13.0->0.14.1 https://github.com/prometheus/memcached_exporter/releases

#### Which issue(s) this PR fixes or relates to

Fixes CVE-2023-39325

#### Checklist

- N/A Tests updated.
- N/A Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
