### PR TITLE
[query-frontend] Set http request headers from querymiddleware request options

### DIFF
--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -390,7 +390,7 @@ func (c prometheusCodec) EncodeRequest(ctx context.Context, r Request) (*http.Re
 		Header:     http.Header{},
 	}
 
-	setRequestHeadersFromOptions(req, r.GetOptions())
+	encodeOptions(req, r.GetOptions())
 
 	switch c.preferredQueryResultResponseFormat {
 	case formatJSON:
@@ -404,7 +404,7 @@ func (c prometheusCodec) EncodeRequest(ctx context.Context, r Request) (*http.Re
 	return req.WithContext(ctx), nil
 }
 
-func setRequestHeadersFromOptions(req *http.Request, o Options) {
+func encodeOptions(req *http.Request, o Options) {
 	if o.CacheDisabled {
 		req.Header.Set(cacheControlHeader, noStoreValue)
 	}

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -408,14 +408,14 @@ func setRequestHeadersFromOptions(req *http.Request, o Options) {
 	if o.ShardingDisabled {
 		req.Header.Set(totalShardsControlHeader, "0")
 	}
-	if totalShards := o.TotalShards; totalShards > 0 {
-		req.Header.Set(totalShardsControlHeader, strconv.Itoa(int(totalShards)))
+	if o.TotalShards > 0 {
+		req.Header.Set(totalShardsControlHeader, strconv.Itoa(int(o.TotalShards)))
 	}
 	if o.InstantSplitDisabled {
 		req.Header.Set(instantSplitControlHeader, "0")
 	}
-	if instantSplitInterval := o.InstantSplitInterval; instantSplitInterval > 0 {
-		req.Header.Set(instantSplitControlHeader, time.Duration(instantSplitInterval).String())
+	if o.InstantSplitInterval > 0 {
+		req.Header.Set(instantSplitControlHeader, time.Duration(o.InstantSplitInterval).String())
 	}
 }
 

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -405,6 +405,9 @@ func (c prometheusCodec) EncodeRequest(ctx context.Context, r Request) (*http.Re
 }
 
 func setRequestHeadersFromOptions(req *http.Request, o Options) {
+	if o.CacheDisabled {
+		req.Header.Set(cacheControlHeader, noStoreValue)
+	}
 	if o.ShardingDisabled {
 		req.Header.Set(totalShardsControlHeader, "0")
 	}

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
@@ -902,6 +903,63 @@ func Test_DecodeOptions(t *testing.T) {
 			actual := &Options{}
 			decodeOptions(tt.input, actual)
 			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+// TestPrometheusCodec_DecodeEncode tests that decoding and re-encoding a
+// request does not lose relevant information about the original request.
+func TestPrometheusCodec_DecodeEncode(t *testing.T) {
+	codec := newTestPrometheusCodec().(prometheusCodec)
+	for _, tt := range []struct {
+		name    string
+		headers http.Header
+	}{
+		{
+			name: "no custom headers",
+		},
+		{
+			name:    "shard count header",
+			headers: http.Header{totalShardsControlHeader: []string{"128"}},
+		},
+		{
+			name:    "shard count disabled via header",
+			headers: http.Header{totalShardsControlHeader: []string{"0"}},
+		},
+		{
+			name:    "split interval header",
+			headers: http.Header{instantSplitControlHeader: []string{"1h0m0s"}},
+		},
+		{
+			name:    "split interval disabled via header",
+			headers: http.Header{instantSplitControlHeader: []string{"0"}},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			queryURL := "/api/v1/query?query=sum%28container_memory_rss%29+by+%28namespace%29&time=1704270202.066"
+			expected, err := http.NewRequest("GET", queryURL, nil)
+			require.NoError(t, err)
+			expected.Body = http.NoBody
+			expected.Header = tt.headers
+			if expected.Header == nil {
+				expected.Header = make(http.Header)
+			}
+
+			// This header is set by EncodeRequest according to the codec's config, so we
+			// should always expect it to be present on the re-encoded request.
+			expected.Header.Set("Accept", "application/json")
+
+			ctx := context.Background()
+			decoded, err := codec.DecodeRequest(ctx, expected)
+			require.NoError(t, err)
+			encoded, err := codec.EncodeRequest(ctx, decoded)
+			require.NoError(t, err)
+
+			assert.Equal(t, expected.URL, encoded.URL)
+			assert.Equal(t, expected.Header, encoded.Header)
 		})
 	}
 }

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -934,6 +934,10 @@ func TestPrometheusCodec_DecodeEncode(t *testing.T) {
 			name:    "split interval disabled via header",
 			headers: http.Header{instantSplitControlHeader: []string{"0"}},
 		},
+		{
+			name:    "cache disabled via header",
+			headers: http.Header{cacheControlHeader: []string{noStoreValue}},
+		},
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

`prometheusCodec` provides the methods `DecodeRequest` and `EncodeRequest` to convert from an `http.Request` to a `querymiddleware.Request` and back. The conversion from an http request sets values in the request options, but these are not considered for the conversion back to an http request. As a consequence, the http request obtained by decoding and re-encoding is not equivalent to the original request in cases where custom headers were present on the initial request.

This PR adds http headers equivalent to the request options to fix this.

#### Which issue(s) this PR fixes or relates to

Fixes n/a

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
