### PR TITLE
Ingest storage local dev env: configure Mimir components to start after Kafka is healthy

### DIFF
--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -121,6 +121,13 @@ std.manifestYamlDoc({
       ports: [
         '29092:29092',
       ],
+      healthcheck: {
+        test: 'nc -z localhost 9092 || exit -1',
+        start_period: '1s',
+        interval: '1s',
+        timeout: '1s',
+        retries: '30',
+      },
     },
   },
 
@@ -164,7 +171,10 @@ std.manifestYamlDoc({
       name: error 'missing name',
       target: error 'missing target',
       publishedHttpPort: error 'missing publishedHttpPort',
-      dependsOn: ['minio', 'kafka'],
+      dependsOn: {
+        minio: { condition: 'service_started' },
+        kafka: { condition: 'service_healthy' },
+      },
       env: {},
       extraVolumes: [],
       memberlistBindPort: self.publishedHttpPort + 2000,

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -31,6 +31,12 @@
       - "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,ORBSTACK:PLAINTEXT"
       - "KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
       - "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1"
+    "healthcheck":
+      "interval": "1s"
+      "retries": "30"
+      "start_period": "1s"
+      "test": "nc -z localhost 9092 || exit -1"
+      "timeout": "1s"
     "image": "confluentinc/cp-kafka:latest"
     "ports":
       - "29092:29092"
@@ -46,8 +52,10 @@
       - "-target=backend"
       - "-activity-tracker.filepath=/activity/mimir-backend-1"
     "depends_on":
-      - "minio"
-      - "kafka"
+      "kafka":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
     "environment": []
     "hostname": "mimir-backend-1"
     "image": "mimir"
@@ -66,8 +74,10 @@
       - "-target=backend"
       - "-activity-tracker.filepath=/activity/mimir-backend-2"
     "depends_on":
-      - "minio"
-      - "kafka"
+      "kafka":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
     "environment": []
     "hostname": "mimir-backend-2"
     "image": "mimir"
@@ -86,8 +96,10 @@
       - "-target=read"
       - "-activity-tracker.filepath=/activity/mimir-read-1"
     "depends_on":
-      - "minio"
-      - "kafka"
+      "kafka":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
     "environment": []
     "hostname": "mimir-read-1"
     "image": "mimir"
@@ -106,8 +118,10 @@
       - "-target=read"
       - "-activity-tracker.filepath=/activity/mimir-read-2"
     "depends_on":
-      - "minio"
-      - "kafka"
+      "kafka":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
     "environment": []
     "hostname": "mimir-read-2"
     "image": "mimir"
@@ -126,8 +140,10 @@
       - "-target=write"
       - "-activity-tracker.filepath=/activity/mimir-write-1"
     "depends_on":
-      - "minio"
-      - "kafka"
+      "kafka":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
     "environment": []
     "hostname": "mimir-write-1"
     "image": "mimir"
@@ -147,8 +163,10 @@
       - "-target=write"
       - "-activity-tracker.filepath=/activity/mimir-write-2"
     "depends_on":
-      - "minio"
-      - "kafka"
+      "kafka":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
     "environment": []
     "hostname": "mimir-write-2"
     "image": "mimir"
@@ -168,8 +186,10 @@
       - "-target=write"
       - "-activity-tracker.filepath=/activity/mimir-write-3"
     "depends_on":
-      - "minio"
-      - "kafka"
+      "kafka":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
     "environment": []
     "hostname": "mimir-write-3"
     "image": "mimir"


### PR DESCRIPTION
#### What this PR does

While working on https://github.com/grafana/mimir/pull/7142 and testing it locally using `development/mimir-ingest-storage` I frequently get mimir-write not starting successfully because Kafka is not ready after all the retries done by the Kafka reader (error: `failed to fetch last committed offset`). A simple solution looks configuring Mimir to wait until Kafka is ready, which is what I do in this PR (tested and fixes the problem).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
