### PR TITLE
Update all release-2.10 release notes

### DIFF
--- a/docs/sources/mimir/release-notes/v2.10.md
+++ b/docs/sources/mimir/release-notes/v2.10.md
@@ -106,6 +106,27 @@ The following configuration option defaults were changed:
 - Ingester: prevented setting "last update time" of TSDB into the future when opening TSDB. This could prevent detecting of idle TSDB for a long time, if sample in distant future was ingested.
 - General: changed ballast to allocate smaller blocks to avoid problem when entire ballast was kept in memory working set.
 
+### 2.10.1
+
+* Security: Update Go version to 1.21.3. [PR 6244](https://github.com/grafana/mimir/pull/6244) [PR 6325](https://github.com/grafana/mimir/pull/6325)
+* Bugfix: Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. [PR 6032](https://github.com/grafana/mimir/pull/6032)
+* Bugfix: Ingester: fix panic in WAL replay of certain native histograms. [PR 6086](https://github.com/grafana/mimir/pull/6086)
+
+### 2.10.2
+
+> **Note**: This release contains a known performance regression fixed in 2.10.3
+
+* [BUGFIX] Update grpc-go library to 1.57.1 and `golang.org/x/net` to `0.17`, which include fix for CVE-2023-44487. [PR 6349](https://github.com/grafana/mimir/pull/6349)
+
+### 2.10.3
+
+* [BUGFIX] Update grpc-go library to 1.57.2-dev that includes a fix for a bug introduced in 1.57.1. [PR 6419](https://github.com/grafana/mimir/pull/6419)
+
+### 2.10.4
+
+* [BUGFIX] Update otelhttp library to v0.44.0 as a mitigation for CVE-2023-45142. [PR 6634](https://github.com/grafana/mimir/pull/6634)
+
 ### 2.10.5
 
 - Security: updated the Alpine base image version to 3.18.5 to address [CVE-2023-5363](https://nvd.nist.gov/vuln/detail/CVE-2023-5363). [PR 6897](https://github.com/grafana/mimir/pull/6897)
+- Bugfix: Ingester: fixed possible series matcher corruption leading to wrong series being included in query results. [PR 6886](https://github.com/grafana/mimir/pull/6886)

--- a/docs/sources/mimir/release-notes/v2.10.md
+++ b/docs/sources/mimir/release-notes/v2.10.md
@@ -106,27 +106,27 @@ The following configuration option defaults were changed:
 - Ingester: prevented setting "last update time" of TSDB into the future when opening TSDB. This could prevent detecting of idle TSDB for a long time, if sample in distant future was ingested.
 - General: changed ballast to allocate smaller blocks to avoid problem when entire ballast was kept in memory working set.
 
-### 2.10.1
+### 2.10.5
 
-* Security: Update Go version to 1.21.3. [PR 6244](https://github.com/grafana/mimir/pull/6244) [PR 6325](https://github.com/grafana/mimir/pull/6325)
-* Bugfix: Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. [PR 6032](https://github.com/grafana/mimir/pull/6032)
-* Bugfix: Ingester: fix panic in WAL replay of certain native histograms. [PR 6086](https://github.com/grafana/mimir/pull/6086)
+- Security: updated the Alpine base image version to 3.18.5 to address [CVE-2023-5363](https://nvd.nist.gov/vuln/detail/CVE-2023-5363). [PR 6897](https://github.com/grafana/mimir/pull/6897)
+- Bugfix: Ingester: fixed possible series matcher corruption leading to wrong series being included in query results. [PR 6886](https://github.com/grafana/mimir/pull/6886)
+
+### 2.10.4
+
+- [BUGFIX] Update otelhttp library to v0.44.0 as a mitigation for CVE-2023-45142. [PR 6634](https://github.com/grafana/mimir/pull/6634)
+
+### 2.10.3
+
+- [BUGFIX] Update grpc-go library to 1.57.2-dev that includes a fix for a bug introduced in 1.57.1. [PR 6419](https://github.com/grafana/mimir/pull/6419)
 
 ### 2.10.2
 
 > **Note**: This release contains a known performance regression fixed in 2.10.3
 
-* [BUGFIX] Update grpc-go library to 1.57.1 and `golang.org/x/net` to `0.17`, which include fix for CVE-2023-44487. [PR 6349](https://github.com/grafana/mimir/pull/6349)
+- [BUGFIX] Update grpc-go library to 1.57.1 and `golang.org/x/net` to `0.17`, which include fix for CVE-2023-44487. [PR 6349](https://github.com/grafana/mimir/pull/6349)
 
-### 2.10.3
+### 2.10.1
 
-* [BUGFIX] Update grpc-go library to 1.57.2-dev that includes a fix for a bug introduced in 1.57.1. [PR 6419](https://github.com/grafana/mimir/pull/6419)
-
-### 2.10.4
-
-* [BUGFIX] Update otelhttp library to v0.44.0 as a mitigation for CVE-2023-45142. [PR 6634](https://github.com/grafana/mimir/pull/6634)
-
-### 2.10.5
-
-- Security: updated the Alpine base image version to 3.18.5 to address [CVE-2023-5363](https://nvd.nist.gov/vuln/detail/CVE-2023-5363). [PR 6897](https://github.com/grafana/mimir/pull/6897)
-- Bugfix: Ingester: fixed possible series matcher corruption leading to wrong series being included in query results. [PR 6886](https://github.com/grafana/mimir/pull/6886)
+- Security: Update Go version to 1.21.3. [PR 6244](https://github.com/grafana/mimir/pull/6244) [PR 6325](https://github.com/grafana/mimir/pull/6325)
+- Bugfix: Query-frontend: Don't retry read requests rejected by the ingester due to utilization based read path limiting. [PR 6032](https://github.com/grafana/mimir/pull/6032)
+- Bugfix: Ingester: fix panic in WAL replay of certain native histograms. [PR 6086](https://github.com/grafana/mimir/pull/6086)


### PR DESCRIPTION
This adds the release notes for 2.10.1-2.10.4, and adds a missing note for the bugfix in 2.10.5
