### PR TITLE
[Build] Use distroless as base image for mimir and fix e2e test user

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -278,7 +278,7 @@ jobs:
       - name: Build Mimir with race-detector
         run: |
           export IMAGE_TAG_RACE=$(make image-tag-race)
-          export MIMIR_IMAGE="grafana/mimir:$IMAGE_TAG_RACE"
+          export MIMIR_IMAGE="grafana/mimir-distroless:$IMAGE_TAG_RACE"
           make BUILD_IN_CONTAINER=false cmd/mimir/.uptodate_race
           docker save $MIMIR_IMAGE -o ./mimir_race_image
       - name: Upload archive with race-enabled Mimir
@@ -342,7 +342,7 @@ jobs:
         run: |
           docker load -i ./mimir_race_image
           export IMAGE_TAG_RACE=$(make image-tag-race)
-          docker run "grafana/mimir:$IMAGE_TAG_RACE" --version
+          docker run "grafana/mimir-distroless:$IMAGE_TAG_RACE" --version
       - name: Preload Images
         # We download docker images used by integration tests so that all images are available
         # locally and the download time doesn't account in the test execution time, which is subject
@@ -351,7 +351,7 @@ jobs:
       - name: Integration Tests
         run: |
           export IMAGE_TAG_RACE=$(make image-tag-race)
-          export MIMIR_IMAGE="grafana/mimir:$IMAGE_TAG_RACE"
+          export MIMIR_IMAGE="grafana/mimir-distroless:$IMAGE_TAG_RACE"
           export IMAGE_TAG=$(make image-tag)
           export MIMIRTOOL_IMAGE="grafana/mimirtool:$IMAGE_TAG"
           export MIMIR_CHECKOUT_DIR="/go/src/github.com/grafana/mimir"

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 # in that case.
 %/$(UPTODATE): GOOS=linux
 %/$(UPTODATE): %/Dockerfile
-	if [ -f $(@D)/Dockerfile.distroless ]; then \
-		$(SUDO) docker build -f $(@D)/Dockerfile.distroless --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D))-distroless:$(IMAGE_TAG) $(@D)/ \
-	fi
+	if [ -f $(@D)/Dockerfile.distroless ]; then $(SUDO) docker build -f $(@D)/Dockerfile.distroless --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D))-distroless:$(IMAGE_TAG) $(@D)/; fi;
 	@echo
 	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG) $(@D)/
 	@echo
@@ -144,9 +142,7 @@ push-multiarch-%/$(UPTODATE):
 	$(SUDO) docker buildx build -o $(PUSH_MULTIARCH_TARGET) --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true -t $(IMAGE_PREFIX)$(shell basename $(DIR)):$(IMAGE_TAG) $(DIR)/
 
 	# Build Dockerfile.distroless if it exists
-	if [ -f $(DIR)/Dockerfile.distroless ]; then \
-		$(SUDO) docker buildx build -f $(DIR)/Dockerfile.distroless -o $(PUSH_MULTIARCH_TARGET) --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true -t $(IMAGE_PREFIX)$(shell basename $(DIR))-distroless:$(IMAGE_TAG) $(DIR)/ \
-	fi
+	if [ -f $(DIR)/Dockerfile.distroless ]; then $(SUDO) docker buildx build -f $(DIR)/Dockerfile.distroless -o $(PUSH_MULTIARCH_TARGET) --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true -t $(IMAGE_PREFIX)$(shell basename $(DIR))-distroless:$(IMAGE_TAG) $(DIR)/; fi;
 
 push-multiarch-mimir: ## Push mimir docker image.
 push-multiarch-mimir: push-multiarch-cmd/mimir/.uptodate

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,8 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 # in that case.
 %/$(UPTODATE): GOOS=linux
 %/$(UPTODATE): %/Dockerfile
-	@echo
 	if [ -f $(@D)/Dockerfile.distroless ]; then \
-		$(SUDO) docker buildx build -f $(@D)/Dockerfile.distroless -o $(PUSH_MULTIARCH_TARGET) --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true -t $(IMAGE_PREFIX)$(shell basename $(@D))-distroless:$(IMAGE_TAG) $(@D)/; \
+		$(SUDO) docker build -f $(@D)/Dockerfile.distroless --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D))-distroless:$(IMAGE_TAG) $(@D)/ \
 	fi
 	@echo
 	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG) $(@D)/
@@ -116,6 +115,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 
 %/$(UPTODATE_RACE): GOOS=linux
 %/$(UPTODATE_RACE): %/Dockerfile
+	if [ -f $(@D)/Dockerfile.distroless ]; then $(SUDO) docker build -f $(@D)/Dockerfile.distroless --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true --build-arg=BINARY_SUFFIX=_race --build-arg=EXTRA_PACKAGES="gcompat" -t $(IMAGE_PREFIX)$(shell basename $(@D))-distroless:$(IMAGE_TAG_RACE) $(@D)/; fi;
 	@echo
 	# We need gcompat -- compatibility layer with glibc, as race-detector currently requires glibc, but Alpine uses musl libc instead.
 	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true --build-arg=BINARY_SUFFIX=_race --build-arg=EXTRA_PACKAGES="gcompat" -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG_RACE) $(@D)/
@@ -145,7 +145,7 @@ push-multiarch-%/$(UPTODATE):
 
 	# Build Dockerfile.distroless if it exists
 	if [ -f $(DIR)/Dockerfile.distroless ]; then \
-		$(SUDO) docker buildx build -f $(DIR)/Dockerfile.distroless -o $(PUSH_MULTIARCH_TARGET) --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true -t $(IMAGE_PREFIX)$(shell basename $(DIR))-distroless:$(IMAGE_TAG) $(DIR)/; \
+		$(SUDO) docker buildx build -f $(DIR)/Dockerfile.distroless -o $(PUSH_MULTIARCH_TARGET) --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true -t $(IMAGE_PREFIX)$(shell basename $(DIR))-distroless:$(IMAGE_TAG) $(DIR)/ \
 	fi
 
 push-multiarch-mimir: ## Push mimir docker image.

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,10 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 %/$(UPTODATE): GOOS=linux
 %/$(UPTODATE): %/Dockerfile
 	@echo
+	if [ -f $(@D)/Dockerfile.distroless ]; then \
+		$(SUDO) docker buildx build -f $(@D)/Dockerfile.distroless -o $(PUSH_MULTIARCH_TARGET) --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true -t $(IMAGE_PREFIX)$(shell basename $(@D))-distroless:$(IMAGE_TAG) $(@D)/; \
+	fi
+	@echo
 	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(IMAGE_PREFIX)$(shell basename $(@D)) -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG) $(@D)/
 	@echo
 	@echo Go binaries were built using GOOS=$(GOOS) and GOARCH=$(GOARCH)
@@ -138,6 +142,11 @@ push-multiarch-%/$(UPTODATE):
 		$(MAKE) GOOS=linux GOARCH=arm64 BINARY_SUFFIX=_linux_arm64 $(DIR)/$(shell basename $(DIR)); \
 	fi
 	$(SUDO) docker buildx build -o $(PUSH_MULTIARCH_TARGET) --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true -t $(IMAGE_PREFIX)$(shell basename $(DIR)):$(IMAGE_TAG) $(DIR)/
+
+	# Build Dockerfile.distroless if it exists
+	if [ -f $(DIR)/Dockerfile.distroless ]; then \
+		$(SUDO) docker buildx build -f $(DIR)/Dockerfile.distroless -o $(PUSH_MULTIARCH_TARGET) --platform linux/amd64,linux/arm64 --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) --build-arg=USE_BINARY_SUFFIX=true -t $(IMAGE_PREFIX)$(shell basename $(DIR))-distroless:$(IMAGE_TAG) $(DIR)/; \
+	fi
 
 push-multiarch-mimir: ## Push mimir docker image.
 push-multiarch-mimir: push-multiarch-cmd/mimir/.uptodate
@@ -682,7 +691,7 @@ integration-tests: cmd/mimir/$(UPTODATE)
 	go test -tags=requires_docker,stringlabels ./integration/...
 
 integration-tests-race: ## Run all integration tests with race-enabled Mimir docker image.
-integration-tests-race: export MIMIR_IMAGE=$(IMAGE_PREFIX)mimir:$(IMAGE_TAG_RACE)
+integration-tests-race: export MIMIR_IMAGE=$(IMAGE_PREFIX)mimir-distroless:$(IMAGE_TAG_RACE)
 integration-tests-race: cmd/mimir/$(UPTODATE_RACE)
 	go test -timeout 30m -tags=requires_docker,stringlabels ./integration/...
 

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -3,9 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.19.1
-ARG        EXTRA_PACKAGES
-RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
+FROM       gcr.io/distroless/base-debian12
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH
@@ -14,6 +12,7 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 ARG        USE_BINARY_SUFFIX
 COPY       mimir${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /bin/mimir
 EXPOSE     8080
+WORKDIR    /
 ENTRYPOINT [ "/bin/mimir" ]
 
 ARG revision

--- a/cmd/mimir/Dockerfile.distroless
+++ b/cmd/mimir/Dockerfile.distroless
@@ -3,9 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.19.1
-ARG        EXTRA_PACKAGES
-RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
+FROM       gcr.io/distroless/base-debian12
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH

--- a/integration/api_endpoints_test.go
+++ b/integration/api_endpoints_test.go
@@ -81,6 +81,7 @@ func TestConfigAPIEndpoint(t *testing.T) {
 	// Start again Mimir in single binary with the exported config
 	// and ensure it starts (pass the readiness probe).
 	require.NoError(t, writeFileToSharedDir(s, mimirConfigFile, body))
+	require.NoError(t, setDirPermission(s.SharedDir()))
 	mimir2 := e2emimir.NewSingleBinary("mimir-2", nil, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile(mimirConfigFile))
 	require.NoError(t, s.StartAndWaitReady(mimir2))
 }

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -74,13 +74,10 @@ func TestMimirtoolBackfill(t *testing.T) {
 	consul := e2edb.NewConsul()
 	minio := e2edb.NewMinio(9000, mimirBucketName)
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
-	dataDir := filepath.Join(s.SharedDir(), "data")
-	err = os.Mkdir(dataDir, os.ModePerm)
-	require.NoError(t, err)
 
 	// Configure the compactor with a data directory and runtime config (for overrides)
 	flags := mergeFlags(CommonStorageBackendFlags(), BlocksStorageFlags(), map[string]string{
-		"-compactor.data-dir":           filepath.Join(e2e.ContainerSharedDir, "data"),
+		"-compactor.data-dir":           filepath.Join("/data"),
 		"-runtime-config.reload-period": "100ms",
 		"-runtime-config.file":          filepath.Join(e2e.ContainerSharedDir, overridesFile),
 	})
@@ -202,7 +199,7 @@ func TestBackfillSlowUploadSpeed(t *testing.T) {
 	const httpServerTimeout = 2 * time.Second
 
 	flags := mergeFlags(CommonStorageBackendFlags(), BlocksStorageFlags(), map[string]string{
-		"-compactor.data-dir": filepath.Join(e2e.ContainerSharedDir, "data"),
+		"-compactor.data-dir": "/data",
 
 		// Enable uploads for all tenants
 		"-compactor.block-upload-enabled": "true",

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -82,6 +82,9 @@ func testSingleBinaryEnv(t *testing.T, tlsEnabled bool, flags map[string]string)
 		mimir3 = newSingleBinary("mimir-3", "", networkName+"-mimir-1:8000", flags)
 	}
 
+	// Set correct permission on certs/ folder
+	require.NoError(t, setDirPermission(s.SharedDir()))
+
 	// start mimir-1 first, as mimir-2 and mimir-3 both connect to mimir-1
 	require.NoError(t, s.StartAndWaitReady(mimir1))
 	require.NoError(t, s.StartAndWaitReady(mimir2, mimir3))

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -199,7 +199,7 @@ func TestQueryFrontendTLSWithBlocksStorageViaFlags(t *testing.T) {
 				filepath.Join(s.SharedDir(), serverCertFile),
 				filepath.Join(s.SharedDir(), serverKeyFile),
 			))
-
+			require.NoError(t, setDirPermission(s.SharedDir()))
 			return "", flags
 		},
 		withHistograms: true,

--- a/integration/util.go
+++ b/integration/util.go
@@ -8,9 +8,11 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"time"
 

--- a/integration/util.go
+++ b/integration/util.go
@@ -67,6 +67,25 @@ func generateAlternatingSeries(i int) generateSeriesFunc {
 // generateNSeriesFunc defines what kind of n * series (and expected vectors) to generate - float samples or native histograms
 type generateNSeriesFunc func(nSeries, nExemplars int, name func() string, ts time.Time, additionalLabels func() []prompb.Label) (series []prompb.TimeSeries, vector model.Vector)
 
+func setDirPermission(dir string) error {
+	// The environment variable is set, we set the folder owner GID, otherwise do nothing
+	if folderGroupID := os.Getenv("FOLDER_GROUP_ID"); folderGroupID != "" {
+		currentUser, err := user.Current()
+		if err != nil {
+			return err
+		}
+
+		if err := exec.Command("chown", "-R", fmt.Sprintf("%s:%s", currentUser.Uid, folderGroupID), dir).Run(); err != nil {
+			return err
+		}
+
+		if err := exec.Command("chmod", "-R", "775", dir).Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func getMimirProjectDir() string {
 	if dir := os.Getenv("MIMIR_CHECKOUT_DIR"); dir != "" {
 		return dir


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Use distroless base image instead of alpine

#### Checklist

- na Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- na [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
