### PR TITLE
Make TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhileRunningRequestOnStoreGateway easier to debug when flaky

### DIFF
--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/limiter"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestBlocksStoreQuerier_Select(t *testing.T) {
@@ -959,6 +960,7 @@ func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhile
 
 	var (
 		block1 = ulid.MustNew(1, nil)
+		logger = test.NewTestingLogger(t)
 	)
 
 	// Create an utility to easily run each test case in isolation.
@@ -1005,8 +1007,8 @@ func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhile
 			maxT:        maxT,
 			finder:      finder,
 			stores:      stores,
-			consistency: NewBlocksConsistency(0, 0, log.NewNopLogger(), nil),
-			logger:      log.NewNopLogger(),
+			consistency: NewBlocksConsistency(0, 0, logger, nil),
+			logger:      logger,
 			metrics:     newBlocksStoreQueryableMetrics(nil),
 			limits:      &blocksStoreLimitsMock{},
 		}

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -993,9 +993,11 @@ func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhile
 
 		// Mock the stores, returning a gRPC client connecting to the gRPC server controlled in this test.
 		stores := &blocksStoreSetMock{mockedResponses: []interface{}{
-			map[BlocksStoreClient][]ulid.ULID{
-				client: {block1},
-			},
+			// These tests only require 1 mocked response, but we mock it multiple times to make debugging easier
+			// when the tests fail because the request is retried (even if we expect not to be retried).
+			map[BlocksStoreClient][]ulid.ULID{client: {block1}},
+			map[BlocksStoreClient][]ulid.ULID{client: {block1}},
+			map[BlocksStoreClient][]ulid.ULID{client: {block1}},
 		}}
 
 		q := &blocksStoreQuerier{


### PR DESCRIPTION
#### What this PR does

@charleskorn reported me that the `TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhileRunningRequestOnStoreGateway` [failed in a CI run](https://github.com/grafana/mimir/actions/runs/7454638805/job/20282329320?pr=7068#step:8:59) with the following error:

```
--- FAIL: TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhileRunningRequestOnStoreGateway (0.01s)
    --- FAIL: TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhileRunningRequestOnStoreGateway/LabelNames() (0.00s)
panic: not enough mocked results [recovered]
	panic: not enough mocked results

goroutine 687 [running]:
testing.tRunner.func1.2({0x203a880, 0x35a4490})
	/usr/local/go/src/testing/testing.go:1545 +0x3f7
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1548 +0x716
panic({0x203a880?, 0x35a4490?})
	/usr/local/go/src/runtime/panic.go:920 +0x270
github.com/grafana/mimir/pkg/querier.(*blocksStoreSetMock).GetClientsFor(0xc0001c20c0, {0xc0011b98c8?, 0x6?}, {0x6?, 0x1?, 0x11?}, 0x38?)
	/__w/mimir/mimir/pkg/querier/blocks_store_queryable_test.go:2181 +0x266
github.com/grafana/mimir/pkg/querier.(*blocksStoreQuerier).queryWithConsistencyCheck(0xc00067c310, {0x35bcbd8, 0xc0001c2150}, 0x2191020?, 0x35a9060?, 0x42b9640?, {0x22f8cfd, 0x6}, 0x0, 0xc0011b9cf8)
	/__w/mimir/mimir/pkg/querier/blocks_store_queryable.go:554 +0x12c5
github.com/grafana/mimir/pkg/querier.(*blocksStoreQuerier).LabelNames(0xc00067c310, {0x35bcc10, 0xc000149270}, {0xc0001423e8, 0x1, 0x1})
	/__w/mimir/mimir/pkg/querier/blocks_store_queryable.go:373 +0xbd1
github.com/grafana/mimir/pkg/querier.TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhileRunningRequestOnStoreGateway.func3(0x0?)
	/__w/mimir/mimir/pkg/querier/blocks_store_queryable_test.go:1077 +0x40c
testing.tRunner(0xc00086ed00, 0xc000665830)
	/usr/local/go/src/testing/testing.go:1595 +0x262
created by testing.(*T).Run in goroutine 661
	/usr/local/go/src/testing/testing.go:1648 +0x846
FAIL	github.com/grafana/mimir/pkg/querier	16.730s
```

The issue happens when a gRPC request is retried, while we expect not to be retried. I haven't been able to reproduce it locally (I've also tried to add some `time.Sleep()` in different places to try to trigger a timing issue). Unfortunately, due to the `panic()` we can't have more details from the actual CI run.

In this PR I suggest to print log messages and to mock the response multiple (3) times so that the panic() should go away and the actual behaviour logged when the test fails.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
