### PR TITLE
Remove default CPU limit for rollout-operator pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 ### Jsonnet
 
 * [CHANGE] Querier: Increase `JAEGER_REPORTER_MAX_QUEUE_SIZE` from 1000 to 5000, to avoid dropping tracing spans. #6764
+* [CHANGE] rollout-operator: remove default CPU limit. #7066
 * [FEATURE] Added support for the following root-level settings to configure the list of matchers to apply to node affinity: #6782 #6829
   * `alertmanager_node_affinity_matchers`
   * `compactor_node_affinity_matchers`

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1015,7 +1015,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "1"
             memory: 200Mi
           requests:
             cpu: 100m

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1386,7 +1386,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "1"
             memory: 200Mi
           requests:
             cpu: 100m

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1413,7 +1413,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "1"
             memory: 200Mi
           requests:
             cpu: 100m

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1015,7 +1015,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "1"
             memory: 200Mi
           requests:
             cpu: 100m

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1083,7 +1083,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "1"
             memory: 200Mi
           requests:
             cpu: 100m

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1015,7 +1015,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "1"
             memory: 200Mi
           requests:
             cpu: 100m

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -630,7 +630,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "1"
             memory: 200Mi
           requests:
             cpu: 100m

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -493,7 +493,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "1"
             memory: 200Mi
           requests:
             cpu: 100m

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -631,7 +631,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: "1"
             memory: 200Mi
           requests:
             cpu: 100m

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -356,7 +356,7 @@
       $.core.v1.containerPort.new('http-metrics', 8001),
     ]) +
     $.util.resourcesRequests('100m', '100Mi') +
-    $.util.resourcesLimits('1', '200Mi') +
+    $.util.resourcesLimits(null, '200Mi') +
     container.mixin.readinessProbe.httpGet.withPath('/ready') +
     container.mixin.readinessProbe.httpGet.withPort(8001) +
     container.mixin.readinessProbe.withInitialDelaySeconds(5) +


### PR DESCRIPTION
#### What this PR does

This PR removes the CPU limit for rollout-operator pods created by Jsonnet.

This limit is not needed and unnecessarily limits the CPU utilisation of the rollout-operator under load.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
