### PR TITLE
Fix flaky TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates

### DIFF
--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -413,9 +413,9 @@ func TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates(t *testing.T) {
 
 	// Create the loader.
 	cfg := LoaderConfig{
-		CheckInterval:         time.Second,
-		UpdateOnStaleInterval: time.Second,
-		UpdateOnErrorInterval: time.Second,
+		CheckInterval:         100 * time.Millisecond,
+		UpdateOnStaleInterval: 100 * time.Millisecond,
+		UpdateOnErrorInterval: time.Hour, // Intentionally high to not hit it.
 		IdleTimeout:           time.Hour, // Intentionally high to not hit it.
 	}
 
@@ -433,22 +433,19 @@ func TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates(t *testing.T) {
 	require.NoError(t, DeleteIndex(ctx, bkt, "user-1", nil))
 
 	// Wait until the next index load attempt occurs.
-	prevLoads := testutil.ToFloat64(loader.loadAttempts)
-	test.Poll(t, 3*time.Second, true, func() interface{} {
-		return testutil.ToFloat64(loader.loadAttempts) > prevLoads
-	})
-
 	// We expect the bucket index is not considered loaded because of the error.
-	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+	test.Poll(t, 3*time.Second, nil, func() interface{} {
+		return testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 			# HELP cortex_bucket_index_loaded Number of bucket indexes currently loaded in-memory.
 			# TYPE cortex_bucket_index_loaded gauge
 			cortex_bucket_index_loaded 0
 		`),
-		"cortex_bucket_index_loaded",
-	))
+			"cortex_bucket_index_loaded",
+		)
+	})
 
 	// Try to get the index again. We expect no load attempt because the error has been cached.
-	prevLoads = testutil.ToFloat64(loader.loadAttempts)
+	prevLoads := testutil.ToFloat64(loader.loadAttempts)
 	actualIdx, err = loader.GetIndex(ctx, "user-1")
 	assert.Equal(t, ErrIndexNotFound, err)
 	assert.Nil(t, actualIdx)


### PR DESCRIPTION
#### What this PR does

I've noticed that `TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates` is flaky while [running in CI](https://github.com/grafana/mimir/actions/runs/7398345777/job/20127331406?pr=7030) for another PR:

```
--- FAIL: TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates (1.15s)
    loader_test.go:442: 
        	Error Trace:	/__w/mimir/mimir/pkg/storage/tsdb/bucketindex/loader_test.go:442
        	Error:      	Received unexpected error:
        	            	
        	            	
        	            	Diff:
        	            	--- metric output does not match expectation; want
        	            	+++ got:
        	            	@@ -2,3 +2,3 @@
        	            	 # TYPE cortex_bucket_index_loaded gauge
        	            	-cortex_bucket_index_loaded 0
        	            	+cortex_bucket_index_loaded 1
        	            	 
        	Test:       	TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates
FAIL
```

The reason why `TestLoader_ShouldCacheIndexNotFoundOnBackgroundUpdates` is flaky is because the `loadAttempts` metric is increased before we read the bucket index from storage (by design), while in the test we need to wait until the attempt is complete. Since we expect the attempt will fail, but the `loadFailures` will not be tracked because it's not tracked when it fails because of a non existing bucket index (the test condition), than to fix the test I've simply removed that wait at all and asserted on the metric using a pool.

I've manually test it running with `-count=100` (before this PR it was failing consistently).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
