### PR TITLE
helm: omit `backend: s3` when minio is disabled

### DIFF
--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -175,7 +175,6 @@ mimir:
 
     # This configures how the store-gateway synchronizes blocks stored in the bucket. It uses Minio by default for getting started (configured via flags) but this should be changed for production deployments.
     blocks_storage:
-      backend: s3
       bucket_store:
         {{- if index .Values "chunks-cache" "enabled" }}
         chunks_cache:
@@ -205,6 +204,7 @@ mimir:
         {{- end }}
         sync_dir: /data/tsdb-sync
       {{- if .Values.minio.enabled }}
+      backend: s3
       s3:
         access_key_id: {{ .Values.minio.rootUser }}
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-tsdb

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -20,7 +20,6 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     blocks_storage:
-      backend: s3
       bucket_store:
         chunks_cache:
           backend: memcached

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -30,7 +30,6 @@ data:
     auth:
       type: enterprise
     blocks_storage:
-      backend: s3
       bucket_store:
         sync_dir: /data/tsdb-sync
       tsdb:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -20,7 +20,6 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     blocks_storage:
-      backend: s3
       bucket_store:
         sync_dir: /data/tsdb-sync
       tsdb:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -20,7 +20,6 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     blocks_storage:
-      backend: s3
       bucket_store:
         chunks_cache:
           backend: memcached


### PR DESCRIPTION
This leads to having to manually override the value of `blocks_storage.backend` when using something other than S3. This is already how the ruler and alertmanager storages work.

This shouldn't break existing installations because S3 is already the default in Mimir.

This was prompted by [this comment](https://github.com/grafana/mimir/discussions/1901#discussioncomment-7930669) by @ksingh-scogo (thanks!)

 For example:

```yaml
mimir:
  structuredConfig:
    common:
      storage:
        backend: azure
        azure:
          account_key: "<YOUR KEY HERE>"
          account_name: <ACKT_NAME>
          endpoint_suffix: "blob.core.windows.net"
    blocks_storage:
      backend: azure ## Without this it doesn't work
      azure:
        container_name: mimir-dev-blocks
```

