### PR TITLE
`/active_series`: generate correct request shards for incoming `GET` requests,  handle gRPC errors

### DIFF
--- a/integration/query_frontend_active_series_test.go
+++ b/integration/query_frontend_active_series_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//go:build requires_docker
+
 package integration
 
 import (

--- a/integration/query_frontend_active_series_test.go
+++ b/integration/query_frontend_active_series_test.go
@@ -1,0 +1,136 @@
+package integration
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/grafana/e2e"
+	e2ecache "github.com/grafana/e2e/cache"
+	e2edb "github.com/grafana/e2e/db"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/integration/e2emimir"
+)
+
+func TestActiveSeriesWithQueryShardingHTTP(t *testing.T) {
+	config := queryFrontendTestConfig{
+		queryStatsEnabled:           true,
+		querySchedulerEnabled:       true,
+		querySchedulerDiscoveryMode: "ring",
+		setup: func(t *testing.T, s *e2e.Scenario) (string, map[string]string) {
+			flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags())
+			minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+			require.NoError(t, s.StartAndWaitReady(minio))
+
+			return "", flags
+		},
+	}
+
+	runTestActiveSeriesWithQueryShardingHTTPTest(t, config)
+}
+
+func runTestActiveSeriesWithQueryShardingHTTPTest(t *testing.T, cfg queryFrontendTestConfig) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	memcached := e2ecache.NewMemcached()
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(consul, memcached))
+
+	configFile, flags := cfg.setup(t, s)
+
+	flags = mergeFlags(flags, map[string]string{
+		"-query-frontend.cache-results":                      "true",
+		"-query-frontend.results-cache.backend":              "memcached",
+		"-query-frontend.results-cache.memcached.addresses":  "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
+		"-query-frontend.query-stats-enabled":                strconv.FormatBool(cfg.queryStatsEnabled),
+		"-query-frontend.query-sharding-total-shards":        "32",
+		"-query-frontend.query-sharding-max-sharded-queries": "128",
+		"-query-frontend.shard-active-series-queries":        "true",
+		"-querier.cardinality-analysis-enabled":              "true",
+	})
+
+	// Start the query-scheduler if enabled.
+	var queryScheduler *e2emimir.MimirService
+	if cfg.querySchedulerEnabled && cfg.querySchedulerDiscoveryMode == "dns" {
+		queryScheduler = e2emimir.NewQueryScheduler("query-scheduler", flags)
+		require.NoError(t, s.StartAndWaitReady(queryScheduler))
+		flags["-query-frontend.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
+		flags["-querier.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
+	} else if cfg.querySchedulerEnabled && cfg.querySchedulerDiscoveryMode == "ring" {
+		flags["-query-scheduler.service-discovery-mode"] = "ring"
+		flags["-query-scheduler.ring.store"] = "consul"
+		flags["-query-scheduler.ring.consul.hostname"] = consul.NetworkHTTPEndpoint()
+
+		queryScheduler = e2emimir.NewQueryScheduler("query-scheduler", flags)
+		require.NoError(t, s.StartAndWaitReady(queryScheduler))
+	}
+
+	// Start the query-frontend.
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags, e2emimir.WithConfigFile(configFile))
+	require.NoError(t, s.Start(queryFrontend))
+
+	if !cfg.querySchedulerEnabled {
+		flags["-querier.frontend-address"] = queryFrontend.NetworkGRPCEndpoint()
+	}
+
+	// Start all other services.
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags, e2emimir.WithConfigFile(configFile))
+
+	require.NoError(t, s.StartAndWaitReady(querier, ingester, distributor))
+	require.NoError(t, s.WaitReady(queryFrontend))
+
+	// Check if we're discovering memcached or not.
+	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(1), "thanos_cache_dns_provider_results"))
+	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Greater(0), "thanos_cache_dns_lookups_total"))
+
+	// Wait until distributor and querier have updated the ingesters ring.
+	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	// Push series for the test user to Mimir.
+	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+	numSeries := 100
+	metricName := "test_metric"
+	now := time.Now()
+	series := make([]prompb.TimeSeries, numSeries)
+	for i := 0; i < numSeries; i++ {
+		ts, _, _ := e2e.GenerateSeries(metricName, now, prompb.Label{Name: "index", Value: strconv.Itoa(i)})
+		series[i] = ts[0]
+	}
+	res, err := c.Push(series)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	// Query active series.
+	for _, options := range [][]e2emimir.ActiveSeriesOption{
+		{e2emimir.WithRequestMethod(http.MethodGet)},
+		{e2emimir.WithRequestMethod(http.MethodPost)},
+		{e2emimir.WithRequestMethod(http.MethodGet), e2emimir.WithEnableCompression()},
+		{e2emimir.WithRequestMethod(http.MethodPost), e2emimir.WithEnableCompression()},
+		{e2emimir.WithQueryShards(1)},
+		{e2emimir.WithQueryShards(12)},
+	} {
+		response, err := c.ActiveSeries(metricName, options...)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Len(t, response.Data, numSeries)
+	}
+
+	_, err = c.ActiveSeries(metricName, e2emimir.WithQueryShards(512))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "shard count 512 exceeds allowed maximum (128)")
+}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -43,8 +43,6 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/cardinality"
 	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
@@ -1850,7 +1848,7 @@ func (d *Distributor) ActiveSeries(ctx context.Context, matchers []*labels.Match
 
 		stream, err := client.ActiveSeries(ctx, req)
 		if err != nil {
-			if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
+			if errors.Is(util.WrapGrpcContextError(err), context.Canceled) {
 				return ignored{}, nil
 			}
 			level.Error(log).Log("msg", "error creating active series response stream", "err", err)
@@ -1860,7 +1858,7 @@ func (d *Distributor) ActiveSeries(ctx context.Context, matchers []*labels.Match
 
 		defer func() {
 			err = util.CloseAndExhaust[*ingester_client.ActiveSeriesResponse](stream)
-			if err != nil && !(errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled) {
+			if err != nil && !(errors.Is(util.WrapGrpcContextError(err), context.Canceled)) {
 				level.Warn(d.log).Log("msg", "error closing active series response stream", "err", err)
 			}
 		}()
@@ -1871,7 +1869,7 @@ func (d *Distributor) ActiveSeries(ctx context.Context, matchers []*labels.Match
 				if errors.Is(err, io.EOF) {
 					break
 				}
-				if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
+				if errors.Is(util.WrapGrpcContextError(err), context.Canceled) {
 					return ignored{}, nil
 				}
 				level.Error(log).Log("msg", "error receiving active series response", "err", err)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1858,7 +1858,7 @@ func (d *Distributor) ActiveSeries(ctx context.Context, matchers []*labels.Match
 
 		defer func() {
 			err = util.CloseAndExhaust[*ingester_client.ActiveSeriesResponse](stream)
-			if err != nil && !(errors.Is(util.WrapGrpcContextError(err), context.Canceled)) {
+			if err != nil && !errors.Is(util.WrapGrpcContextError(err), context.Canceled) {
 				level.Warn(d.log).Log("msg", "error closing active series response stream", "err", err)
 			}
 		}()

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
+	"github.com/grafana/dskit/user"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/s2"
 	"github.com/opentracing/opentracing-go"
@@ -153,6 +154,10 @@ func buildShardedRequests(ctx context.Context, req *http.Request, numRequests in
 		// This is the field read by httpgrpc.FromHTTPRequest, so we need to populate it
 		// here to ensure the request parameter makes it to the querier.
 		r.RequestURI = r.URL.String()
+
+		if err := user.InjectOrgIDIntoHTTPRequest(ctx, r); err != nil {
+			return nil, err
+		}
 
 		reqs[i] = r
 	}

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -183,9 +183,12 @@ func doShardedRequests(ctx context.Context, upstreamRequests []*http.Request, ne
 
 			if resp.StatusCode != http.StatusOK {
 				span.LogFields(otlog.Int("statusCode", resp.StatusCode))
-				body, _ := io.ReadAll(resp.Body)
 				if resp.StatusCode == http.StatusRequestEntityTooLarge {
 					return errShardCountTooLow
+				}
+				var body []byte
+				if resp.Body != nil {
+					body, _ = io.ReadAll(resp.Body)
 				}
 				return fmt.Errorf("received unexpected response from upstream: status %d, body: %s", resp.StatusCode, string(body))
 			}

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -239,6 +239,28 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 			},
 			expectContentEncoding: encodingTypeSnappyFramed,
 		},
+		{
+			name: "builds correct request shards for GET requests",
+			request: func() *http.Request {
+				q := url.Values{}
+				q.Set("selector", "metric")
+				req, _ := http.NewRequest(http.MethodGet, "/active_series", nil)
+				req.URL.RawQuery = q.Encode()
+				req.Header.Add(totalShardsControlHeader, "2")
+				return req
+			},
+			validResponses: [][]labels.Labels{
+				{labels.FromStrings(labels.MetricName, "metric", "shard", "1")},
+				{labels.FromStrings(labels.MetricName, "metric", "shard", "2")},
+			},
+			checkResponseErr: noError,
+			expect: result{
+				Data: []labels.Labels{
+					labels.FromStrings(labels.MetricName, "metric", "shard", "1"),
+					labels.FromStrings(labels.MetricName, "metric", "shard", "2"),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -247,8 +269,10 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 			// Stub upstream with valid or invalid responses.
 			var requestCount atomic.Int32
 			upstream := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
-				defer func(Body io.ReadCloser) {
-					_ = Body.Close()
+				defer func(body io.ReadCloser) {
+					if body != nil {
+						_ = body.Close()
+					}
 				}(r.Body)
 
 				requestCount.Inc()

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -33,6 +33,7 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 
 	validReq := func() *http.Request {
 		r := httptest.NewRequest("POST", "/active_series", strings.NewReader(`selector={__name__="metric"}`))
+		r.Header.Add("X-Scope-OrgID", "test")
 		r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 		return r
 	}
@@ -275,7 +276,9 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 					}
 				}(r.Body)
 
-				_, err := user.ExtractOrgID(r.Context())
+				_, _, err := user.ExtractOrgIDFromHTTPRequest(r)
+				require.NoError(t, err)
+				_, err = user.ExtractOrgID(r.Context())
 				require.NoError(t, err)
 
 				requestCount.Inc()

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -275,6 +275,9 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 					}
 				}(r.Body)
 
+				_, err := user.ExtractOrgID(r.Context())
+				require.NoError(t, err)
+
 				requestCount.Inc()
 
 				if tt.errorResponse != nil {

--- a/pkg/storegateway/storegatewaypb/custom.go
+++ b/pkg/storegateway/storegatewaypb/custom.go
@@ -4,14 +4,12 @@ package storegatewaypb
 
 import (
 	"context"
-	"errors"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util"
 )
 
 // customStoreGatewayClient is a custom StoreGatewayClient which wraps well known gRPC errors into standard golang errors.
@@ -29,7 +27,7 @@ func NewCustomStoreGatewayClient(cc *grpc.ClientConn) StoreGatewayClient {
 func (c *customStoreGatewayClient) Series(ctx context.Context, in *storepb.SeriesRequest, opts ...grpc.CallOption) (StoreGateway_SeriesClient, error) {
 	client, err := c.wrapped.Series(ctx, in, opts...)
 	if err != nil {
-		return client, wrapContextError(err)
+		return client, util.WrapGrpcContextError(err)
 	}
 
 	return newCustomSeriesClient(client), nil
@@ -38,13 +36,13 @@ func (c *customStoreGatewayClient) Series(ctx context.Context, in *storepb.Serie
 // LabelNames implements StoreGatewayClient.
 func (c *customStoreGatewayClient) LabelNames(ctx context.Context, in *storepb.LabelNamesRequest, opts ...grpc.CallOption) (*storepb.LabelNamesResponse, error) {
 	res, err := c.wrapped.LabelNames(ctx, in, opts...)
-	return res, wrapContextError(err)
+	return res, util.WrapGrpcContextError(err)
 }
 
 // LabelValues implements StoreGatewayClient.
 func (c *customStoreGatewayClient) LabelValues(ctx context.Context, in *storepb.LabelValuesRequest, opts ...grpc.CallOption) (*storepb.LabelValuesResponse, error) {
 	res, err := c.wrapped.LabelValues(ctx, in, opts...)
-	return res, wrapContextError(err)
+	return res, util.WrapGrpcContextError(err)
 }
 
 // customStoreGatewayClient is a custom StoreGateway_SeriesClient which wraps well known gRPC errors into standard golang errors.
@@ -63,7 +61,7 @@ func newCustomSeriesClient(client StoreGateway_SeriesClient) *customSeriesClient
 
 func (c *customSeriesClient) Recv() (*storepb.SeriesResponse, error) {
 	res, err := c.wrapped.Recv()
-	return res, wrapContextError(err)
+	return res, util.WrapGrpcContextError(err)
 }
 
 // customClientStream is a custom grpc.ClientStream which wraps well known gRPC errors into standard golang errors.
@@ -74,7 +72,7 @@ type customClientStream struct {
 // Header implements grpc.ClientStream.
 func (c *customClientStream) Header() (metadata.MD, error) {
 	md, err := c.wrapped.Header()
-	return md, wrapContextError(err)
+	return md, util.WrapGrpcContextError(err)
 }
 
 // Trailer implements grpc.ClientStream.
@@ -85,7 +83,7 @@ func (c *customClientStream) Trailer() metadata.MD {
 // CloseSend implements grpc.ClientStream.
 func (c *customClientStream) CloseSend() error {
 	//nolint:forbidigo // Here we're just wrapping CloseSend() so it's OK to call it.
-	return wrapContextError(c.wrapped.CloseSend())
+	return util.WrapGrpcContextError(c.wrapped.CloseSend())
 }
 
 // Context implements grpc.ClientStream.
@@ -95,68 +93,10 @@ func (c *customClientStream) Context() context.Context {
 
 // SendMsg implements grpc.ClientStream.
 func (c *customClientStream) SendMsg(m any) error {
-	return wrapContextError(c.wrapped.SendMsg(m))
+	return util.WrapGrpcContextError(c.wrapped.SendMsg(m))
 }
 
 // RecvMsg implements grpc.ClientStream.
 func (c *customClientStream) RecvMsg(m any) error {
-	return wrapContextError(c.wrapped.RecvMsg(m))
-}
-
-func wrapContextError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	// Get the gRPC status from the error.
-	type grpcErrorStatus interface{ GRPCStatus() *grpcstatus.Status }
-	var grpcError grpcErrorStatus
-	if !errors.As(err, &grpcError) {
-		return err
-	}
-
-	switch status := grpcError.GRPCStatus(); {
-	case status.Code() == codes.Canceled:
-		return &grpcContextError{grpcErr: err, grpcStatus: status, stdErr: context.Canceled}
-	case status.Code() == codes.DeadlineExceeded:
-		return &grpcContextError{grpcErr: err, grpcStatus: status, stdErr: context.DeadlineExceeded}
-	default:
-		return err
-	}
-}
-
-// grpcContextError is a custom error used to wrap gRPC errors which maps to golang standard context errors.
-type grpcContextError struct {
-	// grpcErr is the gRPC error wrapped by grpcContextError.
-	grpcErr error
-
-	// grpcStatus is the gRPC status associated with the gRPC error. It's guaranteed to be non-nil.
-	grpcStatus *grpcstatus.Status
-
-	// stdErr is the equivalent golang standard context error.
-	stdErr error
-}
-
-func (e *grpcContextError) Error() string {
-	return e.grpcErr.Error()
-}
-
-func (e *grpcContextError) Unwrap() error {
-	return e.grpcErr
-}
-
-func (e *grpcContextError) Is(err error) bool {
-	return errors.Is(e.stdErr, err) || errors.Is(e.grpcErr, err)
-}
-
-func (e *grpcContextError) As(target any) bool {
-	if errors.As(e.stdErr, target) {
-		return true
-	}
-
-	return errors.As(e.grpcErr, target)
-}
-
-func (e *grpcContextError) GRPCStatus() *grpcstatus.Status {
-	return e.grpcStatus
+	return util.WrapGrpcContextError(c.wrapped.RecvMsg(m))
 }

--- a/pkg/util/grpc_error.go
+++ b/pkg/util/grpc_error.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package util
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// WrapGrpcContextError wraps a gRPC error with a custom error mapping gRPC to standard golang context errors.
+func WrapGrpcContextError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Get the gRPC status from the error.
+	type grpcErrorStatus interface{ GRPCStatus() *grpcstatus.Status }
+	var grpcError grpcErrorStatus
+	if !errors.As(err, &grpcError) {
+		return err
+	}
+
+	switch status := grpcError.GRPCStatus(); {
+	case status.Code() == codes.Canceled:
+		return &grpcContextError{grpcErr: err, grpcStatus: status, stdErr: context.Canceled}
+	case status.Code() == codes.DeadlineExceeded:
+		return &grpcContextError{grpcErr: err, grpcStatus: status, stdErr: context.DeadlineExceeded}
+	default:
+		return err
+	}
+}
+
+// grpcContextError is a custom error used to wrap gRPC errors which maps to golang standard context errors.
+type grpcContextError struct {
+	// grpcErr is the gRPC error wrapped by grpcContextError.
+	grpcErr error
+
+	// grpcStatus is the gRPC status associated with the gRPC error. It's guaranteed to be non-nil.
+	grpcStatus *grpcstatus.Status
+
+	// stdErr is the equivalent golang standard context error.
+	stdErr error
+}
+
+func (e *grpcContextError) Error() string {
+	return e.grpcErr.Error()
+}
+
+func (e *grpcContextError) Unwrap() error {
+	return e.grpcErr
+}
+
+func (e *grpcContextError) Is(err error) bool {
+	return errors.Is(e.stdErr, err) || errors.Is(e.grpcErr, err)
+}
+
+func (e *grpcContextError) As(target any) bool {
+	if errors.As(e.stdErr, target) {
+		return true
+	}
+
+	return errors.As(e.grpcErr, target)
+}
+
+func (e *grpcContextError) GRPCStatus() *grpcstatus.Status {
+	return e.grpcStatus
+}

--- a/pkg/util/grpc_error_test.go
+++ b/pkg/util/grpc_error_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package storegatewaypb
+package util
 
 import (
 	"context"
@@ -67,7 +67,7 @@ func TestWrapContextError(t *testing.T) {
 
 		for testName, testData := range tests {
 			t.Run(testName, func(t *testing.T) {
-				wrapped := wrapContextError(testData.origErr)
+				wrapped := WrapGrpcContextError(testData.origErr)
 
 				assert.NotEqual(t, testData.origErr, wrapped)
 				assert.Equal(t, testData.origErr, errors.Unwrap(wrapped))
@@ -88,10 +88,10 @@ func TestWrapContextError(t *testing.T) {
 
 	t.Run("should return the input error on a non-gRPC error", func(t *testing.T) {
 		orig := errors.New("mock error")
-		assert.Equal(t, orig, wrapContextError(orig))
+		assert.Equal(t, orig, WrapGrpcContextError(orig))
 
-		assert.Equal(t, context.Canceled, wrapContextError(context.Canceled))
-		assert.Equal(t, context.DeadlineExceeded, wrapContextError(context.DeadlineExceeded))
-		assert.Equal(t, io.EOF, wrapContextError(io.EOF))
+		assert.Equal(t, context.Canceled, WrapGrpcContextError(context.Canceled))
+		assert.Equal(t, context.DeadlineExceeded, WrapGrpcContextError(context.DeadlineExceeded))
+		assert.Equal(t, io.EOF, WrapGrpcContextError(io.EOF))
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR addresses two issues I discovered while testing the active series API.

- Shard requests generated for incoming active series requests with method `GET` and a `selector` parameter in the query string were broken and did not include the modified shard selector. Therefore, the results would always contain the set of series duplicated as many times as there are request shards. 
- Handling `context.Canceled` is not sufficient for grpc related calls, we also need to handle `status.Code(err) == codes.Canceled`. Following up on a review comment, I have moved and reused code from `pkg/storegateway` which already solves this issue.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
