### PR TITLE
"Slow Queries" dashboard: make more fields sortable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [ENHANCEMENT] Dashboards: Add panels for alertmanager activity of a tenant #6826
 * [ENHANCEMENT] Dashboards: Add graphs to "Slow Queries" dashboard. #6880
 * [ENHANCEMENT] Dashboards: remove legacy `graph` panel from Rollout Progress dashboard. #6864
+* [ENHANCEMENT] Dashboards: Make numeric columns in "Slow Queries" sortable. #7000
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * [ENHANCEMENT] Dashboards: Add panels for alertmanager activity of a tenant #6826
 * [ENHANCEMENT] Dashboards: Add graphs to "Slow Queries" dashboard. #6880
 * [ENHANCEMENT] Dashboards: remove legacy `graph` panel from Rollout Progress dashboard. #6864
-* [ENHANCEMENT] Dashboards: Make numeric columns in "Slow Queries" sortable. #7000
+* [ENHANCEMENT] Dashboards: Make most columns in "Slow Queries" sortable. #7000
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33192,6 +33192,7 @@ data:
                                   "user": 2
                                },
                                "renameByName": {
+                                  "err": "Error",
                                   "length_seconds": "Time span",
                                   "param_end": "End",
                                   "param_query": "Query",

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33132,7 +33132,7 @@ data:
                       "span": 12,
                       "targets": [
                          {
-                            "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration}",
+                            "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{duration(response_time)}}\"",
                             "instant": false,
                             "legendFormat": "",
                             "range": true,
@@ -33155,7 +33155,9 @@ data:
                                   "Time": true,
                                   "caller": true,
                                   "cluster": true,
+                                  "component": true,
                                   "container": true,
+                                  "gossip_ring_member": true,
                                   "host": true,
                                   "id": true,
                                   "job": true,
@@ -33175,6 +33177,7 @@ data:
                                   "tsNs": true
                                },
                                "indexByName": {
+                                  "err": 10,
                                   "length": 2,
                                   "param_end": 4,
                                   "param_query": 7,
@@ -33182,6 +33185,7 @@ data:
                                   "param_step": 6,
                                   "param_time": 5,
                                   "response_time": 8,
+                                  "response_time_seconds": 9,
                                   "ts": 0,
                                   "user": 1
                                },
@@ -33189,8 +33193,64 @@ data:
                                   "org_id": "Tenant ID",
                                   "param_query": "Query",
                                   "param_step": "Step",
-                                  "response_time": "Duration"
+                                  "response_time": "Duration",
+                                  "response_time_seconds": "Duration (sec)"
                                }
+                            }
+                         },
+                         {
+                            "id": "convertFieldType",
+                            "options": {
+                               "conversions": [
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "estimated_series_count"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "fetched_chunk_bytes"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "fetched_chunks_count"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "fetched_index_bytes"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "fetched_series_count"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "queue_time_seconds"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "response_size_bytes"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "results_cache_hit_bytes"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "results_cache_miss_bytes"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "sharded_queries"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "split_queries"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "response_time_seconds"
+                                  }
+                               ]
                             }
                          }
                       ],

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33091,7 +33091,103 @@ data:
                             {
                                "matcher": {
                                   "id": "byName",
-                                  "options": "Step"
+                                  "options": "fetched_chunk_bytes"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "bytes"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "fetched_index_bytes"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "bytes"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "response_size_bytes"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "bytes"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "results_cache_hit_bytes"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "bytes"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "results_cache_miss_bytes"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "bytes"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "estimated_series_count"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "short"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "fetched_chunks_count"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "short"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "fetched_series_count"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "short"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "Time span"
                                },
                                "properties": [
                                   {
@@ -33115,7 +33211,19 @@ data:
                             {
                                "matcher": {
                                   "id": "byName",
-                                  "options": "Time span"
+                                  "options": "Step"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "s"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "queue_time_seconds"
                                },
                                "properties": [
                                   {

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33091,22 +33091,9 @@ data:
                             {
                                "matcher": {
                                   "id": "byName",
-                                  "options": "Time range"
+                                  "options": "Step"
                                },
                                "properties": [
-                                  {
-                                     "id": "mappings",
-                                     "value": [
-                                        {
-                                           "from": "",
-                                           "id": 1,
-                                           "text": "Instant query",
-                                           "to": "",
-                                           "type": 1,
-                                           "value": "0"
-                                        }
-                                     ]
-                                  },
                                   {
                                      "id": "unit",
                                      "value": "s"
@@ -33116,7 +33103,19 @@ data:
                             {
                                "matcher": {
                                   "id": "byName",
-                                  "options": "Step"
+                                  "options": "Duration"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "s"
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "Time span"
                                },
                                "properties": [
                                   {
@@ -33132,7 +33131,7 @@ data:
                       "span": 12,
                       "targets": [
                          {
-                            "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{duration(response_time)}}\"",
+                            "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{ duration .response_time }}\",param_step_seconds=\"{{ div .param_step 1000 }}\",length_seconds=\"{{ duration .length }}\"",
                             "instant": false,
                             "legendFormat": "",
                             "range": true,
@@ -33162,39 +33161,46 @@ data:
                                   "id": true,
                                   "job": true,
                                   "labels": true,
+                                  "length": true,
                                   "level": true,
                                   "line": true,
                                   "method": true,
                                   "msg": true,
                                   "name": true,
                                   "namespace": true,
+                                  "param_step": true,
                                   "path": true,
                                   "pod": true,
                                   "pod_template_hash": true,
                                   "query_wall_time_seconds": true,
+                                  "response_time": true,
                                   "stream": true,
                                   "traceID": true,
                                   "tsNs": true
                                },
                                "indexByName": {
                                   "err": 10,
-                                  "length": 2,
-                                  "param_end": 4,
-                                  "param_query": 7,
-                                  "param_start": 3,
-                                  "param_step": 6,
-                                  "param_time": 5,
-                                  "response_time": 8,
+                                  "length_seconds": 3,
+                                  "param_end": 5,
+                                  "param_query": 8,
+                                  "param_start": 4,
+                                  "param_step_seconds": 7,
+                                  "param_time": 6,
                                   "response_time_seconds": 9,
+                                  "status": 1,
                                   "ts": 0,
-                                  "user": 1
+                                  "user": 2
                                },
                                "renameByName": {
-                                  "org_id": "Tenant ID",
+                                  "length_seconds": "Time span",
+                                  "param_end": "End",
                                   "param_query": "Query",
-                                  "param_step": "Step",
-                                  "response_time": "Duration",
-                                  "response_time_seconds": "Duration (sec)"
+                                  "param_start": "Start",
+                                  "param_step_seconds": "Step",
+                                  "param_time": "Time (instant query)",
+                                  "response_time_seconds": "Duration",
+                                  "ts": "Completion date",
+                                  "user": "Tenant ID"
                                }
                             }
                          },
@@ -33245,10 +33251,6 @@ data:
                                   {
                                      "destinationType": "number",
                                      "targetField": "split_queries"
-                                  },
-                                  {
-                                     "destinationType": "number",
-                                     "targetField": "response_time_seconds"
                                   }
                                ]
                             }

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33360,6 +33360,22 @@ data:
                                   {
                                      "destinationType": "number",
                                      "targetField": "split_queries"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "Time span"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "Duration"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "Step"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "queue_time_seconds"
                                   }
                                ]
                             }

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -1338,6 +1338,7 @@
                               "user": 2
                            },
                            "renameByName": {
+                              "err": "Error",
                               "length_seconds": "Time span",
                               "param_end": "End",
                               "param_query": "Query",

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -1506,6 +1506,22 @@
                               {
                                  "destinationType": "number",
                                  "targetField": "split_queries"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "Time span"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "Duration"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "Step"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "queue_time_seconds"
                               }
                            ]
                         }

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -1237,7 +1237,103 @@
                         {
                            "matcher": {
                               "id": "byName",
-                              "options": "Step"
+                              "options": "fetched_chunk_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "fetched_index_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "response_size_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "results_cache_hit_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "results_cache_miss_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "estimated_series_count"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "short"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "fetched_chunks_count"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "short"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "fetched_series_count"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "short"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "Time span"
                            },
                            "properties": [
                               {
@@ -1261,7 +1357,19 @@
                         {
                            "matcher": {
                               "id": "byName",
-                              "options": "Time span"
+                              "options": "Step"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "s"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "queue_time_seconds"
                            },
                            "properties": [
                               {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -1278,7 +1278,7 @@
                   "span": 12,
                   "targets": [
                      {
-                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration}",
+                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{duration(response_time)}}\"",
                         "instant": false,
                         "legendFormat": "",
                         "range": true,
@@ -1301,7 +1301,9 @@
                               "Time": true,
                               "caller": true,
                               "cluster": true,
+                              "component": true,
                               "container": true,
+                              "gossip_ring_member": true,
                               "host": true,
                               "id": true,
                               "job": true,
@@ -1321,6 +1323,7 @@
                               "tsNs": true
                            },
                            "indexByName": {
+                              "err": 10,
                               "length": 2,
                               "param_end": 4,
                               "param_query": 7,
@@ -1328,6 +1331,7 @@
                               "param_step": 6,
                               "param_time": 5,
                               "response_time": 8,
+                              "response_time_seconds": 9,
                               "ts": 0,
                               "user": 1
                            },
@@ -1335,8 +1339,64 @@
                               "org_id": "Tenant ID",
                               "param_query": "Query",
                               "param_step": "Step",
-                              "response_time": "Duration"
+                              "response_time": "Duration",
+                              "response_time_seconds": "Duration (sec)"
                            }
+                        }
+                     },
+                     {
+                        "id": "convertFieldType",
+                        "options": {
+                           "conversions": [
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "estimated_series_count"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_chunk_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_chunks_count"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_index_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_series_count"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "queue_time_seconds"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "response_size_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "results_cache_hit_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "results_cache_miss_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "sharded_queries"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "split_queries"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "response_time_seconds"
+                              }
+                           ]
                         }
                      }
                   ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -1237,22 +1237,9 @@
                         {
                            "matcher": {
                               "id": "byName",
-                              "options": "Time range"
+                              "options": "Step"
                            },
                            "properties": [
-                              {
-                                 "id": "mappings",
-                                 "value": [
-                                    {
-                                       "from": "",
-                                       "id": 1,
-                                       "text": "Instant query",
-                                       "to": "",
-                                       "type": 1,
-                                       "value": "0"
-                                    }
-                                 ]
-                              },
                               {
                                  "id": "unit",
                                  "value": "s"
@@ -1262,7 +1249,19 @@
                         {
                            "matcher": {
                               "id": "byName",
-                              "options": "Step"
+                              "options": "Duration"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "s"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "Time span"
                            },
                            "properties": [
                               {
@@ -1278,7 +1277,7 @@
                   "span": 12,
                   "targets": [
                      {
-                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{duration(response_time)}}\"",
+                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{ duration .response_time }}\",param_step_seconds=\"{{ div .param_step 1000 }}\",length_seconds=\"{{ duration .length }}\"",
                         "instant": false,
                         "legendFormat": "",
                         "range": true,
@@ -1308,39 +1307,46 @@
                               "id": true,
                               "job": true,
                               "labels": true,
+                              "length": true,
                               "level": true,
                               "line": true,
                               "method": true,
                               "msg": true,
                               "name": true,
                               "namespace": true,
+                              "param_step": true,
                               "path": true,
                               "pod": true,
                               "pod_template_hash": true,
                               "query_wall_time_seconds": true,
+                              "response_time": true,
                               "stream": true,
                               "traceID": true,
                               "tsNs": true
                            },
                            "indexByName": {
                               "err": 10,
-                              "length": 2,
-                              "param_end": 4,
-                              "param_query": 7,
-                              "param_start": 3,
-                              "param_step": 6,
-                              "param_time": 5,
-                              "response_time": 8,
+                              "length_seconds": 3,
+                              "param_end": 5,
+                              "param_query": 8,
+                              "param_start": 4,
+                              "param_step_seconds": 7,
+                              "param_time": 6,
                               "response_time_seconds": 9,
+                              "status": 1,
                               "ts": 0,
-                              "user": 1
+                              "user": 2
                            },
                            "renameByName": {
-                              "org_id": "Tenant ID",
+                              "length_seconds": "Time span",
+                              "param_end": "End",
                               "param_query": "Query",
-                              "param_step": "Step",
-                              "response_time": "Duration",
-                              "response_time_seconds": "Duration (sec)"
+                              "param_start": "Start",
+                              "param_step_seconds": "Step",
+                              "param_time": "Time (instant query)",
+                              "response_time_seconds": "Duration",
+                              "ts": "Completion date",
+                              "user": "Tenant ID"
                            }
                         }
                      },
@@ -1391,10 +1397,6 @@
                               {
                                  "destinationType": "number",
                                  "targetField": "split_queries"
-                              },
-                              {
-                                 "destinationType": "number",
-                                 "targetField": "response_time_seconds"
                               }
                            ]
                         }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -1338,6 +1338,7 @@
                               "user": 2
                            },
                            "renameByName": {
+                              "err": "Error",
                               "length_seconds": "Time span",
                               "param_end": "End",
                               "param_query": "Query",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -1506,6 +1506,22 @@
                               {
                                  "destinationType": "number",
                                  "targetField": "split_queries"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "Time span"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "Duration"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "Step"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "queue_time_seconds"
                               }
                            ]
                         }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -1237,7 +1237,103 @@
                         {
                            "matcher": {
                               "id": "byName",
-                              "options": "Step"
+                              "options": "fetched_chunk_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "fetched_index_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "response_size_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "results_cache_hit_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "results_cache_miss_bytes"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "bytes"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "estimated_series_count"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "short"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "fetched_chunks_count"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "short"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "fetched_series_count"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "short"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "Time span"
                            },
                            "properties": [
                               {
@@ -1261,7 +1357,19 @@
                         {
                            "matcher": {
                               "id": "byName",
-                              "options": "Time span"
+                              "options": "Step"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "s"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "queue_time_seconds"
                            },
                            "properties": [
                               {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -1278,7 +1278,7 @@
                   "span": 12,
                   "targets": [
                      {
-                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration}",
+                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{duration(response_time)}}\"",
                         "instant": false,
                         "legendFormat": "",
                         "range": true,
@@ -1301,7 +1301,9 @@
                               "Time": true,
                               "caller": true,
                               "cluster": true,
+                              "component": true,
                               "container": true,
+                              "gossip_ring_member": true,
                               "host": true,
                               "id": true,
                               "job": true,
@@ -1321,6 +1323,7 @@
                               "tsNs": true
                            },
                            "indexByName": {
+                              "err": 10,
                               "length": 2,
                               "param_end": 4,
                               "param_query": 7,
@@ -1328,6 +1331,7 @@
                               "param_step": 6,
                               "param_time": 5,
                               "response_time": 8,
+                              "response_time_seconds": 9,
                               "ts": 0,
                               "user": 1
                            },
@@ -1335,8 +1339,64 @@
                               "org_id": "Tenant ID",
                               "param_query": "Query",
                               "param_step": "Step",
-                              "response_time": "Duration"
+                              "response_time": "Duration",
+                              "response_time_seconds": "Duration (sec)"
                            }
+                        }
+                     },
+                     {
+                        "id": "convertFieldType",
+                        "options": {
+                           "conversions": [
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "estimated_series_count"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_chunk_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_chunks_count"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_index_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_series_count"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "queue_time_seconds"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "response_size_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "results_cache_hit_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "results_cache_miss_bytes"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "sharded_queries"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "split_queries"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "response_time_seconds"
+                              }
+                           ]
                         }
                      }
                   ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -1237,22 +1237,9 @@
                         {
                            "matcher": {
                               "id": "byName",
-                              "options": "Time range"
+                              "options": "Step"
                            },
                            "properties": [
-                              {
-                                 "id": "mappings",
-                                 "value": [
-                                    {
-                                       "from": "",
-                                       "id": 1,
-                                       "text": "Instant query",
-                                       "to": "",
-                                       "type": 1,
-                                       "value": "0"
-                                    }
-                                 ]
-                              },
                               {
                                  "id": "unit",
                                  "value": "s"
@@ -1262,7 +1249,19 @@
                         {
                            "matcher": {
                               "id": "byName",
-                              "options": "Step"
+                              "options": "Duration"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "s"
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "Time span"
                            },
                            "properties": [
                               {
@@ -1278,7 +1277,7 @@
                   "span": 12,
                   "targets": [
                      {
-                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{duration(response_time)}}\"",
+                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{ duration .response_time }}\",param_step_seconds=\"{{ div .param_step 1000 }}\",length_seconds=\"{{ duration .length }}\"",
                         "instant": false,
                         "legendFormat": "",
                         "range": true,
@@ -1308,39 +1307,46 @@
                               "id": true,
                               "job": true,
                               "labels": true,
+                              "length": true,
                               "level": true,
                               "line": true,
                               "method": true,
                               "msg": true,
                               "name": true,
                               "namespace": true,
+                              "param_step": true,
                               "path": true,
                               "pod": true,
                               "pod_template_hash": true,
                               "query_wall_time_seconds": true,
+                              "response_time": true,
                               "stream": true,
                               "traceID": true,
                               "tsNs": true
                            },
                            "indexByName": {
                               "err": 10,
-                              "length": 2,
-                              "param_end": 4,
-                              "param_query": 7,
-                              "param_start": 3,
-                              "param_step": 6,
-                              "param_time": 5,
-                              "response_time": 8,
+                              "length_seconds": 3,
+                              "param_end": 5,
+                              "param_query": 8,
+                              "param_start": 4,
+                              "param_step_seconds": 7,
+                              "param_time": 6,
                               "response_time_seconds": 9,
+                              "status": 1,
                               "ts": 0,
-                              "user": 1
+                              "user": 2
                            },
                            "renameByName": {
-                              "org_id": "Tenant ID",
+                              "length_seconds": "Time span",
+                              "param_end": "End",
                               "param_query": "Query",
-                              "param_step": "Step",
-                              "response_time": "Duration",
-                              "response_time_seconds": "Duration (sec)"
+                              "param_start": "Start",
+                              "param_step_seconds": "Step",
+                              "param_time": "Time (instant query)",
+                              "response_time_seconds": "Duration",
+                              "ts": "Completion date",
+                              "user": "Tenant ID"
                            }
                         }
                      },
@@ -1391,10 +1397,6 @@
                               {
                                  "destinationType": "number",
                                  "targetField": "split_queries"
-                              },
-                              {
-                                 "destinationType": "number",
-                                 "targetField": "response_time_seconds"
                               }
                            ]
                         }

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -221,7 +221,7 @@ local filename = 'mimir-slow-queries.json';
               // Transforma some fields into numbers so sorting in the table doesn't sort them lexicographically.
               id: 'convertFieldType',
               options: {
-                local numericFields = ['estimated_series_count', 'fetched_chunk_bytes', 'fetched_chunks_count', 'fetched_index_bytes', 'fetched_series_count', 'queue_time_seconds', 'response_size_bytes', 'results_cache_hit_bytes', 'results_cache_miss_bytes', 'sharded_queries', 'split_queries'],
+                local numericFields = ['estimated_series_count', 'fetched_chunk_bytes', 'fetched_chunks_count', 'fetched_index_bytes', 'fetched_series_count', 'queue_time_seconds', 'response_size_bytes', 'results_cache_hit_bytes', 'results_cache_miss_bytes', 'sharded_queries', 'split_queries', 'Time span', 'Duration', 'Step', 'queue_time_seconds'],
 
                 conversions: [
                   {

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -213,6 +213,7 @@ local filename = 'mimir-slow-queries.json';
                   param_time: 'Time (instant query)',
                   response_time_seconds: 'Duration',
                   length_seconds: 'Time span',
+                  err: 'Error',
                 },
               },
             },

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -236,20 +236,31 @@ local filename = 'mimir-slow-queries.json';
 
           fieldConfig: {
             // Configure overrides to nicely format field values.
-            overrides: [
-              {
-                matcher: { id: 'byName', options: 'Step' },
-                properties: [{ id: 'unit', value: 's' }],
-              },
-              {
-                matcher: { id: 'byName', options: 'Duration' },
-                properties: [{ id: 'unit', value: 's' }],
-              },
-              {
-                matcher: { id: 'byName', options: 'Time span' },
-                properties: [{ id: 'unit', value: 's' }],
-              },
-            ],
+            overrides:
+              local bytesFields = ['fetched_chunk_bytes', 'fetched_index_bytes', 'response_size_bytes', 'results_cache_hit_bytes', 'results_cache_miss_bytes'];
+              [
+                {
+                  matcher: { id: 'byName', options: fieldName },
+                  properties: [{ id: 'unit', value: 'bytes' }],
+                }
+                for fieldName in bytesFields
+              ] +
+              local shortFields = ['estimated_series_count', 'fetched_chunks_count', 'fetched_series_count'];
+              [
+                {
+                  matcher: { id: 'byName', options: fieldName },
+                  properties: [{ id: 'unit', value: 'short' }],
+                }
+                for fieldName in shortFields
+              ] +
+              local secondsFields = ['Time span', 'Duration', 'Step', 'queue_time_seconds'];
+              [
+                {
+                  matcher: { id: 'byName', options: fieldName },
+                  properties: [{ id: 'unit', value: 's' }],
+                }
+                for fieldName in secondsFields
+              ],
           },
         },
       )


### PR DESCRIPTION
This PR dusts off the Slow queries dashboard. it contains a couple of minor usability changes
* `org_id` label renamed to `user`
* `Time span`, `Step`, `Duration` fields are now parsed as time duration in seconds and can be properly sorted by (e.g. 2.1 s)
* bytes columns display as an IEC byte unit and can be sorted by (e.g. 1GiB)
* chunks and series counts are displayed as short numbers (e.g. 1.2K, 15M) 
* reorder `status` and `err` as earlier columns
* add human-friendly names to a few parameters (`Error`, `Start`, `End`, `Time`, `Completion date`)
* convert all numeric fields to numbers so they can be sorted by