### PR TITLE
ingest consumer: handler Push errors

### DIFF
--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -4,13 +4,16 @@ package ingest
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/gogo/status"
 	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
@@ -27,6 +30,8 @@ func TestPusherConsumer(t *testing.T) {
 		{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1"), mockPreallocTimeseries("series_2")}},
 		{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_3")}},
 		{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_4")}},
+		{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_5")}},
+		{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_6")}},
 	}
 
 	wrBytes := make([][]byte, len(writeReqs))
@@ -93,10 +98,9 @@ func TestPusherConsumer(t *testing.T) {
 			responses: []response{
 				okResponse,
 				{err: assert.AnError},
-				okResponse,
 			},
-			expectedWRs: writeReqs[0:3],
-			expErr:      "",
+			expectedWRs: writeReqs[0:2],
+			expErr:      assert.AnError.Error(),
 		},
 		"failed processing of last record": {
 			records: []record{
@@ -108,7 +112,7 @@ func TestPusherConsumer(t *testing.T) {
 				{err: assert.AnError},
 			},
 			expectedWRs: writeReqs[0:2],
-			expErr:      "",
+			expErr:      assert.AnError.Error(),
 		},
 		"failed processing & failed unmarshalling": {
 			records: []record{
@@ -121,9 +125,40 @@ func TestPusherConsumer(t *testing.T) {
 				{err: assert.AnError},
 			},
 			expectedWRs: writeReqs[0:2],
-			expErr:      "",
+			expErr:      assert.AnError.Error(),
 		},
 		"no records": {},
+		"ingester client error": {
+			records: []record{
+				{content: wrBytes[0], tenantID: tenantID},
+				{content: wrBytes[1], tenantID: tenantID},
+				{content: wrBytes[2], tenantID: tenantID},
+				{content: wrBytes[3], tenantID: tenantID},
+			},
+			responses: []response{
+				{err: ingesterError(mimirpb.BAD_DATA, codes.InvalidArgument, "ingester test error")},
+				{err: ingesterError(mimirpb.BAD_DATA, codes.Unknown, "ingester test error")},     // status code doesn't matter
+				{err: ingesterError(mimirpb.BAD_DATA, http.StatusTeapot, "ingester test error")}, // they might come with http status codes
+				okResponse,
+			},
+			expectedWRs: writeReqs[0:4],
+			expErr:      "", // since all fof those were client errors, we don't return an error
+		},
+		"ingester server error": {
+			records: []record{
+				{content: wrBytes[0], tenantID: tenantID},
+				{content: wrBytes[1], tenantID: tenantID},
+				{content: wrBytes[2], tenantID: tenantID},
+				{content: wrBytes[3], tenantID: tenantID},
+				{content: wrBytes[4], tenantID: tenantID},
+			},
+			responses: []response{
+				{err: ingesterError(mimirpb.BAD_DATA, codes.InvalidArgument, "ingester test error")},
+				{err: ingesterError(mimirpb.TSDB_UNAVAILABLE, codes.Unavailable, "ingester internal error")},
+			},
+			expectedWRs: writeReqs[0:2], // the rest of the requests are not attempted
+			expErr:      "ingester internal error",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -154,4 +189,14 @@ func TestPusherConsumer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ingesterError mimics how the ingester construct errors
+func ingesterError(cause mimirpb.ErrorCause, statusCode codes.Code, message string) error {
+	errorDetails := &mimirpb.ErrorDetails{Cause: cause}
+	statWithDetails, err := status.New(statusCode, message).WithDetails(errorDetails)
+	if err != nil {
+		panic(err)
+	}
+	return statWithDetails.Err()
 }

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"go.uber.org/atomic"
 )
 
 func TestReader(t *testing.T) {
@@ -45,7 +46,7 @@ func TestReader(t *testing.T) {
 	assert.Equal(t, [][]byte{content, content}, records)
 }
 
-func TestReader_IgnoredConsumerErrors(t *testing.T) {
+func TestReader_ConsumerError(t *testing.T) {
 	const (
 		topicName   = "test"
 		partitionID = 1
@@ -56,24 +57,35 @@ func TestReader_IgnoredConsumerErrors(t *testing.T) {
 
 	_, clusterAddr := createTestCluster(t, partitionID+1, topicName)
 
-	content := []byte("special content")
-	consumer := newTestConsumer(1)
+	// We need indirection so we can swap out this function without changing the consumer implementation.
+	invocations := atomic.NewInt64(0)
+	receive := func(records []record) error {
+		// There may be more records, but we only care that the one we failed to consume in the first place is still there.
+		assert.Equal(t, "1", string(records[0].content))
+		invocations.Inc()
+		return errors.New("consumer error")
+	}
+	consumer := consumerFunc(func(_ context.Context, records []record) error {
+		return receive(records)
+	})
 	startReader(ctx, t, clusterAddr, topicName, partitionID, consumer)
 
 	// Write to Kafka.
 	writeClient := newKafkaProduceClient(t, clusterAddr)
 
-	produceRecord(ctx, t, writeClient, topicName, partitionID, content)
+	produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("1"))
+	produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("2"))
 
-	records, err := consumer.waitRecords(1, time.Second, 0)
+	// There are more than one invocation because the reader will retry.
+	assert.Eventually(t, func() bool { return invocations.Load() > 1 }, 5*time.Second, 100*time.Millisecond)
+
+	trackingConsumer := newTestConsumer(2)
+	receive = func(records []record) error {
+		return trackingConsumer.consume(ctx, records)
+	}
+	records, err := trackingConsumer.waitRecords(2, time.Second, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, [][]byte{content}, records)
-
-	produceRecord(ctx, t, writeClient, topicName, partitionID, content)
-
-	records, err = consumer.waitRecords(1, time.Second, 0)
-	assert.NoError(t, err)
-	assert.Equal(t, [][]byte{content}, records)
+	assert.Equal(t, [][]byte{[]byte("1"), []byte("2")}, records)
 }
 
 func newKafkaProduceClient(t *testing.T, addrs string) *kgo.Client {
@@ -325,4 +337,10 @@ func (t testConsumer) waitRecords(numRecords int, waitTimeout, drainPeriod time.
 			return records, nil
 		}
 	}
+}
+
+type consumerFunc func(ctx context.Context, records []record) error
+
+func (c consumerFunc) consume(ctx context.Context, records []record) error {
+	return c(ctx, records)
 }


### PR DESCRIPTION
This adds error handling for ingester errors. **Client errors** are only logged at warning level (like they are with regular gRPC ingestion) and ignored otherwise. **Server errors** trigger a backoff at the consumer; the backoff is unlimited and retries the same batch of records until it is successfully ingested.