### PR TITLE
Ingest storage: configure BrokerMaxReadBytes on Kafka reader

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -279,7 +279,7 @@ func (r *PartitionReader) newKafkaReader(at kgo.Offset) (*kgo.Client, error) {
 
 		// BrokerMaxReadBytes sets the maximum response size that can be read from
 		// Kafka. This is a safety measure to avoid OOMing on invalid responses.
-		// Recommendation is to set it 2x FetchMaxBytes.
+		// franz-go recommendation is to set it 2x FetchMaxBytes.
 		kgo.BrokerMaxReadBytes(2*fetchMaxBytes),
 	)
 	client, err := kgo.NewClient(opts...)


### PR DESCRIPTION
#### What this PR does

A tiny PR to set `BrokerMaxReadBytes` on the Kafka reader (used by the new experimental ingest storage). The Kafka library suggests to set it to 2x `FetchMaxWait`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
