### PR TITLE
Add project ID option for k6 cloud tests

### DIFF
--- a/operations/k6/load-testing-with-k6.js
+++ b/operations/k6/load-testing-with-k6.js
@@ -96,6 +96,12 @@ const HA_CLUSTERS = parseInt(__ENV.K6_HA_CLUSTERS || 1);
 */
 const TENANT_ID = __ENV.K6_TENANT_ID || '';
 
+/**
+ * Project ID to send k6 cloud tests to.
+ * @type {*|string}
+ */
+const PROJECT_ID = __ENV.K6_PROJECT_ID || '';
+
 const remote_write_url = get_remote_write_url();
 console.debug("Remote write URL:", remote_write_url)
 
@@ -129,6 +135,12 @@ const query_request_rates = {
  * @constant {object}
  */
 export const options = {
+    ext: {
+        loadimpact: {
+            projectID: PROJECT_ID || '',
+        }
+    },
+
     thresholds: {
         // SLA: 99.9% of writes succeed.
         'checks{type:write}': ['rate > 0.999'],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This adds a project ID option to the k6 load testing script, so that k6 cloud load tests can be sent to projects other than the default project.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- N/A Tests updated.
- N/A Documentation added.
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
