### PR TITLE
Ingester remains in the LEAVING state if starting() terminates

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -438,7 +438,7 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 		if err != nil {
 			// if starting() fails for any reason (e.g., context canceled),
 			// the lifecycler must be stopped.
-			services.StopAndAwaitTerminated(context.Background(), i.lifecycler)
+			_ = services.StopAndAwaitTerminated(context.Background(), i.lifecycler)
 		}
 	}()
 	if err := i.openExistingTSDB(ctx); err != nil {


### PR DESCRIPTION
#### What this PR does
If starting the ingester service (`Ingester.starting()`) fails for any reason, the corresponding ingester might be in the ring in an inconsistent state. For example, if an ingester receives the SIGTERM while opening TSDBs (replaying WAL), the TSDB opening intentionally doesn't stop, although the context is cancelled (to reduce the likelihood of on-disk corruptions). Nevertheless, the ring lifecycler gets started, and the ingester switches from `LEAVING` to `ACTIVE` state in the ring, although the `Ingester.starting()` function was interrupted due to the context cancellation. The ingester, although terminated, remains in the `ACTIVE` state because `Ingester.stopping()` wasn’t called after the failed `Ingester.starting()`.

This PR fixes the problem explained above, by explicitly stopping ingester's lifecycler, in case of an error during `Ingester.startint()`.

#### Which issue(s) this PR fixes or relates to

Fixes #6753 

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
