### PR TITLE
distributor: deprecate /user_stats and /all_user_stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Ingester: Increase default value of `-blocks-storage.tsdb.head-postings-for-matchers-cache-max-bytes` and `-blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes` to 100 MiB (previous default value was 10 MiB). #6764
+* [CHANGE] Distributor: `/user_stats` and `/all_user_stats` apis have been deprecated, and will be removed in v2.14. #6977
 * [ENHANCEMENT] Store-gateway: add no-compact details column on store-gateway tenants admin UI. #6848
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766
 * [ENHANCEMENT] Distributor: improve efficiency of some errors #6785

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -239,7 +239,7 @@ func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distrib
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},
-		{Desc: "Usage statistics", Path: "/distributor/all_user_stats"},
+		{Desc: "Usage statistics (deprecated)", Path: "/distributor/all_user_stats"},
 		{Desc: "HA tracker status", Path: "/distributor/ha_tracker"},
 	})
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -2161,6 +2161,7 @@ type UserIDStats struct {
 
 // AllUserStats returns statistics about all users.
 // Note it does not divide by the ReplicationFactor like UserStats()
+// TODO: Deprecated, remove in v2.14.
 func (d *Distributor) AllUserStats(ctx context.Context) ([]UserIDStats, error) {
 	// Add up by user, across all responses from ingesters
 	perUserTotals := make(map[string]UserStats)

--- a/pkg/distributor/http_admin.go
+++ b/pkg/distributor/http_admin.go
@@ -39,6 +39,7 @@ func (s userStatsByTimeseries) Less(i, j int) bool {
 }
 
 // AllUserStatsHandler shows stats for all users.
+// TODO: Deprecated, remove in v2.14.
 func (d *Distributor) AllUserStatsHandler(w http.ResponseWriter, r *http.Request) {
 	stats, err := d.AllUserStats(r.Context())
 	if err != nil {

--- a/pkg/distributor/http_server.go
+++ b/pkg/distributor/http_server.go
@@ -21,6 +21,7 @@ type UserStats struct {
 }
 
 // UserStatsHandler handles user stats to the Distributor.
+// TODO: Deprecated, remove in v2.14.
 func (d *Distributor) UserStatsHandler(w http.ResponseWriter, r *http.Request) {
 	stats, err := d.UserStats(r.Context(), cardinality.InMemoryMethod)
 	if err != nil {

--- a/pkg/distributor/ingester_stats.gohtml
+++ b/pkg/distributor/ingester_stats.gohtml
@@ -8,6 +8,7 @@
 <body>
 <h1>Ingester Stats</h1>
 <p>Current time: {{ .Now }}</p>
+<p><b>This feature has been deprecated and will be removed in v2.14</b></p>
 <p><b>NB stats do not account for replication factor, which is currently set to {{ .ReplicationFactor }}</b></p>
 <form action="" method="POST">
     <input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">

--- a/pkg/ingester/client/ingester.proto
+++ b/pkg/ingester/client/ingester.proto
@@ -23,8 +23,8 @@ service Ingester {
 
   rpc LabelValues(LabelValuesRequest) returns (LabelValuesResponse) {};
   rpc LabelNames(LabelNamesRequest) returns (LabelNamesResponse) {};
-  rpc UserStats(UserStatsRequest) returns (UserStatsResponse) {};
-  rpc AllUserStats(UserStatsRequest) returns (UsersStatsResponse) {};
+  rpc UserStats(UserStatsRequest) returns (UserStatsResponse) {}; // TODO: Deprecated, remove in v2.14.
+  rpc AllUserStats(UserStatsRequest) returns (UsersStatsResponse) {}; // TODO: Deprecated, remove in v2.14.
   rpc MetricsForLabelMatchers(MetricsForLabelMatchersRequest) returns (MetricsForLabelMatchersResponse) {};
   rpc MetricsMetadata(MetricsMetadataRequest) returns (MetricsMetadataResponse) {};
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1539,6 +1539,7 @@ func (i *Ingester) MetricsForLabelMatchers(ctx context.Context, req *client.Metr
 	return result, nil
 }
 
+// TODO: Deprecated, remove in v2.14.
 func (i *Ingester) UserStats(ctx context.Context, req *client.UserStatsRequest) (resp *client.UserStatsResponse, err error) {
 	defer func() { err = i.mapReadErrorToErrorWithStatus(err) }()
 	if err := i.checkAvailable(); err != nil {
@@ -1561,6 +1562,7 @@ func (i *Ingester) UserStats(ctx context.Context, req *client.UserStatsRequest) 
 	return createUserStats(db, req)
 }
 
+// TODO: Deprecated, remove in v2.14.
 func (i *Ingester) AllUserStats(_ context.Context, req *client.UserStatsRequest) (resp *client.UsersStatsResponse, err error) {
 	defer func() { err = i.mapReadErrorToErrorWithStatus(err) }()
 	if err := i.checkAvailable(); err != nil {


### PR DESCRIPTION
#### What this PR does

Declare `/user_stats` and `/all_user_stats` deprecated, and put comments on the implementation.
They cost some CPU and memory to provide, and there are metrics which give better information.

#### Checklist

- NA Tests updated.
- NA Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- NA [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
