### PR TITLE
[release-2.11] sync with mimir-prometheus at f51e8aae4265

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 
 ### Tools
 
+## 2.11.0-rc.1
+
+### Grafana Mimir
+
+* [BUGFIX] Fixed possible series matcher corruption leading to wrong series being included in query results. #6884
+
 ## 2.11.0-rc.0
 
 ### Grafana Mimir

--- a/docs/sources/mimir/release-notes/v2.11.md
+++ b/docs/sources/mimir/release-notes/v2.11.md
@@ -86,3 +86,4 @@ The following configuration option defaults were changed:
 - Distributor: Return 529 when ingestion rate limit is hit and the `distributor.service_overload_status_code_on_rate_limit_enabled` flag is active. [PR 6549](https://github.com/grafana/mimir/pull/6549)
 - Query-scheduler: Prevent accumulation of stale querier connections. [PR 6100](https://github.com/grafana/mimir/pull/6100)
 - Packaging: Fix preremove script preventing upgrades on RHEL based OS. [PR 6067](https://github.com/grafana/mimir/pull/6067)
+- Ingester: Fixed possible series matcher corruption leading to wrong series being included in query results. [PR 6884](https://github.com/grafana/mimir/pull/6884)

--- a/go.mod
+++ b/go.mod
@@ -250,7 +250,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231121152630-cdc4e7fd4bb8
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231211122056-f51e8aae4265
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -549,8 +549,8 @@ github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586 h1:/of8Z8taCPft
 github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20231121152630-cdc4e7fd4bb8 h1:ZU7twrg3qD6FNzsJsllI1o9gm4qB0ctGUjXYjVA7uCE=
-github.com/grafana/mimir-prometheus v0.0.0-20231121152630-cdc4e7fd4bb8/go.mod h1:VIbTjmxRZbB1CvLd3TRKcrXU62bXesG4P24dmcugLbY=
+github.com/grafana/mimir-prometheus v0.0.0-20231211122056-f51e8aae4265 h1:sIlRPDD/Lz001iwKCk0LpNRKJ1DH1Dsc8ZCUHfiPyNw=
+github.com/grafana/mimir-prometheus v0.0.0-20231211122056-f51e8aae4265/go.mod h1:VIbTjmxRZbB1CvLd3TRKcrXU62bXesG4P24dmcugLbY=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=

--- a/vendor/github.com/prometheus/prometheus/model/labels/regexp.go
+++ b/vendor/github.com/prometheus/prometheus/model/labels/regexp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 	"github.com/grafana/regexp"
 	"github.com/grafana/regexp/syntax"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -339,7 +340,9 @@ func (m *FastRegexMatcher) MatchString(s string) bool {
 }
 
 func (m *FastRegexMatcher) SetMatches() []string {
-	return m.setMatches
+	// IMPORTANT: always return a copy, otherwise if the caller manipulate this slice it will
+	// also get manipulated in the cached FastRegexMatcher instance.
+	return slices.Clone(m.setMatches)
 }
 
 func (m *FastRegexMatcher) GetRegexString() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -891,7 +891,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231121152630-cdc4e7fd4bb8
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20231211122056-f51e8aae4265
 ## explicit; go 1.20
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1473,7 +1473,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231121152630-cdc4e7fd4bb8
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20231211122056-f51e8aae4265
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6


### PR DESCRIPTION
Sync to the newly created mimir-release-2.11 branch that includes 
https://github.com/grafana/mimir-prometheus/pull/572
https://github.com/grafana/mimir-prometheus/pull/571
