### PR TITLE
Slow queries dashboard: unhide parameters, remove length calculation

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -31951,23 +31951,6 @@ data:
                             }
                          },
                          {
-                            "id": "calculateField",
-                            "options": {
-                               "alias": "Time range",
-                               "binary": {
-                                  "left": "param_end",
-                                  "operator": "-",
-                                  "reducer": "sum",
-                                  "right": "param_start"
-                               },
-                               "mode": "binary",
-                               "reduce": {
-                                  "reducer": "sum"
-                               },
-                               "replaceFields": false
-                            }
-                         },
-                         {
                             "id": "organize",
                             "options": {
                                "excludeByName": {
@@ -31986,9 +31969,6 @@ data:
                                   "msg": true,
                                   "name": true,
                                   "namespace": true,
-                                  "param_end": true,
-                                  "param_start": true,
-                                  "param_time": true,
                                   "path": true,
                                   "pod": true,
                                   "pod_template_hash": true,
@@ -31998,10 +31978,13 @@ data:
                                   "tsNs": true
                                },
                                "indexByName": {
-                                  "Time range": 3,
-                                  "param_query": 2,
-                                  "param_step": 4,
-                                  "response_time": 5,
+                                  "length": 2,
+                                  "param_end": 4,
+                                  "param_query": 7,
+                                  "param_start": 3,
+                                  "param_step": 6,
+                                  "parm_time": 5,
+                                  "response_time": 8,
                                   "ts": 0,
                                   "user": 1
                                },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -97,23 +97,6 @@
                         }
                      },
                      {
-                        "id": "calculateField",
-                        "options": {
-                           "alias": "Time range",
-                           "binary": {
-                              "left": "param_end",
-                              "operator": "-",
-                              "reducer": "sum",
-                              "right": "param_start"
-                           },
-                           "mode": "binary",
-                           "reduce": {
-                              "reducer": "sum"
-                           },
-                           "replaceFields": false
-                        }
-                     },
-                     {
                         "id": "organize",
                         "options": {
                            "excludeByName": {
@@ -132,9 +115,6 @@
                               "msg": true,
                               "name": true,
                               "namespace": true,
-                              "param_end": true,
-                              "param_start": true,
-                              "param_time": true,
                               "path": true,
                               "pod": true,
                               "pod_template_hash": true,
@@ -144,10 +124,13 @@
                               "tsNs": true
                            },
                            "indexByName": {
-                              "Time range": 3,
-                              "param_query": 2,
-                              "param_step": 4,
-                              "response_time": 5,
+                              "length": 2,
+                              "param_end": 4,
+                              "param_query": 7,
+                              "param_start": 3,
+                              "param_step": 6,
+                              "parm_time": 5,
+                              "response_time": 8,
                               "ts": 0,
                               "user": 1
                            },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -97,23 +97,6 @@
                         }
                      },
                      {
-                        "id": "calculateField",
-                        "options": {
-                           "alias": "Time range",
-                           "binary": {
-                              "left": "param_end",
-                              "operator": "-",
-                              "reducer": "sum",
-                              "right": "param_start"
-                           },
-                           "mode": "binary",
-                           "reduce": {
-                              "reducer": "sum"
-                           },
-                           "replaceFields": false
-                        }
-                     },
-                     {
                         "id": "organize",
                         "options": {
                            "excludeByName": {
@@ -132,9 +115,6 @@
                               "msg": true,
                               "name": true,
                               "namespace": true,
-                              "param_end": true,
-                              "param_start": true,
-                              "param_time": true,
                               "path": true,
                               "pod": true,
                               "pod_template_hash": true,
@@ -144,10 +124,13 @@
                               "tsNs": true
                            },
                            "indexByName": {
-                              "Time range": 3,
-                              "param_query": 2,
-                              "param_step": 4,
-                              "response_time": 5,
+                              "length": 2,
+                              "param_end": 4,
+                              "param_query": 7,
+                              "param_start": 3,
+                              "param_step": 6,
+                              "parm_time": 5,
+                              "response_time": 8,
                               "ts": 0,
                               "user": 1
                            },

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -46,7 +46,7 @@ local filename = 'mimir-slow-queries.json';
                 },
 
                 // Order fields.
-                local orderedFields = ['ts', 'user', 'length', 'param_start', 'param_end', 'parm_time', 'param_step', 'param_query', 'Time range', 'param_step', 'response_time'],
+                local orderedFields = ['ts', 'user', 'length', 'param_start', 'param_end', 'parm_time', 'param_step', 'param_query', 'response_time'],
 
                 indexByName: {
                   [orderedFields[i]]: i

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -35,26 +35,10 @@ local filename = 'mimir-slow-queries.json';
               },
             },
             {
-              // Compute the query time range.
-              id: 'calculateField',
-              options: {
-                alias: 'Time range',
-                mode: 'binary',
-                binary: {
-                  left: 'param_end',
-                  operator: '-',
-                  reducer: 'sum',
-                  right: 'param_start',
-                },
-                reduce: { reducer: 'sum' },
-                replaceFields: false,
-              },
-            },
-            {
               id: 'organize',
               options: {
                 // Hide fields we don't care.
-                local hiddenFields = ['caller', 'cluster', 'container', 'host', 'id', 'job', 'level', 'line', 'method', 'msg', 'name', 'namespace', 'param_end', 'param_start', 'param_time', 'path', 'pod', 'pod_template_hash', 'query_wall_time_seconds', 'stream', 'traceID', 'tsNs', 'labels', 'Line', 'Time'],
+                local hiddenFields = ['caller', 'cluster', 'container', 'host', 'id', 'job', 'level', 'line', 'method', 'msg', 'name', 'namespace', 'path', 'pod', 'pod_template_hash', 'query_wall_time_seconds', 'stream', 'traceID', 'tsNs', 'labels', 'Line', 'Time'],
 
                 excludeByName: {
                   [field]: true
@@ -62,7 +46,7 @@ local filename = 'mimir-slow-queries.json';
                 },
 
                 // Order fields.
-                local orderedFields = ['ts', 'user', 'param_query', 'Time range', 'param_step', 'response_time'],
+                local orderedFields = ['ts', 'user', 'length', 'param_start', 'param_end', 'parm_time', 'param_step', 'param_query', 'Time range', 'param_step', 'response_time'],
 
                 indexByName: {
                   [orderedFields[i]]: i


### PR DESCRIPTION
After PR https://github.com/grafana/mimir/pull/6473 we can just use the fields logged by the QF