### PR TITLE
ingest consumer: commit offset on shutdown

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -314,16 +314,18 @@ type partitionCommitter struct {
 	logger log.Logger
 }
 
+const noOffset = -100 // using 0, -1, or -2 would be ambiguous with the semantics of the Kafka offset
+
 func newConsumerCommitter(kafkaCfg KafkaConfig, admClient *kadm.Client, partitionID int32, commitInterval time.Duration, logger log.Logger) *partitionCommitter {
 	c := &partitionCommitter{
 		logger:         logger,
 		kafkaCfg:       kafkaCfg,
 		partitionID:    partitionID,
-		toCommit:       atomic.NewInt64(0),
+		toCommit:       atomic.NewInt64(noOffset),
 		admClient:      admClient,
 		commitInterval: commitInterval,
 	}
-	c.Service = services.NewBasicService(nil, c.run, nil)
+	c.Service = services.NewBasicService(nil, c.run, c.stop)
 	return c
 }
 
@@ -346,22 +348,36 @@ func (r *partitionCommitter) run(ctx context.Context) error {
 				continue
 			}
 			previousOffset = currOffset
-
-			toCommit := kadm.Offsets{}
-			// Commit the offset after the last record.
-			// The reason for this is that we resume consumption at this offset.
-			// Leader epoch is -1 because we don't know it. This lets Kafka figure it out.
-			toCommit.AddOffset(r.kafkaCfg.Topic, r.partitionID, currOffset+1, -1)
-
-			committed, err := r.admClient.CommitOffsets(ctx, consumerGroup, toCommit)
-			if err != nil || !committed.Ok() {
-				level.Error(r.logger).Log("msg", "encountered error while committing offsets", "err", err, "commit_err", committed.Error(), "offset", currOffset)
-			} else {
-				committedOffset, _ := committed.Lookup(r.kafkaCfg.Topic, r.partitionID)
-				level.Debug(r.logger).Log("msg", "committed offset", "offset", committedOffset.Offset.At)
-			}
+			r.commit(ctx, currOffset)
 		}
 	}
+}
+
+func (r *partitionCommitter) commit(ctx context.Context, offset int64) {
+	toCommit := kadm.Offsets{}
+	// Commit the offset after the last record.
+	// The reason for this is that we resume consumption at this offset.
+	// Leader epoch is -1 because we don't know it. This lets Kafka figure it out.
+	toCommit.AddOffset(r.kafkaCfg.Topic, r.partitionID, offset+1, -1)
+
+	committed, err := r.admClient.CommitOffsets(ctx, consumerGroup, toCommit)
+	if err != nil || !committed.Ok() {
+		level.Error(r.logger).Log("msg", "encountered error while committing offsets", "err", err, "commit_err", committed.Error(), "offset", offset)
+	} else {
+		committedOffset, _ := committed.Lookup(r.kafkaCfg.Topic, r.partitionID)
+		level.Debug(r.logger).Log("msg", "committed offset", "offset", committedOffset.Offset.At)
+	}
+}
+
+func (r *partitionCommitter) stop(error) error {
+	offset := r.toCommit.Load()
+	if offset == noOffset {
+		return nil
+	}
+	ctx, cancel := context.WithTimeoutCause(context.Background(), 10*time.Second, fmt.Errorf("timed out while doing final partition commit"))
+	defer cancel()
+	r.commit(ctx, offset)
+	return nil
 }
 
 type readerMetrics struct {

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -161,6 +161,8 @@ func TestReader_Commit(t *testing.T) {
 	)
 
 	t.Run("resume at committed", func(t *testing.T) {
+		t.Parallel()
+
 		const commitInterval = 100 * time.Millisecond
 		ctx, cancel := context.WithCancelCause(context.Background())
 		t.Cleanup(func() { cancel(errors.New("test done")) })
@@ -189,8 +191,10 @@ func TestReader_Commit(t *testing.T) {
 		assert.Equal(t, [][]byte{recordsSentAfterShutdown}, records)
 	})
 
-	t.Run("respect commit interval", func(t *testing.T) {
-		// a very long commit interval effectively means no commits
+	t.Run("commit at shutdown", func(t *testing.T) {
+		t.Parallel()
+
+		// A very long commit interval effectively means no regular commits.
 		const commitInterval = time.Second * 15
 		ctx, cancel := context.WithCancelCause(context.Background())
 		t.Cleanup(func() { cancel(errors.New("test done")) })
@@ -211,7 +215,44 @@ func TestReader_Commit(t *testing.T) {
 		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("4"))
 		startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
 
-		_, err = consumer.waitRecords(4, time.Second, 0)
+		// There should be only one record - the one produced after the shutdown.
+		// The offset of record "3" should have been committed at shutdown and the reader should have resumed from there.
+		_, err = consumer.waitRecords(1, time.Second, time.Second)
+		assert.NoError(t, err)
+	})
+
+	t.Run("commit at shutdown doesn't persist if we haven't consumed any records since startup", func(t *testing.T) {
+		t.Parallel()
+		// A very long commit interval effectively means no regular commits.
+		const commitInterval = time.Second * 15
+		ctx, cancel := context.WithCancelCause(context.Background())
+		t.Cleanup(func() { cancel(errors.New("test done")) })
+
+		_, clusterAddr := createTestCluster(t, partitionID+1, topicName)
+
+		consumer := newTestConsumer(4)
+		reader := startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+
+		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("1"))
+		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("2"))
+		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("3"))
+
+		_, err := consumer.waitRecords(3, time.Second, 0)
+		require.NoError(t, err)
+
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		reader = startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+
+		// No new records since the last commit.
+		_, err = consumer.waitRecords(0, time.Second, 0)
+		assert.NoError(t, err)
+
+		// Shut down without having consumed any records.
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		reader = startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+
+		// No new records since the last commit (2 shutdowns ago).
+		_, err = consumer.waitRecords(0, time.Second, 0)
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
This makes double consumption less likely
