### PR TITLE
Small fixes for `/active_series`

### DIFF
--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -149,6 +149,7 @@ func buildShardedRequests(ctx context.Context, req *http.Request, numRequests in
 
 		reqs[i].Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		reqs[i].Header.Del(totalShardsControlHeader)
+		reqs[i].Header.Del("Accept-Encoding")
 		reqs[i].Body = io.NopCloser(strings.NewReader(vals.Encode()))
 	}
 

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/s2"
@@ -350,6 +351,7 @@ func (s *shardActiveSeriesMiddleware) writeMergedResponse(ctx context.Context, c
 	stream.WriteArrayEnd()
 
 	if err := check(); err != nil {
+		level.Error(s.logger).Log("msg", "error merging partial responses", "err", err.Error())
 		span.LogFields(otlog.Error(err))
 		stream.WriteMore()
 		stream.WriteObjectField("status")

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -262,9 +262,8 @@ func (s *shardActiveSeriesMiddleware) mergeResponses(ctx context.Context, respon
 				// If the field is neither data nor error, we skip it.
 				it.ReadAny()
 			}
-
 			if !foundDataField {
-				return errors.New("expected data field at top level")
+				return fmt.Errorf("expected data field at top level, found %s", it.CurrentBuffer())
 			}
 
 			if it.WhatIsNext() != jsoniter.ArrayValue {

--- a/pkg/frontend/v2/frontend_scheduler_adapter.go
+++ b/pkg/frontend/v2/frontend_scheduler_adapter.go
@@ -85,7 +85,7 @@ func (a *frontendToSchedulerAdapter) extractAdditionalQueueDimensions(
 			return nil, err
 		}
 		return a.queryComponentQueueDimensionFromTimeParams(tenantIDs, start, end, now), nil
-	case querymiddleware.IsCardinalityQuery(httpRequest.URL.Path):
+	case querymiddleware.IsCardinalityQuery(httpRequest.URL.Path), querymiddleware.IsActiveSeriesQuery(httpRequest.URL.Path):
 		// cardinality only hits ingesters
 		return []string{ShouldQueryIngestersQueueDimension}, nil
 	default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This contains four small changes related to the active series API:

- Make request queue scheduling dimension extraction aware of active series requests.
- Add the current json parser buffer to the error message in cases where a querier responds with an unexpected response.
- Log the error message.
- Do not pass along the `Accept-Encoding` header from the query-frontend to upstream services, because its value has been consumed in the query-frontend itself and its presence could lead to unexpected behaviour of upstream components.

#### Which issue(s) this PR fixes or relates to

Fixes n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
