### PR TITLE
Mixin: remove last graph panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * [CHANGE] The `job` label matcher for distributor and gateway have been extended to include any deployment matching `distributor.*` and `cortex-gw.*` respectively. This change allows to match custom and multi-zone distributor and gateway deployments too. #6817
 * [ENHANCEMENT] Dashboards: Add panels for alertmanager activity of a tenant #6826
+* [ENHANCEMENT] Dashboards: remove legacy `graph` panel from Rollout Progress dashboard. #6864
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -28683,12 +28683,15 @@ data:
                 "type": "table"
              },
              {
-                "aliasColors": { },
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
                 "datasource": "$datasource",
-                "fill": 1,
+                "fieldConfig": {
+                   "defaults": {
+                      "custom": {
+                         "fillOpacity": 10
+                      },
+                      "unit": "percentunit"
+                   }
+                },
                 "gridPos": {
                    "h": 8,
                    "w": 8,
@@ -28696,28 +28699,16 @@ data:
                    "y": 8
                 },
                 "id": 12,
-                "legend": {
-                   "avg": false,
-                   "current": false,
-                   "max": false,
-                   "min": false,
-                   "show": true,
-                   "total": false,
-                   "values": false
-                },
-                "lines": true,
-                "linewidth": 1,
                 "links": [ ],
-                "nullPointMode": "null as zero",
-                "percentage": false,
-                "pointradius": 5,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [ ],
-                "spaceLength": 10,
-                "span": 6,
-                "stack": false,
-                "steppedLine": false,
+                "options": {
+                   "legend": {
+                      "showLegend": true
+                   },
+                   "tooltip": {
+                      "mode": "single",
+                      "sort": "none"
+                   }
+                },
                 "targets": [
                    {
                       "expr": "1 - (\n  avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", route=~\"api_(v1|prom)_push|otlp_v1_metrics\"} offset 24h))[1h:])\n  /\n  avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", route=~\"api_(v1|prom)_push|otlp_v1_metrics\"}))[1h:])\n)\n",
@@ -28734,41 +28725,8 @@ data:
                       "legendLink": null
                    }
                 ],
-                "thresholds": [ ],
-                "timeFrom": null,
-                "timeShift": null,
                 "title": "Latency vs 24h ago",
-                "tooltip": {
-                   "shared": false,
-                   "sort": 0,
-                   "value_type": "individual"
-                },
-                "type": "graph",
-                "xaxis": {
-                   "buckets": null,
-                   "mode": "time",
-                   "name": null,
-                   "show": true,
-                   "values": [ ]
-                },
-                "yaxes": [
-                   {
-                      "format": "percentunit",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": true
-                   },
-                   {
-                      "format": "short",
-                      "label": null,
-                      "logBase": 1,
-                      "max": null,
-                      "min": null,
-                      "show": false
-                   }
-                ]
+                "type": "timeseries"
              }
           ],
           "refresh": "10s",

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-rollout-progress.json
@@ -1253,12 +1253,15 @@
             "type": "table"
          },
          {
-            "aliasColors": { },
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
             "datasource": "$datasource",
-            "fill": 1,
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 10
+                  },
+                  "unit": "percentunit"
+               }
+            },
             "gridPos": {
                "h": 8,
                "w": 8,
@@ -1266,28 +1269,16 @@
                "y": 8
             },
             "id": 12,
-            "legend": {
-               "avg": false,
-               "current": false,
-               "max": false,
-               "min": false,
-               "show": true,
-               "total": false,
-               "values": false
-            },
-            "lines": true,
-            "linewidth": 1,
             "links": [ ],
-            "nullPointMode": "null as zero",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [ ],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
+            "options": {
+               "legend": {
+                  "showLegend": true
+               },
+               "tooltip": {
+                  "mode": "single",
+                  "sort": "none"
+               }
+            },
             "targets": [
                {
                   "expr": "1 - (\n  avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", route=~\"api_(v1|prom)_push|otlp_v1_metrics\"} offset 24h))[1h:])\n  /\n  avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", route=~\"api_(v1|prom)_push|otlp_v1_metrics\"}))[1h:])\n)\n",
@@ -1304,41 +1295,8 @@
                   "legendLink": null
                }
             ],
-            "thresholds": [ ],
-            "timeFrom": null,
-            "timeShift": null,
             "title": "Latency vs 24h ago",
-            "tooltip": {
-               "shared": false,
-               "sort": 0,
-               "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-               "buckets": null,
-               "mode": "time",
-               "name": null,
-               "show": true,
-               "values": [ ]
-            },
-            "yaxes": [
-               {
-                  "format": "percentunit",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-               },
-               {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-               }
-            ]
+            "type": "timeseries"
          }
       ],
       "refresh": "10s",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
@@ -1253,12 +1253,15 @@
             "type": "table"
          },
          {
-            "aliasColors": { },
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
             "datasource": "$datasource",
-            "fill": 1,
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 10
+                  },
+                  "unit": "percentunit"
+               }
+            },
             "gridPos": {
                "h": 8,
                "w": 8,
@@ -1266,28 +1269,16 @@
                "y": 8
             },
             "id": 12,
-            "legend": {
-               "avg": false,
-               "current": false,
-               "max": false,
-               "min": false,
-               "show": true,
-               "total": false,
-               "values": false
-            },
-            "lines": true,
-            "linewidth": 1,
             "links": [ ],
-            "nullPointMode": "null as zero",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [ ],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
+            "options": {
+               "legend": {
+                  "showLegend": true
+               },
+               "tooltip": {
+                  "mode": "single",
+                  "sort": "none"
+               }
+            },
             "targets": [
                {
                   "expr": "1 - (\n  avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", route=~\"api_(v1|prom)_push|otlp_v1_metrics\"} offset 24h))[1h:])\n  /\n  avg_over_time(histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", route=~\"api_(v1|prom)_push|otlp_v1_metrics\"}))[1h:])\n)\n",
@@ -1304,41 +1295,8 @@
                   "legendLink": null
                }
             ],
-            "thresholds": [ ],
-            "timeFrom": null,
-            "timeShift": null,
             "title": "Latency vs 24h ago",
-            "tooltip": {
-               "shared": false,
-               "sort": 0,
-               "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-               "buckets": null,
-               "mode": "time",
-               "name": null,
-               "show": true,
-               "values": [ ]
-            },
-            "yaxes": [
-               {
-                  "format": "percentunit",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-               },
-               {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-               }
-            ]
+            "type": "timeseries"
          }
       ],
       "refresh": "10s",

--- a/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
+++ b/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
@@ -382,7 +382,7 @@ local filename = 'mimir-rollout-progress.json';
         //
         // Performance comparison with 24h ago
         //
-        $.panel('Latency vs 24h ago') +
+        $.timeseriesPanel('Latency vs 24h ago') +
         $.queryPanel([|||
           1 - (
             avg_over_time(histogram_quantile(0.99, sum by (le) (%(per_cluster_label)s_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(write_job_matcher)s, route=~"%(write_http_routes_regex)s"} offset 24h))[1h:])
@@ -395,12 +395,18 @@ local filename = 'mimir-rollout-progress.json';
             /
             avg_over_time(histogram_quantile(0.99, sum by (le) (%(per_cluster_label)s_job_route:cortex_request_duration_seconds_bucket:sum_rate{%(read_job_matcher)s, route=~"%(read_http_routes_regex)s"}))[1h:])
           )
-        ||| % config], ['writes', 'reads']) + {
-          yaxes: $.yaxes({
-            format: 'percentunit',
-            min: null,  // Can be negative.
-          }),
-
+        ||| % config], ['writes', 'reads']) +
+        {
+          fieldConfig: {
+            defaults: {
+              unit: 'percentunit',
+              custom: {
+                fillOpacity: 10,
+              },
+            },
+          },
+        } +
+        {
           id: 12,
           gridPos: { h: 8, w: 8, x: 16, y: 8 },
         },


### PR DESCRIPTION
The Latency vs 24h was the last graph panel we have. Those are deprecated are are going away very soon.

This is how the panel look with the changes in this PR

<img width="1109" alt="Screenshot 2023-12-08 at 20 09 12" src="https://github.com/grafana/mimir/assets/21020035/d87c6cd6-4955-4bb1-9715-153793a1d894">

