### PR TITLE
fix additional queue dimensions unsupported request logging

### DIFF
--- a/pkg/frontend/v2/frontend_scheduler_adapter.go
+++ b/pkg/frontend/v2/frontend_scheduler_adapter.go
@@ -4,7 +4,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
@@ -90,7 +89,7 @@ func (a *frontendToSchedulerAdapter) extractAdditionalQueueDimensions(
 		return []string{ShouldQueryIngestersQueueDimension}, nil
 	default:
 		// no query time params to parse; cannot infer query component
-		level.Warn(a.log).Log("msg", "unsupported request type", "query", fmt.Sprintf("%+v", httpRequest))
+		level.Debug(a.log).Log("msg", "unsupported request type for additional queue dimensions", "query", httpRequest.URL.String())
 		return nil, nil
 	}
 }


### PR DESCRIPTION
Don't want to lose this completely while we track down which request types we need to add timestamp parsing for.

But it was logging way too much and the message was a bit too alarming

Switching to debug and only logging the URL so we don't log any potentially sensitive request headers

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
