### PR TITLE
Write query parameters to span attributes instead of events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   * `-ingester.ring.spread-minimizing-join-ring-in-order`
 * [CHANGE] Query-frontend: the default value of the CLI flag `-query-frontend.max-cache-freshness` (and its respective YAML configuration parameter) has been changed from `1m` to `10m`. #7161
 * [CHANGE] Distributor: default the optimization `-distributor.write-requests-buffer-pooling-enabled` to `true`. #7165
+* [CHANGE] Tracing: Move query information to span attributes instead of span logs. #7046
 * [FEATURE] Introduce `-tenant-federation.max-tenants` option to limit the max number of tenants allowed for requests when federation is enabled. #6959
 * [FEATURE] Cardinality API: added a new `count_method` parameter which enables counting active label values. #7085
 * [FEATURE] Querier / query-frontend: added `-querier.promql-experimental-functions-enabled` CLI flag (and respective YAML config option) to enable experimental PromQL functions. The experimental functions introduced are: `mad_over_time()`, `sort_by_label()` and `sort_by_label_desc()`. #7057

--- a/cmd/mimir-continuous-test/main.go
+++ b/cmd/mimir-continuous-test/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/dskit/tracing"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
 
 	"github.com/grafana/mimir/pkg/continuoustest"
 	"github.com/grafana/mimir/pkg/util/instrumentation"
@@ -50,7 +51,7 @@ func main() {
 	util_log.InitLogger(log.LogfmtFormat, cfg.LogLevel, false, util_log.RateLimitedLoggerCfg{})
 
 	// Setting the environment variable JAEGER_AGENT_HOST enables tracing.
-	if trace, err := tracing.NewFromEnv("mimir-continuous-test"); err != nil {
+	if trace, err := tracing.NewFromEnv("mimir-continuous-test", jaegercfg.MaxTagValueLength(16e3)); err != nil {
 		level.Error(util_log.Logger).Log("msg", "Failed to setup tracing", "err", err.Error())
 	} else {
 		defer trace.Close()

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/dskit/tracing"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/mimir"
@@ -193,7 +194,7 @@ func main() {
 		}
 
 		// Setting the environment variable JAEGER_AGENT_HOST enables tracing.
-		if trace, err := tracing.NewFromEnv(name); err != nil {
+		if trace, err := tracing.NewFromEnv(name, jaegercfg.MaxTagValueLength(16e3)); err != nil {
 			level.Error(util_log.Logger).Log("msg", "Failed to setup tracing", "err", err.Error())
 		} else {
 			defer trace.Close()

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -111,8 +111,8 @@ type Request interface {
 	// WithEstimatedSeriesCountHint WithEstimatedCardinalityHint adds a cardinality estimate to this request's Hints.
 	WithEstimatedSeriesCountHint(uint64) Request
 	proto.Message
-	// LogToSpan writes information about this request to an OpenTracing span
-	LogToSpan(opentracing.Span)
+	// AddSpanTags writes information about this request to an OpenTracing span
+	AddSpanTags(opentracing.Span)
 }
 
 // Response represents a query range response.

--- a/pkg/frontend/querymiddleware/instrumentation.go
+++ b/pkg/frontend/querymiddleware/instrumentation.go
@@ -32,7 +32,7 @@ func newInstrumentMiddleware(name string, metrics *instrumentMiddlewareMetrics) 
 			err := instrument.CollectedRequest(ctx, name, durationCol, instrument.ErrorCode, func(ctx context.Context) error {
 				sp := opentracing.SpanFromContext(ctx)
 				if sp != nil {
-					req.LogToSpan(sp)
+					req.AddSpanTags(sp)
 				}
 
 				var err error

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -231,7 +231,7 @@ func (rt limitedParallelismRoundTripper) RoundTrip(r *http.Request) (*http.Respo
 	}
 
 	if span := opentracing.SpanFromContext(ctx); span != nil {
-		request.LogToSpan(span)
+		request.AddSpanTags(span)
 	}
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -16,7 +16,6 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/timestamp"
 
@@ -92,14 +91,13 @@ func (q *PrometheusRangeQueryRequest) WithEstimatedSeriesCountHint(count uint64)
 	return &newRequest
 }
 
-// LogToSpan logs the current `PrometheusRangeQueryRequest` parameters to the specified span.
+// LogToSpan writes the current `PrometheusRangeQueryRequest` parameters to the specified span tags
+// ("attributes" in OpenTelemetry parlance).
 func (q *PrometheusRangeQueryRequest) LogToSpan(sp opentracing.Span) {
-	sp.LogFields(
-		otlog.String("query", q.GetQuery()),
-		otlog.String("start", timestamp.Time(q.GetStart()).String()),
-		otlog.String("end", timestamp.Time(q.GetEnd()).String()),
-		otlog.Int64("step (ms)", q.GetStep()),
-	)
+	sp.SetTag("query", q.GetQuery())
+	sp.SetTag("start", timestamp.Time(q.GetStart()).String())
+	sp.SetTag("end", timestamp.Time(q.GetEnd()).String())
+	sp.SetTag("step_ms", q.GetStep())
 }
 
 func (r *PrometheusInstantQueryRequest) GetStart() int64 {
@@ -156,11 +154,11 @@ func (r *PrometheusInstantQueryRequest) WithEstimatedSeriesCountHint(count uint6
 	return &newRequest
 }
 
+// LogToSpan writes query information about the current `PrometheusInstantQueryRequest`
+// to a span's tag ("attributes" in OpenTelemetry parlance).
 func (r *PrometheusInstantQueryRequest) LogToSpan(sp opentracing.Span) {
-	sp.LogFields(
-		otlog.String("query", r.GetQuery()),
-		otlog.String("time", timestamp.Time(r.GetTime()).String()),
-	)
+	sp.SetTag("query", r.GetQuery())
+	sp.SetTag("time", timestamp.Time(r.GetTime()).String())
 }
 
 func (d *PrometheusData) UnmarshalJSON(b []byte) error {

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -91,9 +91,9 @@ func (q *PrometheusRangeQueryRequest) WithEstimatedSeriesCountHint(count uint64)
 	return &newRequest
 }
 
-// LogToSpan writes the current `PrometheusRangeQueryRequest` parameters to the specified span tags
+// AddSpanTags writes the current `PrometheusRangeQueryRequest` parameters to the specified span tags
 // ("attributes" in OpenTelemetry parlance).
-func (q *PrometheusRangeQueryRequest) LogToSpan(sp opentracing.Span) {
+func (q *PrometheusRangeQueryRequest) AddSpanTags(sp opentracing.Span) {
 	sp.SetTag("query", q.GetQuery())
 	sp.SetTag("start", timestamp.Time(q.GetStart()).String())
 	sp.SetTag("end", timestamp.Time(q.GetEnd()).String())
@@ -154,9 +154,9 @@ func (r *PrometheusInstantQueryRequest) WithEstimatedSeriesCountHint(count uint6
 	return &newRequest
 }
 
-// LogToSpan writes query information about the current `PrometheusInstantQueryRequest`
+// AddSpanTags writes query information about the current `PrometheusInstantQueryRequest`
 // to a span's tag ("attributes" in OpenTelemetry parlance).
-func (r *PrometheusInstantQueryRequest) LogToSpan(sp opentracing.Span) {
+func (r *PrometheusInstantQueryRequest) AddSpanTags(sp opentracing.Span) {
 	sp.SetTag("query", r.GetQuery())
 	sp.SetTag("time", timestamp.Time(r.GetTime()).String())
 }

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -606,7 +606,7 @@ func doRequests(ctx context.Context, downstream Handler, reqs []Request) ([]requ
 			partialStats, childCtx := stats.ContextWithEmptyStats(ctx)
 			var span opentracing.Span
 			span, childCtx = opentracing.StartSpanFromContext(childCtx, "doRequests")
-			req.LogToSpan(span)
+			req.AddSpanTags(span)
 			defer span.Finish()
 
 			resp, err := downstream.Do(childCtx, req)

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -1549,7 +1549,7 @@ func (q roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 
 	if span := opentracing.SpanFromContext(r.Context()); span != nil {
-		request.LogToSpan(span)
+		request.AddSpanTags(span)
 	}
 
 	response, err := q.handler.Do(r.Context(), request)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Currently, it's next to impossible to use Tempo's TraceQL to search for traces on specific queries, as TraceQL doesn't support searching on event attributes. [Here](https://github.com/grafana/tempo/issues/2313#issuecomment-1551490022) is a related comment pointing out this pain for Mimir. 

Since query params aren't really an event in time, and therefore don't benefit from the timestamp that span events/logs require, I propose that instead of logging query parameters as span events, we store them as span attributes (a.k.a. "tags"). This will make traces searchable by query information (e.g., query string and step size) via TraceQL, and removes some span logs whose timing has no significance.

#### Which issue(s) this PR fixes or relates to
Relates to https://github.com/grafana/tempo/issues/2313

#### Checklist

- [N/A] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [N/A] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
