### PR TITLE
add additional queue dimensions to query scheduler queue duration histogram

### DIFF
--- a/pkg/frontend/v2/frontend_scheduler_adapter.go
+++ b/pkg/frontend/v2/frontend_scheduler_adapter.go
@@ -4,6 +4,7 @@ package v2
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
@@ -89,7 +90,7 @@ func (a *frontendToSchedulerAdapter) extractAdditionalQueueDimensions(
 		return []string{ShouldQueryIngestersQueueDimension}, nil
 	default:
 		// no query time params to parse; cannot infer query component
-		level.Warn(a.log).Log("msg", "unsupported request type", "query", httpRequest)
+		level.Warn(a.log).Log("msg", "unsupported request type", "query", fmt.Sprintf("%+v", httpRequest))
 		return nil, nil
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -72,7 +73,7 @@ type Scheduler struct {
 	cancelledRequests        *prometheus.CounterVec
 	connectedQuerierClients  prometheus.GaugeFunc
 	connectedFrontendClients prometheus.GaugeFunc
-	queueDuration            prometheus.Histogram
+	queueDuration            *prometheus.HistogramVec
 	inflightRequests         prometheus.Summary
 }
 
@@ -145,11 +146,11 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 	})
 	s.requestQueue = queue.NewRequestQueue(s.log, cfg.MaxOutstandingPerTenant, cfg.AdditionalQueryQueueDimensionsEnabled, cfg.QuerierForgetDelay, s.queueLength, s.discardedRequests, enqueueDuration)
 
-	s.queueDuration = promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+	s.queueDuration = promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "cortex_query_scheduler_queue_duration_seconds",
 		Help:    "Time spent by requests in queue before getting picked up by a querier.",
 		Buckets: prometheus.DefBuckets,
-	})
+	}, []string{"user", "additional_queue_dimensions"})
 	s.connectedQuerierClients = promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "cortex_query_scheduler_connected_querier_clients",
 		Help: "Number of querier worker clients currently connected to the query-scheduler.",
@@ -399,7 +400,8 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 		r := req.(*queue.SchedulerRequest)
 
 		queueTime := time.Since(r.EnqueueTime)
-		s.queueDuration.Observe(queueTime.Seconds())
+		additionalQueueDimensionLabels := strings.Join(r.AdditionalQueueDimensions, ":")
+		s.queueDuration.WithLabelValues(r.UserID, additionalQueueDimensionLabels).Observe(queueTime.Seconds())
 		r.QueueSpan.Finish()
 
 		/*


### PR DESCRIPTION
This is to allow us to observe the effects of turning on multidimensional queueing, by breaking out the queue duration metric used in the our Mimir / Reads Latency (Time in Queue) panel as well as alerts.

Went back and forth on how to label this, but stuck with the idea that we shouldn't label the additional queue dimensions with a specific meaning in Mimir by doing something like "take the first additional queue dimension and assign it to a label named `query_component`.

Instead I am just concatenating and shipping the additional queue dimensions as is, and we can use the alerts & dashboards to assign meanings to the labels.

Open to feedback on that choice of approach!

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
