### PR TITLE
querier: remove noop if

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -486,10 +486,6 @@ func (q *blocksStoreQuerier) selectSorted(ctx context.Context, sp *storage.Selec
 		}
 	}
 
-	if len(resSeriesSets) == 0 {
-		storage.EmptySeriesSet()
-	}
-
 	return series.NewSeriesSetWithWarnings(
 		storage.NewMergeSeriesSet(resSeriesSets, storage.ChainedSeriesMerge),
 		resWarnings)


### PR DESCRIPTION
While reading the code I noticed this `if` doesn't actually do anything. Since the actual optimization of it is small I chose to keep the code somewhat simpler and remove it.

This has never worked, since being added in 2020, so I don't think we've had a regression at some point.
