### PR TITLE
Add conditional read-after–write support to rules evaluation

### DIFF
--- a/development/mimir-ingest-storage/config/example-rules.yaml
+++ b/development/mimir-ingest-storage/config/example-rules.yaml
@@ -1,9 +1,18 @@
 # Example rules file to load to Mimir via the ruler API.
 groups:
   - name: alerts
+    # Frequently evaluate rules.
+    interval: 10s
     rules:
+      # The following recording rule is independent.
+      - record: cortex_build_info:sum
+        expr: sum(cortex_build_info)
+      # The following recording rule is used by the AlwaysFiring alert.
+      - record: up:count
+        expr: count(up)
       - alert: AlwaysFiring
-        expr: count(up) >= 0
+        expr: up:count >= 0
+        for: 10s
         labels:
           severity: page
         annotations:

--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -51,6 +51,9 @@ ruler:
   alertmanager_url: http://localhost:8080/alertmanager
   # Force the ruler to restore the state of any alert with a "for" period longer than 1s.
   for_grace_period: 1s
+  # Evaluate rules via query-frontend (remote rule evaluation).
+  query_frontend:
+    address: dns:///mimir-read-1:9095
 
 ruler_storage:
   s3:

--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -49,6 +49,8 @@ ruler:
   rule_path: /data/ruler
   # Each ruler is configured to route alerts to the Alertmanager running within the same component.
   alertmanager_url: http://localhost:8080/alertmanager
+  # Force the ruler to restore the state of any alert with a "for" period longer than 1s.
+  for_grace_period: 1s
 
 ruler_storage:
   s3:

--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240116133529-e3a486e7f801
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240122165117-baa5d82b5bc8
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -553,8 +553,8 @@ github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586 h1:/of8Z8taCPft
 github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328 h1:AjrK7M8938nI0gl7Mte5KPSGfxeAEFfqTwqcyP+c614=
-github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328/go.mod h1:W4s/zaz2ypTeyg7h7HDJ4/g0+p5tXBWJ6ToK3g0a5zs=
+github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720 h1:J2esvQ4z9NNyNoA/L9HC3uzcA6EXQVz6W9vFTF2DM3U=
+github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720/go.mod h1:W4s/zaz2ypTeyg7h7HDJ4/g0+p5tXBWJ6ToK3g0a5zs=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvFvdiiYg3COLlTwJiFo=

--- a/go.sum
+++ b/go.sum
@@ -553,8 +553,8 @@ github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586 h1:/of8Z8taCPft
 github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20240116133529-e3a486e7f801 h1:65eoE+Cwgi8PS+TBmdBn3xtS/JFeuTImzQI4GNDrhTQ=
-github.com/grafana/mimir-prometheus v0.0.0-20240116133529-e3a486e7f801/go.mod h1:W4s/zaz2ypTeyg7h7HDJ4/g0+p5tXBWJ6ToK3g0a5zs=
+github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328 h1:AjrK7M8938nI0gl7Mte5KPSGfxeAEFfqTwqcyP+c614=
+github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328/go.mod h1:W4s/zaz2ypTeyg7h7HDJ4/g0+p5tXBWJ6ToK3g0a5zs=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvFvdiiYg3COLlTwJiFo=

--- a/go.sum
+++ b/go.sum
@@ -553,8 +553,8 @@ github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586 h1:/of8Z8taCPft
 github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720 h1:J2esvQ4z9NNyNoA/L9HC3uzcA6EXQVz6W9vFTF2DM3U=
-github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720/go.mod h1:W4s/zaz2ypTeyg7h7HDJ4/g0+p5tXBWJ6ToK3g0a5zs=
+github.com/grafana/mimir-prometheus v0.0.0-20240122165117-baa5d82b5bc8 h1:nicadoSO2KafJRExlss8+PZkgH5OaCAujWSUV7EIB7E=
+github.com/grafana/mimir-prometheus v0.0.0-20240122165117-baa5d82b5bc8/go.mod h1:W4s/zaz2ypTeyg7h7HDJ4/g0+p5tXBWJ6ToK3g0a5zs=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvFvdiiYg3COLlTwJiFo=

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -423,7 +423,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 	// When the ingest storage is used, we expect that each query issued by this test was processed
 	// with strong read consistency by the ingester.
 	if flags["-ingest-storage.enabled"] == "true" {
-		require.NoError(t, ingester.WaitSumMetricsWithOptions(e2e.Equals(expectedIngesterQueriesCount), []string{"cortex_ingest_storage_strong_consistency_requests_total"}))
+		require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(expectedIngesterQueriesCount), "cortex_ingest_storage_strong_consistency_requests_total"))
 	} else {
 		require.NoError(t, ingester.WaitRemovedMetric("cortex_ingest_storage_strong_consistency_requests_total"))
 	}

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -35,13 +35,14 @@ import (
 
 	"github.com/grafana/mimir/integration/ca"
 	"github.com/grafana/mimir/integration/e2emimir"
+	"github.com/grafana/mimir/pkg/querier/api"
 )
 
 func TestRulerAPI(t *testing.T) {
 	var (
 		namespaceOne = "test_/encoded_+namespace/?"
 		namespaceTwo = "test_/encoded_+namespace/?/two"
-		ruleGroup    = createTestRuleGroup(t)
+		ruleGroup    = createTestRuleGroup()
 	)
 
 	s, err := e2e.NewScenario(networkName)
@@ -404,7 +405,7 @@ func TestRulerSharding(t *testing.T) {
 
 func TestRulerAlertmanager(t *testing.T) {
 	var namespaceOne = "test_/encoded_+namespace/?"
-	ruleGroup := createTestRuleGroup(t)
+	ruleGroup := createTestRuleGroup()
 
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
@@ -458,7 +459,7 @@ func TestRulerAlertmanager(t *testing.T) {
 
 func TestRulerAlertmanagerTLS(t *testing.T) {
 	var namespaceOne = "test_/encoded_+namespace/?"
-	ruleGroup := createTestRuleGroup(t)
+	ruleGroup := createTestRuleGroup()
 
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
@@ -1094,6 +1095,128 @@ func TestRulerRemoteEvaluation(t *testing.T) {
 	}
 }
 
+func TestRulerRemoteEvaluation_ShouldEnforceStrongReadConsistencyForDependentRulesWhenUsingTheIngestStorage(t *testing.T) {
+	const (
+		ruleGroupNamespace = "test"
+		ruleGroupName      = "test"
+	)
+
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	t.Cleanup(s.Close)
+
+	flags := mergeFlags(
+		CommonStorageBackendFlags(),
+		RulerFlags(),
+		BlocksStorageFlags(),
+		IngestStorageFlags(),
+		map[string]string{
+			"-ingester.ring.replication-factor": "1",
+
+			// No strong read consistency by default for this test. We want the ruler to enforce the strong
+			// consistency when required.
+			"-ingest-storage.read-consistency": api.ReadConsistencyEventual,
+		},
+	)
+
+	// Start dependencies.
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, mimirBucketName)
+	kafka := e2edb.NewKafka()
+	require.NoError(t, s.StartAndWaitReady(minio, consul, kafka))
+
+	// Start the query-frontend.
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", flags)
+	require.NoError(t, s.Start(queryFrontend))
+	flags["-querier.frontend-address"] = queryFrontend.NetworkGRPCEndpoint()
+
+	// Use query-frontend for rule evaluation.
+	flags["-ruler.query-frontend.address"] = fmt.Sprintf("dns:///%s", queryFrontend.NetworkGRPCEndpoint())
+
+	// Start up services
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	ingester := e2emimir.NewIngester("ingester-0", consul.NetworkHTTPEndpoint(), flags)
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
+
+	require.NoError(t, s.StartAndWaitReady(distributor, ingester, querier))
+	require.NoError(t, s.WaitReady(queryFrontend))
+
+	// Wait until the distributor is ready.
+	// The distributor should have 512 tokens for the ingester ring and 1 for the distributor ring.
+	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
+
+	client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+
+	// Push a test series.
+	now := time.Now()
+	series, _, _ := generateFloatSeries("series_1", now)
+
+	res, err := client.Push(series)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	t.Run("evaluation of independent rules should not require strong consistency", func(t *testing.T) {
+		ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), flags)
+		require.NoError(t, s.StartAndWaitReady(ruler))
+		t.Cleanup(func() {
+			require.NoError(t, s.Stop(ruler))
+		})
+
+		rulerClient, err := e2emimir.NewClient("", "", "", ruler.HTTPEndpoint(), userID)
+		require.NoError(t, err)
+
+		// Create a rule group containing 2 independent rules.
+		group := ruleGroupWithRules(ruleGroupName, time.Second,
+			recordingRule("series_1:count", "count(series_1)"),
+			recordingRule("series_1:sum", "sum(series_1)"),
+		)
+		require.NoError(t, rulerClient.SetRuleGroup(group, ruleGroupNamespace))
+
+		// Cleanup the ruler config when the test will end, so that it doesn't interfere with other test cases.
+		t.Cleanup(func() {
+			require.NoError(t, rulerClient.DeleteRuleNamespace(ruleGroupNamespace))
+		})
+
+		// Wait until the rules are evaluated.
+		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(float64(len(group.Rules))), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WaitMissingMetrics))
+
+		// The rules have been evaluated at least once. We expect the rule queries
+		// have run with eventual consistency because they are independent.
+		require.NoError(t, ingester.WaitSumMetrics(e2e.Equals(0), "cortex_ingest_storage_strong_consistency_requests_total"))
+	})
+
+	t.Run("evaluation of dependent rules should require strong consistency", func(t *testing.T) {
+		ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), flags)
+		require.NoError(t, s.StartAndWaitReady(ruler))
+		t.Cleanup(func() {
+			require.NoError(t, s.Stop(ruler))
+		})
+
+		rulerClient, err := e2emimir.NewClient("", "", "", ruler.HTTPEndpoint(), userID)
+		require.NoError(t, err)
+
+		// Create a rule group containing 2 rules: the 2nd one depends on the 1st one.
+		group := ruleGroupWithRules(ruleGroupName, time.Second,
+			recordingRule("series_1:count", "count(series_1)"),
+			recordingRule("series_1:count:sum", "sum(series_1:count)"),
+		)
+		require.NoError(t, rulerClient.SetRuleGroup(group, ruleGroupNamespace))
+
+		// Cleanup the ruler config when the test will end, so that it doesn't interfere with other test cases.
+		t.Cleanup(func() {
+			require.NoError(t, rulerClient.DeleteRuleNamespace(ruleGroupNamespace))
+		})
+
+		// Wait until the rules are evaluated.
+		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(float64(len(group.Rules))), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WaitMissingMetrics))
+
+		// The rules have been evaluated at least once. We expect the rule queries
+		// have run with strong consistency because they are not independent.
+		require.NoError(t, ingester.WaitSumMetrics(e2e.GreaterOrEqual(2), "cortex_ingest_storage_strong_consistency_requests_total"))
+	})
+}
+
 func TestRuler_RestoreWithLongForPeriod(t *testing.T) {
 	const (
 		forGracePeriod    = 5 * time.Second
@@ -1304,58 +1427,48 @@ func ruleGroupMatcher(user, namespace, groupName string) *labels.Matcher {
 }
 
 func ruleGroupWithRecordingRule(groupName string, ruleName string, expression string) rulefmt.RuleGroup {
-	var recordNode = yaml.Node{}
-	var exprNode = yaml.Node{}
-
-	recordNode.SetString(ruleName)
-	exprNode.SetString(expression)
-
-	return rulefmt.RuleGroup{
-		Name:     groupName,
-		Interval: 10,
-		Rules: []rulefmt.RuleNode{{
-			Record: recordNode,
-			Expr:   exprNode,
-		}},
-	}
+	return ruleGroupWithRules(groupName, 10, recordingRule(ruleName, expression))
 }
 
 func ruleGroupWithAlertingRule(groupName string, ruleName string, expression string) rulefmt.RuleGroup {
-	var recordNode = yaml.Node{}
-	var exprNode = yaml.Node{}
+	return ruleGroupWithRules(groupName, 10, alertingRule(ruleName, expression))
+}
 
-	recordNode.SetString(ruleName)
-	exprNode.SetString(expression)
-
+func ruleGroupWithRules(groupName string, interval time.Duration, rules ...rulefmt.RuleNode) rulefmt.RuleGroup {
 	return rulefmt.RuleGroup{
 		Name:     groupName,
-		Interval: 10,
-		Rules: []rulefmt.RuleNode{{
-			Alert: recordNode,
-			Expr:  exprNode,
-			For:   30,
-		}},
+		Interval: model.Duration(interval),
+		Rules:    rules,
 	}
 }
 
-func createTestRuleGroup(t *testing.T) rulefmt.RuleGroup {
-	t.Helper()
+func createTestRuleGroup() rulefmt.RuleGroup {
+	return ruleGroupWithRules("test_encoded_+\"+group_name/?", 100, recordingRule("test_rule", "up"))
+}
 
-	var (
-		recordNode = yaml.Node{}
-		exprNode   = yaml.Node{}
-	)
+func recordingRule(record, expr string) rulefmt.RuleNode {
+	var recordNode = yaml.Node{}
+	var exprNode = yaml.Node{}
 
-	recordNode.SetString("test_rule")
-	exprNode.SetString("up")
-	return rulefmt.RuleGroup{
-		Name:     "test_encoded_+\"+group_name/?",
-		Interval: 100,
-		Rules: []rulefmt.RuleNode{
-			{
-				Record: recordNode,
-				Expr:   exprNode,
-			},
-		},
+	recordNode.SetString(record)
+	exprNode.SetString(expr)
+
+	return rulefmt.RuleNode{
+		Record: recordNode,
+		Expr:   exprNode,
+	}
+}
+
+func alertingRule(alert, expr string) rulefmt.RuleNode {
+	var alertNode = yaml.Node{}
+	var exprNode = yaml.Node{}
+
+	alertNode.SetString(alert)
+	exprNode.SetString(expr)
+
+	return rulefmt.RuleNode{
+		Alert: alertNode,
+		Expr:  exprNode,
+		For:   30,
 	}
 }

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1211,9 +1211,9 @@ func TestRulerRemoteEvaluation_ShouldEnforceStrongReadConsistencyForDependentRul
 		// Wait until the rules are evaluated.
 		require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(float64(len(group.Rules))), []string{"cortex_prometheus_rule_evaluations_total"}, e2e.WaitMissingMetrics))
 
-		// The rules have been evaluated at least once. We expect the rule queries
-		// have run with strong consistency because they are not independent.
-		require.NoError(t, ingester.WaitSumMetrics(e2e.GreaterOrEqual(2), "cortex_ingest_storage_strong_consistency_requests_total"))
+		// The rules have been evaluated at least once. We expect the 2nd rule query
+		// has run with strong consistency because it depends on the 1st one.
+		require.NoError(t, ingester.WaitSumMetrics(e2e.GreaterOrEqual(1), "cortex_ingest_storage_strong_consistency_requests_total"))
 	})
 }
 

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -312,7 +312,7 @@ func DefaultTenantManagerFactory(
 
 		// Wrap the queryable with our custom logic.
 		wrappedQueryable := WrapQueryableWithReadConsistency(queryable)
-		
+
 		return rules.NewManager(&rules.ManagerOptions{
 			Appendable:                 NewPusherAppendable(p, userID, totalWrites, failedWrites),
 			Queryable:                  wrappedQueryable,

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -164,7 +164,7 @@ func (q *RemoteQuerier) Read(ctx context.Context, query *prompb.Query) (*prompb.
 		Method: http.MethodPost,
 		Url:    q.promHTTPPrefix + readEndpointPath,
 		Body:   snappy.Encode(nil, data),
-		Headers: injectHttpGrpcReadConsistencyHeader(ctx, []*httpgrpc.Header{
+		Headers: injectHTTPGrpcReadConsistencyHeader(ctx, []*httpgrpc.Header{
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Encoding"), Values: []string{"snappy"}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Accept-Encoding"), Values: []string{"snappy"}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Type"), Values: []string{"application/x-protobuf"}},
@@ -271,7 +271,7 @@ func (q *RemoteQuerier) createRequest(ctx context.Context, query string, ts time
 		Method: http.MethodPost,
 		Url:    q.promHTTPPrefix + queryEndpointPath,
 		Body:   body,
-		Headers: injectHttpGrpcReadConsistencyHeader(ctx, []*httpgrpc.Header{
+		Headers: injectHTTPGrpcReadConsistencyHeader(ctx, []*httpgrpc.Header{
 			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{userAgent}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Type"), Values: []string{mimeTypeFormPost}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Length"), Values: []string{strconv.Itoa(len(body))}},
@@ -352,10 +352,10 @@ func getHeader(headers []*httpgrpc.Header, name string) string {
 	return ""
 }
 
-// injectHttpGrpcReadConsistencyHeader reads the read consistency level from the ctx and, if defined, injects
+// injectHTTPGrpcReadConsistencyHeader reads the read consistency level from the ctx and, if defined, injects
 // it as an HTTP header to the list of input headers. This is required to propagate the read consistency
 // through the network when issuing an HTTPgRPC request.
-func injectHttpGrpcReadConsistencyHeader(ctx context.Context, headers []*httpgrpc.Header) []*httpgrpc.Header {
+func injectHTTPGrpcReadConsistencyHeader(ctx context.Context, headers []*httpgrpc.Header) []*httpgrpc.Header {
 	if level, ok := api.ReadConsistencyFromContext(ctx); ok {
 		headers = append(headers, &httpgrpc.Header{
 			Key:    textproto.CanonicalMIMEHeaderKey(api.ReadConsistencyHeader),

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 
+	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/version"
 )
@@ -163,13 +164,13 @@ func (q *RemoteQuerier) Read(ctx context.Context, query *prompb.Query) (*prompb.
 		Method: http.MethodPost,
 		Url:    q.promHTTPPrefix + readEndpointPath,
 		Body:   snappy.Encode(nil, data),
-		Headers: []*httpgrpc.Header{
+		Headers: injectHttpGrpcReadConsistencyHeader(ctx, []*httpgrpc.Header{
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Encoding"), Values: []string{"snappy"}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Accept-Encoding"), Values: []string{"snappy"}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Type"), Values: []string{"application/x-protobuf"}},
 			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{userAgent}},
 			{Key: textproto.CanonicalMIMEHeaderKey("X-Prometheus-Remote-Read-Version"), Values: []string{"0.1.0"}},
-		},
+		}),
 	}
 
 	for _, mdw := range q.middlewares {
@@ -270,12 +271,12 @@ func (q *RemoteQuerier) createRequest(ctx context.Context, query string, ts time
 		Method: http.MethodPost,
 		Url:    q.promHTTPPrefix + queryEndpointPath,
 		Body:   body,
-		Headers: []*httpgrpc.Header{
+		Headers: injectHttpGrpcReadConsistencyHeader(ctx, []*httpgrpc.Header{
 			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{userAgent}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Type"), Values: []string{mimeTypeFormPost}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Length"), Values: []string{strconv.Itoa(len(body))}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Accept"), Values: []string{acceptHeader}},
-		},
+		}),
 	}
 
 	for _, mdw := range q.middlewares {
@@ -349,4 +350,18 @@ func getHeader(headers []*httpgrpc.Header, name string) string {
 	}
 
 	return ""
+}
+
+// injectHttpGrpcReadConsistencyHeader reads the read consistency level from the ctx and, if defined, injects
+// it as an HTTP header to the list of input headers. This is required to propagate the read consistency
+// through the network when issuing an HTTPgRPC request.
+func injectHttpGrpcReadConsistencyHeader(ctx context.Context, headers []*httpgrpc.Header) []*httpgrpc.Header {
+	if level, ok := api.ReadConsistencyFromContext(ctx); ok {
+		headers = append(headers, &httpgrpc.Header{
+			Key:    textproto.CanonicalMIMEHeaderKey(api.ReadConsistencyHeader),
+			Values: []string{level},
+		})
+	}
+
+	return headers
 }

--- a/pkg/ruler/rule_query_consistency.go
+++ b/pkg/ruler/rule_query_consistency.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ruler
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/rules"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/grafana/mimir/pkg/querier/api"
+)
+
+// WrapQueryFuncWithReadConsistency wraps rules.QueryFunc with a function that injects strong read consistency
+// requirement in the context if the query is originated from a non-independent rule.
+func WrapQueryFuncWithReadConsistency(fn rules.QueryFunc) rules.QueryFunc {
+	return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
+		// Get details about the rule.
+		detail := rules.FromOriginContext(ctx)
+
+		// If the rule is not independent then we should enforce strong read consistency,
+		// otherwise we'll fallback to the per-tenant default.
+		if !detail.Independent {
+			ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
+		}
+
+		return fn(ctx, qs, t)
+	}
+}
+
+// WrapQueryableWithReadConsistency wraps storage.Queryable with a queryable that injects strong read consistency
+// requirement in the context for any request matching ALERTS_FOR_STATE metric name.
+//
+// The ALERTS_FOR_STATE metric is used to restore the state of a firing alert each time a rule Group is started.
+// In case of Mimir, it could happen for example when the ruler starts, or rule groups are resharded among rulers.
+//
+// When querying the ALERTS_FOR_STATE, ruler requires strong consistency in order to ensure we restore the state
+// from the last evaluation. Without such guarantee, the ruler may query a previous state.
+func WrapQueryableWithReadConsistency(q storage.Queryable) storage.Queryable {
+	return &readConsistencyQueryable{next: q}
+}
+
+type readConsistencyQueryable struct {
+	next storage.Queryable
+}
+
+// Querier implements storage.Queryable.
+func (q *readConsistencyQueryable) Querier(mint, maxt int64) (storage.Querier, error) {
+	querier, err := q.next.Querier(mint, maxt)
+	if err != nil {
+		return querier, err
+	}
+
+	return &readConsistencyQuerier{next: querier}, nil
+}
+
+type readConsistencyQuerier struct {
+	next storage.Querier
+}
+
+// Select implements storage.Querier.
+func (q *readConsistencyQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	// Enforce strong read consistency if it's querying the ALERTS_FOR_STATE metric, otherwise
+	// fallback to the default.
+	if isQueryingAlertsForStateMetric("", matchers...) {
+		ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
+	}
+
+	return q.next.Select(ctx, sortSeries, hints, matchers...)
+}
+
+// LabelValues implements storage.Querier.
+func (q *readConsistencyQuerier) LabelValues(ctx context.Context, name string, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	// Enforce strong read consistency if it's querying the ALERTS_FOR_STATE metric, otherwise
+	// fallback to the default.
+	if isQueryingAlertsForStateMetric(name, matchers...) {
+		ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
+	}
+
+	return q.next.LabelValues(ctx, name, matchers...)
+}
+
+// LabelNames implements storage.Querier.
+func (q *readConsistencyQuerier) LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	// Enforce strong read consistency if it's querying the ALERTS_FOR_STATE metric, otherwise
+	// fallback to the default.
+	if isQueryingAlertsForStateMetric("", matchers...) {
+		ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
+	}
+
+	return q.next.LabelNames(ctx, matchers...)
+}
+
+// Close implements storage.Querier.
+func (q *readConsistencyQuerier) Close() error {
+	return q.next.Close()
+}
+
+// isQueryingAlertsForStateMetric checks whether the input metricName or matchers match the
+// ALERTS_FOR_STATE metric.
+func isQueryingAlertsForStateMetric(metricName string, matchers ...*labels.Matcher) bool {
+	const alertForStateMetricName = "ALERTS_FOR_STATE"
+
+	if metricName == alertForStateMetricName {
+		return true
+	}
+
+	for _, matcher := range matchers {
+		if matcher.Name == labels.MetricName && matcher.Matches(alertForStateMetricName) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/ruler/rule_query_consistency_test.go
+++ b/pkg/ruler/rule_query_consistency_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ruler
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/rules"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/querier/api"
+)
+
+func TestWrapQueryFuncWithReadConsistency(t *testing.T) {
+	runWrappedFunc := func(ctx context.Context) (hasReadConsistency bool, readConsistencyLevel string) {
+		orig := func(ctx context.Context, _ string, _ time.Time) (promql.Vector, error) {
+			readConsistencyLevel, hasReadConsistency = api.ReadConsistencyFromContext(ctx)
+			return promql.Vector{}, nil
+		}
+
+		_, _ = WrapQueryFuncWithReadConsistency(orig)(ctx, "", time.Now())
+		return
+	}
+
+	t.Run("should inject strong read consistency if the rule detail is missing in the context", func(t *testing.T) {
+		hasReadConsistency, readConsistencyLevel := runWrappedFunc(context.Background())
+		assert.True(t, hasReadConsistency)
+		assert.Equal(t, api.ReadConsistencyStrong, readConsistencyLevel)
+	})
+
+	t.Run("should inject strong read consistency if the rule is not independent", func(t *testing.T) {
+		var (
+			r   = rules.NewRecordingRule("", &parser.StringLiteral{}, labels.New())
+			ctx = rules.NewOriginContext(context.Background(), rules.NewRuleDetail(r, false))
+		)
+
+		hasReadConsistency, readConsistencyLevel := runWrappedFunc(ctx)
+		assert.True(t, hasReadConsistency)
+		assert.Equal(t, api.ReadConsistencyStrong, readConsistencyLevel)
+	})
+
+	t.Run("should not inject read consistency level if the rule is independent, to let run with the per-tenant default", func(t *testing.T) {
+		var (
+			r   = rules.NewRecordingRule("", &parser.StringLiteral{}, labels.New())
+			ctx = rules.NewOriginContext(context.Background(), rules.NewRuleDetail(r, true))
+		)
+
+		hasReadConsistency, _ := runWrappedFunc(ctx)
+		assert.False(t, hasReadConsistency)
+	})
+}
+
+func TestWrapQueryableWithReadConsistency(t *testing.T) {
+	runWrappedSelect := func(matchers ...*labels.Matcher) (hasReadConsistency bool, readConsistencyLevel string) {
+		querier := newQuerierMock()
+		querier.selectFunc = func(ctx context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+			readConsistencyLevel, hasReadConsistency = api.ReadConsistencyFromContext(ctx)
+			return storage.EmptySeriesSet()
+		}
+
+		wrappedQueryable := WrapQueryableWithReadConsistency(&storage.MockQueryable{MockQuerier: querier})
+		wrapperQuerier, err := wrappedQueryable.Querier(math.MinInt64, math.MaxInt64)
+		require.NoError(t, err)
+
+		wrapperQuerier.Select(context.Background(), false, nil, matchers...)
+		return
+	}
+
+	t.Run("should inject strong read consistency if querying ALERTS_FOR_STATE", func(t *testing.T) {
+		hasReadConsistency, readConsistencyLevel := runWrappedSelect(
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "ALERTS_FOR_STATE"),
+			labels.MustNewMatcher(labels.MatchEqual, "alertname", "my_test_alert"),
+		)
+
+		assert.True(t, hasReadConsistency)
+		assert.Equal(t, api.ReadConsistencyStrong, readConsistencyLevel)
+	})
+
+	t.Run("should not inject read consistency level if not querying ALERTS_FOR_STATE", func(t *testing.T) {
+		hasReadConsistency, _ := runWrappedSelect(
+			labels.MustNewMatcher(labels.MatchEqual, "alertname", "my_test_alert"),
+		)
+
+		assert.False(t, hasReadConsistency)
+	})
+}
+
+func TestIsQueryingAlertsForStateMetric(t *testing.T) {
+	assert.False(t, isQueryingAlertsForStateMetric(""))
+	assert.False(t, isQueryingAlertsForStateMetric("test"))
+	assert.False(t, isQueryingAlertsForStateMetric("ALERTS"))
+	assert.True(t, isQueryingAlertsForStateMetric("ALERTS_FOR_STATE"))
+
+	assert.False(t, isQueryingAlertsForStateMetric("", labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "test")))
+	assert.False(t, isQueryingAlertsForStateMetric("", labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "ALERTS")))
+	assert.True(t, isQueryingAlertsForStateMetric("", labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "ALERTS_FOR_STATE")))
+	assert.True(t, isQueryingAlertsForStateMetric("", labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "ALERTS_.*")))
+}
+
+type querierMock struct {
+	storage.Querier
+
+	selectFunc func(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet
+}
+
+func newQuerierMock() *querierMock {
+	return &querierMock{
+		Querier: storage.NoopQuerier(),
+	}
+}
+
+func (m *querierMock) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	return m.selectFunc(ctx, sortSeries, hints, matchers...)
+}

--- a/pkg/ruler/rule_query_consistency_test.go
+++ b/pkg/ruler/rule_query_consistency_test.go
@@ -118,5 +118,9 @@ func newQuerierMock() *querierMock {
 }
 
 func (m *querierMock) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	return m.selectFunc(ctx, sortSeries, hints, matchers...)
+	if m.selectFunc != nil {
+		return m.selectFunc(ctx, sortSeries, hints, matchers...)
+	}
+
+	return storage.EmptySeriesSet()
 }

--- a/vendor/github.com/prometheus/prometheus/rules/alerting.go
+++ b/vendor/github.com/prometheus/prometheus/rules/alerting.go
@@ -323,8 +323,8 @@ const resolvedRetention = 15 * time.Minute
 
 // Eval evaluates the rule expression and then creates pending alerts and fires
 // or removes previously pending alerts accordingly.
-func (r *AlertingRule) Eval(ctx context.Context, evalDelay time.Duration, ts time.Time, query QueryFunc, externalURL *url.URL, limit int) (promql.Vector, error) {
-	ctx = NewOriginContext(ctx, NewRuleDetail(r))
+func (r *AlertingRule) Eval(ctx context.Context, evalDelay time.Duration, ts time.Time, query QueryFunc, externalURL *url.URL, limit int, independent bool) (promql.Vector, error) {
+	ctx = NewOriginContext(ctx, NewRuleDetail(r, independent))
 
 	res, err := query(ctx, r.vector.String(), ts.Add(-evalDelay))
 	if err != nil {

--- a/vendor/github.com/prometheus/prometheus/rules/alerting.go
+++ b/vendor/github.com/prometheus/prometheus/rules/alerting.go
@@ -327,7 +327,7 @@ func (r *AlertingRule) SetNoDependentRules(noDependentRules bool) {
 	r.noDependentRules.Store(noDependentRules)
 }
 
-func (r *AlertingRule) GetNoDependentRules() bool {
+func (r *AlertingRule) NoDependentRules() bool {
 	return r.noDependentRules.Load()
 }
 
@@ -335,7 +335,7 @@ func (r *AlertingRule) SetNoDependencyRules(noDependencyRules bool) {
 	r.noDependencyRules.Store(noDependencyRules)
 }
 
-func (r *AlertingRule) GetNoDependencyRules() bool {
+func (r *AlertingRule) NoDependencyRules() bool {
 	return r.noDependencyRules.Load()
 }
 

--- a/vendor/github.com/prometheus/prometheus/rules/dependency.go
+++ b/vendor/github.com/prometheus/prometheus/rules/dependency.go
@@ -1,0 +1,126 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import "github.com/prometheus/prometheus/promql/parser"
+
+// dependencyMap is a data-structure which contains the relationships between rules within a group.
+// It is used to describe the dependency associations between rules in a group whereby one rule uses the
+// output metric produced by another rule in its expression (i.e. as its "input").
+type dependencyMap map[Rule][]Rule
+
+// dependents returns the count of rules which use the output of the given rule as one of their inputs.
+func (m dependencyMap) dependents(r Rule) int {
+	return len(m[r])
+}
+
+// dependencies returns the count of rules on which the given rule is dependent for input.
+func (m dependencyMap) dependencies(r Rule) int {
+	if len(m) == 0 {
+		return 0
+	}
+
+	var count int
+	for _, children := range m {
+		for _, child := range children {
+			if child == r {
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+// isIndependent determines whether the given rule is not dependent on another rule for its input, nor is any other rule
+// dependent on its output.
+func (m dependencyMap) isIndependent(r Rule) bool {
+	if m == nil {
+		return false
+	}
+
+	return m.dependents(r)+m.dependencies(r) == 0
+}
+
+// buildDependencyMap builds a data-structure which contains the relationships between rules within a group.
+//
+// Alert rules, by definition, cannot have any dependents - but they can have dependencies. Any recording rule on whose
+// output an Alert rule depends will not be able to run concurrently.
+//
+// There is a class of rule expressions which are considered "indeterminate", because either relationships cannot be
+// inferred, or concurrent evaluation of rules depending on these series would produce undefined/unexpected behaviour:
+//   - wildcard queriers like {cluster="prod1"} which would match every series with that label selector
+//   - any "meta" series (series produced by Prometheus itself) like ALERTS, ALERTS_FOR_STATE
+//
+// Rules which are independent can run concurrently with no side-effects.
+func buildDependencyMap(rules []Rule) dependencyMap {
+	dependencies := make(dependencyMap)
+
+	if len(rules) <= 1 {
+		// No relationships if group has 1 or fewer rules.
+		return nil
+	}
+
+	inputs := make(map[string][]Rule, len(rules))
+	outputs := make(map[string][]Rule, len(rules))
+
+	var indeterminate bool
+
+	for _, rule := range rules {
+		rule := rule
+
+		name := rule.Name()
+		outputs[name] = append(outputs[name], rule)
+
+		parser.Inspect(rule.Query(), func(node parser.Node, path []parser.Node) error {
+			if n, ok := node.(*parser.VectorSelector); ok {
+				// A wildcard metric expression means we cannot reliably determine if this rule depends on any other,
+				// which means we cannot safely run any rules concurrently.
+				if n.Name == "" && len(n.LabelMatchers) > 0 {
+					indeterminate = true
+					return nil
+				}
+
+				// Rules which depend on "meta-metrics" like ALERTS and ALERTS_FOR_STATE will have undefined behaviour
+				// if they run concurrently.
+				if n.Name == alertMetricName || n.Name == alertForStateMetricName {
+					indeterminate = true
+					return nil
+				}
+
+				inputs[n.Name] = append(inputs[n.Name], rule)
+			}
+			return nil
+		})
+	}
+
+	if indeterminate {
+		return nil
+	}
+
+	if len(inputs) == 0 || len(outputs) == 0 {
+		// No relationships can be inferred.
+		return nil
+	}
+
+	for output, outRules := range outputs {
+		for _, outRule := range outRules {
+			if rs, found := inputs[output]; found && len(rs) > 0 {
+				dependencies[outRule] = append(dependencies[outRule], rs...)
+			}
+		}
+	}
+
+	return dependencies
+}

--- a/vendor/github.com/prometheus/prometheus/rules/group.go
+++ b/vendor/github.com/prometheus/prometheus/rules/group.go
@@ -22,7 +22,10 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
+
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -437,9 +440,14 @@ func (g *Group) CopyState(from *Group) {
 }
 
 // Eval runs a single evaluation cycle in which all rules are evaluated sequentially.
+// Rules can be evaluated concurrently if the `concurrent-rule-eval` feature flag is enabled.
 func (g *Group) Eval(ctx context.Context, ts time.Time) {
-	var samplesTotal float64
-	evaluationDelay := g.EvaluationDelay()
+	var (
+		samplesTotal    atomic.Float64
+		wg              sync.WaitGroup
+		evaluationDelay = g.EvaluationDelay()
+	)
+
 	for i, rule := range g.rules {
 		select {
 		case <-g.done:
@@ -447,7 +455,14 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 		default:
 		}
 
-		func(i int, rule Rule) {
+		eval := func(i int, rule Rule, independent, async bool) {
+			defer func() {
+				if async {
+					wg.Done()
+					g.opts.RuleConcurrencyController.Done()
+				}
+			}()
+
 			logger := log.WithPrefix(g.logger, "name", rule.Name(), "index", i)
 			ctx, sp := otel.Tracer("").Start(ctx, "rule")
 			sp.SetAttributes(attribute.String("name", rule.Name()))
@@ -466,7 +481,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 
 			g.metrics.EvalTotal.WithLabelValues(GroupKey(g.File(), g.Name())).Inc()
 
-			vector, err := rule.Eval(ctx, evaluationDelay, ts, g.opts.QueryFunc, g.opts.ExternalURL, g.Limit())
+			vector, err := rule.Eval(ctx, evaluationDelay, ts, g.opts.QueryFunc, g.opts.ExternalURL, g.Limit(), independent)
 			if err != nil {
 				rule.SetHealth(HealthBad)
 				rule.SetLastError(err)
@@ -483,7 +498,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			}
 			rule.SetHealth(HealthGood)
 			rule.SetLastError(nil)
-			samplesTotal += float64(len(vector))
+			samplesTotal.Add(float64(len(vector)))
 
 			if ar, ok := rule.(*AlertingRule); ok {
 				ar.sendAlerts(ctx, ts, g.opts.ResendDelay, g.interval, g.opts.NotifyFunc)
@@ -572,10 +587,23 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 					}
 				}
 			}
-		}(i, rule)
+		}
+
+		// If the rule has no dependencies, it can run concurrently because no other rules in this group depend on its output.
+		independent := g.opts.RuleDependencyController.IsRuleIndependent(g, rule)
+
+		// Try run concurrently if there are slots available.
+		if ctrl := g.opts.RuleConcurrencyController; independent && ctrl != nil && ctrl.Allow() {
+			wg.Add(1)
+			go eval(i, rule, independent, true)
+		} else {
+			eval(i, rule, independent, false)
+		}
 	}
+
+	wg.Wait()
 	if g.metrics != nil {
-		g.metrics.GroupSamples.WithLabelValues(GroupKey(g.File(), g.Name())).Set(samplesTotal)
+		g.metrics.GroupSamples.WithLabelValues(GroupKey(g.File(), g.Name())).Set(samplesTotal.Load())
 	}
 	g.cleanupStaleSeries(ctx, ts)
 }
@@ -920,4 +948,114 @@ func NewGroupMetrics(reg prometheus.Registerer) *Metrics {
 	}
 
 	return m
+}
+
+// dependencyMap is a data-structure which contains the relationships between rules within a group.
+// It is used to describe the dependency associations between rules in a group whereby one rule uses the
+// output metric produced by another rule in its expression (i.e. as its "input").
+type dependencyMap map[Rule][]Rule
+
+// dependents returns the count of rules which use the output of the given rule as one of their inputs.
+func (m dependencyMap) dependents(r Rule) int {
+	return len(m[r])
+}
+
+// dependencies returns the count of rules on which the given rule is dependent for input.
+func (m dependencyMap) dependencies(r Rule) int {
+	if len(m) == 0 {
+		return 0
+	}
+
+	var count int
+	for _, children := range m {
+		for _, child := range children {
+			if child == r {
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+// isIndependent determines whether the given rule is not dependent on another rule for its input, nor is any other rule
+// dependent on its output.
+func (m dependencyMap) isIndependent(r Rule) bool {
+	if m == nil {
+		return false
+	}
+
+	return m.dependents(r)+m.dependencies(r) == 0
+}
+
+// buildDependencyMap builds a data-structure which contains the relationships between rules within a group.
+//
+// Alert rules, by definition, cannot have any dependents - but they can have dependencies. Any recording rule on whose
+// output an Alert rule depends will not be able to run concurrently.
+//
+// There is a class of rule expressions which are considered "indeterminate", because either relationships cannot be
+// inferred, or concurrent evaluation of rules depending on these series would produce undefined/unexpected behaviour:
+//   - wildcard queriers like {cluster="prod1"} which would match every series with that label selector
+//   - any "meta" series (series produced by Prometheus itself) like ALERTS, ALERTS_FOR_STATE
+//
+// Rules which are independent can run concurrently with no side-effects.
+func buildDependencyMap(rules []Rule) dependencyMap {
+	dependencies := make(dependencyMap)
+
+	if len(rules) <= 1 {
+		// No relationships if group has 1 or fewer rules.
+		return nil
+	}
+
+	inputs := make(map[string][]Rule, len(rules))
+	outputs := make(map[string][]Rule, len(rules))
+
+	var indeterminate bool
+
+	for _, rule := range rules {
+		rule := rule
+
+		name := rule.Name()
+		outputs[name] = append(outputs[name], rule)
+
+		parser.Inspect(rule.Query(), func(node parser.Node, path []parser.Node) error {
+			if n, ok := node.(*parser.VectorSelector); ok {
+				// A wildcard metric expression means we cannot reliably determine if this rule depends on any other,
+				// which means we cannot safely run any rules concurrently.
+				if n.Name == "" && len(n.LabelMatchers) > 0 {
+					indeterminate = true
+					return nil
+				}
+
+				// Rules which depend on "meta-metrics" like ALERTS and ALERTS_FOR_STATE will have undefined behaviour
+				// if they run concurrently.
+				if n.Name == alertMetricName || n.Name == alertForStateMetricName {
+					indeterminate = true
+					return nil
+				}
+
+				inputs[n.Name] = append(inputs[n.Name], rule)
+			}
+			return nil
+		})
+	}
+
+	if indeterminate {
+		return nil
+	}
+
+	if len(inputs) == 0 || len(outputs) == 0 {
+		// No relationships can be inferred.
+		return nil
+	}
+
+	for output, outRules := range outputs {
+		for _, outRule := range outRules {
+			if rs, found := inputs[output]; found && len(rs) > 0 {
+				dependencies[outRule] = append(dependencies[outRule], rs...)
+			}
+		}
+	}
+
+	return dependencies
 }

--- a/vendor/github.com/prometheus/prometheus/rules/group.go
+++ b/vendor/github.com/prometheus/prometheus/rules/group.go
@@ -22,10 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
-
-	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -440,14 +437,9 @@ func (g *Group) CopyState(from *Group) {
 }
 
 // Eval runs a single evaluation cycle in which all rules are evaluated sequentially.
-// Rules can be evaluated concurrently if the `concurrent-rule-eval` feature flag is enabled.
 func (g *Group) Eval(ctx context.Context, ts time.Time) {
-	var (
-		samplesTotal    atomic.Float64
-		wg              sync.WaitGroup
-		evaluationDelay = g.EvaluationDelay()
-	)
-
+	var samplesTotal float64
+	evaluationDelay := g.EvaluationDelay()
 	for i, rule := range g.rules {
 		select {
 		case <-g.done:
@@ -455,14 +447,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 		default:
 		}
 
-		eval := func(i int, rule Rule, independent, async bool) {
-			defer func() {
-				if async {
-					wg.Done()
-					g.opts.RuleConcurrencyController.Done()
-				}
-			}()
-
+		func(i int, rule Rule) {
 			logger := log.WithPrefix(g.logger, "name", rule.Name(), "index", i)
 			ctx, sp := otel.Tracer("").Start(ctx, "rule")
 			sp.SetAttributes(attribute.String("name", rule.Name()))
@@ -481,7 +466,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 
 			g.metrics.EvalTotal.WithLabelValues(GroupKey(g.File(), g.Name())).Inc()
 
-			vector, err := rule.Eval(ctx, evaluationDelay, ts, g.opts.QueryFunc, g.opts.ExternalURL, g.Limit(), independent)
+			vector, err := rule.Eval(ctx, evaluationDelay, ts, g.opts.QueryFunc, g.opts.ExternalURL, g.Limit())
 			if err != nil {
 				rule.SetHealth(HealthBad)
 				rule.SetLastError(err)
@@ -498,7 +483,7 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 			}
 			rule.SetHealth(HealthGood)
 			rule.SetLastError(nil)
-			samplesTotal.Add(float64(len(vector)))
+			samplesTotal += float64(len(vector))
 
 			if ar, ok := rule.(*AlertingRule); ok {
 				ar.sendAlerts(ctx, ts, g.opts.ResendDelay, g.interval, g.opts.NotifyFunc)
@@ -587,23 +572,10 @@ func (g *Group) Eval(ctx context.Context, ts time.Time) {
 					}
 				}
 			}
-		}
-
-		// If the rule has no dependencies, it can run concurrently because no other rules in this group depend on its output.
-		independent := g.opts.RuleDependencyController.IsRuleIndependent(g, rule)
-
-		// Try run concurrently if there are slots available.
-		if ctrl := g.opts.RuleConcurrencyController; independent && ctrl != nil && ctrl.Allow() {
-			wg.Add(1)
-			go eval(i, rule, independent, true)
-		} else {
-			eval(i, rule, independent, false)
-		}
+		}(i, rule)
 	}
-
-	wg.Wait()
 	if g.metrics != nil {
-		g.metrics.GroupSamples.WithLabelValues(GroupKey(g.File(), g.Name())).Set(samplesTotal.Load())
+		g.metrics.GroupSamples.WithLabelValues(GroupKey(g.File(), g.Name())).Set(samplesTotal)
 	}
 	g.cleanupStaleSeries(ctx, ts)
 }
@@ -948,114 +920,4 @@ func NewGroupMetrics(reg prometheus.Registerer) *Metrics {
 	}
 
 	return m
-}
-
-// dependencyMap is a data-structure which contains the relationships between rules within a group.
-// It is used to describe the dependency associations between rules in a group whereby one rule uses the
-// output metric produced by another rule in its expression (i.e. as its "input").
-type dependencyMap map[Rule][]Rule
-
-// dependents returns the count of rules which use the output of the given rule as one of their inputs.
-func (m dependencyMap) dependents(r Rule) int {
-	return len(m[r])
-}
-
-// dependencies returns the count of rules on which the given rule is dependent for input.
-func (m dependencyMap) dependencies(r Rule) int {
-	if len(m) == 0 {
-		return 0
-	}
-
-	var count int
-	for _, children := range m {
-		for _, child := range children {
-			if child == r {
-				count++
-			}
-		}
-	}
-
-	return count
-}
-
-// isIndependent determines whether the given rule is not dependent on another rule for its input, nor is any other rule
-// dependent on its output.
-func (m dependencyMap) isIndependent(r Rule) bool {
-	if m == nil {
-		return false
-	}
-
-	return m.dependents(r)+m.dependencies(r) == 0
-}
-
-// buildDependencyMap builds a data-structure which contains the relationships between rules within a group.
-//
-// Alert rules, by definition, cannot have any dependents - but they can have dependencies. Any recording rule on whose
-// output an Alert rule depends will not be able to run concurrently.
-//
-// There is a class of rule expressions which are considered "indeterminate", because either relationships cannot be
-// inferred, or concurrent evaluation of rules depending on these series would produce undefined/unexpected behaviour:
-//   - wildcard queriers like {cluster="prod1"} which would match every series with that label selector
-//   - any "meta" series (series produced by Prometheus itself) like ALERTS, ALERTS_FOR_STATE
-//
-// Rules which are independent can run concurrently with no side-effects.
-func buildDependencyMap(rules []Rule) dependencyMap {
-	dependencies := make(dependencyMap)
-
-	if len(rules) <= 1 {
-		// No relationships if group has 1 or fewer rules.
-		return nil
-	}
-
-	inputs := make(map[string][]Rule, len(rules))
-	outputs := make(map[string][]Rule, len(rules))
-
-	var indeterminate bool
-
-	for _, rule := range rules {
-		rule := rule
-
-		name := rule.Name()
-		outputs[name] = append(outputs[name], rule)
-
-		parser.Inspect(rule.Query(), func(node parser.Node, path []parser.Node) error {
-			if n, ok := node.(*parser.VectorSelector); ok {
-				// A wildcard metric expression means we cannot reliably determine if this rule depends on any other,
-				// which means we cannot safely run any rules concurrently.
-				if n.Name == "" && len(n.LabelMatchers) > 0 {
-					indeterminate = true
-					return nil
-				}
-
-				// Rules which depend on "meta-metrics" like ALERTS and ALERTS_FOR_STATE will have undefined behaviour
-				// if they run concurrently.
-				if n.Name == alertMetricName || n.Name == alertForStateMetricName {
-					indeterminate = true
-					return nil
-				}
-
-				inputs[n.Name] = append(inputs[n.Name], rule)
-			}
-			return nil
-		})
-	}
-
-	if indeterminate {
-		return nil
-	}
-
-	if len(inputs) == 0 || len(outputs) == 0 {
-		// No relationships can be inferred.
-		return nil
-	}
-
-	for output, outRules := range outputs {
-		for _, outRule := range outRules {
-			if rs, found := inputs[output]; found && len(rs) > 0 {
-				dependencies[outRule] = append(dependencies[outRule], rs...)
-			}
-		}
-	}
-
-	return dependencies
 }

--- a/vendor/github.com/prometheus/prometheus/rules/manager.go
+++ b/vendor/github.com/prometheus/prometheus/rules/manager.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/slices"
-	"golang.org/x/sync/semaphore"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
@@ -106,28 +105,22 @@ type ContextWrapFunc func(ctx context.Context, g *Group) context.Context
 
 // ManagerOptions bundles options for the Manager.
 type ManagerOptions struct {
-	ExternalURL               *url.URL
-	QueryFunc                 QueryFunc
-	NotifyFunc                NotifyFunc
-	Context                   context.Context
-	Appendable                storage.Appendable
-	Queryable                 storage.Queryable
-	Logger                    log.Logger
-	Registerer                prometheus.Registerer
-	OutageTolerance           time.Duration
-	ForGracePeriod            time.Duration
-	ResendDelay               time.Duration
-	GroupLoader               GroupLoader
-	MaxConcurrentEvals        int64
-	ConcurrentEvalsEnabled    bool
-	RuleDependencyController  RuleDependencyController
-	RuleConcurrencyController RuleConcurrencyController
-
-	DefaultEvaluationDelay func() time.Duration
-
+	ExternalURL *url.URL
+	QueryFunc   QueryFunc
+	NotifyFunc  NotifyFunc
+	Context     context.Context
 	// GroupEvaluationContextFunc will be called to wrap Context based on the group being evaluated.
 	// Will be skipped if nil.
 	GroupEvaluationContextFunc ContextWrapFunc
+	Appendable                 storage.Appendable
+	Queryable                  storage.Queryable
+	Logger                     log.Logger
+	Registerer                 prometheus.Registerer
+	OutageTolerance            time.Duration
+	ForGracePeriod             time.Duration
+	ResendDelay                time.Duration
+	GroupLoader                GroupLoader
+	DefaultEvaluationDelay     func() time.Duration
 
 	// AlwaysRestoreAlertState forces all new or changed groups in calls to Update to restore.
 	// Useful when you know you will be adding alerting rules after the manager has already started.
@@ -145,14 +138,6 @@ func NewManager(o *ManagerOptions) *Manager {
 
 	if o.GroupLoader == nil {
 		o.GroupLoader = FileLoader{}
-	}
-
-	if o.RuleDependencyController == nil {
-		o.RuleDependencyController = NewRuleDependencyController()
-	}
-
-	if o.RuleConcurrencyController == nil {
-		o.RuleConcurrencyController = newRuleConcurrencyController(o.ConcurrentEvalsEnabled, o.MaxConcurrentEvals)
 	}
 
 	m := &Manager{
@@ -200,10 +185,6 @@ func (m *Manager) Stop() {
 func (m *Manager) Update(interval time.Duration, files []string, externalLabels labels.Labels, externalURL string, groupEvalIterationFunc GroupEvalIterationFunc) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
-
-	if m.opts.RuleDependencyController != nil {
-		m.opts.RuleDependencyController.Invalidate()
-	}
 
 	groups, errs := m.LoadGroups(interval, externalLabels, externalURL, groupEvalIterationFunc, files...)
 
@@ -342,6 +323,13 @@ func (m *Manager) LoadGroups(
 				))
 			}
 
+			// Check dependencies between rules and store it on the Rule itself.
+			depMap := buildDependencyMap(rules)
+			for _, r := range rules {
+				r.SetNoDependentRules(depMap.dependents(r) == 0)
+				r.SetNoDependencyRules(depMap.dependencies(r) == 0)
+			}
+
 			groups[GroupKey(fn, rg.Name)] = NewGroup(GroupOptions{
 				Name:                          rg.Name,
 				File:                          fn,
@@ -439,86 +427,4 @@ func SendAlerts(s Sender, externalURL string) NotifyFunc {
 			s.Send(res...)
 		}
 	}
-}
-
-// TODO doc
-type RuleDependencyController interface {
-	// TODO doc
-	IsRuleIndependent(g *Group, r Rule) bool
-
-	// TODO doc
-	Invalidate()
-}
-
-// TODO unit test
-type ruleDependencyController struct {
-	depMapsMu sync.Mutex
-	depMaps   map[*Group]dependencyMap
-}
-
-func NewRuleDependencyController() RuleDependencyController {
-	return &ruleDependencyController{
-		depMaps: map[*Group]dependencyMap{},
-	}
-}
-
-func (c *ruleDependencyController) IsRuleIndependent(g *Group, r Rule) bool {
-	c.depMapsMu.Lock()
-	defer c.depMapsMu.Unlock()
-
-	depMap, found := c.depMaps[g]
-	if !found {
-		depMap = buildDependencyMap(g.rules)
-		c.depMaps[g] = depMap
-	}
-
-	return depMap.isIndependent(r)
-}
-
-func (c *ruleDependencyController) Invalidate() {
-	c.depMapsMu.Lock()
-	defer c.depMapsMu.Unlock()
-
-	// Clear out the memoized dependency maps because some or all groups may have been updated.
-	c.depMaps = map[*Group]dependencyMap{}
-}
-
-// RuleConcurrencyController controls whether rules can be evaluated concurrently. Its purpose it to bound the amount
-// of concurrency in rule evaluations, to not overwhelm the Prometheus server with additional query load.
-// Concurrency is controlled globally, not on a per-group basis.
-type RuleConcurrencyController interface {
-	// Allow determines whether any concurrent evaluation slots are available.
-	Allow() bool
-
-	// Done releases a concurrent evaluation slot.
-	Done()
-}
-
-func newRuleConcurrencyController(enabled bool, maxConcurrency int64) RuleConcurrencyController {
-	return &concurrentRuleEvalController{
-		enabled: enabled,
-		sema:    semaphore.NewWeighted(maxConcurrency),
-	}
-}
-
-// concurrentRuleEvalController holds a weighted semaphore which controls the concurrent evaluation of rules.
-type concurrentRuleEvalController struct {
-	enabled bool
-	sema    *semaphore.Weighted
-}
-
-func (c *concurrentRuleEvalController) Allow() bool {
-	if !c.enabled {
-		return false
-	}
-
-	return c.sema.TryAcquire(1)
-}
-
-func (c *concurrentRuleEvalController) Done() {
-	if !c.enabled {
-		return
-	}
-
-	c.sema.Release(1)
 }

--- a/vendor/github.com/prometheus/prometheus/rules/origin.go
+++ b/vendor/github.com/prometheus/prometheus/rules/origin.go
@@ -28,6 +28,10 @@ type RuleDetail struct {
 	Query  string
 	Labels labels.Labels
 	Kind   string
+
+	// Independent holds whether this rule depends on the result of other rules
+	// within the same rule group or not.
+	Independent bool
 }
 
 const (
@@ -36,7 +40,7 @@ const (
 )
 
 // NewRuleDetail creates a RuleDetail from a given Rule.
-func NewRuleDetail(r Rule) RuleDetail {
+func NewRuleDetail(r Rule, independent bool) RuleDetail {
 	var kind string
 	switch r.(type) {
 	case *AlertingRule:
@@ -48,10 +52,11 @@ func NewRuleDetail(r Rule) RuleDetail {
 	}
 
 	return RuleDetail{
-		Name:   r.Name(),
-		Query:  r.Query().String(),
-		Labels: r.Labels(),
-		Kind:   kind,
+		Name:        r.Name(),
+		Query:       r.Query().String(),
+		Labels:      r.Labels(),
+		Kind:        kind,
+		Independent: independent,
 	}
 }
 

--- a/vendor/github.com/prometheus/prometheus/rules/origin.go
+++ b/vendor/github.com/prometheus/prometheus/rules/origin.go
@@ -61,8 +61,8 @@ func NewRuleDetail(r Rule) RuleDetail {
 		Labels: r.Labels(),
 		Kind:   kind,
 
-		NoDependentRules:  r.GetNoDependentRules(),
-		NoDependencyRules: r.GetNoDependencyRules(),
+		NoDependentRules:  r.NoDependentRules(),
+		NoDependencyRules: r.NoDependencyRules(),
 	}
 }
 

--- a/vendor/github.com/prometheus/prometheus/rules/origin.go
+++ b/vendor/github.com/prometheus/prometheus/rules/origin.go
@@ -29,9 +29,13 @@ type RuleDetail struct {
 	Labels labels.Labels
 	Kind   string
 
-	// Independent holds whether this rule depends on the result of other rules
-	// within the same rule group or not.
-	Independent bool
+	// NoDependentRules is set to true if it's guaranteed that in the rule group there's no other rule
+	// which depends on this one.
+	NoDependentRules bool
+
+	// NoDependencyRules is set to true if it's guaranteed that this rule doesn't depend on any other
+	// rule within the rule group.
+	NoDependencyRules bool
 }
 
 const (
@@ -40,7 +44,7 @@ const (
 )
 
 // NewRuleDetail creates a RuleDetail from a given Rule.
-func NewRuleDetail(r Rule, independent bool) RuleDetail {
+func NewRuleDetail(r Rule) RuleDetail {
 	var kind string
 	switch r.(type) {
 	case *AlertingRule:
@@ -52,11 +56,13 @@ func NewRuleDetail(r Rule, independent bool) RuleDetail {
 	}
 
 	return RuleDetail{
-		Name:        r.Name(),
-		Query:       r.Query().String(),
-		Labels:      r.Labels(),
-		Kind:        kind,
-		Independent: independent,
+		Name:   r.Name(),
+		Query:  r.Query().String(),
+		Labels: r.Labels(),
+		Kind:   kind,
+
+		NoDependentRules:  r.GetNoDependentRules(),
+		NoDependencyRules: r.GetNoDependencyRules(),
 	}
 }
 

--- a/vendor/github.com/prometheus/prometheus/rules/recording.go
+++ b/vendor/github.com/prometheus/prometheus/rules/recording.go
@@ -72,8 +72,8 @@ func (rule *RecordingRule) Labels() labels.Labels {
 }
 
 // Eval evaluates the rule and then overrides the metric names and labels accordingly.
-func (rule *RecordingRule) Eval(ctx context.Context, evalDelay time.Duration, ts time.Time, query QueryFunc, _ *url.URL, limit int) (promql.Vector, error) {
-	ctx = NewOriginContext(ctx, NewRuleDetail(rule))
+func (rule *RecordingRule) Eval(ctx context.Context, evalDelay time.Duration, ts time.Time, query QueryFunc, _ *url.URL, limit int, independent bool) (promql.Vector, error) {
+	ctx = NewOriginContext(ctx, NewRuleDetail(rule, independent))
 
 	vector, err := query(ctx, rule.vector.String(), ts.Add(-evalDelay))
 	if err != nil {

--- a/vendor/github.com/prometheus/prometheus/rules/recording.go
+++ b/vendor/github.com/prometheus/prometheus/rules/recording.go
@@ -177,7 +177,7 @@ func (rule *RecordingRule) SetNoDependentRules(noDependentRules bool) {
 	rule.noDependentRules.Store(noDependentRules)
 }
 
-func (rule *RecordingRule) GetNoDependentRules() bool {
+func (rule *RecordingRule) NoDependentRules() bool {
 	return rule.noDependentRules.Load()
 }
 
@@ -185,6 +185,6 @@ func (rule *RecordingRule) SetNoDependencyRules(noDependencyRules bool) {
 	rule.noDependencyRules.Store(noDependencyRules)
 }
 
-func (rule *RecordingRule) GetNoDependencyRules() bool {
+func (rule *RecordingRule) NoDependencyRules() bool {
 	return rule.noDependencyRules.Load()
 }

--- a/vendor/github.com/prometheus/prometheus/rules/recording.go
+++ b/vendor/github.com/prometheus/prometheus/rules/recording.go
@@ -41,6 +41,9 @@ type RecordingRule struct {
 	lastError *atomic.Error
 	// Duration of how long it took to evaluate the recording rule.
 	evaluationDuration *atomic.Duration
+
+	noDependentRules  *atomic.Bool
+	noDependencyRules *atomic.Bool
 }
 
 // NewRecordingRule returns a new recording rule.
@@ -53,6 +56,9 @@ func NewRecordingRule(name string, vector parser.Expr, lset labels.Labels) *Reco
 		evaluationTimestamp: atomic.NewTime(time.Time{}),
 		evaluationDuration:  atomic.NewDuration(0),
 		lastError:           atomic.NewError(nil),
+
+		noDependentRules:  atomic.NewBool(false),
+		noDependencyRules: atomic.NewBool(false),
 	}
 }
 
@@ -72,8 +78,8 @@ func (rule *RecordingRule) Labels() labels.Labels {
 }
 
 // Eval evaluates the rule and then overrides the metric names and labels accordingly.
-func (rule *RecordingRule) Eval(ctx context.Context, evalDelay time.Duration, ts time.Time, query QueryFunc, _ *url.URL, limit int, independent bool) (promql.Vector, error) {
-	ctx = NewOriginContext(ctx, NewRuleDetail(rule, independent))
+func (rule *RecordingRule) Eval(ctx context.Context, evalDelay time.Duration, ts time.Time, query QueryFunc, _ *url.URL, limit int) (promql.Vector, error) {
+	ctx = NewOriginContext(ctx, NewRuleDetail(rule))
 
 	vector, err := query(ctx, rule.vector.String(), ts.Add(-evalDelay))
 	if err != nil {
@@ -165,4 +171,20 @@ func (rule *RecordingRule) SetEvaluationTimestamp(ts time.Time) {
 // GetEvaluationTimestamp returns the time the evaluation took place.
 func (rule *RecordingRule) GetEvaluationTimestamp() time.Time {
 	return rule.evaluationTimestamp.Load()
+}
+
+func (rule *RecordingRule) SetNoDependentRules(noDependentRules bool) {
+	rule.noDependentRules.Store(noDependentRules)
+}
+
+func (rule *RecordingRule) GetNoDependentRules() bool {
+	return rule.noDependentRules.Load()
+}
+
+func (rule *RecordingRule) SetNoDependencyRules(noDependencyRules bool) {
+	rule.noDependencyRules.Store(noDependencyRules)
+}
+
+func (rule *RecordingRule) GetNoDependencyRules() bool {
+	return rule.noDependencyRules.Load()
 }

--- a/vendor/github.com/prometheus/prometheus/rules/rule.go
+++ b/vendor/github.com/prometheus/prometheus/rules/rule.go
@@ -41,7 +41,7 @@ type Rule interface {
 	Labels() labels.Labels
 	// Eval evaluates the rule, including any associated recording or alerting actions.
 	// The duration passed is the evaluation delay.
-	Eval(context.Context, time.Duration, time.Time, QueryFunc, *url.URL, int) (promql.Vector, error)
+	Eval(_ context.Context, evalDelay time.Duration, ts time.Time, _ QueryFunc, externalURL *url.URL, limit int, independent bool) (promql.Vector, error)
 	// String returns a human-readable string representation of the rule.
 	String() string
 	// Query returns the rule query expression.

--- a/vendor/github.com/prometheus/prometheus/rules/rule.go
+++ b/vendor/github.com/prometheus/prometheus/rules/rule.go
@@ -41,7 +41,7 @@ type Rule interface {
 	Labels() labels.Labels
 	// Eval evaluates the rule, including any associated recording or alerting actions.
 	// The duration passed is the evaluation delay.
-	Eval(_ context.Context, evalDelay time.Duration, ts time.Time, _ QueryFunc, externalURL *url.URL, limit int, independent bool) (promql.Vector, error)
+	Eval(context.Context, time.Duration, time.Time, QueryFunc, *url.URL, int) (promql.Vector, error)
 	// String returns a human-readable string representation of the rule.
 	String() string
 	// Query returns the rule query expression.
@@ -62,4 +62,12 @@ type Rule interface {
 	// GetEvaluationTimestamp returns last evaluation timestamp.
 	// NOTE: Used dynamically by rules.html template.
 	GetEvaluationTimestamp() time.Time
+
+	// SetNoDependentRules sets whether there's no other rule in the rule group that depends on this rule.
+	SetNoDependentRules(bool)
+	GetNoDependentRules() bool
+
+	// SetNoDependencyRules sets whether this rule doesn't depend on the output of any rule in the rule group.
+	SetNoDependencyRules(bool)
+	GetNoDependencyRules() bool
 }

--- a/vendor/github.com/prometheus/prometheus/rules/rule.go
+++ b/vendor/github.com/prometheus/prometheus/rules/rule.go
@@ -65,9 +65,17 @@ type Rule interface {
 
 	// SetNoDependentRules sets whether there's no other rule in the rule group that depends on this rule.
 	SetNoDependentRules(bool)
-	GetNoDependentRules() bool
+
+	// NoDependentRules returns true if it's guaranteed that in the rule group there's no other rule
+	// which depends on this one. In case this function returns false there's no such guarantee, which
+	// means there may or may not be other rules depending on this one.
+	NoDependentRules() bool
 
 	// SetNoDependencyRules sets whether this rule doesn't depend on the output of any rule in the rule group.
 	SetNoDependencyRules(bool)
-	GetNoDependencyRules() bool
+
+	// NoDependencyRules returns true if it's guaranteed that this rule doesn't depend on the output of
+	// any other rule in the group. In case this function returns false there's no such guarantee, which
+	// means the rule may or may not depend on other rules.
+	NoDependencyRules() bool
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -904,7 +904,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720
 ## explicit; go 1.20
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1519,7 +1519,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -904,7 +904,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20240122165117-baa5d82b5bc8
 ## explicit; go 1.20
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1519,7 +1519,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240119151822-7a46f9927720
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240122165117-baa5d82b5bc8
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -904,7 +904,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20240116133529-e3a486e7f801
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328
 ## explicit; go 1.20
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1519,7 +1519,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240116133529-e3a486e7f801
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240116143805-34dc57361328
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6


### PR DESCRIPTION
#### What this PR does

This PR introduces conditional read-after-write (or strong read consistency) support for rule evaluations. This PR is based on https://github.com/grafana/mimir-prometheus/pull/587.

How it works:

- The Prometheus ruler evaluates whether each rule in a group is independent or not. A rule is independent if no other rule depends on it and it doesn't depend on any other in the group.
- The information whether a rule is independent or not is stored in the `RuleDetail` inside the context passed down to the ruler's query function.
- Mimir uses a custom query function. In this PR I've introduced a query function wrapper which reads the `RuleDetail` from the context and inject Mimir-specific read consistency requirement in the context.
- The Mimir-specific read consistency requirement is passed, via context and HTTP header (remote querier), through the network so that it gets correctly enforced in the ingesters.

> code easier in Prometheus

I will try to upstream the `mimir-prometheus` changes to Prometheus, in coordination with [Danny's PR](https://github.com/prometheus/prometheus/pull/12946) from which I've tool the dependency analysis code. However, I will not block on it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
