### PR TITLE
Use correct port in ruler helper script for microservices Docker Compose setup

### DIFF
--- a/development/mimir-microservices-mode/ruler.sh
+++ b/development/mimir-microservices-mode/ruler.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # SPDX-License-Identifier: AGPL-3.0-only
 
-export MIMIR_ADDRESS=http://localhost:8021/
+export MIMIR_ADDRESS=http://localhost:8022/
 export MIMIR_TENANT_ID=anonymous
 
 mimirtool rules $@


### PR DESCRIPTION
#### What this PR does

[#6536](https://github.com/grafana/mimir/pull/6536/commits/91c806cbcac6e8a7a5c269418b99c90f7761349e) changed the port for the ruler containers in the microservices Docker Compose setup to 8022 and 8023, but didn't update the `ruler.sh` helper script.

This PR updates the port in that script.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
