### PR TITLE
Handle `context.Canceled` in active series requests

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1842,6 +1842,7 @@ func (d *Distributor) ActiveSeries(ctx context.Context, matchers []*labels.Match
 			}
 			level.Error(log).Log("msg", "error creating active series response stream", "err", err)
 			ext.Error.Set(log.Span, true)
+			return nil, err
 		}
 
 		defer func() {
@@ -1853,10 +1854,10 @@ func (d *Distributor) ActiveSeries(ctx context.Context, matchers []*labels.Match
 
 		for {
 			msg, err := stream.Recv()
-			if errors.Is(err, io.EOF) {
-				break
-			}
 			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
 				if errors.Is(err, context.Canceled) {
 					return nil, nil
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The invocation of the active series `ingesterQuery` through `forReplicationSet` can be canceled via its context if the quorum has been established otherwise. In these cases, we should not return an error from `ingesterQuery`.

#### Which issue(s) this PR fixes or relates to

Fixes n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
