### PR TITLE
Fix context cancellation handling when request is canceled while querying ingester

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,8 @@ lint: check-makefiles
 
 	# Ensure we use our custom gRPC clients.
 	faillint -paths \
-		"github.com/grafana/mimir/pkg/storegateway/storegatewaypb.{NewStoreGatewayClient}=github.com/grafana/mimir/pkg/storegateway/storegatewaypb.NewCustomStoreGatewayClient" \
+		"github.com/grafana/mimir/pkg/ingester/client.{NewIngesterClient}=github.com/grafana/mimir/pkg/ingester/client.NewWrappedIngesterClient, \
+		github.com/grafana/mimir/pkg/storegateway/storegatewaypb.{NewStoreGatewayClient}=github.com/grafana/mimir/pkg/storegateway/storegatewaypb.NewCustomStoreGatewayClient" \
 		./pkg/... ./cmd/... ./tools/... ./integration/...
 
 format: ## Run gofmt and goimports.

--- a/pkg/ingester/client/buffering_client_test.go
+++ b/pkg/ingester/client/buffering_client_test.go
@@ -51,7 +51,7 @@ func TestWriteRequestBufferingClient_Push(t *testing.T) {
 	serv, conn := setupGrpc(t)
 
 	// Converted to IngesterClient to make sure we only use methods from the interface.
-	bufferingClient := IngesterClient(newBufferPoolingIngesterClient(NewIngesterClient(conn), conn))
+	bufferingClient := IngesterClient(newBufferPoolingIngesterClient(NewWrappedIngesterClient(conn), conn))
 
 	var requestsToSend []*mimirpb.WriteRequest
 	for i := 0; i < 10; i++ {
@@ -95,7 +95,7 @@ func TestWriteRequestBufferingClient_Push(t *testing.T) {
 func TestWriteRequestBufferingClient_PushWithCancelContext(t *testing.T) {
 	_, conn := setupGrpc(t)
 
-	bufferingClient := IngesterClient(newBufferPoolingIngesterClient(NewIngesterClient(conn), conn))
+	bufferingClient := IngesterClient(newBufferPoolingIngesterClient(NewWrappedIngesterClient(conn), conn))
 
 	var requestsToSend []*mimirpb.WriteRequest
 	for i := 0; i < 100; i++ {
@@ -128,7 +128,7 @@ func TestWriteRequestBufferingClient_PushWithCancelContext(t *testing.T) {
 func TestWriteRequestBufferingClient_Push_WithMultipleMarshalCalls(t *testing.T) {
 	serv, conn := setupGrpc(t)
 
-	bufferingClient := newBufferPoolingIngesterClient(NewIngesterClient(conn), conn)
+	bufferingClient := newBufferPoolingIngesterClient(NewWrappedIngesterClient(conn), conn)
 	bufferingClient.pushRawFn = func(ctx context.Context, conn *grpc.ClientConn, msg interface{}, opts ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
 		// Call Marshal several times. We are testing if all buffers from the pool are returned.
 		_, _ = msg.(*wrappedRequest).Marshal()
@@ -188,7 +188,7 @@ func BenchmarkWriteRequestBufferingClient_Push(b *testing.B) {
 func TestWriteRequestBufferingClient_PushConcurrent(t *testing.T) {
 	serv, conn := setupGrpc(t)
 
-	bufferingClient := newBufferPoolingIngesterClient(NewIngesterClient(conn), conn)
+	bufferingClient := newBufferPoolingIngesterClient(NewWrappedIngesterClient(conn), conn)
 	serv.trackSamples = true
 
 	pool := &pool2.TrackedPool{Parent: &sync.Pool{}}

--- a/pkg/ingester/client/client.go
+++ b/pkg/ingester/client/client.go
@@ -53,7 +53,7 @@ func MakeIngesterClient(inst ring.InstanceDesc, cfg Config, metrics *Metrics, lo
 		return nil, err
 	}
 
-	ingClient := NewIngesterClient(conn)
+	ingClient := NewWrappedIngesterClient(conn)
 	ingClient = newBufferPoolingIngesterClient(ingClient, conn)
 
 	return &closableHealthAndIngesterClient{

--- a/pkg/ingester/client/ingester.wrapped.go
+++ b/pkg/ingester/client/ingester.wrapped.go
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package client
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+// wrappedIngesterClient is a custom IngesterClient which wraps well known gRPC errors into standard golang errors.
+type wrappedIngesterClient struct {
+	wrapped IngesterClient
+}
+
+func NewWrappedIngesterClient(cc *grpc.ClientConn) IngesterClient {
+	return &wrappedIngesterClient{
+		wrapped: NewIngesterClient(cc),
+	}
+}
+
+func (c *wrappedIngesterClient) Push(ctx context.Context, in *mimirpb.WriteRequest, opts ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
+	res, err := c.wrapped.Push(ctx, in, opts...)
+	return res, wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) QueryStream(ctx context.Context, in *QueryRequest, opts ...grpc.CallOption) (Ingester_QueryStreamClient, error) {
+	res, err := c.wrapped.QueryStream(ctx, in, opts...)
+	return wrapIngesterQueryStreamClient(res), wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) QueryExemplars(ctx context.Context, in *ExemplarQueryRequest, opts ...grpc.CallOption) (*ExemplarQueryResponse, error) {
+	res, err := c.wrapped.QueryExemplars(ctx, in, opts...)
+	return res, wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) LabelValues(ctx context.Context, in *LabelValuesRequest, opts ...grpc.CallOption) (*LabelValuesResponse, error) {
+	res, err := c.wrapped.LabelValues(ctx, in, opts...)
+	return res, wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) LabelNames(ctx context.Context, in *LabelNamesRequest, opts ...grpc.CallOption) (*LabelNamesResponse, error) {
+	res, err := c.wrapped.LabelNames(ctx, in, opts...)
+	return res, wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) UserStats(ctx context.Context, in *UserStatsRequest, opts ...grpc.CallOption) (*UserStatsResponse, error) {
+	res, err := c.wrapped.UserStats(ctx, in, opts...)
+	return res, wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) AllUserStats(ctx context.Context, in *UserStatsRequest, opts ...grpc.CallOption) (*UsersStatsResponse, error) {
+	res, err := c.wrapped.AllUserStats(ctx, in, opts...)
+	return res, wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) MetricsForLabelMatchers(ctx context.Context, in *MetricsForLabelMatchersRequest, opts ...grpc.CallOption) (*MetricsForLabelMatchersResponse, error) {
+	res, err := c.wrapped.MetricsForLabelMatchers(ctx, in, opts...)
+	return res, wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) MetricsMetadata(ctx context.Context, in *MetricsMetadataRequest, opts ...grpc.CallOption) (*MetricsMetadataResponse, error) {
+	res, err := c.wrapped.MetricsMetadata(ctx, in, opts...)
+	return res, wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) LabelNamesAndValues(ctx context.Context, in *LabelNamesAndValuesRequest, opts ...grpc.CallOption) (Ingester_LabelNamesAndValuesClient, error) {
+	res, err := c.wrapped.LabelNamesAndValues(ctx, in, opts...)
+	return wrapIngesterLabelNamesAndValuesClient(res), wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) LabelValuesCardinality(ctx context.Context, in *LabelValuesCardinalityRequest, opts ...grpc.CallOption) (Ingester_LabelValuesCardinalityClient, error) {
+	res, err := c.wrapped.LabelValuesCardinality(ctx, in, opts...)
+	return wrapIngesterLabelValuesCardinalityClient(res), wrapContextError(err)
+}
+
+func (c *wrappedIngesterClient) ActiveSeries(ctx context.Context, in *ActiveSeriesRequest, opts ...grpc.CallOption) (Ingester_ActiveSeriesClient, error) {
+	res, err := c.wrapped.ActiveSeries(ctx, in, opts...)
+	return wrapIngesterActiveSeriesClient(res), wrapContextError(err)
+}
+
+type wrappedIngesterQueryStreamClient struct {
+	*wrappedClientStream
+
+	wrapped Ingester_QueryStreamClient
+}
+
+func wrapIngesterQueryStreamClient(client Ingester_QueryStreamClient) *wrappedIngesterQueryStreamClient {
+	if client == nil {
+		return nil
+	}
+
+	return &wrappedIngesterQueryStreamClient{
+		wrappedClientStream: &wrappedClientStream{client},
+		wrapped:             client,
+	}
+}
+
+func (c *wrappedIngesterQueryStreamClient) Recv() (*QueryStreamResponse, error) {
+	res, err := c.wrapped.Recv()
+	return res, wrapContextError(err)
+}
+
+type wrappedIngesterLabelNamesAndValuesClient struct {
+	*wrappedClientStream
+
+	wrapped Ingester_LabelNamesAndValuesClient
+}
+
+func wrapIngesterLabelNamesAndValuesClient(client Ingester_LabelNamesAndValuesClient) *wrappedIngesterLabelNamesAndValuesClient {
+	if client == nil {
+		return nil
+	}
+
+	return &wrappedIngesterLabelNamesAndValuesClient{
+		wrappedClientStream: &wrappedClientStream{client},
+		wrapped:             client,
+	}
+}
+
+func (c *wrappedIngesterLabelNamesAndValuesClient) Recv() (*LabelNamesAndValuesResponse, error) {
+	res, err := c.wrapped.Recv()
+	return res, wrapContextError(err)
+}
+
+type wrappedIngesterLabelValuesCardinalityClient struct {
+	*wrappedClientStream
+
+	wrapped Ingester_LabelValuesCardinalityClient
+}
+
+func wrapIngesterLabelValuesCardinalityClient(client Ingester_LabelValuesCardinalityClient) *wrappedIngesterLabelValuesCardinalityClient {
+	if client == nil {
+		return nil
+	}
+
+	return &wrappedIngesterLabelValuesCardinalityClient{
+		wrappedClientStream: &wrappedClientStream{client},
+		wrapped:             client,
+	}
+}
+
+func (c *wrappedIngesterLabelValuesCardinalityClient) Recv() (*LabelValuesCardinalityResponse, error) {
+	res, err := c.wrapped.Recv()
+	return res, wrapContextError(err)
+}
+
+type wrappedIngesterActiveSeriesClient struct {
+	*wrappedClientStream
+
+	wrapped Ingester_ActiveSeriesClient
+}
+
+func wrapIngesterActiveSeriesClient(client Ingester_ActiveSeriesClient) *wrappedIngesterActiveSeriesClient {
+	if client == nil {
+		return nil
+	}
+
+	return &wrappedIngesterActiveSeriesClient{
+		wrappedClientStream: &wrappedClientStream{client},
+		wrapped:             client,
+	}
+}
+
+func (c *wrappedIngesterActiveSeriesClient) Recv() (*ActiveSeriesResponse, error) {
+	res, err := c.wrapped.Recv()
+	return res, wrapContextError(err)
+}
+
+// TODO move everything below this to dskit
+
+func wrapContextError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Get the gRPC status from the error.
+	type grpcErrorStatus interface{ GRPCStatus() *grpcstatus.Status }
+	var grpcError grpcErrorStatus
+	if !errors.As(err, &grpcError) {
+		return err
+	}
+
+	switch status := grpcError.GRPCStatus(); {
+	case status.Code() == codes.Canceled:
+		return &grpcContextError{grpcErr: err, grpcStatus: status, stdErr: context.Canceled}
+	case status.Code() == codes.DeadlineExceeded:
+		return &grpcContextError{grpcErr: err, grpcStatus: status, stdErr: context.DeadlineExceeded}
+	default:
+		return err
+	}
+}
+
+// grpcContextError is a custom error used to wrap gRPC errors which maps to golang standard context errors.
+type grpcContextError struct {
+	// grpcErr is the gRPC error wrapped by grpcContextError.
+	grpcErr error
+
+	// grpcStatus is the gRPC status associated with the gRPC error. It's guaranteed to be non-nil.
+	grpcStatus *grpcstatus.Status
+
+	// stdErr is the equivalent golang standard context error.
+	stdErr error
+}
+
+func (e *grpcContextError) Error() string {
+	return e.grpcErr.Error()
+}
+
+func (e *grpcContextError) Unwrap() error {
+	return e.grpcErr
+}
+
+func (e *grpcContextError) Is(err error) bool {
+	return errors.Is(e.stdErr, err) || errors.Is(e.grpcErr, err)
+}
+
+func (e *grpcContextError) As(target any) bool {
+	if errors.As(e.stdErr, target) {
+		return true
+	}
+
+	return errors.As(e.grpcErr, target)
+}
+
+func (e *grpcContextError) GRPCStatus() *grpcstatus.Status {
+	return e.grpcStatus
+}
+
+// wrappedClientStream is a custom grpc.ClientStream which wraps well known gRPC errors into standard golang errors.
+type wrappedClientStream struct {
+	wrapped grpc.ClientStream
+}
+
+// Header implements grpc.ClientStream.
+func (c *wrappedClientStream) Header() (metadata.MD, error) {
+	md, err := c.wrapped.Header()
+	return md, wrapContextError(err)
+}
+
+// Trailer implements grpc.ClientStream.
+func (c *wrappedClientStream) Trailer() metadata.MD {
+	return c.wrapped.Trailer()
+}
+
+// CloseSend implements grpc.ClientStream.
+func (c *wrappedClientStream) CloseSend() error {
+	//nolint:forbidigo // Here we're just wrapping CloseSend() so it's OK to call it.
+	return wrapContextError(c.wrapped.CloseSend())
+}
+
+// Context implements grpc.ClientStream.
+func (c *wrappedClientStream) Context() context.Context {
+	return c.wrapped.Context()
+}
+
+// SendMsg implements grpc.ClientStream.
+func (c *wrappedClientStream) SendMsg(m any) error {
+	return wrapContextError(c.wrapped.SendMsg(m))
+}
+
+// RecvMsg implements grpc.ClientStream.
+func (c *wrappedClientStream) RecvMsg(m any) error {
+	return wrapContextError(c.wrapped.RecvMsg(m))
+}

--- a/pkg/ingester/client/mimir_util_test.go
+++ b/pkg/ingester/client/mimir_util_test.go
@@ -72,7 +72,7 @@ func TestSendQueryStream(t *testing.T) {
 	}()
 	t.Cleanup(server.Stop)
 
-	client := NewIngesterClient(conn)
+	client := NewWrappedIngesterClient(conn)
 	stream, err := client.QueryStream(clientCtx, &QueryRequest{})
 	require.NoError(t, err)
 

--- a/pkg/storegateway/storegatewaypb/custom.go
+++ b/pkg/storegateway/storegatewaypb/custom.go
@@ -32,7 +32,7 @@ func (c *customStoreGatewayClient) Series(ctx context.Context, in *storepb.Serie
 		return client, wrapContextError(err)
 	}
 
-	return newCustomSeriesClient(client), nil
+	return wrapStoreGatewaySeriesClient(client), nil
 }
 
 // LabelNames implements StoreGatewayClient.
@@ -54,7 +54,7 @@ type customSeriesClient struct {
 	wrapped StoreGateway_SeriesClient
 }
 
-func newCustomSeriesClient(client StoreGateway_SeriesClient) *customSeriesClient {
+func wrapStoreGatewaySeriesClient(client StoreGateway_SeriesClient) *customSeriesClient {
 	return &customSeriesClient{
 		customClientStream: &customClientStream{client},
 		wrapped:            client,


### PR DESCRIPTION
#### What this PR does

This is like https://github.com/grafana/mimir/pull/6934 but for the ingester client. There are some places where context error returned by ingester client are not correctly handled, like [here](https://github.com/grafana/mimir/blob/main/pkg/ingester/client/streaming.go#L111-L125) and [here](https://github.com/grafana/mimir/blob/4b64a89316dc24d60287be06be38422085a9ede4/pkg/distributor/distributor.go#L1325-L1327). This PR is expected to fix it.

Draft because:
- Missing unit tests
- Missing CHANGELOG entry
- Want to move common logic to dskit gRPC utils

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir-squad/issues/1788

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
