### PR TITLE
Add strong read consistency support in ingester for experimental ingest storage

### DIFF
--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingester
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/test"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/querier/api"
+	"github.com/grafana/mimir/pkg/storage/ingest"
+	util_test "github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/testkafka"
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+func TestIngester_QueryStream_IngestStorageReadConsistency(t *testing.T) {
+	const (
+		metricName = "series_1"
+	)
+
+	for _, readConsistency := range []string{api.ReadConsistencyEventual, api.ReadConsistencyStrong} {
+		t.Run(fmt.Sprintf("read consistency = %s", readConsistency), func(t *testing.T) {
+			var (
+				cfg     = defaultIngesterTestConfig(t)
+				limits  = defaultLimitsTestConfig()
+				reg     = prometheus.NewRegistry()
+				ctx     = context.Background()
+				series1 = mimirpb.PreallocTimeseries{
+					TimeSeries: &mimirpb.TimeSeries{
+						Labels:  mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(labels.MetricName, metricName)),
+						Samples: []mimirpb.Sample{{TimestampMs: 1000, Value: 10}},
+					},
+				}
+			)
+
+			limits.IngestStorageReadConsistency = readConsistency
+
+			// Create the ingester.
+			overrides, err := validation.NewOverrides(limits, nil)
+			require.NoError(t, err)
+			ingester, kafkaCluster := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
+
+			// Mock the Kafka cluster to fail the Fetch operation until we unblock it later in the test.
+			// If read consistency is "eventual" then these failures shouldn't affect queries, but if it's set
+			// to "strong" then a query shouldn't succeed until the Fetch requests succeed.
+			failFetch := atomic.NewBool(true)
+
+			kafkaCluster.ControlKey(int16(kmsg.Fetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+				kafkaCluster.KeepControl()
+
+				if failFetch.Load() {
+					return nil, errors.New("mocked error"), true
+				}
+
+				return nil, nil, false
+			})
+
+			// Start the ingester (after the Kafka cluster has been mocked).
+			require.NoError(t, services.StartAndAwaitRunning(ctx, ingester))
+			defer t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(ctx, ingester))
+			})
+
+			// Wait until the ingester is healthy.
+			test.Poll(t, 1*time.Second, 1, func() interface{} {
+				return ingester.lifecycler.HealthyInstancesCount()
+			})
+
+			// Create a Kafka writer and then write a series.
+			writer := ingest.NewWriter(cfg.IngestStorageConfig.KafkaConfig, log.NewNopLogger(), nil)
+			require.NoError(t, services.StartAndAwaitRunning(ctx, writer))
+			defer t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(ctx, writer))
+			})
+
+			partitionID, err := ingest.IngesterPartition(cfg.IngesterRing.InstanceID)
+			require.NoError(t, err)
+			require.NoError(t, writer.WriteSync(ctx, partitionID, userID, &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1}, Source: mimirpb.API}))
+
+			// Run a query in a separate goroutine and collect the result.
+			var (
+				queryRes model.Matrix
+				queryWg  = sync.WaitGroup{}
+			)
+
+			queryWg.Add(1)
+			go func() {
+				defer queryWg.Done()
+
+				// Ensure the query will eventually terminate.
+				queryCtx, cancel := context.WithTimeout(user.InjectOrgID(ctx, userID), 5*time.Second)
+				defer cancel()
+
+				queryRes, _, err = runTestQuery(queryCtx, t, ingester, labels.MatchEqual, labels.MetricName, metricName)
+				require.NoError(t, err)
+			}()
+
+			// Wait some time and then unblock the Fetch.
+			time.Sleep(time.Second)
+			failFetch.Store(false)
+
+			// Wait until the query returns.
+			queryWg.Wait()
+
+			switch readConsistency {
+			case api.ReadConsistencyEventual:
+				// We expect no series because the query didn't wait for the read consistency to be guaranteed.
+				assert.Len(t, queryRes, 0)
+
+			case api.ReadConsistencyStrong:
+				// We expect query did wait for the read consistency to be guaranteed.
+				assert.Len(t, queryRes, 1)
+			}
+		})
+	}
+}
+
+func createTestIngesterWithIngestStorage(t testing.TB, ingesterCfg *Config, overrides *validation.Overrides, reg prometheus.Registerer) (*Ingester, *kfake.Cluster) {
+	var (
+		dataDir   = t.TempDir()
+		bucketDir = t.TempDir()
+	)
+
+	ingesterCfg.IngestStorageConfig.Enabled = true
+	ingesterCfg.IngestStorageConfig.KafkaConfig.Topic = "mimir"
+	ingesterCfg.IngestStorageConfig.KafkaConfig.LastProducedOffsetPollInterval = 100 * time.Millisecond
+
+	// Create a fake Kafka cluster.
+	kafkaCluster, kafkaAddr := testkafka.CreateCluster(t, 10, ingesterCfg.IngestStorageConfig.KafkaConfig.Topic, ingest.ConsumerGroup)
+	ingesterCfg.IngestStorageConfig.KafkaConfig.Address = kafkaAddr
+
+	// The ingest storage requires the ingester ID to have a well known format.
+	ingesterCfg.IngesterRing.InstanceID = "ingester-zone-a-0"
+
+	ingesterCfg.BlocksStorageConfig.TSDB.Dir = dataDir
+	ingesterCfg.BlocksStorageConfig.Bucket.Backend = "filesystem"
+	ingesterCfg.BlocksStorageConfig.Bucket.Filesystem.Directory = bucketDir
+
+	// Disable TSDB head compaction jitter to have predictable tests.
+	ingesterCfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalJitterEnabled = false
+
+	ingester, err := New(*ingesterCfg, overrides, nil, nil, reg, util_test.NewTestingLogger(t))
+	require.NoError(t, err)
+
+	return ingester, kafkaCluster
+}

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -75,7 +75,7 @@ func TestIngester_QueryStream_IngestStorageReadConsistency(t *testing.T) {
 
 			// Start the ingester (after the Kafka cluster has been mocked).
 			require.NoError(t, services.StartAndAwaitRunning(ctx, ingester))
-			defer t.Cleanup(func() {
+			t.Cleanup(func() {
 				require.NoError(t, services.StopAndAwaitTerminated(ctx, ingester))
 			})
 
@@ -87,7 +87,7 @@ func TestIngester_QueryStream_IngestStorageReadConsistency(t *testing.T) {
 			// Create a Kafka writer and then write a series.
 			writer := ingest.NewWriter(cfg.IngestStorageConfig.KafkaConfig, log.NewNopLogger(), nil)
 			require.NoError(t, services.StartAndAwaitRunning(ctx, writer))
-			defer t.Cleanup(func() {
+			t.Cleanup(func() {
 				require.NoError(t, services.StopAndAwaitTerminated(ctx, writer))
 			})
 

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -144,7 +144,7 @@ func createTestIngesterWithIngestStorage(t testing.TB, ingesterCfg *Config, over
 	ingesterCfg.IngestStorageConfig.KafkaConfig.LastProducedOffsetPollInterval = 100 * time.Millisecond
 
 	// Create a fake Kafka cluster.
-	kafkaCluster, kafkaAddr := testkafka.CreateCluster(t, 10, ingesterCfg.IngestStorageConfig.KafkaConfig.Topic, ingest.ConsumerGroup)
+	kafkaCluster, kafkaAddr := testkafka.CreateCluster(t, 10, ingesterCfg.IngestStorageConfig.KafkaConfig.Topic)
 	ingesterCfg.IngestStorageConfig.KafkaConfig.Address = kafkaAddr
 
 	// The ingest storage requires the ingester ID to have a well known format.

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -38,6 +38,7 @@ func defaultIngesterTestConfig(t testing.TB) Config {
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
 	flagext.DefaultValues(&cfg.BlocksStorageConfig)
+	flagext.DefaultValues(&cfg.IngestStorageConfig)
 	cfg.IngesterRing.KVStore.Mock = consul
 	cfg.IngesterRing.NumTokens = 1
 	cfg.IngesterRing.ListenPort = 0

--- a/pkg/mimir/runtime_config_test.go
+++ b/pkg/mimir/runtime_config_test.go
@@ -17,12 +17,16 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
+func TestMain(m *testing.M) {
+	validation.SetDefaultLimitsForYAMLUnmarshalling(getDefaultLimits())
+
+	m.Run()
+}
+
 // Given limits are usually loaded via a config file, and that
 // a configmap is limited to 1MB, we need to minimise the limits file.
 // One way to do it is via YAML anchors.
 func TestRuntimeConfigLoader_ShouldLoadAnchoredYAML(t *testing.T) {
-	validation.SetDefaultLimitsForYAMLUnmarshalling(getDefaultLimits())
-
 	yamlFile := strings.NewReader(`
 overrides:
   '1234': &id001
@@ -56,8 +60,6 @@ overrides:
 }
 
 func TestRuntimeConfigLoader_ShouldLoadEmptyFile(t *testing.T) {
-	validation.SetDefaultLimitsForYAMLUnmarshalling(getDefaultLimits())
-
 	yamlFile := strings.NewReader(`
 # This is an empty YAML.
 `)
@@ -69,8 +71,6 @@ func TestRuntimeConfigLoader_ShouldLoadEmptyFile(t *testing.T) {
 }
 
 func TestRuntimeConfigLoader_MissingPointerFieldsAreNil(t *testing.T) {
-	validation.SetDefaultLimitsForYAMLUnmarshalling(getDefaultLimits())
-
 	yamlFile := strings.NewReader(`
 # This is an empty YAML.
 `)
@@ -86,8 +86,6 @@ func TestRuntimeConfigLoader_MissingPointerFieldsAreNil(t *testing.T) {
 }
 
 func TestRuntimeConfigLoader_ShouldReturnErrorOnMultipleDocumentsInTheConfig(t *testing.T) {
-	validation.SetDefaultLimitsForYAMLUnmarshalling(getDefaultLimits())
-
 	cases := []string{
 		`
 ---
@@ -127,8 +125,6 @@ overrides:
 }
 
 func TestRuntimeConfigLoader_RunsValidation(t *testing.T) {
-	validation.SetDefaultLimitsForYAMLUnmarshalling(getDefaultLimits())
-
 	for _, tc := range []struct {
 		name     string
 		validate func(limits validation.Limits) error

--- a/pkg/querier/api/consistency.go
+++ b/pkg/querier/api/consistency.go
@@ -2,10 +2,6 @@
 
 package api
 
-import (
-	"github.com/grafana/mimir/pkg/util"
-)
-
 const (
 	// ReadConsistencyStrong means that a query sent by the same client will always observe the writes
 	// that have completed before issuing the query.
@@ -17,7 +13,3 @@ const (
 )
 
 var ReadConsistencies = []string{ReadConsistencyStrong, ReadConsistencyEventual}
-
-func IsValidReadConsistency(lvl string) bool {
-	return util.StringsContain(ReadConsistencies, lvl)
-}

--- a/pkg/querier/api/consistency.go
+++ b/pkg/querier/api/consistency.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package api
+
+import (
+	"github.com/grafana/mimir/pkg/util"
+)
+
+const (
+	// ReadConsistencyStrong means that a query sent by the same client will always observe the writes
+	// that have completed before issuing the query.
+	ReadConsistencyStrong = "strong"
+
+	// ReadConsistencyEventual is the default consistency level for all queries.
+	// This level means that a query sent by a client may not observe some of the writes that the same client has recently made.
+	ReadConsistencyEventual = "eventual"
+)
+
+var ReadConsistencies = []string{ReadConsistencyStrong, ReadConsistencyEventual}
+
+func IsValidReadConsistency(lvl string) bool {
+	return util.StringsContain(ReadConsistencies, lvl)
+}

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/util/testkafka"
 )
 
 func TestPartitionOffsetReader(t *testing.T) {
@@ -33,7 +35,7 @@ func TestPartitionOffsetReader(t *testing.T) {
 
 	t.Run("should notify waiting goroutines when stopped", func(t *testing.T) {
 		var (
-			_, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 		)
 
@@ -82,7 +84,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 		t.Parallel()
 
 		var (
-			_, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 			client         = createTestKafkaClient(t, kafkaCfg)
 			reg            = prometheus.NewPedanticRegistry()
@@ -123,7 +125,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 		t.Parallel()
 
 		var (
-			cluster, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			cluster, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reg                  = prometheus.NewPedanticRegistry()
@@ -175,7 +177,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 	t.Run("should honor the configured retry timeout", func(t *testing.T) {
 		t.Parallel()
 
-		cluster, clusterAddr := createTestCluster(t, numPartitions, topicName)
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
 
 		// Configure a short retry timeout.
 		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
@@ -223,7 +225,7 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 
 	t.Run("should wait the result of the next request issued", func(t *testing.T) {
 		var (
-			cluster, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			cluster, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reader               = newPartitionOffsetReader(client, topicName, partitionID, pollInterval, nil, logger)
@@ -284,7 +286,7 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 
 	t.Run("should immediately return if the context gets canceled", func(t *testing.T) {
 		var (
-			_, clusterAddr = createTestCluster(t, numPartitions, topicName)
+			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 			client         = createTestKafkaClient(t, kafkaCfg)
 		)
@@ -297,6 +299,5 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 
 		_, err := reader.FetchLastProducedOffset(canceledCtx)
 		assert.ErrorIs(t, err, context.Canceled)
-
 	})
 }

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -35,7 +35,7 @@ func TestPartitionOffsetReader(t *testing.T) {
 
 	t.Run("should notify waiting goroutines when stopped", func(t *testing.T) {
 		var (
-			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 		)
 
@@ -84,7 +84,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 		t.Parallel()
 
 		var (
-			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 			client         = createTestKafkaClient(t, kafkaCfg)
 			reg            = prometheus.NewPedanticRegistry()
@@ -125,7 +125,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 		t.Parallel()
 
 		var (
-			cluster, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+			cluster, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reg                  = prometheus.NewPedanticRegistry()
@@ -177,7 +177,7 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 	t.Run("should honor the configured retry timeout", func(t *testing.T) {
 		t.Parallel()
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
 		// Configure a short retry timeout.
 		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
@@ -225,7 +225,7 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 
 	t.Run("should wait the result of the next request issued", func(t *testing.T) {
 		var (
-			cluster, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+			cluster, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reader               = newPartitionOffsetReader(client, topicName, partitionID, pollInterval, nil, logger)
@@ -286,7 +286,7 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 
 	t.Run("should immediately return if the context gets canceled", func(t *testing.T) {
 		var (
-			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 			client         = createTestKafkaClient(t, kafkaCfg)
 		)

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -24,8 +24,8 @@ import (
 	"go.uber.org/atomic"
 )
 
-// consumerGroup is only used to store commit offsets, not for actual consuming.
-const consumerGroup = "mimir"
+// ConsumerGroup is only used to store commit offsets, not for actual consuming.
+const ConsumerGroup = "mimir"
 
 type record struct {
 	tenantID string
@@ -323,7 +323,7 @@ func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context) (int64, 
 	adm := kadm.NewClient(cl)
 	defer adm.Close()
 
-	offsets, err := adm.FetchOffsets(ctx, consumerGroup)
+	offsets, err := adm.FetchOffsets(ctx, ConsumerGroup)
 	if errors.Is(err, kerr.UnknownTopicOrPartition) {
 		// In case we are booting up for the first time ever against this topic.
 		return endOffset, nil
@@ -428,7 +428,7 @@ func (r *partitionCommitter) commit(ctx context.Context, offset int64) {
 	// Leader epoch is -1 because we don't know it. This lets Kafka figure it out.
 	toCommit.AddOffset(r.kafkaCfg.Topic, r.partitionID, offset+1, -1)
 
-	committed, err := r.admClient.CommitOffsets(ctx, consumerGroup, toCommit)
+	committed, err := r.admClient.CommitOffsets(ctx, ConsumerGroup, toCommit)
 	if err != nil || !committed.Ok() {
 		level.Error(r.logger).Log("msg", "encountered error while committing offsets", "err", err, "commit_err", committed.Error(), "offset", offset)
 	} else {

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -24,8 +24,8 @@ import (
 	"go.uber.org/atomic"
 )
 
-// ConsumerGroup is only used to store commit offsets, not for actual consuming.
-const ConsumerGroup = "mimir"
+// consumerGroup is only used to store commit offsets, not for actual consuming.
+const consumerGroup = "mimir"
 
 type record struct {
 	tenantID string
@@ -323,7 +323,7 @@ func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context) (int64, 
 	adm := kadm.NewClient(cl)
 	defer adm.Close()
 
-	offsets, err := adm.FetchOffsets(ctx, ConsumerGroup)
+	offsets, err := adm.FetchOffsets(ctx, consumerGroup)
 	if errors.Is(err, kerr.UnknownTopicOrPartition) {
 		// In case we are booting up for the first time ever against this topic.
 		return endOffset, nil
@@ -428,7 +428,7 @@ func (r *partitionCommitter) commit(ctx context.Context, offset int64) {
 	// Leader epoch is -1 because we don't know it. This lets Kafka figure it out.
 	toCommit.AddOffset(r.kafkaCfg.Topic, r.partitionID, offset+1, -1)
 
-	committed, err := r.admClient.CommitOffsets(ctx, ConsumerGroup, toCommit)
+	committed, err := r.admClient.CommitOffsets(ctx, consumerGroup, toCommit)
 	if err != nil || !committed.Ok() {
 		level.Error(r.logger).Log("msg", "encountered error while committing offsets", "err", err, "commit_err", committed.Error(), "offset", offset)
 	} else {

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -31,7 +31,7 @@ func TestPartitionReader(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
 
-	_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, ConsumerGroup)
+	_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 
 	content := []byte("special content")
 	consumer := newTestConsumer(2)
@@ -57,7 +57,7 @@ func TestReader_ConsumerError(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
 
-	_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, ConsumerGroup)
+	_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 
 	invocations := atomic.NewInt64(0)
 	returnErrors := atomic.NewBool(true)
@@ -102,7 +102,7 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 	setup := func(t *testing.T) (testConsumer, *PartitionReader, *kgo.Client, *prometheus.Registry) {
 		reg := prometheus.NewPedanticRegistry()
 
-		_, clusterAddr := testkafka.CreateCluster(t, 1, topicName, ConsumerGroup)
+		_, clusterAddr := testkafka.CreateCluster(t, 1, topicName)
 
 		// Create a consumer with no buffer capacity.
 		consumer := newTestConsumer(0)
@@ -329,7 +329,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 		ctx, cancel := context.WithCancelCause(context.Background())
 		t.Cleanup(func() { cancel(errors.New("test done")) })
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, ConsumerGroup)
+		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 
 		consumer := newTestConsumer(3)
 		reader := startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
@@ -361,7 +361,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 		ctx, cancel := context.WithCancelCause(context.Background())
 		t.Cleanup(func() { cancel(errors.New("test done")) })
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, ConsumerGroup)
+		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 
 		consumer := newTestConsumer(4)
 		reader := startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
@@ -390,7 +390,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 		ctx, cancel := context.WithCancelCause(context.Background())
 		t.Cleanup(func() { cancel(errors.New("test done")) })
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, ConsumerGroup)
+		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 
 		consumer := newTestConsumer(4)
 		reader := startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -58,14 +58,9 @@ func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registere
 
 		// Metrics.
 		writeLatency: promauto.With(reg).NewSummary(prometheus.SummaryOpts{
-			Name: "cortex_ingest_storage_writer_latency_seconds",
-			Help: "Latency to write an incoming request to the ingest storage.",
-			Objectives: map[float64]float64{
-				0.5:   0.05,
-				0.99:  0.001,
-				0.999: 0.001,
-				1:     0.001,
-			},
+			Name:       "cortex_ingest_storage_writer_latency_seconds",
+			Help:       "Latency to write an incoming request to the ingest storage.",
+			Objectives: latencySummaryObjectives,
 			MaxAge:     time.Minute,
 			AgeBuckets: 10,
 		}),

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -51,7 +51,7 @@ func TestWriter_WriteSync(t *testing.T) {
 	t.Run("should block until data has been committed to storage", func(t *testing.T) {
 		t.Parallel()
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		writer, reg := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
 
 		produceRequestProcessed := atomic.NewBool(false)
@@ -111,7 +111,7 @@ func TestWriter_WriteSync(t *testing.T) {
 			receivedBatchesLength   []int
 		)
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		writer, _ := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
 
 		cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
@@ -171,7 +171,7 @@ func TestWriter_WriteSync(t *testing.T) {
 			receivedBatchesLength   []int
 		)
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		writer, _ := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
 
 		// Allow only 1 in-flight Produce request in this test, to easily reproduce the scenario.
@@ -226,7 +226,7 @@ func TestWriter_WriteSync(t *testing.T) {
 	t.Run("should return error on non existing partition", func(t *testing.T) {
 		t.Parallel()
 
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		writer, _ := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
 
 		// Write to a non-existing partition.
@@ -237,7 +237,7 @@ func TestWriter_WriteSync(t *testing.T) {
 	t.Run("should return an error and stop retrying sending a record once the write timeout expires", func(t *testing.T) {
 		t.Parallel()
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
 		writer, _ := createTestWriter(t, kafkaCfg)
 
@@ -259,7 +259,7 @@ func TestWriter_WriteSync(t *testing.T) {
 	t.Run("should fail all buffered records and close the connection on timeout while waiting for Produce response", func(t *testing.T) {
 		t.Parallel()
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, ConsumerGroup)
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
 		writer, _ := createTestWriter(t, kafkaCfg)
 

--- a/pkg/util/testkafka/cluster.go
+++ b/pkg/util/testkafka/cluster.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CreateCluster returns a fake Kafka cluster for unit testing.
-func CreateCluster(t testing.TB, numPartitions int32, topicName, consumerGroup string) (*kfake.Cluster, string) {
+func CreateCluster(t testing.TB, numPartitions int32, topicName string) (*kfake.Cluster, string) {
 	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(numPartitions, topicName))
 	require.NoError(t, err)
 	t.Cleanup(cluster.Close)
@@ -20,6 +20,7 @@ func CreateCluster(t testing.TB, numPartitions int32, topicName, consumerGroup s
 	addrs := cluster.ListenAddrs()
 	require.Len(t, addrs, 1)
 
+	const consumerGroup = "mimir"
 	addSupportForConsumerGroups(t, cluster, topicName, numPartitions, consumerGroup)
 
 	return cluster, addrs[0]

--- a/pkg/util/testkafka/cluster.go
+++ b/pkg/util/testkafka/cluster.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package testkafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// CreateCluster returns a fake Kafka cluster for unit testing.
+func CreateCluster(t testing.TB, numPartitions int32, topicName, consumerGroup string) (*kfake.Cluster, string) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(numPartitions, topicName))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	addrs := cluster.ListenAddrs()
+	require.Len(t, addrs, 1)
+
+	addSupportForConsumerGroups(t, cluster, topicName, numPartitions, consumerGroup)
+
+	return cluster, addrs[0]
+}
+
+// addSupportForConsumerGroups adds very bare-bones support for one consumer group.
+// It expects that only one partition is consumed at a time.
+func addSupportForConsumerGroups(t testing.TB, cluster *kfake.Cluster, topicName string, numPartitions int32, consumerGroup string) {
+	committedOffsets := make([]int64, numPartitions+1)
+
+	cluster.ControlKey(kmsg.OffsetCommit.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		commitR := request.(*kmsg.OffsetCommitRequest)
+		assert.Equal(t, consumerGroup, commitR.Group)
+		assert.Len(t, commitR.Topics, 1, "test only has support for one topic per request")
+		topic := commitR.Topics[0]
+		assert.Equal(t, topicName, topic.Topic)
+		assert.Len(t, topic.Partitions, 1, "test only has support for one partition per request")
+
+		partitionID := topic.Partitions[0].Partition
+		committedOffsets[partitionID] = topic.Partitions[0].Offset
+
+		resp := request.ResponseKind().(*kmsg.OffsetCommitResponse)
+		resp.Default()
+		resp.Topics = []kmsg.OffsetCommitResponseTopic{
+			{
+				Topic:      topicName,
+				Partitions: []kmsg.OffsetCommitResponseTopicPartition{{Partition: partitionID}},
+			},
+		}
+
+		return resp, nil, true
+	})
+
+	cluster.ControlKey(kmsg.OffsetFetch.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		commitR := request.(*kmsg.OffsetFetchRequest)
+		assert.Len(t, commitR.Groups, 1, "test only has support for one consumer group per request")
+		assert.Equal(t, commitR.Groups[0].Group, consumerGroup)
+
+		const allPartitions = -1
+		var partitionID int32
+
+		if len(commitR.Groups[0].Topics) == 0 {
+			// An empty request means fetch all topic-partitions for this group.
+			partitionID = allPartitions
+		} else {
+			partitionID = commitR.Groups[0].Topics[0].Partitions[0]
+			assert.Len(t, commitR.Groups[0], 1, "test only has support for one partition per request")
+			assert.Len(t, commitR.Groups[0].Topics[0].Partitions, 1, "test only has support for one partition per request")
+		}
+
+		var partitionsResp []kmsg.OffsetFetchResponseGroupTopicPartition
+		if partitionID == allPartitions {
+			for i := int32(1); i < numPartitions+1; i++ {
+				partitionsResp = append(partitionsResp, kmsg.OffsetFetchResponseGroupTopicPartition{
+					Partition: i,
+					Offset:    committedOffsets[i],
+				})
+			}
+		} else {
+			partitionsResp = append(partitionsResp, kmsg.OffsetFetchResponseGroupTopicPartition{
+				Partition: partitionID,
+				Offset:    committedOffsets[partitionID],
+			})
+		}
+
+		resp := request.ResponseKind().(*kmsg.OffsetFetchResponse)
+		resp.Default()
+		resp.Groups = []kmsg.OffsetFetchResponseGroup{
+			{
+				Group: consumerGroup,
+				Topics: []kmsg.OffsetFetchResponseGroupTopic{
+					{
+						Topic:      topicName,
+						Partitions: partitionsResp,
+					},
+				},
+			},
+		}
+		return resp, nil, true
+	})
+}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
 	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	"github.com/grafana/mimir/pkg/util"
 )
 
 const (
@@ -404,7 +405,7 @@ func (l *Limits) validate() error {
 		return errInvalidMaxEstimatedChunksPerQueryMultiplier
 	}
 
-	if !api.IsValidReadConsistency(l.IngestStorageReadConsistency) {
+	if !util.StringsContain(api.ReadConsistencies, l.IngestStorageReadConsistency) {
 		return errInvalidIngestStorageReadConsistency
 	}
 

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
+	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 )
 
@@ -58,6 +59,11 @@ const (
 
 	// MinCompactorPartialBlockDeletionDelay is the minimum partial blocks deletion delay that can be configured in Mimir.
 	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
+)
+
+var (
+	errInvalidIngestStorageReadConsistency         = fmt.Errorf("invalid ingest storage read consistency (supported values: %s)", strings.Join(api.ReadConsistencies, ", "))
+	errInvalidMaxEstimatedChunksPerQueryMultiplier = errors.New("invalid value for -" + MaxEstimatedChunksPerQueryMultiplierFlag + ": must be 0 or greater than or equal to 1")
 )
 
 // LimitError is a marker interface for the errors that do not comply with the specified limits.
@@ -210,6 +216,9 @@ type Limits struct {
 	// OpenTelemetry
 	OTelMetricSuffixesEnabled bool `yaml:"otel_metric_suffixes_enabled" json:"otel_metric_suffixes_enabled" category:"advanced"`
 
+	// Ingest storage.
+	IngestStorageReadConsistency string `yaml:"ingest_storage_read_consistency" json:"ingest_storage_read_consistency" category:"experimental" doc:"hidden"`
+
 	extensions map[string]interface{}
 }
 
@@ -325,6 +334,9 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.AlertmanagerMaxDispatcherAggregationGroups, "alertmanager.max-dispatcher-aggregation-groups", 0, "Maximum number of aggregation groups in Alertmanager's dispatcher that a tenant can have. Each active aggregation group uses single goroutine. When the limit is reached, dispatcher will not dispatch alerts that belong to additional aggregation groups, but existing groups will keep working properly. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxAlertsCount, "alertmanager.max-alerts-count", 0, "Maximum number of alerts that a single tenant can have. Inserting more alerts will fail with a log message and metric increment. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxAlertsSizeBytes, "alertmanager.max-alerts-size-bytes", 0, "Maximum total size of alerts that a single tenant can have, alert size is the sum of the bytes of its labels, annotations and generatorURL. Inserting more alerts will fail with a log message and metric increment. 0 = no limit.")
+
+	// Ingest storage.
+	f.StringVar(&l.IngestStorageReadConsistency, "ingest-storage.read-consistency", api.ReadConsistencyEventual, fmt.Sprintf("The default consistency level to enforce to queries when using the ingest storage. Supports values: %s.", strings.Join(api.ReadConsistencies, ", ")))
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -389,7 +401,11 @@ func (l *Limits) validate() error {
 	}
 
 	if l.MaxEstimatedChunksPerQueryMultiplier < 1 && l.MaxEstimatedChunksPerQueryMultiplier != 0 {
-		return errors.New("invalid value for -" + MaxEstimatedChunksPerQueryMultiplierFlag + ": must be 0 or greater than or equal to 1")
+		return errInvalidMaxEstimatedChunksPerQueryMultiplier
+	}
+
+	if !api.IsValidReadConsistency(l.IngestStorageReadConsistency) {
+		return errInvalidIngestStorageReadConsistency
 	}
 
 	return nil
@@ -937,6 +953,10 @@ func (o *Overrides) OTelMetricSuffixesEnabled(tenantID string) bool {
 
 func (o *Overrides) AlignQueriesWithStep(userID string) bool {
 	return o.getOverridesForUser(userID).AlignQueriesWithStep
+}
+
+func (o *Overrides) IngestStorageReadConsistency(userID string) string {
+	return o.getOverridesForUser(userID).IngestStorageReadConsistency
 }
 
 func (o *Overrides) getOverridesForUser(userID string) *Limits {

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -813,11 +813,6 @@ func TestExtensions(t *testing.T) {
 	})
 
 	t.Run("default limits does not interfere with tenants extensions", func(t *testing.T) {
-		// Reset the default limits at the end of the test.
-		t.Cleanup(func() {
-			SetDefaultLimitsForYAMLUnmarshalling(getDefaultLimits())
-		})
-
 		// This test makes sure that sharing the default limits does not leak extensions values between tenants.
 		// Since we assign l = *defaultLimits before unmarshaling,
 		// there's a chance of unmarshaling on top of a reference that is already being used in different tenant's limits.
@@ -825,6 +820,12 @@ func TestExtensions(t *testing.T) {
 		def := getDefaultLimits()
 		require.NoError(t, json.Unmarshal([]byte(`{"test_extension_string": "default"}`), &def), "parsing overrides")
 		require.Equal(t, stringExtension("default"), getExtensionString(&def))
+
+		// Reset the default limits at the end of the test.
+		t.Cleanup(func() {
+			SetDefaultLimitsForYAMLUnmarshalling(getDefaultLimits())
+		})
+
 		SetDefaultLimitsForYAMLUnmarshalling(def)
 
 		cfg := `{"one": {"test_extension_string": "one"}, "two": {"test_extension_string": "two"}}`


### PR DESCRIPTION
#### What this PR does

This is another step forward in the experimental ingest storage conditional read-after-write implementation. In this PR I'm introducing a per-tenant config option to set the default read consistency guarantee (used only when ingest storage is enabled). When the read consistency is set to `strong`, then in the ingester we wait until all the data has been replayed from Kafka up until that point before executing a query.

Notes:
- The per-query conditional support will be later upstreamed by @dimitarvdimitrov (work was done by him).
- In the ingester unit tests I've picked a simple path, just testing `QueryStream()`. Reason why I would suggest to not test every function for now is because we may change the strong consistency implementation later, moving it from the ingester to an upper layer in the read path.
- Some tests on runtime config / limits have changed because we need to use the Limits initialised with defaults (like Mimir real logic does) and not the zero value. If we don't do it, then the new validation I've introduced will fail.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
