### PR TITLE
scheduler queue benchmark: factor out & clarify functions

### DIFF
--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -48,76 +48,87 @@ func randAdditionalQueueDimension() []string {
 	return secondQueueDimensionOptions[idx : idx+1]
 }
 
+func makeSchedulerRequest(tenantID string) *SchedulerRequest {
+	return &SchedulerRequest{
+		Ctx:             context.Background(),
+		FrontendAddress: "http://query-frontend:8007",
+		UserID:          tenantID,
+		Request: &httpgrpc.HTTPRequest{
+			Method: "GET",
+			Headers: []*httpgrpc.Header{
+				{Key: "QueryId", Values: []string{"12345678901234567890"}},
+				{Key: "Accept", Values: []string{"application/vnd.mimir.queryresponse+protobuf", "application/json"}},
+				{Key: "X-Scope-OrgId", Values: []string{tenantID}},
+				{Key: "uber-trace-id", Values: []string{"48475050943e8e05:70e8b02d28e4337b:077cd9b649b6ac02:1"}},
+			},
+			Url: "/prometheus/api/v1/query_range?end=1701720000&query=rate%28go_goroutines%7Bcluster%3D%22docker-compose-local%22%2Cjob%3D%22mimir-microservices-mode%2Fquery-scheduler%22%2Cnamespace%3D%22mimir-microservices-mode%22%7D%5B10m15s%5D%29&start=1701648000&step=60",
+		},
+		AdditionalQueueDimensions: randAdditionalQueueDimension(),
+	}
+}
+
+func queueActorIterationCount(benchmarkIters int, numActors int, actorIdx int) int {
+	actorIters := benchmarkIters / numActors
+	remainderIters := benchmarkIters % numActors
+
+	if remainderIters == 0 {
+		// iterations are spread equally across actors without a remainder
+		return actorIters
+	}
+
+	// If we can't perfectly spread iterations across all actors,
+	// assign remaining iterations to the actors at the beginning of the list.
+	if actorIdx < remainderIters {
+		// this actor is early enough in the list to get one of the remaining iterations
+		return actorIters + 1
+	}
+
+	return actorIters
+}
+
 func BenchmarkConcurrentQueueOperations(b *testing.B) {
-	maxQueriers := 0
+	maxQueriersPerTenant := 0 // disable shuffle sharding
+	maxOutstandingRequestsPerTenant := 100
 
 	for _, numTenants := range []int{1, 10, 1000} {
 		b.Run(fmt.Sprintf("%v tenants", numTenants), func(b *testing.B) {
-			for _, numProducers := range []int{10, 25} { // Query-frontends run 5 parallel streams per scheduler by default, and we typically see 2-5 frontends running at any one time.
+
+			// Query-frontends run 5 parallel streams per scheduler by default,
+			// and we typically see 2-5 frontends running at any one time.
+			for _, numProducers := range []int{10, 25} {
 				b.Run(fmt.Sprintf("%v concurrent producers", numProducers), func(b *testing.B) {
-					for _, numConsumers := range []int{16, 160, 1600} { // Queriers run with parallelism of 16 when query sharding is enabled.
+
+					// Queriers run with parallelism of 16 when query sharding is enabled.
+					for _, numConsumers := range []int{16, 160, 1600} {
 						b.Run(fmt.Sprintf("%v concurrent consumers", numConsumers), func(b *testing.B) {
-							queueLength := promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"})
-							discardedRequests := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"})
+							queueLength := promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"tenant"})
+							discardedRequests := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"tenant"})
 							enqueueDuration := promauto.With(nil).NewHistogram(prometheus.HistogramOpts{})
-							queue := NewRequestQueue(log.NewNopLogger(), 100, true, 0, queueLength, discardedRequests, enqueueDuration)
+							queue := NewRequestQueue(log.NewNopLogger(), maxOutstandingRequestsPerTenant, true, 0, queueLength, discardedRequests, enqueueDuration)
 
 							start := make(chan struct{})
-							producersAndConsumers, ctx := errgroup.WithContext(context.Background())
+							producersAndConsumersWaitGroup, ctx := errgroup.WithContext(context.Background())
 							require.NoError(b, queue.starting(ctx))
 							b.Cleanup(func() {
 								require.NoError(b, queue.stop(nil))
 							})
 
-							requestCount := func(total int, instanceCount int, instanceIdx int) int {
-								count := total / instanceCount
-								totalCountWithoutAdjustment := count * instanceCount
-
-								if totalCountWithoutAdjustment >= total {
-									return count
-								}
-
-								additionalRequests := total - totalCountWithoutAdjustment
-
-								if instanceIdx < additionalRequests {
-									// If we can't perfectly spread requests across all instances, assign remaining requests to the first instances.
-									return count + 1
-								}
-
-								return count
-							}
-
 							runProducer := func(producerIdx int) error {
-								requestCount := requestCount(b.N, numProducers, producerIdx)
+								producerIters := queueActorIterationCount(b.N, numProducers, producerIdx)
 								tenantID := producerIdx % numTenants
 								tenantIDStr := strconv.Itoa(tenantID)
 								<-start
 
-								for i := 0; i < requestCount; i++ {
+								for i := 0; i < producerIters; i++ {
 									for {
 										// when running this benchmark for memory usage comparison,
 										// we want to have a relatively representative size of request
 										// in order not to skew the % delta between queue implementations.
 										// Unless the request starts to get copied, the size of the requests in the queue
 										// should significantly outweigh the memory used to implement the queue mechanics.
-										req := &SchedulerRequest{
-											Ctx:             context.Background(),
-											FrontendAddress: "http://query-frontend:8007",
-											UserID:          tenantIDStr,
-											Request: &httpgrpc.HTTPRequest{
-												Method: "GET",
-												Headers: []*httpgrpc.Header{
-													{Key: "QueryId", Values: []string{"12345678901234567890"}},
-													{Key: "Accept", Values: []string{"application/vnd.mimir.queryresponse+protobuf", "application/json"}},
-													{Key: "X-Scope-OrgId", Values: []string{tenantIDStr}},
-													{Key: "uber-trace-id", Values: []string{"48475050943e8e05:70e8b02d28e4337b:077cd9b649b6ac02:1"}},
-												},
-												Url: "/prometheus/api/v1/query_range?end=1701720000&query=rate%28go_goroutines%7Bcluster%3D%22docker-compose-local%22%2Cjob%3D%22mimir-microservices-mode%2Fquery-scheduler%22%2Cnamespace%3D%22mimir-microservices-mode%22%7D%5B10m15s%5D%29&start=1701648000&step=60",
-											},
-											AdditionalQueueDimensions: randAdditionalQueueDimension(),
-										}
+										req := makeSchedulerRequest(tenantIDStr)
 										//req.AdditionalQueueDimensions = randAdditionalQueueDimension()
-										err := queue.EnqueueRequestToDispatcher(strconv.Itoa(tenantID), req, maxQueriers, func() {})
+										err := queue.EnqueueRequestToDispatcher(strconv.Itoa(tenantID), req, maxQueriersPerTenant, func() {})
 										if err == nil {
 											break
 										}
@@ -136,13 +147,13 @@ func BenchmarkConcurrentQueueOperations(b *testing.B) {
 
 							for producerIdx := 0; producerIdx < numProducers; producerIdx++ {
 								producerIdx := producerIdx
-								producersAndConsumers.Go(func() error {
+								producersAndConsumersWaitGroup.Go(func() error {
 									return runProducer(producerIdx)
 								})
 							}
 
 							runConsumer := func(consumerIdx int) error {
-								requestCount := requestCount(b.N, numConsumers, consumerIdx)
+								consumerIters := queueActorIterationCount(b.N, numConsumers, consumerIdx)
 								lastTenantIndex := FirstUser()
 								querierID := fmt.Sprintf("consumer-%v", consumerIdx)
 								queue.RegisterQuerierConnection(querierID)
@@ -150,7 +161,7 @@ func BenchmarkConcurrentQueueOperations(b *testing.B) {
 
 								<-start
 
-								for i := 0; i < requestCount; i++ {
+								for i := 0; i < consumerIters; i++ {
 									_, idx, err := queue.GetNextRequestForQuerier(ctx, lastTenantIndex, querierID)
 									if err != nil {
 										return err
@@ -164,14 +175,14 @@ func BenchmarkConcurrentQueueOperations(b *testing.B) {
 
 							for consumerIdx := 0; consumerIdx < numConsumers; consumerIdx++ {
 								consumerIdx := consumerIdx
-								producersAndConsumers.Go(func() error {
+								producersAndConsumersWaitGroup.Go(func() error {
 									return runConsumer(consumerIdx)
 								})
 							}
 
 							b.ResetTimer()
 							close(start)
-							err := producersAndConsumers.Wait()
+							err := producersAndConsumersWaitGroup.Wait()
 							if err != nil {
 								require.NoError(b, err)
 							}


### PR DESCRIPTION
Will be adding a benchmark test to prove out the effects of the query scheduler additional queue dimensions when there is a slow querier - factoring out some methods here first to make this more reusable and easier to understand.

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
