### PR TITLE
6964 mimir istio fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
   * `store_gateway_zone_c_node_affinity_matchers`
 * [FEATURE] Ingester: Allow automated zone-by-zone downscaling, that can be enabled via the `ingester_automated_downscale_enabled` flag. It is disabled by default. #6850
 * [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
+* [BUGFIX] Always generate query-frontend headless service (otherwise istio doesn't register the pod ip's for querier to report back the results) #6964
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
   * `store_gateway_zone_c_node_affinity_matchers`
 * [FEATURE] Ingester: Allow automated zone-by-zone downscaling, that can be enabled via the `ingester_automated_downscale_enabled` flag. It is disabled by default. #6850
 * [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
-* [BUGFIX] Always generate query-frontend headless service (otherwise istio doesn't register the pod ip's for querier to report back the results) #6964
+* [BUGFIX] Always generate query-frontend headless service (otherwise, istio doesn't register the pod IPs for querier to report back the results). #6965
 
 ### Mimirtool
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -40,7 +40,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Let the unified gatway/nginx config listen on IPv6 as well. Followup to #5948. #6204
 * [BUGFIX] Quote `checksum/config` when using external config. This allows setting `externalConfigVersion` to numeric values. #6407
 * [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
-* [BUGFIX] Allow Mimir to run injected (istio); optionally add appProtocol to memcached services and gRPC ports and always generate query-frontend headless service (otherwise, istio doesn't register the pod IPs for querier to report back the results). #6965
+* [BUGFIX] Allow Mimir to run injected (istio); optionally add appProtocol to memcached services and gRPC ports and always generate query-frontend headless service (otherwise, istio doesn't register the pod IPs for querier to report back the results) and add gRPC port to ruler service and generate ruler headless service (otherwise the ruler cannot connect with the alertmanager). #6965
 
 ## 5.1.4
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -40,6 +40,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Let the unified gatway/nginx config listen on IPv6 as well. Followup to #5948. #6204
 * [BUGFIX] Quote `checksum/config` when using external config. This allows setting `externalConfigVersion` to numeric values. #6407
 * [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
+* [BUGFIX] Allow Mimir to run injected (istio); optionally add appProtocol to memcached svc's and grpc ports and always generate query-frontend headless service (otherwise istio doesn't register the pod ip's for querier to report back the results) #6964
 
 ## 5.1.4
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -40,7 +40,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Let the unified gatway/nginx config listen on IPv6 as well. Followup to #5948. #6204
 * [BUGFIX] Quote `checksum/config` when using external config. This allows setting `externalConfigVersion` to numeric values. #6407
 * [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
-* [BUGFIX] Allow Mimir to run injected (istio); optionally add appProtocol to memcached svc's and grpc ports and always generate query-frontend headless service (otherwise istio doesn't register the pod ip's for querier to report back the results) #6964
+* [BUGFIX] Allow Mimir to run injected (istio); optionally add appProtocol to memcached services and gRPC ports and always generate query-frontend headless service (otherwise, istio doesn't register the pod IPs for querier to report back the results). #6965
 
 ## 5.1.4
 

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -22,6 +22,9 @@ spec:
       protocol: TCP
       name: http-metrics
       targetPort: http-metrics
+      {{- if .Values.alertmanager.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.alertmanager.service.appProtocol.httpMetrics }}
+      {{- end }}
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -26,6 +26,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.alertmanager.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.alertmanager.service.appProtocol.grpc }}
+      {{- end }}
     - port: {{ $clusterPort }}
       protocol: TCP
       name: cluster

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -31,6 +31,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.alertmanager.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.alertmanager.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" $args | nindent 4 }}
 

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -21,5 +21,8 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.compactor.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.compactor.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "compactor" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -23,5 +23,8 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.distributor.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.distributor.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -21,5 +21,8 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.distributor.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.distributor.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "distributor" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -23,5 +23,8 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.ingester.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.ingester.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "ingester" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -30,6 +30,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.ingester.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.ingester.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" $args | nindent 4 }}
 

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
@@ -23,8 +23,8 @@ spec:
     - name: memcached-client
       port: {{ .port }}
       targetPort: {{ .port }}
-      {{- if .appProtocol.client }}
-      appProtocol: {{ .appProtocol.client }}
+      {{- if .appProtocol.memcachedClient }}
+      appProtocol: {{ .appProtocol.memcachedClient }}
       {{- end }}
     {{ if $.ctx.Values.memcachedExporter.enabled }}
     - name: http-metrics

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
@@ -23,6 +23,9 @@ spec:
     - name: memcached-client
       port: {{ .port }}
       targetPort: {{ .port }}
+      {{- if .appProtocol.client }}
+      appProtocol: {{ .appProtocol.client }}
+      {{- end }}
     {{ if $.ctx.Values.memcachedExporter.enabled }}
     - name: http-metrics
       port: 9150

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
@@ -21,5 +21,8 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.querier.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.querier.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "querier" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.query_scheduler.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,4 +26,3 @@ spec:
       targetPort: grpc
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
-{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc-headless.yaml
@@ -24,5 +24,8 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.query_frontend.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.query_frontend.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -21,5 +21,8 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.query_frontend.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.query_frontend.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
@@ -25,6 +25,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.query_scheduler.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.query_scheduler.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-scheduler") | nindent 4 }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -22,6 +22,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.query_scheduler.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.query_scheduler.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-scheduler") | nindent 4 }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc-headless.yaml
@@ -2,9 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler") }}
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler") }}-headless
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "ruler" "memberlist" true) | nindent 4 }}
+    prometheus.io/service-monitor: "false"
     {{- with .Values.ruler.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -13,6 +14,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -23,5 +23,8 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.store_gateway.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.store_gateway.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "store-gateway" "memberlist" true) | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -30,6 +30,9 @@ spec:
       protocol: TCP
       name: grpc
       targetPort: grpc
+      {{- if .Values.store_gateway.service.appProtocol.grpc }}
+      appProtocol: {{ .Values.store_gateway.service.appProtocol.grpc }}
+      {{- end }}
   selector:
     {{- include "mimir.selectorLabels" $args | nindent 4 }}
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1083,6 +1083,9 @@ ruler:
   service:
     annotations: {}
     labels: {}
+    appProtocol:
+      # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
+      grpc: null
 
   resources:
     requests:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -472,6 +472,9 @@ alertmanager:
   service:
     annotations: {}
     labels: {}
+    appProtocol:
+      # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
+      grpc: null
 
   # -- Optionally set the scheduler for pods of the alertmanager
   schedulerName: ""
@@ -710,6 +713,9 @@ distributor:
   service:
     annotations: {}
     labels: {}
+    appProtocol:
+      # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
+      grpc: null
 
   resources:
     requests:
@@ -791,6 +797,9 @@ ingester:
   service:
     annotations: {}
     labels: {}
+    appProtocol:
+      # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
+      grpc: null
 
   # -- Optionally set the scheduler for pods of the ingester
   schedulerName: ""
@@ -1146,6 +1155,9 @@ querier:
   service:
     annotations: {}
     labels: {}
+    appProtocol:
+      # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
+      grpc: null
 
   resources:
     requests:
@@ -1221,6 +1233,9 @@ query_frontend:
   service:
     annotations: {}
     labels: {}
+    appProtocol:
+      # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
+      grpc: null
 
   resources:
     requests:
@@ -1296,6 +1311,9 @@ query_scheduler:
   service:
     annotations: {}
     labels: {}
+    appProtocol:
+      # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
+      grpc: null
 
   resources:
     requests:
@@ -1374,6 +1392,9 @@ store_gateway:
   service:
     annotations: {}
     labels: {}
+    appProtocol:
+      # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
+      grpc: null
 
   # -- Optionally set the scheduler for pods of the store-gateway
   schedulerName: ""
@@ -1573,6 +1594,9 @@ compactor:
   service:
     annotations: {}
     labels: {}
+    appProtocol:
+      # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
+      grpc: null
 
   # -- Optionally set the scheduler for pods of the compactor
   schedulerName: ""

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -473,6 +473,8 @@ alertmanager:
     annotations: {}
     labels: {}
     appProtocol:
+      # -- Set the optional http service protocol. Ex: "http" or "tcp"
+      httpMetrics: null
       # -- Set the optional grpc service protocol. Ex: "grpc" or "tcp"
       grpc: null
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1825,6 +1825,10 @@ chunks-cache:
   service:
     annotations: {}
     labels: {}
+  
+  appProtocol:
+    # -- Set the optional service protocol. Ex: "tcp"
+    client: null
 
 index-cache:
   # -- Specifies whether memcached based index-cache should be enabled
@@ -1918,6 +1922,10 @@ index-cache:
     annotations: {}
     labels: {}
 
+  appProtocol:
+    # -- Set the optional service protocol. Ex: "tcp"
+    client: null
+
 metadata-cache:
   # -- Specifies whether memcached based metadata-cache should be enabled
   enabled: false
@@ -2010,6 +2018,10 @@ metadata-cache:
     annotations: {}
     labels: {}
 
+  appProtocol:
+    # -- Set the optional service protocol. Ex: "tcp"
+    client: null
+
 results-cache:
   # -- Specifies whether memcached based results-cache should be enabled
   enabled: false
@@ -2101,6 +2113,10 @@ results-cache:
   service:
     annotations: {}
     labels: {}
+
+  appProtocol:
+    # -- Set the optional service protocol. Ex: "tcp"
+    client: null
 
 # -- Setting for the Grafana Rollout Operator https://github.com/grafana/helm-charts/tree/main/charts/rollout-operator
 rollout_operator:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1849,7 +1849,7 @@ chunks-cache:
   service:
     annotations: {}
     labels: {}
-  
+
   appProtocol:
     # -- Set the optional service protocol. Ex: "tcp"
     client: null

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1852,7 +1852,7 @@ chunks-cache:
 
   appProtocol:
     # -- Set the optional service protocol. Ex: "tcp"
-    client: null
+    memcachedClient: null
 
 index-cache:
   # -- Specifies whether memcached based index-cache should be enabled
@@ -1948,7 +1948,7 @@ index-cache:
 
   appProtocol:
     # -- Set the optional service protocol. Ex: "tcp"
-    client: null
+    memcachedClient: null
 
 metadata-cache:
   # -- Specifies whether memcached based metadata-cache should be enabled
@@ -2044,7 +2044,7 @@ metadata-cache:
 
   appProtocol:
     # -- Set the optional service protocol. Ex: "tcp"
-    client: null
+    memcachedClient: null
 
 results-cache:
   # -- Specifies whether memcached based results-cache should be enabled
@@ -2140,7 +2140,7 @@ results-cache:
 
   appProtocol:
     # -- Set the optional service protocol. Ex: "tcp"
-    client: null
+    memcachedClient: null
 
 # -- Setting for the Grafana Rollout Operator https://github.com/grafana/helm-charts/tree/main/charts/rollout-operator
 rollout_operator:

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -53,7 +53,7 @@
   query_frontend_service: if !$._config.is_microservices_deployment_mode then null else
     $.util.serviceFor($.query_frontend_deployment, $._config.service_ignored_labels),
 
-  query_frontend_discovery_service: if !$._config.is_microservices_deployment_mode || $._config.query_scheduler_enabled then null else
+  query_frontend_discovery_service: if !$._config.is_microservices_deployment_mode then null else
     // Make sure that query frontend worker, running in the querier, do resolve
     // each query-frontend pod IP and NOT the service IP. To make it, we do NOT
     // use the service cluster IP so that when the service DNS is resolved it


### PR DESCRIPTION
#### What this PR does

Solves networking issues when running mimir injected (istio). Following issue's are addressed:
1. When query_scheduler is enabled the helm chart does not render the headless service for the query-frontend, but istio needs it to register the (headless) svc route that the querier is using to report back query results.
2. When memcached is enabled the svc cannot connect to the caches because the port naming prevent istio to do proper protocol selection.
3. grpc ports do need appProtocol setting to make sure istio selects the correct protocol.

#### Which issue(s) this PR fixes or relates to

Fixes #6964 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
