### PR TITLE
store-gateway: remove obsolete comments for fine-grained chunks caching

### DIFF
--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -171,8 +171,8 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesChunks, 
 			return errors.Wrap(err, "populate chunk")
 		}
 		localStats.chunksTouched++
-		// Also account for the crc32 at the end. We ignore the bytes, but the counter for "returned" chunks with fine-grained caching
-		// also includes the size of crc32 and the length varint size encoding. By including it we can have a more accurate ratio of touched/returned for small chunks,
+		// Also account for the crc32 at the end. We ignore the bytes, but include the size of crc32 and the length varint size encoding.
+		// By including them we can have a more accurate ratio of touched/returned for small chunks,
 		// where the crc32 + length varint size are a substantial part of the chunk.
 		localStats.chunksTouchedSizeSum += varint.UvarintSize(chunkDataLen) + chunkEncDataLen + crc32.Size
 	}

--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -27,9 +27,8 @@ const (
 	// number of chunks (across series).
 	seriesChunksSlabSize = 1000
 
-	// Selected so that many chunks fit within the slab size with low fragmentation, either when
-	// fine-grained chunks cache is enabled (byte slices have variable size and contain many chunks) or disabled (byte slices
-	// are at most 16KB each).
+	// Selected so that many chunks fit within the slab size with low fragmentation, because
+	// byte slices are at most 16KB each as received by the caching bucket.
 	chunkBytesSlabSize = 160 * 1024
 
 	// Selected so that most series fit it and at the same time it's not too large for requests with few series.


### PR DESCRIPTION
fine-grained chunks were removed in #5816 and #5875. These comments do not apply anymore
