### PR TITLE
Fix context cancellation handling when request is canceled while querying store-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * [BUGFIX] Ruler: fix issue where "failed to remotely evaluate query expression, will retry" messages are logged without context such as the trace ID and do not appear in trace events. #6789
 * [BUGFIX] Querier: fix issue where spans in query request traces were not nested correctly. #6893
 * [BUGFIX] Fix issue where all incoming HTTP requests have duplicate trace spans. #6920
+* [BUGFIX] Querier: do not retry requests to store-gateway when a query gets canceled. #6934
+* [BUGFIX] Querier: return 499 status code instead of 500 when a request to remote read endpoint gets canceled. #6934
 
 ### Mixin
 

--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,11 @@ lint: check-makefiles
 		"flag.{Parse,NArg,Arg,Args}=github.com/grafana/dskit/flagext.{ParseFlagsAndArguments,ParseFlagsWithoutArguments}" \
 		./pkg/... ./cmd/... ./tools/... ./integration/...
 
+	# Ensure we use our custom gRPC clients.
+	faillint -paths \
+		"github.com/grafana/mimir/pkg/storegateway/storegatewaypb.{NewStoreGatewayClient}=github.com/grafana/mimir/pkg/storegateway/storegatewaypb.NewCustomStoreGatewayClient" \
+		./pkg/... ./cmd/... ./tools/... ./integration/...
+
 format: ## Run gofmt and goimports.
 	find . $(DONT_FIND) -name '*.pb.go' -prune -o -type f -name '*.go' -exec gofmt -w -s {} \;
 	find . $(DONT_FIND) -name '*.pb.go' -prune -o -type f -name '*.go' -exec goimports -w -local github.com/grafana/mimir {} \;

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -595,8 +595,9 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(
 	}
 
 	// We've not been able to query all expected blocks after all retries.
-	level.Warn(util_log.WithContext(ctx, spanLog)).Log("msg", "failed consistency check", "err", err)
-	return newStoreConsistencyCheckFailedError(remainingBlocks)
+	err = newStoreConsistencyCheckFailedError(remainingBlocks)
+	level.Warn(util_log.WithContext(ctx, spanLog)).Log("msg", "failed consistency check after all attempts", "err", err)
+	return err
 }
 
 func newStoreConsistencyCheckFailedError(remainingBlocks []ulid.ULID) error {

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -984,7 +985,7 @@ func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhile
 		clientCfg := grpcclient.Config{}
 		flagext.DefaultValues(&clientCfg)
 
-		client, err := dialStoreGatewayClient(clientCfg, ring.InstanceDesc{Addr: listener.Addr().String()}, prometheus.NewHistogramVec(prometheus.HistogramOpts{}, []string{"route", "status_code"}))
+		client, err := dialStoreGatewayClient(clientCfg, ring.InstanceDesc{Addr: listener.Addr().String()}, promauto.With(nil).NewHistogramVec(prometheus.HistogramOpts{}, []string{"route", "status_code"}))
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, client.Close())

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -144,7 +144,7 @@ func remoteReadStreamedXORChunks(
 	for i, qr := range req.Queries {
 		if err := processReadStreamedQueryRequest(ctx, i, qr, q, w, f, maxBytesInFrame); err != nil {
 			if errors.Is(err, context.Canceled) {
-				level.Warn(logger).Log("msg", "the remote read request has been canceled", "err", err)
+				// We're intentionally not logging in this case to reduce noise about an unactionable condition.
 				http.Error(w, err.Error(), statusClientClosedRequest)
 				return
 			}

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -34,6 +34,8 @@ const (
 	// Google's recommendation is to keep protobuf message not larger than 1MB.
 	// https://developers.google.com/protocol-buffers/docs/techniques#large-data
 	maxRemoteReadFrameBytes = 1024 * 1024
+
+	statusClientClosedRequest = 499
 )
 
 // RemoteReadHandler handles Prometheus remote read requests.
@@ -141,7 +143,13 @@ func remoteReadStreamedXORChunks(
 
 	for i, qr := range req.Queries {
 		if err := processReadStreamedQueryRequest(ctx, i, qr, q, w, f, maxBytesInFrame); err != nil {
-			level.Error(logger).Log("msg", "error streaming remote read response", "err", err)
+			if errors.Is(err, context.Canceled) {
+				level.Warn(logger).Log("msg", "the remote read request has been canceled", "err", err)
+				http.Error(w, err.Error(), statusClientClosedRequest)
+				return
+			}
+
+			level.Error(logger).Log("msg", "error while processing remote read request", "err", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/pkg/querier/store_gateway_client.go
+++ b/pkg/querier/store_gateway_client.go
@@ -49,7 +49,7 @@ func dialStoreGatewayClient(clientCfg grpcclient.Config, inst ring.InstanceDesc,
 	}
 
 	return &storeGatewayClient{
-		StoreGatewayClient: storegatewaypb.NewStoreGatewayClient(conn),
+		StoreGatewayClient: storegatewaypb.NewCustomStoreGatewayClient(conn),
 		HealthClient:       grpc_health_v1.NewHealthClient(conn),
 		conn:               conn,
 	}, nil

--- a/pkg/storegateway/bucket_store_server_test.go
+++ b/pkg/storegateway/bucket_store_server_test.go
@@ -75,7 +75,7 @@ func newStoreGatewayTestServer(t testing.TB, store storegatewaypb.StoreGatewaySe
 		server:         grpc.NewServer(),
 		serverListener: listener,
 		requestSeries: func(ctx context.Context, conn *grpc.ClientConn, req *storepb.SeriesRequest) (storepb.Store_SeriesClient, error) {
-			client := storegatewaypb.NewStoreGatewayClient(conn)
+			client := storegatewaypb.NewCustomStoreGatewayClient(conn)
 			return client.Series(ctx, req)
 		},
 	}

--- a/pkg/storegateway/storegatewaypb/custom.go
+++ b/pkg/storegateway/storegatewaypb/custom.go
@@ -84,6 +84,7 @@ func (c *customClientStream) Trailer() metadata.MD {
 
 // CloseSend implements grpc.ClientStream.
 func (c *customClientStream) CloseSend() error {
+	//nolint:forbidigo // Here we're just wrapping CloseSend() so it's OK to call it.
 	return wrapContextError(c.wrapped.CloseSend())
 }
 

--- a/pkg/storegateway/storegatewaypb/custom.go
+++ b/pkg/storegateway/storegatewaypb/custom.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package storegatewaypb
+
+import (
+	"context"
+
+	"github.com/grafana/dskit/grpcutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	"github.com/grafana/mimir/pkg/storegateway/storepb"
+)
+
+// customStoreGatewayClient is a custom client which wraps the real gRPC client and re-maps well known
+// gRPC errors into standard golang errors.
+type customStoreGatewayClient struct {
+	wrapped StoreGatewayClient
+}
+
+func NewCustomStoreGatewayClient(cc *grpc.ClientConn) StoreGatewayClient {
+	return &customStoreGatewayClient{
+		wrapped: NewStoreGatewayClient(cc),
+	}
+}
+
+// Series implements StoreGatewayClient.
+func (c *customStoreGatewayClient) Series(ctx context.Context, in *storepb.SeriesRequest, opts ...grpc.CallOption) (StoreGateway_SeriesClient, error) {
+	client, err := c.wrapped.Series(ctx, in, opts...)
+	if err != nil {
+		return client, mapError(err)
+	}
+
+	return &customSeriesClient{client}, nil
+}
+
+// LabelNames implements StoreGatewayClient.
+func (c *customStoreGatewayClient) LabelNames(ctx context.Context, in *storepb.LabelNamesRequest, opts ...grpc.CallOption) (*storepb.LabelNamesResponse, error) {
+	res, err := c.wrapped.LabelNames(ctx, in, opts...)
+	return res, mapError(err)
+}
+
+// LabelValues implements StoreGatewayClient.
+func (c *customStoreGatewayClient) LabelValues(ctx context.Context, in *storepb.LabelValuesRequest, opts ...grpc.CallOption) (*storepb.LabelValuesResponse, error) {
+	res, err := c.wrapped.LabelValues(ctx, in, opts...)
+	return res, mapError(err)
+}
+
+type customSeriesClient struct {
+	StoreGateway_SeriesClient
+}
+
+func (c *customSeriesClient) Recv() (*storepb.SeriesResponse, error) {
+	res, err := c.StoreGateway_SeriesClient.Recv()
+	return res, mapError(err)
+}
+
+func mapError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case grpcutil.IsCanceled(err):
+		return context.Canceled
+	case grpcutil.ErrorToStatusCode(err) == codes.DeadlineExceeded:
+		return context.DeadlineExceeded
+	default:
+		return err
+	}
+}

--- a/pkg/storegateway/storegatewaypb/custom.go
+++ b/pkg/storegateway/storegatewaypb/custom.go
@@ -4,6 +4,7 @@ package storegatewaypb
 
 import (
 	"context"
+	"errors"
 
 	"github.com/grafana/dskit/grpcutil"
 	"google.golang.org/grpc"
@@ -28,7 +29,7 @@ func NewCustomStoreGatewayClient(cc *grpc.ClientConn) StoreGatewayClient {
 func (c *customStoreGatewayClient) Series(ctx context.Context, in *storepb.SeriesRequest, opts ...grpc.CallOption) (StoreGateway_SeriesClient, error) {
 	client, err := c.wrapped.Series(ctx, in, opts...)
 	if err != nil {
-		return client, mapError(err)
+		return client, wrapContextError(err)
 	}
 
 	return &customSeriesClient{client}, nil
@@ -37,13 +38,13 @@ func (c *customStoreGatewayClient) Series(ctx context.Context, in *storepb.Serie
 // LabelNames implements StoreGatewayClient.
 func (c *customStoreGatewayClient) LabelNames(ctx context.Context, in *storepb.LabelNamesRequest, opts ...grpc.CallOption) (*storepb.LabelNamesResponse, error) {
 	res, err := c.wrapped.LabelNames(ctx, in, opts...)
-	return res, mapError(err)
+	return res, wrapContextError(err)
 }
 
 // LabelValues implements StoreGatewayClient.
 func (c *customStoreGatewayClient) LabelValues(ctx context.Context, in *storepb.LabelValuesRequest, opts ...grpc.CallOption) (*storepb.LabelValuesResponse, error) {
 	res, err := c.wrapped.LabelValues(ctx, in, opts...)
-	return res, mapError(err)
+	return res, wrapContextError(err)
 }
 
 type customSeriesClient struct {
@@ -52,18 +53,47 @@ type customSeriesClient struct {
 
 func (c *customSeriesClient) Recv() (*storepb.SeriesResponse, error) {
 	res, err := c.StoreGateway_SeriesClient.Recv()
-	return res, mapError(err)
+	return res, wrapContextError(err)
 }
 
-func mapError(err error) error {
+func wrapContextError(err error) error {
 	switch {
 	case err == nil:
 		return nil
-	case grpcutil.IsCanceled(err):
-		return context.Canceled
+	case err != context.Canceled && grpcutil.IsCanceled(err):
+		return &grpcContextError{grpcErr: err, stdErr: context.Canceled}
 	case grpcutil.ErrorToStatusCode(err) == codes.DeadlineExceeded:
-		return context.DeadlineExceeded
+		return &grpcContextError{grpcErr: err, stdErr: context.DeadlineExceeded}
 	default:
 		return err
 	}
+}
+
+// grpcContextError is a custom error used to wrap gRPC errors which maps to golang standard context errors.
+type grpcContextError struct {
+	// grpcErr is the gRPC error wrapped by grpcContextError.
+	grpcErr error
+
+	// stdErr is the equivalent golang standard context error.
+	stdErr error
+}
+
+func (e *grpcContextError) Error() string {
+	return e.grpcErr.Error()
+}
+
+func (e *grpcContextError) Unwrap() error {
+	return e.grpcErr
+}
+
+func (e *grpcContextError) Is(err error) bool {
+	return errors.Is(e.stdErr, err) || errors.Is(e.grpcErr, err)
+}
+
+func (e *grpcContextError) As(target any) bool {
+	if errors.As(e.stdErr, target) {
+		return true
+	}
+
+	return errors.As(e.grpcErr, target)
 }

--- a/pkg/storegateway/storegatewaypb/custom.go
+++ b/pkg/storegateway/storegatewaypb/custom.go
@@ -106,7 +106,7 @@ func wrapContextError(err error) error {
 	switch {
 	case err == nil:
 		return nil
-	case err != context.Canceled && grpcutil.IsCanceled(err):
+	case grpcutil.ErrorToStatusCode(err) == codes.Canceled:
 		return &grpcContextError{grpcErr: err, stdErr: context.Canceled}
 	case grpcutil.ErrorToStatusCode(err) == codes.DeadlineExceeded:
 		return &grpcContextError{grpcErr: err, stdErr: context.DeadlineExceeded}

--- a/pkg/storegateway/storegatewaypb/custom_test.go
+++ b/pkg/storegateway/storegatewaypb/custom_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package storegatewaypb
 
 import (

--- a/pkg/storegateway/storegatewaypb/custom_test.go
+++ b/pkg/storegateway/storegatewaypb/custom_test.go
@@ -1,0 +1,76 @@
+package storegatewaypb
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/gogo/status"
+	"github.com/grafana/dskit/grpcutil"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+)
+
+func TestWrapContextError(t *testing.T) {
+	t.Run("should return the input error on a non-gRPC error", func(t *testing.T) {
+		orig := errors.New("mock error")
+		assert.Equal(t, orig, wrapContextError(orig))
+
+		assert.Equal(t, context.Canceled, wrapContextError(context.Canceled))
+		assert.Equal(t, context.DeadlineExceeded, wrapContextError(context.DeadlineExceeded))
+		assert.Equal(t, io.EOF, wrapContextError(io.EOF))
+	})
+
+	t.Run("should wrap gRPC Canceled error", func(t *testing.T) {
+		orig := status.Error(codes.Canceled, context.Canceled.Error())
+		wrapped := wrapContextError(orig)
+
+		assert.NotEqual(t, orig, wrapped)
+		assert.Equal(t, orig, errors.Unwrap(wrapped))
+
+		assert.True(t, errors.Is(wrapped, context.Canceled))
+		assert.False(t, errors.Is(wrapped, context.DeadlineExceeded))
+
+		assert.Equal(t, codes.Canceled, grpcutil.ErrorToStatusCode(wrapped))
+	})
+
+	t.Run("should wrap a wrapped gRPC Canceled error", func(t *testing.T) {
+		orig := errors.Wrap(status.Error(codes.Canceled, context.Canceled.Error()), "custom message")
+		wrapped := wrapContextError(orig)
+
+		assert.NotEqual(t, orig, wrapped)
+		assert.Equal(t, orig, errors.Unwrap(wrapped))
+
+		assert.True(t, errors.Is(wrapped, context.Canceled))
+		assert.False(t, errors.Is(wrapped, context.DeadlineExceeded))
+
+		assert.Equal(t, codes.Canceled, grpcutil.ErrorToStatusCode(wrapped))
+	})
+
+	t.Run("should wrap gRPC DeadlineExceeded error", func(t *testing.T) {
+		orig := status.Error(codes.DeadlineExceeded, context.Canceled.Error())
+		wrapped := wrapContextError(orig)
+
+		assert.NotEqual(t, orig, wrapped)
+		assert.Equal(t, orig, errors.Unwrap(wrapped))
+
+		assert.True(t, errors.Is(wrapped, context.DeadlineExceeded))
+		assert.False(t, errors.Is(wrapped, context.Canceled))
+
+		assert.Equal(t, codes.DeadlineExceeded, grpcutil.ErrorToStatusCode(wrapped))
+	})
+
+	t.Run("should wrap a wrapped gRPC DeadlineExceeded error", func(t *testing.T) {
+		orig := errors.Wrap(status.Error(codes.DeadlineExceeded, context.Canceled.Error()), "custom message")
+		wrapped := wrapContextError(orig)
+
+		assert.NotEqual(t, orig, wrapped)
+		assert.Equal(t, orig, errors.Unwrap(wrapped))
+
+		assert.True(t, errors.Is(wrapped, context.DeadlineExceeded))
+		assert.False(t, errors.Is(wrapped, context.Canceled))
+
+		assert.Equal(t, codes.DeadlineExceeded, grpcutil.ErrorToStatusCode(wrapped))
+	})
+}


### PR DESCRIPTION
#### What this PR does

Today I've been paged because of some 500 errors tracked by **querier**. After some investigation I learned that these 500 errors were caused by remote read queries being cancelled. Such requests should be tracked as 499 and not 500.

**Why requests are tracked as 500?**

There are two bugs:

1. In the remote read handler we don't check for context cancellation and and so we always return 500 on any error. In this PR I'm doing the smallest change to fix this specific issue, which is just checking for context cancellation. A better error handling would be required in the remote read handler, but I would defer to a follow up work.
2. TIL that when the context is cancelled while running a gRPC function, the error returned is **not** `context.Canceled` but a gRPC error with `codes.Canceled`. I confirmed it both writing a unit test and looking at the gRPC internals.

**Why the gRPC canceled errors are a pain?**

This is a pain because we're not used to check for gRPC context canceled errors in every place we check for `context.Canceled`. Even if we check for such gRPC errors in `blocksStoreQuerier` but we propagate them, the callers will not handle them correctly because they only check `context.Canceled` (it's an issue I've experienced while working on the fix).

So, instead of checking for gRPC Canceled errors I propose to remap them into `context.Canceled`. Instead of doing it in `blocksStoreQuerier` (which is very specific), I propose to address it once and for all, wrapping the gRPC StoreGatewayClient with a custom one which remaps errors.

If this PR gets accepted, I will do it for every other gRPC client in follow up PRs, so that we'll not have to deal with this pain anymore.

**A second bug fixed**

The fix of gRPC context cancellation handling has fixed another bug which I've seen in the past in prod but I've never got down to the root cause: cancelled queries are retried and then "failed consistency check" is logged, when actually it's just the query being canceled. Why are they retried? Because `shouldStopQueryFunc()` doesn't check for gRPC canceled errors.

**Manual tests**

In addition to unit tests, I've also done some manual tests which confirm the bug fix.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
