### PR TITLE
ingester: add experimental support for consuming records from kafka

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/prometheus/procfs v0.12.0
 	github.com/thanos-io/objstore v0.0.0-20231123170144-bffedaa58acb
 	github.com/twmb/franz-go v1.15.3
+	github.com/twmb/franz-go/pkg/kadm v1.10.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20231206062516-c09dc92d2db1
 	github.com/twmb/franz-go/pkg/kmsg v1.7.0
 	github.com/twmb/franz-go/plugin/kprom v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -946,6 +946,8 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twmb/franz-go v1.15.3 h1:96nCgxz4DvGPSCumz6giquYy8GGDNsYCwWcloBdjJ4w=
 github.com/twmb/franz-go v1.15.3/go.mod h1:aos+d/UBuigWkOs+6WoqEPto47EvC2jipLAO5qrAu48=
+github.com/twmb/franz-go/pkg/kadm v1.10.0 h1:3oYKNP+e3HGo4GYadrDeRxOaAIsOXmX6LBVMz9PxpCU=
+github.com/twmb/franz-go/pkg/kadm v1.10.0/go.mod h1:hUMoV4SRho+2ij/S9cL39JaLsr+XINjn0ZkCdBY2DXc=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20231206062516-c09dc92d2db1 h1:xbSGm02av1df+hkaY+2jGfkuj/XwGaDnUpLo0VvOrY0=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20231206062516-c09dc92d2db1/go.mod h1:n45fs28DdNx7PRAiYwBTwOORJGUMGqHzmFlr0pcW+BY=
 github.com/twmb/franz-go/pkg/kmsg v1.7.0 h1:a457IbvezYfA5UkiBvyV3zj0Is3y1i8EJgqjJYoij2E=

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -412,7 +412,7 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 		if err != nil {
 			return nil, errors.Wrap(err, "calculating ingest storage partition ID")
 		}
-		i.ingestReader, err = ingest.NewReaderForPusher(kafkaCfg, partitionID, i, log.With(logger, "component", "ingest_reader"), registerer)
+		i.ingestReader, err = ingest.NewPartitionReaderForPusher(kafkaCfg, partitionID, i, log.With(logger, "component", "ingest_reader"), registerer)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating ingest storage reader")
 		}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -414,7 +414,7 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 		}
 		i.ingestReader, err = ingest.NewReaderForPusher(kafkaCfg, partitionID, i, log.With(logger, "component", "ingest_reader"), registerer)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating ingestion client")
+			return nil, errors.Wrap(err, "creating ingest storage reader")
 		}
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -54,6 +54,7 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/bucket"
+	"github.com/grafana/mimir/pkg/storage/ingest"
 	"github.com/grafana/mimir/pkg/storage/sharding"
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
@@ -179,6 +180,9 @@ type Config struct {
 	UseIngesterOwnedSeriesForLimits bool          `yaml:"use_ingester_owned_series_for_limits" category:"experimental"`
 	UpdateIngesterOwnedSeries       bool          `yaml:"track_ingester_owned_series" category:"experimental"`
 	OwnedSeriesUpdateInterval       time.Duration `yaml:"owned_series_update_interval" category:"experimental"`
+
+	// This config is dynamically injected because defined outside the ingester config.
+	IngestStorageConfig ingest.Config `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -298,6 +302,8 @@ type Ingester struct {
 	utilizationBasedLimiter utilizationBasedLimiter
 
 	errorSamplers ingesterErrSamplers
+
+	ingestReader *ingest.PartitionReader
 }
 
 func newIngester(cfg Config, limits *validation.Overrides, registerer prometheus.Registerer, logger log.Logger) (*Ingester, error) {
@@ -399,6 +405,19 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 	i.compactionIdleTimeout = util.DurationWithPositiveJitter(i.cfg.BlocksStorageConfig.TSDB.HeadCompactionIdleTimeout, compactionIdleTimeoutJitter)
 	level.Info(i.logger).Log("msg", "TSDB idle compaction timeout set", "timeout", i.compactionIdleTimeout)
 
+	if ingestCfg := cfg.IngestStorageConfig; ingestCfg.Enabled {
+		kafkaCfg := ingestCfg.KafkaConfig
+
+		partitionID, err := ingest.IngesterPartition(cfg.IngesterRing.InstanceID)
+		if err != nil {
+			return nil, errors.Wrap(err, "calculating ingest storage partition ID")
+		}
+		i.ingestReader, err = ingest.NewReaderForPusher(kafkaCfg.Address, kafkaCfg.Topic, kafkaCfg.ClientID, partitionID, i, log.With(logger, "component", "ingest_reader"), registerer)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating ingestion client")
+		}
+	}
+
 	i.BasicService = services.NewBasicService(i.starting, i.updateLoop, i.stopping)
 	return i, nil
 }
@@ -475,6 +494,10 @@ func (i *Ingester) starting(ctx context.Context) error {
 
 	if i.ownedSeriesService != nil {
 		servs = append(servs, i.ownedSeriesService)
+	}
+
+	if i.ingestReader != nil {
+		servs = append(servs, i.ingestReader)
 	}
 
 	shutdownMarkerPath := shutdownmarker.GetPath(i.cfg.BlocksStorageConfig.TSDB.Dir)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -412,7 +412,7 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 		if err != nil {
 			return nil, errors.Wrap(err, "calculating ingest storage partition ID")
 		}
-		i.ingestReader, err = ingest.NewReaderForPusher(kafkaCfg.Address, kafkaCfg.Topic, kafkaCfg.ClientID, partitionID, i, log.With(logger, "component", "ingest_reader"), registerer)
+		i.ingestReader, err = ingest.NewReaderForPusher(kafkaCfg, partitionID, i, log.With(logger, "component", "ingest_reader"), registerer)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating ingestion client")
 		}

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -636,6 +636,7 @@ func (t *Mimir) initIngesterService() (serv services.Service, err error) {
 	t.Cfg.Ingester.IngesterRing.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.Cfg.Ingester.StreamTypeFn = ingesterChunkStreaming(t.RuntimeConfig)
 	t.Cfg.Ingester.InstanceLimitsFn = ingesterInstanceLimits(t.RuntimeConfig)
+	t.Cfg.Ingester.IngestStorageConfig = t.Cfg.IngestStorage
 	t.tsdbIngesterConfig()
 
 	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Overrides, t.IngesterRing, t.ActiveGroupsCleanup, t.Registerer, util_log.Logger)

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package ingest
 
 import (

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -53,6 +53,7 @@ func (c pusherConsumer) consume(ctx context.Context, records []record) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(cancellation.NewErrorf("done consuming records"))
 
+	// Speed up consumption by unmarhsalling the next request while the previous one is being pushed.
 	go c.unmarshalRequests(ctx, records, recC)
 	err := c.pushRequests(ctx, recC)
 	if err != nil {

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -18,7 +19,9 @@ type Pusher interface {
 
 type pusherConsumer struct {
 	p Pusher
-	l log.Logger
+
+	metrics readerMetrics
+	l       log.Logger
 }
 
 type parsedRecord struct {
@@ -27,10 +30,11 @@ type parsedRecord struct {
 	err      error
 }
 
-func newPusherConsumer(p Pusher, l log.Logger) *pusherConsumer {
+func newPusherConsumer(p Pusher, metrics readerMetrics, l log.Logger) *pusherConsumer {
 	return &pusherConsumer{
-		p: p,
-		l: l,
+		p:       p,
+		metrics: metrics,
+		l:       l,
 	}
 }
 
@@ -40,21 +44,25 @@ func (c pusherConsumer) Consume(ctx context.Context, records []Record) error {
 	defer cancel(cancellation.NewErrorf("done consuming records"))
 
 	go c.unmarshalRequests(ctx, records, recC)
-	err := c.consumeRequests(ctx, recC)
+	err := c.pushRequests(ctx, recC)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (c pusherConsumer) consumeRequests(ctx context.Context, reqC <-chan parsedRecord) error {
+func (c pusherConsumer) pushRequests(ctx context.Context, reqC <-chan parsedRecord) error {
 	for wr := range reqC {
 		if wr.err != nil {
 			level.Error(c.l).Log("msg", "failed to parse write request; skipping", "err", wr.err)
 			continue
 		}
+		processingStart := time.Now()
+
 		ctx := user.InjectOrgID(ctx, wr.tenantId)
 		_, err := c.p.Push(ctx, wr.WriteRequest)
+
+		c.metrics.processingTime.Observe(time.Since(processingStart).Seconds())
 		if err != nil {
 			level.Error(c.l).Log("msg", "failed to push write request; skipping", "err", err)
 			// TODO move distributor's isClientError to a separate package and use that here to swallow only client errors and abort on others

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -26,7 +26,7 @@ type pusherConsumer struct {
 
 type parsedRecord struct {
 	*mimirpb.WriteRequest
-	tenantId string
+	tenantID string
 	err      error
 }
 
@@ -59,7 +59,7 @@ func (c pusherConsumer) pushRequests(ctx context.Context, reqC <-chan parsedReco
 		}
 		processingStart := time.Now()
 
-		ctx := user.InjectOrgID(ctx, wr.tenantId)
+		ctx := user.InjectOrgID(ctx, wr.tenantID)
 		_, err := c.p.Push(ctx, wr.WriteRequest)
 
 		c.metrics.processingTime.Observe(time.Since(processingStart).Seconds())
@@ -78,7 +78,7 @@ func (c pusherConsumer) unmarshalRequests(ctx context.Context, records []Record,
 
 	for _, record := range records {
 		pRecord := parsedRecord{
-			tenantId:     record.TenantID,
+			tenantID:     record.TenantID,
 			WriteRequest: &mimirpb.WriteRequest{},
 		}
 		// We don't free the WriteRequest slices because they are being freed by the Pusher.

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -40,7 +40,7 @@ func newPusherConsumer(p Pusher, metrics readerMetrics, l log.Logger) *pusherCon
 	}
 }
 
-func (c pusherConsumer) Consume(ctx context.Context, records []Record) error {
+func (c pusherConsumer) consume(ctx context.Context, records []record) error {
 	recC := make(chan parsedRecord)
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(cancellation.NewErrorf("done consuming records"))
@@ -74,17 +74,17 @@ func (c pusherConsumer) pushRequests(ctx context.Context, reqC <-chan parsedReco
 	return nil
 }
 
-func (c pusherConsumer) unmarshalRequests(ctx context.Context, records []Record, reqC chan<- parsedRecord) {
+func (c pusherConsumer) unmarshalRequests(ctx context.Context, records []record, reqC chan<- parsedRecord) {
 	defer close(reqC)
 	done := ctx.Done()
 
 	for _, record := range records {
 		pRecord := parsedRecord{
-			tenantID:     record.TenantID,
+			tenantID:     record.tenantID,
 			WriteRequest: &mimirpb.WriteRequest{},
 		}
 		// We don't free the WriteRequest slices because they are being freed by the Pusher.
-		err := pRecord.WriteRequest.Unmarshal(record.Content)
+		err := pRecord.WriteRequest.Unmarshal(record.content)
 		if err != nil {
 			err = errors.Wrap(err, "parsing ingest consumer write request")
 			pRecord.err = err

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -1,0 +1,88 @@
+package ingest
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/cancellation"
+	"github.com/grafana/dskit/user"
+	"github.com/pkg/errors"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+type Pusher interface {
+	Push(context.Context, *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error)
+}
+
+type pusherConsumer struct {
+	p Pusher
+	l log.Logger
+}
+
+type parsedRecord struct {
+	*mimirpb.WriteRequest
+	tenantId string
+	err      error
+}
+
+func newPusherConsumer(p Pusher, l log.Logger) *pusherConsumer {
+	return &pusherConsumer{
+		p: p,
+		l: l,
+	}
+}
+
+func (c pusherConsumer) Consume(ctx context.Context, records []Record) error {
+	recC := make(chan parsedRecord)
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(cancellation.NewErrorf("done consuming records"))
+
+	go c.unmarshalRequests(ctx, records, recC)
+	err := c.consumeRequests(ctx, recC)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c pusherConsumer) consumeRequests(ctx context.Context, reqC <-chan parsedRecord) error {
+	for wr := range reqC {
+		if wr.err != nil {
+			level.Error(c.l).Log("msg", "failed to parse write request; skipping", "err", wr.err)
+			continue
+		}
+		ctx := user.InjectOrgID(ctx, wr.tenantId)
+		_, err := c.p.Push(ctx, wr.WriteRequest)
+		if err != nil {
+			level.Error(c.l).Log("msg", "failed to push write request; skipping", "err", err)
+			// TODO move distributor's isClientError to a separate package and use that here to swallow only client errors and abort on others
+			continue
+		}
+	}
+	return nil
+}
+
+func (c pusherConsumer) unmarshalRequests(ctx context.Context, records []Record, reqC chan<- parsedRecord) {
+	defer close(reqC)
+	done := ctx.Done()
+
+	for _, record := range records {
+		pRecord := parsedRecord{
+			tenantId:     record.TenantID,
+			WriteRequest: &mimirpb.WriteRequest{},
+		}
+		// We don't free the WriteRequest slices because they are being freed by the Pusher.
+		err := pRecord.WriteRequest.Unmarshal(record.Content)
+		if err != nil {
+			err = errors.Wrap(err, "parsing ingest consumer write request")
+			pRecord.err = err
+		}
+		select {
+		case <-done:
+			return
+		case reqC <- pRecord:
+		}
+	}
+}

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -82,8 +82,8 @@ func (c pusherConsumer) pushRequests(ctx context.Context, reqC <-chan parsedReco
 	return nil
 }
 
-func (c pusherConsumer) unmarshalRequests(ctx context.Context, records []record, reqC chan<- parsedRecord) {
-	defer close(reqC)
+func (c pusherConsumer) unmarshalRequests(ctx context.Context, records []record, recC chan<- parsedRecord) {
+	defer close(recC)
 	done := ctx.Done()
 
 	for _, record := range records {
@@ -100,7 +100,7 @@ func (c pusherConsumer) unmarshalRequests(ctx context.Context, records []record,
 		select {
 		case <-done:
 			return
-		case reqC <- pRecord:
+		case recC <- pRecord:
 		}
 	}
 }

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package ingest
 
 import (

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -44,14 +44,14 @@ func TestPusherConsumer(t *testing.T) {
 	okResponse := response{WriteResponse: &mimirpb.WriteResponse{}}
 
 	testCases := map[string]struct {
-		records     []Record
+		records     []record
 		responses   []response
 		expectedWRs []*mimirpb.WriteRequest
 		expErr      string
 	}{
 		"single record": {
-			records: []Record{
-				{Content: wrBytes[0], TenantID: tenantID},
+			records: []record{
+				{content: wrBytes[0], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -59,10 +59,10 @@ func TestPusherConsumer(t *testing.T) {
 			expectedWRs: writeReqs[0:1],
 		},
 		"multiple records": {
-			records: []Record{
-				{Content: wrBytes[0], TenantID: tenantID},
-				{Content: wrBytes[1], TenantID: tenantID},
-				{Content: wrBytes[2], TenantID: tenantID},
+			records: []record{
+				{content: wrBytes[0], tenantID: tenantID},
+				{content: wrBytes[1], tenantID: tenantID},
+				{content: wrBytes[2], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -72,10 +72,10 @@ func TestPusherConsumer(t *testing.T) {
 			expectedWRs: writeReqs[0:3],
 		},
 		"unparsable record": {
-			records: []Record{
-				{Content: wrBytes[0], TenantID: tenantID},
-				{Content: []byte{0}, TenantID: tenantID},
-				{Content: wrBytes[1], TenantID: tenantID},
+			records: []record{
+				{content: wrBytes[0], tenantID: tenantID},
+				{content: []byte{0}, tenantID: tenantID},
+				{content: wrBytes[1], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -85,10 +85,10 @@ func TestPusherConsumer(t *testing.T) {
 			expErr:      "",
 		},
 		"failed processing of record": {
-			records: []Record{
-				{Content: wrBytes[0], TenantID: tenantID},
-				{Content: wrBytes[1], TenantID: tenantID},
-				{Content: wrBytes[2], TenantID: tenantID},
+			records: []record{
+				{content: wrBytes[0], tenantID: tenantID},
+				{content: wrBytes[1], tenantID: tenantID},
+				{content: wrBytes[2], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -99,9 +99,9 @@ func TestPusherConsumer(t *testing.T) {
 			expErr:      "",
 		},
 		"failed processing of last record": {
-			records: []Record{
-				{Content: wrBytes[0], TenantID: tenantID},
-				{Content: wrBytes[1], TenantID: tenantID},
+			records: []record{
+				{content: wrBytes[0], tenantID: tenantID},
+				{content: wrBytes[1], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -111,10 +111,10 @@ func TestPusherConsumer(t *testing.T) {
 			expErr:      "",
 		},
 		"failed processing & failed unmarshalling": {
-			records: []Record{
-				{Content: wrBytes[0], TenantID: tenantID},
-				{Content: wrBytes[1], TenantID: tenantID},
-				{Content: []byte{0}, TenantID: tenantID},
+			records: []record{
+				{content: wrBytes[0], tenantID: tenantID},
+				{content: wrBytes[1], tenantID: tenantID},
+				{content: []byte{0}, tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -146,7 +146,7 @@ func TestPusherConsumer(t *testing.T) {
 				return tc.responses[receivedReqs].WriteResponse, tc.responses[receivedReqs].err
 			})
 			c := newPusherConsumer(pusher, newReaderMetrics(1, prometheus.NewPedanticRegistry()), log.NewNopLogger())
-			err := c.Consume(context.Background(), tc.records)
+			err := c.consume(context.Background(), tc.records)
 			if tc.expErr == "" {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -1,0 +1,154 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+type pusherFunc func(context.Context, *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error)
+
+func (p pusherFunc) Push(ctx context.Context, request *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
+	return p(ctx, request)
+}
+
+func TestPusherConsumer(t *testing.T) {
+	const tenantID = "t1"
+	writeReqs := []*mimirpb.WriteRequest{
+		{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1"), mockPreallocTimeseries("series_2")}},
+		{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_3")}},
+		{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_4")}},
+	}
+
+	wrBytes := make([][]byte, len(writeReqs))
+	for i, wr := range writeReqs {
+		var err error
+		wrBytes[i], err = wr.Marshal()
+		require.NoError(t, err)
+	}
+
+	type response struct {
+		*mimirpb.WriteResponse
+		err error
+	}
+
+	okResponse := response{WriteResponse: &mimirpb.WriteResponse{}}
+
+	testCases := map[string]struct {
+		records     []Record
+		responses   []response
+		expectedWRs []*mimirpb.WriteRequest
+		expErr      string
+	}{
+		"single record": {
+			records: []Record{
+				{Content: wrBytes[0], TenantID: tenantID},
+			},
+			responses: []response{
+				okResponse,
+			},
+			expectedWRs: writeReqs[0:1],
+		},
+		"multiple records": {
+			records: []Record{
+				{Content: wrBytes[0], TenantID: tenantID},
+				{Content: wrBytes[1], TenantID: tenantID},
+				{Content: wrBytes[2], TenantID: tenantID},
+			},
+			responses: []response{
+				okResponse,
+				okResponse,
+				okResponse,
+			},
+			expectedWRs: writeReqs[0:3],
+		},
+		"unparsable record": {
+			records: []Record{
+				{Content: wrBytes[0], TenantID: tenantID},
+				{Content: []byte{0}, TenantID: tenantID},
+				{Content: wrBytes[1], TenantID: tenantID},
+			},
+			responses: []response{
+				okResponse,
+				okResponse,
+			},
+			expectedWRs: writeReqs[0:2],
+			expErr:      "",
+		},
+		"failed processing of record": {
+			records: []Record{
+				{Content: wrBytes[0], TenantID: tenantID},
+				{Content: wrBytes[1], TenantID: tenantID},
+				{Content: wrBytes[2], TenantID: tenantID},
+			},
+			responses: []response{
+				okResponse,
+				{err: assert.AnError},
+				okResponse,
+			},
+			expectedWRs: writeReqs[0:3],
+			expErr:      "",
+		},
+		"failed processing of last record": {
+			records: []Record{
+				{Content: wrBytes[0], TenantID: tenantID},
+				{Content: wrBytes[1], TenantID: tenantID},
+			},
+			responses: []response{
+				okResponse,
+				{err: assert.AnError},
+			},
+			expectedWRs: writeReqs[0:2],
+			expErr:      "",
+		},
+		"failed processing & failed unmarshalling": {
+			records: []Record{
+				{Content: wrBytes[0], TenantID: tenantID},
+				{Content: wrBytes[1], TenantID: tenantID},
+				{Content: []byte{0}, TenantID: tenantID},
+			},
+			responses: []response{
+				okResponse,
+				{err: assert.AnError},
+			},
+			expectedWRs: writeReqs[0:2],
+			expErr:      "",
+		},
+		"no records": {},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			receivedReqs := 0
+			pusher := pusherFunc(func(ctx context.Context, request *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
+				defer func() { receivedReqs++ }()
+				require.GreaterOrEqualf(t, len(tc.expectedWRs), receivedReqs+1, "received more requests (%d) than expected (%d)", receivedReqs+1, len(tc.expectedWRs))
+
+				expectedWR := tc.expectedWRs[receivedReqs]
+				for i, ts := range request.Timeseries {
+					assert.Truef(t, ts.Equal(expectedWR.Timeseries[i].TimeSeries), "timeseries %d not equal; got %v, expected %v", i, ts, expectedWR.Timeseries[i].TimeSeries)
+				}
+
+				actualTenantID, err := tenant.TenantID(ctx)
+				assert.NoError(t, err)
+				assert.Equal(t, tenantID, actualTenantID)
+
+				return tc.responses[receivedReqs].WriteResponse, tc.responses[receivedReqs].err
+			})
+			c := newPusherConsumer(pusher, log.NewNopLogger())
+			err := c.Consume(context.Background(), tc.records)
+			if tc.expErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.expErr)
+			}
+		})
+	}
+}

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/tenant"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -142,7 +143,7 @@ func TestPusherConsumer(t *testing.T) {
 
 				return tc.responses[receivedReqs].WriteResponse, tc.responses[receivedReqs].err
 			})
-			c := newPusherConsumer(pusher, log.NewNopLogger())
+			c := newPusherConsumer(pusher, newReaderMetrics(1, prometheus.NewPedanticRegistry()), log.NewNopLogger())
 			err := c.Consume(context.Background(), tc.records)
 			if tc.expErr == "" {
 				assert.NoError(t, err)

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -145,7 +145,7 @@ func TestPusherConsumer(t *testing.T) {
 
 				return tc.responses[receivedReqs].WriteResponse, tc.responses[receivedReqs].err
 			})
-			c := newPusherConsumer(pusher, newReaderMetrics(1, prometheus.NewPedanticRegistry()), log.NewNopLogger())
+			c := newPusherConsumer(pusher, prometheus.NewPedanticRegistry(), log.NewNopLogger())
 			err := c.consume(context.Background(), tc.records)
 			if tc.expErr == "" {
 				assert.NoError(t, err)

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package ingest
 
 import (

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -246,7 +246,7 @@ func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context) (kgo.Off
 	defer adm.Close()
 
 	offsets, err := adm.FetchOffsets(ctx, consumerGroup)
-	if errors.Is(err, kerr.GroupIDNotFound) || errors.Is(err, kerr.UnknownTopicOrPartition) {
+	if errors.Is(err, kerr.UnknownTopicOrPartition) {
 		// In case we are booting up for the first time ever against this topic.
 		return kgo.NewOffset().AtEnd(), nil
 	}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -55,13 +55,13 @@ type PartitionReader struct {
 	logger log.Logger
 }
 
-func NewReaderForPusher(kafkaCfg KafkaConfig, partitionID int32, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
+func NewPartitionReaderForPusher(kafkaCfg KafkaConfig, partitionID int32, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
 	metrics := newReaderMetrics(partitionID, reg)
 	consumer := newPusherConsumer(pusher, metrics, logger)
-	return newReader(kafkaCfg, partitionID, consumer, logger, metrics)
+	return newPartitionReader(kafkaCfg, partitionID, consumer, logger, metrics)
 }
 
-func newReader(kafkaCfg KafkaConfig, partitionID int32, consumer recordConsumer, logger log.Logger, metrics readerMetrics) (*PartitionReader, error) {
+func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, consumer recordConsumer, logger log.Logger, metrics readerMetrics) (*PartitionReader, error) {
 	r := &PartitionReader{
 		kafkaAddress:   kafkaCfg.Address,
 		kafkaTopic:     kafkaCfg.Topic,

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -4,6 +4,7 @@ package ingest
 
 import (
 	"context"
+	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -146,7 +147,10 @@ func (r *PartitionReader) enqueueCommit(fetches kgo.Fetches) {
 func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetches) {
 	records := make([]record, 0, len(fetches.Records()))
 
-	var minOffset, maxOffset int
+	var (
+		minOffset = math.MaxInt
+		maxOffset = 0
+	)
 	fetches.EachRecord(func(record *kgo.Record) {
 		minOffset = min(minOffset, int(record.Offset))
 		maxOffset = max(maxOffset, int(record.Offset))

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -55,17 +55,17 @@ type PartitionReader struct {
 	logger log.Logger
 }
 
-func NewReaderForPusher(kafkaAddress, kafkaTopic, kafkaClientID string, partitionID int32, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
+func NewReaderForPusher(kafkaCfg KafkaConfig, partitionID int32, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
 	metrics := newReaderMetrics(partitionID, reg)
 	consumer := newPusherConsumer(pusher, metrics, logger)
-	return newReader(kafkaAddress, kafkaTopic, kafkaClientID, partitionID, consumer, logger, metrics)
+	return newReader(kafkaCfg, partitionID, consumer, logger, metrics)
 }
 
-func newReader(kafkaAddress, kafkaTopic, kafkaClientID string, partitionID int32, consumer recordConsumer, logger log.Logger, metrics readerMetrics) (*PartitionReader, error) {
+func newReader(kafkaCfg KafkaConfig, partitionID int32, consumer recordConsumer, logger log.Logger, metrics readerMetrics) (*PartitionReader, error) {
 	r := &PartitionReader{
-		kafkaAddress:   kafkaAddress,
-		kafkaTopic:     kafkaTopic,
-		kafkaClientID:  kafkaClientID,
+		kafkaAddress:   kafkaCfg.Address,
+		kafkaTopic:     kafkaCfg.Topic,
+		kafkaClientID:  kafkaCfg.ClientID,
 		partitionID:    partitionID,
 		consumer:       consumer, // TODO consume records in parallel
 		commitInterval: time.Second,

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -1,0 +1,329 @@
+package ingest
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/multierror"
+	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/plugin/kprom"
+)
+
+// consumerGroup is only used to store commit offsets, not for actual consuming.
+const consumerGroup = "mimir"
+
+type Record struct {
+	TenantID string
+	Content  []byte
+}
+
+type RecordConsumer interface {
+	Consume(context.Context, []Record) error
+}
+
+type PartitionReader struct {
+	services.Service
+
+	kafkaAddress  string
+	kafkaTopic    string
+	kafkaClientID string
+	partitionID   int32
+
+	client    *kgo.Client
+	admClient *kadm.Client
+
+	consumer RecordConsumer
+	metrics  readerMetrics
+
+	commitInterval time.Duration
+	commitLoopWg   *sync.WaitGroup
+	commitFetches  chan kgo.Fetches
+
+	logger log.Logger
+}
+
+func NewReaderForPusher(kafkaAddress, kafkaTopic, kafkaClientID string, partitionID int32, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
+	metrics := newReaderMetrics(partitionID, reg)
+	consumer := newPusherConsumer(pusher, logger)
+	return newReader(kafkaAddress, kafkaTopic, kafkaClientID, partitionID, consumer, logger, metrics)
+}
+
+func newReader(kafkaAddress, kafkaTopic, kafkaClientID string, partitionID int32, consumer RecordConsumer, logger log.Logger, metrics readerMetrics) (*PartitionReader, error) {
+	r := &PartitionReader{
+		kafkaAddress:   kafkaAddress,
+		kafkaTopic:     kafkaTopic,
+		kafkaClientID:  kafkaClientID,
+		partitionID:    partitionID,
+		consumer:       consumer, // TODO consume records in parallel
+		commitInterval: time.Second,
+		commitLoopWg:   &sync.WaitGroup{},
+		commitFetches:  make(chan kgo.Fetches, 1),
+		metrics:        metrics,
+		logger:         log.With(logger, "partition", partitionID),
+	}
+
+	r.Service = services.NewBasicService(r.start, r.run, r.stop)
+	return r, nil
+}
+
+func (r *PartitionReader) start(ctx context.Context) error {
+	offset, err := r.fetchLastCommittedOffsetWithRetries(ctx)
+	if err != nil {
+		return err
+	}
+	level.Info(r.logger).Log("msg", "resuming consumption from offset", "offset", offset)
+
+	r.client, err = r.newKafkaReader(offset)
+	if err != nil {
+		return errors.Wrap(err, "creating kafka reader client")
+	}
+	r.admClient = kadm.NewClient(r.client)
+
+	return nil
+}
+
+func (r *PartitionReader) stop(error) error {
+	r.client.Close()
+	// r.admClient needs no closing since it's using r.client
+	return nil
+}
+
+func (r *PartitionReader) run(ctx context.Context) error {
+	defer r.commitLoopWg.Wait()
+
+	consumeCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r.commitLoopWg.Add(1)
+	go r.commitLoop(consumeCtx)
+
+	for ctx.Err() == nil {
+		fetches := r.client.PollFetches(ctx)
+		if fetches.Err() != nil {
+			if errors.Is(fetches.Err(), context.Canceled) {
+				return nil
+			}
+			err := collectFetchErrs(fetches)
+			level.Error(r.logger).Log("msg", "encountered error while fetching", "err", err)
+			continue
+		}
+
+		r.recordFetchesMetrics(fetches)
+		r.consumeFetches(consumeCtx, fetches)
+		r.enqueueCommit(fetches)
+	}
+
+	return nil
+}
+
+func collectFetchErrs(fetches kgo.Fetches) (_ error) {
+	mErr := multierror.New()
+	fetches.EachError(func(s string, i int32, err error) {
+		// kgo advises to "restart" the kafka client if the returned error is a kerr.Error.
+		// Recreating the client would cause duplicate metrics registration, so we don't do it for now.
+		mErr.Add(err)
+	})
+	return mErr.Err()
+}
+
+func (r *PartitionReader) enqueueCommit(fetches kgo.Fetches) {
+	r.commitFetches <- fetches
+}
+
+func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetches) {
+	records := make([]Record, 0, len(fetches.Records()))
+
+	var minOffset, maxOffset int
+	fetches.EachRecord(func(record *kgo.Record) {
+		minOffset = min(minOffset, int(record.Offset))
+		maxOffset = max(maxOffset, int(record.Offset))
+		records = append(records, mapRecord(record))
+	})
+
+	err := r.consumer.Consume(ctx, records)
+	if err != nil {
+		level.Error(r.logger).Log("msg", "encountered error processing records; skipping", "min_offset", minOffset, "max_offset", maxOffset, "err", err)
+		// TODO abort ingesting & back off if it's a server error, ignore error if it's a client error
+	}
+}
+
+func mapRecord(record *kgo.Record) Record {
+	return Record{
+		Content:  record.Value,
+		TenantID: string(record.Key),
+	}
+}
+
+func (r *PartitionReader) recordFetchesMetrics(fetches kgo.Fetches) {
+	var (
+		now        = time.Now()
+		numRecords = 0
+	)
+
+	fetches.EachRecord(func(record *kgo.Record) {
+		numRecords++
+		r.metrics.receiveDelay.Observe(now.Sub(record.Timestamp).Seconds())
+	})
+
+	r.metrics.recordsPerFetch.Observe(float64(numRecords))
+}
+
+func (r *PartitionReader) newKafkaReader(at kgo.Offset) (*kgo.Client, error) {
+	client, err := kgo.NewClient(
+		kgo.ClientID(r.kafkaClientID),
+		kgo.SeedBrokers(r.kafkaAddress),
+		kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{
+			r.kafkaTopic: {r.partitionID: at},
+		}),
+		kgo.FetchMinBytes(1),
+		kgo.FetchMaxBytes(100_000_000),
+		kgo.FetchMaxWait(5*time.Second),
+		kgo.FetchMaxPartitionBytes(50_000_000),
+		// Frequently refresh the cluster metadata. This allows us to quickly react in case some brokers are unhealthy,
+		// because the client updates the cluster info only at this frequency (and not after errors too).
+		//
+		// The side effect of frequently refreshing the cluster metadata is that if the backend returns each time a
+		// different authoritative owner for a partition, then each time cluster metadata is updated the Kafka client
+		// will client a new connection for each partition, leading to an high connections churn rate.
+		kgo.MetadataMaxAge(10*time.Second),
+		kgo.WithHooks(r.metrics.kprom),
+		kgo.WithLogger(newKafkaLogger(r.logger)),
+	)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "creating kafka client")
+	}
+
+	return client, nil
+}
+
+func (r *PartitionReader) fetchLastCommittedOffsetWithRetries(ctx context.Context) (offset kgo.Offset, err error) {
+	var (
+		retry = backoff.New(ctx, backoff.Config{
+			MinBackoff: 100 * time.Millisecond,
+			MaxBackoff: 2 * time.Second,
+			MaxRetries: 10,
+		})
+	)
+
+	for retry.Ongoing() {
+		offset, err = r.fetchLastCommittedOffset(ctx)
+		if err == nil {
+			return offset, nil
+		}
+
+		level.Warn(r.logger).Log("msg", "failed to fetch last committed offset", "partition", r.partitionID, "err", err)
+		retry.Wait()
+	}
+
+	// Handle the case the context was canceled before the first attempt.
+	if err == nil {
+		err = retry.Err()
+	}
+
+	return offset, err
+}
+
+func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context) (kgo.Offset, error) {
+	cl, err := kgo.NewClient(kgo.SeedBrokers(r.kafkaAddress))
+	if err != nil {
+		return kgo.NewOffset(), errors.Wrap(err, "unable to create admin client")
+	}
+	adm := kadm.NewClient(cl)
+	defer adm.Close()
+
+	offsets, err := adm.FetchOffsets(ctx, consumerGroup)
+	if errors.Is(err, kerr.GroupIDNotFound) || errors.Is(err, kerr.UnknownTopicOrPartition) {
+		// In case we are booting up for the first time ever against this topic.
+		return kgo.NewOffset().AtEnd(), nil
+	}
+	if err != nil {
+		return kgo.NewOffset(), errors.Wrap(err, "unable to fetch group offsets")
+	}
+	offset, _ := offsets.Lookup(r.kafkaTopic, r.partitionID)
+	return kgo.NewOffset().At(offset.At), nil
+}
+
+func (r *PartitionReader) commitLoop(ctx context.Context) {
+	defer r.commitLoopWg.Done()
+
+	commitTicker := time.NewTicker(r.commitInterval)
+	defer commitTicker.Stop()
+
+	toCommit := kadm.Offsets{}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case fetches := <-r.commitFetches:
+			fetches.EachPartition(func(p kgo.FetchTopicPartition) {
+				if len(p.Records) == 0 {
+					return
+				}
+				r := p.Records[len(p.Records)-1]
+				toCommit.AddOffset(r.Topic, r.Partition, r.Offset+1, r.LeaderEpoch)
+			})
+		case <-commitTicker.C:
+			if len(toCommit) == 0 {
+				continue
+			}
+			committed, err := r.admClient.CommitOffsets(ctx, consumerGroup, toCommit)
+			if err != nil || !committed.Ok() {
+				level.Error(r.logger).Log("msg", "encountered error while committing offsets", "err", err, "commit_err", committed.Error())
+			} else {
+				committedOffset, _ := committed.Lookup(r.kafkaTopic, r.partitionID)
+				level.Debug(r.logger).Log("msg", "committed offset", "offset", committedOffset.Offset.At)
+				clear(toCommit)
+			}
+		}
+	}
+}
+
+type readerMetrics struct {
+	processingTime  prometheus.Summary
+	receiveDelay    prometheus.Summary
+	recordsPerFetch prometheus.Histogram
+	kprom           *kprom.Metrics
+}
+
+func newReaderMetrics(partitionID int32, reg prometheus.Registerer) readerMetrics {
+	factory := promauto.With(reg)
+
+	return readerMetrics{
+		processingTime: factory.NewSummary(prometheus.SummaryOpts{
+			Name:       "cortex_ingest_storage_reader_processing_time_seconds",
+			Help:       "Time taken to process a single record (write request).",
+			Objectives: latencySummaryObjectives,
+			MaxAge:     time.Minute,
+			AgeBuckets: 10,
+		}),
+		receiveDelay: factory.NewSummary(prometheus.SummaryOpts{
+			Name:       "cortex_ingest_storage_reader_receive_delay_seconds",
+			Help:       "Delay between producing a record and receiving it in the consumer.",
+			Objectives: latencySummaryObjectives,
+			MaxAge:     time.Minute,
+			AgeBuckets: 10,
+		}),
+		recordsPerFetch: factory.NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_ingest_storage_reader_records_per_fetch",
+			Help:    "The number of records received by the consumer in a single fetch operation.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 15),
+		}),
+		kprom: kprom.NewMetrics("cortex_ingest_storage_reader",
+			kprom.Registerer(prometheus.WrapRegistererWith(prometheus.Labels{"partition": strconv.Itoa(int(partitionID))}, reg)),
+			// Do not export the client ID, because we use it to specify options to the backend.
+			kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes)),
+	}
+}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -55,7 +55,7 @@ type PartitionReader struct {
 
 func NewReaderForPusher(kafkaAddress, kafkaTopic, kafkaClientID string, partitionID int32, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
 	metrics := newReaderMetrics(partitionID, reg)
-	consumer := newPusherConsumer(pusher, logger)
+	consumer := newPusherConsumer(pusher, metrics, logger)
 	return newReader(kafkaAddress, kafkaTopic, kafkaClientID, partitionID, consumer, logger, metrics)
 }
 

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package ingest
 
 import (

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -114,10 +113,10 @@ func withCommitInterval(i time.Duration) func(cfg *readerTestCfg) {
 	}
 }
 
-func defaultTestConfig(addr string, topicName string, partitionID int32, consumer RecordConsumer) *readerTestCfg {
+func defaultReaderTestConfig(addr string, topicName string, partitionID int32, consumer RecordConsumer) *readerTestCfg {
 	return &readerTestCfg{
 		registry:       prometheus.NewPedanticRegistry(),
-		logger:         log.NewLogfmtLogger(os.Stdout),
+		logger:         log.NewNopLogger(),
 		addr:           addr,
 		topicName:      topicName,
 		partitionID:    partitionID,
@@ -127,7 +126,7 @@ func defaultTestConfig(addr string, topicName string, partitionID int32, consume
 }
 
 func startReader(ctx context.Context, t *testing.T, addr string, topicName string, partitionID int32, consumer RecordConsumer, opts ...readerTestCfgOtp) *PartitionReader {
-	cfg := defaultTestConfig(addr, topicName, partitionID, consumer)
+	cfg := defaultReaderTestConfig(addr, topicName, partitionID, consumer)
 	for _, o := range opts {
 		o(cfg)
 	}

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -302,7 +302,7 @@ func (t testConsumer) consume(_ context.Context, records []record) error {
 }
 
 // waitRecords expects to receive numRecords records within waitTimeout.
-// waitRecords waits for drainPeriod after receiving numRecords records to ensure that no more records are received.
+// waitRecords waits for an additional drainPeriod after receiving numRecords records to ensure that no more records are received.
 // waitRecords returns an error if a different number of records is received.
 func (t testConsumer) waitRecords(numRecords int, waitTimeout, drainPeriod time.Duration) ([][]byte, error) {
 	var messages [][]byte

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -101,7 +101,7 @@ type readerTestCfg struct {
 	addr           string
 	topicName      string
 	partitionID    int32
-	consumer       RecordConsumer
+	consumer       recordConsumer
 	registry       *prometheus.Registry
 	logger         log.Logger
 	commitInterval time.Duration
@@ -115,7 +115,7 @@ func withCommitInterval(i time.Duration) func(cfg *readerTestCfg) {
 	}
 }
 
-func defaultReaderTestConfig(addr string, topicName string, partitionID int32, consumer RecordConsumer) *readerTestCfg {
+func defaultReaderTestConfig(addr string, topicName string, partitionID int32, consumer recordConsumer) *readerTestCfg {
 	return &readerTestCfg{
 		registry:       prometheus.NewPedanticRegistry(),
 		logger:         log.NewNopLogger(),
@@ -127,7 +127,7 @@ func defaultReaderTestConfig(addr string, topicName string, partitionID int32, c
 	}
 }
 
-func startReader(ctx context.Context, t *testing.T, addr string, topicName string, partitionID int32, consumer RecordConsumer, opts ...readerTestCfgOtp) *PartitionReader {
+func startReader(ctx context.Context, t *testing.T, addr string, topicName string, partitionID int32, consumer recordConsumer, opts ...readerTestCfgOtp) *PartitionReader {
 	cfg := defaultReaderTestConfig(addr, topicName, partitionID, consumer)
 	for _, o := range opts {
 		o(cfg)
@@ -260,9 +260,9 @@ func newTestConsumer(capacity int) testConsumer {
 	}
 }
 
-func (t testConsumer) Consume(_ context.Context, records []Record) error {
+func (t testConsumer) consume(_ context.Context, records []record) error {
 	for _, r := range records {
-		t.messages <- r.Content
+		t.messages <- r.content
 	}
 	return nil
 }

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -133,7 +133,7 @@ func startReader(ctx context.Context, t *testing.T, addr string, topicName strin
 	for _, o := range opts {
 		o(cfg)
 	}
-	reader, err := newReader(cfg.kafka, cfg.partitionID, cfg.consumer, cfg.logger, newReaderMetrics(partitionID, cfg.registry))
+	reader, err := newPartitionReader(cfg.kafka, cfg.partitionID, cfg.consumer, cfg.logger, newReaderMetrics(partitionID, cfg.registry))
 	require.NoError(t, err)
 	reader.commitInterval = cfg.commitInterval
 

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1,0 +1,293 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func TestReader(t *testing.T) {
+	const (
+		topicName   = "test"
+		partitionID = 1
+	)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	_, clusterAddr := createTestCluster(t, partitionID+1, topicName)
+
+	content := []byte("special content")
+	consumer := newTestConsumer(2)
+
+	startReader(t, ctx, clusterAddr, topicName, partitionID, consumer)
+
+	writeClient := newKafkaProduceClient(t, clusterAddr)
+
+	produceRecord(t, ctx, writeClient, topicName, partitionID, content)
+	produceRecord(t, ctx, writeClient, topicName, partitionID, content)
+
+	messages, err := consumer.waitRecords(2, 5*time.Second, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, [][]byte{content, content}, messages)
+}
+
+func TestReader_IgnoredConsumerErrors(t *testing.T) {
+	const (
+		topicName   = "test"
+		partitionID = 1
+	)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	_, clusterAddr := createTestCluster(t, partitionID+1, topicName)
+
+	content := []byte("special content")
+	consumer := newTestConsumer(1)
+	startReader(t, ctx, clusterAddr, topicName, partitionID, consumer)
+
+	// Write to Kafka.
+	writeClient := newKafkaProduceClient(t, clusterAddr)
+
+	produceRecord(t, ctx, writeClient, topicName, partitionID, content)
+
+	messages, err := consumer.waitRecords(1, time.Second, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, [][]byte{content}, messages)
+
+	produceRecord(t, ctx, writeClient, topicName, partitionID, content)
+
+	messages, err = consumer.waitRecords(1, time.Second, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, [][]byte{content}, messages)
+}
+
+func newKafkaProduceClient(t *testing.T, addrs string) *kgo.Client {
+	writeClient, err := kgo.NewClient(
+		kgo.SeedBrokers(addrs),
+		// We will choose the partition of each record.
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(writeClient.Close)
+	return writeClient
+}
+
+func produceRecord(t *testing.T, ctx context.Context, writeClient *kgo.Client, topicName string, partitionID int32, content []byte) {
+	rec := &kgo.Record{
+		Value:     content,
+		Topic:     topicName,
+		Partition: partitionID,
+	}
+	produceResult := writeClient.ProduceSync(ctx, rec)
+	require.NoError(t, produceResult.FirstErr())
+}
+
+type readerTestCfg struct {
+	addr           string
+	topicName      string
+	partitionID    int32
+	consumer       RecordConsumer
+	registry       *prometheus.Registry
+	logger         log.Logger
+	commitInterval time.Duration
+}
+
+type readerTestCfgOtp func(cfg *readerTestCfg)
+
+func withCommitInterval(i time.Duration) func(cfg *readerTestCfg) {
+	return func(cfg *readerTestCfg) {
+		cfg.commitInterval = i
+	}
+}
+
+func defaultTestConfig(addr string, topicName string, partitionID int32, consumer RecordConsumer) *readerTestCfg {
+	return &readerTestCfg{
+		registry:       prometheus.NewPedanticRegistry(),
+		logger:         log.NewLogfmtLogger(os.Stdout),
+		addr:           addr,
+		topicName:      topicName,
+		partitionID:    partitionID,
+		consumer:       consumer,
+		commitInterval: 10 * time.Second,
+	}
+}
+
+func startReader(t *testing.T, ctx context.Context, addr string, topicName string, partitionID int32, consumer RecordConsumer, opts ...readerTestCfgOtp) *PartitionReader {
+	cfg := defaultTestConfig(addr, topicName, partitionID, consumer)
+	for _, o := range opts {
+		o(cfg)
+	}
+	reader, err := newReader(cfg.addr, cfg.topicName, "", cfg.partitionID, cfg.consumer, cfg.logger, newReaderMetrics(partitionID, cfg.registry))
+	require.NoError(t, err)
+	reader.commitInterval = cfg.commitInterval
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+	t.Cleanup(func() { _ = services.StopAndAwaitTerminated(ctx, reader) })
+
+	return reader
+}
+
+func TestReader_Commit(t *testing.T) {
+	const (
+		topicName   = "test"
+		partitionID = 1
+	)
+
+	t.Run("resume at committed", func(t *testing.T) {
+		const commitInterval = 100 * time.Millisecond
+		ctx, cancel := context.WithCancelCause(context.Background())
+		t.Cleanup(func() { cancel(errors.New("test done")) })
+
+		cluster, clusterAddr := createTestCluster(t, partitionID+1, topicName)
+		addSupportForConsumerGroups(t, cluster, topicName, partitionID)
+
+		consumer := newTestConsumer(3)
+		reader := startReader(t, ctx, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+
+		produceRecord(t, ctx, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("1"))
+		produceRecord(t, ctx, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("2"))
+		produceRecord(t, ctx, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("3"))
+
+		_, err := consumer.waitRecords(3, time.Second, commitInterval*2) // wait for a few commits to make sure empty commits don't cause issues
+		require.NoError(t, err)
+
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+
+		messageSentAfterShutdown := []byte("4")
+		produceRecord(t, ctx, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, messageSentAfterShutdown)
+
+		startReader(t, ctx, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+
+		messages, err := consumer.waitRecords(1, time.Second, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, [][]byte{messageSentAfterShutdown}, messages)
+	})
+
+	t.Run("respect commit interval", func(t *testing.T) {
+		// a very long commit interval effectively means no commits
+		const commitInterval = time.Second * 15
+		ctx, cancel := context.WithCancelCause(context.Background())
+		t.Cleanup(func() { cancel(errors.New("test done")) })
+
+		cluster, clusterAddr := createTestCluster(t, partitionID+1, topicName)
+		addSupportForConsumerGroups(t, cluster, topicName, partitionID)
+
+		consumer := newTestConsumer(4)
+		reader := startReader(t, ctx, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+
+		produceRecord(t, ctx, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("1"))
+		produceRecord(t, ctx, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("2"))
+		produceRecord(t, ctx, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("3"))
+
+		_, err := consumer.waitRecords(3, time.Second, 0)
+		require.NoError(t, err)
+
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		produceRecord(t, ctx, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("4"))
+		startReader(t, ctx, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+
+		_, err = consumer.waitRecords(4, time.Second, 0)
+		assert.NoError(t, err)
+	})
+}
+
+// addSupportForConsumerGroups adds very bare-bones support for one consumer group.
+func addSupportForConsumerGroups(t *testing.T, cluster *kfake.Cluster, topicName string, partitionID int32) {
+	var committedOffset int64
+
+	cluster.ControlKey(kmsg.OffsetCommit.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		commitR := request.(*kmsg.OffsetCommitRequest)
+		assert.Equal(t, consumerGroup, commitR.Group)
+		assert.Len(t, commitR.Topics, 1)
+		topic := commitR.Topics[0]
+		assert.Equal(t, topicName, topic.Topic)
+		assert.Len(t, topic.Partitions, 1)
+		assert.EqualValues(t, partitionID, topic.Partitions[0].Partition)
+
+		committedOffset = topic.Partitions[0].Offset
+
+		resp := request.ResponseKind().(*kmsg.OffsetCommitResponse)
+		resp.Topics = []kmsg.OffsetCommitResponseTopic{{}}
+		resp.Topics[0].Topic = topicName
+		resp.Topics[0].Partitions = []kmsg.OffsetCommitResponseTopicPartition{{}}
+		resp.Topics[0].Partitions[0].Partition = partitionID
+		t.Log("recorded committed offset", committedOffset)
+		return resp, nil, true
+	})
+
+	cluster.ControlKey(kmsg.OffsetFetch.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		commitR := request.(*kmsg.OffsetFetchRequest)
+		assert.Len(t, commitR.Groups, 1)
+		assert.Equal(t, commitR.Groups[0].Group, consumerGroup)
+
+		resp := request.ResponseKind().(*kmsg.OffsetFetchResponse)
+		resp.Groups = []kmsg.OffsetFetchResponseGroup{{}}
+		resp.Groups[0].Group = consumerGroup
+		resp.Groups[0].Topics = []kmsg.OffsetFetchResponseGroupTopic{{}}
+		resp.Groups[0].Topics[0].Topic = topicName
+		resp.Groups[0].Topics[0].Partitions = []kmsg.OffsetFetchResponseGroupTopicPartition{{}}
+		resp.Groups[0].Topics[0].Partitions[0].Partition = partitionID
+		resp.Groups[0].Topics[0].Partitions[0].Offset = committedOffset
+		t.Log("responding with committed offset", committedOffset)
+		return resp, nil, true
+	})
+}
+
+type testConsumer struct {
+	messages chan []byte
+}
+
+func newTestConsumer(capacity int) testConsumer {
+	return testConsumer{
+		messages: make(chan []byte, capacity),
+	}
+}
+
+func (t testConsumer) Consume(_ context.Context, records []Record) error {
+	for _, r := range records {
+		t.messages <- r.Content
+	}
+	return nil
+}
+
+// waitRecords expects to receive numRecords records within waitTimeout.
+// waitRecords waits for drainPeriod after receiving numRecords records to ensure that no more records are received.
+// waitRecords returns an error if a different number of records is received.
+func (t testConsumer) waitRecords(numRecords int, waitTimeout, drainPeriod time.Duration) ([][]byte, error) {
+	var messages [][]byte
+	timeout := time.After(waitTimeout)
+	for {
+		select {
+		case msg := <-t.messages:
+			messages = append(messages, msg)
+			if len(messages) != numRecords {
+				continue
+			}
+			if drainPeriod == 0 {
+				return messages, nil
+			}
+			timeout = time.After(drainPeriod)
+		case <-timeout:
+			if len(messages) != numRecords {
+				return nil, fmt.Errorf("waiting for records: received %d, expected %d", len(messages), numRecords)
+			}
+			return messages, nil
+		}
+	}
+}

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -6,8 +6,12 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/regexp"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/plugin/kprom"
 )
 
 var (
@@ -56,4 +60,37 @@ func IngesterPartition(ingesterID string) (int32, error) {
 
 	partitionID := int32(ingesterSeq<<2) | (zoneID & 0b11)
 	return partitionID, nil
+}
+
+func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger) []kgo.Opt {
+	return []kgo.Opt{
+		kgo.ClientID(cfg.ClientID),
+		kgo.SeedBrokers(cfg.Address),
+		kgo.AllowAutoTopicCreation(),
+		kgo.DialTimeout(cfg.DialTimeout),
+
+		// A cluster metadata update is a request sent to a broker and getting back the map of partitions and
+		// the leader broker for each partition. The cluster metadata can be updated (a) periodically or
+		// (b) when some events occur (e.g. backoff due to errors).
+		//
+		// MetadataMinAge() sets the minimum time between two cluster metadata updates due to events.
+		// MetadataMaxAge() sets how frequently the periodic update should occur.
+		//
+		// It's important to note that the periodic update is also used to discover new brokers (e.g. during a
+		// rolling update or after a scale up). For this reason, it's important to run the update frequently.
+		//
+		// The other two side effects of frequently updating the cluster metadata:
+		// 1. The "metadata" request may be expensive to run on the Kafka backend.
+		// 2. If the backend returns each time a different authoritative owner for a partition, then each time
+		//    the cluster metadata is updated the Kafka client will create a new connection for each partition,
+		//    leading to a high connections churn rate.
+		//
+		// We currently set min and max age to the same value to have constant load on the Kafka backend: regardless
+		// there are errors or not, the metadata requests frequency doesn't change.
+		kgo.MetadataMinAge(10 * time.Second),
+		kgo.MetadataMaxAge(10 * time.Second),
+
+		kgo.WithHooks(metrics),
+		kgo.WithLogger(newKafkaLogger(logger)),
+	}
 }

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -10,8 +10,20 @@ import (
 	"github.com/grafana/regexp"
 )
 
-// Regular expression used to parse the ingester numeric ID.
-var ingesterIDRegexp = regexp.MustCompile("-(zone-.-)?([0-9]+)$")
+var (
+	// Regular expression used to parse the ingester numeric ID.
+	ingesterIDRegexp = regexp.MustCompile("-(zone-.-)?([0-9]+)$")
+
+	// The Prometheus summary objectives used when tracking latency.
+	latencySummaryObjectives = map[float64]float64{
+		0.5:   0.05,
+		0.90:  0.01,
+		0.99:  0.001,
+		0.995: 0.001,
+		0.999: 0.001,
+		1:     0.001,
+	}
+)
 
 // IngesterPartition returns the partition ID to use to write to a specific ingester partition.
 // The input ingester ID is expected to end either with "zone-X-Y" or only "-Y" where "X" is a letter in the range [a,d]

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -380,6 +380,8 @@ func createTestCluster(t *testing.T, numPartitions int32, topicName string) (*kf
 	addrs := cluster.ListenAddrs()
 	require.Len(t, addrs, 1)
 
+	addSupportForConsumerGroups(t, cluster, topicName, numPartitions)
+
 	return cluster, addrs[0]
 }
 

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/LICENSE
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2020, Travis Bischel.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the library nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/acls.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/acls.go
@@ -1,0 +1,1109 @@
+package kadm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// ACLBuilder is a builder that is used for batch creating / listing / deleting
+// ACLS.
+//
+// An ACL consists of five components:
+//
+//   - the user (principal)
+//   - the host the user runs on
+//   - what resource to access (topic name, group id, etc.)
+//   - the operation (read, write)
+//   - whether to allow or deny the above
+//
+// This builder allows for adding the above five components in batches and then
+// creating, listing, or deleting a batch of ACLs in one go. This builder
+// merges the fifth component (allowing or denying) into allowing principals
+// and hosts and denying principals and hosts. The builder must always have an
+// Allow or Deny. For creating, the host is optional and defaults to the
+// wildcard * that allows or denies all hosts. For listing / deleting, the host
+// is also required (specifying no hosts matches all hosts, but you must
+// specify this).
+//
+// Building works on a multiplying factor: every user, every host, every
+// resource, and every operation is combined (principals * hosts * resources *
+// operations).
+//
+// With the Kafka simple authorizer (and most reimplementations), all
+// principals are required to have the "User:" prefix. The PrefixUserExcept
+// function can be used to easily add the "User:" prefix if missing.
+//
+// The full set of operations and which requests require what operations is
+// described in a large doc comment on the ACLOperation type.
+//
+// Lastly, resources to access / deny access to can be created / matched based
+// on literal (exact) names, or on prefix names, or more. See the ACLPattern
+// docs for more information.
+type ACLBuilder struct {
+	any         []string
+	anyResource bool
+	topics      []string
+	anyTopic    bool
+	groups      []string
+	anyGroup    bool
+	anyCluster  bool
+	txnIDs      []string
+	anyTxn      bool
+	tokens      []string
+	anyToken    bool
+
+	allow         []string
+	anyAllow      bool
+	allowHosts    []string
+	anyAllowHosts bool
+	deny          []string
+	anyDeny       bool
+	denyHosts     []string
+	anyDenyHosts  bool
+
+	ops []ACLOperation
+
+	pattern ACLPattern
+}
+
+// PrefixUser prefixes all allowed and denied principals with "User:".
+func (b *ACLBuilder) PrefixUser() {
+	b.PrefixUserExcept()
+}
+
+// PrefixUserExcept prefixes all allowed and denied principals with "User:",
+// unless they have any of the given except prefixes.
+func (b *ACLBuilder) PrefixUserExcept(except ...string) {
+	replace := func(u string) string {
+		if !strings.HasPrefix(u, "User:") {
+			for _, e := range except {
+				if strings.HasPrefix(u, e) {
+					return u
+				}
+			}
+			return "User:" + u
+		}
+		return u
+	}
+
+	for i, u := range b.allow {
+		b.allow[i] = replace(u)
+	}
+	for i, u := range b.deny {
+		b.deny[i] = replace(u)
+	}
+}
+
+// NewACLs returns a new ACL builder.
+func NewACLs() *ACLBuilder {
+	return new(ACLBuilder)
+}
+
+// AnyResource lists & deletes ACLs of any type matching the given names
+// (pending other filters). If no names are given, this matches all names.
+//
+// This returns the input pointer.
+//
+// This function does nothing for creating.
+func (b *ACLBuilder) AnyResource(name ...string) *ACLBuilder {
+	b.any = name
+	if len(name) == 0 {
+		b.anyResource = true
+	}
+	return b
+}
+
+// Topics lists/deletes/creates ACLs of resource type "topic" for the given
+// topics.
+//
+// This returns the input pointer.
+//
+// For listing or deleting, if this is provided no topics, all "topic" resource
+// type ACLs are matched. For creating, if no topics are provided, this
+// function does nothing.
+func (b *ACLBuilder) Topics(t ...string) *ACLBuilder {
+	b.topics = t
+	if len(t) == 0 {
+		b.anyTopic = true
+	}
+	return b
+}
+
+// MaybeTopics is the same as Topics, but does not match all topics if none are
+// provided.
+func (b *ACLBuilder) MaybeTopics(t ...string) *ACLBuilder { b.topics = t; return b }
+
+// Groups lists/deletes/creates ACLs of resource type "group" for the given
+// groups.
+//
+// This returns the input pointer.
+//
+// For listing or deleting, if this is provided no groups, all "group" resource
+// type ACLs are matched. For creating, if no groups are provided, this
+// function does nothing.
+func (b *ACLBuilder) Groups(g ...string) *ACLBuilder {
+	b.groups = g
+	if len(g) == 0 {
+		b.anyGroup = true
+	}
+	return b
+}
+
+// MaybeGroups is the same as Groups, but does not match all groups if none are
+// provided.
+func (b *ACLBuilder) MaybeGroups(g ...string) *ACLBuilder { b.groups = g; return b }
+
+// Clusters lists/deletes/creates ACLs of resource type "cluster".
+//
+// This returns the input pointer.
+//
+// There is only one type of cluster in Kafka, "kafka-cluster". Opting in to
+// listing or deleting by cluster inherently matches all ACLS of resource type
+// cluster. For creating, this function allows for creating cluster ACLs.
+func (b *ACLBuilder) Clusters() *ACLBuilder {
+	b.anyCluster = true
+	return b
+}
+
+// MaybeClusters is the same as Clusters, but only matches clusters if c is
+// true.
+func (b *ACLBuilder) MaybeClusters(c bool) *ACLBuilder { b.anyCluster = c; return b }
+
+// TransactionalIDs lists/deletes/creates ACLs of resource type
+// "transactional_id" for the given transactional IDs.
+//
+// This returns the input pointer.
+//
+// For listing or deleting, if this is provided no IDs, all "transactional_id"
+// resource type ACLs matched. For creating, if no IDs are provided, this
+// function does nothing.
+func (b *ACLBuilder) TransactionalIDs(x ...string) *ACLBuilder {
+	b.txnIDs = x
+	if len(x) == 0 {
+		b.anyTxn = true
+	}
+	return b
+}
+
+// MaybeTransactionalIDs is the same as TransactionalIDs, but does not match
+// all transactional ID's if none are provided.
+func (b *ACLBuilder) MaybeTransactionalIDs(x ...string) *ACLBuilder { b.txnIDs = x; return b }
+
+// DelegationTokens lists/deletes/creates ACLs of resource type
+// "delegation_token" for the given delegation tokens.
+//
+// This returns the input pointer.
+//
+// For listing or deleting, if this is provided no tokens, all
+// "delegation_token" resource type ACLs are matched. For creating, if no
+// tokens are provided, this function does nothing.
+func (b *ACLBuilder) DelegationTokens(t ...string) *ACLBuilder {
+	b.tokens = t
+	if len(t) == 0 {
+		b.anyToken = true
+	}
+	return b
+}
+
+// MaybeDelegationTokens is the same as DelegationTokens, but does not match
+// all tokens if none are provided.
+func (b *ACLBuilder) MaybeDelegationTokens(t ...string) *ACLBuilder { b.tokens = t; return b }
+
+// Allow sets the principals to add allow permissions for. For listing and
+// deleting, you must also use AllowHosts.
+//
+// This returns the input pointer.
+//
+// For creating, if this is not paired with AllowHosts, the user will have
+// access to all hosts (the wildcard *).
+//
+// For listing & deleting, if the principals are empty, this matches any user.
+func (b *ACLBuilder) Allow(principals ...string) *ACLBuilder {
+	b.allow = principals
+	if len(principals) == 0 {
+		b.anyAllow = true
+	}
+	return b
+}
+
+// MaybeAllow is the same as Allow, but does not match all allowed principals
+// if none are provided.
+func (b *ACLBuilder) MaybeAllow(principals ...string) *ACLBuilder { b.allow = principals; return b }
+
+// AllowHosts sets the hosts to add allow permissions for. If using this, you
+// must also use Allow.
+//
+// This returns the input pointer.
+//
+// For creating, if this is empty, the user will have access to all hosts (the
+// wildcard *) and this function is actually not necessary.
+//
+// For listing & deleting, if the hosts are empty, this matches any host.
+func (b *ACLBuilder) AllowHosts(hosts ...string) *ACLBuilder {
+	b.allowHosts = hosts
+	if len(hosts) == 0 {
+		b.anyAllowHosts = true
+	}
+	return b
+}
+
+// MaybeAllowHosts is the same as AllowHosts, but does not match all allowed
+// hosts if none are provided.
+func (b *ACLBuilder) MaybeAllowHosts(hosts ...string) *ACLBuilder { b.allowHosts = hosts; return b }
+
+// Deny sets the principals to add deny permissions for. For listing and
+// deleting, you must also use DenyHosts.
+//
+// This returns the input pointer.
+//
+// For creating, if this is not paired with DenyHosts, the user will be denied
+// access to all hosts (the wildcard *).
+//
+// For listing & deleting, if the principals are empty, this matches any user.
+func (b *ACLBuilder) Deny(principals ...string) *ACLBuilder {
+	b.deny = principals
+	if len(principals) == 0 {
+		b.anyDeny = true
+	}
+	return b
+}
+
+// MaybeDeny is the same as Deny, but does not match all denied principals if
+// none are provided.
+func (b *ACLBuilder) MaybeDeny(principals ...string) *ACLBuilder { b.deny = principals; return b }
+
+// DenyHosts sets the hosts to add deny permissions for. If using this, you
+// must also use Deny.
+//
+// This returns the input pointer.
+//
+// For creating, if this is empty, the user will be denied access to all hosts
+// (the wildcard *) and this function is actually not necessary.
+//
+// For listing & deleting, if the hosts are empty, this matches any host.
+func (b *ACLBuilder) DenyHosts(hosts ...string) *ACLBuilder {
+	b.denyHosts = hosts
+	if len(hosts) == 0 {
+		b.anyDenyHosts = true
+	}
+	return b
+}
+
+// MaybeDenyHosts is the same as DenyHosts, but does not match all denied
+// hosts if none are provided.
+func (b *ACLBuilder) MaybeDenyHosts(hosts ...string) *ACLBuilder { b.denyHosts = hosts; return b }
+
+// ACLOperation is a type alias for kmsg.ACLOperation, which is an enum
+// containing all Kafka ACL operations and has helper functions.
+//
+// Kafka requests require the following operations (broker <=> broker ACLs
+// elided):
+//
+//	PRODUCING/CONSUMING
+//	===================
+//	Produce      WRITE on TOPIC for topics
+//	             WRITE on TRANSACTIONAL_ID for txn id (if transactionally producing)
+//
+//	Fetch        READ on TOPIC for topics
+//
+//	ListOffsets  DESCRIBE on TOPIC for topics
+//
+//	Metadata     DESCRIBE on TOPIC for topics
+//	             CREATE on CLUSTER for kafka-cluster (if automatically creating new topics)
+//	             CREATE on TOPIC for topics (if automatically creating new topics)
+//
+//	OffsetForLeaderEpoch  DESCRIBE on TOPIC for topics
+//
+//	GROUPS
+//	======
+//	FindCoordinator  DESCRIBE on GROUP for group (if finding group coordinator)
+//	                 DESCRIBE on TRANSACTIONAL_ID for id (if finding transactiona coordinator)
+//
+//	OffsetCommit     READ on GROUP for group
+//	                 READ on TOPIC for topics
+//
+//	OffsetFetch      DESCRIBE on GROUP for group
+//	                 DESCRIBE on TOPIC for topics
+//
+//	OffsetDelete     DELETE on GROUP For group
+//	                 READ on TOPIC for topics
+//
+//	JoinGroup        READ on GROUP for group
+//	Heartbeat        READ on GROUP for group
+//	LeaveGroup       READ on GROUP for group
+//	SyncGroup        READ on GROUP for group
+//
+//	DescribeGroup    DESCRIBE on GROUP for groups
+//
+//	ListGroups       DESCRIBE on GROUP for groups
+//	                 or, DESCRIBE on CLUSTER for kafka-cluster
+//
+//	DeleteGroups     DELETE on GROUP for groups
+//
+//	TRANSACTIONS (including FindCoordinator above)
+//	============
+//	InitProducerID      WRITE on TRANSACTIONAL_ID for id, if using transactions
+//	                    or, IDEMPOTENT_WRITE on CLUSTER for kafka-cluster, if pre Kafka 3.0
+//	                    or, WRITE on TOPIC for any topic, if Kafka 3.0+
+//
+//	AddPartitionsToTxn  WRITE on TRANSACTIONAL_ID for id
+//	                    WRITE on TOPIC for topics
+//
+//	AddOffsetsToTxn     WRITE on TRANSACTIONAL_ID for id
+//	                    READ on GROUP for group
+//
+//	EndTxn              WRITE on TRANSACTIONAL_ID for id
+//
+//	TxnOffsetCommit     WRITE on TRANSACTIONAL_ID for id
+//	                    READ on GROUP for group
+//	                    READ on TOPIC for topics
+//
+//	TOPIC ADMIN
+//	===========
+//	CreateTopics      CREATE on CLUSTER for kafka-cluster
+//	                  CREATE on TOPIC for topics
+//	                  DESCRIBE_CONFIGS on TOPIC for topics, for returning topic configs on create
+//
+//	CreatePartitions  ALTER on TOPIC for topics
+//
+//	DeleteTopics      DELETE on TOPIC for topics
+//	                  DESCRIBE on TOPIC for topics, if deleting by topic id (in addition to prior ACL)
+//
+//	DeleteRecords     DELETE on TOPIC for topics
+//
+//	CONFIG ADMIN
+//	============
+//	DescribeConfigs          DESCRIBE_CONFIGS on CLUSTER for kafka-cluster, for broker or broker-logger describing
+//	                         DESCRIBE_CONFIGS on TOPIC for topics, for topic describing
+//
+//	AlterConfigs             ALTER_CONFIGS on CLUSTER for kafka-cluster, for broker altering
+//	                         ALTER_CONFIGS on TOPIC for topics, for topic altering
+//
+//	IncrementalAlterConfigs  ALTER_CONFIGS on CLUSTER for kafka-cluster, for broker or broker-logger altering
+//	                         ALTER_CONFIGS on TOPIC for topics, for topic altering
+//
+//
+//	MISC ADMIN
+//	==========
+//	AlterReplicaLogDirs  ALTER on CLUSTER for kafka-cluster
+//	DescribeLogDirs      DESCRIBE on CLUSTER for kafka-cluster
+//
+//	AlterPartitionAssignments   ALTER on CLUSTER for kafka-cluster
+//	ListPartitionReassignments  DESCRIBE on CLUSTER for kafka-cluster
+//
+//	DescribeDelegationTokens    DESCRIBE on DELEGATION_TOKEN for id
+//
+//	ElectLeaders          ALTER on CLUSTER for kafka-cluster
+//
+//	DescribeClientQuotas  DESCRIBE_CONFIGS on CLUSTER for kafka-cluster
+//	AlterClientQuotas     ALTER_CONFIGS on CLUSTER for kafka-cluster
+//
+//	DescribeUserScramCredentials  DESCRIBE on CLUSTER for kafka-cluster
+//	AlterUserScramCredentials     ALTER on CLUSTER for kafka-cluster
+//
+//	UpdateFeatures        ALTER on CLUSTER for kafka-cluster
+//
+//	DescribeCluster       DESCRIBE on CLUSTER for kafka-cluster
+//
+//	DescribeProducerIDs   READ on TOPIC for topics
+//	DescribeTransactions  DESCRIBE on TRANSACTIONAL_ID for ids
+//	                      DESCRIBE on TOPIC for topics
+//	ListTransactions      DESCRIBE on TRANSACTIONAL_ID for ids
+type ACLOperation = kmsg.ACLOperation
+
+const (
+	// OpUnknown is returned for unknown operations.
+	OpUnknown ACLOperation = kmsg.ACLOperationUnknown
+
+	// OpAny, used for listing and deleting, matches any operation.
+	OpAny ACLOperation = kmsg.ACLOperationAny
+
+	// OpAll is a shortcut for allowing / denying all operations.
+	OpAll ACLOperation = kmsg.ACLOperationAll
+
+	// OpRead is the READ operation.
+	OpRead ACLOperation = kmsg.ACLOperationRead
+
+	// OpWrite is the WRITE operation.
+	OpWrite ACLOperation = kmsg.ACLOperationWrite
+
+	// OpCreate is the CREATE operation.
+	OpCreate ACLOperation = kmsg.ACLOperationCreate
+
+	// OpDelete is the DELETE operation.
+	OpDelete ACLOperation = kmsg.ACLOperationDelete
+
+	// OpAlter is the ALTER operation.
+	OpAlter ACLOperation = kmsg.ACLOperationAlter
+
+	// OpDescribe is the DESCRIBE operation.
+	OpDescribe ACLOperation = kmsg.ACLOperationDescribe
+
+	// OpClusterAction is the CLUSTER_ACTION operation. This operation is
+	// used for any broker<=>broker communication and is not needed by
+	// clients.
+	OpClusterAction ACLOperation = kmsg.ACLOperationClusterAction
+
+	// OpDescribeConfigs is the DESCRIBE_CONFIGS operation.
+	OpDescribeConfigs ACLOperation = kmsg.ACLOperationDescribeConfigs
+
+	// OpAlterConfigs is the ALTER_CONFIGS operation.
+	OpAlterConfigs ACLOperation = kmsg.ACLOperationAlterConfigs
+
+	// OpIdempotentWrite is the IDEMPOTENT_WRITE operation. As of Kafka
+	// 3.0+, this has been deprecated and replaced by the ability to WRITE
+	// on any topic.
+	OpIdempotentWrite ACLOperation = kmsg.ACLOperationIdempotentWrite
+)
+
+// Operations sets operations to allow or deny. Passing no operations defaults
+// to OpAny.
+//
+// This returns the input pointer.
+//
+// For creating, OpAny returns an error, for it is strictly used for filters
+// (listing & deleting).
+func (b *ACLBuilder) Operations(operations ...ACLOperation) *ACLBuilder {
+	b.ops = operations
+	if len(operations) == 0 {
+		b.ops = []ACLOperation{OpAny}
+	}
+	return b
+}
+
+// MaybeOperations is the same as Operations, but does not match all operations
+// if none are provided.
+func (b *ACLBuilder) MaybeOperations(operations ...ACLOperation) *ACLBuilder {
+	if len(operations) > 0 {
+		b.Operations(operations...)
+	}
+	return b
+}
+
+// ACLPattern is a type alias for kmsg.ACLResourcePatternType, which is an enum
+// containing all Kafka ACL resource pattern options.
+//
+// Creating/listing/deleting ACLs works on a resource name basis: every ACL
+// created has a name, and every ACL filtered for listing / deleting matches by
+// name. The name by default is "literal", meaning created ACLs will have the
+// exact name, and matched ACLs must match completely.
+//
+// Prefixed names allow for creating an ACL that matches any prefix: principals
+// foo-bar and foo-baz both have the prefix "foo-", meaning a READ on TOPIC for
+// User:foo- with prefix pattern will allow both of those principals to read
+// the topic.
+//
+// Any and match are used for listing and deleting. Any will match any name, be
+// it literal or prefix or a wildcard name. There is no need for specifying
+// topics, groups, etc. when using any resource pattern.
+//
+// Alternatively, match requires a name, but it matches any literal name (exact
+// match), any prefix, and any wildcard.
+type ACLPattern = kmsg.ACLResourcePatternType
+
+const (
+	// ACLPatternUnknown is returned for unknown patterns.
+	ACLPatternUnknown ACLPattern = kmsg.ACLResourcePatternTypeUnknown
+
+	// ACLPatternAny is the ANY resource pattern.
+	ACLPatternAny ACLPattern = kmsg.ACLResourcePatternTypeAny
+
+	// ACLPatternMatch is the MATCH resource pattern.
+	ACLPatternMatch ACLPattern = kmsg.ACLResourcePatternTypeMatch
+
+	// ACLPatternLiteral is the LITERAL resource pattern, the default.
+	ACLPatternLiteral ACLPattern = kmsg.ACLResourcePatternTypeLiteral
+
+	// ACLPatternPrefixed is the PREFIXED resource pattern.
+	ACLPatternPrefixed ACLPattern = kmsg.ACLResourcePatternTypePrefixed
+)
+
+// ResourcePatternType sets the pattern type to use when creating or filtering
+// ACL resource names, overriding the default of LITERAL.
+//
+// This returns the input pointer.
+//
+// For creating, only LITERAL and PREFIXED are supported.
+func (b *ACLBuilder) ResourcePatternType(pattern ACLPattern) *ACLBuilder {
+	b.pattern = pattern
+	return b
+}
+
+// ValidateCreate returns an error if the builder is invalid for creating ACLs.
+func (b *ACLBuilder) ValidateCreate() error {
+	for _, op := range b.ops {
+		switch op {
+		case OpAny, OpUnknown:
+			return fmt.Errorf("invalid operation %s for creating ACLs", op)
+		}
+	}
+
+	switch b.pattern {
+	case ACLPatternLiteral, ACLPatternPrefixed:
+	default:
+		return fmt.Errorf("invalid acl resource pattern %s for creating ACLs", b.pattern)
+	}
+
+	if len(b.allowHosts) != 0 && len(b.allow) == 0 {
+		return fmt.Errorf("invalid allow hosts with no allow principals")
+	}
+	if len(b.denyHosts) != 0 && len(b.deny) == 0 {
+		return fmt.Errorf("invalid deny hosts with no deny principals")
+	}
+	return nil
+}
+
+// ValidateDelete is an alias for ValidateFilter.
+func (b *ACLBuilder) ValidateDelete() error { return b.ValidateFilter() }
+
+// ValidateDescribe is an alias for ValidateFilter.
+func (b *ACLBuilder) ValidateDescribe() error { return b.ValidateFilter() }
+
+// ValidateFilter returns an error if the builder is invalid for deleting or
+// describing ACLs (which both operate on a filter basis).
+func (b *ACLBuilder) ValidateFilter() error {
+	if len(b.allowHosts) != 0 && len(b.allow) == 0 && !b.anyAllow {
+		return fmt.Errorf("invalid allow hosts with no allow principals")
+	}
+	if len(b.allow) != 0 && len(b.allowHosts) == 0 && !b.anyAllowHosts {
+		return fmt.Errorf("invalid allow principals with no allow hosts")
+	}
+	if len(b.denyHosts) != 0 && len(b.deny) == 0 && !b.anyDeny {
+		return fmt.Errorf("invalid deny hosts with no deny principals")
+	}
+	if len(b.deny) != 0 && len(b.denyHosts) == 0 && !b.anyDenyHosts {
+		return fmt.Errorf("invalid deny principals with no deny hosts")
+	}
+	return nil
+}
+
+// HasAnyFilter returns whether any field in this builder is opted into "any",
+// meaning a wide glob. This would be if you used Topics with no topics, and so
+// on. This function can be used to detect if you accidentally opted into a
+// non-specific ACL.
+//
+// The evaluated fields are: resources, principals/hosts, a single OpAny
+// operation, and an Any pattern.
+func (b *ACLBuilder) HasAnyFilter() bool {
+	return b.anyResource ||
+		b.anyTopic ||
+		b.anyGroup ||
+		b.anyTxn ||
+		b.anyToken ||
+		b.anyAllow ||
+		b.anyAllowHosts ||
+		b.anyDeny ||
+		b.anyDenyHosts ||
+		b.hasOpAny() ||
+		b.pattern == ACLPatternAny
+}
+
+func (b *ACLBuilder) hasOpAny() bool {
+	for _, op := range b.ops {
+		if op == OpAny {
+			return true
+		}
+	}
+	return false
+}
+
+// HasResource returns true if the builder has a non-empty resource (topic,
+// group, ...), or if any resource has "any" set to true.
+func (b *ACLBuilder) HasResource() bool {
+	l := len(b.any) +
+		len(b.topics) +
+		len(b.groups) +
+		len(b.txnIDs) +
+		len(b.tokens)
+	return l > 0 ||
+		b.anyResource ||
+		b.anyTopic ||
+		b.anyGroup ||
+		b.anyCluster ||
+		b.anyTxn ||
+		b.anyToken
+}
+
+// HasPrincipals returns if any allow or deny principals have been set, or if
+// their "any" field is true.
+func (b *ACLBuilder) HasPrincipals() bool {
+	return len(b.allow) > 0 ||
+		b.anyAllow ||
+		len(b.deny) > 0 ||
+		b.anyDeny
+}
+
+// HasHosts returns if any allow or deny hosts have been set, or if their "any"
+// field is true.
+func (b *ACLBuilder) HasHosts() bool {
+	return len(b.allowHosts) > 0 ||
+		b.anyAllowHosts ||
+		len(b.denyHosts) > 0 ||
+		b.anyDenyHosts
+}
+
+func (b *ACLBuilder) dup() *ACLBuilder { // shallow copy
+	d := *b
+	return &d
+}
+
+// CreateACLsResult is a result for an individual ACL creation.
+type CreateACLsResult struct {
+	Principal string
+	Host      string
+
+	Type       kmsg.ACLResourceType   // Type is the type of resource this is.
+	Name       string                 // Name is the name of the resource allowed / denied.
+	Pattern    ACLPattern             // Pattern is the name pattern.
+	Operation  ACLOperation           // Operation is the operation allowed / denied.
+	Permission kmsg.ACLPermissionType // Permission is whether this is allowed / denied.
+
+	Err error // Err is the error for this ACL creation.
+}
+
+// CreateACLsResults contains all results to created ACLs.
+type CreateACLsResults []CreateACLsResult
+
+// CreateACLs creates a batch of ACLs using the ACL builder, validating the
+// input before issuing the CreateACLs request.
+//
+// If the input is invalid, or if the response fails, or if the response does
+// not contain as many ACLs as we issued in our create request, this returns an
+// error.
+func (cl *Client) CreateACLs(ctx context.Context, b *ACLBuilder) (CreateACLsResults, error) {
+	if err := b.ValidateCreate(); err != nil {
+		return nil, err
+	}
+	if len(b.allow) != 0 && len(b.allowHosts) == 0 {
+		b.allowHosts = []string{"*"}
+	}
+	if len(b.deny) != 0 && len(b.denyHosts) == 0 {
+		b.denyHosts = []string{"*"}
+	}
+
+	var clusters []string
+	if b.anyCluster {
+		clusters = []string{"kafka-cluster"}
+	}
+
+	req := kmsg.NewPtrCreateACLsRequest()
+	for _, typeNames := range []struct {
+		t     kmsg.ACLResourceType
+		names []string
+	}{
+		{kmsg.ACLResourceTypeTopic, b.topics},
+		{kmsg.ACLResourceTypeGroup, b.groups},
+		{kmsg.ACLResourceTypeCluster, clusters},
+		{kmsg.ACLResourceTypeTransactionalId, b.txnIDs},
+		{kmsg.ACLResourceTypeDelegationToken, b.tokens},
+	} {
+		for _, name := range typeNames.names {
+			for _, op := range b.ops {
+				for _, perm := range []struct {
+					principals []string
+					hosts      []string
+					permType   kmsg.ACLPermissionType
+				}{
+					{b.allow, b.allowHosts, kmsg.ACLPermissionTypeAllow},
+					{b.deny, b.denyHosts, kmsg.ACLPermissionTypeDeny},
+				} {
+					for _, principal := range perm.principals {
+						for _, host := range perm.hosts {
+							c := kmsg.NewCreateACLsRequestCreation()
+							c.ResourceType = typeNames.t
+							c.ResourceName = name
+							c.ResourcePatternType = b.pattern
+							c.Operation = op
+							c.Principal = principal
+							c.Host = host
+							c.PermissionType = perm.permType
+							req.Creations = append(req.Creations, c)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Results) != len(req.Creations) {
+		return nil, fmt.Errorf("received %d results to %d creations", len(resp.Results), len(req.Creations))
+	}
+
+	var rs CreateACLsResults
+	for i, r := range resp.Results {
+		c := &req.Creations[i]
+		rs = append(rs, CreateACLsResult{
+			Principal: c.Principal,
+			Host:      c.Host,
+
+			Type:       c.ResourceType,
+			Name:       c.ResourceName,
+			Pattern:    c.ResourcePatternType,
+			Operation:  c.Operation,
+			Permission: c.PermissionType,
+
+			Err: kerr.ErrorForCode(r.ErrorCode),
+		})
+	}
+
+	return rs, nil
+}
+
+// DeletedACL an ACL that was deleted.
+type DeletedACL struct {
+	Principal string // Principal is this deleted ACL's principal.
+	Host      string // Host is this deleted ACL's host.
+
+	Type       kmsg.ACLResourceType   // Type is this deleted ACL's resource type.
+	Name       string                 // Name is this deleted ACL's resource name.
+	Pattern    ACLPattern             // Pattern is this deleted ACL's resource name pattern.
+	Operation  ACLOperation           // Operation is this deleted ACL's operation.
+	Permission kmsg.ACLPermissionType // Permission this deleted ACLs permission.
+
+	Err error // Err is non-nil if this match has an error.
+}
+
+// DeletedACLs contains ACLs that were deleted from a single delete filter.
+type DeletedACLs []DeletedACL
+
+// DeleteACLsResult contains the input used for a delete ACL filter, and the
+// deletes that the filter matched or the error for this filter.
+//
+// All fields but Deleted and Err are set from the request input. The response
+// sets either Deleted (potentially to nothing if the filter matched nothing)
+// or Err.
+type DeleteACLsResult struct {
+	Principal *string // Principal is the optional user that was used in this filter.
+	Host      *string // Host is the optional host that was used in this filter.
+
+	Type       kmsg.ACLResourceType   // Type is the type of resource used for this filter.
+	Name       *string                // Name is the name of the resource used for this filter.
+	Pattern    ACLPattern             // Pattern is the name pattern used for this filter.
+	Operation  ACLOperation           // Operation is the operation used for this filter.
+	Permission kmsg.ACLPermissionType // Permission is permission used for this filter.
+
+	Deleted DeletedACLs // Deleted contains all ACLs this delete filter matched.
+
+	Err error // Err is non-nil if this filter has an error.
+}
+
+// DeleteACLsResults contains all results to deleted ACLs.
+type DeleteACLsResults []DeleteACLsResult
+
+// DeleteACLs deletes a batch of ACLs using the ACL builder, validating the
+// input before issuing the DeleteACLs request.
+//
+// If the input is invalid, or if the response fails, or if the response does
+// not contain as many ACL results as we issued in our delete request, this
+// returns an error.
+//
+// Deleting ACLs works on a filter basis: a single filter can match many ACLs.
+// For example, deleting with operation ANY matches any operation. For safety /
+// verification purposes, you an DescribeACLs with the same builder first to
+// see what would be deleted.
+func (cl *Client) DeleteACLs(ctx context.Context, b *ACLBuilder) (DeleteACLsResults, error) {
+	dels, _, err := createDelDescACL(b)
+	if err != nil {
+		return nil, err
+	}
+
+	req := kmsg.NewPtrDeleteACLsRequest()
+	req.Filters = dels
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Results) != len(req.Filters) {
+		return nil, fmt.Errorf("received %d results to %d filters", len(resp.Results), len(req.Filters))
+	}
+
+	var rs DeleteACLsResults
+	for i, r := range resp.Results {
+		f := &req.Filters[i]
+		var ms DeletedACLs
+		for _, m := range r.MatchingACLs {
+			ms = append(ms, DeletedACL{
+				Principal:  m.Principal,
+				Host:       m.Host,
+				Type:       m.ResourceType,
+				Name:       m.ResourceName,
+				Pattern:    m.ResourcePatternType,
+				Operation:  m.Operation,
+				Permission: m.PermissionType,
+				Err:        kerr.ErrorForCode(m.ErrorCode),
+			})
+		}
+		rs = append(rs, DeleteACLsResult{
+			Principal:  f.Principal,
+			Host:       f.Host,
+			Type:       f.ResourceType,
+			Name:       f.ResourceName,
+			Pattern:    f.ResourcePatternType,
+			Operation:  f.Operation,
+			Permission: f.PermissionType,
+			Deleted:    ms,
+			Err:        kerr.ErrorForCode(r.ErrorCode),
+		})
+	}
+	return rs, nil
+}
+
+// DescribedACL is an ACL that was described.
+type DescribedACL struct {
+	Principal string // Principal is this described ACL's principal.
+	Host      string // Host is this described ACL's host.
+
+	Type       kmsg.ACLResourceType   // Type is this described ACL's resource type.
+	Name       string                 // Name is this described ACL's resource name.
+	Pattern    ACLPattern             // Pattern is this described ACL's resource name pattern.
+	Operation  ACLOperation           // Operation is this described ACL's operation.
+	Permission kmsg.ACLPermissionType // Permission this described ACLs permission.
+}
+
+// DescribedACLs contains ACLs that were described from a single describe
+// filter.
+type DescribedACLs []DescribedACL
+
+// DescribeACLsResults contains the input used for a describe ACL filter, and
+// the describes that the filter matched or the error for this filter.
+//
+// All fields but Described and Err are set from the request input. The
+// response sets either Described (potentially to nothing if the filter matched
+// nothing) or Err.
+type DescribeACLsResult struct {
+	Principal *string // Principal is the optional user that was used in this filter.
+	Host      *string // Host is the optional host that was used in this filter.
+
+	Type       kmsg.ACLResourceType   // Type is the type of resource used for this filter.
+	Name       *string                // Name is the name of the resource used for this filter.
+	Pattern    ACLPattern             // Pattern is the name pattern used for this filter.
+	Operation  ACLOperation           // Operation is the operation used for this filter.
+	Permission kmsg.ACLPermissionType // Permission is permission used for this filter.
+
+	Described DescribedACLs // Described contains all ACLs this describe filter matched.
+
+	Err error // Err is non-nil if this filter has an error.
+}
+
+// DescribeACLsResults contains all results to described ACLs.
+type DescribeACLsResults []DescribeACLsResult
+
+// DescribeACLs describes a batch of ACLs using the ACL builder, validating the
+// input before issuing DescribeACLs requests.
+//
+// If the input is invalid, or if any response fails, this returns an error.
+//
+// Listing ACLs works on a filter basis: a single filter can match many ACLs.
+// For example, describing with operation ANY matches any operation. Under the
+// hood, this method issues one describe request per filter, because describing
+// ACLs does not work on a batch basis (unlike creating & deleting). The return
+// of this function can be used to see what would be deleted given the same
+// builder input.
+func (cl *Client) DescribeACLs(ctx context.Context, b *ACLBuilder) (DescribeACLsResults, error) {
+	_, descs, err := createDelDescACL(b)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		ictx, cancel = context.WithCancel(ctx)
+		mu           sync.Mutex
+		wg           sync.WaitGroup
+		firstErr     error
+		resps        = make([]*kmsg.DescribeACLsResponse, len(descs))
+	)
+	defer cancel()
+	for i := range descs {
+		req := descs[i] // each req is unique per loop, we are not reusing req, this is safe
+		myIdx := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := req.RequestWith(ictx, cl.cl)
+			resps[myIdx] = resp
+			if err == nil {
+				return
+			}
+			cancel()
+			mu.Lock()
+			defer mu.Unlock()
+			if firstErr == nil { // keep the first err
+				firstErr = err
+			}
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	var rs DescribeACLsResults
+	for i, r := range resps {
+		f := descs[i]
+		var ds DescribedACLs
+		for _, resource := range r.Resources {
+			for _, acl := range resource.ACLs {
+				ds = append(ds, DescribedACL{
+					Principal:  acl.Principal,
+					Host:       acl.Host,
+					Type:       resource.ResourceType,
+					Name:       resource.ResourceName,
+					Pattern:    resource.ResourcePatternType,
+					Operation:  acl.Operation,
+					Permission: acl.PermissionType,
+				})
+			}
+		}
+		rs = append(rs, DescribeACLsResult{
+			Principal:  f.Principal,
+			Host:       f.Host,
+			Type:       f.ResourceType,
+			Name:       f.ResourceName,
+			Pattern:    f.ResourcePatternType,
+			Operation:  f.Operation,
+			Permission: f.PermissionType,
+			Described:  ds,
+			Err:        kerr.ErrorForCode(r.ErrorCode),
+		})
+	}
+	return rs, nil
+}
+
+var sliceAny = []string{"any"}
+
+func createDelDescACL(b *ACLBuilder) ([]kmsg.DeleteACLsRequestFilter, []*kmsg.DescribeACLsRequest, error) {
+	if err := b.ValidateFilter(); err != nil {
+		return nil, nil, err
+	}
+
+	// As a special shortcut, if we have any allow and deny principals and
+	// hosts, we collapse these into one "any" group. The anyAny and
+	// anyAnyHosts vars are used in our looping below, and if we do this,
+	// we dup and set all the relevant fields to false to not expand them
+	// in our loops.
+	var anyAny, anyAnyHosts bool
+	if b.anyAllow && b.anyDeny && b.anyAllowHosts && b.anyDenyHosts {
+		anyAny = true
+		anyAnyHosts = true
+
+		b = b.dup()
+		b.allow = nil
+		b.allowHosts = nil
+		b.deny = nil
+		b.denyHosts = nil
+		b.anyAllow = false
+		b.anyAllowHosts = false
+		b.anyDeny = false
+		b.anyDenyHosts = false
+	}
+
+	var clusters []string
+	if b.anyCluster {
+		clusters = []string{"kafka-cluster"}
+	}
+	var deletions []kmsg.DeleteACLsRequestFilter
+	var describes []*kmsg.DescribeACLsRequest
+	for _, typeNames := range []struct {
+		t     kmsg.ACLResourceType
+		names []string
+		any   bool
+	}{
+		{kmsg.ACLResourceTypeAny, b.any, b.anyResource},
+		{kmsg.ACLResourceTypeTopic, b.topics, b.anyTopic},
+		{kmsg.ACLResourceTypeGroup, b.groups, b.anyGroup},
+		{kmsg.ACLResourceTypeCluster, clusters, b.anyCluster},
+		{kmsg.ACLResourceTypeTransactionalId, b.txnIDs, b.anyTxn},
+		{kmsg.ACLResourceTypeDelegationToken, b.tokens, b.anyToken},
+	} {
+		if typeNames.any {
+			typeNames.names = sliceAny
+		}
+		for _, name := range typeNames.names {
+			for _, op := range b.ops {
+				for _, perm := range []struct {
+					principals   []string
+					anyPrincipal bool
+					hosts        []string
+					anyHost      bool
+					permType     kmsg.ACLPermissionType
+				}{
+					{
+						b.allow,
+						b.anyAllow,
+						b.allowHosts,
+						b.anyAllowHosts,
+						kmsg.ACLPermissionTypeAllow,
+					},
+					{
+						b.deny,
+						b.anyDeny,
+						b.denyHosts,
+						b.anyDenyHosts,
+						kmsg.ACLPermissionTypeDeny,
+					},
+					{
+						nil,
+						anyAny,
+						nil,
+						anyAnyHosts,
+						kmsg.ACLPermissionTypeAny,
+					},
+				} {
+					if perm.anyPrincipal {
+						perm.principals = sliceAny
+					}
+					if perm.anyHost {
+						perm.hosts = sliceAny
+					}
+					for _, principal := range perm.principals {
+						for _, host := range perm.hosts {
+							deletion := kmsg.NewDeleteACLsRequestFilter()
+							describe := kmsg.NewPtrDescribeACLsRequest()
+
+							deletion.ResourceType = typeNames.t
+							describe.ResourceType = typeNames.t
+
+							if !typeNames.any {
+								deletion.ResourceName = kmsg.StringPtr(name)
+								describe.ResourceName = kmsg.StringPtr(name)
+							}
+
+							deletion.ResourcePatternType = b.pattern
+							describe.ResourcePatternType = b.pattern
+
+							deletion.Operation = op
+							describe.Operation = op
+
+							if !perm.anyPrincipal {
+								deletion.Principal = kmsg.StringPtr(principal)
+								describe.Principal = kmsg.StringPtr(principal)
+							}
+
+							if !perm.anyHost {
+								deletion.Host = kmsg.StringPtr(host)
+								describe.Host = kmsg.StringPtr(host)
+							}
+
+							deletion.PermissionType = perm.permType
+							describe.PermissionType = perm.permType
+
+							deletions = append(deletions, deletion)
+							describes = append(describes, describe)
+						}
+					}
+				}
+			}
+		}
+	}
+	return deletions, describes, nil
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/configs.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/configs.go
@@ -1,0 +1,412 @@
+package kadm
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// ConfigSynonym is a fallback value for a config.
+type ConfigSynonym struct {
+	Key    string            // Key is the fallback config name.
+	Value  *string           // Value is the fallback config value, if any (sensitive is elided).
+	Source kmsg.ConfigSource // Source is where this config synonym is defined from.
+}
+
+// Config is a configuration for a resource (topic, broker)
+type Config struct {
+	Key       string            // Key is the config name.
+	Value     *string           // Value is the config value, if any.
+	Sensitive bool              // Sensitive is if this config is sensitive (if so, Value is nil).
+	Source    kmsg.ConfigSource // Source is where this config is defined from.
+
+	// Synonyms contains fallback key/value pairs for this same
+	// configuration key in order or preference. That is, if a config entry
+	// is both dynamically defined and has a default value as well, the top
+	// level config will be the dynamic value, while the synonym will be
+	// the default.
+	Synonyms []ConfigSynonym
+}
+
+// MaybeValue returns the config's value if it is non-nil, otherwise an empty
+// string.
+func (c *Config) MaybeValue() string {
+	if c.Value != nil {
+		return *c.Value
+	}
+	return ""
+}
+
+// ResourceConfig contains the configuration values for a resource (topic,
+// broker, broker logger).
+type ResourceConfig struct {
+	Name    string   // Name is the name of this resource.
+	Configs []Config // Configs are the configs for this topic.
+	Err     error    // Err is any error preventing configs from loading (likely, an unknown topic).
+}
+
+// ResourceConfigs contains the configuration values for many resources.
+type ResourceConfigs []ResourceConfig
+
+// On calls fn for the response config if it exists, returning the config and
+// the error returned from fn. If fn is nil, this simply returns the config.
+//
+// The fn is given a copy of the config. This function returns the copy as
+// well; any modifications within fn are modifications on the returned copy.
+//
+// If the resource does not exist, this returns kerr.UnknownTopicOrPartition.
+func (rs ResourceConfigs) On(name string, fn func(*ResourceConfig) error) (ResourceConfig, error) {
+	for _, r := range rs {
+		if r.Name == name {
+			if fn == nil {
+				return r, nil
+			}
+			return r, fn(&r)
+		}
+	}
+	return ResourceConfig{}, kerr.UnknownTopicOrPartition
+}
+
+// DescribeTopicConfigs returns the configuration for the requested topics.
+//
+// This may return *ShardErrors.
+func (cl *Client) DescribeTopicConfigs(
+	ctx context.Context,
+	topics ...string,
+) (ResourceConfigs, error) {
+	if len(topics) == 0 {
+		return nil, nil
+	}
+	return cl.describeConfigs(ctx, kmsg.ConfigResourceTypeTopic, topics)
+}
+
+// DescribeBrokerConfigs returns configuration for the requested brokers. If no
+// brokers are requested, a single request is issued and any broker in the
+// cluster replies with the cluster-level dynamic config values.
+//
+// This may return *ShardErrors.
+func (cl *Client) DescribeBrokerConfigs(
+	ctx context.Context,
+	brokers ...int32,
+) (ResourceConfigs, error) {
+	var names []string
+	if len(brokers) == 0 {
+		names = append(names, "")
+	}
+	for _, b := range brokers {
+		names = append(names, strconv.Itoa(int(b)))
+	}
+	return cl.describeConfigs(ctx, kmsg.ConfigResourceTypeBroker, names)
+}
+
+func (cl *Client) describeConfigs(
+	ctx context.Context,
+	kind kmsg.ConfigResourceType,
+	names []string,
+) (ResourceConfigs, error) {
+	req := kmsg.NewPtrDescribeConfigsRequest()
+	req.IncludeSynonyms = true
+	for _, name := range names {
+		rr := kmsg.NewDescribeConfigsRequestResource()
+		rr.ResourceName = name
+		rr.ResourceType = kind
+		req.Resources = append(req.Resources, rr)
+	}
+	shards := cl.cl.RequestSharded(ctx, req)
+
+	var configs []ResourceConfig
+	return configs, shardErrEach(req, shards, func(kr kmsg.Response) error {
+		resp := kr.(*kmsg.DescribeConfigsResponse)
+		for _, r := range resp.Resources {
+			if err := maybeAuthErr(r.ErrorCode); err != nil {
+				return err
+			}
+			rc := ResourceConfig{
+				Name: r.ResourceName,
+				Err:  kerr.ErrorForCode(r.ErrorCode),
+			}
+			for _, c := range r.Configs {
+				rcv := Config{
+					Key:       c.Name,
+					Value:     c.Value,
+					Sensitive: c.IsSensitive,
+					Source:    c.Source,
+				}
+				for _, syn := range c.ConfigSynonyms {
+					rcv.Synonyms = append(rcv.Synonyms, ConfigSynonym{
+						Key:    syn.Name,
+						Value:  syn.Value,
+						Source: syn.Source,
+					})
+				}
+				rc.Configs = append(rc.Configs, rcv)
+			}
+			configs = append(configs, rc) // we are not storing in a map, no existence-check possible
+		}
+		return nil
+	})
+}
+
+// IncrementalOp is a typed int8 that is used for incrementally updating
+// configuration keys for topics and brokers.
+type IncrementalOp int8
+
+const (
+	// SetConfig is an incremental operation to set an individual config
+	// key.
+	SetConfig IncrementalOp = iota
+
+	// DeleteConfig is an incremental operation to delete an individual
+	// config key.
+	DeleteConfig
+
+	// AppendConfig is an incremental operation to append a value to a
+	// config key that is a list type.
+	AppendConfig
+
+	// SubtractConfig is an incremental operation to remove a value from a
+	// config key that is a list type.
+	SubtractConfig
+)
+
+// AlterConfig is an individual key/value operation to perform when altering
+// configs.
+//
+// This package includes a StringPtr function to aid in building config values.
+type AlterConfig struct {
+	Op    IncrementalOp // Op is the incremental alter operation to perform. This is ignored for State alter functions.
+	Name  string        // Name is the name of the config to alter.
+	Value *string       // Value is the value to use when altering, if any.
+}
+
+// AlteredConfigsResponse contains the response for an individual alteration.
+type AlterConfigsResponse struct {
+	Name string // Name is the name of this resource (topic name or broker number).
+	Err  error  // Err is non-nil if the config could not be altered.
+}
+
+// AlterConfigsResponses contains responses for many alterations.
+type AlterConfigsResponses []AlterConfigsResponse
+
+// On calls fn for the response name if it exists, returning the response and
+// the error returned from fn. If fn is nil, this simply returns the response.
+//
+// The fn is given a copy of the response. This function returns the copy as
+// well; any modifications within fn are modifications on the returned copy.
+//
+// If the resource does not exist, this returns kerr.UnknownTopicOrPartition.
+func (rs AlterConfigsResponses) On(name string, fn func(*AlterConfigsResponse) error) (AlterConfigsResponse, error) {
+	for _, r := range rs {
+		if r.Name == name {
+			if fn == nil {
+				return r, nil
+			}
+			return r, fn(&r)
+		}
+	}
+	return AlterConfigsResponse{}, kerr.UnknownTopicOrPartition
+}
+
+// AlterTopicConfigs incrementally alters topic configuration values.
+//
+// This method requires talking to a cluster that supports
+// IncrementalAlterConfigs (officially introduced in Kafka v2.3, but many
+// broker reimplementations support this request even if they do not support
+// all other requests from Kafka v2.3).
+//
+// If you want to alter the entire configs state using the older AlterConfigs
+// request, use AlterTopicConfigsState.
+//
+// This may return *ShardErrors. You may consider checking
+// ValidateAlterTopicConfigs before using this method.
+func (cl *Client) AlterTopicConfigs(ctx context.Context, configs []AlterConfig, topics ...string) (AlterConfigsResponses, error) {
+	return cl.alterConfigs(ctx, false, configs, kmsg.ConfigResourceTypeTopic, topics)
+}
+
+// ValidateAlterTopicConfigs validates an incremental alter config for the given
+// topics.
+//
+// This returns exactly what AlterTopicConfigs returns, but does not actually
+// alter configurations.
+func (cl *Client) ValidateAlterTopicConfigs(ctx context.Context, configs []AlterConfig, topics ...string) (AlterConfigsResponses, error) {
+	return cl.alterConfigs(ctx, true, configs, kmsg.ConfigResourceTypeTopic, topics)
+}
+
+// AlterBrokerConfigs incrementally alters broker configuration values. If
+// brokers are specified, this updates each specific broker. If no brokers are
+// specified, this updates whole-cluster broker configuration values.
+//
+// This method requires talking to a cluster that supports
+// IncrementalAlterConfigs (officially introduced in Kafka v2.3, but many
+// broker reimplementations support this request even if they do not support
+// all other requests from Kafka v2.3).
+//
+// If you want to alter the entire configs state using the older AlterConfigs
+// request, use AlterBrokerConfigsState.
+//
+// This may return *ShardErrors. You may consider checking
+// ValidateAlterBrokerConfigs before using this method.
+func (cl *Client) AlterBrokerConfigs(ctx context.Context, configs []AlterConfig, brokers ...int32) (AlterConfigsResponses, error) {
+	var names []string
+	if len(brokers) == 0 {
+		names = append(names, "")
+	}
+	for _, broker := range brokers {
+		names = append(names, strconv.Itoa(int(broker)))
+	}
+	return cl.alterConfigs(ctx, false, configs, kmsg.ConfigResourceTypeBroker, names)
+}
+
+// ValidateAlterBrokerConfigs validates an incremental alter config for the given
+// brokers.
+//
+// This returns exactly what AlterBrokerConfigs returns, but does not actually
+// alter configurations.
+func (cl *Client) ValidateAlterBrokerConfigs(ctx context.Context, configs []AlterConfig, brokers ...int32) (AlterConfigsResponses, error) {
+	var names []string
+	if len(brokers) == 0 {
+		names = append(names, "")
+	}
+	for _, broker := range brokers {
+		names = append(names, strconv.Itoa(int(broker)))
+	}
+	return cl.alterConfigs(ctx, true, configs, kmsg.ConfigResourceTypeBroker, names)
+}
+
+func (cl *Client) alterConfigs(
+	ctx context.Context,
+	dry bool,
+	configs []AlterConfig,
+	kind kmsg.ConfigResourceType,
+	names []string,
+) (AlterConfigsResponses, error) {
+	req := kmsg.NewPtrIncrementalAlterConfigsRequest()
+	req.ValidateOnly = dry
+	for _, name := range names {
+		rr := kmsg.NewIncrementalAlterConfigsRequestResource()
+		rr.ResourceType = kind
+		rr.ResourceName = name
+		for _, config := range configs {
+			rc := kmsg.NewIncrementalAlterConfigsRequestResourceConfig()
+			rc.Name = config.Name
+			rc.Value = config.Value
+			switch config.Op {
+			case SetConfig:
+				rc.Op = kmsg.IncrementalAlterConfigOpSet
+			case DeleteConfig:
+				rc.Op = kmsg.IncrementalAlterConfigOpDelete
+			case AppendConfig:
+				rc.Op = kmsg.IncrementalAlterConfigOpAppend
+			case SubtractConfig:
+				rc.Op = kmsg.IncrementalAlterConfigOpSubtract
+			}
+			rr.Configs = append(rr.Configs, rc)
+		}
+		req.Resources = append(req.Resources, rr)
+	}
+
+	shards := cl.cl.RequestSharded(ctx, req)
+
+	var rs []AlterConfigsResponse
+	return rs, shardErrEach(req, shards, func(kr kmsg.Response) error {
+		resp := kr.(*kmsg.IncrementalAlterConfigsResponse)
+		for _, r := range resp.Resources {
+			rs = append(rs, AlterConfigsResponse{ // we are not storing in a map, no existence check possible
+				Name: r.ResourceName,
+				Err:  kerr.ErrorForCode(r.ErrorCode),
+			})
+		}
+		return nil
+	})
+}
+
+// AlterTopicConfigsState alters the full state of topic configurations.
+// All prior configuration is lost.
+//
+// This may return *ShardErrors. You may consider checking
+// ValidateAlterTopicConfigs before using this method.
+func (cl *Client) AlterTopicConfigsState(ctx context.Context, configs []AlterConfig, topics ...string) (AlterConfigsResponses, error) {
+	return cl.alterConfigsState(ctx, false, configs, kmsg.ConfigResourceTypeTopic, topics)
+}
+
+// ValidateAlterTopicConfigs validates an AlterTopicConfigsState for the given
+// topics.
+//
+// This returns exactly what AlterTopicConfigsState returns, but does not
+// actually alter configurations.
+func (cl *Client) ValidateAlterTopicConfigsState(ctx context.Context, configs []AlterConfig, topics ...string) (AlterConfigsResponses, error) {
+	return cl.alterConfigsState(ctx, true, configs, kmsg.ConfigResourceTypeTopic, topics)
+}
+
+// AlterBrokerConfigs alters the full state of broker configurations. If
+// broker are specified, this updates each specific broker. If no brokers are
+// specified, this updates whole-cluster broker configuration values.
+// All prior configuration is lost.
+//
+// This may return *ShardErrors. You may consider checking
+// ValidateAlterBrokerConfigs before using this method.
+func (cl *Client) AlterBrokerConfigsState(ctx context.Context, configs []AlterConfig, brokers ...int32) (AlterConfigsResponses, error) {
+	var names []string
+	if len(brokers) == 0 {
+		names = append(names, "")
+	}
+	for _, broker := range brokers {
+		names = append(names, strconv.Itoa(int(broker)))
+	}
+	return cl.alterConfigsState(ctx, false, configs, kmsg.ConfigResourceTypeBroker, names)
+}
+
+// ValidateAlterBrokerConfigs validates an AlterBrokerconfigsState for the
+// given brokers.
+//
+// This returns exactly what AlterBrokerConfigs returns, but does not actually
+// alter configurations.
+func (cl *Client) ValidateAlterBrokerConfigsState(ctx context.Context, configs []AlterConfig, brokers ...int32) (AlterConfigsResponses, error) {
+	var names []string
+	if len(brokers) == 0 {
+		names = append(names, "")
+	}
+	for _, broker := range brokers {
+		names = append(names, strconv.Itoa(int(broker)))
+	}
+	return cl.alterConfigsState(ctx, true, configs, kmsg.ConfigResourceTypeBroker, names)
+}
+
+func (cl *Client) alterConfigsState(
+	ctx context.Context,
+	dry bool,
+	configs []AlterConfig,
+	kind kmsg.ConfigResourceType,
+	names []string,
+) (AlterConfigsResponses, error) {
+	req := kmsg.NewPtrAlterConfigsRequest()
+	req.ValidateOnly = dry
+	for _, name := range names {
+		rr := kmsg.NewAlterConfigsRequestResource()
+		rr.ResourceType = kind
+		rr.ResourceName = name
+		for _, config := range configs {
+			rc := kmsg.NewAlterConfigsRequestResourceConfig()
+			rc.Name = config.Name
+			rc.Value = config.Value
+			rr.Configs = append(rr.Configs, rc)
+		}
+		req.Resources = append(req.Resources, rr)
+	}
+
+	shards := cl.cl.RequestSharded(ctx, req)
+
+	var rs []AlterConfigsResponse
+	return rs, shardErrEach(req, shards, func(kr kmsg.Response) error {
+		resp := kr.(*kmsg.AlterConfigsResponse)
+		for _, r := range resp.Resources {
+			rs = append(rs, AlterConfigsResponse{ // we are not storing in a map, no existence check possible
+				Name: r.ResourceName,
+				Err:  kerr.ErrorForCode(r.ErrorCode),
+			})
+		}
+		return nil
+	})
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/dtoken.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/dtoken.go
@@ -1,0 +1,229 @@
+package kadm
+
+import (
+	"context"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// Principal is a principal that owns or renews a delegation token. This is the
+// same as an ACL's principal, but rather than being a single string, the type
+// and name are split into two fields.
+type Principal struct {
+	Type string // Type is the type of a principal owner or renewer. If empty, this defaults to "User".
+	Name string // Name is the name of a principal owner or renewer.
+}
+
+// DelegationToken contains information about a delegation token.
+type DelegationToken struct {
+	// Owner is the owner of the delegation token.
+	Owner Principal
+	// TokenRequesterPrincipal is the principal of the creator of the
+	// token. This exists for v3+, where you can override the owner.
+	// For prior than v3, this is just the Owner.
+	TokenRequesterPrincipal Principal
+	// IssueTimestamp is timestamp the delegation token creation request
+	// is received within the broker.
+	IssueTimestamp time.Time
+	// ExpiryTimestamp is the timestamp the delegation token will expire.
+	// This field is:
+	//     min(MaxTimestamp, IssueTimestamp+delegation.token.expiry.time.ms)
+	// where the default expiry is 24hr.
+	ExpiryTimestamp time.Time
+	// MaxTimestamp is the timestamp past which the delegation token cannot
+	// be renewed. This is either the requested MaxLifetime, or the
+	// broker's delegation.token.max.lifetime.ms which is 7d by default.
+	MaxTimestamp time.Time
+	// TokenID is the username of this token for use in authorization.
+	TokenID string
+	// HMAC is the password of this token for use for in authorization.
+	HMAC []byte
+	// Renewers is the list of principals that can renew this token in
+	// addition to the owner (which always can).
+	Renewers []Principal
+}
+
+// DelegationTokens contains a list of delegation tokens.
+type DelegationTokens []DelegationToken
+
+// CreateDelegationToken is a create delegation token request, allowing you to
+// create scoped tokens with the same ACLs as the creator. This allows you to
+// more easily manage authorization for a wide array of clients. All delegation
+// tokens use SCRAM-SHA-256 SASL for authorization.
+type CreateDelegationToken struct {
+	// Owner overrides the owner of the token from the principal issuing
+	// the request to the principal in this field. This allows a superuser
+	// to create tokens without requiring individual user credentials, and
+	// for a superuser to run clients on behalf of another user. These
+	// fields require Kafka 3.3+; see KIP-373 for more details.
+	Owner *Principal
+	// Renewers is a list of principals that can renew the delegation
+	// token in addition to the owner of the token. This list does not
+	// include the owner.
+	Renewers []Principal
+	// MaxLifetime is how long the delegation token is valid for.
+	// If -1, the default is the server's delegation.token.max.lifetime.ms,
+	// which is by default 7d.
+	MaxLifetime time.Duration
+}
+
+// CreateDelegationToken creates a delegation token, which is a scoped
+// SCRAM-SHA-256 username and password.
+//
+// Creating delegation tokens allows for an (ideally) quicker and easier method
+// of enabling authorization for a wide array of clients. Rather than having to
+// manage many passwords external to Kafka, you only need to manage a few
+// accounts and use those to create delegation tokens per client.
+//
+// Note that delegation tokens inherit the same ACLs as the user creating the
+// token. Thus, if you want to properly scope ACLs, you should not create
+// delegation tokens with admin accounts.
+//
+// This can return *AuthError.
+func (cl *Client) CreateDelegationToken(ctx context.Context, d CreateDelegationToken) (DelegationToken, error) {
+	req := kmsg.NewPtrCreateDelegationTokenRequest()
+	if d.Owner != nil {
+		req.OwnerPrincipalType = &d.Owner.Type
+		req.OwnerPrincipalName = &d.Owner.Name
+	}
+	for _, renewer := range d.Renewers {
+		rr := kmsg.NewCreateDelegationTokenRequestRenewer()
+		rr.PrincipalType = renewer.Type
+		rr.PrincipalName = renewer.Name
+		req.Renewers = append(req.Renewers, rr)
+	}
+	req.MaxLifetimeMillis = d.MaxLifetime.Milliseconds()
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return DelegationToken{}, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return DelegationToken{}, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return DelegationToken{}, err
+	}
+
+	t := DelegationToken{
+		Owner: Principal{
+			Type: resp.PrincipalType,
+			Name: resp.PrincipalName,
+		},
+		TokenRequesterPrincipal: Principal{
+			Type: resp.TokenRequesterPrincipalType,
+			Name: resp.TokenRequesterPrincipalName,
+		},
+		IssueTimestamp:  time.UnixMilli(resp.IssueTimestamp).UTC(),
+		ExpiryTimestamp: time.UnixMilli(resp.ExpiryTimestamp).UTC(),
+		MaxTimestamp:    time.UnixMilli(resp.MaxTimestamp).UTC(),
+		TokenID:         resp.TokenID,
+		HMAC:            resp.HMAC,
+		Renewers:        append([]Principal(nil), d.Renewers...),
+	}
+	if resp.Version < 3 {
+		t.TokenRequesterPrincipal = t.Owner
+	}
+	return t, nil
+}
+
+// RenewDelegationToken renews a delegation token that has not yet hit its max
+// timestamp and returns the new expiry timestamp.
+//
+// This can return *AuthError.
+func (cl *Client) RenewDelegationToken(ctx context.Context, hmac []byte, renewTime time.Duration) (expiryTimestamp time.Time, err error) {
+	req := kmsg.NewPtrRenewDelegationTokenRequest()
+	req.HMAC = hmac
+	req.RenewTimeMillis = renewTime.Milliseconds()
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return time.Time{}, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return time.Time{}, err
+	}
+	return time.UnixMilli(resp.ExpiryTimestamp).UTC(), nil
+}
+
+// ExpireDelegationToken changes a delegation token's expiry timestamp and
+// returns the new expiry timestamp, which is min(now+expiry, maxTimestamp).
+// This request can be used to force tokens to expire quickly, or to give
+// tokens a grace period before expiry. Using an expiry of -1 expires the token
+// immediately.
+//
+// This can return *AuthError.
+func (cl *Client) ExpireDelegationToken(ctx context.Context, hmac []byte, expiry time.Duration) (expiryTimestamp time.Time, err error) {
+	req := kmsg.NewPtrExpireDelegationTokenRequest()
+	req.HMAC = hmac
+	req.ExpiryPeriodMillis = expiry.Milliseconds()
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return time.Time{}, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return time.Time{}, err
+	}
+	return time.UnixMilli(resp.ExpiryTimestamp).UTC(), nil
+}
+
+// DescribeDelegationTokens describes delegation tokens. This returns either
+// all delegation tokens, or returns only tokens with owners in the requested
+// owners list.
+//
+// This can return *AuthError.
+func (cl *Client) DescribeDelegationTokens(ctx context.Context, owners ...Principal) (DelegationTokens, error) {
+	req := kmsg.NewPtrDescribeDelegationTokenRequest()
+	for _, owner := range owners {
+		ro := kmsg.NewDescribeDelegationTokenRequestOwner()
+		ro.PrincipalType = owner.Type
+		ro.PrincipalName = owner.Name
+		req.Owners = append(req.Owners, ro)
+	}
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+
+	var ts DelegationTokens
+	for _, d := range resp.TokenDetails {
+		t := DelegationToken{
+			Owner: Principal{
+				Type: d.PrincipalType,
+				Name: d.PrincipalName,
+			},
+			TokenRequesterPrincipal: Principal{
+				Type: d.TokenRequesterPrincipalType,
+				Name: d.TokenRequesterPrincipalName,
+			},
+			IssueTimestamp:  time.UnixMilli(d.IssueTimestamp).UTC(),
+			ExpiryTimestamp: time.UnixMilli(d.ExpiryTimestamp).UTC(),
+			MaxTimestamp:    time.UnixMilli(d.MaxTimestamp).UTC(),
+			TokenID:         d.TokenID,
+			HMAC:            d.HMAC,
+		}
+		if resp.Version < 3 {
+			t.TokenRequesterPrincipal = t.Owner
+		}
+		for _, r := range d.Renewers {
+			t.Renewers = append(t.Renewers, Principal{
+				Type: r.PrincipalType,
+				Name: r.PrincipalName,
+			})
+		}
+		ts = append(ts, t)
+	}
+	return ts, nil
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/errors.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/errors.go
@@ -1,0 +1,123 @@
+package kadm
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// AuthError can be returned from requests for resources that you are not
+// authorized for.
+type AuthError struct {
+	Err error // Err is the inner *kerr.Error authorization error.
+}
+
+func (a *AuthError) Error() string     { return a.Err.Error() }
+func (a *AuthError) Unwrap() error     { return a.Err }
+func (a *AuthError) Is(err error) bool { return a.Err == err }
+
+func maybeAuthErr(code int16) error {
+	switch err := kerr.ErrorForCode(code); err {
+	case kerr.ClusterAuthorizationFailed,
+		kerr.TopicAuthorizationFailed,
+		kerr.GroupAuthorizationFailed,
+		kerr.TransactionalIDAuthorizationFailed,
+		kerr.DelegationTokenAuthorizationFailed:
+		return &AuthError{err}
+	}
+	return nil
+}
+
+// ShardError is a piece of a request that failed. See ShardErrors for more
+// detail.
+type ShardError struct {
+	Req kmsg.Request // Req is a piece of the original request.
+	Err error        // Err is the error that resulted in this request failing.
+
+	// Broker, if non-nil, is the broker this request was meant to be
+	// issued to. If the NodeID is -1, then this piece of the request
+	// failed before being mapped to a broker.
+	Broker BrokerDetail
+}
+
+// ShardErrors contains each individual error shard of a request.
+//
+// Under the hood, some requests to Kafka need to be mapped to brokers, split,
+// and sent to many brokers. The kgo.Client handles this all internally, but
+// returns the individual pieces that were requested as "shards". Internally,
+// each of these pieces can also fail, and they can all fail uniquely.
+//
+// The kadm package takes one further step and hides the failing pieces into
+// one meta error, the ShardErrors. Methods in this package that can return
+// this meta error are documented; if desired, you can use errors.As to check
+// and unwrap any ShardErrors return.
+//
+// If a request returns ShardErrors, it is possible that some aspects of the
+// request were still successful. You can check ShardErrors.AllFailed as a
+// shortcut for whether any of the response is usable or not.
+type ShardErrors struct {
+	Name      string       // Name is the name of the request these shard errors are for.
+	AllFailed bool         // AllFailed indicates if the original request was entirely unsuccessful.
+	Errs      []ShardError // Errs contains all individual shard errors.
+}
+
+func shardErrEach(req kmsg.Request, shards []kgo.ResponseShard, fn func(kmsg.Response) error) error {
+	return shardErrEachBroker(req, shards, func(_ BrokerDetail, resp kmsg.Response) error {
+		return fn(resp)
+	})
+}
+
+func shardErrEachBroker(req kmsg.Request, shards []kgo.ResponseShard, fn func(BrokerDetail, kmsg.Response) error) error {
+	se := ShardErrors{
+		Name: kmsg.NameForKey(req.Key()),
+	}
+	var ae *AuthError
+	for _, shard := range shards {
+		if shard.Err != nil {
+			se.Errs = append(se.Errs, ShardError{
+				Req:    shard.Req,
+				Err:    shard.Err,
+				Broker: shard.Meta,
+			})
+			continue
+		}
+		if err := fn(shard.Meta, shard.Resp); errors.As(err, &ae) {
+			return ae
+		}
+	}
+	se.AllFailed = len(shards) == len(se.Errs)
+	return se.into()
+}
+
+func (se *ShardErrors) into() error {
+	if se == nil || len(se.Errs) == 0 {
+		return nil
+	}
+	return se
+}
+
+// Merges two shard errors; the input errors should come from the same request.
+func mergeShardErrs(e1, e2 error) error {
+	var se1, se2 *ShardErrors
+	if !errors.As(e1, &se1) {
+		return e2
+	}
+	if !errors.As(e2, &se2) {
+		return e1
+	}
+	se1.Errs = append(se1.Errs, se2.Errs...)
+	se1.AllFailed = se1.AllFailed && se2.AllFailed
+	return se1
+}
+
+// Error returns an error indicating the name of the request that failed, the
+// number of separate errors, and the first error.
+func (e *ShardErrors) Error() string {
+	if len(e.Errs) == 0 {
+		return "INVALID: ShardErrors contains no errors!"
+	}
+	return fmt.Sprintf("request %s has %d separate shard errors, first: %s", e.Name, len(e.Errs), e.Errs[0].Err)
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/groups.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/groups.go
@@ -1,0 +1,1666 @@
+package kadm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// GroupMemberMetadata is the metadata that a client sent in a JoinGroup request.
+// This can have one of three types:
+//
+//	*kmsg.ConsumerMemberMetadata, if the group's ProtocolType is "consumer"
+//	*kmsg.ConnectMemberMetadata, if the group's ProtocolType is "connect"
+//	[]byte, if the group's ProtocolType is unknown
+type GroupMemberMetadata struct{ i any }
+
+// AsConsumer returns the metadata as a ConsumerMemberMetadata if possible.
+func (m GroupMemberMetadata) AsConsumer() (*kmsg.ConsumerMemberMetadata, bool) {
+	c, ok := m.i.(*kmsg.ConsumerMemberMetadata)
+	return c, ok
+}
+
+// AsConnect returns the metadata as ConnectMemberMetadata if possible.
+func (m GroupMemberMetadata) AsConnect() (*kmsg.ConnectMemberMetadata, bool) {
+	c, ok := m.i.(*kmsg.ConnectMemberMetadata)
+	return c, ok
+}
+
+// Raw returns the metadata as a raw byte slice, if it is neither of consumer
+// type nor connect type.
+func (m GroupMemberMetadata) Raw() ([]byte, bool) {
+	c, ok := m.i.([]byte)
+	return c, ok
+}
+
+// GroupMemberAssignment is the assignment that a leader sent / a member
+// received in a SyncGroup request.  This can have one of three types:
+//
+//	*kmsg.ConsumerMemberAssignment, if the group's ProtocolType is "consumer"
+//	*kmsg.ConnectMemberAssignment, if the group's ProtocolType is "connect"
+//	[]byte, if the group's ProtocolType is unknown
+type GroupMemberAssignment struct{ i any }
+
+// AsConsumer returns the assignment as a ConsumerMemberAssignment if possible.
+func (m GroupMemberAssignment) AsConsumer() (*kmsg.ConsumerMemberAssignment, bool) {
+	c, ok := m.i.(*kmsg.ConsumerMemberAssignment)
+	return c, ok
+}
+
+// AsConnect returns the assignment as ConnectMemberAssignment if possible.
+func (m GroupMemberAssignment) AsConnect() (*kmsg.ConnectMemberAssignment, bool) {
+	c, ok := m.i.(*kmsg.ConnectMemberAssignment)
+	return c, ok
+}
+
+// Raw returns the assignment as a raw byte slice, if it is neither of consumer
+// type nor connect type.
+func (m GroupMemberAssignment) Raw() ([]byte, bool) {
+	c, ok := m.i.([]byte)
+	return c, ok
+}
+
+// DescribedGroupMember is the detail of an individual group member as returned
+// by a describe groups response.
+type DescribedGroupMember struct {
+	MemberID   string  // MemberID is the Kafka assigned member ID of this group member.
+	InstanceID *string // InstanceID is a potential user assigned instance ID of this group member (KIP-345).
+	ClientID   string  // ClientID is the Kafka client given ClientID of this group member.
+	ClientHost string  // ClientHost is the host this member is running on.
+
+	Join     GroupMemberMetadata   // Join is what this member sent in its join group request; what it wants to consume.
+	Assigned GroupMemberAssignment // Assigned is what this member was assigned to consume by the leader.
+}
+
+// AssignedPartitions returns the set of unique topics and partitions that are
+// assigned across all members in this group.
+//
+// This function is only relevant if the group is of type "consumer".
+func (d *DescribedGroup) AssignedPartitions() TopicsSet {
+	s := make(TopicsSet)
+	for _, m := range d.Members {
+		if c, ok := m.Assigned.AsConsumer(); ok {
+			for _, t := range c.Topics {
+				s.Add(t.Topic, t.Partitions...)
+			}
+		}
+	}
+	return s
+}
+
+// DescribedGroup contains data from a describe groups response for a single
+// group.
+type DescribedGroup struct {
+	Group string // Group is the name of the described group.
+
+	Coordinator  BrokerDetail           // Coordinator is the coordinator broker for this group.
+	State        string                 // State is the state this group is in (Empty, Dead, Stable, etc.).
+	ProtocolType string                 // ProtocolType is the type of protocol the group is using, "consumer" for normal consumers, "connect" for Kafka connect.
+	Protocol     string                 // Protocol is the partition assignor strategy this group is using.
+	Members      []DescribedGroupMember // Members contains the members of this group sorted first by InstanceID, or if nil, by MemberID.
+
+	Err error // Err is non-nil if the group could not be described.
+}
+
+// DescribedGroups contains data for multiple groups from a describe groups
+// response.
+type DescribedGroups map[string]DescribedGroup
+
+// AssignedPartitions returns the set of unique topics and partitions that are
+// assigned across all members in all groups. This is the all-group analogue to
+// DescribedGroup.AssignedPartitions.
+//
+// This function is only relevant for groups of type "consumer".
+func (ds DescribedGroups) AssignedPartitions() TopicsSet {
+	s := make(TopicsSet)
+	for _, g := range ds {
+		for _, m := range g.Members {
+			if c, ok := m.Assigned.AsConsumer(); ok {
+				for _, t := range c.Topics {
+					s.Add(t.Topic, t.Partitions...)
+				}
+			}
+		}
+	}
+	return s
+}
+
+// Sorted returns all groups sorted by group name.
+func (ds DescribedGroups) Sorted() []DescribedGroup {
+	s := make([]DescribedGroup, 0, len(ds))
+	for _, d := range ds {
+		s = append(s, d)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].Group < s[j].Group })
+	return s
+}
+
+// On calls fn for the group if it exists, returning the group and the error
+// returned from fn. If fn is nil, this simply returns the group.
+//
+// The fn is given a shallow copy of the group. This function returns the copy
+// as well; any modifications within fn are modifications on the returned copy.
+// Modifications on a described group's inner fields are persisted to the
+// original map (because slices are pointers).
+//
+// If the group does not exist, this returns kerr.GroupIDNotFound.
+func (rs DescribedGroups) On(group string, fn func(*DescribedGroup) error) (DescribedGroup, error) {
+	if len(rs) > 0 {
+		r, ok := rs[group]
+		if ok {
+			if fn == nil {
+				return r, nil
+			}
+			return r, fn(&r)
+		}
+	}
+	return DescribedGroup{}, kerr.GroupIDNotFound
+}
+
+// Topics returns a sorted list of all group names.
+func (ds DescribedGroups) Names() []string {
+	all := make([]string, 0, len(ds))
+	for g := range ds {
+		all = append(all, g)
+	}
+	sort.Strings(all)
+	return all
+}
+
+// ListedGroup contains data from a list groups response for a single group.
+type ListedGroup struct {
+	Coordinator  int32  // Coordinator is the node ID of the coordinator for this group.
+	Group        string // Group is the name of this group.
+	ProtocolType string // ProtocolType is the type of protocol the group is using, "consumer" for normal consumers, "connect" for Kafka connect.
+	State        string // State is the state this group is in (Empty, Dead, Stable, etc.; only if talking to Kafka 2.6+).
+}
+
+// ListedGroups contains information from a list groups response.
+type ListedGroups map[string]ListedGroup
+
+// Sorted returns all groups sorted by group name.
+func (ls ListedGroups) Sorted() []ListedGroup {
+	s := make([]ListedGroup, 0, len(ls))
+	for _, l := range ls {
+		s = append(s, l)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].Group < s[j].Group })
+	return s
+}
+
+// Groups returns a sorted list of all group names.
+func (ls ListedGroups) Groups() []string {
+	all := make([]string, 0, len(ls))
+	for g := range ls {
+		all = append(all, g)
+	}
+	sort.Strings(all)
+	return all
+}
+
+// ListGroups returns all groups in the cluster. If you are talking to Kafka
+// 2.6+, filter states can be used to return groups only in the requested
+// states. By default, this returns all groups. In almost all cases,
+// DescribeGroups is more useful.
+//
+// This may return *ShardErrors or *AuthError.
+func (cl *Client) ListGroups(ctx context.Context, filterStates ...string) (ListedGroups, error) {
+	req := kmsg.NewPtrListGroupsRequest()
+	req.StatesFilter = append(req.StatesFilter, filterStates...)
+	shards := cl.cl.RequestSharded(ctx, req)
+	list := make(ListedGroups)
+	return list, shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
+		resp := kr.(*kmsg.ListGroupsResponse)
+		if err := maybeAuthErr(resp.ErrorCode); err != nil {
+			return err
+		}
+		if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+			return err
+		}
+		for _, g := range resp.Groups {
+			list[g.Group] = ListedGroup{ // group only lives on one broker, no need to exist-check
+				Coordinator:  b.NodeID,
+				Group:        g.Group,
+				ProtocolType: g.ProtocolType,
+				State:        g.GroupState,
+			}
+		}
+		return nil
+	})
+}
+
+// DescribeGroups describes either all groups specified, or all groups in the
+// cluster if none are specified.
+//
+// This may return *ShardErrors or *AuthError.
+//
+// If no groups are specified and this method first lists groups, and list
+// groups returns a *ShardErrors, this function describes all successfully
+// listed groups and appends the list shard errors to any describe shard
+// errors.
+//
+// If only one group is described, there will be at most one request issued,
+// and there is no need to deeply inspect the error.
+func (cl *Client) DescribeGroups(ctx context.Context, groups ...string) (DescribedGroups, error) {
+	var seList *ShardErrors
+	if len(groups) == 0 {
+		listed, err := cl.ListGroups(ctx)
+		switch {
+		case err == nil:
+		case errors.As(err, &seList):
+		default:
+			return nil, err
+		}
+		groups = listed.Groups()
+		if len(groups) == 0 {
+			return nil, err
+		}
+	}
+
+	req := kmsg.NewPtrDescribeGroupsRequest()
+	req.Groups = groups
+
+	shards := cl.cl.RequestSharded(ctx, req)
+	described := make(DescribedGroups)
+	err := shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
+		resp := kr.(*kmsg.DescribeGroupsResponse)
+		for _, rg := range resp.Groups {
+			if err := maybeAuthErr(rg.ErrorCode); err != nil {
+				return err
+			}
+			g := DescribedGroup{
+				Group:        rg.Group,
+				Coordinator:  b,
+				State:        rg.State,
+				ProtocolType: rg.ProtocolType,
+				Protocol:     rg.Protocol,
+				Err:          kerr.ErrorForCode(rg.ErrorCode),
+			}
+			for _, rm := range rg.Members {
+				gm := DescribedGroupMember{
+					MemberID:   rm.MemberID,
+					InstanceID: rm.InstanceID,
+					ClientID:   rm.ClientID,
+					ClientHost: rm.ClientHost,
+				}
+
+				var mi, ai any
+				switch g.ProtocolType {
+				case "consumer":
+					m := new(kmsg.ConsumerMemberMetadata)
+					a := new(kmsg.ConsumerMemberAssignment)
+
+					m.ReadFrom(rm.ProtocolMetadata)
+					a.ReadFrom(rm.MemberAssignment)
+
+					mi, ai = m, a
+				case "connect":
+					m := new(kmsg.ConnectMemberMetadata)
+					a := new(kmsg.ConnectMemberAssignment)
+
+					m.ReadFrom(rm.ProtocolMetadata)
+					a.ReadFrom(rm.MemberAssignment)
+
+					mi, ai = m, a
+				default:
+					mi, ai = rm.ProtocolMetadata, rm.MemberAssignment
+				}
+
+				gm.Join = GroupMemberMetadata{mi}
+				gm.Assigned = GroupMemberAssignment{ai}
+				g.Members = append(g.Members, gm)
+			}
+			sort.Slice(g.Members, func(i, j int) bool {
+				if g.Members[i].InstanceID != nil {
+					if g.Members[j].InstanceID == nil {
+						return true
+					}
+					return *g.Members[i].InstanceID < *g.Members[j].InstanceID
+				}
+				if g.Members[j].InstanceID != nil {
+					return false
+				}
+				return g.Members[i].MemberID < g.Members[j].MemberID
+			})
+			described[g.Group] = g // group only lives on one broker, no need to exist-check
+		}
+		return nil
+	})
+
+	var seDesc *ShardErrors
+	switch {
+	case err == nil:
+		return described, seList.into()
+	case errors.As(err, &seDesc):
+		if seList != nil {
+			seDesc.Errs = append(seList.Errs, seDesc.Errs...)
+		}
+		return described, seDesc.into()
+	default:
+		return nil, err
+	}
+}
+
+// DeleteGroupResponse contains the response for an individual deleted group.
+type DeleteGroupResponse struct {
+	Group string // Group is the group this response is for.
+	Err   error  // Err is non-nil if the group failed to be deleted.
+}
+
+// DeleteGroupResponses contains per-group responses to deleted groups.
+type DeleteGroupResponses map[string]DeleteGroupResponse
+
+// Sorted returns all deleted group responses sorted by group name.
+func (ds DeleteGroupResponses) Sorted() []DeleteGroupResponse {
+	s := make([]DeleteGroupResponse, 0, len(ds))
+	for _, d := range ds {
+		s = append(s, d)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].Group < s[j].Group })
+	return s
+}
+
+// On calls fn for the response group if it exists, returning the response and
+// the error returned from fn. If fn is nil, this simply returns the group.
+//
+// The fn is given a copy of the response. This function returns the copy as
+// well; any modifications within fn are modifications on the returned copy.
+//
+// If the group does not exist, this returns kerr.GroupIDNotFound.
+func (rs DeleteGroupResponses) On(group string, fn func(*DeleteGroupResponse) error) (DeleteGroupResponse, error) {
+	if len(rs) > 0 {
+		r, ok := rs[group]
+		if ok {
+			if fn == nil {
+				return r, nil
+			}
+			return r, fn(&r)
+		}
+	}
+	return DeleteGroupResponse{}, kerr.GroupIDNotFound
+}
+
+// DeleteGroups deletes all groups specified.
+//
+// The purpose of this request is to allow operators a way to delete groups
+// after Kafka 1.1, which removed RetentionTimeMillis from offset commits. See
+// KIP-229 for more details.
+//
+// This may return *ShardErrors. This does not return on authorization
+// failures, instead, authorization failures are included in the responses.
+func (cl *Client) DeleteGroups(ctx context.Context, groups ...string) (DeleteGroupResponses, error) {
+	if len(groups) == 0 {
+		return nil, nil
+	}
+	req := kmsg.NewPtrDeleteGroupsRequest()
+	req.Groups = append(req.Groups, groups...)
+	shards := cl.cl.RequestSharded(ctx, req)
+
+	rs := make(map[string]DeleteGroupResponse)
+	return rs, shardErrEach(req, shards, func(kr kmsg.Response) error {
+		resp := kr.(*kmsg.DeleteGroupsResponse)
+		for _, g := range resp.Groups {
+			rs[g.Group] = DeleteGroupResponse{ // group is always on one broker, no need to exist-check
+				Group: g.Group,
+				Err:   kerr.ErrorForCode(g.ErrorCode),
+			}
+		}
+		return nil
+	})
+}
+
+// LeaveGroupBuilder helps build a leave group request, rather than having
+// a function signature (string, string, ...string).
+//
+// All functions on this type accept and return the same pointer, allowing
+// for easy build-and-use usage.
+type LeaveGroupBuilder struct {
+	group       string
+	reason      *string
+	instanceIDs []*string
+}
+
+// LeaveGroup returns a LeaveGroupBuilder for the input group.
+func LeaveGroup(group string) *LeaveGroupBuilder {
+	return &LeaveGroupBuilder{
+		group: group,
+	}
+}
+
+// Reason attaches a reason to all members in the leave group request.
+// This requires Kafka 3.2+.
+func (b *LeaveGroupBuilder) Reason(reason string) *LeaveGroupBuilder {
+	b.reason = StringPtr(reason)
+	return b
+}
+
+// InstanceIDs are members to remove from a group.
+func (b *LeaveGroupBuilder) InstanceIDs(ids ...string) *LeaveGroupBuilder {
+	for _, id := range ids {
+		if id != "" {
+			b.instanceIDs = append(b.instanceIDs, StringPtr(id))
+		}
+	}
+	return b
+}
+
+// LeaveGroupResponse contains the response for an individual instance ID that
+// left a group.
+type LeaveGroupResponse struct {
+	Group      string // Group is the group that was left.
+	InstanceID string // InstanceID is the instance ID that left the group.
+	MemberID   string // MemberID is the member ID that left the group.
+	Err        error  // Err is non-nil if this member did not exist.
+}
+
+// LeaveGroupResponses contains responses for each member of a leave group
+// request. The map key is the instance ID that was removed from the group.
+type LeaveGroupResponses map[string]LeaveGroupResponse
+
+// Sorted returns all removed group members by instance ID.
+func (ls LeaveGroupResponses) Sorted() []LeaveGroupResponse {
+	s := make([]LeaveGroupResponse, 0, len(ls))
+	for _, l := range ls {
+		s = append(s, l)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].InstanceID < s[j].InstanceID })
+	return s
+}
+
+// EachError calls fn for every removed member that has a non-nil error.
+func (ls LeaveGroupResponses) EachError(fn func(l LeaveGroupResponse)) {
+	for _, l := range ls {
+		if l.Err != nil {
+			fn(l)
+		}
+	}
+}
+
+// Each calls fn for every removed member.
+func (ls LeaveGroupResponses) Each(fn func(l LeaveGroupResponse)) {
+	for _, l := range ls {
+		fn(l)
+	}
+}
+
+// Error iterates over all removed members and returns the first error
+// encountered, if any.
+func (ls LeaveGroupResponses) Error() error {
+	for _, l := range ls {
+		if l.Err != nil {
+			return l.Err
+		}
+	}
+	return nil
+}
+
+// Ok returns true if there are no errors. This is a shortcut for ls.Error() ==
+// nil.
+func (ls LeaveGroupResponses) Ok() bool {
+	return ls.Error() == nil
+}
+
+// LeaveGroup causes instance IDs to leave a group.
+//
+// This function allows manually removing members using instance IDs from a
+// group, which allows for fast scale down / host replacement (see KIP-345 for
+// more detail). This returns an *AuthErr if the use is not authorized to
+// remove members from groups.
+func (cl *Client) LeaveGroup(ctx context.Context, b *LeaveGroupBuilder) (LeaveGroupResponses, error) {
+	if b == nil || len(b.instanceIDs) == 0 {
+		return nil, nil
+	}
+	req := kmsg.NewPtrLeaveGroupRequest()
+	req.Group = b.group
+	for _, id := range b.instanceIDs {
+		m := kmsg.NewLeaveGroupRequestMember()
+		id := id
+		m.InstanceID = id
+		m.Reason = b.reason
+		req.Members = append(req.Members, m)
+	}
+
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+
+	resps := make(LeaveGroupResponses)
+	for _, m := range resp.Members {
+		if m.InstanceID == nil {
+			continue // highly unexpected, buggy kafka
+		}
+		resps[*m.InstanceID] = LeaveGroupResponse{
+			Group:      b.group,
+			MemberID:   m.MemberID,
+			InstanceID: *m.InstanceID,
+			Err:        kerr.ErrorForCode(resp.ErrorCode),
+		}
+	}
+	return resps, err
+}
+
+// OffsetResponse contains the response for an individual offset for offset
+// methods.
+type OffsetResponse struct {
+	Offset
+	Err error // Err is non-nil if the offset operation failed.
+}
+
+// OffsetResponses contains per-partition responses to offset methods.
+type OffsetResponses map[string]map[int32]OffsetResponse
+
+// Lookup returns the offset at t and p and whether it exists.
+func (os OffsetResponses) Lookup(t string, p int32) (OffsetResponse, bool) {
+	if len(os) == 0 {
+		return OffsetResponse{}, false
+	}
+	ps := os[t]
+	if len(ps) == 0 {
+		return OffsetResponse{}, false
+	}
+	o, exists := ps[p]
+	return o, exists
+}
+
+// Keep filters the responses to only keep the input offsets.
+func (os OffsetResponses) Keep(o Offsets) {
+	os.DeleteFunc(func(r OffsetResponse) bool {
+		if len(o) == 0 {
+			return true // keep nothing, delete
+		}
+		ot := o[r.Topic]
+		if ot == nil {
+			return true // topic missing, delete
+		}
+		_, ok := ot[r.Partition]
+		return !ok // does not exist, delete
+	})
+}
+
+// Offsets returns these offset responses as offsets.
+func (os OffsetResponses) Offsets() Offsets {
+	i := make(Offsets)
+	os.Each(func(o OffsetResponse) {
+		i.Add(o.Offset)
+	})
+	return i
+}
+
+// KOffsets returns these offset responses as a kgo offset map.
+func (os OffsetResponses) KOffsets() map[string]map[int32]kgo.Offset {
+	return os.Offsets().KOffsets()
+}
+
+// DeleteFunc keeps only the offsets for which fn returns true.
+func (os OffsetResponses) KeepFunc(fn func(OffsetResponse) bool) {
+	for t, ps := range os {
+		for p, o := range ps {
+			if !fn(o) {
+				delete(ps, p)
+			}
+		}
+		if len(ps) == 0 {
+			delete(os, t)
+		}
+	}
+}
+
+// DeleteFunc deletes any offset for which fn returns true.
+func (os OffsetResponses) DeleteFunc(fn func(OffsetResponse) bool) {
+	os.KeepFunc(func(o OffsetResponse) bool { return !fn(o) })
+}
+
+// Add adds an offset for a given topic/partition to this OffsetResponses map
+// (even if it exists).
+func (os *OffsetResponses) Add(o OffsetResponse) {
+	if *os == nil {
+		*os = make(map[string]map[int32]OffsetResponse)
+	}
+	ot := (*os)[o.Topic]
+	if ot == nil {
+		ot = make(map[int32]OffsetResponse)
+		(*os)[o.Topic] = ot
+	}
+	ot[o.Partition] = o
+}
+
+// EachError calls fn for every offset that as a non-nil error.
+func (os OffsetResponses) EachError(fn func(o OffsetResponse)) {
+	for _, ps := range os {
+		for _, o := range ps {
+			if o.Err != nil {
+				fn(o)
+			}
+		}
+	}
+}
+
+// Sorted returns the responses sorted by topic and partition.
+func (os OffsetResponses) Sorted() []OffsetResponse {
+	var s []OffsetResponse
+	os.Each(func(o OffsetResponse) { s = append(s, o) })
+	sort.Slice(s, func(i, j int) bool {
+		return s[i].Topic < s[j].Topic ||
+			s[i].Topic == s[j].Topic && s[i].Partition < s[j].Partition
+	})
+	return s
+}
+
+// Each calls fn for every offset.
+func (os OffsetResponses) Each(fn func(OffsetResponse)) {
+	for _, ps := range os {
+		for _, o := range ps {
+			fn(o)
+		}
+	}
+}
+
+// Partitions returns the set of unique topics and partitions in these offsets.
+func (os OffsetResponses) Partitions() TopicsSet {
+	s := make(TopicsSet)
+	os.Each(func(o OffsetResponse) {
+		s.Add(o.Topic, o.Partition)
+	})
+	return s
+}
+
+// Error iterates over all offsets and returns the first error encountered, if
+// any. This can be used to check if an operation was entirely successful or
+// not.
+//
+// Note that offset operations can be partially successful. For example, some
+// offsets could succeed in an offset commit while others fail (maybe one topic
+// does not exist for some reason, or you are not authorized for one topic). If
+// this is something you need to worry about, you may need to check all offsets
+// manually.
+func (os OffsetResponses) Error() error {
+	for _, ps := range os {
+		for _, o := range ps {
+			if o.Err != nil {
+				return o.Err
+			}
+		}
+	}
+	return nil
+}
+
+// Ok returns true if there are no errors. This is a shortcut for os.Error() ==
+// nil.
+func (os OffsetResponses) Ok() bool {
+	return os.Error() == nil
+}
+
+// CommitOffsets issues an offset commit request for the input offsets.
+//
+// This function can be used to manually commit offsets when directly consuming
+// partitions outside of an actual consumer group. For example, if you assign
+// partitions manually, but want still use Kafka to checkpoint what you have
+// consumed, you can manually issue an offset commit request with this method.
+//
+// This does not return on authorization failures, instead, authorization
+// failures are included in the responses.
+func (cl *Client) CommitOffsets(ctx context.Context, group string, os Offsets) (OffsetResponses, error) {
+	req := kmsg.NewPtrOffsetCommitRequest()
+	req.Group = group
+	for t, ps := range os {
+		rt := kmsg.NewOffsetCommitRequestTopic()
+		rt.Topic = t
+		for p, o := range ps {
+			rp := kmsg.NewOffsetCommitRequestTopicPartition()
+			rp.Partition = p
+			rp.Offset = o.At
+			rp.LeaderEpoch = o.LeaderEpoch
+			if len(o.Metadata) > 0 {
+				rp.Metadata = kmsg.StringPtr(o.Metadata)
+			}
+			rt.Partitions = append(rt.Partitions, rp)
+		}
+		req.Topics = append(req.Topics, rt)
+	}
+
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+
+	rs := make(OffsetResponses)
+	for _, t := range resp.Topics {
+		rt := make(map[int32]OffsetResponse)
+		rs[t.Topic] = rt
+		for _, p := range t.Partitions {
+			rt[p.Partition] = OffsetResponse{
+				Offset: os[t.Topic][p.Partition],
+				Err:    kerr.ErrorForCode(p.ErrorCode),
+			}
+		}
+	}
+
+	for t, ps := range os {
+		respt := rs[t]
+		if respt == nil {
+			respt = make(map[int32]OffsetResponse)
+			rs[t] = respt
+		}
+		for p, o := range ps {
+			if _, exists := respt[p]; exists {
+				continue
+			}
+			respt[p] = OffsetResponse{
+				Offset: o,
+				Err:    errOffsetCommitMissing,
+			}
+		}
+	}
+
+	return rs, nil
+}
+
+var errOffsetCommitMissing = errors.New("partition missing in commit response")
+
+// CommitAllOffsets is identical to CommitOffsets, but returns an error if the
+// offset commit was successful, but some offset within the commit failed to be
+// committed.
+//
+// This is a shortcut function provided to avoid checking two errors, but you
+// must be careful with this if partially successful commits can be a problem
+// for you.
+func (cl *Client) CommitAllOffsets(ctx context.Context, group string, os Offsets) error {
+	commits, err := cl.CommitOffsets(ctx, group, os)
+	if err != nil {
+		return err
+	}
+	return commits.Error()
+}
+
+// FetchOffsets issues an offset fetch requests for all topics and partitions
+// in the group. Because Kafka returns only partitions you are authorized to
+// fetch, this only returns an auth error if you are not authorized to describe
+// the group at all.
+//
+// This method requires talking to Kafka v0.11+.
+func (cl *Client) FetchOffsets(ctx context.Context, group string) (OffsetResponses, error) {
+	req := kmsg.NewPtrOffsetFetchRequest()
+	req.Group = group
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	rs := make(OffsetResponses)
+	for _, t := range resp.Topics {
+		rt := make(map[int32]OffsetResponse)
+		rs[t.Topic] = rt
+		for _, p := range t.Partitions {
+			if err := maybeAuthErr(p.ErrorCode); err != nil {
+				return nil, err
+			}
+			var meta string
+			if p.Metadata != nil {
+				meta = *p.Metadata
+			}
+			rt[p.Partition] = OffsetResponse{
+				Offset: Offset{
+					Topic:       t.Topic,
+					Partition:   p.Partition,
+					At:          p.Offset,
+					LeaderEpoch: p.LeaderEpoch,
+					Metadata:    meta,
+				},
+				Err: kerr.ErrorForCode(p.ErrorCode),
+			}
+		}
+	}
+	return rs, nil
+}
+
+// FetchAllGroupTopics is a kadm "internal" topic name that can be used in
+// [FetchOffsetsForTopics]. By default, [FetchOffsetsForTopics] only returns
+// topics that are explicitly requested. Other topics that may be committed to
+// in the group are not returned. Using FetchAllRequestedTopics switches the
+// behavior to return the union of all committed topics and all requested
+// topics.
+const FetchAllGroupTopics = "|fetch-all-group-topics|"
+
+// FetchOffsetsForTopics is a helper function that returns the currently
+// committed offsets for the given group, as well as default -1 offsets for any
+// topic/partition that does not yet have a commit.
+//
+// If any partition fetched or listed has an error, this function returns an
+// error. The returned offset responses are ready to be used or converted
+// directly to pure offsets with `Into`, and again into kgo offsets with
+// another `Into`.
+//
+// By default, this function returns offsets for only the requested topics. You
+// can use the special "topic" [FetchAllGroupTopics] to return all committed-to
+// topics in addition to all requested topics.
+func (cl *Client) FetchOffsetsForTopics(ctx context.Context, group string, topics ...string) (OffsetResponses, error) {
+	os := make(Offsets)
+
+	var all bool
+	keept := topics[:0]
+	for _, topic := range topics {
+		if topic == FetchAllGroupTopics {
+			all = true
+			continue
+		}
+		keept = append(keept, topic)
+	}
+	topics = keept
+
+	if !all && len(topics) == 0 {
+		return make(OffsetResponses), nil
+	}
+
+	// We have to request metadata to learn all partitions in all the
+	// topics. The default returned offset for all partitions is filled in
+	// to be -1.
+	if len(topics) > 0 {
+		listed, err := cl.ListTopics(ctx, topics...)
+		if err != nil {
+			return nil, fmt.Errorf("unable to list topics: %w", err)
+		}
+
+		for _, topic := range topics {
+			t := listed[topic]
+			if t.Err != nil {
+				return nil, fmt.Errorf("unable to describe topics, topic err: %w", t.Err)
+			}
+			for _, p := range t.Partitions {
+				os.AddOffset(topic, p.Partition, -1, -1)
+			}
+		}
+	}
+
+	resps, err := cl.FetchOffsets(ctx, group)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch offsets: %w", err)
+	}
+	if err := resps.Error(); err != nil {
+		return nil, fmt.Errorf("offset fetches had a load error, first error: %w", err)
+	}
+
+	// For any topic (and any partition) we explicitly asked for, if the
+	// partition does not exist in the response, we fill the default -1
+	// from above.
+	os.Each(func(o Offset) {
+		if _, ok := resps.Lookup(o.Topic, o.Partition); !ok {
+			resps.Add(OffsetResponse{Offset: o})
+		}
+	})
+
+	// If we are not requesting all group offsets, then we strip any topic
+	// that was not explicitly requested.
+	if !all {
+		tset := make(map[string]struct{})
+		for _, t := range topics {
+			tset[t] = struct{}{}
+		}
+		for t := range resps {
+			if _, ok := tset[t]; !ok {
+				delete(resps, t)
+			}
+		}
+	}
+	return resps, nil
+}
+
+// FetchOffsetsResponse contains a fetch offsets response for a single group.
+type FetchOffsetsResponse struct {
+	Group   string          // Group is the offsets these fetches correspond to.
+	Fetched OffsetResponses // Fetched contains offsets fetched for this group, if any.
+	Err     error           // Err contains any error preventing offsets from being fetched.
+}
+
+// CommittedPartitions returns the set of unique topics and partitions that
+// have been committed to in this group.
+func (r FetchOffsetsResponse) CommittedPartitions() TopicsSet {
+	return r.Fetched.Partitions()
+}
+
+// FetchOFfsetsResponses contains responses for many fetch offsets requests.
+type FetchOffsetsResponses map[string]FetchOffsetsResponse
+
+// EachError calls fn for every response that as a non-nil error.
+func (rs FetchOffsetsResponses) EachError(fn func(FetchOffsetsResponse)) {
+	for _, r := range rs {
+		if r.Err != nil {
+			fn(r)
+		}
+	}
+}
+
+// AllFailed returns whether all fetch offsets requests failed.
+func (rs FetchOffsetsResponses) AllFailed() bool {
+	var n int
+	rs.EachError(func(FetchOffsetsResponse) { n++ })
+	return len(rs) > 0 && n == len(rs)
+}
+
+// CommittedPartitions returns the set of unique topics and partitions that
+// have been committed to across all members in all responses. This is the
+// all-group analogue to FetchOffsetsResponse.CommittedPartitions.
+func (rs FetchOffsetsResponses) CommittedPartitions() TopicsSet {
+	s := make(TopicsSet)
+	for _, r := range rs {
+		s.Merge(r.CommittedPartitions())
+	}
+	return s
+}
+
+// On calls fn for the response group if it exists, returning the response and
+// the error returned from fn. If fn is nil, this simply returns the group.
+//
+// The fn is given a copy of the response. This function returns the copy as
+// well; any modifications within fn are modifications on the returned copy.
+//
+// If the group does not exist, this returns kerr.GroupIDNotFound.
+func (rs FetchOffsetsResponses) On(group string, fn func(*FetchOffsetsResponse) error) (FetchOffsetsResponse, error) {
+	if len(rs) > 0 {
+		r, ok := rs[group]
+		if ok {
+			if fn == nil {
+				return r, nil
+			}
+			return r, fn(&r)
+		}
+	}
+	return FetchOffsetsResponse{}, kerr.GroupIDNotFound
+}
+
+// FetchManyOffsets issues a fetch offsets requests for each group specified.
+//
+// This function is a batch version of FetchOffsets. FetchOffsets and
+// CommitOffsets are important to provide as simple APIs for users that manage
+// group offsets outside of a consumer group. Each individual group may have an
+// auth error.
+func (cl *Client) FetchManyOffsets(ctx context.Context, groups ...string) FetchOffsetsResponses {
+	fetched := make(FetchOffsetsResponses)
+	if len(groups) == 0 {
+		return fetched
+	}
+
+	req := kmsg.NewPtrOffsetFetchRequest()
+	for _, group := range groups {
+		rg := kmsg.NewOffsetFetchRequestGroup()
+		rg.Group = group
+		req.Groups = append(req.Groups, rg)
+	}
+
+	groupErr := func(g string, err error) {
+		fetched[g] = FetchOffsetsResponse{
+			Group: g,
+			Err:   err,
+		}
+	}
+	allGroupsErr := func(req *kmsg.OffsetFetchRequest, err error) {
+		for _, g := range req.Groups {
+			groupErr(g.Group, err)
+		}
+	}
+
+	shards := cl.cl.RequestSharded(ctx, req)
+	for _, shard := range shards {
+		req := shard.Req.(*kmsg.OffsetFetchRequest)
+		if shard.Err != nil {
+			allGroupsErr(req, shard.Err)
+			continue
+		}
+		resp := shard.Resp.(*kmsg.OffsetFetchResponse)
+		if err := maybeAuthErr(resp.ErrorCode); err != nil {
+			allGroupsErr(req, err)
+			continue
+		}
+		for _, g := range resp.Groups {
+			if err := maybeAuthErr(g.ErrorCode); err != nil {
+				groupErr(g.Group, err)
+				continue
+			}
+			rs := make(OffsetResponses)
+			fg := FetchOffsetsResponse{
+				Group:   g.Group,
+				Fetched: rs,
+				Err:     kerr.ErrorForCode(g.ErrorCode),
+			}
+			fetched[g.Group] = fg // group coordinator owns all of a group, no need to check existence
+			for _, t := range g.Topics {
+				rt := make(map[int32]OffsetResponse)
+				rs[t.Topic] = rt
+				for _, p := range t.Partitions {
+					var meta string
+					if p.Metadata != nil {
+						meta = *p.Metadata
+					}
+					rt[p.Partition] = OffsetResponse{
+						Offset: Offset{
+							Topic:       t.Topic,
+							Partition:   p.Partition,
+							At:          p.Offset,
+							LeaderEpoch: p.LeaderEpoch,
+							Metadata:    meta,
+						},
+						Err: kerr.ErrorForCode(p.ErrorCode),
+					}
+				}
+			}
+		}
+	}
+	return fetched
+}
+
+// DeleteOffsetsResponses contains the per topic, per partition errors. If an
+// offset deletion for a partition was successful, the error will be nil.
+type DeleteOffsetsResponses map[string]map[int32]error
+
+// Lookup returns the response at t and p and whether it exists.
+func (ds DeleteOffsetsResponses) Lookup(t string, p int32) (error, bool) {
+	if len(ds) == 0 {
+		return nil, false
+	}
+	ps := ds[t]
+	if len(ps) == 0 {
+		return nil, false
+	}
+	r, exists := ps[p]
+	return r, exists
+}
+
+// EachError calls fn for every partition that as a non-nil deletion error.
+func (ds DeleteOffsetsResponses) EachError(fn func(string, int32, error)) {
+	for t, ps := range ds {
+		for p, err := range ps {
+			if err != nil {
+				fn(t, p, err)
+			}
+		}
+	}
+}
+
+// DeleteOffsets deletes offsets for the given group.
+//
+// Originally, offset commits were persisted in Kafka for some retention time.
+// This posed problematic for infrequently committing consumers, so the
+// retention time concept was removed in Kafka v2.1 in favor of deleting
+// offsets for a group only when the group became empty. However, if a group
+// stops consuming from a topic, then the offsets will persist and lag
+// monitoring for the group will notice an ever increasing amount of lag for
+// these no-longer-consumed topics. Thus, Kafka v2.4 introduced an OffsetDelete
+// request to allow admins to manually delete offsets for no longer consumed
+// topics.
+//
+// This method requires talking to Kafka v2.4+. This returns an *AuthErr if the
+// user is not authorized to delete offsets in the group at all. This does not
+// return on per-topic authorization failures, instead, per-topic authorization
+// failures are included in the responses.
+func (cl *Client) DeleteOffsets(ctx context.Context, group string, s TopicsSet) (DeleteOffsetsResponses, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+
+	req := kmsg.NewPtrOffsetDeleteRequest()
+	req.Group = group
+	for t, ps := range s {
+		rt := kmsg.NewOffsetDeleteRequestTopic()
+		rt.Topic = t
+		for p := range ps {
+			rp := kmsg.NewOffsetDeleteRequestTopicPartition()
+			rp.Partition = p
+			rt.Partitions = append(rt.Partitions, rp)
+		}
+		req.Topics = append(req.Topics, rt)
+	}
+
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+
+	r := make(DeleteOffsetsResponses)
+	for _, t := range resp.Topics {
+		rt := make(map[int32]error)
+		r[t.Topic] = rt
+		for _, p := range t.Partitions {
+			rt[p.Partition] = kerr.ErrorForCode(p.ErrorCode)
+		}
+	}
+	return r, nil
+}
+
+// GroupMemberLag is the lag between a group member's current offset commit and
+// the current end offset.
+//
+// If either the offset commits have load errors, or the listed end offsets
+// have load errors, the Lag field will be -1 and the Err field will be set (to
+// the first of either the commit error, or else the list error).
+//
+// If the group is in the Empty state, lag is calculated for all partitions in
+// a topic, but the member is nil. The calculate function assumes that any
+// assigned topic is meant to be entirely consumed. If the group is Empty and
+// topics could not be listed, some partitions may be missing.
+type GroupMemberLag struct {
+	// Member is a reference to the group member consuming this partition.
+	// If the group is in state Empty, the member will be nil.
+	Member    *DescribedGroupMember
+	Topic     string // Topic is the topic this lag is for.
+	Partition int32  // Partition is the partition this lag is for.
+
+	Commit Offset       // Commit is this member's current offset commit.
+	End    ListedOffset // EndOffset is a reference to the end offset of this partition.
+	Lag    int64        // Lag is how far behind this member is, or -1 if there is a commit error or list offset error.
+
+	Err error // Err is either the commit error, or the list end offsets error, or nil.
+}
+
+// IsEmpty returns if the this lag is for a group in the Empty state.
+func (g *GroupMemberLag) IsEmpty() bool { return g.Member == nil }
+
+// GroupLag is the per-topic, per-partition lag of members in a group.
+type GroupLag map[string]map[int32]GroupMemberLag
+
+// Lookup returns the lag at t and p and whether it exists.
+func (l GroupLag) Lookup(t string, p int32) (GroupMemberLag, bool) {
+	if len(l) == 0 {
+		return GroupMemberLag{}, false
+	}
+	ps := l[t]
+	if len(ps) == 0 {
+		return GroupMemberLag{}, false
+	}
+	m, exists := ps[p]
+	return m, exists
+}
+
+// Sorted returns the per-topic, per-partition lag by member sorted in order by
+// topic then partition.
+func (l GroupLag) Sorted() []GroupMemberLag {
+	var all []GroupMemberLag
+	for _, ps := range l {
+		for _, l := range ps {
+			all = append(all, l)
+		}
+	}
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		if l.Topic < r.Topic {
+			return true
+		}
+		if l.Topic > r.Topic {
+			return false
+		}
+		return l.Partition < r.Partition
+	})
+	return all
+}
+
+// IsEmpty returns if the group is empty.
+func (l GroupLag) IsEmpty() bool {
+	for _, ps := range l {
+		for _, m := range ps {
+			return m.IsEmpty()
+		}
+	}
+	return false
+}
+
+// Total returns the total lag across all topics.
+func (l GroupLag) Total() int64 {
+	var tot int64
+	for _, tl := range l.TotalByTopic() {
+		tot += tl.Lag
+	}
+	return tot
+}
+
+// TotalByTopic returns the total lag for each topic.
+func (l GroupLag) TotalByTopic() GroupTopicsLag {
+	m := make(map[string]TopicLag)
+	for t, ps := range l {
+		mt := TopicLag{
+			Topic: t,
+		}
+		for _, l := range ps {
+			if l.Lag > 0 {
+				mt.Lag += l.Lag
+			}
+		}
+		m[t] = mt
+	}
+	return m
+}
+
+// GroupTopicsLag is the total lag per topic within a group.
+type GroupTopicsLag map[string]TopicLag
+
+// TopicLag is the lag for an individual topic within a group.
+type TopicLag struct {
+	Topic string
+	Lag   int64
+}
+
+// Sorted returns the per-topic lag, sorted by topic.
+func (l GroupTopicsLag) Sorted() []TopicLag {
+	var all []TopicLag
+	for _, tl := range l {
+		all = append(all, tl)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Topic < all[j].Topic
+	})
+	return all
+}
+
+// DescribedGroupLag contains a described group and its lag, or the errors that
+// prevent the lag from being calculated.
+type DescribedGroupLag struct {
+	Group string // Group is the group name.
+
+	Coordinator  BrokerDetail           // Coordinator is the coordinator broker for this group.
+	State        string                 // State is the state this group is in (Empty, Dead, Stable, etc.).
+	ProtocolType string                 // ProtocolType is the type of protocol the group is using, "consumer" for normal consumers, "connect" for Kafka connect.
+	Protocol     string                 // Protocol is the partition assignor strategy this group is using.
+	Members      []DescribedGroupMember // Members contains the members of this group sorted first by InstanceID, or if nil, by MemberID.
+	Lag          GroupLag               // Lag is the lag for the group.
+
+	DescribeErr error // DescribeErr is the error returned from describing the group, if any.
+	FetchErr    error // FetchErr is the error returned from fetching offsets, if any.
+}
+
+// Err returns the first of DescribeErr or FetchErr that is non-nil.
+func (l *DescribedGroupLag) Error() error {
+	if l.DescribeErr != nil {
+		return l.DescribeErr
+	}
+	return l.FetchErr
+}
+
+// DescribedGroupLags is a map of group names to the described group with its
+// lag, or error for those groups.
+type DescribedGroupLags map[string]DescribedGroupLag
+
+// Sorted returns all lags sorted by group name.
+func (ls DescribedGroupLags) Sorted() []DescribedGroupLag {
+	s := make([]DescribedGroupLag, 0, len(ls))
+	for _, l := range ls {
+		s = append(s, l)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].Group < s[j].Group })
+	return s
+}
+
+// EachError calls fn for every group that has a non-nil error.
+func (ls DescribedGroupLags) EachError(fn func(l DescribedGroupLag)) {
+	for _, l := range ls {
+		if l.Error() != nil {
+			fn(l)
+		}
+	}
+}
+
+// Each calls fn for every group.
+func (ls DescribedGroupLags) Each(fn func(l DescribedGroupLag)) {
+	for _, l := range ls {
+		fn(l)
+	}
+}
+
+// Error iterates over all groups and returns the first error encountered, if
+// any.
+func (ls DescribedGroupLags) Error() error {
+	for _, l := range ls {
+		if l.Error() != nil {
+			return l.Error()
+		}
+	}
+	return nil
+}
+
+// Ok returns true if there are no errors. This is a shortcut for ls.Error() ==
+// nil.
+func (ls DescribedGroupLags) Ok() bool {
+	return ls.Error() == nil
+}
+
+// Lag returns the lag for all input groups. This function is a shortcut for
+// the steps required to use CalculateGroupLag properly, with some opinionated
+// choices for error handling since calculating lag is multi-request process.
+// If a group cannot be described or the offsets cannot be fetched, an error is
+// returned for the group. If any topic cannot have its end offsets listed, the
+// lag for the partition has a corresponding error. If any request fails with
+// an auth error, this returns *AuthError.
+func (cl *Client) Lag(ctx context.Context, groups ...string) (DescribedGroupLags, error) {
+	set := make(map[string]struct{}, len(groups))
+	for _, g := range groups {
+		set[g] = struct{}{}
+	}
+	rem := func() []string {
+		groups = groups[:0]
+		for g := range set {
+			groups = append(groups, g)
+		}
+		return groups
+	}
+	lags := make(DescribedGroupLags)
+
+	described, err := cl.DescribeGroups(ctx, rem()...)
+	// For auth err: always return.
+	// For shard errors, if we had some partial success, then we continue
+	// to the rest of the logic in this function.
+	// If every shard failed, or on all other errors, we return.
+	var ae *AuthError
+	var se *ShardErrors
+	switch {
+	case errors.As(err, &ae):
+		return nil, err
+	case errors.As(err, &se) && !se.AllFailed:
+		for _, se := range se.Errs {
+			for _, g := range se.Req.(*kmsg.DescribeGroupsRequest).Groups {
+				lags[g] = DescribedGroupLag{
+					Group:       g,
+					Coordinator: se.Broker,
+					DescribeErr: se.Err,
+				}
+				delete(set, g)
+			}
+		}
+	case err != nil:
+		return nil, err
+	}
+	for _, g := range described {
+		lags[g.Group] = DescribedGroupLag{
+			Group:        g.Group,
+			Coordinator:  g.Coordinator,
+			State:        g.State,
+			ProtocolType: g.ProtocolType,
+			Protocol:     g.Protocol,
+			Members:      g.Members,
+			DescribeErr:  g.Err,
+		}
+		if g.Err != nil {
+			delete(set, g.Group)
+		}
+	}
+	if len(set) == 0 {
+		return lags, nil
+	}
+
+	// Same thought here. For auth errors, we always return.
+	// If a group offset fetch failed, we delete it from described
+	// because we cannot calculate lag for it.
+	fetched := cl.FetchManyOffsets(ctx, rem()...)
+	for _, r := range fetched {
+		switch {
+		case errors.As(r.Err, &ae):
+			return nil, err
+		case r.Err != nil:
+			l := lags[r.Group]
+			l.FetchErr = r.Err
+			lags[r.Group] = l
+			delete(set, r.Group)
+			delete(described, r.Group)
+		}
+	}
+	if len(set) == 0 {
+		return lags, nil
+	}
+
+	// Lastly, we have to list the end offset for all assigned and
+	// committed partitions.
+	var listed ListedOffsets
+	listPartitions := described.AssignedPartitions()
+	listPartitions.Merge(fetched.CommittedPartitions())
+	if topics := listPartitions.Topics(); len(topics) > 0 {
+		listed, err = cl.ListEndOffsets(ctx, topics...)
+		// As above: return on auth error. If there are shard errors,
+		// the topics will be missing in the response and then
+		// CalculateGroupLag will return UnknownTopicOrPartition.
+		switch {
+		case errors.As(err, &ae):
+			return nil, err
+		case errors.As(err, &se):
+			// do nothing: these show up as errListMissing
+		case err != nil:
+			return nil, err
+		}
+		// For anything that lists with a single -1 partition, the
+		// topic does not exist. We add an UnknownTopicOrPartition
+		// error for all partitions that were committed to, so that
+		// this shows up in the lag output as UnknownTopicOrPartition
+		// rather than errListMissing.
+		for t, ps := range listed {
+			if len(ps) != 1 {
+				continue
+			}
+			if _, ok := ps[-1]; !ok {
+				continue
+			}
+			delete(ps, -1)
+			for p := range listPartitions[t] {
+				ps[p] = ListedOffset{
+					Topic:     t,
+					Partition: p,
+					Err:       kerr.UnknownTopicOrPartition,
+				}
+			}
+		}
+	}
+
+	for _, g := range described {
+		l := lags[g.Group]
+		l.Lag = CalculateGroupLag(g, fetched[g.Group].Fetched, listed)
+		lags[g.Group] = l
+	}
+	return lags, nil
+}
+
+// CalculateGroupLag returns the per-partition lag of all members in a group.
+// The input to this method is the returns from the following methods (make
+// sure to check shard errors):
+//
+//	// Note that FetchOffsets exists to fetch only one group's offsets,
+//	// but some of the code below slightly changes.
+//	groups := DescribeGroups(ctx, group)
+//	commits := FetchManyOffsets(ctx, group)
+//	var endOffsets ListedOffsets
+//	listPartitions := described.AssignedPartitions()
+//	listPartitions.Merge(commits.CommittedPartitions()
+//	if topics := listPartitions.Topics(); len(topics) > 0 {
+//		endOffsets = ListEndOffsets(ctx, listPartitions.Topics())
+//	}
+//	for _, group := range groups {
+//		lag := CalculateGroupLag(group, commits[group.Group].Fetched, endOffsets)
+//	}
+//
+// If assigned partitions are missing in the listed end offsets, the partition
+// will have an error indicating it is missing. A missing topic or partition in
+// the commits is assumed to be nothing committing yet.
+func CalculateGroupLag(
+	group DescribedGroup,
+	commit OffsetResponses,
+	endOffsets ListedOffsets,
+) GroupLag {
+	if group.State == "Empty" {
+		return calculateEmptyLag(commit, endOffsets)
+	}
+	if commit == nil { // avoid panics below
+		commit = make(OffsetResponses)
+	}
+	if endOffsets == nil {
+		endOffsets = make(ListedOffsets)
+	}
+
+	l := make(map[string]map[int32]GroupMemberLag)
+	for mi, m := range group.Members {
+		c, ok := m.Assigned.AsConsumer()
+		if !ok {
+			continue
+		}
+		for _, t := range c.Topics {
+			lt := l[t.Topic]
+			if lt == nil {
+				lt = make(map[int32]GroupMemberLag)
+				l[t.Topic] = lt
+			}
+
+			tcommit := commit[t.Topic]
+			tend := endOffsets[t.Topic]
+			for _, p := range t.Partitions {
+				var (
+					pcommit OffsetResponse
+					pend    ListedOffset
+					perr    error
+					ok      bool
+				)
+
+				if tcommit != nil {
+					if pcommit, ok = tcommit[p]; !ok {
+						pcommit = OffsetResponse{Offset: Offset{
+							Topic:     t.Topic,
+							Partition: p,
+							At:        -1,
+						}}
+					}
+				}
+				if tend == nil {
+					perr = errListMissing
+				} else {
+					if pend, ok = tend[p]; !ok {
+						perr = errListMissing
+					}
+				}
+
+				if perr == nil {
+					if perr = pcommit.Err; perr == nil {
+						perr = pend.Err
+					}
+				}
+
+				lag := int64(-1)
+				if perr == nil {
+					lag = pend.Offset
+					if pcommit.At >= 0 {
+						lag = pend.Offset - pcommit.At
+					}
+				}
+
+				lt[p] = GroupMemberLag{
+					Member:    &group.Members[mi],
+					Topic:     t.Topic,
+					Partition: p,
+					Commit:    pcommit.Offset,
+					End:       pend,
+					Lag:       lag,
+					Err:       perr,
+				}
+
+			}
+		}
+	}
+
+	return l
+}
+
+func calculateEmptyLag(commit OffsetResponses, endOffsets ListedOffsets) GroupLag {
+	l := make(map[string]map[int32]GroupMemberLag)
+	for t, ps := range commit {
+		lt := l[t]
+		if lt == nil {
+			lt = make(map[int32]GroupMemberLag)
+			l[t] = lt
+		}
+		tend := endOffsets[t]
+		for p, pcommit := range ps {
+			var (
+				pend ListedOffset
+				perr error
+				ok   bool
+			)
+			if tend == nil {
+				perr = errListMissing
+			} else {
+				if pend, ok = tend[p]; !ok {
+					perr = errListMissing
+				}
+			}
+			if perr == nil {
+				if perr = pcommit.Err; perr == nil {
+					perr = pend.Err
+				}
+			}
+
+			lag := int64(-1)
+			if perr == nil {
+				lag = pend.Offset
+				if pcommit.At >= 0 {
+					lag = pend.Offset - pcommit.At
+				}
+			}
+
+			lt[p] = GroupMemberLag{
+				Topic:     t,
+				Partition: p,
+				Commit:    pcommit.Offset,
+				End:       pend,
+				Lag:       lag,
+				Err:       perr,
+			}
+		}
+	}
+
+	// Now we look at all topics that we calculated lag for, and check out
+	// the partitions we listed. If those partitions are missing from the
+	// lag calculations above, the partitions were not committed to and we
+	// count that as entirely lagging.
+	for t, lt := range l {
+		tend := endOffsets[t]
+		for p, pend := range tend {
+			if _, ok := lt[p]; ok {
+				continue
+			}
+			pcommit := Offset{
+				Topic:       t,
+				Partition:   p,
+				At:          -1,
+				LeaderEpoch: -1,
+			}
+			perr := pend.Err
+			lag := int64(-1)
+			if perr == nil {
+				lag = pend.Offset
+			}
+			lt[p] = GroupMemberLag{
+				Topic:     t,
+				Partition: p,
+				Commit:    pcommit,
+				End:       pend,
+				Lag:       lag,
+				Err:       perr,
+			}
+		}
+	}
+
+	return l
+}
+
+var errListMissing = errors.New("missing from list offsets")

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/kadm.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/kadm.go
@@ -1,0 +1,655 @@
+// Package kadm provides a helper Kafka admin client around a *kgo.Client.
+//
+// This package is meant to cover the common use cases for dropping into an
+// "admin" like interface for Kafka. As with any admin client, this package
+// must make opinionated decisions on what to provide and what to hide. The
+// underlying Kafka protocol gives more detailed information in responses, or
+// allows more fine tuning in requests, but most of the time, these details are
+// unnecessary.
+//
+// By virtue of making opinionated decisions, this package cannot satisfy every
+// need for requests and responses. If you need more control than this admin
+// client provides, you can use the kmsg package directly.
+//
+// This package contains a lot of types, but the main two types type to know
+// are Client and ShardErrors. Every other type is used for inputs or outputs
+// to methods on the client.
+//
+// The Client type is a simple small wrapper around a *kgo.Client that exists
+// solely to namespace methods. The ShardErrors type is a bit more complicated.
+// When issuing requests, under the hood some of these requests actually need
+// to be mapped to brokers and split, issuing different pieces of the input
+// request to different brokers. The *kgo.Client handles this all internally,
+// but (if using RequestSharded as directed), returns each response to each of
+// these split requests individually. Each response can fail or be successful.
+// This package goes one step further and merges these failures into one meta
+// failure, ShardErrors. Any function that returns ShardErrors is documented as
+// such, and if a function returns a non-nil ShardErrors, it is possible that
+// the returned data is actually valid and usable. If you care to, you can log
+// / react to the partial failures and continue using the partial successful
+// result. This is in contrast to other clients, which either require to to
+// request individual brokers directly, or they completely hide individual
+// failures, or they completely fail on any individual failure.
+//
+// For methods that list or describe things, this package often completely
+// fails responses on auth failures. If you use a method that accepts two
+// topics, one that you are authorized to and one that you are not, you will
+// not receive a partial successful response. Instead, you will receive an
+// AuthError. Methods that do *not* fail on auth errors are explicitly
+// documented as such.
+//
+// Users may often find it easy to work with lists of topics or partitions.
+// Rather than needing to build deeply nested maps directly, this package has a
+// few helper types that are worth knowing:
+//
+//	TopicsList  - a slice of topics and their partitions
+//	TopicsSet   - a set of topics, each containing a set of partitions
+//	Partitions  - a slice of partitions
+//	OffsetsList - a slice of offsets
+//	Offsets     - a map of offsets
+//
+// These types are meant to be easy to build and use, and can be used as the
+// starting point for other types.
+//
+// Many functions in this package are variadic and return either a map or a
+// list of responses, and you may only use one element as input and are only
+// interested in one element of output. This package provides the following
+// functions to help:
+//
+//	Any(map)
+//	AnyE(map, err)
+//	First(slice)
+//	FirstE(slice, err)
+//
+// The intended use case of these is something like `kadm.AnyE(kadm.CreateTopics(..., "my-one-topic"))`,
+// such that you can immediately get the response for the one topic you are
+// creating.
+package kadm
+
+import (
+	"errors"
+	"regexp"
+	"runtime/debug"
+	"sort"
+	"sync"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func unptrStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+var (
+	reVersion     *regexp.Regexp
+	reVersionOnce sync.Once
+)
+
+// Copied from kgo, but we use the kadm package version.
+func softwareVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		reVersionOnce.Do(func() { reVersion = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?$`) })
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/twmb/franz-go/pkg/kadm" {
+				if reVersion.MatchString(dep.Version) {
+					return dep.Version
+				}
+			}
+		}
+	}
+	return "unknown"
+}
+
+// Client is an admin client.
+//
+// This is a simple wrapper around a *kgo.Client to provide helper admin methods.
+type Client struct {
+	cl *kgo.Client
+
+	timeoutMillis int32
+}
+
+// NewClient returns an admin client.
+func NewClient(cl *kgo.Client) *Client {
+	return &Client{cl, 15000} // 15s timeout default, matching kmsg
+}
+
+// NewOptClient returns a new client directly from kgo options. This is a
+// wrapper around creating a new *kgo.Client and then creating an admin client.
+func NewOptClient(opts ...kgo.Opt) (*Client, error) {
+	cl, err := kgo.NewClient(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(cl), nil
+}
+
+// Close closes the underlying *kgo.Client.
+func (cl *Client) Close() {
+	cl.cl.Close()
+}
+
+// SetTimeoutMillis sets the timeout to use for requests that have a timeout,
+// overriding the default of 15,000 (15s).
+//
+// Not all requests have timeouts. Most requests are expected to return
+// immediately or are expected to deliberately hang. The following requests
+// have timeout fields:
+//
+//	Produce
+//	CreateTopics
+//	DeleteTopics
+//	DeleteRecords
+//	CreatePartitions
+//	ElectLeaders
+//	AlterPartitionAssignments
+//	ListPartitionReassignments
+//	UpdateFeatures
+//
+// Not all requests above are supported in the admin API.
+func (cl *Client) SetTimeoutMillis(millis int32) {
+	cl.timeoutMillis = millis
+}
+
+// StringPtr is a shortcut function to aid building configs for creating or
+// altering topics.
+func StringPtr(s string) *string {
+	return &s
+}
+
+// BrokerDetail is a type alias for kgo.BrokerMetadata.
+type BrokerDetail = kgo.BrokerMetadata
+
+// BrokerDetails contains the details for many brokers.
+type BrokerDetails []BrokerDetail
+
+// NodeIDs returns the IDs of all nodes.
+func (ds BrokerDetails) NodeIDs() []int32 {
+	var all []int32
+	for _, d := range ds {
+		all = append(all, d.NodeID)
+	}
+	return int32s(all)
+}
+
+// Partition is a partition for a topic.
+type Partition struct {
+	Topic     string // Topic is the topic for this partition.
+	Partition int32  // Partition is this partition's number.
+}
+
+// Offset is an offset for a topic.
+type Offset struct {
+	Topic       string
+	Partition   int32
+	At          int64  // Offset is the partition to set.
+	LeaderEpoch int32  // LeaderEpoch is the broker leader epoch of the record at this offset.
+	Metadata    string // Metadata, if non-empty, is used for offset commits.
+}
+
+// Partitions wraps many partitions.
+type Partitions []Partition
+
+// TopicsSet returns these partitions as TopicsSet.
+func (ps Partitions) TopicsSet() TopicsSet {
+	s := make(TopicsSet)
+	for _, p := range ps {
+		s.Add(p.Topic, p.Partition)
+	}
+	return s
+}
+
+// TopicsList returns these partitions as sorted TopicsList.
+func (ps Partitions) TopicsList() TopicsList {
+	return ps.TopicsSet().Sorted()
+}
+
+// OffsetsList wraps many offsets and is a helper for building Offsets.
+type OffsetsList []Offset
+
+// Offsets returns this list as the non-list Offsets. All fields in each
+// Offset must be set properly.
+func (l OffsetsList) Offsets() Offsets {
+	os := make(Offsets)
+	for _, o := range l {
+		os.Add(o)
+	}
+	return os
+}
+
+// KOffsets returns this list as a kgo offset map.
+func (l OffsetsList) KOffsets() map[string]map[int32]kgo.Offset {
+	return l.Offsets().KOffsets()
+}
+
+// Offsets wraps many offsets and is the type used for offset functions.
+type Offsets map[string]map[int32]Offset
+
+// Lookup returns the offset at t and p and whether it exists.
+func (os Offsets) Lookup(t string, p int32) (Offset, bool) {
+	if len(os) == 0 {
+		return Offset{}, false
+	}
+	ps := os[t]
+	if len(ps) == 0 {
+		return Offset{}, false
+	}
+	o, exists := ps[p]
+	return o, exists
+}
+
+// Add adds an offset for a given topic/partition to this Offsets map.
+//
+// If the partition already exists, the offset is only added if:
+//
+//   - the new leader epoch is higher than the old, or
+//   - the leader epochs equal, and the new offset is higher than the old
+//
+// If you would like to add offsets forcefully no matter what, use the Delete
+// method before this.
+func (os *Offsets) Add(o Offset) {
+	if *os == nil {
+		*os = make(map[string]map[int32]Offset)
+	}
+	ot := (*os)[o.Topic]
+	if ot == nil {
+		ot = make(map[int32]Offset)
+		(*os)[o.Topic] = ot
+	}
+
+	prior, exists := ot[o.Partition]
+	if !exists || prior.LeaderEpoch < o.LeaderEpoch ||
+		prior.LeaderEpoch == o.LeaderEpoch && prior.At < o.At {
+		ot[o.Partition] = o
+	}
+}
+
+// Delete removes any offset at topic t and partition p.
+func (os Offsets) Delete(t string, p int32) {
+	if os == nil {
+		return
+	}
+	ot := os[t]
+	if ot == nil {
+		return
+	}
+	delete(ot, p)
+	if len(ot) == 0 {
+		delete(os, t)
+	}
+}
+
+// AddOffset is a helper to add an offset for a given topic and partition. The
+// leader epoch field must be -1 if you do not know the leader epoch or if
+// you do not have an offset yet.
+func (os *Offsets) AddOffset(t string, p int32, o int64, leaderEpoch int32) {
+	os.Add(Offset{
+		Topic:       t,
+		Partition:   p,
+		At:          o,
+		LeaderEpoch: leaderEpoch,
+	})
+}
+
+// KeepFunc calls fn for every offset, keeping the offset if fn returns true.
+func (os Offsets) KeepFunc(fn func(o Offset) bool) {
+	for t, ps := range os {
+		for p, o := range ps {
+			if !fn(o) {
+				delete(ps, p)
+			}
+		}
+		if len(ps) == 0 {
+			delete(os, t)
+		}
+	}
+}
+
+// DeleteFunc calls fn for every offset, deleting the offset if fn returns
+// true.
+func (os Offsets) DeleteFunc(fn func(o Offset) bool) {
+	os.KeepFunc(func(o Offset) bool { return !fn(o) })
+}
+
+// Topics returns the set of topics and partitions currently used in these
+// offsets.
+func (os Offsets) TopicsSet() TopicsSet {
+	s := make(TopicsSet)
+	os.Each(func(o Offset) { s.Add(o.Topic, o.Partition) })
+	return s
+}
+
+// Each calls fn for each offset in these offsets.
+func (os Offsets) Each(fn func(Offset)) {
+	for _, ps := range os {
+		for _, o := range ps {
+			fn(o)
+		}
+	}
+}
+
+// KOffsets returns these offsets as a kgo offset map.
+func (os Offsets) KOffsets() map[string]map[int32]kgo.Offset {
+	tskgo := make(map[string]map[int32]kgo.Offset)
+	for t, ps := range os {
+		pskgo := make(map[int32]kgo.Offset)
+		for p, o := range ps {
+			pskgo[p] = kgo.NewOffset().
+				At(o.At).
+				WithEpoch(o.LeaderEpoch)
+		}
+		tskgo[t] = pskgo
+	}
+	return tskgo
+}
+
+// Sorted returns the offsets sorted by topic and partition.
+func (os Offsets) Sorted() []Offset {
+	var s []Offset
+	os.Each(func(o Offset) { s = append(s, o) })
+	sort.Slice(s, func(i, j int) bool {
+		return s[i].Topic < s[j].Topic ||
+			s[i].Topic == s[j].Topic && s[i].Partition < s[j].Partition
+	})
+	return s
+}
+
+// OffsetsFromFetches returns Offsets for the final record in any partition in
+// the fetches. This is a helper to enable committing an entire returned batch.
+//
+// This function looks at only the last record per partition, assuming that the
+// last record is the highest offset (which is the behavior returned by kgo's
+// Poll functions). The returned offsets are one past the offset contained in
+// the records.
+func OffsetsFromFetches(fs kgo.Fetches) Offsets {
+	os := make(Offsets)
+	fs.EachPartition(func(p kgo.FetchTopicPartition) {
+		if len(p.Records) == 0 {
+			return
+		}
+		r := p.Records[len(p.Records)-1]
+		os.AddOffset(r.Topic, r.Partition, r.Offset+1, r.LeaderEpoch)
+	})
+	return os
+}
+
+// OffsetsFromRecords returns offsets for all given records, using the highest
+// offset per partition. The returned offsets are one past the offset contained
+// in the records.
+func OffsetsFromRecords(rs ...kgo.Record) Offsets {
+	os := make(Offsets)
+	for _, r := range rs {
+		os.AddOffset(r.Topic, r.Partition, r.Offset+1, r.LeaderEpoch)
+	}
+	return os
+}
+
+// TopicsSet is a set of topics and, per topic, a set of partitions.
+//
+// All methods provided for TopicsSet are safe to use on a nil (default) set.
+type TopicsSet map[string]map[int32]struct{}
+
+// Lookup returns whether the topic and partition exists.
+func (s TopicsSet) Lookup(t string, p int32) bool {
+	if len(s) == 0 {
+		return false
+	}
+	ps := s[t]
+	if len(ps) == 0 {
+		return false
+	}
+	_, exists := ps[p]
+	return exists
+}
+
+// Each calls fn for each topic / partition in the topics set.
+func (s TopicsSet) Each(fn func(t string, p int32)) {
+	for t, ps := range s {
+		for p := range ps {
+			fn(t, p)
+		}
+	}
+}
+
+// EachPartitions calls fn for each topic and its partitions in the topics set.
+func (s TopicsSet) EachPartitions(fn func(t string, ps []int32)) {
+	for t, ps := range s {
+		sliced := make([]int32, 0, len(ps))
+		for p := range ps {
+			sliced = append(sliced, p)
+		}
+		fn(t, sliced)
+	}
+}
+
+// EmptyTopics returns all topics with no partitions.
+func (s TopicsSet) EmptyTopics() []string {
+	var e []string
+	for t, ps := range s {
+		if len(ps) == 0 {
+			e = append(e, t)
+		}
+	}
+	return e
+}
+
+// Add adds partitions for a topic to the topics set. If no partitions are
+// added, this still creates the topic.
+func (s *TopicsSet) Add(t string, ps ...int32) {
+	if *s == nil {
+		*s = make(map[string]map[int32]struct{})
+	}
+	existing := (*s)[t]
+	if existing == nil {
+		existing = make(map[int32]struct{}, len(ps))
+		(*s)[t] = existing
+	}
+	for _, p := range ps {
+		existing[p] = struct{}{}
+	}
+}
+
+// Delete removes partitions from a topic from the topics set. If the topic
+// ends up with no partitions, the topic is removed from the set.
+func (s TopicsSet) Delete(t string, ps ...int32) {
+	if s == nil || len(ps) == 0 {
+		return
+	}
+	existing := s[t]
+	if existing == nil {
+		return
+	}
+	for _, p := range ps {
+		delete(existing, p)
+	}
+	if len(existing) == 0 {
+		delete(s, t)
+	}
+}
+
+// Topics returns all topics in this set in sorted order.
+func (s TopicsSet) Topics() []string {
+	ts := make([]string, 0, len(s))
+	for t := range s {
+		ts = append(ts, t)
+	}
+	sort.Strings(ts)
+	return ts
+}
+
+// Merge merges another topic set into this one.
+func (s TopicsSet) Merge(other TopicsSet) {
+	for t, ps := range other {
+		for p := range ps {
+			s.Add(t, p)
+		}
+	}
+}
+
+// IntoList returns this set as a list.
+func (s TopicsSet) IntoList() TopicsList {
+	l := make(TopicsList, 0, len(s))
+	for t, ps := range s {
+		lps := make([]int32, 0, len(ps))
+		for p := range ps {
+			lps = append(lps, p)
+		}
+		l = append(l, TopicPartitions{
+			Topic:      t,
+			Partitions: lps,
+		})
+	}
+	return l
+}
+
+// Sorted returns this set as a list in topic-sorted order, with each topic
+// having sorted partitions.
+func (s TopicsSet) Sorted() TopicsList {
+	l := make(TopicsList, 0, len(s))
+	for t, ps := range s {
+		tps := TopicPartitions{
+			Topic:      t,
+			Partitions: make([]int32, 0, len(ps)),
+		}
+		for p := range ps {
+			tps.Partitions = append(tps.Partitions, p)
+		}
+		tps.Partitions = int32s(tps.Partitions)
+		l = append(l, tps)
+	}
+	sort.Slice(l, func(i, j int) bool { return l[i].Topic < l[j].Topic })
+	return l
+}
+
+// TopicPartitions is a topic and partitions.
+type TopicPartitions struct {
+	Topic      string
+	Partitions []int32
+}
+
+// TopicsList is a list of topics and partitions.
+type TopicsList []TopicPartitions
+
+// Each calls fn for each topic / partition in the topics list.
+func (l TopicsList) Each(fn func(t string, p int32)) {
+	for _, t := range l {
+		for _, p := range t.Partitions {
+			fn(t.Topic, p)
+		}
+	}
+}
+
+// EachPartitions calls fn for each topic and its partitions in the topics
+// list.
+func (l TopicsList) EachPartitions(fn func(t string, ps []int32)) {
+	for _, t := range l {
+		fn(t.Topic, t.Partitions)
+	}
+}
+
+// EmptyTopics returns all topics with no partitions.
+func (l TopicsList) EmptyTopics() []string {
+	var e []string
+	for _, t := range l {
+		if len(t.Partitions) == 0 {
+			e = append(e, t.Topic)
+		}
+	}
+	return e
+}
+
+// Topics returns all topics in this set in sorted order.
+func (l TopicsList) Topics() []string {
+	ts := make([]string, 0, len(l))
+	for _, t := range l {
+		ts = append(ts, t.Topic)
+	}
+	sort.Strings(ts)
+	return ts
+}
+
+// IntoSet returns this list as a set.
+func (l TopicsList) IntoSet() TopicsSet {
+	s := make(TopicsSet)
+	for _, t := range l {
+		s.Add(t.Topic, t.Partitions...)
+	}
+	return s
+}
+
+// First returns the first element of the input slice and whether it exists.
+// This is the non-error-accepting equivalent of FirstE.
+//
+// Many client methods in kadm accept a variadic amount of input arguments and
+// return either a slice or a map of responses, but you often use the method
+// with only one argument. This function can help extract the one response you
+// are interested in.
+func First[S ~[]T, T any](s S) (T, bool) {
+	if len(s) == 0 {
+		var t T
+		return t, false
+	}
+	return s[0], true
+}
+
+// Any returns the first range element of the input map and whether it exists.
+// This is the non-error-accepting equivalent of AnyE.
+//
+// Many client methods in kadm accept a variadic amount of input arguments and
+// return either a slice or a map of responses, but you often use the method
+// with only one argument. This function can help extract the one response you
+// are interested in.
+func Any[M ~map[K]V, K comparable, V any](m M) (V, bool) {
+	for _, v := range m {
+		return v, true
+	}
+	var v V
+	return v, false
+}
+
+// ErrEmpty is returned from FirstE or AnyE if the input is empty.
+var ErrEmpty = errors.New("empty")
+
+// FirstE returns the first element of the input slice, or the input error
+// if it is non-nil. If the error is nil but the slice is empty, this returns
+// ErrEmpty. This is the error-accepting equivalent of First.
+//
+// Many client methods in kadm accept a variadic amount of input arguments and
+// return either a slice or a map of responses, but you often use the method
+// with only one argument. This function can help extract the one response you
+// are interested in.
+func FirstE[S ~[]T, T any](s S, err error) (T, error) {
+	if err != nil {
+		var t T
+		return t, err
+	}
+	if len(s) == 0 {
+		var t T
+		return t, ErrEmpty
+	}
+	return s[0], err
+}
+
+// AnyE returns the first range element of the input map, or the input error if
+// it is non-nil. If the error is nil but the map is empty, this returns
+// ErrEmpty. This is the error-accepting equivalent of Any.
+//
+// Many client methods in kadm accept a variadic amount of input arguments and
+// return either a slice or a map of responses, but you often use the method
+// with only one argument. This function can help extract the one response you
+// are interested in.
+func AnyE[M ~map[K]V, K comparable, V any](m M, err error) (V, error) {
+	if err != nil {
+		var v V
+		return v, err
+	}
+	for _, v := range m {
+		return v, nil
+	}
+	var v V
+	return v, ErrEmpty
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/logdirs.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/logdirs.go
@@ -1,0 +1,592 @@
+package kadm
+
+import (
+	"context"
+	"sort"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// AlterReplicaLogDirsReq is the input for a request to alter replica log
+// directories. The key is the directory that all topics and partitions in
+// the topic set will move to.
+type AlterReplicaLogDirsReq map[string]TopicsSet
+
+// Add merges the input topic set into the given directory.
+func (r *AlterReplicaLogDirsReq) Add(d string, s TopicsSet) {
+	if *r == nil {
+		*r = make(map[string]TopicsSet)
+	}
+	existing := (*r)[d]
+	if existing == nil {
+		existing = make(TopicsSet)
+		(*r)[d] = existing
+	}
+	existing.Merge(s)
+}
+
+func (r AlterReplicaLogDirsReq) req() *kmsg.AlterReplicaLogDirsRequest {
+	req := kmsg.NewPtrAlterReplicaLogDirsRequest()
+	for dir, ts := range r {
+		rd := kmsg.NewAlterReplicaLogDirsRequestDir()
+		rd.Dir = dir
+		for t, ps := range ts {
+			rt := kmsg.NewAlterReplicaLogDirsRequestDirTopic()
+			rt.Topic = t
+			for p := range ps {
+				rt.Partitions = append(rt.Partitions, p)
+			}
+			rd.Topics = append(rd.Topics, rt)
+		}
+		req.Dirs = append(req.Dirs, rd)
+	}
+	return req
+}
+
+func (r AlterReplicaLogDirsReq) dirfor(t string, p int32) string {
+	for d, dts := range r {
+		if dts == nil {
+			continue
+		}
+		dtps, ok := dts[t] // does this dir contain this topic?
+		if !ok {
+			continue
+		}
+		if _, ok = dtps[p]; !ok { // does this topic in this dir contain this partition?
+			continue
+		}
+		return d // yes
+	}
+	return ""
+}
+
+// AlterAllReplicaLogDirsResponses contains per-broker responses to altered
+// partition directories.
+type AlterAllReplicaLogDirsResponses map[int32]AlterReplicaLogDirsResponses
+
+// Sorted returns the responses sorted by broker, topic, and partition.
+func (rs AlterAllReplicaLogDirsResponses) Sorted() []AlterReplicaLogDirsResponse {
+	var all []AlterReplicaLogDirsResponse
+	rs.Each(func(r AlterReplicaLogDirsResponse) {
+		all = append(all, r)
+	})
+	sort.Slice(all, func(i, j int) bool { return all[i].Less(all[j]) })
+	return all
+}
+
+// Each calls fn for every response.
+func (rs AlterAllReplicaLogDirsResponses) Each(fn func(AlterReplicaLogDirsResponse)) {
+	for _, ts := range rs {
+		ts.Each(fn)
+	}
+}
+
+// AlterReplicaLogDirsResponses contains responses to altered partition
+// directories for a single broker.
+type AlterReplicaLogDirsResponses map[string]map[int32]AlterReplicaLogDirsResponse
+
+// Sorted returns the responses sorted by topic and partition.
+func (rs AlterReplicaLogDirsResponses) Sorted() []AlterReplicaLogDirsResponse {
+	var all []AlterReplicaLogDirsResponse
+	rs.Each(func(r AlterReplicaLogDirsResponse) {
+		all = append(all, r)
+	})
+	sort.Slice(all, func(i, j int) bool { return all[i].Less(all[j]) })
+	return all
+}
+
+// Each calls fn for every response.
+func (rs AlterReplicaLogDirsResponses) Each(fn func(AlterReplicaLogDirsResponse)) {
+	for _, ps := range rs {
+		for _, r := range ps {
+			fn(r)
+		}
+	}
+}
+
+// AlterReplicaLogDirsResponse contains a the response for an individual
+// altered partition directory.
+type AlterReplicaLogDirsResponse struct {
+	Broker    int32  // Broker is the broker this response came from.
+	Dir       string // Dir is the directory this partition was requested to be moved to.
+	Topic     string // Topic is the topic for this partition.
+	Partition int32  // Partition is the partition that was moved.
+	Err       error  // Err is non-nil if this move had an error.
+}
+
+// Less returns if the response is less than the other by broker, dir, topic,
+// and partition.
+func (a AlterReplicaLogDirsResponse) Less(other AlterReplicaLogDirsResponse) bool {
+	if a.Broker < other.Broker {
+		return true
+	}
+	if a.Broker > other.Broker {
+		return false
+	}
+	if a.Dir < other.Dir {
+		return true
+	}
+	if a.Dir > other.Dir {
+		return false
+	}
+	if a.Topic < other.Topic {
+		return true
+	}
+	if a.Topic > other.Topic {
+		return false
+	}
+	return a.Partition < other.Partition
+}
+
+func newAlterLogDirsResp(node int32, req AlterReplicaLogDirsReq, resp *kmsg.AlterReplicaLogDirsResponse) AlterReplicaLogDirsResponses {
+	a := make(AlterReplicaLogDirsResponses)
+	for _, kt := range resp.Topics {
+		ps := make(map[int32]AlterReplicaLogDirsResponse)
+		a[kt.Topic] = ps
+		for _, kp := range kt.Partitions {
+			ps[kp.Partition] = AlterReplicaLogDirsResponse{
+				Broker:    node,
+				Dir:       req.dirfor(kt.Topic, kp.Partition),
+				Topic:     kt.Topic,
+				Partition: kp.Partition,
+				Err:       kerr.ErrorForCode(kp.ErrorCode),
+			}
+		}
+	}
+	return a
+}
+
+// AlterAllReplicaLogDirs alters the log directories for the input topic
+// partitions, moving each partition to the requested directory. This function
+// moves all replicas on any broker.
+//
+// This may return *ShardErrors.
+func (cl *Client) AlterAllReplicaLogDirs(ctx context.Context, alter AlterReplicaLogDirsReq) (AlterAllReplicaLogDirsResponses, error) {
+	if len(alter) == 0 {
+		return make(AlterAllReplicaLogDirsResponses), nil
+	}
+	req := alter.req()
+	shards := cl.cl.RequestSharded(ctx, req)
+	resps := make(AlterAllReplicaLogDirsResponses)
+	return resps, shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
+		resp := kr.(*kmsg.AlterReplicaLogDirsResponse)
+		resps[b.NodeID] = newAlterLogDirsResp(b.NodeID, alter, resp) // one node ID, no need to unique-check
+		return nil
+	})
+}
+
+// AlterBrokerReplicaLogDirs alters the log directories for the input topic on the
+// given broker, moving each partition to the requested directory.
+func (cl *Client) AlterBrokerReplicaLogDirs(ctx context.Context, broker int32, alter AlterReplicaLogDirsReq) (AlterReplicaLogDirsResponses, error) {
+	if len(alter) == 0 {
+		return make(AlterReplicaLogDirsResponses), nil
+	}
+	b := cl.cl.Broker(int(broker))
+	kresp, err := b.RetriableRequest(ctx, alter.req())
+	if err != nil {
+		return nil, err
+	}
+	resp := kresp.(*kmsg.AlterReplicaLogDirsResponse)
+	return newAlterLogDirsResp(broker, alter, resp), nil
+}
+
+func describeLogDirsReq(s TopicsSet) *kmsg.DescribeLogDirsRequest {
+	req := kmsg.NewPtrDescribeLogDirsRequest()
+	for t, ps := range s {
+		rt := kmsg.NewDescribeLogDirsRequestTopic()
+		rt.Topic = t
+		for p := range ps {
+			rt.Partitions = append(rt.Partitions, p)
+		}
+		req.Topics = append(req.Topics, rt)
+	}
+	return req
+}
+
+// DescribedAllLogDirs contains per-broker responses to described log
+// directories.
+type DescribedAllLogDirs map[int32]DescribedLogDirs
+
+// Sorted returns each log directory sorted by broker, then by directory.
+func (ds DescribedAllLogDirs) Sorted() []DescribedLogDir {
+	var all []DescribedLogDir
+	ds.Each(func(d DescribedLogDir) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Broker < r.Broker || l.Broker == r.Broker && l.Dir < r.Dir
+	})
+	return all
+}
+
+// Each calls fn for every described log dir in all responses.
+func (ds DescribedAllLogDirs) Each(fn func(DescribedLogDir)) {
+	for _, bds := range ds {
+		bds.Each(fn)
+	}
+}
+
+// DescribedLogDirs contains per-directory responses to described log
+// directories for a single broker.
+type DescribedLogDirs map[string]DescribedLogDir
+
+// Lookup returns the described partition if it exists.
+func (ds DescribedLogDirs) Lookup(d, t string, p int32) (DescribedLogDirPartition, bool) {
+	dir, exists := ds[d]
+	if !exists {
+		return DescribedLogDirPartition{}, false
+	}
+	ps, exists := dir.Topics[t]
+	if !exists {
+		return DescribedLogDirPartition{}, false
+	}
+	dp, exists := ps[p]
+	if !exists {
+		return DescribedLogDirPartition{}, false
+	}
+	return dp, true
+}
+
+// LookupPartition returns the described partition if it exists in any
+// directory. Brokers should only have one replica of a partition, so this
+// should always find at most one partition.
+func (ds DescribedLogDirs) LookupPartition(t string, p int32) (DescribedLogDirPartition, bool) {
+	for _, dir := range ds {
+		ps, exists := dir.Topics[t]
+		if !exists {
+			continue
+		}
+		dp, exists := ps[p]
+		if !exists {
+			continue
+		}
+		return dp, true
+	}
+	return DescribedLogDirPartition{}, false
+}
+
+// Size returns the total size of all directories.
+func (ds DescribedLogDirs) Size() int64 {
+	var tot int64
+	ds.EachPartition(func(d DescribedLogDirPartition) {
+		tot += d.Size
+	})
+	return tot
+}
+
+// Error iterates over all directories and returns the first error encounted,
+// if any. This can be used to check if describing was entirely successful or
+// not.
+func (ds DescribedLogDirs) Error() error {
+	for _, d := range ds {
+		if d.Err != nil {
+			return d.Err
+		}
+	}
+	return nil
+}
+
+// Ok returns true if there are no errors. This is a shortcut for ds.Error() ==
+// nil.
+func (ds DescribedLogDirs) Ok() bool {
+	return ds.Error() == nil
+}
+
+// Sorted returns all directories sorted by dir.
+func (ds DescribedLogDirs) Sorted() []DescribedLogDir {
+	var all []DescribedLogDir
+	ds.Each(func(d DescribedLogDir) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Broker < r.Broker || l.Broker == r.Broker && l.Dir < r.Dir
+	})
+	return all
+}
+
+// SortedPartitions returns all partitions sorted by dir, then topic, then
+// partition.
+func (ds DescribedLogDirs) SortedPartitions() []DescribedLogDirPartition {
+	var all []DescribedLogDirPartition
+	ds.EachPartition(func(d DescribedLogDirPartition) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool { return all[i].Less(all[j]) })
+	return all
+}
+
+// SortedBySize returns all directories sorted from smallest total directory
+// size to largest.
+func (ds DescribedLogDirs) SortedBySize() []DescribedLogDir {
+	var all []DescribedLogDir
+	ds.Each(func(d DescribedLogDir) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		ls, rs := l.Size(), r.Size()
+		return ls < rs || ls == rs &&
+			(l.Broker < r.Broker || l.Broker == r.Broker &&
+				l.Dir < r.Dir)
+	})
+	return all
+}
+
+// SortedPartitionsBySize returns all partitions across all directories sorted
+// by smallest to largest, falling back to by broker, dir, topic, and
+// partition.
+func (ds DescribedLogDirs) SortedPartitionsBySize() []DescribedLogDirPartition {
+	var all []DescribedLogDirPartition
+	ds.EachPartition(func(d DescribedLogDirPartition) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool { return all[i].LessBySize(all[j]) })
+	return all
+}
+
+// SmallestPartitionBySize returns the smallest partition by directory size, or
+// no partition if there are no partitions.
+func (ds DescribedLogDirs) SmallestPartitionBySize() (DescribedLogDirPartition, bool) {
+	sorted := ds.SortedPartitionsBySize()
+	if len(sorted) == 0 {
+		return DescribedLogDirPartition{}, false
+	}
+	return sorted[0], true
+}
+
+// LargestPartitionBySize returns the largest partition by directory size, or
+// no partition if there are no partitions.
+func (ds DescribedLogDirs) LargestPartitionBySize() (DescribedLogDirPartition, bool) {
+	sorted := ds.SortedPartitionsBySize()
+	if len(sorted) == 0 {
+		return DescribedLogDirPartition{}, false
+	}
+	return sorted[len(sorted)-1], true
+}
+
+// Each calls fn for each log directory.
+func (ds DescribedLogDirs) Each(fn func(DescribedLogDir)) {
+	for _, d := range ds {
+		fn(d)
+	}
+}
+
+// Each calls fn for each partition in any directory.
+func (ds DescribedLogDirs) EachPartition(fn func(d DescribedLogDirPartition)) {
+	for _, d := range ds {
+		d.Topics.Each(fn)
+	}
+}
+
+// EachError calls fn for every directory that has a non-nil error.
+func (ds DescribedLogDirs) EachError(fn func(DescribedLogDir)) {
+	for _, d := range ds {
+		if d.Err != nil {
+			fn(d)
+		}
+	}
+}
+
+// DescribedLogDir is a described log directory.
+type DescribedLogDir struct {
+	Broker int32                 // Broker is the broker being described.
+	Dir    string                // Dir is the described directory.
+	Topics DescribedLogDirTopics // Partitions are the partitions in this directory.
+	Err    error                 // Err is non-nil if this directory could not be described.
+}
+
+// Size returns the total size of all partitions in this directory. This is
+// a shortcut for .Topics.Size().
+func (ds DescribedLogDir) Size() int64 {
+	return ds.Topics.Size()
+}
+
+// DescribedLogDirTopics contains per-partition described log directories.
+type DescribedLogDirTopics map[string]map[int32]DescribedLogDirPartition
+
+// Lookup returns the described partition if it exists.
+func (ds DescribedLogDirTopics) Lookup(t string, p int32) (DescribedLogDirPartition, bool) {
+	ps, exists := ds[t]
+	if !exists {
+		return DescribedLogDirPartition{}, false
+	}
+	d, exists := ps[p]
+	return d, exists
+}
+
+// Size returns the total size of all partitions in this directory.
+func (ds DescribedLogDirTopics) Size() int64 {
+	var tot int64
+	ds.Each(func(d DescribedLogDirPartition) {
+		tot += d.Size
+	})
+	return tot
+}
+
+// Sorted returns all partitions sorted by topic then partition.
+func (ds DescribedLogDirTopics) Sorted() []DescribedLogDirPartition {
+	var all []DescribedLogDirPartition
+	ds.Each(func(d DescribedLogDirPartition) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool { return all[i].Less(all[j]) })
+	return all
+}
+
+// SortedBySize returns all partitions sorted by smallest size to largest. If
+// partitions are of equal size, the sorting is topic then partition.
+func (ds DescribedLogDirTopics) SortedBySize() []DescribedLogDirPartition {
+	var all []DescribedLogDirPartition
+	ds.Each(func(d DescribedLogDirPartition) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool { return all[i].LessBySize(all[j]) })
+	return all
+}
+
+// Each calls fn for every partition.
+func (ds DescribedLogDirTopics) Each(fn func(p DescribedLogDirPartition)) {
+	for _, ps := range ds {
+		for _, d := range ps {
+			fn(d)
+		}
+	}
+}
+
+// DescribedLogDirPartition is the information for a single partitions described
+// log directory.
+type DescribedLogDirPartition struct {
+	Broker    int32  // Broker is the broker this partition is on.
+	Dir       string // Dir is the directory this partition lives in.
+	Topic     string // Topic is the topic for this partition.
+	Partition int32  // Partition is this partition.
+	Size      int64  // Size is the total size of the log segments of this partition, in bytes.
+
+	// OffsetLag is how far behind the log end offset this partition is.
+	// The math is:
+	//
+	//     if IsFuture {
+	//         logEndOffset - futureLogEndOffset
+	//     } else {
+	//         max(highWaterMark - logEndOffset)
+	//     }
+	//
+	OffsetLag int64
+	// IsFuture is true if this replica was created by an
+	// AlterReplicaLogDirsRequest and will replace the current log of the
+	// replica in the future.
+	IsFuture bool
+}
+
+// Less returns if one dir partition is less than the other, by dir, topic,
+// partition, and size.
+func (p DescribedLogDirPartition) Less(other DescribedLogDirPartition) bool {
+	if p.Broker < other.Broker {
+		return true
+	}
+	if p.Broker > other.Broker {
+		return false
+	}
+	if p.Dir < other.Dir {
+		return true
+	}
+	if p.Dir > other.Dir {
+		return false
+	}
+	if p.Topic < other.Topic {
+		return true
+	}
+	if p.Topic > other.Topic {
+		return false
+	}
+	if p.Partition < other.Partition {
+		return true
+	}
+	if p.Partition > other.Partition {
+		return false
+	}
+	return p.Size < other.Size
+}
+
+// LessBySize returns if one dir partition is less than the other by size,
+// otherwise by normal Less semantics.
+func (p DescribedLogDirPartition) LessBySize(other DescribedLogDirPartition) bool {
+	if p.Size < other.Size {
+		return true
+	}
+	return p.Less(other)
+}
+
+func newDescribeLogDirsResp(node int32, resp *kmsg.DescribeLogDirsResponse) DescribedLogDirs {
+	ds := make(DescribedLogDirs)
+	for _, rd := range resp.Dirs {
+		d := DescribedLogDir{
+			Broker: node,
+			Dir:    rd.Dir,
+			Topics: make(DescribedLogDirTopics),
+			Err:    kerr.ErrorForCode(rd.ErrorCode),
+		}
+		for _, rt := range rd.Topics {
+			t := make(map[int32]DescribedLogDirPartition)
+			d.Topics[rt.Topic] = t
+			for _, rp := range rt.Partitions {
+				t[rp.Partition] = DescribedLogDirPartition{
+					Broker:    node,
+					Dir:       rd.Dir,
+					Topic:     rt.Topic,
+					Partition: rp.Partition,
+					Size:      rp.Size,
+					OffsetLag: rp.OffsetLag,
+					IsFuture:  rp.IsFuture,
+				}
+			}
+		}
+		ds[rd.Dir] = d
+	}
+	return ds
+}
+
+// DescribeAllLogDirs describes the log directores for every input topic
+// partition on every broker. If the input set is nil, this describes all log
+// directories.
+//
+// This may return *ShardErrors.
+func (cl *Client) DescribeAllLogDirs(ctx context.Context, s TopicsSet) (DescribedAllLogDirs, error) {
+	req := describeLogDirsReq(s)
+	shards := cl.cl.RequestSharded(ctx, req)
+	resps := make(DescribedAllLogDirs)
+	return resps, shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
+		resp := kr.(*kmsg.DescribeLogDirsResponse)
+		if err := maybeAuthErr(resp.ErrorCode); err != nil {
+			return err
+		}
+		if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+			return err
+		}
+		resps[b.NodeID] = newDescribeLogDirsResp(b.NodeID, resp) // one node ID, no need to unique-check
+		return nil
+	})
+}
+
+// DescribeBrokerLogDirs describes the log directories for the input topic
+// partitions on the given broker. If the input set is nil, this describes all
+// log directories.
+func (cl *Client) DescribeBrokerLogDirs(ctx context.Context, broker int32, s TopicsSet) (DescribedLogDirs, error) {
+	req := describeLogDirsReq(s)
+	b := cl.cl.Broker(int(broker))
+	kresp, err := b.RetriableRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	resp := kresp.(*kmsg.DescribeLogDirsResponse)
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	return newDescribeLogDirsResp(broker, resp), nil
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/metadata.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/metadata.go
@@ -1,0 +1,518 @@
+package kadm
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"sort"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// TopicID is the 16 byte underlying topic ID.
+type TopicID [16]byte
+
+// String returns the topic ID encoded as base64.
+func (t TopicID) String() string { return base64.StdEncoding.EncodeToString(t[:]) }
+
+// MarshalJSON returns the topic ID encoded as quoted base64.
+func (t TopicID) MarshalJSON() ([]byte, error) { return []byte(`"` + t.String() + `"`), nil }
+
+// Less returns if this ID is less than the other, byte by byte.
+func (t TopicID) Less(other TopicID) bool {
+	return bytes.Compare(t[:], other[:]) == -1
+}
+
+// PartitionDetail is the detail of a partition as returned by a metadata
+// response. If the partition fails to load / has an error, then only the
+// partition number itself and the Err fields will be set.
+type PartitionDetail struct {
+	Topic     string // Topic is the topic this partition belongs to.
+	Partition int32  // Partition is the partition number these details are for.
+
+	Leader          int32   // Leader is the broker leader, if there is one, otherwise -1.
+	LeaderEpoch     int32   // LeaderEpoch is the leader's current epoch.
+	Replicas        []int32 // Replicas is the list of replicas.
+	ISR             []int32 // ISR is the list of in sync replicas.
+	OfflineReplicas []int32 // OfflineReplicas is the list of offline replicas.
+
+	Err error // Err is non-nil if the partition currently has a load error.
+}
+
+// PartitionDetails contains details for partitions as returned by a metadata
+// response.
+type PartitionDetails map[int32]PartitionDetail
+
+// Sorted returns the partitions in sorted order.
+func (ds PartitionDetails) Sorted() []PartitionDetail {
+	s := make([]PartitionDetail, 0, len(ds))
+	for _, d := range ds {
+		s = append(s, d)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].Partition < s[j].Partition })
+	return s
+}
+
+// Numbers returns a sorted list of all partition numbers.
+func (ds PartitionDetails) Numbers() []int32 {
+	all := make([]int32, 0, len(ds))
+	for p := range ds {
+		all = append(all, p)
+	}
+	return int32s(all)
+}
+
+// NumReplicas returns the number of replicas for these partitions
+//
+// It is assumed that all partitions have the same number of replicas, so this
+// simply returns the number of replicas in the first encountered partition.
+func (ds PartitionDetails) NumReplicas() int {
+	for _, p := range ds {
+		return len(p.Replicas)
+	}
+	return 0
+}
+
+// TopicDetail is the detail of a topic as returned by a metadata response. If
+// the topic fails to load / has an error, then there will be no partitions.
+type TopicDetail struct {
+	Topic string // Topic is the topic these details are for.
+
+	ID         TopicID          // TopicID is the topic's ID, or all 0 if the broker does not support IDs.
+	IsInternal bool             // IsInternal is whether the topic is an internal topic.
+	Partitions PartitionDetails // Partitions contains details about the topic's partitions.
+
+	Err error // Err is non-nil if the topic could not be loaded.
+}
+
+// TopicDetails contains details for topics as returned by a metadata response.
+type TopicDetails map[string]TopicDetail
+
+// Topics returns a sorted list of all topic names.
+func (ds TopicDetails) Names() []string {
+	all := make([]string, 0, len(ds))
+	for t := range ds {
+		all = append(all, t)
+	}
+	sort.Strings(all)
+	return all
+}
+
+// Sorted returns all topics in sorted order.
+func (ds TopicDetails) Sorted() []TopicDetail {
+	s := make([]TopicDetail, 0, len(ds))
+	for _, d := range ds {
+		s = append(s, d)
+	}
+	sort.Slice(s, func(i, j int) bool {
+		if s[i].Topic == "" {
+			if s[j].Topic == "" {
+				return bytes.Compare(s[i].ID[:], s[j].ID[:]) == -1
+			}
+			return true
+		}
+		if s[j].Topic == "" {
+			return false
+		}
+		return s[i].Topic < s[j].Topic
+	})
+	return s
+}
+
+// Has returns whether the topic details has the given topic and, if so, that
+// the topic's load error is not an unknown topic error.
+func (ds TopicDetails) Has(topic string) bool {
+	d, ok := ds[topic]
+	return ok && d.Err != kerr.UnknownTopicOrPartition
+}
+
+// FilterInternal deletes any internal topics from this set of topic details.
+func (ds TopicDetails) FilterInternal() {
+	for t, d := range ds {
+		if d.IsInternal {
+			delete(ds, t)
+		}
+	}
+}
+
+// EachPartition calls fn for every partition in all topics.
+func (ds TopicDetails) EachPartition(fn func(PartitionDetail)) {
+	for _, td := range ds {
+		for _, d := range td.Partitions {
+			fn(d)
+		}
+	}
+}
+
+// EachError calls fn for each topic that could not be loaded.
+func (ds TopicDetails) EachError(fn func(TopicDetail)) {
+	for _, td := range ds {
+		if td.Err != nil {
+			fn(td)
+		}
+	}
+}
+
+// Error iterates over all topic details and returns the first error
+// encountered, if any.
+func (ds TopicDetails) Error() error {
+	for _, t := range ds {
+		if t.Err != nil {
+			return t.Err
+		}
+	}
+	return nil
+}
+
+// TopicsSet returns the topics and partitions as a set.
+func (ds TopicDetails) TopicsSet() TopicsSet {
+	var s TopicsSet
+	ds.EachPartition(func(d PartitionDetail) {
+		s.Add(d.Topic, d.Partition)
+	})
+	return s
+}
+
+// TopicsList returns the topics and partitions as a list.
+func (ds TopicDetails) TopicsList() TopicsList {
+	return ds.TopicsSet().Sorted()
+}
+
+// Metadata is the data from a metadata response.
+type Metadata struct {
+	Cluster    string        // Cluster is the cluster name, if any.
+	Controller int32         // Controller is the node ID of the controller broker, if available, otherwise -1.
+	Brokers    BrokerDetails // Brokers contains broker details, sorted by default.
+	Topics     TopicDetails  // Topics contains topic details.
+}
+
+func int32s(is []int32) []int32 {
+	sort.Slice(is, func(i, j int) bool { return is[i] < is[j] })
+	return is
+}
+
+// ListBrokers issues a metadata request and returns BrokerDetails. This
+// returns an error if the request fails to be issued, or an *AuthError.
+func (cl *Client) ListBrokers(ctx context.Context) (BrokerDetails, error) {
+	m, err := cl.Metadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return m.Brokers, nil
+}
+
+// BrokerMetadata issues a metadata request and returns it, and does not ask
+// for any topics.
+//
+// This returns an error if the request fails to be issued, or an *AuthErr.
+func (cl *Client) BrokerMetadata(ctx context.Context) (Metadata, error) {
+	return cl.metadata(ctx, true, nil)
+}
+
+// Metadata issues a metadata request and returns it. Specific topics to
+// describe can be passed as additional arguments. If no topics are specified,
+// all topics are requested.
+//
+// This returns an error if the request fails to be issued, or an *AuthErr.
+func (cl *Client) Metadata(
+	ctx context.Context,
+	topics ...string,
+) (Metadata, error) {
+	return cl.metadata(ctx, false, topics)
+}
+
+func (cl *Client) metadata(ctx context.Context, noTopics bool, topics []string) (Metadata, error) {
+	req := kmsg.NewPtrMetadataRequest()
+	for _, t := range topics {
+		rt := kmsg.NewMetadataRequestTopic()
+		rt.Topic = kmsg.StringPtr(t)
+		req.Topics = append(req.Topics, rt)
+	}
+	if noTopics {
+		req.Topics = []kmsg.MetadataRequestTopic{}
+	}
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return Metadata{}, err
+	}
+
+	tds := make(map[string]TopicDetail, len(resp.Topics))
+	for _, t := range resp.Topics {
+		if err := maybeAuthErr(t.ErrorCode); err != nil {
+			return Metadata{}, err
+		}
+		td := TopicDetail{
+			ID:         t.TopicID,
+			Partitions: make(map[int32]PartitionDetail),
+			IsInternal: t.IsInternal,
+			Err:        kerr.ErrorForCode(t.ErrorCode),
+		}
+		if t.Topic != nil {
+			td.Topic = *t.Topic
+		}
+		for _, p := range t.Partitions {
+			td.Partitions[p.Partition] = PartitionDetail{
+				Topic:     td.Topic,
+				Partition: p.Partition,
+
+				Leader:          p.Leader,
+				LeaderEpoch:     p.LeaderEpoch,
+				Replicas:        p.Replicas,
+				ISR:             p.ISR,
+				OfflineReplicas: p.OfflineReplicas,
+
+				Err: kerr.ErrorForCode(p.ErrorCode),
+			}
+		}
+		tds[*t.Topic] = td
+	}
+
+	m := Metadata{
+		Controller: resp.ControllerID,
+		Topics:     tds,
+	}
+	if resp.ClusterID != nil {
+		m.Cluster = *resp.ClusterID
+	}
+
+	for _, b := range resp.Brokers {
+		m.Brokers = append(m.Brokers, kgo.BrokerMetadata{
+			NodeID: b.NodeID,
+			Host:   b.Host,
+			Port:   b.Port,
+			Rack:   b.Rack,
+		})
+	}
+	sort.Slice(m.Brokers, func(i, j int) bool { return m.Brokers[i].NodeID < m.Brokers[j].NodeID })
+
+	if len(topics) > 0 && len(m.Topics) != len(topics) {
+		return Metadata{}, fmt.Errorf("metadata returned only %d topics of %d requested", len(m.Topics), len(topics))
+	}
+
+	return m, nil
+}
+
+// ListedOffset contains record offset information.
+type ListedOffset struct {
+	Topic     string // Topic is the topic this offset is for.
+	Partition int32  // Partition is the partition this offset is for.
+
+	Timestamp   int64 // Timestamp is the millisecond of the offset if listing after a time, otherwise -1.
+	Offset      int64 // Offset is the record offset, or -1 if one could not be found.
+	LeaderEpoch int32 // LeaderEpoch is the leader epoch at this offset, if any, otherwise -1.
+
+	Err error // Err is non-nil if the partition has a load error.
+}
+
+// ListedOffsets contains per-partition record offset information that is
+// returned from any of the List.*Offsets functions.
+type ListedOffsets map[string]map[int32]ListedOffset
+
+// Lookup returns the offset at t and p and whether it exists.
+func (l ListedOffsets) Lookup(t string, p int32) (ListedOffset, bool) {
+	if len(l) == 0 {
+		return ListedOffset{}, false
+	}
+	ps := l[t]
+	if len(ps) == 0 {
+		return ListedOffset{}, false
+	}
+	o, exists := ps[p]
+	return o, exists
+}
+
+// Each calls fn for each listed offset.
+func (l ListedOffsets) Each(fn func(ListedOffset)) {
+	for _, ps := range l {
+		for _, o := range ps {
+			fn(o)
+		}
+	}
+}
+
+// Error iterates over all offsets and returns the first error encountered, if
+// any. This can be to check if a listing was entirely successful or not.
+//
+// Note that offset listing can be partially successful. For example, some
+// offsets could succeed to be listed, while other could fail (maybe one
+// partition is offline). If this is something you need to worry about, you may
+// need to check all offsets manually.
+func (l ListedOffsets) Error() error {
+	for _, ps := range l {
+		for _, o := range ps {
+			if o.Err != nil {
+				return o.Err
+			}
+		}
+	}
+	return nil
+}
+
+// Offsets returns these listed offsets as offsets.
+func (l ListedOffsets) Offsets() Offsets {
+	o := make(Offsets)
+	l.Each(func(l ListedOffset) {
+		o.Add(Offset{
+			Topic:       l.Topic,
+			Partition:   l.Partition,
+			At:          l.Offset,
+			LeaderEpoch: l.LeaderEpoch,
+		})
+	})
+	return o
+}
+
+// KOffsets returns these listed offsets as a kgo offset map.
+func (l ListedOffsets) KOffsets() map[string]map[int32]kgo.Offset {
+	return l.Offsets().KOffsets()
+}
+
+// ListStartOffsets returns the start (oldest) offsets for each partition in
+// each requested topic. In Kafka terms, this returns the log start offset. If
+// no topics are specified, all topics are listed. If a requested topic does
+// not exist, no offsets for it are listed and it is not present in the
+// response.
+//
+// If any topics being listed do not exist, a special -1 partition is added
+// to the response with the expected error code kerr.UnknownTopicOrPartition.
+//
+// This may return *ShardErrors.
+func (cl *Client) ListStartOffsets(ctx context.Context, topics ...string) (ListedOffsets, error) {
+	return cl.listOffsets(ctx, 0, -2, topics)
+}
+
+// ListEndOffsets returns the end (newest) offsets for each partition in each
+// requested topic. In Kafka terms, this returns high watermarks. If no topics
+// are specified, all topics are listed. If a requested topic does not exist,
+// no offsets for it are listed and it is not present in the response.
+//
+// If any topics being listed do not exist, a special -1 partition is added
+// to the response with the expected error code kerr.UnknownTopicOrPartition.
+//
+// This may return *ShardErrors.
+func (cl *Client) ListEndOffsets(ctx context.Context, topics ...string) (ListedOffsets, error) {
+	return cl.listOffsets(ctx, 0, -1, topics)
+}
+
+// ListCommittedOffsets returns newest committed offsets for each partition in
+// each requested topic. A committed offset may be slightly less than the
+// latest offset. In Kafka terms, committed means the last stable offset, and
+// newest means the high watermark. Record offsets in active, uncommitted
+// transactions will not be returned. If no topics are specified, all topics
+// are listed. If a requested topic does not exist, no offsets for it are
+// listed and it is not present in the response.
+//
+// If any topics being listed do not exist, a special -1 partition is added
+// to the response with the expected error code kerr.UnknownTopicOrPartition.
+//
+// This may return *ShardErrors.
+func (cl *Client) ListCommittedOffsets(ctx context.Context, topics ...string) (ListedOffsets, error) {
+	return cl.listOffsets(ctx, 1, -1, topics)
+}
+
+// ListOffsetsAfterMilli returns the first offsets after the requested
+// millisecond timestamp. Unlike listing start/end/committed offsets, offsets
+// returned from this function also include the timestamp of the offset. If no
+// topics are specified, all topics are listed. If a partition has no offsets
+// after the requested millisecond, the offset will be the current end offset.
+// If a requested topic does not exist, no offsets for it are listed and it is
+// not present in the response.
+//
+// If any topics being listed do not exist, a special -1 partition is added
+// to the response with the expected error code kerr.UnknownTopicOrPartition.
+//
+// This may return *ShardErrors.
+func (cl *Client) ListOffsetsAfterMilli(ctx context.Context, millisecond int64, topics ...string) (ListedOffsets, error) {
+	return cl.listOffsets(ctx, 0, millisecond, topics)
+}
+
+func (cl *Client) listOffsets(ctx context.Context, isolation int8, timestamp int64, topics []string) (ListedOffsets, error) {
+	tds, err := cl.ListTopics(ctx, topics...)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we request with timestamps, we may request twice: once for after
+	// timestamps, and once for any -1 (and no error) offsets where the
+	// timestamp is in the future.
+	list := make(ListedOffsets)
+
+	for _, td := range tds {
+		if td.Err != nil {
+			list[td.Topic] = map[int32]ListedOffset{
+				-1: {
+					Topic:     td.Topic,
+					Partition: -1,
+					Err:       td.Err,
+				},
+			}
+		}
+	}
+	rerequest := make(map[string][]int32)
+	shardfn := func(kr kmsg.Response) error {
+		resp := kr.(*kmsg.ListOffsetsResponse)
+		for _, t := range resp.Topics {
+			lt, ok := list[t.Topic]
+			if !ok {
+				lt = make(map[int32]ListedOffset)
+				list[t.Topic] = lt
+			}
+			for _, p := range t.Partitions {
+				if err := maybeAuthErr(p.ErrorCode); err != nil {
+					return err
+				}
+				lt[p.Partition] = ListedOffset{
+					Topic:       t.Topic,
+					Partition:   p.Partition,
+					Timestamp:   p.Timestamp,
+					Offset:      p.Offset,
+					LeaderEpoch: p.LeaderEpoch,
+					Err:         kerr.ErrorForCode(p.ErrorCode),
+				}
+				if timestamp != -1 && p.Offset == -1 && p.ErrorCode == 0 {
+					rerequest[t.Topic] = append(rerequest[t.Topic], p.Partition)
+				}
+			}
+		}
+		return nil
+	}
+
+	req := kmsg.NewPtrListOffsetsRequest()
+	req.IsolationLevel = isolation
+	for t, td := range tds {
+		rt := kmsg.NewListOffsetsRequestTopic()
+		if td.Err != nil {
+			continue
+		}
+		rt.Topic = t
+		for p := range td.Partitions {
+			rp := kmsg.NewListOffsetsRequestTopicPartition()
+			rp.Partition = p
+			rp.Timestamp = timestamp
+			rt.Partitions = append(rt.Partitions, rp)
+		}
+		req.Topics = append(req.Topics, rt)
+	}
+	shards := cl.cl.RequestSharded(ctx, req)
+	err = shardErrEach(req, shards, shardfn)
+	if len(rerequest) > 0 {
+		req.Topics = req.Topics[:0]
+		for t, ps := range rerequest {
+			rt := kmsg.NewListOffsetsRequestTopic()
+			rt.Topic = t
+			for _, p := range ps {
+				rp := kmsg.NewListOffsetsRequestTopicPartition()
+				rp.Partition = p
+				rp.Timestamp = -1 // we always list end offsets when rerequesting
+				rt.Partitions = append(rt.Partitions, rp)
+			}
+			req.Topics = append(req.Topics, rt)
+		}
+		shards = cl.cl.RequestSharded(ctx, req)
+		err = mergeShardErrs(err, shardErrEach(req, shards, shardfn))
+	}
+	return list, err
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/misc.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/misc.go
@@ -1,0 +1,939 @@
+package kadm
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/kversion"
+)
+
+// FindCoordinatorResponse contains information for the coordinator for a group
+// or transactional ID.
+type FindCoordinatorResponse struct {
+	Name       string // Name is the coordinator key this response is for.
+	NodeID     int32  // NodeID is the node ID of the coordinator for this key.
+	Host       string // Host is the host of the coordinator for this key.
+	Port       int32  // Port is the port of the coordinator for this key.
+	Err        error  // Err is any error encountered when requesting the coordinator.
+	ErrMessage string // ErrMessage a potential extra message describing any error.
+}
+
+// FindCoordinatorResponses contains responses to finding coordinators for
+// groups or transactions.
+type FindCoordinatorResponses map[string]FindCoordinatorResponse
+
+// AllFailed returns whether all responses are errored.
+func (rs FindCoordinatorResponses) AllFailed() bool {
+	var n int
+	rs.EachError(func(FindCoordinatorResponse) { n++ })
+	return len(rs) > 0 && n == len(rs)
+}
+
+// Sorted returns all coordinator responses sorted by name.
+func (rs FindCoordinatorResponses) Sorted() []FindCoordinatorResponse {
+	s := make([]FindCoordinatorResponse, 0, len(rs))
+	for _, r := range rs {
+		s = append(s, r)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].Name < s[j].Name })
+	return s
+}
+
+// EachError calls fn for every response that has a non-nil error.
+func (rs FindCoordinatorResponses) EachError(fn func(FindCoordinatorResponse)) {
+	for _, r := range rs {
+		if r.Err != nil {
+			fn(r)
+		}
+	}
+}
+
+// Each calls fn for every response.
+func (rs FindCoordinatorResponses) Each(fn func(FindCoordinatorResponse)) {
+	for _, r := range rs {
+		fn(r)
+	}
+}
+
+// Error iterates over all responses and returns the first error encountered,
+// if any.
+func (rs FindCoordinatorResponses) Error() error {
+	for _, r := range rs {
+		if r.Err != nil {
+			return r.Err
+		}
+	}
+	return nil
+}
+
+// Ok returns true if there are no errors. This is a shortcut for rs.Error() ==
+// nil.
+func (rs FindCoordinatorResponses) Ok() bool {
+	return rs.Error() == nil
+}
+
+// FindGroupCoordinators returns the coordinator for all requested group names.
+//
+// This may return *ShardErrors or *AuthError.
+func (cl *Client) FindGroupCoordinators(ctx context.Context, groups ...string) FindCoordinatorResponses {
+	return cl.findCoordinators(ctx, 0, groups...)
+}
+
+// FindTxnCoordinators returns the coordinator for all requested transactional
+// IDs.
+//
+// This may return *ShardErrors or *AuthError.
+func (cl *Client) FindTxnCoordinators(ctx context.Context, txnIDs ...string) FindCoordinatorResponses {
+	return cl.findCoordinators(ctx, 1, txnIDs...)
+}
+
+func (cl *Client) findCoordinators(ctx context.Context, kind int8, names ...string) FindCoordinatorResponses {
+	resps := make(FindCoordinatorResponses)
+	if len(names) == 0 {
+		return resps
+	}
+
+	req := kmsg.NewPtrFindCoordinatorRequest()
+	req.CoordinatorType = kind
+	req.CoordinatorKeys = names
+
+	keyErr := func(k string, err error) {
+		resps[k] = FindCoordinatorResponse{
+			Name: k,
+			Err:  err,
+		}
+	}
+	allKeysErr := func(req *kmsg.FindCoordinatorRequest, err error) {
+		for _, k := range req.CoordinatorKeys {
+			keyErr(k, err)
+		}
+	}
+
+	shards := cl.cl.RequestSharded(ctx, req)
+	for _, shard := range shards {
+		req := shard.Req.(*kmsg.FindCoordinatorRequest)
+		if shard.Err != nil {
+			allKeysErr(req, shard.Err)
+			continue
+		}
+		resp := shard.Resp.(*kmsg.FindCoordinatorResponse)
+		if err := maybeAuthErr(resp.ErrorCode); err != nil {
+			allKeysErr(req, err)
+			continue
+		}
+		for _, c := range resp.Coordinators {
+			if err := maybeAuthErr(c.ErrorCode); err != nil {
+				keyErr(c.Key, err)
+				continue
+			}
+			resps[c.Key] = FindCoordinatorResponse{ // key is always on one broker, no need to check existence
+				Name:       c.Key,
+				NodeID:     c.NodeID,
+				Host:       c.Host,
+				Port:       c.Port,
+				Err:        kerr.ErrorForCode(c.ErrorCode),
+				ErrMessage: unptrStr(c.ErrorMessage),
+			}
+		}
+	}
+	return resps
+}
+
+type minmax struct {
+	min, max int16
+}
+
+// BrokerApiVersions contains the API versions for a single broker.
+type BrokerApiVersions struct {
+	NodeID int32 // NodeID is the node this API versions response is for.
+
+	raw         *kmsg.ApiVersionsResponse
+	keyVersions map[int16]minmax
+
+	Err error // Err is non-nil if the API versions request failed.
+}
+
+// Raw returns the raw API versions response.
+func (v *BrokerApiVersions) Raw() *kmsg.ApiVersionsResponse {
+	return v.raw
+}
+
+// KeyVersions returns the broker's min and max version for an API key and
+// whether this broker supports the request.
+func (v *BrokerApiVersions) KeyVersions(key int16) (min, max int16, exists bool) {
+	vs, exists := v.keyVersions[key]
+	return vs.min, vs.max, exists
+}
+
+// KeyVersions returns the broker's min version for an API key and whether this
+// broker supports the request.
+func (v *BrokerApiVersions) KeyMinVersion(key int16) (min int16, exists bool) {
+	min, _, exists = v.KeyVersions(key)
+	return min, exists
+}
+
+// KeyVersions returns the broker's max version for an API key and whether this
+// broker supports the request.
+func (v *BrokerApiVersions) KeyMaxVersion(key int16) (max int16, exists bool) {
+	_, max, exists = v.KeyVersions(key)
+	return max, exists
+}
+
+// EachKeySorted calls fn for every API key in the broker response, from the
+// smallest API key to the largest.
+func (v *BrokerApiVersions) EachKeySorted(fn func(key, min, max int16)) {
+	type kmm struct {
+		k, min, max int16
+	}
+	kmms := make([]kmm, 0, len(v.keyVersions))
+	for key, minmax := range v.keyVersions {
+		kmms = append(kmms, kmm{key, minmax.min, minmax.max})
+	}
+	sort.Slice(kmms, func(i, j int) bool { return kmms[i].k < kmms[j].k })
+	for _, kmm := range kmms {
+		fn(kmm.k, kmm.min, kmm.max)
+	}
+}
+
+// VersionGuess returns the best guess of Kafka that this broker is. This is a
+// shorcut for:
+//
+//	kversion.FromApiVersionsResponse(v.Raw()).VersionGuess(opt...)
+//
+// Check the kversion.VersionGuess API docs for more details.
+func (v *BrokerApiVersions) VersionGuess(opt ...kversion.VersionGuessOpt) string {
+	return kversion.FromApiVersionsResponse(v.raw).VersionGuess(opt...)
+}
+
+// BrokerApiVersions contains API versions for all brokers that are reachable
+// from a metadata response.
+type BrokersApiVersions map[int32]BrokerApiVersions
+
+// Sorted returns all broker responses sorted by node ID.
+func (vs BrokersApiVersions) Sorted() []BrokerApiVersions {
+	s := make([]BrokerApiVersions, 0, len(vs))
+	for _, v := range vs {
+		s = append(s, v)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].NodeID < s[j].NodeID })
+	return s
+}
+
+// Each calls fn for every broker response.
+func (vs BrokersApiVersions) Each(fn func(BrokerApiVersions)) {
+	for _, v := range vs {
+		fn(v)
+	}
+}
+
+// ApiVersions queries every broker in a metadata response for their API
+// versions. This returns an error only if the metadata request fails.
+func (cl *Client) ApiVersions(ctx context.Context) (BrokersApiVersions, error) {
+	m, err := cl.BrokerMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	vs := make(BrokersApiVersions, len(m.Brokers))
+	for _, n := range m.Brokers.NodeIDs() {
+		n := n
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := kmsg.NewPtrApiVersionsRequest()
+			req.ClientSoftwareName = "kadm"
+			req.ClientSoftwareVersion = softwareVersion()
+			v := BrokerApiVersions{NodeID: n, keyVersions: make(map[int16]minmax)}
+			v.raw, v.Err = req.RequestWith(ctx, cl.cl.Broker(int(n)))
+
+			mu.Lock()
+			defer mu.Unlock()
+			defer func() { vs[n] = v }()
+			if v.Err != nil {
+				return
+			}
+
+			v.Err = kerr.ErrorForCode(v.raw.ErrorCode)
+			for _, k := range v.raw.ApiKeys {
+				v.keyVersions[k.ApiKey] = minmax{
+					min: k.MinVersion,
+					max: k.MaxVersion,
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	return vs, nil
+}
+
+// ClientQuotaEntityComponent is a quota entity component.
+type ClientQuotaEntityComponent struct {
+	Type string  // Type is the entity type ("user", "client-id", "ip").
+	Name *string // Name is the entity name, or null if the default.
+}
+
+// String returns key=value, or key=<default> if value is nil.
+func (d ClientQuotaEntityComponent) String() string {
+	if d.Name == nil {
+		return d.Type + "=<default>"
+	}
+	return fmt.Sprintf("%s=%s", d.Type, *d.Name)
+}
+
+// ClientQuotaEntity contains the components that make up a single entity.
+type ClientQuotaEntity []ClientQuotaEntityComponent
+
+// String returns {key=value, key=value}, joining all entities with a ", " and
+// wrapping in braces.
+func (ds ClientQuotaEntity) String() string {
+	var ss []string
+	for _, d := range ds {
+		ss = append(ss, d.String())
+	}
+	return "{" + strings.Join(ss, ", ") + "}"
+}
+
+// ClientQuotaValue is a quota name and value.
+type ClientQuotaValue struct {
+	Key   string  // Key is the quota configuration key.
+	Value float64 // Value is the quota configuration value.
+}
+
+// String returns key=value.
+func (d ClientQuotaValue) String() string {
+	return fmt.Sprintf("%s=%f", d.Key, d.Value)
+}
+
+// ClientQuotaValues contains all client quota values.
+type ClientQuotaValues []ClientQuotaValue
+
+// QuotasMatchType specifies how to match a described client quota entity.
+//
+// 0 means to match the name exactly: user=foo will only match components of
+// entity type "user" and entity name "foo".
+//
+// 1 means to match the default of the name: entity type "user" with a default
+// match will return the default quotas for user entities.
+//
+// 2 means to match any name: entity type "user" with any matching will return
+// both names and defaults.
+type QuotasMatchType = kmsg.QuotasMatchType
+
+// DescribeClientQuotaComponent is an input entity component to describing
+// client quotas: we define the type of quota ("client-id", "user"), how to
+// match, and the match name if needed.
+type DescribeClientQuotaComponent struct {
+	Type      string          // Type is the type of entity component to describe ("user", "client-id", "ip").
+	MatchName *string         // MatchName is the name to match again; this is only needed when MatchType is 0 (exact).
+	MatchType QuotasMatchType // MatchType is how to match an entity.
+}
+
+// DescribedClientQuota contains a described quota. A single quota is made up
+// of multiple entities and multiple values, for example, "user=foo" is one
+// component of the entity, and "client-id=bar" is another.
+type DescribedClientQuota struct {
+	Entity ClientQuotaEntity // Entity is the entity of this described client quota.
+	Values ClientQuotaValues // Values contains the quota valies for this entity.
+}
+
+// DescribedClientQuota contains client quotas that were described.
+type DescribedClientQuotas []DescribedClientQuota
+
+// DescribeClientQuotas describes client quotas. If strict is true, the
+// response includes only the requested components.
+func (cl *Client) DescribeClientQuotas(ctx context.Context, strict bool, entityComponents []DescribeClientQuotaComponent) (DescribedClientQuotas, error) {
+	req := kmsg.NewPtrDescribeClientQuotasRequest()
+	req.Strict = strict
+	for _, entity := range entityComponents {
+		rc := kmsg.NewDescribeClientQuotasRequestComponent()
+		rc.EntityType = entity.Type
+		rc.Match = entity.MatchName
+		rc.MatchType = entity.MatchType
+		req.Components = append(req.Components, rc)
+	}
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	var qs DescribedClientQuotas
+	for _, entry := range resp.Entries {
+		var q DescribedClientQuota
+		for _, e := range entry.Entity {
+			q.Entity = append(q.Entity, ClientQuotaEntityComponent{
+				Type: e.Type,
+				Name: e.Name,
+			})
+		}
+		for _, v := range entry.Values {
+			q.Values = append(q.Values, ClientQuotaValue{
+				Key:   v.Key,
+				Value: v.Value,
+			})
+		}
+		qs = append(qs, q)
+	}
+	return qs, nil
+}
+
+// AlterClientQuotaOp sets or remove a client quota.
+type AlterClientQuotaOp struct {
+	Key    string  // Key is the quota configuration key to set or remove.
+	Value  float64 // Value is the quota configuration value to set or remove.
+	Remove bool    // Remove, if true, removes this quota rather than sets it.
+}
+
+// AlterClientQuotaEntry pairs an entity with quotas to set or remove.
+type AlterClientQuotaEntry struct {
+	Entity ClientQuotaEntity    // Entity is the entity to alter quotas for.
+	Ops    []AlterClientQuotaOp // Ops are quotas to set or remove.
+}
+
+// AlteredClientQuota is the result for a single entity that was altered.
+type AlteredClientQuota struct {
+	Entity     ClientQuotaEntity // Entity is the entity this result is for.
+	Err        error             // Err is non-nil if the alter operation on this entity failed.
+	ErrMessage string            // ErrMessage is an optional additional message on error.
+}
+
+// AlteredClientQuotas contains results for all altered entities.
+type AlteredClientQuotas []AlteredClientQuota
+
+// AlterClientQuotas alters quotas for the input entries. You may consider
+// checking ValidateAlterClientQuotas before using this method.
+func (cl *Client) AlterClientQuotas(ctx context.Context, entries []AlterClientQuotaEntry) (AlteredClientQuotas, error) {
+	return cl.alterClientQuotas(ctx, false, entries)
+}
+
+// ValidateAlterClientQuotas validates an alter client quota request. This
+// returns exactly what AlterClientQuotas returns, but does not actually alter
+// quotas.
+func (cl *Client) ValidateAlterClientQuotas(ctx context.Context, entries []AlterClientQuotaEntry) (AlteredClientQuotas, error) {
+	return cl.alterClientQuotas(ctx, true, entries)
+}
+
+func (cl *Client) alterClientQuotas(ctx context.Context, validate bool, entries []AlterClientQuotaEntry) (AlteredClientQuotas, error) {
+	req := kmsg.NewPtrAlterClientQuotasRequest()
+	req.ValidateOnly = validate
+	for _, entry := range entries {
+		re := kmsg.NewAlterClientQuotasRequestEntry()
+		for _, c := range entry.Entity {
+			rec := kmsg.NewAlterClientQuotasRequestEntryEntity()
+			rec.Type = c.Type
+			rec.Name = c.Name
+			re.Entity = append(re.Entity, rec)
+		}
+		for _, op := range entry.Ops {
+			reo := kmsg.NewAlterClientQuotasRequestEntryOp()
+			reo.Key = op.Key
+			reo.Value = op.Value
+			reo.Remove = op.Remove
+			re.Ops = append(re.Ops, reo)
+		}
+		req.Entries = append(req.Entries, re)
+	}
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	var as AlteredClientQuotas
+	for _, entry := range resp.Entries {
+		var e ClientQuotaEntity
+		for _, c := range entry.Entity {
+			e = append(e, ClientQuotaEntityComponent{
+				Type: c.Type,
+				Name: c.Name,
+			})
+		}
+		a := AlteredClientQuota{
+			Entity:     e,
+			Err:        kerr.ErrorForCode(entry.ErrorCode),
+			ErrMessage: unptrStr(entry.ErrorMessage),
+		}
+		as = append(as, a)
+	}
+	return as, nil
+}
+
+// ScramMechanism is a SCRAM mechanism.
+type ScramMechanism int8
+
+const (
+	// ScramSha256 represents the SCRAM-SHA-256 mechanism.
+	ScramSha256 ScramMechanism = 1
+	// ScramSha512 represents the SCRAM-SHA-512 mechanism.
+	ScramSha512 ScramMechanism = 2
+)
+
+// String returns either SCRAM-SHA-256, SCRAM-SHA-512, or UNKNOWN.
+func (s ScramMechanism) String() string {
+	switch s {
+	case ScramSha256:
+		return "SCRAM-SHA-256"
+	case ScramSha512:
+		return "SCRAM-SHA-512"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// CredInfo contains the SCRAM mechanism and iterations for a password.
+type CredInfo struct {
+	// Mechanism is the SCRAM mechanism a password exists for. This is 0
+	// for UNKNOWN, 1 for SCRAM-SHA-256, and 2 for SCRAM-SHA-512.
+	Mechanism ScramMechanism
+	// Iterations is the number of SCRAM iterations for this password.
+	Iterations int32
+}
+
+// String returns MECHANISM=iterations={c.Iterations}.
+func (c CredInfo) String() string {
+	return fmt.Sprintf("%s=iterations=%d", c.Mechanism, c.Iterations)
+}
+
+// DescribedUserSCRAM contains a user, the SCRAM mechanisms that the user has
+// passwords for, and if describing the user SCRAM credentials errored.
+type DescribedUserSCRAM struct {
+	User       string     // User is the user this described user credential is for.
+	CredInfos  []CredInfo // CredInfos contains SCRAM mechanisms the user has passwords for.
+	Err        error      // Err is any error encountered when describing the user.
+	ErrMessage string     // ErrMessage a potential extra message describing any error.
+}
+
+// DescribedUserSCRAMs contains described user SCRAM credentials keyed by user.
+type DescribedUserSCRAMs map[string]DescribedUserSCRAM
+
+// Sorted returns the described user credentials ordered by user.
+func (ds DescribedUserSCRAMs) Sorted() []DescribedUserSCRAM {
+	s := make([]DescribedUserSCRAM, 0, len(ds))
+	for _, d := range ds {
+		s = append(s, d)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].User < s[j].User })
+	return s
+}
+
+// AllFailed returns whether all described user credentials are errored.
+func (ds DescribedUserSCRAMs) AllFailed() bool {
+	var n int
+	ds.EachError(func(DescribedUserSCRAM) { n++ })
+	return len(ds) > 0 && n == len(ds)
+}
+
+// EachError calls fn for every described user that has a non-nil error.
+func (ds DescribedUserSCRAMs) EachError(fn func(DescribedUserSCRAM)) {
+	for _, d := range ds {
+		if d.Err != nil {
+			fn(d)
+		}
+	}
+}
+
+// Each calls fn for every described user.
+func (ds DescribedUserSCRAMs) Each(fn func(DescribedUserSCRAM)) {
+	for _, d := range ds {
+		fn(d)
+	}
+}
+
+// Error iterates over all described users and returns the first error
+// encountered, if any.
+func (ds DescribedUserSCRAMs) Error() error {
+	for _, d := range ds {
+		if d.Err != nil {
+			return d.Err
+		}
+	}
+	return nil
+}
+
+// Ok returns true if there are no errors. This is a shortcut for rs.Error() ==
+// nil.
+func (ds DescribedUserSCRAMs) Ok() bool {
+	return ds.Error() == nil
+}
+
+// DescribeUserSCRAMs returns a small bit of information about all users in the
+// input request that have SCRAM passwords configured.  No users requests all
+// users.
+func (cl *Client) DescribeUserSCRAMs(ctx context.Context, users ...string) (DescribedUserSCRAMs, error) {
+	req := kmsg.NewPtrDescribeUserSCRAMCredentialsRequest()
+	for _, u := range users {
+		ru := kmsg.NewDescribeUserSCRAMCredentialsRequestUser()
+		ru.Name = u
+		req.Users = append(req.Users, ru)
+	}
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	rs := make(DescribedUserSCRAMs)
+	for _, res := range resp.Results {
+		r := DescribedUserSCRAM{
+			User:       res.User,
+			Err:        kerr.ErrorForCode(res.ErrorCode),
+			ErrMessage: unptrStr(res.ErrorMessage),
+		}
+		for _, i := range res.CredentialInfos {
+			r.CredInfos = append(r.CredInfos, CredInfo{
+				Mechanism:  ScramMechanism(i.Mechanism),
+				Iterations: i.Iterations,
+			})
+		}
+		rs[r.User] = r
+	}
+	return rs, nil
+}
+
+// DeleteSCRAM deletes a password with the given mechanism for the user.
+type DeleteSCRAM struct {
+	User      string         // User is the username to match for deletion.
+	Mechanism ScramMechanism // Mechanism is the mechanism to match to delete a password for.
+}
+
+// UpsertSCRAM either updates or creates (inserts) a new password for a user.
+// There are two ways to specify a password: either with the Password field
+// directly, or by specifying both Salt and SaltedPassword. If you specify just
+// a password, this package generates a 24 byte salt and uses pbkdf2 to create
+// the salted password.
+type UpsertSCRAM struct {
+	User           string         // User is the username to use.
+	Mechanism      ScramMechanism // Mechanism is the mechanism to use.
+	Iterations     int32          // Iterations is the SCRAM iterations to use; must be between 4096 and 16384.
+	Password       string         // Password is the password to salt and convert to a salted password. Requires Salt and SaltedPassword to be empty.
+	Salt           []byte         // Salt must be paired with SaltedPassword and requires Password to be empty.
+	SaltedPassword []byte         // SaltedPassword must be paired with Salt and requires Password to be empty.
+}
+
+// AlteredUserSCRAM is the result of an alter operation.
+type AlteredUserSCRAM struct {
+	User       string // User is the username that was altered.
+	Err        error  // Err is any error encountered when altering the user.
+	ErrMessage string // ErrMessage a potential extra message describing any error.
+}
+
+// AlteredUserSCRAMs contains altered user SCRAM credentials keyed by user.
+type AlteredUserSCRAMs map[string]AlteredUserSCRAM
+
+// Sorted returns the altered user credentials ordered by user.
+func (as AlteredUserSCRAMs) Sorted() []AlteredUserSCRAM {
+	s := make([]AlteredUserSCRAM, 0, len(as))
+	for _, a := range as {
+		s = append(s, a)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].User < s[j].User })
+	return s
+}
+
+// AllFailed returns whether all altered user credentials are errored.
+func (as AlteredUserSCRAMs) AllFailed() bool {
+	var n int
+	as.EachError(func(AlteredUserSCRAM) { n++ })
+	return len(as) > 0 && n == len(as)
+}
+
+// EachError calls fn for every altered user that has a non-nil error.
+func (as AlteredUserSCRAMs) EachError(fn func(AlteredUserSCRAM)) {
+	for _, a := range as {
+		if a.Err != nil {
+			fn(a)
+		}
+	}
+}
+
+// Each calls fn for every altered user.
+func (as AlteredUserSCRAMs) Each(fn func(AlteredUserSCRAM)) {
+	for _, a := range as {
+		fn(a)
+	}
+}
+
+// Error iterates over all altered users and returns the first error
+// encountered, if any.
+func (as AlteredUserSCRAMs) Error() error {
+	for _, a := range as {
+		if a.Err != nil {
+			return a.Err
+		}
+	}
+	return nil
+}
+
+// Ok returns true if there are no errors. This is a shortcut for rs.Error() ==
+// nil.
+func (as AlteredUserSCRAMs) Ok() bool {
+	return as.Error() == nil
+}
+
+// AlterUserSCRAMs deletes, updates, or creates (inserts) user SCRAM
+// credentials. Note that a username can only appear once across both upserts
+// and deletes. This modifies elements of the upsert slice that need to have a
+// salted password generated.
+func (cl *Client) AlterUserSCRAMs(ctx context.Context, del []DeleteSCRAM, upsert []UpsertSCRAM) (AlteredUserSCRAMs, error) {
+	for i, u := range upsert {
+		if u.Password != "" {
+			if len(u.Salt) > 0 || len(u.SaltedPassword) > 0 {
+				return nil, fmt.Errorf("user %s: cannot specify both a password and a salt / salted password", u.User)
+			}
+			u.Salt = make([]byte, 24)
+			if _, err := rand.Read(u.Salt); err != nil {
+				return nil, fmt.Errorf("user %s: unable to generate salt: %v", u.User, err)
+			}
+			switch u.Mechanism {
+			case ScramSha256:
+				u.SaltedPassword = pbkdf2.Key([]byte(u.Password), u.Salt, int(u.Iterations), sha256.Size, sha256.New)
+			case ScramSha512:
+				u.SaltedPassword = pbkdf2.Key([]byte(u.Password), u.Salt, int(u.Iterations), sha512.Size, sha512.New)
+			default:
+				return nil, fmt.Errorf("user %s: unknown mechanism, unable to generate password", u.User)
+			}
+			upsert[i] = u
+		} else {
+			if len(u.Salt) == 0 || len(u.SaltedPassword) == 0 {
+				return nil, fmt.Errorf("user %s: must specify either a password or a salt and salted password", u.User)
+			}
+		}
+	}
+
+	req := kmsg.NewPtrAlterUserSCRAMCredentialsRequest()
+	for _, d := range del {
+		rd := kmsg.NewAlterUserSCRAMCredentialsRequestDeletion()
+		rd.Name = d.User
+		rd.Mechanism = int8(d.Mechanism)
+		req.Deletions = append(req.Deletions, rd)
+	}
+	for _, u := range upsert {
+		ru := kmsg.NewAlterUserSCRAMCredentialsRequestUpsertion()
+		ru.Name = u.User
+		ru.Mechanism = int8(u.Mechanism)
+		ru.Iterations = u.Iterations
+		ru.Salt = u.Salt
+		ru.SaltedPassword = u.SaltedPassword
+		req.Upsertions = append(req.Upsertions, ru)
+	}
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	rs := make(AlteredUserSCRAMs)
+	for _, res := range resp.Results {
+		if err := maybeAuthErr(res.ErrorCode); err != nil {
+			return nil, err
+		}
+		r := AlteredUserSCRAM{
+			User:       res.User,
+			Err:        kerr.ErrorForCode(res.ErrorCode),
+			ErrMessage: unptrStr(res.ErrorMessage),
+		}
+		rs[r.User] = r
+	}
+	return rs, nil
+}
+
+// ElectLeadersHow is how partition leaders should be elected.
+type ElectLeadersHow int8
+
+const (
+	// ElectPreferredReplica elects the preferred replica for a partition.
+	ElectPreferredReplica ElectLeadersHow = 0
+	// ElectLiveReplica elects the first life replica if there are no
+	// in-sync replicas (i.e., this is unclean leader election).
+	ElectLiveReplica ElectLeadersHow = 1
+)
+
+// ElectLeadersResult is the result for a single partition in an elect leaders
+// request.
+type ElectLeadersResult struct {
+	Topic      string          // Topic is the topic this result is for.
+	Partition  int32           // Partition is the partition this result is for.
+	How        ElectLeadersHow // How is the type of election that was performed.
+	Err        error           // Err is non-nil if electing this partition's leader failed, such as the partition not existing or the preferred leader is not available and you used ElectPreferredReplica.
+	ErrMessage string          // ErrMessage a potential extra message describing any error.
+}
+
+// ElectLeadersResults contains per-topic, per-partition results for an elect
+// leaders request.
+type ElectLeadersResults map[string]map[int32]ElectLeadersResult
+
+// ElectLeaders elects leaders for partitions. This request was added in Kafka
+// 2.2 to replace the previously-ZooKeeper-only option of triggering leader
+// elections. See KIP-183 for more details.
+//
+// Kafka 2.4 introduced the ability to use unclean leader election. If you use
+// unclean leader election on a Kafka 2.2 or 2.3 cluster, the client will
+// instead fall back to preferred replica (clean) leader election. You can
+// check the result's How function (or field) to see.
+//
+// If s is nil, this will elect leaders for all partitions.
+//
+// This will return *AuthError if you do not have ALTER on CLUSTER for
+// kafka-cluster.
+func (cl *Client) ElectLeaders(ctx context.Context, how ElectLeadersHow, s TopicsSet) (ElectLeadersResults, error) {
+	req := kmsg.NewPtrElectLeadersRequest()
+	req.ElectionType = int8(how)
+	for _, t := range s.IntoList() {
+		rt := kmsg.NewElectLeadersRequestTopic()
+		rt.Topic = t.Topic
+		rt.Partitions = t.Partitions
+		req.Topics = append(req.Topics, rt)
+	}
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if err := maybeAuthErr(resp.ErrorCode); err != nil {
+		return nil, err
+	}
+	if resp.Version == 0 { // v0 does not have the election type field
+		how = ElectPreferredReplica
+	}
+	rs := make(ElectLeadersResults)
+	for _, t := range resp.Topics {
+		rt := make(map[int32]ElectLeadersResult)
+		rs[t.Topic] = rt
+		for _, p := range t.Partitions {
+			if err := maybeAuthErr(p.ErrorCode); err != nil {
+				return nil, err // v0 has no top-level err
+			}
+			rt[p.Partition] = ElectLeadersResult{
+				Topic:      t.Topic,
+				Partition:  p.Partition,
+				How:        how,
+				Err:        kerr.ErrorForCode(p.ErrorCode),
+				ErrMessage: unptrStr(p.ErrorMessage),
+			}
+		}
+	}
+	return rs, nil
+}
+
+// OffsetForLeaderEpochRequest contains topics, partitions, and leader epochs
+// to request offsets for in an OffsetForLeaderEpoch.
+type OffsetForLeaderEpochRequest map[string]map[int32]int32
+
+// Add adds a topic, partition, and leader epoch to the request.
+func (l *OffsetForLeaderEpochRequest) Add(topic string, partition, leaderEpoch int32) {
+	if *l == nil {
+		*l = make(map[string]map[int32]int32)
+	}
+	t := (*l)[topic]
+	if t == nil {
+		t = make(map[int32]int32)
+		(*l)[topic] = t
+	}
+	t[partition] = leaderEpoch
+}
+
+// OffsetForLeaderEpoch contains a response for a single partition in an
+// OffsetForLeaderEpoch request.
+type OffsetForLeaderEpoch struct {
+	NodeID    int32  // NodeID is the node that is the leader of this topic / partition.
+	Topic     string // Topic is the topic this leader epoch response is for.
+	Partition int32  // Partition is the partition this leader epoch response is for.
+
+	// LeaderEpoch is either
+	//
+	// 1) -1, if the requested LeaderEpoch is unknown.
+	//
+	// 2) Less than the requested LeaderEpoch, if the requested LeaderEpoch
+	// exists but has no records in it. For example, epoch 1 had end offset
+	// 37, then epoch 2 and 3 had no records: if you request LeaderEpoch 3,
+	// this will return LeaderEpoch 1 with EndOffset 37.
+	//
+	// 3) Equal to the requested LeaderEpoch, if the requested LeaderEpoch
+	// is equal to or less than the current epoch for the partition.
+	LeaderEpoch int32
+
+	// EndOffset is either
+	//
+	// 1) The LogEndOffset, if the broker has the same LeaderEpoch as the
+	// request.
+	//
+	// 2) the beginning offset of the next LeaderEpoch, if the broker has a
+	// higher LeaderEpoch.
+	//
+	// The second option allows the user to detect data loss: if the
+	// consumer consumed past the EndOffset that is returned, then the
+	// consumer should reset to the returned offset and the consumer knows
+	// that everything from the returned offset to the requested offset was
+	// lost.
+	EndOffset int64
+
+	// Err is non-nil if this partition had a response error.
+	Err error
+}
+
+// OffsetsForLeaderEpochs contains responses for partitions in a
+// OffsetForLeaderEpochRequest.
+type OffsetsForLeaderEpochs map[string]map[int32]OffsetForLeaderEpoch
+
+// OffsetForLeaderEpoch requests end offsets for the requested leader epoch in
+// partitions in the request. This is a relatively advanced and client internal
+// request, for more details, see the doc comments on the OffsetForLeaderEpoch
+// type.
+//
+// This may return *ShardErrors or *AuthError.
+func (cl *Client) OffetForLeaderEpoch(ctx context.Context, r OffsetForLeaderEpochRequest) (OffsetsForLeaderEpochs, error) {
+	req := kmsg.NewPtrOffsetForLeaderEpochRequest()
+	for t, ps := range r {
+		rt := kmsg.NewOffsetForLeaderEpochRequestTopic()
+		rt.Topic = t
+		for p, e := range ps {
+			rp := kmsg.NewOffsetForLeaderEpochRequestTopicPartition()
+			rp.Partition = p
+			rp.LeaderEpoch = e
+			rt.Partitions = append(rt.Partitions, rp)
+		}
+		req.Topics = append(req.Topics, rt)
+	}
+	shards := cl.cl.RequestSharded(ctx, req)
+	ls := make(OffsetsForLeaderEpochs)
+	return ls, shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
+		resp := kr.(*kmsg.OffsetForLeaderEpochResponse)
+		for _, rt := range resp.Topics {
+			lps, exists := ls[rt.Topic]
+			if !exists { // topic partitions could be spread around brokers, need to check existence
+				lps = make(map[int32]OffsetForLeaderEpoch)
+				ls[rt.Topic] = lps
+			}
+			for _, rp := range rt.Partitions {
+				if err := maybeAuthErr(rp.ErrorCode); err != nil {
+					return err
+				}
+				lps[rp.Partition] = OffsetForLeaderEpoch{ // one partition globally, no need to exist check
+					NodeID:      b.NodeID,
+					Topic:       rt.Topic,
+					Partition:   rp.Partition,
+					LeaderEpoch: rp.LeaderEpoch,
+					EndOffset:   rp.EndOffset,
+					Err:         kerr.ErrorForCode(rp.ErrorCode),
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/partas.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/partas.go
@@ -1,0 +1,196 @@
+package kadm
+
+import (
+	"context"
+	"sort"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// AlterPartitionAssignmentsReq is the input for a request to alter partition
+// assignments. The keys are topics and partitions, and the final slice
+// corresponds to brokers that replicas will be assigneed to. If the brokers
+// for a given partition are null, the request will *cancel* any active
+// reassignment for that partition.
+type AlterPartitionAssignmentsReq map[string]map[int32][]int32
+
+// Assign specifies brokers that a partition should be placed on. Using null
+// for the brokers cancels a pending reassignment of the parititon.
+func (r *AlterPartitionAssignmentsReq) Assign(t string, p int32, brokers []int32) {
+	if *r == nil {
+		*r = make(map[string]map[int32][]int32)
+	}
+	ps := (*r)[t]
+	if ps == nil {
+		ps = make(map[int32][]int32)
+		(*r)[t] = ps
+	}
+	ps[p] = brokers
+}
+
+// CancelAssign cancels a reassignment of the given partition.
+func (r *AlterPartitionAssignmentsReq) CancelAssign(t string, p int32) {
+	r.Assign(t, p, nil)
+}
+
+// AlterPartitionAssignmentsResponse contains a response for an individual
+// partition that was assigned.
+type AlterPartitionAssignmentsResponse struct {
+	Topic      string // Topic is the topic that was assigned.
+	Partition  int32  // Partition is the partition that was assigned.
+	Err        error  // Err is non-nil if this assignment errored.
+	ErrMessage string // ErrMessage is an optional additional message on error.
+}
+
+// AlterPartitionAssignmentsResponses contains responses to all partitions in an
+// alter assignment request.
+type AlterPartitionAssignmentsResponses map[string]map[int32]AlterPartitionAssignmentsResponse
+
+// Sorted returns the responses sorted by topic and partition.
+func (rs AlterPartitionAssignmentsResponses) Sorted() []AlterPartitionAssignmentsResponse {
+	var all []AlterPartitionAssignmentsResponse
+	rs.Each(func(r AlterPartitionAssignmentsResponse) {
+		all = append(all, r)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic || l.Topic == r.Topic && l.Partition < r.Partition
+	})
+	return all
+}
+
+// Each calls fn for every response.
+func (rs AlterPartitionAssignmentsResponses) Each(fn func(AlterPartitionAssignmentsResponse)) {
+	for _, ps := range rs {
+		for _, r := range ps {
+			fn(r)
+		}
+	}
+}
+
+// AlterPartitionAssignments alters partition assignments for the requested
+// partitions, returning an error if the response could not be issued or if
+// you do not have permissions.
+func (cl *Client) AlterPartitionAssignments(ctx context.Context, req AlterPartitionAssignmentsReq) (AlterPartitionAssignmentsResponses, error) {
+	if len(req) == 0 {
+		return make(AlterPartitionAssignmentsResponses), nil
+	}
+
+	kreq := kmsg.NewPtrAlterPartitionAssignmentsRequest()
+	kreq.TimeoutMillis = cl.timeoutMillis
+	for t, ps := range req {
+		rt := kmsg.NewAlterPartitionAssignmentsRequestTopic()
+		rt.Topic = t
+		for p, bs := range ps {
+			rp := kmsg.NewAlterPartitionAssignmentsRequestTopicPartition()
+			rp.Partition = p
+			rp.Replicas = bs
+			rt.Partitions = append(rt.Partitions, rp)
+		}
+		kreq.Topics = append(kreq.Topics, rt)
+	}
+
+	kresp, err := kreq.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if err = kerr.ErrorForCode(kresp.ErrorCode); err != nil {
+		return nil, err
+	}
+
+	a := make(AlterPartitionAssignmentsResponses)
+	for _, kt := range kresp.Topics {
+		ps := make(map[int32]AlterPartitionAssignmentsResponse)
+		a[kt.Topic] = ps
+		for _, kp := range kt.Partitions {
+			ps[kp.Partition] = AlterPartitionAssignmentsResponse{
+				Topic:      kt.Topic,
+				Partition:  kp.Partition,
+				Err:        kerr.ErrorForCode(kp.ErrorCode),
+				ErrMessage: unptrStr(kp.ErrorMessage),
+			}
+		}
+	}
+	return a, nil
+}
+
+// ListPartitionReassignmentsResponse contains a response for an individual
+// partition that was listed.
+type ListPartitionReassignmentsResponse struct {
+	Topic            string  // Topic is the topic that was listed.
+	Partition        int32   // Partition is the partition that was listed.
+	Replicas         []int32 // Replicas are the partition's current replicas.
+	AddingReplicas   []int32 // AddingReplicas are replicas currently being added to the partition.
+	RemovingReplicas []int32 // RemovingReplicas are replicas currently being removed from the partition.
+}
+
+// ListPartitionReassignmentsResponses contains responses to all partitions in
+// a list reassignment request.
+type ListPartitionReassignmentsResponses map[string]map[int32]ListPartitionReassignmentsResponse
+
+// Sorted returns the responses sorted by topic and partition.
+func (rs ListPartitionReassignmentsResponses) Sorted() []ListPartitionReassignmentsResponse {
+	var all []ListPartitionReassignmentsResponse
+	rs.Each(func(r ListPartitionReassignmentsResponse) {
+		all = append(all, r)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic || l.Topic == r.Topic && l.Partition < r.Partition
+	})
+	return all
+}
+
+// Each calls fn for every response.
+func (rs ListPartitionReassignmentsResponses) Each(fn func(ListPartitionReassignmentsResponse)) {
+	for _, ps := range rs {
+		for _, r := range ps {
+			fn(r)
+		}
+	}
+}
+
+// ListPartitionReassignments lists the state of any active reassignments for
+// all requested partitions, returning an error if the response could not be
+// issued or if you do not have permissions.
+func (cl *Client) ListPartitionReassignments(ctx context.Context, s TopicsSet) (ListPartitionReassignmentsResponses, error) {
+	if len(s) == 0 {
+		return make(ListPartitionReassignmentsResponses), nil
+	}
+
+	kreq := kmsg.NewPtrListPartitionReassignmentsRequest()
+	kreq.TimeoutMillis = cl.timeoutMillis
+	for t, ps := range s {
+		rt := kmsg.NewListPartitionReassignmentsRequestTopic()
+		rt.Topic = t
+		for p := range ps {
+			rt.Partitions = append(rt.Partitions, p)
+		}
+		kreq.Topics = append(kreq.Topics, rt)
+	}
+
+	kresp, err := kreq.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+	if err = kerr.ErrorForCode(kresp.ErrorCode); err != nil {
+		return nil, err
+	}
+
+	a := make(ListPartitionReassignmentsResponses)
+	for _, kt := range kresp.Topics {
+		ps := make(map[int32]ListPartitionReassignmentsResponse)
+		a[kt.Topic] = ps
+		for _, kp := range kt.Partitions {
+			ps[kp.Partition] = ListPartitionReassignmentsResponse{
+				Topic:            kt.Topic,
+				Partition:        kp.Partition,
+				Replicas:         kp.Replicas,
+				AddingReplicas:   kp.AddingReplicas,
+				RemovingReplicas: kp.RemovingReplicas,
+			}
+		}
+	}
+	return a, nil
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/topics.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/topics.go
@@ -1,0 +1,596 @@
+package kadm
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// ListTopics issues a metadata request and returns TopicDetails. Specific
+// topics to describe can be passed as additional arguments. If no topics are
+// specified, all topics are requested. Internal topics are not returned unless
+// specifically requested. To see all topics including internal topics, use
+// ListTopicsWithInternal.
+//
+// This returns an error if the request fails to be issued, or an *AuthError.
+func (cl *Client) ListTopics(
+	ctx context.Context,
+	topics ...string,
+) (TopicDetails, error) {
+	t, err := cl.ListTopicsWithInternal(ctx, topics...)
+	if err != nil {
+		return nil, err
+	}
+	t.FilterInternal()
+	return t, nil
+}
+
+// ListTopicsWithInternal is the same as ListTopics, but does not filter
+// internal topics before returning.
+func (cl *Client) ListTopicsWithInternal(
+	ctx context.Context,
+	topics ...string,
+) (TopicDetails, error) {
+	m, err := cl.Metadata(ctx, topics...)
+	if err != nil {
+		return nil, err
+	}
+	return m.Topics, nil
+}
+
+// CreateTopicResponse contains the response for an individual created topic.
+type CreateTopicResponse struct {
+	Topic             string            // Topic is the topic that was created.
+	ID                TopicID           // ID is the topic ID for this topic, if talking to Kafka v2.8+.
+	Err               error             // Err is any error preventing this topic from being created.
+	NumPartitions     int32             // NumPartitions is the number of partitions in the response, if talking to Kafka v2.4+.
+	ReplicationFactor int16             // ReplicationFactor is how many replicas every partition has for this topic, if talking to Kafka 2.4+.
+	Configs           map[string]Config // Configs contains the topic configuration (minus config synonyms), if talking to Kafka 2.4+.
+}
+
+// CreateTopicRepsonses contains per-topic responses for created topics.
+type CreateTopicResponses map[string]CreateTopicResponse
+
+// Sorted returns all create topic responses sorted first by topic ID, then by
+// topic name.
+func (rs CreateTopicResponses) Sorted() []CreateTopicResponse {
+	s := make([]CreateTopicResponse, 0, len(rs))
+	for _, d := range rs {
+		s = append(s, d)
+	}
+	sort.Slice(s, func(i, j int) bool {
+		l, r := s[i], s[j]
+		if l.ID.Less(r.ID) {
+			return true
+		}
+		return l.Topic < r.Topic
+	})
+	return s
+}
+
+// On calls fn for the response topic if it exists, returning the response and
+// the error returned from fn. If fn is nil, this simply returns the response.
+//
+// The fn is given a copy of the response. This function returns the copy as
+// well; any modifications within fn are modifications on the returned copy.
+//
+// If the topic does not exist, this returns kerr.UnknownTopicOrPartition.
+func (rs CreateTopicResponses) On(topic string, fn func(*CreateTopicResponse) error) (CreateTopicResponse, error) {
+	if len(rs) > 0 {
+		r, ok := rs[topic]
+		if ok {
+			if fn == nil {
+				return r, nil
+			}
+			return r, fn(&r)
+		}
+	}
+	return CreateTopicResponse{}, kerr.UnknownTopicOrPartition
+}
+
+// CreateTopic issues a create topics request with the given partitions,
+// replication factor, and (optional) configs for the given topic name. Under
+// the hood, this uses the default 15s request timeout and lets Kafka choose
+// where to place partitions. This function exists to complement CreateTopics,
+// making the single-topic creation case easier to handle.
+//
+// Version 4 of the underlying create topic request was introduced in Kafka 2.4
+// and brought client support for creation defaults. If talking to a 2.4+
+// cluster, you can use -1 for partitions and replicationFactor to use broker
+// defaults.
+//
+// This package includes a StringPtr function to aid in building config values.
+//
+// If the topic could not be created this function will return an error. An
+// error may be returned due to authorization failure, a failed network
+// request, a missing controller or other issues. If the request was successful
+// but the CreateTopicResponse.Err is non-nil, this returns the error, so you
+// do not need to additionally check the Err field.
+func (cl *Client) CreateTopic(
+	ctx context.Context,
+	partitions int32,
+	replicationFactor int16,
+	configs map[string]*string,
+	topic string,
+) (CreateTopicResponse, error) {
+	createTopicResponse, err := cl.CreateTopics(
+		ctx,
+		partitions,
+		replicationFactor,
+		configs,
+		topic,
+	)
+	if err != nil {
+		return CreateTopicResponse{}, err
+	}
+
+	response, exists := createTopicResponse[topic]
+	if !exists {
+		return CreateTopicResponse{}, errors.New("requested topic was not part of create topic response")
+	}
+
+	return response, response.Err
+}
+
+// CreateTopics issues a create topics request with the given partitions,
+// replication factor, and (optional) configs for every topic. Under the hood,
+// this uses the default 15s request timeout and lets Kafka choose where to
+// place partitions.
+//
+// Version 4 of the underlying create topic request was introduced in Kafka 2.4
+// and brought client support for creation defaults. If talking to a 2.4+
+// cluster, you can use -1 for partitions and replicationFactor to use broker
+// defaults.
+//
+// This package includes a StringPtr function to aid in building config values.
+//
+// This does not return an error on authorization failures, instead,
+// authorization failures are included in the responses. This only returns an
+// error if the request fails to be issued. You may consider checking
+// ValidateCreateTopics before using this method.
+func (cl *Client) CreateTopics(
+	ctx context.Context,
+	partitions int32,
+	replicationFactor int16,
+	configs map[string]*string,
+	topics ...string,
+) (CreateTopicResponses, error) {
+	return cl.createTopics(ctx, false, partitions, replicationFactor, configs, topics)
+}
+
+// ValidateCreateTopics validates a create topics request with the given
+// partitions, replication factor, and (optional) configs for every topic.
+//
+// This package includes a StringPtr function to aid in building config values.
+//
+// This uses the same logic as CreateTopics, but with the request's
+// ValidateOnly field set to true. The response is the same response you would
+// receive from CreateTopics, but no topics are actually created.
+func (cl *Client) ValidateCreateTopics(
+	ctx context.Context,
+	partitions int32,
+	replicationFactor int16,
+	configs map[string]*string,
+	topics ...string,
+) (CreateTopicResponses, error) {
+	return cl.createTopics(ctx, true, partitions, replicationFactor, configs, topics)
+}
+
+func (cl *Client) createTopics(ctx context.Context, dry bool, p int32, rf int16, configs map[string]*string, topics []string) (CreateTopicResponses, error) {
+	if len(topics) == 0 {
+		return make(CreateTopicResponses), nil
+	}
+
+	req := kmsg.NewCreateTopicsRequest()
+	req.TimeoutMillis = cl.timeoutMillis
+	req.ValidateOnly = dry
+	for _, t := range topics {
+		rt := kmsg.NewCreateTopicsRequestTopic()
+		rt.Topic = t
+		rt.NumPartitions = p
+		rt.ReplicationFactor = rf
+		for k, v := range configs {
+			rc := kmsg.NewCreateTopicsRequestTopicConfig()
+			rc.Name = k
+			rc.Value = v
+			rt.Configs = append(rt.Configs, rc)
+		}
+		req.Topics = append(req.Topics, rt)
+	}
+
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+
+	rs := make(CreateTopicResponses)
+	for _, t := range resp.Topics {
+		rt := CreateTopicResponse{
+			Topic:             t.Topic,
+			ID:                t.TopicID,
+			Err:               kerr.ErrorForCode(t.ErrorCode),
+			NumPartitions:     t.NumPartitions,
+			ReplicationFactor: t.ReplicationFactor,
+			Configs:           make(map[string]Config),
+		}
+		for _, c := range t.Configs {
+			rt.Configs[c.Name] = Config{
+				Key:       c.Name,
+				Value:     c.Value,
+				Source:    kmsg.ConfigSource(c.Source),
+				Sensitive: c.IsSensitive,
+			}
+		}
+		rs[t.Topic] = rt
+	}
+	return rs, nil
+}
+
+// DeleteTopicResponse contains the response for an individual deleted topic.
+type DeleteTopicResponse struct {
+	Topic      string  // Topic is the topic that was deleted, if not using topic IDs.
+	ID         TopicID // ID is the topic ID for this topic, if talking to Kafka v2.8+ and using topic IDs.
+	Err        error   // Err is any error preventing this topic from being deleted.
+	ErrMessage string  // ErrMessage a potential extra message describing any error.
+}
+
+// DeleteTopicResponses contains per-topic responses for deleted topics.
+type DeleteTopicResponses map[string]DeleteTopicResponse
+
+// Sorted returns all delete topic responses sorted first by topic ID, then by
+// topic name.
+func (rs DeleteTopicResponses) Sorted() []DeleteTopicResponse {
+	s := make([]DeleteTopicResponse, 0, len(rs))
+	for _, d := range rs {
+		s = append(s, d)
+	}
+	sort.Slice(s, func(i, j int) bool {
+		l, r := s[i], s[j]
+		if l.ID.Less(r.ID) {
+			return true
+		}
+		return l.Topic < r.Topic
+	})
+	return s
+}
+
+// On calls fn for the response topic if it exists, returning the response and
+// the error returned from fn. If fn is nil, this simply returns the response.
+//
+// The fn is given a copy of the response. This function returns the copy as
+// well; any modifications within fn are modifications on the returned copy.
+//
+// If the topic does not exist, this returns kerr.UnknownTopicOrPartition.
+func (rs DeleteTopicResponses) On(topic string, fn func(*DeleteTopicResponse) error) (DeleteTopicResponse, error) {
+	if len(rs) > 0 {
+		r, ok := rs[topic]
+		if ok {
+			if fn == nil {
+				return r, nil
+			}
+			return r, fn(&r)
+		}
+	}
+	return DeleteTopicResponse{}, kerr.UnknownTopicOrPartition
+}
+
+// DeleteTopics issues a delete topics request for the given topic names with a
+// 15s timeout.
+//
+// This does not return an error on authorization failures, instead,
+// authorization failures are included in the responses. This only returns an
+// error if the request fails to be issued.
+func (cl *Client) DeleteTopics(ctx context.Context, topics ...string) (DeleteTopicResponses, error) {
+	if len(topics) == 0 {
+		return make(DeleteTopicResponses), nil
+	}
+
+	req := kmsg.NewDeleteTopicsRequest()
+	req.TimeoutMillis = cl.timeoutMillis
+	req.TopicNames = topics
+	for _, t := range topics {
+		rt := kmsg.NewDeleteTopicsRequestTopic()
+		rt.Topic = kmsg.StringPtr(t)
+		req.Topics = append(req.Topics, rt)
+	}
+
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+
+	rs := make(DeleteTopicResponses)
+	for _, t := range resp.Topics {
+		// A valid Kafka will return non-nil topics here, because we
+		// are deleting by topic name, not ID. We still check to be
+		// sure, but multiple invalid (nil) topics will collide.
+		var topic string
+		if t.Topic != nil {
+			topic = *t.Topic
+		}
+		rs[topic] = DeleteTopicResponse{
+			Topic:      topic,
+			ID:         t.TopicID,
+			Err:        kerr.ErrorForCode(t.ErrorCode),
+			ErrMessage: unptrStr(t.ErrorMessage),
+		}
+	}
+	return rs, nil
+}
+
+// DeleteRecordsResponse contains the response for an individual partition from
+// a delete records request.
+type DeleteRecordsResponse struct {
+	Topic        string // Topic is the topic this response is for.
+	Partition    int32  // Partition is the partition this response is for.
+	LowWatermark int64  // LowWatermark is the new earliest / start offset for this partition if the request was successful.
+	Err          error  // Err is any error preventing the delete records request from being successful for this partition.
+}
+
+// DeleteRecordsResponses contains per-partition responses to a delete records request.
+type DeleteRecordsResponses map[string]map[int32]DeleteRecordsResponse
+
+// Lookup returns the response at t and p and whether it exists.
+func (ds DeleteRecordsResponses) Lookup(t string, p int32) (DeleteRecordsResponse, bool) {
+	if len(ds) == 0 {
+		return DeleteRecordsResponse{}, false
+	}
+	ps := ds[t]
+	if len(ps) == 0 {
+		return DeleteRecordsResponse{}, false
+	}
+	r, exists := ps[p]
+	return r, exists
+}
+
+// Each calls fn for every delete records response.
+func (ds DeleteRecordsResponses) Each(fn func(DeleteRecordsResponse)) {
+	for _, ps := range ds {
+		for _, d := range ps {
+			fn(d)
+		}
+	}
+}
+
+// Sorted returns all delete records responses sorted first by topic, then by
+// partition.
+func (rs DeleteRecordsResponses) Sorted() []DeleteRecordsResponse {
+	var s []DeleteRecordsResponse
+	for _, ps := range rs {
+		for _, d := range ps {
+			s = append(s, d)
+		}
+	}
+	sort.Slice(s, func(i, j int) bool {
+		l, r := s[i], s[j]
+		if l.Topic < r.Topic {
+			return true
+		}
+		if l.Topic > r.Topic {
+			return false
+		}
+		return l.Partition < r.Partition
+	})
+	return s
+}
+
+// On calls fn for the response topic/partition if it exists, returning the
+// response and the error returned from fn. If fn is nil, this simply returns
+// the response.
+//
+// The fn is given a copy of the response. This function returns the copy as
+// well; any modifications within fn are modifications on the returned copy.
+//
+// If the topic or partition does not exist, this returns
+// kerr.UnknownTopicOrPartition.
+func (rs DeleteRecordsResponses) On(topic string, partition int32, fn func(*DeleteRecordsResponse) error) (DeleteRecordsResponse, error) {
+	if len(rs) > 0 {
+		t, ok := rs[topic]
+		if ok {
+			p, ok := t[partition]
+			if ok {
+				if fn == nil {
+					return p, nil
+				}
+				return p, fn(&p)
+			}
+		}
+	}
+	return DeleteRecordsResponse{}, kerr.UnknownTopicOrPartition
+}
+
+// DeleteRecords issues a delete records request for the given offsets. Per
+// offset, only the Offset field needs to be set.
+//
+// To delete records, Kafka sets the LogStartOffset for partitions to the
+// requested offset. All segments whose max partition is before the requested
+// offset are deleted, and any records within the segment before the requested
+// offset can no longer be read.
+//
+// This does not return an error on authorization failures, instead,
+// authorization failures are included in the responses.
+//
+// This may return *ShardErrors.
+func (cl *Client) DeleteRecords(ctx context.Context, os Offsets) (DeleteRecordsResponses, error) {
+	if len(os) == 0 {
+		return make(DeleteRecordsResponses), nil
+	}
+
+	req := kmsg.NewPtrDeleteRecordsRequest()
+	req.TimeoutMillis = cl.timeoutMillis
+	for t, ps := range os {
+		rt := kmsg.NewDeleteRecordsRequestTopic()
+		rt.Topic = t
+		for p, o := range ps {
+			rp := kmsg.NewDeleteRecordsRequestTopicPartition()
+			rp.Partition = p
+			rp.Offset = o.At
+			rt.Partitions = append(rt.Partitions, rp)
+		}
+		req.Topics = append(req.Topics, rt)
+	}
+
+	shards := cl.cl.RequestSharded(ctx, req)
+	rs := make(DeleteRecordsResponses)
+	return rs, shardErrEach(req, shards, func(kr kmsg.Response) error {
+		resp := kr.(*kmsg.DeleteRecordsResponse)
+		for _, t := range resp.Topics {
+			rt, exists := rs[t.Topic]
+			if !exists { // topic could be spread around brokers, we need to check existence
+				rt = make(map[int32]DeleteRecordsResponse)
+				rs[t.Topic] = rt
+			}
+			for _, p := range t.Partitions {
+				rt[p.Partition] = DeleteRecordsResponse{
+					Topic:        t.Topic,
+					Partition:    p.Partition,
+					LowWatermark: p.LowWatermark,
+					Err:          kerr.ErrorForCode(p.ErrorCode),
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// CreatePartitionsResponse contains the response for an individual topic from
+// a create partitions request.
+type CreatePartitionsResponse struct {
+	Topic      string // Topic is the topic this response is for.
+	Err        error  // Err is non-nil if partitions were unable to be added to this topic.
+	ErrMessage string // ErrMessage a potential extra message describing any error.
+}
+
+// CreatePartitionsResponses contains per-topic responses for a create
+// partitions request.
+type CreatePartitionsResponses map[string]CreatePartitionsResponse
+
+// Sorted returns all create partitions responses sorted by topic.
+func (rs CreatePartitionsResponses) Sorted() []CreatePartitionsResponse {
+	var s []CreatePartitionsResponse
+	for _, r := range rs {
+		s = append(s, r)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].Topic < s[j].Topic })
+	return s
+}
+
+// On calls fn for the response topic if it exists, returning the response and
+// the error returned from fn. If fn is nil, this simply returns the response.
+//
+// The fn is given a copy of the response. This function returns the copy as
+// well; any modifications within fn are modifications on the returned copy.
+//
+// If the topic does not exist, this returns kerr.UnknownTopicOrPartition.
+func (rs CreatePartitionsResponses) On(topic string, fn func(*CreatePartitionsResponse) error) (CreatePartitionsResponse, error) {
+	if len(rs) > 0 {
+		r, ok := rs[topic]
+		if ok {
+			if fn == nil {
+				return r, nil
+			}
+			return r, fn(&r)
+		}
+	}
+	return CreatePartitionsResponse{}, kerr.UnknownTopicOrPartition
+}
+
+// CreatePartitions issues a create partitions request for the given topics,
+// adding "add" partitions to each topic. This request lets Kafka choose where
+// the new partitions should be.
+//
+// This does not return an error on authorization failures for the create
+// partitions request itself, instead, authorization failures are included in
+// the responses. Before adding partitions, this request must issue a metadata
+// request to learn the current count of partitions. If that fails, this
+// returns the metadata request error. If you already know the final amount of
+// partitions you want, you can use UpdatePartitions to set the count directly
+// (rather than adding to the current count). You may consider checking
+// ValidateCreatePartitions before using this method.
+func (cl *Client) CreatePartitions(ctx context.Context, add int, topics ...string) (CreatePartitionsResponses, error) {
+	return cl.createPartitions(ctx, false, add, -1, topics)
+}
+
+// UpdatePartitions issues a create partitions request for the given topics,
+// setting the final partition count to "set" for each topic. This request lets
+// Kafka choose where the new partitions should be.
+//
+// This does not return an error on authorization failures for the create
+// partitions request itself, instead, authorization failures are included in
+// the responses. Unlike CreatePartitions, this request uses your "set" value
+// to set the new final count of partitions. "set" must be equal to or larger
+// than the current count of partitions in the topic. All topics will have the
+// same final count of partitions (unlike CreatePartitions, which allows you to
+// add a specific count of partitions to topics that have a different amount of
+// current partitions). You may consider checking ValidateUpdatePartitions
+// before using this method.
+func (cl *Client) UpdatePartitions(ctx context.Context, set int, topics ...string) (CreatePartitionsResponses, error) {
+	return cl.createPartitions(ctx, false, -1, set, topics)
+}
+
+// ValidateCreatePartitions validates a create partitions request for adding
+// "add" partitions to the given topics.
+//
+// This uses the same logic as CreatePartitions, but with the request's
+// ValidateOnly field set to true. The response is the same response you would
+// receive from CreatePartitions, but no partitions are actually added.
+func (cl *Client) ValidateCreatePartitions(ctx context.Context, add int, topics ...string) (CreatePartitionsResponses, error) {
+	return cl.createPartitions(ctx, true, add, -1, topics)
+}
+
+// ValidateUpdatePartitions validates a create partitions request for setting
+// the partition count on the given topics to "set".
+//
+// This uses the same logic as UpdatePartitions, but with the request's
+// ValidateOnly field set to true. The response is the same response you would
+// receive from UpdatePartitions, but no partitions are actually added.
+func (cl *Client) ValidateUpdatePartitions(ctx context.Context, set int, topics ...string) (CreatePartitionsResponses, error) {
+	return cl.createPartitions(ctx, true, -1, set, topics)
+}
+
+func (cl *Client) createPartitions(ctx context.Context, dry bool, add, set int, topics []string) (CreatePartitionsResponses, error) {
+	if len(topics) == 0 {
+		return make(CreatePartitionsResponses), nil
+	}
+
+	var td TopicDetails
+	var err error
+	if add != -1 {
+		td, err = cl.ListTopics(ctx, topics...)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req := kmsg.NewCreatePartitionsRequest()
+	req.TimeoutMillis = cl.timeoutMillis
+	req.ValidateOnly = dry
+	for _, t := range topics {
+		rt := kmsg.NewCreatePartitionsRequestTopic()
+		rt.Topic = t
+		if add == -1 {
+			rt.Count = int32(set)
+		} else {
+			rt.Count = int32(len(td[t].Partitions) + add)
+		}
+		req.Topics = append(req.Topics, rt)
+	}
+
+	resp, err := req.RequestWith(ctx, cl.cl)
+	if err != nil {
+		return nil, err
+	}
+
+	rs := make(CreatePartitionsResponses)
+	for _, t := range resp.Topics {
+		rs[t.Topic] = CreatePartitionsResponse{
+			Topic:      t.Topic,
+			Err:        kerr.ErrorForCode(t.ErrorCode),
+			ErrMessage: unptrStr(t.ErrorMessage),
+		}
+	}
+	return rs, nil
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/txn.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/txn.go
@@ -1,0 +1,759 @@
+package kadm
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// DescribedProducer contains the state of a transactional producer's last
+// produce.
+type DescribedProducer struct {
+	Leader                int32  // Leader is the leader broker for this topic / partition.
+	Topic                 string // Topic is the topic being produced to.
+	Partition             int32  // Partition is the partition being produced to.
+	ProducerID            int64  // ProducerID is the producer ID that produced.
+	ProducerEpoch         int16  // ProducerEpoch is the epoch that produced.
+	LastSequence          int32  // LastSequence is the last sequence number the producer produced.
+	LastTimestamp         int64  // LastTimestamp is the last time this producer produced.
+	CoordinatorEpoch      int32  // CoordinatorEpoch is the epoch of the transactional coordinator for the last produce.
+	CurrentTxnStartOffset int64  // CurrentTxnStartOffset is the first offset in the transaction.
+}
+
+// Less returns whether the left described producer is less than the right,
+// in order of:
+//
+//   - Topic
+//   - Partition
+//   - ProducerID
+//   - ProducerEpoch
+//   - LastTimestamp
+//   - LastSequence
+func (l *DescribedProducer) Less(r *DescribedProducer) bool {
+	if l.Topic < r.Topic {
+		return true
+	}
+	if l.Topic > r.Topic {
+		return false
+	}
+	if l.Partition < r.Partition {
+		return true
+	}
+	if l.Partition > r.Partition {
+		return false
+	}
+	if l.ProducerID < r.ProducerID {
+		return true
+	}
+	if l.ProducerID > r.ProducerID {
+		return false
+	}
+	if l.ProducerEpoch < r.ProducerEpoch {
+		return true
+	}
+	if l.ProducerEpoch > r.ProducerEpoch {
+		return false
+	}
+	if l.LastTimestamp < r.LastTimestamp {
+		return true
+	}
+	if l.LastTimestamp > r.LastTimestamp {
+		return false
+	}
+	return l.LastSequence < r.LastSequence
+}
+
+// DescribedProducers maps producer IDs to the full described producer.
+type DescribedProducers map[int64]DescribedProducer
+
+// Sorted returns the described producers sorted by topic, partition, and
+// producer ID.
+func (ds DescribedProducers) Sorted() []DescribedProducer {
+	var all []DescribedProducer
+	for _, d := range ds {
+		all = append(all, d)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic || l.Topic == r.Topic && (l.Partition < r.Partition || l.Partition == r.Partition && l.ProducerID < r.ProducerID)
+	})
+	return all
+}
+
+// Each calls fn for each described producer.
+func (ds DescribedProducers) Each(fn func(DescribedProducer)) {
+	for _, d := range ds {
+		fn(d)
+	}
+}
+
+// DescribedProducersPartition is a partition whose producer's were described.
+type DescribedProducersPartition struct {
+	Leader          int32              // Leader is the leader broker for this topic / partition.
+	Topic           string             // Topic is the topic whose producer's were described.
+	Partition       int32              // Partition is the partition whose producer's were described.
+	ActiveProducers DescribedProducers // ActiveProducers are producer's actively transactionally producing to this partition.
+	Err             error              // Err is non-nil if describing this partition failed.
+}
+
+// DescribedProducersPartitions contains partitions whose producer's were described.
+type DescribedProducersPartitions map[int32]DescribedProducersPartition
+
+// Sorted returns the described partitions sorted by topic and partition.
+func (ds DescribedProducersPartitions) Sorted() []DescribedProducersPartition {
+	var all []DescribedProducersPartition
+	for _, d := range ds {
+		all = append(all, d)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic || l.Topic == r.Topic && l.Partition < r.Partition
+	})
+	return all
+}
+
+// SortedProducer returns all producers sorted first by partition, then by producer ID.
+func (ds DescribedProducersPartitions) SortedProducers() []DescribedProducer {
+	var all []DescribedProducer
+	ds.EachProducer(func(d DescribedProducer) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic || l.Topic == r.Topic && (l.Partition < r.Partition || l.Partition == r.Partition && l.ProducerID < r.ProducerID)
+	})
+	return all
+}
+
+// Each calls fn for each partition.
+func (ds DescribedProducersPartitions) Each(fn func(DescribedProducersPartition)) {
+	for _, d := range ds {
+		fn(d)
+	}
+}
+
+// EachProducer calls fn for each producer in all partitions.
+func (ds DescribedProducersPartitions) EachProducer(fn func(DescribedProducer)) {
+	for _, d := range ds {
+		for _, p := range d.ActiveProducers {
+			fn(p)
+		}
+	}
+}
+
+// DescribedProducersTopic contains topic partitions whose producer's were described.
+type DescribedProducersTopic struct {
+	Topic      string                       // Topic is the topic whose producer's were described.
+	Partitions DescribedProducersPartitions // Partitions are partitions whose producer's were described.
+}
+
+// DescribedProducersTopics contains topics whose producer's were described.
+type DescribedProducersTopics map[string]DescribedProducersTopic
+
+// Sorted returns the described topics sorted by topic.
+func (ds DescribedProducersTopics) Sorted() []DescribedProducersTopic {
+	var all []DescribedProducersTopic
+	ds.Each(func(d DescribedProducersTopic) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic
+	})
+	return all
+}
+
+// Sorted returns the described partitions sorted by topic and partition.
+func (ds DescribedProducersTopics) SortedPartitions() []DescribedProducersPartition {
+	var all []DescribedProducersPartition
+	ds.EachPartition(func(d DescribedProducersPartition) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic || l.Topic == r.Topic && l.Partition < r.Partition
+	})
+	return all
+}
+
+// SortedProducer returns all producers sorted first by partition, then by producer ID.
+func (ds DescribedProducersTopics) SortedProducers() []DescribedProducer {
+	var all []DescribedProducer
+	ds.EachProducer(func(d DescribedProducer) {
+		all = append(all, d)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic || l.Topic == r.Topic && (l.Partition < r.Partition || l.Partition == r.Partition && l.ProducerID < r.ProducerID)
+	})
+	return all
+}
+
+// Each calls fn for every topic.
+func (ds DescribedProducersTopics) Each(fn func(DescribedProducersTopic)) {
+	for _, d := range ds {
+		fn(d)
+	}
+}
+
+// EachPartitions calls fn for all topic partitions.
+func (ds DescribedProducersTopics) EachPartition(fn func(DescribedProducersPartition)) {
+	for _, d := range ds {
+		for _, p := range d.Partitions {
+			fn(p)
+		}
+	}
+}
+
+// EachProducer calls fn for each producer in all topics and partitions.
+func (ds DescribedProducersTopics) EachProducer(fn func(DescribedProducer)) {
+	for _, d := range ds {
+		for _, p := range d.Partitions {
+			for _, b := range p.ActiveProducers {
+				fn(b)
+			}
+		}
+	}
+}
+
+// DescribeProducers describes all producers that are transactionally producing
+// to the requested topic set. This request can be used to detect hanging
+// transactions or other transaction related problems. If the input set is
+// empty, this requests data for all partitions.
+//
+// This may return *ShardErrors or *AuthError.
+func (cl *Client) DescribeProducers(ctx context.Context, s TopicsSet) (DescribedProducersTopics, error) {
+	if len(s) == 0 {
+		m, err := cl.Metadata(ctx)
+		if err != nil {
+			return nil, err
+		}
+		s = m.Topics.TopicsSet()
+	} else if e := s.EmptyTopics(); len(e) > 0 {
+		m, err := cl.Metadata(ctx, e...)
+		if err != nil {
+			return nil, err
+		}
+		for t, ps := range m.Topics.TopicsSet() {
+			s[t] = ps
+		}
+	}
+
+	req := kmsg.NewPtrDescribeProducersRequest()
+	for _, t := range s.IntoList() {
+		rt := kmsg.NewDescribeProducersRequestTopic()
+		rt.Topic = t.Topic
+		rt.Partitions = t.Partitions
+		req.Topics = append(req.Topics, rt)
+	}
+	shards := cl.cl.RequestSharded(ctx, req)
+	dts := make(DescribedProducersTopics)
+	return dts, shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
+		resp := kr.(*kmsg.DescribeProducersResponse)
+		for _, rt := range resp.Topics {
+			dt, exists := dts[rt.Topic]
+			if !exists { // topic could be spread around brokers, we need to check existence
+				dt = DescribedProducersTopic{
+					Topic:      rt.Topic,
+					Partitions: make(DescribedProducersPartitions),
+				}
+				dts[rt.Topic] = dt
+			}
+			dps := dt.Partitions
+			for _, rp := range rt.Partitions {
+				if err := maybeAuthErr(rp.ErrorCode); err != nil {
+					return err
+				}
+				drs := make(DescribedProducers)
+				dp := DescribedProducersPartition{
+					Leader:          b.NodeID,
+					Topic:           rt.Topic,
+					Partition:       rp.Partition,
+					ActiveProducers: drs,
+					Err:             kerr.ErrorForCode(rp.ErrorCode),
+				}
+				dps[rp.Partition] = dp // one partition globally, no need to exist-check
+				for _, rr := range rp.ActiveProducers {
+					dr := DescribedProducer{
+						Leader:                b.NodeID,
+						Topic:                 rt.Topic,
+						Partition:             rp.Partition,
+						ProducerID:            rr.ProducerID,
+						ProducerEpoch:         int16(rr.ProducerEpoch),
+						LastSequence:          rr.LastSequence,
+						LastTimestamp:         rr.LastTimestamp,
+						CoordinatorEpoch:      rr.CoordinatorEpoch,
+						CurrentTxnStartOffset: rr.CurrentTxnStartOffset,
+					}
+					drs[dr.ProducerID] = dr
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// DescribedTransaction contains data from a describe transactions response for
+// a single transactional ID.
+type DescribedTransaction struct {
+	Coordinator    int32  // Coordinator is the coordinator broker for this transactional ID.
+	TxnID          string // TxnID is the name of this transactional ID.
+	State          string // State is the state this transaction is in (Empty, Ongoing, PrepareCommit, PrepareAbort, CompleteCommit, CompleteAbort, Dead, PrepareEpochFence).
+	TimeoutMillis  int32  // TimeoutMillis is the timeout of this transaction in milliseconds.
+	StartTimestamp int64  // StartTimestamp is millisecond when this transaction started.
+	ProducerID     int64  // ProducerID is the ID in use by the transactional ID.
+	ProducerEpoch  int16  // ProducerEpoch is the epoch associated with the produce rID.
+
+	// Topics is the set of partitions in the transaction, if active. When
+	// preparing to commit or abort, this includes only partitions which do
+	// not have markers. This does not include topics the user is not
+	// authorized to describe.
+	Topics TopicsSet
+
+	Err error // Err is non-nil if the transaction could not be described.
+}
+
+// DescribedTransactions contains information from a describe transactions
+// response.
+type DescribedTransactions map[string]DescribedTransaction
+
+// Sorted returns all described transactions sorted by transactional ID.
+func (ds DescribedTransactions) Sorted() []DescribedTransaction {
+	s := make([]DescribedTransaction, 0, len(ds))
+	for _, d := range ds {
+		s = append(s, d)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].TxnID < s[j].TxnID })
+	return s
+}
+
+// Each calls fn for each described transaction.
+func (ds DescribedTransactions) Each(fn func(DescribedTransaction)) {
+	for _, d := range ds {
+		fn(d)
+	}
+}
+
+// On calls fn for the transactional ID if it exists, returning the transaction
+// and the error returned from fn. If fn is nil, this simply returns the
+// transaction.
+//
+// The fn is given a shallow copy of the transaction. This function returns the
+// copy as well; any modifications within fn are modifications on the returned
+// copy.  Modifications on a described transaction's inner fields are persisted
+// to the original map (because slices are pointers).
+//
+// If the transaction does not exist, this returns
+// kerr.TransactionalIDNotFound.
+func (rs DescribedTransactions) On(txnID string, fn func(*DescribedTransaction) error) (DescribedTransaction, error) {
+	if len(rs) > 0 {
+		r, ok := rs[txnID]
+		if ok {
+			if fn == nil {
+				return r, nil
+			}
+			return r, fn(&r)
+		}
+	}
+	return DescribedTransaction{}, kerr.TransactionalIDNotFound
+}
+
+// TransactionalIDs returns a sorted list of all transactional IDs.
+func (ds DescribedTransactions) TransactionalIDs() []string {
+	all := make([]string, 0, len(ds))
+	for t := range ds {
+		all = append(all, t)
+	}
+	sort.Strings(all)
+	return all
+}
+
+// DescribeTransactions describes either all transactional IDs specified, or
+// all transactional IDs in the cluster if none are specified.
+//
+// This may return *ShardErrors or *AuthError.
+//
+// If no transactional IDs are specified and this method first lists
+// transactional IDs, and listing IDs returns a *ShardErrors, this function
+// describes all successfully listed IDs and appends the list shard errors to
+// any describe shard errors.
+//
+// If only one ID is described, there will be at most one request issued and
+// there is no need to deeply inspect the error.
+func (cl *Client) DescribeTransactions(ctx context.Context, txnIDs ...string) (DescribedTransactions, error) {
+	var seList *ShardErrors
+	if len(txnIDs) == 0 {
+		listed, err := cl.ListTransactions(ctx, nil, nil)
+		switch {
+		case err == nil:
+		case errors.As(err, &seList):
+		default:
+			return nil, err
+		}
+		txnIDs = listed.TransactionalIDs()
+		if len(txnIDs) == 0 {
+			return nil, err
+		}
+	}
+
+	req := kmsg.NewPtrDescribeTransactionsRequest()
+	req.TransactionalIDs = txnIDs
+
+	shards := cl.cl.RequestSharded(ctx, req)
+	described := make(DescribedTransactions)
+	err := shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
+		resp := kr.(*kmsg.DescribeTransactionsResponse)
+		for _, rt := range resp.TransactionStates {
+			if err := maybeAuthErr(rt.ErrorCode); err != nil {
+				return err
+			}
+			t := DescribedTransaction{
+				Coordinator:    b.NodeID,
+				TxnID:          rt.TransactionalID,
+				State:          rt.State,
+				TimeoutMillis:  rt.TimeoutMillis,
+				StartTimestamp: rt.StartTimestamp,
+				ProducerID:     rt.ProducerID,
+				ProducerEpoch:  rt.ProducerEpoch,
+				Err:            kerr.ErrorForCode(rt.ErrorCode),
+			}
+			for _, rtt := range rt.Topics {
+				t.Topics.Add(rtt.Topic, rtt.Partitions...)
+			}
+			described[t.TxnID] = t // txnID lives on one coordinator, no need to exist-check
+		}
+		return nil
+	})
+
+	var seDesc *ShardErrors
+	switch {
+	case err == nil:
+		return described, seList.into()
+	case errors.As(err, &seDesc):
+		if seList != nil {
+			seDesc.Errs = append(seList.Errs, seDesc.Errs...)
+		}
+		return described, seDesc.into()
+	default:
+		return nil, err
+	}
+}
+
+// ListedTransaction contains data from a list transactions response for a
+// single transactional ID.
+type ListedTransaction struct {
+	Coordinator int32  // Coordinator the coordinator broker for this transactional ID.
+	TxnID       string // TxnID is the name of this transactional ID.
+	ProducerID  int64  // ProducerID is the producer ID for this transaction.
+	State       string // State is the state this transaction is in (Empty, Ongoing, PrepareCommit, PrepareAbort, CompleteCommit, CompleteAbort, Dead, PrepareEpochFence).
+}
+
+// ListedTransactions contains information from a list transactions response.
+type ListedTransactions map[string]ListedTransaction
+
+// Sorted returns all transactions sorted by transactional ID.
+func (ls ListedTransactions) Sorted() []ListedTransaction {
+	s := make([]ListedTransaction, 0, len(ls))
+	for _, l := range ls {
+		s = append(s, l)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].TxnID < s[j].TxnID })
+	return s
+}
+
+// Each calls fn for each listed transaction.
+func (ls ListedTransactions) Each(fn func(ListedTransaction)) {
+	for _, l := range ls {
+		fn(l)
+	}
+}
+
+// TransactionalIDs returns a sorted list of all transactional IDs.
+func (ls ListedTransactions) TransactionalIDs() []string {
+	all := make([]string, 0, len(ls))
+	for t := range ls {
+		all = append(all, t)
+	}
+	sort.Strings(all)
+	return all
+}
+
+// ListTransactions returns all transactions and their states in the cluster.
+// Filter states can be used to return transactions only in the requested
+// states. By default, this returns all transactions you have DESCRIBE access
+// to. Producer IDs can be specified to filter for transactions from the given
+// producer.
+//
+// This may return *ShardErrors or *AuthError.
+func (cl *Client) ListTransactions(ctx context.Context, producerIDs []int64, filterStates []string) (ListedTransactions, error) {
+	req := kmsg.NewPtrListTransactionsRequest()
+	req.ProducerIDFilters = producerIDs
+	req.StateFilters = filterStates
+	shards := cl.cl.RequestSharded(ctx, req)
+	list := make(ListedTransactions)
+	return list, shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
+		resp := kr.(*kmsg.ListTransactionsResponse)
+		if err := maybeAuthErr(resp.ErrorCode); err != nil {
+			return err
+		}
+		if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+			return err
+		}
+		for _, t := range resp.TransactionStates {
+			list[t.TransactionalID] = ListedTransaction{ // txnID lives on one coordinator, no need to exist-check
+				Coordinator: b.NodeID,
+				TxnID:       t.TransactionalID,
+				ProducerID:  t.ProducerID,
+				State:       t.TransactionState,
+			}
+		}
+		return nil
+	})
+}
+
+// TxnMarkers marks the end of a partition: the producer ID / epoch doing the
+// writing, whether this is a commit, the coordinator epoch of the broker we
+// are writing to (for fencing), and the topics and partitions that we are
+// writing this abort or commit for.
+//
+// This is a very low level admin request and should likely be built from data
+// in a DescribeProducers response. See KIP-664 if you are trying to use this.
+type TxnMarkers struct {
+	ProducerID       int64     // ProducerID is the ID to write markers for.
+	ProducerEpoch    int16     // ProducerEpoch is the epoch to write markers for.
+	Commit           bool      // Commit is true if we are committing, false if we are aborting.
+	CoordinatorEpoch int32     // CoordinatorEpoch is the epoch of the transactional coordinator we are writing to; this is used for fencing.
+	Topics           TopicsSet // Topics are topics and partitions to write markers for.
+}
+
+// TxnMarkersPartitionResponse is a response to a topic's partition within a
+// single marker written.
+type TxnMarkersPartitionResponse struct {
+	NodeID     int32  // NodeID is the node that this marker was written to.
+	ProducerID int64  // ProducerID corresponds to the PID in the write marker request.
+	Topic      string // Topic is the topic being responded to.
+	Partition  int32  // Partition is the partition being responded to.
+	Err        error  // Err is non-nil if the WriteTxnMarkers request for this pid/topic/partition failed.
+}
+
+// TxnMarkersPartitionResponses contains per-partition responses to a
+// WriteTxnMarkers request.
+type TxnMarkersPartitionResponses map[int32]TxnMarkersPartitionResponse
+
+// Sorted returns all partitions sorted by partition.
+func (ps TxnMarkersPartitionResponses) Sorted() []TxnMarkersPartitionResponse {
+	var all []TxnMarkersPartitionResponse
+	ps.Each(func(p TxnMarkersPartitionResponse) {
+		all = append(all, p)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Partition < r.Partition
+	})
+	return all
+}
+
+// Each calls fn for each partition.
+func (ps TxnMarkersPartitionResponses) Each(fn func(TxnMarkersPartitionResponse)) {
+	for _, p := range ps {
+		fn(p)
+	}
+}
+
+// TxnMarkersTopicResponse is a response to a topic within a single marker
+// written.
+type TxnMarkersTopicResponse struct {
+	ProducerID int64                        // ProducerID corresponds to the PID in the write marker request.
+	Topic      string                       // Topic is the topic being responded to.
+	Partitions TxnMarkersPartitionResponses // Partitions are the responses for partitions in this marker.
+}
+
+// TxnMarkersTopicResponses contains per-topic responses to a WriteTxnMarkers
+// request.
+type TxnMarkersTopicResponses map[string]TxnMarkersTopicResponse
+
+// Sorted returns all topics sorted by topic.
+func (ts TxnMarkersTopicResponses) Sorted() []TxnMarkersTopicResponse {
+	var all []TxnMarkersTopicResponse
+	ts.Each(func(t TxnMarkersTopicResponse) {
+		all = append(all, t)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic
+	})
+	return all
+}
+
+// SortedPartitions returns all topics sorted by topic then partition.
+func (ts TxnMarkersTopicResponses) SortedPartitions() []TxnMarkersPartitionResponse {
+	var all []TxnMarkersPartitionResponse
+	ts.EachPartition(func(p TxnMarkersPartitionResponse) {
+		all = append(all, p)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.Topic < r.Topic || l.Topic == r.Topic && l.Partition < r.Partition
+	})
+	return all
+}
+
+// Each calls fn for each topic.
+func (ts TxnMarkersTopicResponses) Each(fn func(TxnMarkersTopicResponse)) {
+	for _, t := range ts {
+		fn(t)
+	}
+}
+
+// EachPartition calls fn for every partition in all topics.
+func (ts TxnMarkersTopicResponses) EachPartition(fn func(TxnMarkersPartitionResponse)) {
+	for _, t := range ts {
+		for _, p := range t.Partitions {
+			fn(p)
+		}
+	}
+}
+
+// TxnMarkersResponse is a response for a single marker written.
+type TxnMarkersResponse struct {
+	ProducerID int64                    // ProducerID corresponds to the PID in the write marker request.
+	Topics     TxnMarkersTopicResponses // Topics contains the topics that markers were written for, for this ProducerID.
+}
+
+// TxnMarkersResponse contains per-partition-ID responses to a WriteTxnMarkers
+// request.
+type TxnMarkersResponses map[int64]TxnMarkersResponse
+
+// Sorted returns all markers sorted by producer ID.
+func (ms TxnMarkersResponses) Sorted() []TxnMarkersResponse {
+	var all []TxnMarkersResponse
+	ms.Each(func(m TxnMarkersResponse) {
+		all = append(all, m)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.ProducerID < r.ProducerID
+	})
+	return all
+}
+
+// SortedTopics returns all marker topics sorted by producer ID then topic.
+func (ms TxnMarkersResponses) SortedTopics() []TxnMarkersTopicResponse {
+	var all []TxnMarkersTopicResponse
+	ms.EachTopic(func(t TxnMarkersTopicResponse) {
+		all = append(all, t)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.ProducerID < r.ProducerID || l.ProducerID == r.ProducerID && l.Topic < r.Topic
+	})
+	return all
+}
+
+// SortedPartitions returns all marker topic partitions sorted by producer ID
+// then topic then partition.
+func (ms TxnMarkersResponses) SortedPartitions() []TxnMarkersPartitionResponse {
+	var all []TxnMarkersPartitionResponse
+	ms.EachPartition(func(p TxnMarkersPartitionResponse) {
+		all = append(all, p)
+	})
+	sort.Slice(all, func(i, j int) bool {
+		l, r := all[i], all[j]
+		return l.ProducerID < r.ProducerID || l.ProducerID == r.ProducerID && l.Topic < r.Topic || l.Topic == r.Topic && l.Partition < r.Partition
+	})
+	return all
+}
+
+// Each calls fn for each marker response.
+func (ms TxnMarkersResponses) Each(fn func(TxnMarkersResponse)) {
+	for _, m := range ms {
+		fn(m)
+	}
+}
+
+// EachTopic calls fn for every topic in all marker responses.
+func (ms TxnMarkersResponses) EachTopic(fn func(TxnMarkersTopicResponse)) {
+	for _, m := range ms {
+		for _, t := range m.Topics {
+			fn(t)
+		}
+	}
+}
+
+// EachPartition calls fn for every partition in all topics in all marker
+// responses.
+func (ms TxnMarkersResponses) EachPartition(fn func(TxnMarkersPartitionResponse)) {
+	for _, m := range ms {
+		for _, t := range m.Topics {
+			for _, p := range t.Partitions {
+				fn(p)
+			}
+		}
+	}
+}
+
+// WriteTxnMarkers writes transaction markers to brokers. This is an advanced
+// admin way to close out open transactions. See KIP-664 for more details.
+//
+// This may return *ShardErrors or *AuthError.
+func (cl *Client) WriteTxnMarkers(ctx context.Context, markers ...TxnMarkers) (TxnMarkersResponses, error) {
+	req := kmsg.NewPtrWriteTxnMarkersRequest()
+	for _, m := range markers {
+		rm := kmsg.NewWriteTxnMarkersRequestMarker()
+		rm.ProducerID = m.ProducerID
+		rm.ProducerEpoch = m.ProducerEpoch
+		rm.Committed = m.Commit
+		rm.CoordinatorEpoch = m.CoordinatorEpoch
+		for t, ps := range m.Topics {
+			rt := kmsg.NewWriteTxnMarkersRequestMarkerTopic()
+			rt.Topic = t
+			for p := range ps {
+				rt.Partitions = append(rt.Partitions, p)
+			}
+			rm.Topics = append(rm.Topics, rt)
+		}
+		req.Markers = append(req.Markers, rm)
+	}
+	shards := cl.cl.RequestSharded(ctx, req)
+	rs := make(TxnMarkersResponses)
+	return rs, shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
+		resp := kr.(*kmsg.WriteTxnMarkersResponse)
+		for _, rm := range resp.Markers {
+			m, exists := rs[rm.ProducerID] // partitions are spread around, our marker could be split: we need to check existence
+			if !exists {
+				m = TxnMarkersResponse{
+					ProducerID: rm.ProducerID,
+					Topics:     make(TxnMarkersTopicResponses),
+				}
+				rs[rm.ProducerID] = m
+			}
+			for _, rt := range rm.Topics {
+				t, exists := m.Topics[rt.Topic]
+				if !exists { // same thought
+					t = TxnMarkersTopicResponse{
+						ProducerID: rm.ProducerID,
+						Topic:      rt.Topic,
+						Partitions: make(TxnMarkersPartitionResponses),
+					}
+					m.Topics[rt.Topic] = t
+				}
+				for _, rp := range rt.Partitions {
+					if err := maybeAuthErr(rp.ErrorCode); err != nil {
+						return err
+					}
+					t.Partitions[rp.Partition] = TxnMarkersPartitionResponse{ // one partition globally, no need to exist-check
+						NodeID:     b.NodeID,
+						ProducerID: rm.ProducerID,
+						Topic:      rt.Topic,
+						Partition:  rp.Partition,
+						Err:        kerr.ErrorForCode(rp.ErrorCode),
+					}
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1021,6 +1021,9 @@ github.com/twmb/franz-go/pkg/kgo
 github.com/twmb/franz-go/pkg/kgo/internal/sticky
 github.com/twmb/franz-go/pkg/kversion
 github.com/twmb/franz-go/pkg/sasl
+# github.com/twmb/franz-go/pkg/kadm v1.10.0
+## explicit; go 1.19
+github.com/twmb/franz-go/pkg/kadm
 # github.com/twmb/franz-go/pkg/kfake v0.0.0-20231206062516-c09dc92d2db1
 ## explicit; go 1.20
 github.com/twmb/franz-go/pkg/kfake


### PR DESCRIPTION
This PR adds experimental support to the ingester to consume write requests from a Kafka topic. The configuration is the same as used in #6888 - it is hidden because it is _very_ experimental. For the same reason this PR doesn't include a changelog entry.

 The consumption logic is following fairly basic manual kafka consumption (outside a consumer group) with a few twists:

1. unmarshalling and Push() invocation happen concurrently. Roughly 14% of the time spent serving a write request is in unmarhsalling it. Making these two work concurrently speeds up consumption.
2. the ingester is using a consumer group to persist how far it has consumed, so it picks up from there after a restart. But it doesn't consume in a consumer group - partition allocations is manual based on the ingester ID in the hash ring
3. committing to the consumer group happens every second to slightly speed up consumption

Incoming work:
* consume records for different tenants in parallel
* improve (add) error handling so that only client errors are swallowed, not server errors

