### PR TITLE
Ensure cardinality estimate cache keys are valid

### DIFF
--- a/pkg/frontend/querymiddleware/cardinality.go
+++ b/pkg/frontend/querymiddleware/cardinality.go
@@ -171,6 +171,11 @@ func generateCardinalityEstimationCacheKey(userID string, r Request, bucketSize 
 	startBucket := (r.GetStart() + int64(offset)) / bucketSize.Milliseconds()
 	rangeBucket := (r.GetEnd() - r.GetStart()) / bucketSize.Milliseconds()
 
+	// Apply a hash function to user controlled input to make sure we don't exceed
+	// the max number of bytes for the cache key (250 bytes in Memcached).
+	queryHash := cacheHashKey(r.GetQuery())
+	userIDHash := cacheHashKey(userID)
+
 	// Prefix key with `QS` (short for "query statistics").
-	return fmt.Sprintf("QS:%s:%s:%d:%d", userID, cacheHashKey(r.GetQuery()), startBucket, rangeBucket)
+	return fmt.Sprintf("QS:%s:%s:%d:%d", userIDHash, queryHash, startBucket, rangeBucket)
 }

--- a/pkg/frontend/querymiddleware/cardinality_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_test.go
@@ -39,7 +39,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_keyFormat(t *testing.T) {
 				Time:  requestTime.UnixMilli(),
 				Query: "up",
 			},
-			expected: fmt.Sprintf("QS:tenant-a:%s:%d:%d", cacheHashKey("up"), daysSinceEpoch, 0),
+			expected: fmt.Sprintf("QS:%s:%s:%d:%d", cacheHashKey("tenant-a"), cacheHashKey("up"), daysSinceEpoch, 0),
 		},
 		{
 			name:   "range query",
@@ -49,7 +49,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_keyFormat(t *testing.T) {
 				End:   requestTime.Add(2 * time.Hour).UnixMilli(),
 				Query: "up",
 			},
-			expected: fmt.Sprintf("QS:tenant-b:%s:%d:%d", cacheHashKey("up"), daysSinceEpoch, 0),
+			expected: fmt.Sprintf("QS:%s:%s:%d:%d", cacheHashKey("tenant-b"), cacheHashKey("up"), daysSinceEpoch, 0),
 		},
 		{
 			name:   "range query with large range",
@@ -60,7 +60,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_keyFormat(t *testing.T) {
 				End:   requestTime.Add(25 * time.Hour).UnixMilli(),
 				Query: "up",
 			},
-			expected: fmt.Sprintf("QS:tenant-b:%s:%d:%d", cacheHashKey("up"), daysSinceEpoch, 1),
+			expected: fmt.Sprintf("QS:%s:%s:%d:%d", cacheHashKey("tenant-b"), cacheHashKey("up"), daysSinceEpoch, 1),
 		},
 	}
 


### PR DESCRIPTION
#### What this PR does

Ensure that cache keys generated from cardinality estimate middleware are less than 250 bytes in length by hashing the tenant IDs that are included in them. This is especially evident when using tenant federation where multiple tenant IDs in a request.

#### Which issue(s) this PR fixes or relates to

Fixes #6931

#### Checklist

- [X] Tests updated.
- [NA] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
