### PR TITLE
Add flag to enable remote rule evaluation in microservices Docker Compose setup

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -13,6 +13,9 @@ std.manifestYamlDoc({
     // Whether query-frontend and querier should use query-scheduler. If set to true, query-scheduler is started as well.
     use_query_scheduler: true,
 
+    // Whether ruler should use the query-frontend and queriers to execute queries, rather than executing them in-process
+    ruler_use_remote_execution: false,
+
     // Three options are supported for ring in this jsonnet:
     // - consul
     // - memberlist (consul is not started at all)
@@ -136,6 +139,7 @@ std.manifestYamlDoc({
       target: 'ruler',
       httpPort: 8021 + id,
       jaegerApp: 'ruler-%d' % id,
+      extraArguments: if $._config.ruler_use_remote_execution then '-ruler.query-frontend.address=dns:///query-frontend:9007' else '',
     })
     for id in std.range(1, count)
   },


### PR DESCRIPTION
#### What this PR does

This PR adds a flag to enable remote rule evaluation in the microservices Docker Compose setup.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
