### PR TITLE
Introduce type for Unix timestamps in JSON

### DIFF
--- a/pkg/storage/tsdb/tenant_deletion_mark.go
+++ b/pkg/storage/tsdb/tenant_deletion_mark.go
@@ -17,6 +17,7 @@ import (
 	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
+	"github.com/grafana/mimir/pkg/util"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
@@ -25,14 +26,14 @@ const TenantDeletionMarkPath = "markers/tenant-deletion-mark.json"
 
 type TenantDeletionMark struct {
 	// Unix timestamp when deletion marker was created.
-	DeletionTime int64 `json:"deletion_time"`
+	DeletionTime util.JSONSecondsTimestamp `json:"deletion_time"`
 
 	// Unix timestamp when cleanup was finished.
-	FinishedTime int64 `json:"finished_time,omitempty"`
+	FinishedTime util.JSONSecondsTimestamp `json:"finished_time,omitempty"`
 }
 
 func NewTenantDeletionMark(deletionTime time.Time) *TenantDeletionMark {
-	return &TenantDeletionMark{DeletionTime: deletionTime.Unix()}
+	return &TenantDeletionMark{DeletionTime: util.JSONSecondsTimestamp(deletionTime)}
 }
 
 // Checks for deletion mark for tenant. Errors other than "object not found" are returned.


### PR DESCRIPTION
#### What this PR does

This PR shows how we could replace `int64` fields in our JSON structs that we use for storing Unix timestamps with typed field.

Benefit is stronger typing and fewer ad-hoc conversions between units.

In this PR I've modified tenant deletion marks only to use this format, but there are other fields (deletion marker, no compact marker, bucket index) where we could use this.

#### Which issue(s) this PR fixes or relates to

Inspired by changes in https://github.com/grafana/mimir/pull/6848.

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
