### PR TITLE
Delete docs on removed configuration parameters

### DIFF
--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -171,17 +171,6 @@ The following features are currently experimental:
 Deprecated features are usable up until the release that indicates their removal.
 For details about what _deprecated_ means, see [Parameter lifecycle]({{< relref "./configuration-parameters#parameter-lifecycle" >}}).
 
-The following features or configuration parameters are currently deprecated and will be **removed in Mimir 2.11**:
-
-- Store-gateway
-  - `-blocks-storage.bucket-store.chunk-pool-min-bucket-size-bytes`
-  - `-blocks-storage.bucket-store.chunk-pool-max-bucket-size-bytes`
-  - `-blocks-storage.bucket-store.max-chunk-pool-bytes`
-- Querier, ruler, store-gateway
-  - `-blocks-storage.bucket-store.bucket-index.enabled`
-- Querier
-  - `-querier.iterators` and `-querier.batch-iterators` (Mimir 2.11 onwards will always use `-querier.batch-iterators=true`)
-
 The following features or configuration parameters are currently deprecated and will be **removed in Mimir 2.13**:
 
 - Logging


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

As mentioned in https://github.com/grafana/mimir/pull/6673, the configuration parameters removed ahead of the 2.11 release were not also removed from `about-versioning.md`. This PR takes care of that.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/6670

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
