### PR TITLE
Fix missing "annotation" key in create-bucket-job template of helm chart

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -16,6 +16,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- with .Values.minio.makeBucketJob.annotations }}
+  annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:


### PR DESCRIPTION
#### What this PR does

The PR fixes a typo in the Helm chart's template from the Minio's create-bucket-job.

#### Which issue(s) this PR fixes or relates to

Fixes #7060 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
