### PR TITLE
docs: Fix rounding for determining max number of failing zones

### DIFF
--- a/docs/sources/mimir/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/configure/configure-zone-aware-replication.md
@@ -71,7 +71,7 @@ With a replication factor of 3, which is the default, deploy the Grafana Mimir c
 Deploying Grafana Mimir clusters to more zones than the configured replication factor does not have a negative impact.
 Deploying Grafana Mimir clusters to fewer zones than the configured replication factor can cause writes to the replica to be missed, or can cause writes to fail completely.
 
-If there are fewer than `ceil(replication factor / 2)` zones with failing replicas, reads and writes can withstand zone failures.
+There can be at most `floor(replication factor / 2)` zones with failing replicas, otherwise reads and writes will fail.
 
 ## Unbalanced zones
 

--- a/docs/sources/mimir/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/configure/configure-zone-aware-replication.md
@@ -71,7 +71,7 @@ With a replication factor of 3, which is the default, deploy the Grafana Mimir c
 Deploying Grafana Mimir clusters to more zones than the configured replication factor does not have a negative impact.
 Deploying Grafana Mimir clusters to fewer zones than the configured replication factor can cause writes to the replica to be missed, or can cause writes to fail completely.
 
-If there are fewer than `floor(replication factor / 2)` zones with failing replicas, reads and writes can withstand zone failures.
+If there are fewer than `ceil(replication factor / 2)` zones with failing replicas, reads and writes can withstand zone failures.
 
 ## Unbalanced zones
 


### PR DESCRIPTION
#### What this PR does
In docs, fix formula for determining max number of failing zones. The current phrasing combined with downwards rounding (`floor`) means you may end up requiring too few failing zones. E.g., if RF is 3, we would require fewer than 1 failing zone, while it should be *max* 1.

Examples:

* replication factor 3, max 1 (`floor(3 / 2)`) failing zone
* replication factor 6, max 3 (`floor(6/2)`) failing zones
* replication factor 9, max 4 (`floor(9/2)`) failing zones

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated.
- [x] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
