### PR TITLE
Fix panic in TestPartitionOffsetWatcher_Concurrency

### DIFF
--- a/pkg/storage/ingest/partition_offset_watcher_test.go
+++ b/pkg/storage/ingest/partition_offset_watcher_test.go
@@ -228,7 +228,12 @@ func TestPartitionOffsetWatcher_Concurrency(t *testing.T) {
 				// Notify an offset between the last notified offset and the last watched offset.
 				// The update to lastNotifiedOffset by multiple goroutines suffer a race condition
 				// but it's fine for the purpose of this test.
-				offset := lastNotifiedOffset.Load() + rand.Int63n(lastWatchedOffset.Load()-lastNotifiedOffset.Load())
+				maxOffsetRange := lastWatchedOffset.Load() - lastNotifiedOffset.Load()
+				if maxOffsetRange <= 0 {
+					continue
+				}
+
+				offset := lastNotifiedOffset.Load() + rand.Int63n(maxOffsetRange)
 				lastNotifiedOffset.Store(offset)
 
 				w.Notify(offset)


### PR DESCRIPTION
#### What this PR does
Earlier today I merged https://github.com/grafana/mimir/pull/6982, which introduces the test `TestPartitionOffsetWatcher_Concurrency`. The test panics if `lastNotifiedOffset == lastWatchedOffset` because `rand.In63n(0)` is not a valid input value:

```
panic: invalid argument to Int63n

goroutine 1684 [running]:
math/rand.(*Rand).Int63n(0xc000447470, 0x0)
	/usr/local/go/src/math/rand/rand.go:122 +0x125
math/rand.Int63n(0xc0007a4960?)
	/usr/local/go/src/math/rand/rand.go:443 +0x2f
github.com/grafana/mimir/pkg/storage/ingest.TestPartitionOffsetWatcher_Concurrency.func2()
	/__w/mimir/mimir/pkg/storage/ingest/partition_offset_watcher_test.go:231 +0xb8
github.com/grafana/mimir/pkg/storage/ingest.runAsync.func1()
	/__w/mimir/mimir/pkg/storage/ingest/writer_test.go:354 +0x82
created by github.com/grafana/mimir/pkg/storage/ingest.runAsync in goroutine 675
	/__w/mimir/mimir/pkg/storage/ingest/writer_test.go:352 +0xd1
```

Thanks @dimitarvdimitrov for reporting it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
