### PR TITLE
Fix formatting in querier component doc

### DIFF
--- a/docs/sources/mimir/references/architecture/components/querier.md
+++ b/docs/sources/mimir/references/architecture/components/querier.md
@@ -46,8 +46,8 @@ The request to the ingesters fetches samples that have not yet been uploaded to 
 
 The configured period for `-querier.query-ingesters-within` should be:
 
-- greater than `-querier.query-store-after` and,
-  - greater than the estimated minimum amount of time for the oldest samples stored in a block uploaded by ingester to be discovered and available for querying.
+- greater than `-querier.query-store-after`
+- greater than the estimated minimum amount of time for the oldest samples stored in a block uploaded by ingester to be discovered and available for querying.
     When running Grafana Mimir with the default configuration, the estimated minimum amount of time for the oldest sample in an uploaded block to be available for querying is `3h`.
 
 After all samples have been fetched from both the store-gateways and the ingesters, the querier runs the PromQL engine to execute the query and sends back the result to the client.

--- a/docs/sources/mimir/references/architecture/components/querier.md
+++ b/docs/sources/mimir/references/architecture/components/querier.md
@@ -44,10 +44,10 @@ Query failure due to the querier not querying all blocks ensures the correctness
 If the query time range overlaps with the `-querier.query-ingesters-within` duration, the querier also sends the request to ingesters.
 The request to the ingesters fetches samples that have not yet been uploaded to the long-term storage or are not yet available for querying through the store-gateway.
 
-The configured period for `-querier.query-ingesters-within` should be:
+The configured period for `-querier.query-ingesters-within` should be greater than both:
 
-- greater than `-querier.query-store-after`
-- greater than the estimated minimum amount of time for the oldest samples stored in a block uploaded by ingester to be discovered and available for querying.
+- `-querier.query-store-after`
+- the estimated minimum amount of time for the oldest samples stored in a block uploaded by ingester to be discovered and available for querying.
   When running Grafana Mimir with the default configuration, the estimated minimum amount of time for the oldest sample in an uploaded block to be available for querying is `3h`.
 
 After all samples have been fetched from both the store-gateways and the ingesters, the querier runs the PromQL engine to execute the query and sends back the result to the client.

--- a/docs/sources/mimir/references/architecture/components/querier.md
+++ b/docs/sources/mimir/references/architecture/components/querier.md
@@ -48,7 +48,7 @@ The configured period for `-querier.query-ingesters-within` should be:
 
 - greater than `-querier.query-store-after`
 - greater than the estimated minimum amount of time for the oldest samples stored in a block uploaded by ingester to be discovered and available for querying.
-    When running Grafana Mimir with the default configuration, the estimated minimum amount of time for the oldest sample in an uploaded block to be available for querying is `3h`.
+  When running Grafana Mimir with the default configuration, the estimated minimum amount of time for the oldest sample in an uploaded block to be available for querying is `3h`.
 
 After all samples have been fetched from both the store-gateways and the ingesters, the querier runs the PromQL engine to execute the query and sends back the result to the client.
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Fixes the formatting in the querier component doc to have two top level bullet points to describe -querier.query-ingesters-within usage. 

Before the change, docs render as:

<img width="906" alt="Screenshot 2024-01-08 at 8 21 40 PM" src="https://github.com/grafana/mimir/assets/228804/fb5ca578-6b72-431e-a223-52c0dd8e558e">

After the change, docs render as:

<img width="904" alt="Screenshot 2024-01-08 at 8 21 20 PM" src="https://github.com/grafana/mimir/assets/228804/65f4502c-f8b5-4d17-ab9b-11cf7a4db92e">

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
