### PR TITLE
docs: update link to Grafana Agent Operator CRDs

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -142,7 +142,7 @@ The Grafana Mimir Helm chart can collect metrics, logs, or both, about Grafana M
 In the example that follows, metamonitoring scrapes metrics about Grafana Mimir itself, and then writes those metrics to the same Grafana Mimir instance.
 
 1. Download the Grafana Agent Operator Custom Resource Definitions (CRDs) from
-   https://github.com/grafana/agent/tree/main/production/operator/crds.
+   https://github.com/grafana/agent/tree/main/operations/agent-static-operator/crds.
 
    Helm only installs Custom Resource Definitions on an initial chart installation, and not on a chart upgrade.
    For details, see [Some caveats and explanations](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations).
@@ -152,7 +152,7 @@ In the example that follows, metamonitoring scrapes metrics about Grafana Mimir 
 2. Install the CRDs on your cluster:
 
    ```bash
-   kubectl create -f production/operator/crds/
+   kubectl create -f operations/agent-static-operator/crds/
    ```
 
 3. Create a YAML file called `custom.yaml` for your Helm values overrides.

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
@@ -241,11 +241,11 @@ a Prometheus-compatible server and logs to a Loki or GEL (Grafana Enterprise
 Metrics) server.
 
 1. Download the Grafana Agent Operator Custom Resource Definitions (CRDs) from
-   https://github.com/grafana/agent/tree/main/production/operator/crds
+   https://github.com/grafana/agent/tree/main/operations/agent-static-operator/crds
 2. Install the CRDs on your cluster:
 
    ```bash
-   kubectl apply -f production/operator/crds/
+   kubectl apply -f operations/agent-static-operator/crds/
    ```
 
 3. Add the following YAML snippet to your

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -34,7 +34,7 @@ by using the [Grafana Agent operator](/docs/agent/latest/operator/).
 The Helm chart can install and use the Grafana Agent operator.
 
 > **Note:** Before the Helm chart can use the operator,
-> you need to manually install all of the Kubernetes [Custom Resource Definitions (CRDs)](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) from the [Grafana Agent operator YAML files](https://github.com/grafana/agent/tree/main/production/operator/crds).
+> you need to manually install all of the Kubernetes [Custom Resource Definitions (CRDs)](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) from the [Grafana Agent operator YAML files](https://github.com/grafana/agent/tree/main/operations/agent-static-operator/crds).
 
 It’s best to use the Grafana Agent operator for metrics and logs collection.
 However, if you prefer not to use it or you already have an existing Grafana Agent that you want to use, see _Collect metrics and logs via Grafana Agent_ documentation in Grafana Mimir version 2.5.0.

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2974,7 +2974,7 @@ metaMonitoring:
 
     # -- Controls whether to install the Grafana Agent Operator and its CRDs.
     # Note that helm will not install CRDs if this flag is enabled during an upgrade.
-    # In that case install the CRDs manually from https://github.com/grafana/agent/tree/main/production/operator/crds
+    # In that case install the CRDs manually from https://github.com/grafana/agent/tree/main/operations/agent-static-operator/crds
     installOperator: false
 
     logs:


### PR DESCRIPTION
The location where Grafana Agent Operator CRDs is changing to a new folder as part of grafana/agent#6077. The old link still works, but it will stop working in a few days after all references to the old links have been removed.