### PR TITLE
util.RequestBuffers: Add tests

### DIFF
--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+package util
+
+import (
+	"bytes"
+	"sync"
+)
+
+// RequestBuffers provides pooled request buffers.
+type RequestBuffers struct {
+	p       *sync.Pool
+	buffers []*bytes.Buffer
+	// Allows avoiding heap allocation
+	buffersBacking [10]*bytes.Buffer
+}
+
+// NewRequestBuffers returns a new RequestBuffers given a sync.Pool.
+func NewRequestBuffers(p *sync.Pool) *RequestBuffers {
+	rb := &RequestBuffers{
+		p: p,
+	}
+	rb.buffers = rb.buffersBacking[:0]
+	return rb
+}
+
+// Get obtains a buffer from the pool. It will be returned back to the pool when CleanUp is called.
+func (rb *RequestBuffers) Get(size int) *bytes.Buffer {
+	if rb == nil {
+		if size < 0 {
+			size = 0
+		}
+		return bytes.NewBuffer(make([]byte, 0, size))
+	}
+
+	b := rb.p.Get().(*bytes.Buffer)
+	b.Reset()
+	if size > 0 {
+		b.Grow(size)
+	}
+	rb.buffers = append(rb.buffers, b)
+	return b
+}
+
+// CleanUp releases buffers back to the pool.
+func (rb *RequestBuffers) CleanUp() {
+	for i, b := range rb.buffers {
+		// Make sure the backing array doesn't retain a reference
+		rb.buffers[i] = nil
+		rb.p.Put(b)
+	}
+	rb.buffers = rb.buffers[:0]
+}

--- a/pkg/util/requestbuffers_test.go
+++ b/pkg/util/requestbuffers_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+package util
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestBuffers(t *testing.T) {
+	p := sync.Pool{
+		New: func() any {
+			return bytes.NewBuffer(nil)
+		},
+	}
+	rb := NewRequestBuffers(&p)
+	t.Cleanup(rb.CleanUp)
+
+	b := rb.Get(1024)
+	require.NotNil(t, b)
+	assert.Equal(t, 1024, b.Cap())
+	assert.Zero(t, b.Len())
+	// Make sure that the buffer gets reset upon next Get
+	_, err := b.Write([]byte("test"))
+	require.NoError(t, err)
+
+	rb.CleanUp()
+	assert.Nil(t, rb.buffersBacking[0])
+
+	b1 := rb.Get(2048)
+	assert.Same(t, b1, b)
+	assert.Equal(t, 2048, b1.Cap())
+	assert.Zero(t, b1.Len())
+
+	t.Run("as nil pointer", func(t *testing.T) {
+		var rb *RequestBuffers
+		b := rb.Get(1024)
+		require.NotNil(t, b)
+		assert.Equal(t, 1024, b.Cap())
+		assert.Zero(t, b.Len())
+	})
+}


### PR DESCRIPTION
#### What this PR does
Add some tests for `util.RequestBuffers`. Have to make a new file, since `pkg/util/http_test.go` has its own package and can't access `util` internals.

Also make sure that `bytes.Buffer` pointers in the backing array are nil-ed in `CleanUp`.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
