### PR TITLE
querier: don't log errors on stream connection reset

### DIFF
--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -37,12 +37,12 @@ func TestFrontendProcessor_processQueriesOnSingleStream(t *testing.T) {
 
 			// No query to execute, so wait until terminated.
 			<-processClient.Context().Done()
-			return nil, processClient.Context().Err()
+			return nil, toRPCErr(processClient.Context().Err())
 		})
 
 		requestHandler.On("Handle", mock.Anything, mock.Anything).Return(&httpgrpc.HTTPResponse{}, nil)
 
-		fp.processQueriesOnSingleStream(workerCtx, nil, "12.0.0.1")
+		fp.processQueriesOnSingleStream(workerCtx, nil, "127.0.0.1")
 
 		// We expect at this point, the execution context has been canceled too.
 		require.Error(t, processClient.Context().Err())
@@ -66,7 +66,7 @@ func TestFrontendProcessor_processQueriesOnSingleStream(t *testing.T) {
 			default:
 				// No more messages to process, so waiting until terminated.
 				<-processClient.Context().Done()
-				return nil, processClient.Context().Err()
+				return nil, toRPCErr(processClient.Context().Err())
 			}
 		})
 
@@ -94,6 +94,7 @@ func TestFrontendProcessor_processQueriesOnSingleStream(t *testing.T) {
 		processClient.AssertNumberOfCalls(t, "Send", 1)
 	})
 }
+
 func TestFrontendProcessor_QueryTime(t *testing.T) {
 	runTest := func(t *testing.T, statsEnabled bool) {
 		fp, processClient, requestHandler := prepareFrontendProcessor()
@@ -113,7 +114,7 @@ func TestFrontendProcessor_QueryTime(t *testing.T) {
 			default:
 				// No more messages to process, so waiting until terminated.
 				<-processClient.Context().Done()
-				return nil, processClient.Context().Err()
+				return nil, toRPCErr(processClient.Context().Err())
 			}
 		})
 

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -125,13 +125,14 @@ func (sp *schedulerProcessor) processQueriesOnSingleStream(workerCtx context.Con
 		}
 
 		if err := sp.querierLoop(execCtx, c, address, inflightQuery); err != nil {
-			// Do not log an error if the query-scheduler is shutting down.
-			if s, ok := status.FromError(err); !ok || !strings.Contains(s.Message(), schedulerpb.ErrSchedulerIsNotRunning.Error()) {
-				level.Error(sp.log).Log("msg", "error processing requests from scheduler", "err", err, "addr", address)
+			if !isErrCancel(err, log.With(sp.log, "addr", address)) {
+				// Do not log an error if the query-scheduler is shutting down.
+				if s, ok := status.FromError(err); !ok || !strings.Contains(s.Message(), schedulerpb.ErrSchedulerIsNotRunning.Error()) {
+					level.Error(sp.log).Log("msg", "error processing requests from scheduler", "err", err, "addr", address)
+				}
+				backoff.Wait()
+				continue
 			}
-
-			backoff.Wait()
-			continue
 		}
 
 		backoff.Reset()
@@ -158,9 +159,9 @@ func (sp *schedulerProcessor) querierLoop(execCtx context.Context, c schedulerpb
 			return
 		default:
 			// Query is not complete.
-			level.Info(sp.log).Log("msg", "query-scheduler loop in querier received non-cancellation error, waiting for inflight query to complete...", "err", err, "address", address)
+			level.Info(sp.log).Log("msg", "query-scheduler loop in querier received non-cancellation error, waiting for inflight query to complete...", "err", err, "addr", address)
 			<-queryComplete
-			level.Info(sp.log).Log("msg", "query-scheduler loop in querier received non-cancellation error and inflight query is complete, continuing", "err", err, "address", address)
+			level.Info(sp.log).Log("msg", "query-scheduler loop in querier received non-cancellation error and inflight query is complete, continuing", "err", err, "addr", address)
 		}
 	}
 

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -462,23 +462,3 @@ func (f *frontendForQuerierMockServer) QueryResult(context.Context, *frontendv2p
 
 	return &frontendv2pb.QueryResultResponse{}, nil
 }
-
-// This function emulates the error-translating behaviour of google.golang.org/grpc.toRPCErr(),
-// which is used by the gRPC client to translate errors (including client-side context cancellations)
-// to gRPC-style errors.
-//
-// This implementation does not cover all the cases supported by the real implementation - it has just
-// enough to support the test cases in this file.
-//
-// Based on https://github.com/grpc/grpc-go/blob/c0aa20a8ac825f86edd59b2cab842de6da77a841/rpc_util.go#L874.
-func toRPCErr(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	if errors.Is(err, context.Canceled) {
-		return status.Error(codes.Canceled, context.Canceled.Error())
-	}
-
-	return status.Error(codes.Unknown, err.Error())
-}

--- a/pkg/querier/worker/util_test.go
+++ b/pkg/querier/worker/util_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package worker
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gogo/status"
+	"google.golang.org/grpc/codes"
+)
+
+// This function emulates the error-translating behaviour of google.golang.org/grpc.toRPCErr(),
+// which is used by the gRPC client to translate errors (including client-side context cancellations)
+// to gRPC-style errors.
+//
+// This implementation does not cover all the cases supported by the real implementation - it has just
+// enough to support the test cases in this file.
+//
+// Based on https://github.com/grpc/grpc-go/blob/c0aa20a8ac825f86edd59b2cab842de6da77a841/rpc_util.go#L874.
+func toRPCErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return status.Error(codes.Canceled, context.Canceled.Error())
+	}
+
+	return status.Error(codes.Unknown, err.Error())
+}


### PR DESCRIPTION
#### What this PR does

If a gRPC server configured with `grpc_server_connection_max_age`, it closes the client's connections after a period of max_age + age_grace (refer to discussion https://github.com/grafana/mimir/issues/7023#issuecomment-1893752220).

At the moment there is nothing we expect a user to act on after the errors, the frontend- and scheduler-processors' client streams log, when the server resets the connection. This PR updates both processors, moving the logging to the debug level, to reduce any possible confusion.

_Sidenote: a more general solution, the gRPC folks suggested, is to implement an application specific lifetime management of the client stream. I.e. the stream's client should implement its own lifetime, to reconnect before the server drops it. So far, I'm not sure, it's worth the effort for the querier's use-case._

Also, the PR fixes some small inconsistencies in the related logs.

#### Which issue(s) this PR fixes or relates to

Fixes #7023

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
