### PR TITLE
ingest: include gRPC status code validation only when running ingester

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -239,7 +239,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.IngestStorage.Validate(); err != nil {
 		return errors.Wrap(err, "invalid ingest storage config")
 	}
-	if c.IngestStorage.Enabled && !c.Ingester.ReturnOnlyGRPCErrors {
+	if c.isAnyModuleEnabled(Ingester, Write, All) && c.IngestStorage.Enabled && !c.Ingester.ReturnOnlyGRPCErrors {
 		return errors.New("to use ingest storage (-ingest-storage.enabled) also enable -ingester.return-only-grpc-errors")
 	}
 	if err := c.BlocksStorage.Validate(c.Ingester.ActiveSeriesMetrics, log); err != nil {

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -420,6 +420,34 @@ func TestConfigValidation(t *testing.T) {
 			},
 			expectAnyError: true,
 		},
+		{
+			name: "should pass if grpc errors are disabled, and the distributor is running with ingest storage",
+			getTestConfig: func() *Config {
+				cfg := newDefaultConfig()
+				_ = cfg.Target.Set("distributor")
+				cfg.IngestStorage.Enabled = true
+				cfg.IngestStorage.KafkaConfig.Address = "localhost:123"
+				cfg.IngestStorage.KafkaConfig.Topic = "topic"
+				cfg.Ingester.ReturnOnlyGRPCErrors = false
+
+				return cfg
+			},
+			expectAnyError: false,
+		},
+		{
+			name: "should fails if grpc errors are disabled, and the ingester is running with ingest storage",
+			getTestConfig: func() *Config {
+				cfg := newDefaultConfig()
+				_ = cfg.Target.Set("ingester")
+				cfg.IngestStorage.Enabled = true
+				cfg.IngestStorage.KafkaConfig.Address = "localhost:123"
+				cfg.IngestStorage.KafkaConfig.Topic = "topic"
+				cfg.Ingester.ReturnOnlyGRPCErrors = false
+
+				return cfg
+			},
+			expectAnyError: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.getTestConfig().Validate(log.NewNopLogger())


### PR DESCRIPTION


The current validation added in #6940 also applies to the distributor and ends up blocking distributor startup unnecessarily.
