### PR TITLE
Improve validation.LimitError usages

### DIFF
--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -335,8 +335,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 
 	quorumConfig := d.queryQuorumConfig(ctx, replicationSet)
 	quorumConfig.IsTerminalError = func(err error) bool {
-		_, isLimitError := err.(validation.LimitError)
-		return isLimitError
+		return validation.IsLimitError(err)
 	}
 
 	results, err := ring.DoUntilQuorumWithoutSuccessfulContextCancellation(ctx, replicationSet, quorumConfig, queryIngester, cleanup)

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -334,9 +334,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSet ri
 	}
 
 	quorumConfig := d.queryQuorumConfig(ctx, replicationSet)
-	quorumConfig.IsTerminalError = func(err error) bool {
-		return validation.IsLimitError(err)
-	}
+	quorumConfig.IsTerminalError = validation.IsLimitError
 
 	results, err := ring.DoUntilQuorumWithoutSuccessfulContextCancellation(ctx, replicationSet, quorumConfig, queryIngester, cleanup)
 	if err != nil {

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -233,7 +233,7 @@ func (s *SeriesChunksStreamReader) readNextBatch(seriesIndex uint64) error {
 		select {
 		case err, haveError := <-s.errorChan:
 			if haveError {
-				if _, ok := err.(validation.LimitError); ok {
+				if validation.IsLimitError(err) {
 					return err
 				}
 				return fmt.Errorf("attempted to read series at index %v from ingester chunks stream, but the stream has failed: %w", seriesIndex, err)

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -51,7 +51,6 @@ import (
 	"github.com/grafana/mimir/pkg/util/limiter"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
-	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 const (
@@ -831,9 +830,8 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(ctx context.Context, sp *stor
 				if ss := resp.GetStreamingSeries(); ss != nil {
 					for _, s := range ss.Series {
 						// Add series fingerprint to query limiter; will return error if we are over the limit
-						limitErr := queryLimiter.AddSeries(s.Labels)
-						if limitErr != nil {
-							return validation.LimitError(limitErr.Error())
+						if limitErr := queryLimiter.AddSeries(s.Labels); limitErr != nil {
+							return limitErr
 						}
 					}
 					myStreamingSeries = append(myStreamingSeries, ss.Series...)

--- a/pkg/querier/error_translate_queryable_test.go
+++ b/pkg/querier/error_translate_queryable_test.go
@@ -44,7 +44,7 @@ func TestApiStatusCodes(t *testing.T) {
 		},
 
 		{
-			err:            validation.LimitError("limit exceeded"),
+			err:            validation.NewLimitError("limit exceeded"),
 			expectedString: "limit exceeded",
 			expectedCode:   422,
 		},

--- a/pkg/querier/errors.go
+++ b/pkg/querier/errors.go
@@ -18,7 +18,7 @@ var (
 )
 
 func NewMaxQueryLengthError(actualQueryLen, maxQueryLength time.Duration) validation.LimitError {
-	return validation.LimitError(globalerror.MaxQueryLength.MessageWithPerTenantLimitConfig(
+	return validation.NewLimitError(globalerror.MaxQueryLength.MessageWithPerTenantLimitConfig(
 		fmt.Sprintf("the query time range exceeds the limit (query length: %s, limit: %s)", actualQueryLen, maxQueryLength),
 		validation.MaxPartialQueryLengthFlag))
 }

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -270,7 +270,7 @@ func TestBlockLabelNames(t *testing.T) {
 	slices.Sort(jNotFooLabelNames)
 
 	sl := NewLimiter(math.MaxUint64, promauto.With(nil).NewCounter(prometheus.CounterOpts{Name: "test"}), func(limit uint64) validation.LimitError {
-		return validation.LimitError(fmt.Sprintf("exceeded unlimited limit of %v", limit))
+		return validation.NewLimitError(fmt.Sprintf("exceeded unlimited limit of %v", limit))
 	})
 	newTestBucketBlock := prepareTestBlock(test.NewTB(t), appendTestSeries(series))
 

--- a/pkg/storegateway/limiter_test.go
+++ b/pkg/storegateway/limiter_test.go
@@ -22,7 +22,7 @@ import (
 func TestLimiter(t *testing.T) {
 	c := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
 	l := NewLimiter(10, c, func(limit uint64) validation.LimitError {
-		return validation.LimitError(fmt.Sprintf("limit of %v exceeded", limit))
+		return validation.NewLimitError(fmt.Sprintf("limit of %v exceeded", limit))
 	})
 
 	assert.NoError(t, l.Reserve(5))

--- a/pkg/util/limiter/errors.go
+++ b/pkg/util/limiter/errors.go
@@ -33,7 +33,7 @@ var (
 )
 
 func limitError(format string, limit uint64) validation.LimitError {
-	return validation.LimitError(fmt.Sprintf(format, limit))
+	return validation.NewLimitError(fmt.Sprintf(format, limit))
 }
 
 func NewMaxSeriesHitLimitError(maxSeriesPerQuery uint64) validation.LimitError {

--- a/pkg/util/limiter/query_limiter.go
+++ b/pkg/util/limiter/query_limiter.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 type queryLimiterCtxKey struct{}
@@ -73,7 +74,7 @@ func QueryLimiterFromContextWithFallback(ctx context.Context) *QueryLimiter {
 }
 
 // AddSeries adds the input series and returns an error if the limit is reached.
-func (ql *QueryLimiter) AddSeries(seriesLabels []mimirpb.LabelAdapter) error {
+func (ql *QueryLimiter) AddSeries(seriesLabels []mimirpb.LabelAdapter) validation.LimitError {
 	// If the max series is unlimited just return without managing map
 	if ql.maxSeriesPerQuery == 0 {
 		return nil
@@ -106,7 +107,7 @@ func (ql *QueryLimiter) uniqueSeriesCount() int {
 }
 
 // AddChunkBytes adds the input chunk size in bytes and returns an error if the limit is reached.
-func (ql *QueryLimiter) AddChunkBytes(chunkSizeInBytes int) error {
+func (ql *QueryLimiter) AddChunkBytes(chunkSizeInBytes int) validation.LimitError {
 	if ql.maxChunkBytesPerQuery == 0 {
 		return nil
 	}
@@ -124,7 +125,7 @@ func (ql *QueryLimiter) AddChunkBytes(chunkSizeInBytes int) error {
 	return nil
 }
 
-func (ql *QueryLimiter) AddChunks(count int) error {
+func (ql *QueryLimiter) AddChunks(count int) validation.LimitError {
 	if ql.maxChunksPerQuery == 0 {
 		return nil
 	}
@@ -142,7 +143,7 @@ func (ql *QueryLimiter) AddChunks(count int) error {
 	return nil
 }
 
-func (ql *QueryLimiter) AddEstimatedChunks(count int) error {
+func (ql *QueryLimiter) AddEstimatedChunks(count int) validation.LimitError {
 	if ql.maxEstimatedChunksPerQuery == 0 {
 		return nil
 	}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -60,11 +60,29 @@ const (
 	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
 )
 
-// LimitError are errors that do not comply with the limits specified.
-type LimitError string
+// LimitError is a marker interface for the errors that do not comply with the specified limits.
+type LimitError interface {
+	error
+	limitError()
+}
 
-func (e LimitError) Error() string {
+type limitErr string
+
+// limitErr implements error and LimitError interfaces
+func (e limitErr) Error() string {
 	return string(e)
+}
+
+// limitErr implements LimitError interface
+func (e limitErr) limitError() {}
+
+func NewLimitError(msg string) LimitError {
+	return limitErr(msg)
+}
+
+func IsLimitError(err error) bool {
+	var limitErr LimitError
+	return errors.As(err, &limitErr)
 }
 
 // Limits describe all the limits for users; can be used to describe global default


### PR DESCRIPTION
#### What this PR does

This PR improves usages of `validation.LimitError` errors. It addresses the following problems found in the code:
- In case of an unexpected behaviour, functions `limiter.AddSeries()`, `limiter.AddChunkBytes()`, `limiter.AddChunks()` and `limiter.AddEstimatedChunks()` return an error of type `validate.LimitError`. In some cases, the caller of those functions used to wrap the returned error into `validation.LimitError`, although it was not necessary. In order to prevent this, the signature of the above mentioned methods has been changed from `func AddXyz(...) error` to `func AddXyz(...) validation.LimitError`. This way we enforced that the only allowed errors returned by these functions are of type `validation.LimitError`. 
- Type `validation.LimitError` is now an interface, instead of a struct as it used to be.

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
