### PR TITLE
util.RequestBuffers: Fix test flakiness

### DIFF
--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -3,19 +3,26 @@ package util
 
 import (
 	"bytes"
-	"sync"
 )
+
+// Pool is an abstraction of sync.Pool, for testability.
+type Pool interface {
+	// Get a pooled object.
+	Get() any
+	// Put back an object into the pool.
+	Put(any)
+}
 
 // RequestBuffers provides pooled request buffers.
 type RequestBuffers struct {
-	p       *sync.Pool
+	p       Pool
 	buffers []*bytes.Buffer
 	// Allows avoiding heap allocation
 	buffersBacking [10]*bytes.Buffer
 }
 
-// NewRequestBuffers returns a new RequestBuffers given a sync.Pool.
-func NewRequestBuffers(p *sync.Pool) *RequestBuffers {
+// NewRequestBuffers returns a new RequestBuffers given a Pool.
+func NewRequestBuffers(p Pool) *RequestBuffers {
 	rb := &RequestBuffers{
 		p: p,
 	}


### PR DESCRIPTION
#### What this PR does
`util.TestRequestBuffers` is flaky due to `sync.Pool` not always being deterministic, see [example CI failure](https://github.com/grafana/mimir/actions/runs/7180763125/job/19553728989?pr=6900).

This PR abstracts `sync.Pool` through an interface, which gets faked in tests for deterministic behaviour.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
