### PR TITLE
Fix issue where querier trace spans are not nested correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [BUGFIX] Fix panic during tsdb Commit #6766
 * [BUGFIX] tsdb/head: wlog exemplars after samples #6766
 * [BUGFIX] Ruler: fix issue where "failed to remotely evaluate query expression, will retry" messages are logged without context such as the trace ID and do not appear in trace events. #6789
+* [BUGFIX] Querier: fix issue where spans in query request traces were not nested correctly. #6893
 
 ### Mixin
 


### PR DESCRIPTION
#### What this PR does

This PR fixes #5341: trace spans created by queriers are not nested correctly.

Before this change:

<img width="1914" alt="Before" src="https://github.com/grafana/mimir/assets/4017646/597c98a5-b81c-4b35-98a9-cb101056d0a5">

After this change:

<img width="1914" alt="After" src="https://github.com/grafana/mimir/assets/4017646/9ff08936-b1b9-41a2-a192-63502bf92a0f">

Note that the `HTTP GET - prometheus_api_v1_query_range` span is nested under the `querier_processor_runRequest` span.

The duplicate `HTTP GET - prometheus_api_v1_query_range` spans are a separate issue, I suspect this was introduced by https://github.com/grafana/dskit/pull/372.

#### Which issue(s) this PR fixes or relates to

Resolves #5341

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
