### PR TITLE
Set -server.grpc.num-workers=100 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [ENHANCEMENT] Querier: add `cortex_querier_queries_storage_type_total ` metric that indicates how many queries have executed for a source, ingesters or store-gateways. Add `cortex_query_storegateway_chunks_total` metric to count the number of chunks fetched from a store gateway. #7099
 * [ENHANCEMENT] Query-frontend: add experimental support for sharding active series queries via `-query-frontend.shard-active-series-queries`. #6784
 * [ENHANCEMENT] Distributor: set `-distributor.reusable-ingester-push-workers=2000` by default and mark feature as `advanced`. #7128
+* [ENHANCEMENT] All: set `-server.grpc.num-workers=100` by default and mark feature as `advanced`. #7131
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -595,10 +595,10 @@
           "required": false,
           "desc": "If non-zero, configures the amount of GRPC server workers used to serve the requests.",
           "fieldValue": null,
-          "fieldDefaultValue": 0,
+          "fieldDefaultValue": 100,
           "fieldFlag": "server.grpc.num-workers",
           "fieldType": "int",
-          "fieldCategory": "experimental"
+          "fieldCategory": "advanced"
         },
         {
           "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2602,7 +2602,7 @@ Usage of ./cmd/mimir/mimir:
   -server.grpc.keepalive.timeout duration
     	After having pinged for keepalive check, the duration after which an idle connection should be closed, Default: 20s (default 20s)
   -server.grpc.num-workers int
-    	[experimental] If non-zero, configures the amount of GRPC server workers used to serve the requests.
+    	If non-zero, configures the amount of GRPC server workers used to serve the requests. (default 100)
   -server.http-conn-limit int
     	Maximum number of simultaneous http connections, <=0 to disable
   -server.http-idle-timeout duration

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -158,7 +158,6 @@ The following features are currently experimental:
     - `-<prefix>.memcached.read-buffer-size-bytes`
 - Timeseries Unmarshal caching optimization in distributor (`-timeseries-unmarshal-caching-optimization-enabled`)
 - Reusing buffers for marshalling write requests in distributors (`-distributor.write-requests-buffer-pooling-enabled`)
-- Using a worker pool for handling GRPC requests (`-server.grpc.num-workers`)
 - Limiting inflight requests to Distributor and Ingester via gRPC limiter:
   - `-distributor.limit-inflight-requests-using-grpc-method-limiter`
   - `-ingester.limit-inflight-requests-using-grpc-method-limiter`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -674,10 +674,10 @@ grpc_tls_config:
 # CLI flag: -server.grpc.keepalive.ping-without-stream-allowed
 [grpc_server_ping_without_stream_allowed: <boolean> | default = true]
 
-# (experimental) If non-zero, configures the amount of GRPC server workers used
-# to serve the requests.
+# (advanced) If non-zero, configures the amount of GRPC server workers used to
+# serve the requests.
 # CLI flag: -server.grpc.num-workers
-[grpc_server_num_workers: <int> | default = 0]
+[grpc_server_num_workers: <int> | default = 100]
 
 # Output log messages in the given format. Valid formats: [logfmt, json]
 # CLI flag: -log.format

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -537,12 +537,13 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 	c.Server.RegisterFlags(throwaway)
 
 	defaultsOverrides := map[string]string{
-		"server.http-write-timeout":                         "2m",
-		"server.grpc.keepalive.min-time-between-pings":      "10s",
-		"server.grpc.keepalive.ping-without-stream-allowed": "true",
-		"server.http-listen-port":                           "8080",
 		"server.grpc-max-recv-msg-size-bytes":               strconv.Itoa(100 * 1024 * 1024),
 		"server.grpc-max-send-msg-size-bytes":               strconv.Itoa(100 * 1024 * 1024),
+		"server.grpc.keepalive.min-time-between-pings":      "10s",
+		"server.grpc.keepalive.ping-without-stream-allowed": "true",
+		"server.grpc.num-workers":                           "100",
+		"server.http-listen-port":                           "8080",
+		"server.http-write-timeout":                         "2m",
 	}
 
 	throwaway.VisitAll(func(f *flag.Flag) {

--- a/pkg/util/fieldcategory/overrides.go
+++ b/pkg/util/fieldcategory/overrides.go
@@ -53,7 +53,7 @@ var overrides = map[string]Category{
 	"server.grpc.keepalive.ping-without-stream-allowed": Advanced,
 	"server.grpc.keepalive.time":                        Advanced,
 	"server.grpc.keepalive.timeout":                     Advanced,
-	"server.grpc.num-workers":                           Experimental,
+	"server.grpc.num-workers":                           Advanced,
 	"server.http-conn-limit":                            Advanced,
 	"server.http-idle-timeout":                          Advanced,
 	"server.http-listen-network":                        Advanced,


### PR DESCRIPTION
#### What this PR does

This sets the `-server.grpc.num-workers` to 100 by default, and changes the category of that flag to `advanced`.

This is the value we've tested in Grafana Cloud for a while. We've observed an improvement of around 5% in ingester CPU compared to running without this flag set.

Note that this is not a limit, but the number of pre-allocated long-lived workers. When all workers are busy, a new goroutine will be spawned (previous default behaviour).

#### Which issue(s) this PR fixes or relates to

There was no public issue for this.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
