### PR TITLE
Update RELEASE.md with tentative 2024 release schedule

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,6 @@ The following table contains past releases and tentative dates for upcoming rele
 | 2.14.0  | 2024-09-09 | _To be announced_  |
 | 2.15.0  | 2024-12-09 | _To be announced_  |
 
-
 ## Release shepherd responsibilities
 
 The release shepherd is responsible for an entire minor release series, meaning all pre- and patch releases of a minor release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,12 @@ The following table contains past releases and tentative dates for upcoming rele
 | 2.8.0   | 2023-04-17 | Jon Kartago Lamida |
 | 2.9.0   | 2023-05-29 | Felix Beuke        |
 | 2.10.0  | 2023-09-06 | Oleg Zaytsev       |
-| 2.11.0  | 2023-12-06 | _To be announced_  |
+| 2.11.0  | 2023-12-06 | Justin Lei         |
+| 2.12.0  | 2023-03-11 | Yuri Nikolic       |
+| 2.13.0  | 2023-06-10 | _To be announced_  |
+| 2.14.0  | 2023-09-09 | _To be announced_  |
+| 2.15.0  | 2023-12-09 | _To be announced_  |
+
 
 ## Release shepherd responsibilities
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,10 +21,10 @@ The following table contains past releases and tentative dates for upcoming rele
 | 2.9.0   | 2023-05-29 | Felix Beuke        |
 | 2.10.0  | 2023-09-06 | Oleg Zaytsev       |
 | 2.11.0  | 2023-12-06 | Justin Lei         |
-| 2.12.0  | 2023-03-11 | Yuri Nikolic       |
-| 2.13.0  | 2023-06-10 | _To be announced_  |
-| 2.14.0  | 2023-09-09 | _To be announced_  |
-| 2.15.0  | 2023-12-09 | _To be announced_  |
+| 2.12.0  | 2024-03-11 | Yuri Nikolic       |
+| 2.13.0  | 2024-06-10 | _To be announced_  |
+| 2.14.0  | 2024-09-09 | _To be announced_  |
+| 2.15.0  | 2024-12-09 | _To be announced_  |
 
 
 ## Release shepherd responsibilities


### PR DESCRIPTION
#### What this PR does
This PR sets tentative dates for Mimir releases in 2024, which are the second Monday of March, June, September and December. Moreover, the PR sets the shepherds for releases Mimir 2.11.0 (already done) and Mimir 2.12.0 (the next one).

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
