### PR TITLE
[mimir-distributed-release-5.1] Helm/Jsonnet: update memcached-exporter to 0.14.1 

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+## 5.1.4
+
+* [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325.
+
 ## 5.1.3
 
 * [BUGFIX] Updated Mimir image to 2.10.4 and GEM images to v2.10.4. #6654

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1683,7 +1683,7 @@ memcachedExporter:
 
   image:
     repository: prom/memcached-exporter
-    tag: v0.11.2
+    tag: v0.14.1
     pullPolicy: IfNotPresent
 
   resources:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: exporter
-          image: prom/memcached-exporter:v0.11.2
+          image: prom/memcached-exporter:v0.14.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1578,7 +1578,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1632,7 +1632,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1686,7 +1686,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1740,7 +1740,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1578,7 +1578,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1632,7 +1632,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1686,7 +1686,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1740,7 +1740,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1602,7 +1602,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1656,7 +1656,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1710,7 +1710,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1764,7 +1764,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -2057,7 +2057,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2111,7 +2111,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2165,7 +2165,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2219,7 +2219,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1475,7 +1475,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1529,7 +1529,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1583,7 +1583,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1637,7 +1637,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -1035,7 +1035,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1089,7 +1089,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1143,7 +1143,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1197,7 +1197,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -981,7 +981,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1035,7 +1035,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1089,7 +1089,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1143,7 +1143,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -2105,7 +2105,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2159,7 +2159,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2213,7 +2213,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2267,7 +2267,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-disable-chunk-streaming-generated.yaml
@@ -1232,7 +1232,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1286,7 +1286,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1340,7 +1340,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1394,7 +1394,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1236,7 +1236,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1290,7 +1290,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1344,7 +1344,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1398,7 +1398,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -981,7 +981,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1035,7 +1035,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1089,7 +1089,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1143,7 +1143,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1279,7 +1279,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1333,7 +1333,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1387,7 +1387,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1441,7 +1441,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1338,7 +1338,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1392,7 +1392,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1446,7 +1446,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1500,7 +1500,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1231,7 +1231,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1285,7 +1285,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1339,7 +1339,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1393,7 +1393,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1237,7 +1237,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1291,7 +1291,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1345,7 +1345,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1399,7 +1399,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1243,7 +1243,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1297,7 +1297,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1351,7 +1351,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1405,7 +1405,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1237,7 +1237,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1291,7 +1291,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1345,7 +1345,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1399,7 +1399,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1602,7 +1602,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1656,7 +1656,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1710,7 +1710,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1764,7 +1764,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1687,7 +1687,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1741,7 +1741,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1795,7 +1795,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1849,7 +1849,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1687,7 +1687,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1741,7 +1741,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1795,7 +1795,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1849,7 +1849,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1687,7 +1687,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1741,7 +1741,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1795,7 +1795,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1849,7 +1849,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1687,7 +1687,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1741,7 +1741,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1795,7 +1795,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1849,7 +1849,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1234,7 +1234,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1288,7 +1288,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1342,7 +1342,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1396,7 +1396,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1231,7 +1231,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1285,7 +1285,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1339,7 +1339,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1393,7 +1393,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -1304,7 +1304,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1381,7 +1381,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1458,7 +1458,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1535,7 +1535,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1721,7 +1721,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1775,7 +1775,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1829,7 +1829,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1883,7 +1883,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1879,7 +1879,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1933,7 +1933,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1987,7 +1987,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2041,7 +2041,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1612,7 +1612,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1666,7 +1666,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1720,7 +1720,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1774,7 +1774,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1643,7 +1643,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1697,7 +1697,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1751,7 +1751,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1805,7 +1805,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1262,7 +1262,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1316,7 +1316,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1370,7 +1370,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1424,7 +1424,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1250,7 +1250,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1304,7 +1304,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1358,7 +1358,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1412,7 +1412,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1236,7 +1236,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1290,7 +1290,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1344,7 +1344,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1398,7 +1398,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -683,7 +683,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -737,7 +737,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -791,7 +791,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -845,7 +845,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -684,7 +684,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -738,7 +738,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -792,7 +792,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -846,7 +846,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1585,7 +1585,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1639,7 +1639,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1693,7 +1693,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1747,7 +1747,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1583,7 +1583,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1637,7 +1637,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1691,7 +1691,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1745,7 +1745,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1240,7 +1240,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1294,7 +1294,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1348,7 +1348,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1402,7 +1402,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1241,7 +1241,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1295,7 +1295,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1349,7 +1349,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1403,7 +1403,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1241,7 +1241,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1295,7 +1295,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1349,7 +1349,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1403,7 +1403,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1231,7 +1231,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1285,7 +1285,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1339,7 +1339,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1393,7 +1393,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1236,7 +1236,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1290,7 +1290,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1344,7 +1344,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1398,7 +1398,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -885,7 +885,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -939,7 +939,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -993,7 +993,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1047,7 +1047,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.11.2
+        image: prom/memcached-exporter:v0.14.1
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -2,7 +2,7 @@
   _images+:: {
     // Various third-party images.
     memcached: 'memcached:1.6.19-alpine',
-    memcachedExporter: 'prom/memcached-exporter:v0.11.2',
+    memcachedExporter: 'prom/memcached-exporter:v0.14.1',
 
     // Our services.
     mimir: 'grafana/mimir:2.9.0',


### PR DESCRIPTION
Backport of #6861 
Cherry-pick of https://github.com/grafana/mimir/commit/0440c409748a07852f769e6b54feea6220e9cdb3

* Helm/Jsonnet: update memcached-exporter to 0.14.1

CVE-2023-39325
