### PR TITLE
[release-2.11] Fix .metricsUsed in mimirtool analyze rule-file (#6953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 * [BUGFIX] Fix the issue where `--read-timeout` was applied to the entire `mimirtool analyze grafana` invocation rather than to individual Grafana API calls. #5915
 * [BUGFIX] Fix incorrect remote-read path joining for `mimirtool remote-read` commands on Windows. #6011
 * [BUGFIX] Fix template files full path being sent in `mimirtool alertmanager load` command. #6138
+* [BUGFIX] Analyze rule-file: .metricsUsed field wasn't populated. #6953
 
 ### Mimir Continuous Test
 

--- a/docs/sources/mimir/release-notes/v2.11.md
+++ b/docs/sources/mimir/release-notes/v2.11.md
@@ -87,3 +87,4 @@ The following configuration option defaults were changed:
 - Query-scheduler: Prevent accumulation of stale querier connections. [PR 6100](https://github.com/grafana/mimir/pull/6100)
 - Packaging: Fix preremove script preventing upgrades on RHEL based OS. [PR 6067](https://github.com/grafana/mimir/pull/6067)
 - Ingester: Fixed possible series matcher corruption leading to wrong series being included in query results. [PR 6884](https://github.com/grafana/mimir/pull/6884)
+- Mimirtool: Fixed missing .metricsUsed field in the output of analyze rule-file. [PR 6953](https://github.com/grafana/mimir/pull/6953)

--- a/pkg/mimirtool/commands/analyse_rulefiles.go
+++ b/pkg/mimirtool/commands/analyse_rulefiles.go
@@ -6,8 +6,11 @@
 package commands
 
 import (
+	"sort"
+
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 
 	"github.com/grafana/mimir/pkg/mimirtool/analyze"
 	"github.com/grafana/mimir/pkg/mimirtool/rules"
@@ -51,5 +54,12 @@ func AnalyzeRuleFiles(ruleFiles []string) (*analyze.MetricsInRuler, error) {
 			}
 		}
 	}
+	var metricsUsed model.LabelValues
+	for metric := range output.OverallMetrics {
+		metricsUsed = append(metricsUsed, model.LabelValue(metric))
+	}
+	sort.Sort(metricsUsed)
+	output.MetricsUsed = metricsUsed
+
 	return output, nil
 }

--- a/pkg/mimirtool/commands/analyse_rulefiles_test.go
+++ b/pkg/mimirtool/commands/analyse_rulefiles_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeRuleFiles(t *testing.T) {
+	mir, err := AnalyzeRuleFiles([]string{"testdata/prometheus_rules.yaml"})
+	require.NoError(t, err)
+	require.Equal(t, 24, len(mir.MetricsUsed))
+	expectedMetrics := model.LabelValues{
+		"apiserver_request_duration_seconds_bucket",
+		"apiserver_request_duration_seconds_count",
+		"apiserver_request_total",
+		"container_memory_cache",
+		"container_memory_rss",
+		"container_memory_swap",
+		"container_memory_working_set_bytes",
+		"kube_pod_container_resource_limits",
+		"kube_pod_container_resource_requests",
+		"kube_pod_info",
+		"kube_pod_owner",
+		"kube_pod_status_phase",
+		"kube_replicaset_owner",
+		"kubelet_node_name",
+		"kubelet_pleg_relist_duration_seconds_bucket",
+		"node_cpu_seconds_total",
+		"node_memory_Buffers_bytes",
+		"node_memory_Cached_bytes",
+		"node_memory_MemAvailable_bytes",
+		"node_memory_MemFree_bytes",
+		"node_memory_Slab_bytes",
+		"scheduler_binding_duration_seconds_bucket",
+		"scheduler_e2e_scheduling_duration_seconds_bucket",
+		"scheduler_scheduling_algorithm_duration_seconds_bucket",
+	}
+	require.Equal(t, expectedMetrics, mir.MetricsUsed)
+}


### PR DESCRIPTION
Backporting [Fix .metricsUsed in mimirtool analyze rule-file](https://github.com/grafana/mimir/pull/6953) to release-2.11

Pending to know the state of 2.11 to choose the proper CHANGELOG entry.