### PR TITLE
Chore: disable the pr on release branch except for security update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     "packageRules": [
       {
         "matchBaseBranches": ["release-2.10","release-2.9"],
-        "packagePatterns": ["*"],
+        "excludeDepPatterns": [".*SECURITY.*"],
         "enabled": false
       },
       {


### PR DESCRIPTION
This PR aim to enable renovate just for security update, previous approach make renovate bot confused and re-close opened security PRs, the config seems working based on my personal repo https://github.com/ying-jeanne/mimir/pulls

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
