### PR TITLE
Chore: simplify runAsync() and runAsyncAfter() usage in ingest storage tests

### DIFF
--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -45,7 +45,6 @@ func TestPartitionOffsetReader(t *testing.T) {
 
 		// Run few goroutines waiting for the last produced offset.
 		wg := sync.WaitGroup{}
-		wg.Add(2)
 
 		for i := 0; i < 2; i++ {
 			runAsync(&wg, func() {
@@ -151,7 +150,6 @@ func TestPartitionOffsetReader_getLastProducedOffset(t *testing.T) {
 		})
 
 		wg := sync.WaitGroup{}
-		wg.Add(2)
 
 		// Run the 1st getLastProducedOffset() with a timeout which is expected to expire
 		// before the request will succeed.
@@ -257,7 +255,6 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 		})
 
 		wg := sync.WaitGroup{}
-		wg.Add(2)
 
 		// The 1st FetchLastProducedOffset() is called before the service start so it's expected
 		// to wait the result of the 1st request.

--- a/pkg/storage/ingest/partition_offset_watcher_test.go
+++ b/pkg/storage/ingest/partition_offset_watcher_test.go
@@ -166,7 +166,6 @@ func TestPartitionOffsetWatcher(t *testing.T) {
 		require.NoError(t, services.StartAndAwaitRunning(ctx, w))
 
 		wg := sync.WaitGroup{}
-		wg.Add(2)
 
 		runAsync(&wg, func() {
 			assert.Equal(t, errPartitionOffsetWatcherStopped, w.Wait(ctx, 1))
@@ -208,7 +207,6 @@ func TestPartitionOffsetWatcher_Concurrency(t *testing.T) {
 	t.Cleanup(cancelCtx)
 
 	wg := sync.WaitGroup{}
-	wg.Add(numWatchingGoroutines + numNotifyingGoroutines)
 
 	// Start all watching goroutines.
 	for i := 0; i < numWatchingGoroutines; i++ {
@@ -264,7 +262,6 @@ func BenchmarkPartitionOffsetWatcher(b *testing.B) {
 
 		// Start all watching goroutines.
 		wg := sync.WaitGroup{}
-		wg.Add(numWatchingGoroutines)
 
 		for i := 0; i < numWatchingGoroutines; i++ {
 			runAsync(&wg, func() {
@@ -305,7 +302,6 @@ func BenchmarkPartitionOffsetWatcher(b *testing.B) {
 
 		// Start all watching goroutines.
 		wg := sync.WaitGroup{}
-		wg.Add(numWatchingGoroutines)
 
 		for i := 0; i < numWatchingGoroutines; i++ {
 			runAsync(&wg, func() {

--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -106,8 +106,6 @@ func TestResultPromise(t *testing.T) {
 		)
 
 		// Spawn few goroutines waiting for the result.
-		wg.Add(3)
-
 		for i := 0; i < 3; i++ {
 			runAsync(&wg, func() {
 				actual, err := rw.wait(ctx)
@@ -132,8 +130,6 @@ func TestResultPromise(t *testing.T) {
 		)
 
 		// Spawn few goroutines waiting for the result.
-		wg.Add(3)
-
 		for i := 0; i < 3; i++ {
 			runAsync(&wg, func() {
 				actual, err := rw.wait(ctx)


### PR DESCRIPTION
#### What this PR does

A chore PR to slightly simplify `runAsync()` and `runAsyncAfter()` usage in ingest storage tests. Now, these functions directly add themselves to the `sync.WaitGroup`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
