### PR TITLE
Fix max_fetched_series_per_query not applied to /series from ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [BUGFIX] Fix issue where all incoming HTTP requests have duplicate trace spans. #6920
 * [BUGFIX] Querier: do not retry requests to store-gateway when a query gets canceled. #6934
 * [BUGFIX] Querier: return 499 status code instead of 500 when a request to remote read endpoint gets canceled. #6934
+* [BUGFIX] Querier: fix issue where `-querier.max-fetched-series-per-query` is not applied to `/series` endpoint if the series are loaded from ingesters. #7055
 
 ### Mixin
 


### PR DESCRIPTION
#### What this PR does

Fix max_fetched_series_per_query not applied to /series from ingesters in the querier.

The code is slightly inefficient as it checks for unique hashes twice, once in distributor.go and once in query_limiter.go. On the other hand the limiter uses a lock, so it makes sense to first merge the results from ingesters and throw out the duplicates before calling the limiter under lock.

I chose pkg/distributor and not pkg/querier for the placement to align with the limit check in the ingester streaming code in pkg/distributor/query.go

#### Which issue(s) this PR fixes or relates to

Fixes: reported directly.

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
