### PR TITLE
remove non-ascii characters from invalid metric names in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [ENHANCEMENT] Query-frontend: add experimental support for sharding active series queries via `-query-frontend.shard-active-series-queries`. #6784
 * [ENHANCEMENT] Distributor: set `-distributor.reusable-ingester-push-workers=2000` by default and mark feature as `advanced`. #7128
 * [ENHANCEMENT] All: set `-server.grpc.num-workers=100` by default and mark feature as `advanced`. #7131
+* [ENHANCEMENT] Distributor: invalid metric name error message gets cleaned up to not include non-ascii strings. #7146
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -312,19 +312,19 @@ type labelValidationConfig interface {
 	MaxLabelValueLength(userID string) int
 }
 
-func removeNonAsciiChars(in string) (out string) {
-	foundNonAscii := false
+func removeNonASCIIChars(in string) (out string) {
+	foundNonASCII := false
 
 	out = strings.Map(func(r rune) rune {
 		if r <= unicode.MaxASCII {
 			return r
 		}
 
-		foundNonAscii = true
+		foundNonASCII = true
 		return -1
 	}, in)
 
-	if foundNonAscii {
+	if foundNonASCII {
 		out = out + " (non-ascii characters removed)"
 	}
 
@@ -342,7 +342,7 @@ func validateLabels(m *sampleValidationMetrics, cfg labelValidationConfig, userI
 
 	if !model.IsValidMetricName(model.LabelValue(unsafeMetricName)) {
 		m.invalidMetricName.WithLabelValues(userID, group).Inc()
-		return fmt.Errorf(invalidMetricNameMsgFormat, removeNonAsciiChars(unsafeMetricName))
+		return fmt.Errorf(invalidMetricNameMsgFormat, removeNonASCIIChars(unsafeMetricName))
 	}
 
 	numLabelNames := len(ls)

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -81,6 +81,11 @@ func TestValidateLabels(t *testing.T) {
 			fmt.Errorf(invalidMetricNameMsgFormat, " "),
 		},
 		{
+			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "metric_name_with_\xb0_invalid_utf8_\xb0"},
+			false,
+			fmt.Errorf(invalidMetricNameMsgFormat, "metric_name_with__invalid_utf8_ (non-ascii characters removed)"),
+		},
+		{
 			map[model.LabelName]model.LabelValue{model.MetricNameLabel: "valid", "foo ": "bar"},
 			false,
 			fmt.Errorf(
@@ -162,7 +167,7 @@ func TestValidateLabels(t *testing.T) {
 			cortex_discarded_samples_total{group="custom label",reason="label_name_too_long",user="testUser"} 1
 			cortex_discarded_samples_total{group="custom label",reason="label_value_too_long",user="testUser"} 1
 			cortex_discarded_samples_total{group="custom label",reason="max_label_names_per_series",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="metric_name_invalid",user="testUser"} 1
+			cortex_discarded_samples_total{group="custom label",reason="metric_name_invalid",user="testUser"} 2
 			cortex_discarded_samples_total{group="custom label",reason="missing_metric_name",user="testUser"} 1
 
 			cortex_discarded_samples_total{group="custom label",reason="random reason",user="different user"} 1


### PR DESCRIPTION
When a metric with a non-ascii characters gets received the input validation correctly rejects it, but depending on the invalid character the serialization of the generated error message can fail, for example:

```
2024/01/16 17:24:39 ERROR: [transport] [server-transport 0xc05a8c21a0] Failed to marshal rpc status: code:400 message:"received a series with invalid metric name: 'invalid_metric_name_\xb0c' (err-mimir-metric-name-invalid)\n" details:{type_url:"type.googleapis.com/httpgrpc.HTTPResponse" value:"\x08\x90\x03\x12)\n\x0cContent-Type\x12\x19text/plain; charset=utf-8\x12!\n\x16X-Content-Type-Options\x12\x07nosniff\x1a\x80\x01received a series with invalid metric name: 'invalid_metric_name_\xb0c' (err-mimir-metric-name-invalid)\n"}, error: string field contains invalid UTF-8
```

This change removes the non-ascii characters from the metric name when generating the invalid metric name error message. It appends the string ` (non-ascii characters removed)` to the modified metric name in the error message because if we'd just return the cleaned up string as part of the error message then the user who's looking at the error might not understand what the problem was.