### PR TITLE
Kafka ingestion experiment: add PartitionReader.WaitReadConsistency()

### DIFF
--- a/pkg/storage/ingest/DESIGN.md
+++ b/pkg/storage/ingest/DESIGN.md
@@ -9,7 +9,7 @@ This document aims to summarise some design principles and technical decisions a
 The offset of the **next** record in a partition can be read from Kafka issuing `ListOffsets` request with `timestamp = -1`.
 The special value `-1` means "latest" but in practice it's the "last produced offset + 1".
 
-This has been verified both testing it in Confluent Kafka 7.5 and Warpstream v524. In details:
+This has been verified both testing it in Apache Kafka 3.5 (Confluent Kafka 7.5) and Warpstream v524. In details:
 
 - Partition is empty: `ListOffsets(timestamp = -1)` returns offset `0`
 - Write 1st record: offset of the written record is `0`

--- a/pkg/storage/ingest/DESIGN.md
+++ b/pkg/storage/ingest/DESIGN.md
@@ -1,0 +1,18 @@
+# Ingest storage design
+
+This document aims to summarise some design principles and technical decisions applied when building the ingest storage.
+
+## Kafka offsets
+
+### Last produced offset
+
+The offset of the **next** record in a partition can be read from Kafka issuing `ListOffsets` request with `timestamp = -1`.
+The special value `-1` means "latest" but in practice it's the "last produced offset + 1".
+
+This has been verified both testing it in Confluent Kafka 7.5 and Warpstream v524. In details:
+
+- Partition is empty: `ListOffsets(timestamp = -1)` returns offset `0`
+- Write 1st record: offset of the written record is `0`
+- Partition contains 1 record: `ListOffsets(timestamp = -1)` returns offset `1`
+
+For this reason, the offset of the last produced record in a partition is `ListOffsets(timestamp = -1) - 1`.

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -45,6 +45,9 @@ type KafkaConfig struct {
 	ClientID     string        `yaml:"client_id"`
 	DialTimeout  time.Duration `yaml:"dial_timeout"`
 	WriteTimeout time.Duration `yaml:"write_timeout"`
+
+	LastProducedOffsetPollInterval time.Duration `yaml:"last_produced_offset_poll_interval"`
+	LastProducedOffsetRetryTimeout time.Duration `yaml:"last_produced_offset_retry_timeout"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
@@ -57,6 +60,9 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.StringVar(&cfg.ClientID, prefix+".client-id", "", "The Kafka client ID.")
 	f.DurationVar(&cfg.DialTimeout, prefix+".dial-timeout", 2*time.Second, "The maximum time allowed to open a connection to a Kafka broker.")
 	f.DurationVar(&cfg.WriteTimeout, prefix+".write-timeout", 10*time.Second, "How long to wait for an incoming write request to be successfully committed to the Kafka backend.")
+
+	f.DurationVar(&cfg.LastProducedOffsetPollInterval, prefix+".last-produced-offset-poll-interval", time.Second, "How frequently to poll the last produced offset, used to enforce strong read consistency.")
+	f.DurationVar(&cfg.LastProducedOffsetRetryTimeout, prefix+".last-produced-offset-retry-timeout", 10*time.Second, "How long to retry a failed request to get the last produced offset.")
 }
 
 func (cfg *KafkaConfig) Validate() error {

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package ingest
 
 import (

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -114,8 +114,6 @@ func (p *partitionOffsetReader) getAndNotifyLastProducedOffset(ctx context.Conte
 	offset, err := p.getLastProducedOffset(ctx)
 	if err != nil {
 		level.Warn(p.logger).Log("msg", "failed to fetch the last produced offset", "err", err)
-	} else {
-		level.Info(p.logger).Log("msg", "fetched the last produced offset", "offset", offset)
 	}
 
 	// Notify whoever was waiting for it.

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -193,6 +193,9 @@ func (p *partitionOffsetReader) getLastProducedOffset(ctx context.Context) (_ in
 
 // FetchLastProducedOffset returns the result of the *next* "last produced offset" request
 // that will be issued.
+//
+// The "last produced offset" is the offset of the last message written to the partition (starting from 0), or -1 if no
+// message has been written yet.
 func (p *partitionOffsetReader) FetchLastProducedOffset(ctx context.Context) (int64, error) {
 	// Get the promise for the result of the next request that will be issued.
 	p.nextResultPromiseMx.RLock()

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -191,9 +191,9 @@ func (p *partitionOffsetReader) getLastProducedOffset(ctx context.Context) (_ in
 	return listRes.Topics[0].Partitions[0].Offset - 1, nil
 }
 
-// WaitLastProducedOffset waits and returns the result of the *next* "last produced offset" request
+// FetchLastProducedOffset returns the result of the *next* "last produced offset" request
 // that will be issued.
-func (p *partitionOffsetReader) WaitLastProducedOffset(ctx context.Context) (int64, error) {
+func (p *partitionOffsetReader) FetchLastProducedOffset(ctx context.Context) (int64, error) {
 	// Get the promise for the result of the next request that will be issued.
 	p.nextResultPromiseMx.RLock()
 	promise := p.nextResultPromise

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -104,7 +104,7 @@ func (p *partitionOffsetReader) stopping(_ error) error {
 func (p *partitionOffsetReader) getAndNotifyLastProducedOffset(ctx context.Context) {
 	// Swap the next promise with a new one.
 	p.nextResultPromiseMx.Lock()
-	wg := p.nextResultPromise
+	promise := p.nextResultPromise
 	p.nextResultPromise = newResultPromise[int64]()
 	p.nextResultPromiseMx.Unlock()
 
@@ -119,7 +119,7 @@ func (p *partitionOffsetReader) getAndNotifyLastProducedOffset(ctx context.Conte
 	}
 
 	// Notify whoever was waiting for it.
-	wg.notify(offset, err)
+	promise.notify(offset, err)
 }
 
 // getLastProducedOffset fetches and returns the last produced offset for a partition, or -1 if the
@@ -198,8 +198,8 @@ func (p *partitionOffsetReader) getLastProducedOffset(ctx context.Context) (_ in
 func (p *partitionOffsetReader) WaitLastProducedOffset(ctx context.Context) (int64, error) {
 	// Get the promise for the result of the next request that will be issued.
 	p.nextResultPromiseMx.RLock()
-	wg := p.nextResultPromise
+	promise := p.nextResultPromise
 	p.nextResultPromiseMx.RUnlock()
 
-	return wg.wait(ctx)
+	return promise.wait(ctx)
 }

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -1,0 +1,203 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+var (
+	errPartitionOffsetReaderStopped = errors.New("partition offset reader is stopped")
+)
+
+// partitionOffsetReader is responsible to read the offsets of a single partition.
+//
+// If in the future we'll need to read offsets of multiple partitions at once, then we shouldn't use
+// this structure but create a new one which fetches multiple partition offsets in a single request.
+type partitionOffsetReader struct {
+	services.Service
+
+	client      *kgo.Client
+	logger      log.Logger
+	topic       string
+	partitionID int32
+
+	// nextResultWaiter is the waiter that will be notified about the result of the *next* "last produced offset"
+	// request that will be issued (not the current in-flight one, if any).
+	nextResultWaiterMx sync.RWMutex
+	nextResultWaiter   *resultWaiter[int64]
+
+	// Metrics.
+	lastProducedOffsetRequestsTotal prometheus.Counter
+	lastProducedOffsetFailuresTotal prometheus.Counter
+	lastProducedOffsetLatency       prometheus.Summary
+}
+
+func newPartitionOffsetReader(client *kgo.Client, topic string, partitionID int32, pollFrequency time.Duration, reg prometheus.Registerer, logger log.Logger) *partitionOffsetReader {
+	p := &partitionOffsetReader{
+		client:           client,
+		topic:            topic,
+		partitionID:      partitionID,
+		logger:           logger, // Do not wrap with partition ID because it's already done by the caller.
+		nextResultWaiter: newResultWaiter[int64](),
+
+		lastProducedOffsetRequestsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        "cortex_ingest_storage_reader_last_produced_offset_requests_total",
+			Help:        "Total number of requests issued to get the last produced offset.",
+			ConstLabels: prometheus.Labels{"partition": strconv.Itoa(int(partitionID))},
+		}),
+		lastProducedOffsetFailuresTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name:        "cortex_ingest_storage_reader_last_produced_offset_failures_total",
+			Help:        "Total number of failed requests to get the last produced offset.",
+			ConstLabels: prometheus.Labels{"partition": strconv.Itoa(int(partitionID))},
+		}),
+		lastProducedOffsetLatency: promauto.With(reg).NewSummary(prometheus.SummaryOpts{
+			Name:        "cortex_ingest_storage_reader_last_produced_offset_request_duration_seconds",
+			Help:        "The duration of requests to fetch the last produced offset of a given partition.",
+			ConstLabels: prometheus.Labels{"partition": strconv.Itoa(int(partitionID))},
+			Objectives:  latencySummaryObjectives,
+			MaxAge:      time.Minute,
+			AgeBuckets:  10,
+		}),
+	}
+
+	p.Service = services.NewTimerService(pollFrequency, nil, p.onPollInterval, p.stopping)
+
+	return p
+}
+
+func (p *partitionOffsetReader) onPollInterval(ctx context.Context) error {
+	// The following call blocks until the last produced offset has been fetched from Kafka. If fetching
+	// the offset takes longer than the poll interval, than we'll poll less frequently than configured.
+	p.getAndNotifyLastProducedOffset(ctx)
+
+	// Never return error, otherwise the service stops.
+	return nil
+}
+
+func (p *partitionOffsetReader) stopping(_ error) error {
+	// Release any waiting goroutine without swapping the result waiter so that if any other goroutine
+	// will watch it after this point it will get immediately notified.
+	p.nextResultWaiterMx.Lock()
+	p.nextResultWaiter.notify(0, errPartitionOffsetReaderStopped)
+	p.nextResultWaiterMx.Unlock()
+
+	return nil
+}
+
+// getAndNotifyLastProducedOffset fetches the last produced offset for a partition and notifies all waiting
+// goroutines (if any).
+func (p *partitionOffsetReader) getAndNotifyLastProducedOffset(ctx context.Context) {
+	// Swap the next waiter with a new one.
+	p.nextResultWaiterMx.Lock()
+	wg := p.nextResultWaiter
+	p.nextResultWaiter = newResultWaiter[int64]()
+	p.nextResultWaiterMx.Unlock()
+
+	// We call getLastProducedOffset() even if there are no goroutines waiting on the result in order to get
+	// a constant load on the Kafka backend. In other words, the load produced on Kafka by this component is
+	// constant, regardless the number of received queries with strong consistency enabled.
+	offset, err := p.getLastProducedOffset(ctx)
+	if err != nil {
+		level.Warn(p.logger).Log("msg", "failed to fetch the last produced offset", "err", err)
+	} else {
+		level.Info(p.logger).Log("msg", "fetched the last produced offset", "offset", offset)
+	}
+
+	// Notify whoever was waiting for it.
+	wg.notify(offset, err)
+}
+
+// getLastProducedOffset fetches and returns the last produced offset for a partition, or -1 if the
+// partition is empty. This function issues a single request, but the Kafka client used under the
+// hood may retry a failed request until the retry timeout is hit.
+func (p *partitionOffsetReader) getLastProducedOffset(ctx context.Context) (_ int64, returnErr error) {
+	startTime := time.Now()
+
+	p.lastProducedOffsetRequestsTotal.Inc()
+	defer func() {
+		// We track the latency also in case of error, so that if the request times out it gets
+		// pretty clear looking at latency too.
+		p.lastProducedOffsetLatency.Observe(time.Since(startTime).Seconds())
+
+		if returnErr != nil {
+			p.lastProducedOffsetFailuresTotal.Inc()
+		}
+	}()
+
+	// Create a custom request to fetch the latest offset of a specific partition.
+	partitionReq := kmsg.NewListOffsetsRequestTopicPartition()
+	partitionReq.Partition = p.partitionID
+	partitionReq.Timestamp = -1 // -1 means "latest".
+
+	topicReq := kmsg.NewListOffsetsRequestTopic()
+	topicReq.Topic = p.topic
+	topicReq.Partitions = []kmsg.ListOffsetsRequestTopicPartition{partitionReq}
+
+	req := kmsg.NewPtrListOffsetsRequest()
+	req.IsolationLevel = 0 // 0 means READ_UNCOMMITTED.
+	req.Topics = []kmsg.ListOffsetsRequestTopic{topicReq}
+
+	// Even if we share the same client, other in-flight requests are not canceled once this context is canceled
+	// (or its deadline is exceeded). We've verified it with a unit test.
+	resps := p.client.RequestSharded(ctx, req)
+
+	// Since we issued a request for only 1 partition, we expect exactly 1 response.
+	if expected := 1; len(resps) != expected {
+		return 0, fmt.Errorf("unexpected number of responses (expected: %d, got: %d)", expected, len(resps))
+	}
+
+	// Ensure no error occurred.
+	res := resps[0]
+	if res.Err != nil {
+		return 0, res.Err
+	}
+
+	// Parse the response.
+	listRes, ok := res.Resp.(*kmsg.ListOffsetsResponse)
+	if !ok {
+		return 0, errors.New("unexpected response type")
+	}
+	if expected, actual := 1, len(listRes.Topics); actual != expected {
+		return 0, fmt.Errorf("unexpected number of topics in the response (expected: %d, got: %d)", expected, actual)
+	}
+	if expected, actual := p.topic, listRes.Topics[0].Topic; expected != actual {
+		return 0, fmt.Errorf("unexpected topic in the response (expected: %s, got: %s)", expected, actual)
+	}
+	if expected, actual := 1, len(listRes.Topics[0].Partitions); actual != expected {
+		return 0, fmt.Errorf("unexpected number of partitions in the response (expected: %d, got: %d)", expected, actual)
+	}
+	if expected, actual := p.partitionID, listRes.Topics[0].Partitions[0].Partition; actual != expected {
+		return 0, fmt.Errorf("unexpected partition in the response (expected: %d, got: %d)", expected, actual)
+	}
+	if err := kerr.ErrorForCode(listRes.Topics[0].Partitions[0].ErrorCode); err != nil {
+		return 0, err
+	}
+
+	// The offset we get is the offset at which the next message will be written, so to get the last produced offset
+	// we have to subtract 1. See DESIGN.md for more details.
+	return listRes.Topics[0].Partitions[0].Offset - 1, nil
+}
+
+// WaitLastProducedOffset waits and returns the result of the *next* "last produced offset" request
+// that will be issued.
+func (p *partitionOffsetReader) WaitLastProducedOffset(ctx context.Context) (int64, error) {
+	// Get the waiter for the result of the next request that will be issued.
+	p.nextResultWaiterMx.RLock()
+	wg := p.nextResultWaiter
+	p.nextResultWaiterMx.RUnlock()
+
+	return wg.wait(ctx)
+}

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -47,7 +47,7 @@ type partitionOffsetReader struct {
 	lastProducedOffsetLatency       prometheus.Summary
 }
 
-func newPartitionOffsetReader(client *kgo.Client, topic string, partitionID int32, pollFrequency time.Duration, reg prometheus.Registerer, logger log.Logger) *partitionOffsetReader {
+func newPartitionOffsetReader(client *kgo.Client, topic string, partitionID int32, pollInterval time.Duration, reg prometheus.Registerer, logger log.Logger) *partitionOffsetReader {
 	p := &partitionOffsetReader{
 		client:            client,
 		topic:             topic,
@@ -75,7 +75,7 @@ func newPartitionOffsetReader(client *kgo.Client, topic string, partitionID int3
 		}),
 	}
 
-	p.Service = services.NewTimerService(pollFrequency, nil, p.onPollInterval, p.stopping)
+	p.Service = services.NewTimerService(pollInterval, nil, p.onPollInterval, p.stopping)
 
 	return p
 }

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package ingest
 
 import (

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -1,0 +1,306 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+func TestPartitionOffsetReader(t *testing.T) {
+	const (
+		numPartitions = 1
+		topicName     = "test"
+		partitionID   = int32(0)
+	)
+
+	var (
+		ctx = context.Background()
+	)
+
+	t.Run("should notify waiting goroutines when stopped", func(t *testing.T) {
+		var (
+			_, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
+		)
+
+		// Run with a very high polling frequency, so that it will never run in this test.
+		reader := newPartitionOffsetReader(createTestKafkaClient(t, kafkaCfg), topicName, partitionID, time.Hour, nil, log.NewNopLogger())
+		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+
+		// Run few goroutines waiting for the last produced offset.
+		wg := sync.WaitGroup{}
+		wg.Add(2)
+
+		for i := 0; i < 2; i++ {
+			runAsync(&wg, func() {
+				_, err := reader.WaitLastProducedOffset(ctx)
+				assert.Equal(t, errPartitionOffsetReaderStopped, err)
+			})
+		}
+
+		// Stop the reader.
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+
+		// At the point we expect the waiting goroutines to be unblocked.
+		wg.Wait()
+
+		// The next call to WaitLastProducedOffset() should return immediately.
+		_, err := reader.WaitLastProducedOffset(ctx)
+		assert.Equal(t, errPartitionOffsetReaderStopped, err)
+	})
+}
+
+func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
+	const (
+		numPartitions = 1
+		userID        = "user-1"
+		topicName     = "test"
+		partitionID   = int32(0)
+		pollFrequency = time.Second
+	)
+
+	var (
+		ctx     = context.Background()
+		logger  = log.NewNopLogger()
+		series1 = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1")}
+		series2 = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_2")}
+	)
+
+	t.Run("should return the last produced offset, or -1 if the partition is empty", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			_, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
+			writer, _      = createTestWriter(t, kafkaCfg)
+			client         = createTestKafkaClient(t, kafkaCfg)
+			reg            = prometheus.NewPedanticRegistry()
+			reader         = newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, reg, logger)
+		)
+
+		offset, err := reader.getLastProducedOffset(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(-1), offset)
+
+		// Write the 1st message.
+		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series1, nil, mimirpb.API))
+
+		offset, err = reader.getLastProducedOffset(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), offset)
+
+		// Write the 2nd message.
+		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series2, nil, mimirpb.API))
+
+		offset, err = reader.getLastProducedOffset(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), offset)
+
+		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+			# HELP cortex_ingest_storage_reader_last_produced_offset_failures_total Total number of failed requests to get the last produced offset.
+			# TYPE cortex_ingest_storage_reader_last_produced_offset_failures_total counter
+			cortex_ingest_storage_reader_last_produced_offset_failures_total{partition="0"} 0
+
+			# HELP cortex_ingest_storage_reader_last_produced_offset_requests_total Total number of requests issued to get the last produced offset.
+			# TYPE cortex_ingest_storage_reader_last_produced_offset_requests_total counter
+			cortex_ingest_storage_reader_last_produced_offset_requests_total{partition="0"} 3
+		`), "cortex_ingest_storage_reader_last_produced_offset_requests_total",
+			"cortex_ingest_storage_reader_last_produced_offset_failures_total"))
+	})
+
+	t.Run("should honor context deadline and not fail other in-flight requests issued while the canceled one was still running", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			cluster, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
+			writer, _            = createTestWriter(t, kafkaCfg)
+			client               = createTestKafkaClient(t, kafkaCfg)
+			reg                  = prometheus.NewPedanticRegistry()
+			reader               = newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, reg, logger)
+
+			firstRequest         = atomic.NewBool(true)
+			firstRequestReceived = make(chan struct{})
+			firstRequestTimeout  = time.Second
+		)
+
+		// Write some messages.
+		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series1, nil, mimirpb.API))
+		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series2, nil, mimirpb.API))
+		expectedOffset := int64(1)
+
+		// Slow down the 1st ListOffsets request.
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			if firstRequest.CompareAndSwap(true, false) {
+				close(firstRequestReceived)
+				time.Sleep(2 * firstRequestTimeout)
+			}
+			return nil, nil, false
+		})
+
+		wg := sync.WaitGroup{}
+		wg.Add(2)
+
+		// Run the 1st getLastProducedOffset() with a timeout which is expected to expire
+		// before the request will succeed.
+		runAsync(&wg, func() {
+			ctxWithTimeout, cancel := context.WithTimeout(ctx, firstRequestTimeout)
+			defer cancel()
+
+			_, err := reader.getLastProducedOffset(ctxWithTimeout)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+		})
+
+		// Run a 2nd getLastProducedOffset() once the 1st request is received. This request
+		// is expected to succeed.
+		runAsyncAfter(&wg, firstRequestReceived, func() {
+			offset, err := reader.getLastProducedOffset(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, expectedOffset, offset)
+		})
+
+		wg.Wait()
+	})
+
+	t.Run("should honor the configured retry timeout", func(t *testing.T) {
+		t.Parallel()
+
+		cluster, clusterAddr := createTestCluster(t, numPartitions, topicName)
+
+		// Configure a short retry timeout.
+		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+		kafkaCfg.LastProducedOffsetRetryTimeout = time.Second
+
+		client := createTestKafkaClient(t, kafkaCfg)
+		reg := prometheus.NewPedanticRegistry()
+		reader := newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, reg, logger)
+
+		// Make the ListOffsets request failing.
+		actualTries := atomic.NewInt64(0)
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+			actualTries.Inc()
+			return nil, errors.New("mocked error"), true
+		})
+
+		startTime := time.Now()
+		_, err := reader.getLastProducedOffset(ctx)
+		elapsedTime := time.Since(startTime)
+
+		require.Error(t, err)
+
+		// Ensure the retry timeout has been honored.
+		toleranceSeconds := 0.5
+		assert.InDelta(t, kafkaCfg.LastProducedOffsetRetryTimeout.Seconds(), elapsedTime.Seconds(), toleranceSeconds)
+
+		// Ensure the request was retried.
+		assert.Greater(t, actualTries.Load(), int64(1))
+	})
+}
+
+func TestPartitionOffsetReader_WaitLastProducedOffset(t *testing.T) {
+	const (
+		numPartitions = 1
+		topicName     = "test"
+		partitionID   = int32(0)
+		pollFrequency = time.Second
+	)
+
+	var (
+		ctx    = context.Background()
+		logger = log.NewNopLogger()
+	)
+
+	t.Run("should wait the result of the next request issued", func(t *testing.T) {
+		var (
+			cluster, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
+			client               = createTestKafkaClient(t, kafkaCfg)
+			reader               = newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, nil, logger)
+
+			lastOffset           = atomic.NewInt64(1)
+			firstRequestReceived = make(chan struct{})
+		)
+
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+
+			if lastOffset.Load() == 1 {
+				close(firstRequestReceived)
+			}
+
+			// Mock the response so that we can increase the offset each time.
+			req := kreq.(*kmsg.ListOffsetsRequest)
+			res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+			res.Topics = []kmsg.ListOffsetsResponseTopic{{
+				Topic: topicName,
+				Partitions: []kmsg.ListOffsetsResponseTopicPartition{{
+					Partition: partitionID,
+					ErrorCode: 0,
+					Offset:    lastOffset.Inc(),
+				}},
+			}}
+
+			return res, nil, true
+		})
+
+		wg := sync.WaitGroup{}
+		wg.Add(2)
+
+		// The 1st WaitLastProducedOffset() is called before the service start so it's expected
+		// to wait the result of the 1st request.
+		runAsync(&wg, func() {
+			actual, err := reader.WaitLastProducedOffset(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, int64(1), actual)
+		})
+
+		// The 2nd WaitLastProducedOffset() is called while the 1st request is running, so it's expected
+		// to wait the result of the 2nd request.
+		runAsyncAfter(&wg, firstRequestReceived, func() {
+			actual, err := reader.WaitLastProducedOffset(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, int64(2), actual)
+		})
+
+		// Now we can start the service.
+		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		})
+
+		wg.Wait()
+	})
+
+	t.Run("should immediately return if the context gets canceled", func(t *testing.T) {
+		var (
+			_, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
+			client         = createTestKafkaClient(t, kafkaCfg)
+		)
+
+		// Create the reader but do NOT start it, so that the "last produced offset" will be never fetched.
+		reader := newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, nil, logger)
+
+		canceledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		_, err := reader.WaitLastProducedOffset(canceledCtx)
+		assert.ErrorIs(t, err, context.Canceled)
+
+	})
+}

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -74,10 +74,10 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 	)
 
 	var (
-		ctx     = context.Background()
-		logger  = log.NewNopLogger()
-		series1 = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1")}
-		series2 = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_2")}
+		ctx        = context.Background()
+		logger     = log.NewNopLogger()
+		series1Req = &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1")}, Source: mimirpb.API}
+		series2Req = &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_2")}, Source: mimirpb.API}
 	)
 
 	t.Run("should return the last produced offset, or -1 if the partition is empty", func(t *testing.T) {
@@ -97,14 +97,14 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 		assert.Equal(t, int64(-1), offset)
 
 		// Write the 1st message.
-		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series1, nil, mimirpb.API))
+		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series1Req))
 
 		offset, err = reader.getLastProducedOffset(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), offset)
 
 		// Write the 2nd message.
-		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series2, nil, mimirpb.API))
+		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series2Req))
 
 		offset, err = reader.getLastProducedOffset(ctx)
 		require.NoError(t, err)
@@ -139,8 +139,8 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 		)
 
 		// Write some messages.
-		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series1, nil, mimirpb.API))
-		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series2, nil, mimirpb.API))
+		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series1Req))
+		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, series2Req))
 		expectedOffset := int64(1)
 
 		// Slow down the 1st ListOffsets request.

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -47,7 +47,7 @@ func TestPartitionOffsetReader(t *testing.T) {
 
 		for i := 0; i < 2; i++ {
 			runAsync(&wg, func() {
-				_, err := reader.WaitLastProducedOffset(ctx)
+				_, err := reader.FetchLastProducedOffset(ctx)
 				assert.Equal(t, errPartitionOffsetReaderStopped, err)
 			})
 		}
@@ -58,8 +58,8 @@ func TestPartitionOffsetReader(t *testing.T) {
 		// At the point we expect the waiting goroutines to be unblocked.
 		wg.Wait()
 
-		// The next call to WaitLastProducedOffset() should return immediately.
-		_, err := reader.WaitLastProducedOffset(ctx)
+		// The next call to FetchLastProducedOffset() should return immediately.
+		_, err := reader.FetchLastProducedOffset(ctx)
 		assert.Equal(t, errPartitionOffsetReaderStopped, err)
 	})
 }
@@ -208,7 +208,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 	})
 }
 
-func TestPartitionOffsetReader_WaitLastProducedOffset(t *testing.T) {
+func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 	const (
 		numPartitions = 1
 		topicName     = "test"
@@ -257,18 +257,18 @@ func TestPartitionOffsetReader_WaitLastProducedOffset(t *testing.T) {
 		wg := sync.WaitGroup{}
 		wg.Add(2)
 
-		// The 1st WaitLastProducedOffset() is called before the service start so it's expected
+		// The 1st FetchLastProducedOffset() is called before the service start so it's expected
 		// to wait the result of the 1st request.
 		runAsync(&wg, func() {
-			actual, err := reader.WaitLastProducedOffset(ctx)
+			actual, err := reader.FetchLastProducedOffset(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, int64(1), actual)
 		})
 
-		// The 2nd WaitLastProducedOffset() is called while the 1st request is running, so it's expected
+		// The 2nd FetchLastProducedOffset() is called while the 1st request is running, so it's expected
 		// to wait the result of the 2nd request.
 		runAsyncAfter(&wg, firstRequestReceived, func() {
-			actual, err := reader.WaitLastProducedOffset(ctx)
+			actual, err := reader.FetchLastProducedOffset(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, int64(2), actual)
 		})
@@ -295,7 +295,7 @@ func TestPartitionOffsetReader_WaitLastProducedOffset(t *testing.T) {
 		canceledCtx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		_, err := reader.WaitLastProducedOffset(canceledCtx)
+		_, err := reader.FetchLastProducedOffset(canceledCtx)
 		assert.ErrorIs(t, err, context.Canceled)
 
 	})

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -39,7 +39,7 @@ func TestPartitionOffsetReader(t *testing.T) {
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 		)
 
-		// Run with a very high polling frequency, so that it will never run in this test.
+		// Run with a very high polling interval, so that it will never run in this test.
 		reader := newPartitionOffsetReader(createTestKafkaClient(t, kafkaCfg), topicName, partitionID, time.Hour, nil, log.NewNopLogger())
 		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
 
@@ -72,7 +72,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 		userID        = "user-1"
 		topicName     = "test"
 		partitionID   = int32(0)
-		pollFrequency = time.Second
+		pollInterval  = time.Second
 	)
 
 	var (
@@ -91,7 +91,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 			writer, _      = createTestWriter(t, kafkaCfg)
 			client         = createTestKafkaClient(t, kafkaCfg)
 			reg            = prometheus.NewPedanticRegistry()
-			reader         = newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, reg, logger)
+			reader         = newPartitionOffsetReader(client, topicName, partitionID, pollInterval, reg, logger)
 		)
 
 		offset, err := reader.getLastProducedOffset(ctx)
@@ -133,7 +133,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 			writer, _            = createTestWriter(t, kafkaCfg)
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reg                  = prometheus.NewPedanticRegistry()
-			reader               = newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, reg, logger)
+			reader               = newPartitionOffsetReader(client, topicName, partitionID, pollInterval, reg, logger)
 
 			firstRequest         = atomic.NewBool(true)
 			firstRequestReceived = make(chan struct{})
@@ -189,7 +189,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 
 		client := createTestKafkaClient(t, kafkaCfg)
 		reg := prometheus.NewPedanticRegistry()
-		reader := newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, reg, logger)
+		reader := newPartitionOffsetReader(client, topicName, partitionID, pollInterval, reg, logger)
 
 		// Make the ListOffsets request failing.
 		actualTries := atomic.NewInt64(0)
@@ -219,7 +219,7 @@ func TestPartitionOffsetReader_WaitLastProducedOffset(t *testing.T) {
 		numPartitions = 1
 		topicName     = "test"
 		partitionID   = int32(0)
-		pollFrequency = time.Second
+		pollInterval  = time.Second
 	)
 
 	var (
@@ -232,7 +232,7 @@ func TestPartitionOffsetReader_WaitLastProducedOffset(t *testing.T) {
 			cluster, clusterAddr = createTestCluster(t, numPartitions, topicName)
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
-			reader               = newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, nil, logger)
+			reader               = newPartitionOffsetReader(client, topicName, partitionID, pollInterval, nil, logger)
 
 			lastOffset           = atomic.NewInt64(1)
 			firstRequestReceived = make(chan struct{})
@@ -296,7 +296,7 @@ func TestPartitionOffsetReader_WaitLastProducedOffset(t *testing.T) {
 		)
 
 		// Create the reader but do NOT start it, so that the "last produced offset" will be never fetched.
-		reader := newPartitionOffsetReader(client, topicName, partitionID, pollFrequency, nil, logger)
+		reader := newPartitionOffsetReader(client, topicName, partitionID, pollInterval, nil, logger)
 
 		canceledCtx, cancel := context.WithCancel(ctx)
 		cancel()

--- a/pkg/storage/ingest/partition_offset_watcher.go
+++ b/pkg/storage/ingest/partition_offset_watcher.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package ingest
 
 import (

--- a/pkg/storage/ingest/partition_offset_watcher.go
+++ b/pkg/storage/ingest/partition_offset_watcher.go
@@ -1,0 +1,185 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/grafana/dskit/services"
+	"go.uber.org/atomic"
+)
+
+var (
+	errPartitionOffsetWatcherStopped = errors.New("partition offset watcher is stopped")
+)
+
+type partitionOffsetWatcher struct {
+	services.Service
+
+	// mx protects the following fields.
+	mx sync.Mutex
+
+	// lastConsumedOffset holds the last consumed offset or -1 if nothing has been consumed yet.
+	// We don't worry about exhausting the int64 space because it seems implausible.
+	lastConsumedOffset int64
+
+	// watchGroups is a map where the key is the offset a group of goroutines is waiting for.
+	//
+	// Why a map? Because what goroutines will wait for is the "last produced offset". Since we poll it
+	// periodically, we expect at any given time we have many goroutines waiting on few different offsets.
+	watchGroups map[int64]*partitionOffsetWatchGroup
+
+	// stopped holds whether the watcher has been stopped.
+	stopped bool
+}
+
+func newPartitionOffsetWatcher() *partitionOffsetWatcher {
+	w := &partitionOffsetWatcher{
+		lastConsumedOffset: -1, // -1 means nothing has been consumed yet.
+		watchGroups:        map[int64]*partitionOffsetWatchGroup{},
+	}
+
+	w.Service = services.NewIdleService(nil, w.stopping)
+
+	return w
+}
+
+func (w *partitionOffsetWatcher) stopping(_ error) error {
+	w.mx.Lock()
+	defer w.mx.Unlock()
+
+	// Ensure no other goroutine will Notify() or Wait() once stopped.
+	w.stopped = true
+
+	// Release all waiting goroutines.
+	for waitForOffset, watchGroup := range w.watchGroups {
+		delete(w.watchGroups, waitForOffset)
+		watchGroup.releaseWaiting(errPartitionOffsetWatcherStopped)
+	}
+
+	return nil
+}
+
+// Notify that a given offset has been consumed. This function is expected to run very quickly
+// and never block in practice.
+func (w *partitionOffsetWatcher) Notify(lastConsumedOffset int64) {
+	w.mx.Lock()
+	defer w.mx.Unlock()
+
+	// Ensure the service has not been stopped.
+	if w.stopped {
+		return
+	}
+
+	// Ensure the input offset is greater than the previous one.
+	if lastConsumedOffset < w.lastConsumedOffset {
+		return
+	}
+
+	w.lastConsumedOffset = lastConsumedOffset
+
+	// Wake up all goroutines waiting for an offset which has been consumed.
+	for waitForOffset, watchGroup := range w.watchGroups {
+		if waitForOffset <= w.lastConsumedOffset {
+			delete(w.watchGroups, waitForOffset)
+			watchGroup.releaseWaiting(nil)
+		}
+	}
+}
+
+// Wait until the given offset has been consumed or the context is canceled.
+func (w *partitionOffsetWatcher) Wait(ctx context.Context, waitForOffset int64) error {
+	// A negative offset is used to signal the partition is empty,
+	// so we can immediately return.
+	if waitForOffset < 0 {
+		return nil
+	}
+
+	var watchGroup *partitionOffsetWatchGroup
+
+	{
+		w.mx.Lock()
+
+		// Ensure the service has not been stopped.
+		if w.stopped {
+			w.mx.Unlock()
+			return errPartitionOffsetWatcherStopped
+		}
+
+		// Check if the condition is already met.
+		if waitForOffset <= w.lastConsumedOffset {
+			w.mx.Unlock()
+			return nil
+		}
+
+		// Add to or create the watch group.
+		var ok bool
+		watchGroup, ok = w.watchGroups[waitForOffset]
+		if !ok {
+			watchGroup = &partitionOffsetWatchGroup{
+				waitDone: make(chan struct{}),
+				count:    atomic.NewInt64(1),
+			}
+
+			w.watchGroups[waitForOffset] = watchGroup
+		} else {
+			// To avoid race conditions with the garbage collection done when this counter drops to 0,
+			// it's important to increase this counter while holding the lock (even if this counter
+			// is an atomic).
+			watchGroup.count.Inc()
+		}
+
+		w.mx.Unlock()
+	}
+
+	defer func() {
+		if watchGroup.count.Dec() == 0 {
+			// Garbage collection:
+			//
+			// If it was the last goroutine to wait in the group, then ensure the group is removed
+			// from the map. This garbage collection is important to avoid accumulating entries
+			// in the watchGroups map if consumption is stuck and Wait() goroutines stop
+			// waiting because context has been canceled or their deadline expired.
+			w.mx.Lock()
+
+			if actualWatchGroup, ok := w.watchGroups[waitForOffset]; ok && watchGroup == actualWatchGroup {
+				delete(w.watchGroups, waitForOffset)
+			}
+
+			w.mx.Unlock()
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-watchGroup.waitDone:
+		return watchGroup.waitErr
+	}
+}
+
+// waitingGoroutinesCount returns the number of active watch groups (an active group has at least
+// 1 goroutine waiting). This function is useful for testing.
+func (w *partitionOffsetWatcher) watchGroupsCount() int {
+	w.mx.Lock()
+	defer w.mx.Unlock()
+
+	return len(w.watchGroups)
+}
+
+type partitionOffsetWatchGroup struct {
+	// waitDone channel gets closed once the waiting goroutines should be released.
+	waitDone chan struct{}
+
+	// waitErr is the error to return to waiting goroutines once waitDone channel is closed.
+	// It's safe to read this value without holding any lock after waitDone is closed.
+	waitErr error
+
+	// count is the number of waiting goroutines.
+	count *atomic.Int64
+}
+
+func (g *partitionOffsetWatchGroup) releaseWaiting(err error) {
+	g.waitErr = err
+	close(g.waitDone)
+}

--- a/pkg/storage/ingest/partition_offset_watcher.go
+++ b/pkg/storage/ingest/partition_offset_watcher.go
@@ -147,7 +147,8 @@ func (w *partitionOffsetWatcher) Wait(ctx context.Context, waitForOffset int64) 
 		// waiting because context has been canceled or their deadline expired.
 		w.mx.Lock()
 
-		if actualWatchGroup, ok := w.watchGroups[waitForOffset]; ok && watchGroup == actualWatchGroup {
+		// We need to check the count again while holding the lock to avoid race conditions.
+		if actualWatchGroup, ok := w.watchGroups[waitForOffset]; ok && watchGroup == actualWatchGroup && actualWatchGroup.count.Load() == 0 {
 			delete(w.watchGroups, waitForOffset)
 		}
 

--- a/pkg/storage/ingest/partition_offset_watcher_test.go
+++ b/pkg/storage/ingest/partition_offset_watcher_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package ingest
 
 import (

--- a/pkg/storage/ingest/partition_offset_watcher_test.go
+++ b/pkg/storage/ingest/partition_offset_watcher_test.go
@@ -1,0 +1,324 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"math"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestPartitionOffsetWatcher(t *testing.T) {
+	const shortSleep = 100 * time.Millisecond
+
+	t.Run("should support a single goroutine waiting for an offset", func(t *testing.T) {
+		var (
+			ctx       = context.Background()
+			w         = newPartitionOffsetWatcher()
+			firstDone = atomic.NewBool(false)
+		)
+
+		go func() {
+			assert.NoError(t, w.Wait(ctx, 2))
+			firstDone.Store(true)
+		}()
+
+		// Wait a short time and then make sure the wait() hasn't returned yet.
+		time.Sleep(shortSleep)
+		assert.False(t, firstDone.Load())
+
+		// Notify an offset lower than the expected one. At this point the wait() shouldn't return yet.
+		w.Notify(1)
+
+		time.Sleep(shortSleep)
+		assert.False(t, firstDone.Load())
+
+		// Notify the expected offset. At this point wait() should return.
+		w.Notify(2)
+		assert.Eventually(t, firstDone.Load, shortSleep, shortSleep/10)
+
+		assert.Equal(t, 0, w.watchGroupsCount())
+	})
+
+	t.Run("should support two goroutines waiting for the same offset", func(t *testing.T) {
+		var (
+			ctx        = context.Background()
+			w          = newPartitionOffsetWatcher()
+			firstDone  = atomic.NewBool(false)
+			secondDone = atomic.NewBool(false)
+		)
+
+		go func() {
+			assert.NoError(t, w.Wait(ctx, 2))
+			firstDone.Store(true)
+		}()
+
+		go func() {
+			assert.NoError(t, w.Wait(ctx, 2))
+			secondDone.Store(true)
+		}()
+
+		// Wait a short time and then make sure the wait() hasn't returned yet.
+		time.Sleep(shortSleep)
+		assert.False(t, firstDone.Load())
+		assert.False(t, secondDone.Load())
+
+		// Notify an offset lower than the expected one. At this point the wait() shouldn't return yet.
+		w.Notify(1)
+
+		time.Sleep(shortSleep)
+		assert.False(t, firstDone.Load())
+		assert.False(t, secondDone.Load())
+
+		// Notify the expected offset. At this point wait() should return.
+		w.Notify(2)
+		assert.Eventually(t, firstDone.Load, shortSleep, shortSleep/10)
+		assert.Eventually(t, secondDone.Load, shortSleep, shortSleep/10)
+
+		assert.Equal(t, 0, w.watchGroupsCount())
+	})
+
+	t.Run("should support two goroutines waiting for a different offset", func(t *testing.T) {
+		var (
+			ctx        = context.Background()
+			w          = newPartitionOffsetWatcher()
+			firstDone  = atomic.NewBool(false)
+			secondDone = atomic.NewBool(false)
+		)
+
+		go func() {
+			assert.NoError(t, w.Wait(ctx, 1))
+			firstDone.Store(true)
+		}()
+
+		go func() {
+			assert.NoError(t, w.Wait(ctx, 2))
+			secondDone.Store(true)
+		}()
+
+		// Wait a short time and then make sure the wait() hasn't returned yet.
+		time.Sleep(shortSleep)
+		assert.False(t, firstDone.Load())
+		assert.False(t, secondDone.Load())
+
+		// Notify the offset expected by the 1st goroutine.
+		w.Notify(1)
+		assert.Eventually(t, firstDone.Load, shortSleep, shortSleep/10)
+
+		time.Sleep(shortSleep)
+		assert.False(t, secondDone.Load())
+
+		// Notify the offset expected by the 2nd goroutine.
+		w.Notify(2)
+		assert.Eventually(t, secondDone.Load, shortSleep, shortSleep/10)
+
+		assert.Equal(t, 0, w.watchGroupsCount())
+	})
+
+	t.Run("Wait() should immediately return if the input offset has already been consumed", func(t *testing.T) {
+		var (
+			ctx = context.Background()
+			w   = newPartitionOffsetWatcher()
+		)
+
+		w.Notify(10)
+		require.NoError(t, w.Wait(ctx, 7))
+
+		assert.Equal(t, 0, w.watchGroupsCount())
+	})
+
+	t.Run("Wait() should immediately return if the input offset is -1, even if no consumed offset has been notified yet", func(t *testing.T) {
+		var (
+			ctx = context.Background()
+			w   = newPartitionOffsetWatcher()
+		)
+
+		require.NoError(t, w.Wait(ctx, -1))
+
+		assert.Equal(t, 0, w.watchGroupsCount())
+	})
+
+	t.Run("Wait() should return as soon as the watcher service is stopped", func(t *testing.T) {
+		ctx := context.Background()
+
+		w := newPartitionOffsetWatcher()
+		require.NoError(t, services.StartAndAwaitRunning(ctx, w))
+
+		wg := sync.WaitGroup{}
+		wg.Add(2)
+
+		runAsync(&wg, func() {
+			assert.Equal(t, errPartitionOffsetWatcherStopped, w.Wait(ctx, 1))
+		})
+
+		runAsync(&wg, func() {
+			assert.Equal(t, errPartitionOffsetWatcherStopped, w.Wait(ctx, 2))
+		})
+
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, w))
+
+		// Wait until goroutines have done.
+		wg.Wait()
+
+		// A call to Wait() on a stopped service should immediately return.
+		assert.Equal(t, errPartitionOffsetWatcherStopped, w.Wait(ctx, 3))
+
+		// A call to Notify() on a stopped service should be a no-op.
+		w.Notify(1)
+	})
+}
+
+func TestPartitionOffsetWatcher_Concurrency(t *testing.T) {
+	const (
+		numTotalNotifications  = 10000
+		numNotifyingGoroutines = 10
+		numWatchingGoroutines  = 1000
+	)
+
+	var (
+		ctx, cancelCtx     = context.WithCancel(context.Background())
+		w                  = newPartitionOffsetWatcher()
+		lastNotifiedOffset = atomic.NewInt64(0)
+		lastWatchedOffset  = atomic.NewInt64(0)
+		notificationsCount = atomic.NewInt64(0)
+	)
+
+	// Ensure the context will be canceled even if the test fail earlier.
+	t.Cleanup(cancelCtx)
+
+	wg := sync.WaitGroup{}
+	wg.Add(numWatchingGoroutines + numNotifyingGoroutines)
+
+	// Start all watching goroutines.
+	for i := 0; i < numWatchingGoroutines; i++ {
+		runAsync(&wg, func() {
+			for ctx.Err() == nil {
+				if err := w.Wait(ctx, lastWatchedOffset.Inc()); err != nil && !errors.Is(err, context.Canceled) {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+
+	// Start all notifying goroutines.
+	for i := 0; i < numNotifyingGoroutines; i++ {
+		runAsync(&wg, func() {
+			for ctx.Err() == nil {
+				// Notify an offset between the last notified offset and the last watched offset.
+				// The update to lastNotifiedOffset by multiple goroutines suffer a race condition
+				// but it's fine for the purpose of this test.
+				offset := lastNotifiedOffset.Load() + rand.Int63n(lastWatchedOffset.Load()-lastNotifiedOffset.Load())
+				lastNotifiedOffset.Store(offset)
+
+				w.Notify(offset)
+
+				// Cancel the test execution once the required number of notifications have been sent.
+				if notificationsCount.Inc() == int64(numTotalNotifications) {
+					cancelCtx()
+				}
+			}
+		})
+	}
+
+	// Wait until the test is over.
+	wg.Wait()
+
+	// We expect a clean state at the end of the test.
+	require.Equal(t, 0, w.watchGroupsCount())
+}
+
+func BenchmarkPartitionOffsetWatcher(b *testing.B) {
+	b.Run("high notify() rate but condition is never met", func(b *testing.B) {
+		const numWatchingGoroutines = 1000
+
+		var (
+			ctx = context.Background()
+			w   = newPartitionOffsetWatcher()
+		)
+
+		// Start all watching goroutines.
+		wg := sync.WaitGroup{}
+		wg.Add(numWatchingGoroutines)
+
+		for i := 0; i < numWatchingGoroutines; i++ {
+			runAsync(&wg, func() {
+				if err := w.Wait(ctx, math.MaxInt64); err != nil {
+					b.Fatal(err)
+				}
+			})
+		}
+
+		// Release the watching goroutines when cleaning up.
+		b.Cleanup(func() {
+			w.Notify(math.MaxInt64)
+			wg.Wait()
+
+			// We expect a clean state at the end of the test.
+			require.Equal(b, 0, w.watchGroupsCount())
+		})
+
+		// Give some time to start all goroutines.
+		time.Sleep(time.Second)
+
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			w.Notify(int64(n))
+		}
+	})
+
+	b.Run("high concurrency between wait() and notify()", func(b *testing.B) {
+		const numWatchingGoroutines = 100
+
+		var (
+			ctx, cancelCtx = context.WithCancel(context.Background())
+			w              = newPartitionOffsetWatcher()
+			nextOffset     = atomic.NewInt64(0)
+			done           = atomic.NewBool(false)
+		)
+
+		// Start all watching goroutines.
+		wg := sync.WaitGroup{}
+		wg.Add(numWatchingGoroutines)
+
+		for i := 0; i < numWatchingGoroutines; i++ {
+			runAsync(&wg, func() {
+				for !done.Load() {
+					// Continuously wait for an offset soon in the future.
+					err := w.Wait(ctx, nextOffset.Inc()+numWatchingGoroutines)
+
+					// When done the context is cancelled, so we don't check for an error in that case.
+					if !done.Load() && err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+
+		// Release the watching goroutines when cleaning up.
+		b.Cleanup(func() {
+			done.Store(true)
+			cancelCtx()
+			wg.Wait()
+
+			// We expect a clean state at the end of the test.
+			require.Equal(b, 0, w.watchGroupsCount())
+		})
+
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			w.Notify(nextOffset.Inc())
+
+			// Small throttling.
+			time.Sleep(10 * time.Nanosecond)
+		}
+	})
+}

--- a/pkg/storage/ingest/partition_offset_watcher_test.go
+++ b/pkg/storage/ingest/partition_offset_watcher_test.go
@@ -21,6 +21,8 @@ func TestPartitionOffsetWatcher(t *testing.T) {
 	const shortSleep = 100 * time.Millisecond
 
 	t.Run("should support a single goroutine waiting for an offset", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			ctx       = context.Background()
 			w         = newPartitionOffsetWatcher()
@@ -50,6 +52,8 @@ func TestPartitionOffsetWatcher(t *testing.T) {
 	})
 
 	t.Run("should support two goroutines waiting for the same offset", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			ctx        = context.Background()
 			w          = newPartitionOffsetWatcher()
@@ -88,6 +92,8 @@ func TestPartitionOffsetWatcher(t *testing.T) {
 	})
 
 	t.Run("should support two goroutines waiting for a different offset", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			ctx        = context.Background()
 			w          = newPartitionOffsetWatcher()
@@ -125,6 +131,8 @@ func TestPartitionOffsetWatcher(t *testing.T) {
 	})
 
 	t.Run("Wait() should immediately return if the input offset has already been consumed", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			ctx = context.Background()
 			w   = newPartitionOffsetWatcher()
@@ -137,6 +145,8 @@ func TestPartitionOffsetWatcher(t *testing.T) {
 	})
 
 	t.Run("Wait() should immediately return if the input offset is -1, even if no consumed offset has been notified yet", func(t *testing.T) {
+		t.Parallel()
+
 		var (
 			ctx = context.Background()
 			w   = newPartitionOffsetWatcher()
@@ -148,6 +158,8 @@ func TestPartitionOffsetWatcher(t *testing.T) {
 	})
 
 	t.Run("Wait() should return as soon as the watcher service is stopped", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := context.Background()
 
 		w := newPartitionOffsetWatcher()
@@ -319,7 +331,8 @@ func BenchmarkPartitionOffsetWatcher(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			w.Notify(nextOffset.Inc())
 
-			// Small throttling.
+			// Give a short time to multiple watching goroutines to call Wait() so that the next Notify()
+			// will likely return the result for multiple waiting goroutines at the same time.
 			time.Sleep(10 * time.Nanosecond)
 		}
 	})

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -362,7 +362,7 @@ func (r *PartitionReader) WaitReadConsistency(ctx context.Context) (returnErr er
 	}
 
 	// Get the last produced offset.
-	lastProducedOffset, err := r.offsetReader.WaitLastProducedOffset(ctx)
+	lastProducedOffset, err := r.offsetReader.FetchLastProducedOffset(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -341,7 +341,7 @@ func (r *PartitionReader) WaitReadConsistency(ctx context.Context) (returnErr er
 	r.metrics.strongConsistencyRequests.Inc()
 
 	defer func() {
-		// Do not track failure or latency if the request was canceled (because the tracking would be falsed).
+		// Do not track failure or latency if the request was canceled (because the tracking would be incorrect).
 		if errors.Is(returnErr, context.Canceled) {
 			return
 		}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -355,9 +355,9 @@ func (r *PartitionReader) WaitReadConsistency(ctx context.Context) (returnErr er
 		}
 	}()
 
-	// Ensure the service has been started. Some subservices used below are created when starting
+	// Ensure the service is running. Some subservices used below are created when starting
 	// so they're not available before that.
-	if state := r.Service.State(); state != services.Running && state != services.Stopping {
+	if state := r.Service.State(); state != services.Running {
 		return fmt.Errorf("partition reader service is not running (state: %s)", state.String())
 	}
 

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -52,23 +52,30 @@ type PartitionReader struct {
 	committer      *partitionCommitter
 	commitInterval time.Duration
 
+	// consumedOffsetWatcher is used to wait until a given offset has been consumed.
+	// This gets initialised with -1 which means nothing has been consumed from the partition yet.
+	consumedOffsetWatcher *partitionOffsetWatcher
+	offsetReader          *partitionOffsetReader
+
 	logger log.Logger
+	reg    prometheus.Registerer
 }
 
 func NewPartitionReaderForPusher(kafkaCfg KafkaConfig, partitionID int32, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
-	metrics := newReaderMetrics(partitionID, reg)
 	consumer := newPusherConsumer(pusher, reg, logger)
-	return newPartitionReader(kafkaCfg, partitionID, consumer, logger, metrics)
+	return newPartitionReader(kafkaCfg, partitionID, consumer, logger, reg)
 }
 
-func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, consumer recordConsumer, logger log.Logger, metrics readerMetrics) (*PartitionReader, error) {
+func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, consumer recordConsumer, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
 	r := &PartitionReader{
-		kafkaCfg:       kafkaCfg,
-		partitionID:    partitionID,
-		consumer:       consumer,
-		metrics:        metrics,
-		commitInterval: time.Second,
-		logger:         log.With(logger, "partition", partitionID),
+		kafkaCfg:              kafkaCfg,
+		partitionID:           partitionID,
+		consumer:              consumer,
+		metrics:               newReaderMetrics(partitionID, reg),
+		commitInterval:        time.Second,
+		consumedOffsetWatcher: newPartitionOffsetWatcher(),
+		logger:                log.With(logger, "partition", partitionID),
+		reg:                   reg,
 	}
 
 	r.Service = services.NewBasicService(r.start, r.run, r.stop)
@@ -76,19 +83,22 @@ func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, consumer record
 }
 
 func (r *PartitionReader) start(ctx context.Context) error {
-	offset, err := r.fetchLastCommittedOffsetWithRetries(ctx)
+	startFromOffset, err := r.fetchLastCommittedOffsetWithRetries(ctx)
 	if err != nil {
 		return err
 	}
-	level.Info(r.logger).Log("msg", "resuming consumption from offset", "offset", offset)
+	r.consumedOffsetWatcher.Notify(startFromOffset - 1)
+	level.Info(r.logger).Log("msg", "resuming consumption from offset", "offset", startFromOffset)
 
-	r.client, err = r.newKafkaReader(offset)
+	r.client, err = r.newKafkaReader(kgo.NewOffset().At(startFromOffset))
 	if err != nil {
 		return errors.Wrap(err, "creating kafka reader client")
 	}
 	r.committer = newConsumerCommitter(r.kafkaCfg, kadm.NewClient(r.client), r.partitionID, r.commitInterval, r.logger)
 
-	r.dependencies, err = services.NewManager(r.committer)
+	r.offsetReader = newPartitionOffsetReader(r.client, r.kafkaCfg.Topic, r.partitionID, r.kafkaCfg.LastProducedOffsetPollInterval, r.reg, r.logger)
+
+	r.dependencies, err = services.NewManager(r.committer, r.offsetReader, r.consumedOffsetWatcher)
 	if err != nil {
 		return errors.Wrap(err, "creating service manager")
 	}
@@ -96,7 +106,6 @@ func (r *PartitionReader) start(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "starting service manager")
 	}
-
 	return nil
 }
 
@@ -112,16 +121,18 @@ func (r *PartitionReader) stop(error) error {
 }
 
 func (r *PartitionReader) run(ctx context.Context) error {
-	consumeCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	for ctx.Err() == nil {
 		fetches := r.client.PollFetches(ctx)
 		r.recordFetchesMetrics(fetches)
 		r.logFetchErrs(fetches)
 		fetches = filterOutErrFetches(fetches)
-		r.consumeFetches(consumeCtx, fetches)
+
+		// TODO consumeFetches() may get interrupted in the middle because of ctx canceled due to PartitionReader stopped.
+		// 		We should improve it, but we shouldn't just pass a context.Background() because if consumption is stuck
+		// 		then PartitionReader will never stop.
+		r.consumeFetches(ctx, fetches)
 		r.enqueueCommit(fetches)
+		r.notifyLastConsumedOffset(fetches)
 	}
 
 	return nil
@@ -220,6 +231,24 @@ func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetche
 
 }
 
+func (r *PartitionReader) notifyLastConsumedOffset(fetches kgo.Fetches) {
+	fetches.EachPartition(func(partition kgo.FetchTopicPartition) {
+		// We expect all records to belong to the partition consumed by this reader,
+		// but we double check it here.
+		if partition.Partition != r.partitionID {
+			return
+		}
+
+		if len(partition.Records) == 0 {
+			return
+		}
+
+		// Records are expected to be sorted by offsets, so we can simply look at the last one.
+		rec := partition.Records[len(partition.Records)-1]
+		r.consumedOffsetWatcher.Notify(rec.Offset)
+	})
+}
+
 func (r *PartitionReader) recordFetchesMetrics(fetches kgo.Fetches) {
 	var (
 		now        = time.Now()
@@ -254,7 +283,7 @@ func (r *PartitionReader) newKafkaReader(at kgo.Offset) (*kgo.Client, error) {
 	return client, nil
 }
 
-func (r *PartitionReader) fetchLastCommittedOffsetWithRetries(ctx context.Context) (offset kgo.Offset, err error) {
+func (r *PartitionReader) fetchLastCommittedOffsetWithRetries(ctx context.Context) (offset int64, err error) {
 	var (
 		retry = backoff.New(ctx, backoff.Config{
 			MinBackoff: 100 * time.Millisecond,
@@ -281,10 +310,15 @@ func (r *PartitionReader) fetchLastCommittedOffsetWithRetries(ctx context.Contex
 	return offset, err
 }
 
-func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context) (kgo.Offset, error) {
+func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context) (int64, error) {
+	const endOffset = -1 // -1 is a special value for kafka that means "the last offset"
+
+	// We use an ephemeral client to fetch the offset and then create a new client with this offset.
+	// The reason for this is that changing the offset of an existing client requires to have used this client for fetching at least once.
+	// We don't want to do noop fetches just to warm up the client, so we create a new client instead.
 	cl, err := kgo.NewClient(kgo.SeedBrokers(r.kafkaCfg.Address))
 	if err != nil {
-		return kgo.NewOffset(), errors.Wrap(err, "unable to create admin client")
+		return endOffset, errors.Wrap(err, "unable to create admin client")
 	}
 	adm := kadm.NewClient(cl)
 	defer adm.Close()
@@ -292,13 +326,49 @@ func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context) (kgo.Off
 	offsets, err := adm.FetchOffsets(ctx, consumerGroup)
 	if errors.Is(err, kerr.UnknownTopicOrPartition) {
 		// In case we are booting up for the first time ever against this topic.
-		return kgo.NewOffset().AtEnd(), nil
+		return endOffset, nil
 	}
 	if err != nil {
-		return kgo.NewOffset(), errors.Wrap(err, "unable to fetch group offsets")
+		return endOffset, errors.Wrap(err, "unable to fetch group offsets")
 	}
 	offset, _ := offsets.Lookup(r.kafkaCfg.Topic, r.partitionID)
-	return kgo.NewOffset().At(offset.At), nil
+	return offset.At, nil
+}
+
+// WaitReadConsistency waits until all data produced up until now has been consumed by the reader.
+func (r *PartitionReader) WaitReadConsistency(ctx context.Context) (returnErr error) {
+	startTime := time.Now()
+	r.metrics.strongConsistencyRequests.Inc()
+
+	defer func() {
+		// Do not track failure or latency if the request was canceled (because the tracking would be falsed).
+		if errors.Is(returnErr, context.Canceled) {
+			return
+		}
+
+		// Track latency for failures too, so that we have a better measurement of latency if
+		// backend latency is high and requests fail because of timeouts.
+		r.metrics.strongConsistencyLatency.Observe(time.Since(startTime).Seconds())
+
+		if returnErr != nil {
+			r.metrics.strongConsistencyFailures.Inc()
+		}
+	}()
+
+	// Ensure the service has been started. Some subservices used below are created when starting
+	// so they're not available before that.
+	if state := r.Service.State(); state != services.Running && state != services.Stopping {
+		return fmt.Errorf("partition reader service is not running (state: %s)", state.String())
+	}
+
+	// Get the last produced offset.
+	lastProducedOffset, err := r.offsetReader.WaitLastProducedOffset(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Then wait for it.
+	return r.consumedOffsetWatcher.Wait(ctx, lastProducedOffset)
 }
 
 type partitionCommitter struct {
@@ -378,11 +448,14 @@ func (r *partitionCommitter) stop(error) error {
 }
 
 type readerMetrics struct {
-	receiveDelay    prometheus.Summary
-	recordsPerFetch prometheus.Histogram
-	fetchesErrors   prometheus.Counter
-	fetchesTotal    prometheus.Counter
-	kprom           *kprom.Metrics
+	receiveDelay              prometheus.Summary
+	recordsPerFetch           prometheus.Histogram
+	fetchesErrors             prometheus.Counter
+	fetchesTotal              prometheus.Counter
+	strongConsistencyRequests prometheus.Counter
+	strongConsistencyFailures prometheus.Counter
+	strongConsistencyLatency  prometheus.Summary
+	kprom                     *kprom.Metrics
 }
 
 func newReaderMetrics(partitionID int32, reg prometheus.Registerer) readerMetrics {
@@ -408,6 +481,21 @@ func newReaderMetrics(partitionID int32, reg prometheus.Registerer) readerMetric
 		fetchesTotal: factory.NewCounter(prometheus.CounterOpts{
 			Name: "cortex_ingest_storage_reader_fetches_total",
 			Help: "Total number of Kafka fetches received by the consumer.",
+		}),
+		strongConsistencyRequests: factory.NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingest_storage_strong_consistency_requests_total",
+			Help: "Total number of requests for which strong consistency has been requested.",
+		}),
+		strongConsistencyFailures: factory.NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingest_storage_strong_consistency_failures_total",
+			Help: "Total number of failures while waiting for strong consistency to be enforced.",
+		}),
+		strongConsistencyLatency: factory.NewSummary(prometheus.SummaryOpts{
+			Name:       "cortex_ingest_storage_strong_consistency_wait_duration_seconds",
+			Help:       "How long a request spent waiting for strong consistency to be guaranteed.",
+			Objectives: latencySummaryObjectives,
+			MaxAge:     time.Minute,
+			AgeBuckets: 10,
 		}),
 		kprom: kprom.NewMetrics("cortex_ingest_storage_reader",
 			kprom.Registerer(prometheus.WrapRegistererWith(prometheus.Labels{"partition": strconv.Itoa(int(partitionID))}, reg)),

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -107,8 +107,8 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 	}
 }
 
-// resultWaiter is a simple utility to have multiple goroutines waiting for a result from another one.
-type resultWaiter[T any] struct {
+// resultPromise is a simple utility to have multiple goroutines waiting for a result from another one.
+type resultPromise[T any] struct {
 	// done is a channel used to wait the result. Once the channel is closed
 	// it's safe to read resultValue and resultErr without any lock.
 	done chan struct{}
@@ -117,20 +117,20 @@ type resultWaiter[T any] struct {
 	resultErr   error
 }
 
-func newResultWaiter[T any]() *resultWaiter[T] {
-	return &resultWaiter[T]{
+func newResultPromise[T any]() *resultPromise[T] {
+	return &resultPromise[T]{
 		done: make(chan struct{}),
 	}
 }
 
 // notify the result to waiting goroutines. This function must be called exactly once.
-func (w *resultWaiter[T]) notify(value T, err error) {
+func (w *resultPromise[T]) notify(value T, err error) {
 	w.resultValue = value
 	w.resultErr = err
 	close(w.done)
 }
 
-func (w *resultWaiter[T]) wait(ctx context.Context) (T, error) {
+func (w *resultPromise[T]) wait(ctx context.Context) (T, error) {
 	select {
 	case <-ctx.Done():
 		var zero T

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -3,6 +3,7 @@
 package ingest
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/regexp"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/plugin/kprom"
 )
 
@@ -92,5 +94,48 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 
 		kgo.WithHooks(metrics),
 		kgo.WithLogger(newKafkaLogger(logger)),
+
+		kgo.RetryTimeoutFn(func(key int16) time.Duration {
+			switch key {
+			case ((*kmsg.ListOffsetsRequest)(nil)).Key():
+				return cfg.LastProducedOffsetRetryTimeout
+			}
+
+			// 30s is the default timeout in the Kafka client.
+			return 30 * time.Second
+		}),
+	}
+}
+
+// resultWaiter is a simple utility to have multiple goroutines waiting for a result from another one.
+type resultWaiter[T any] struct {
+	// done is a channel used to wait the result. Once the channel is closed
+	// it's safe to read resultValue and resultErr without any lock.
+	done chan struct{}
+
+	resultValue T
+	resultErr   error
+}
+
+func newResultWaiter[T any]() *resultWaiter[T] {
+	return &resultWaiter[T]{
+		done: make(chan struct{}),
+	}
+}
+
+// notify the result to waiting goroutines. This function must be called exactly once.
+func (w *resultWaiter[T]) notify(value T, err error) {
+	w.resultValue = value
+	w.resultErr = err
+	close(w.done)
+}
+
+func (w *resultWaiter[T]) wait(ctx context.Context) (T, error) {
+	select {
+	case <-ctx.Done():
+		var zero T
+		return zero, context.Cause(ctx)
+	case <-w.done:
+		return w.resultValue, w.resultErr
 	}
 }

--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -97,11 +97,11 @@ func TestIngesterPartition(t *testing.T) {
 	})
 }
 
-func TestResultWaiter(t *testing.T) {
+func TestResultPromise(t *testing.T) {
 	t.Run("wait() should block until a result has been notified", func(t *testing.T) {
 		var (
 			wg  = sync.WaitGroup{}
-			rw  = newResultWaiter[int]()
+			rw  = newResultPromise[int]()
 			ctx = context.Background()
 		)
 
@@ -126,7 +126,7 @@ func TestResultWaiter(t *testing.T) {
 	t.Run("wait() should block until an error has been notified", func(t *testing.T) {
 		var (
 			wg        = sync.WaitGroup{}
-			rw        = newResultWaiter[int]()
+			rw        = newResultPromise[int]()
 			ctx       = context.Background()
 			resultErr = errors.New("test error")
 		)
@@ -151,7 +151,7 @@ func TestResultWaiter(t *testing.T) {
 
 	t.Run("wait() should return when the input context timeout expires", func(t *testing.T) {
 		var (
-			rw  = newResultWaiter[int]()
+			rw  = newResultPromise[int]()
 			ctx = context.Background()
 		)
 

--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -3,7 +3,11 @@
 package ingest
 
 import (
+	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -90,5 +94,72 @@ func TestIngesterPartition(t *testing.T) {
 
 		_, err = IngesterPartition("ingester-zone-a")
 		require.Error(t, err)
+	})
+}
+
+func TestResultWaiter(t *testing.T) {
+	t.Run("wait() should block until a result has been notified", func(t *testing.T) {
+		var (
+			wg  = sync.WaitGroup{}
+			rw  = newResultWaiter[int]()
+			ctx = context.Background()
+		)
+
+		// Spawn few goroutines waiting for the result.
+		wg.Add(3)
+
+		for i := 0; i < 3; i++ {
+			runAsync(&wg, func() {
+				actual, err := rw.wait(ctx)
+				require.NoError(t, err)
+				require.Equal(t, 12345, actual)
+			})
+		}
+
+		// Notify the result.
+		rw.notify(12345, nil)
+
+		// Wait until all goroutines have done.
+		wg.Wait()
+	})
+
+	t.Run("wait() should block until an error has been notified", func(t *testing.T) {
+		var (
+			wg        = sync.WaitGroup{}
+			rw        = newResultWaiter[int]()
+			ctx       = context.Background()
+			resultErr = errors.New("test error")
+		)
+
+		// Spawn few goroutines waiting for the result.
+		wg.Add(3)
+
+		for i := 0; i < 3; i++ {
+			runAsync(&wg, func() {
+				actual, err := rw.wait(ctx)
+				require.Equal(t, resultErr, err)
+				require.Equal(t, 0, actual)
+			})
+		}
+
+		// Notify the result.
+		rw.notify(0, resultErr)
+
+		// Wait until all goroutines have done.
+		wg.Wait()
+	})
+
+	t.Run("wait() should return when the input context timeout expires", func(t *testing.T) {
+		var (
+			rw  = newResultWaiter[int]()
+			ctx = context.Background()
+		)
+
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+
+		actual, err := rw.wait(ctxWithTimeout)
+		require.Equal(t, context.DeadlineExceeded, err)
+		require.Equal(t, 0, actual)
 	})
 }


### PR DESCRIPTION
#### What this PR does

This PR is another piece of the puzzle for the experimental support to ingest data through Kafka. In this PR I'm upstreaming `PartitionReader.WaitReadConsistency()`, which is the building block to add condition read-after-write support (this function will be used in a follow up PR).

The idea of `PartitionReader.WaitReadConsistency()` is pretty simple: wait until the last produced offset (at the time of the function call) has been consumed in each ingester. This function will be used in the ingester to wait before running a query which requires strong read consistency.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
