### PR TITLE
[BUGFIX] Update nginx deployment to mount nginx.conf as file

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -88,7 +88,8 @@ spec:
             {{ toYaml .extraVolumeMounts | nindent 12 }}
             {{- end }}
             - name: nginx-config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             {{- if .nginx.basicAuth.enabled }}
             - name: auth
               mountPath: /etc/nginx/secrets

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -81,7 +81,8 @@ spec:
             {{- toYaml .Values.nginx.containerSecurityContext | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             {{- if .Values.nginx.basicAuth.enabled }}
             - name: auth
               mountPath: /etc/nginx/secrets

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -50,7 +50,8 @@ spec:
           args:
           volumeMounts:
             - name: nginx-config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -67,7 +67,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -67,7 +67,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -67,7 +67,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -67,7 +67,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -67,7 +67,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -66,7 +66,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -67,7 +67,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -67,7 +67,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -70,7 +70,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -67,7 +67,8 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
             - name: tmp
               mountPath: /tmp
             - name: docker-entrypoint-d-override


### PR DESCRIPTION
#### What this PR does

At the moment, the nginx-config configmap is mounted as folder, masking everything else that is located in `/etc/nginx`.
I'm trying to load a module in the `nginx.conf` with `load_module modules/ngx_http_js_module.so;`.

With the current setup, this fails with the following logs:
`/docker-entrypoint.sh: No files found in /docker-entrypoint.d/, skipping configuration
2023/05/09 11:46:27 [emerg] 1#1: dlopen() "/etc/nginx/modules/ngx_http_js_module.so" failed (/etc/nginx/modules/ngx_http_js_module.so: cannot open shared object file: No such file or directory) in /etc/nginx/nginx.conf:1
nginx: [emerg] dlopen() "/etc/nginx/modules/ngx_http_js_module.so" failed (/etc/nginx/modules/ngx_http_js_module.so: cannot open shared object file: No such file or directory) in /etc/nginx/nginx.conf:1`

With the proposed change, the `nginx.conf` file is still mounted to `/etc/nginx/nginx.conf`, however loading modules is now possible.

Unfortunately, I did not find any parameters to nginx which would allow an alternative module path (e.g. in `/usr/lib/nginx/modules`) and since the directory is mounted read-only, it is not possible copying the module through an entrypoint script.

Alternative fixes would include larger changes, such as moving the config volume & mount to the `values.yaml`
#### Which issue(s) this PR fixes or relates to

Recreates https://github.com/grafana/mimir/pull/4954

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
