### PR TITLE
Add optional querier response streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [FEATURE] Querier: added `histogram_avg()` function support to PromQL. #7293
 * [FEATURE] Ingester: added `-blocks-storage.tsdb.timely-head-compaction` flag, which enables more timely head compaction, and defaults to `false`. #7372
 * [FEATURE] Compactor: Added `/compactor/tenants` and `/compactor/tenant/{tenant}/planned_jobs` endpoints that provide functionality that was provided by `tools/compaction-planner` -- listing of planned compaction jobs based on tenants' bucket index. #7381
+* [FEATURE] Add experimental support for streaming response bodies from queriers to frontends via `-querier.response-streaming-enabled`. This is currently only supported for the `/api/v1/cardinality/active_series` endpoint.
 * [ENHANCEMENT] Distributor: Add a new metric `cortex_distributor_otlp_requests_total` to track the total number of OTLP requests. #7385
 * [ENHANCEMENT] Vault: add lifecycle manager for token used to authenticate to Vault. This ensures the client token is always valid. Includes a gauge (`cortex_vault_token_lease_renewal_active`) to check whether token renewal is active, and the counters `cortex_vault_token_lease_renewal_success_total` and `cortex_vault_auth_success_total` to see the total number of successful lease renewals / authentications. #7337
 * [ENHANCEMENT] Store-gateway: add no-compact details column on store-gateway tenants admin UI. #6848

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 * [FEATURE] Querier: added `histogram_avg()` function support to PromQL. #7293
 * [FEATURE] Ingester: added `-blocks-storage.tsdb.timely-head-compaction` flag, which enables more timely head compaction, and defaults to `false`. #7372
 * [FEATURE] Compactor: Added `/compactor/tenants` and `/compactor/tenant/{tenant}/planned_jobs` endpoints that provide functionality that was provided by `tools/compaction-planner` -- listing of planned compaction jobs based on tenants' bucket index. #7381
-* [FEATURE] Add experimental support for streaming response bodies from queriers to frontends via `-querier.response-streaming-enabled`. This is currently only supported for the `/api/v1/cardinality/active_series` endpoint.
+* [FEATURE] Add experimental support for streaming response bodies from queriers to frontends via `-querier.response-streaming-enabled`. This is currently only supported for the `/api/v1/cardinality/active_series` endpoint. #7173
 * [ENHANCEMENT] Distributor: Add a new metric `cortex_distributor_otlp_requests_total` to track the total number of OTLP requests. #7385
 * [ENHANCEMENT] Vault: add lifecycle manager for token used to authenticate to Vault. This ensures the client token is always valid. Includes a gauge (`cortex_vault_token_lease_renewal_active`) to check whether token renewal is active, and the counters `cortex_vault_token_lease_renewal_success_total` and `cortex_vault_auth_success_total` to see the total number of successful lease renewals / authentications. #7337
 * [ENHANCEMENT] Store-gateway: add no-compact details column on store-gateway tenants admin UI. #6848

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4627,7 +4627,7 @@
           "kind": "field",
           "name": "response_streaming_enabled",
           "required": false,
-          "desc": "Enables streaming of responses from querier to query-frontend.",
+          "desc": "Enables streaming of responses from querier to query-frontend for responses that request it. This is an experimental feature and may be removed in the future.",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "querier.response-streaming-enabled",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4627,7 +4627,7 @@
           "kind": "field",
           "name": "response_streaming_enabled",
           "required": false,
-          "desc": "Enables streaming of responses from querier to query-frontend for responses that request it. This is an experimental feature and may be removed in the future.",
+          "desc": "Enables streaming of responses from querier to query-frontend for response types that support it (currently only `active_series` responses do).",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "querier.response-streaming-enabled",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4622,6 +4622,17 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
+        },
+        {
+          "kind": "field",
+          "name": "response_streaming_enabled",
+          "required": false,
+          "desc": "Enables streaming of responses from querier to query-frontend.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "querier.response-streaming-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1733,6 +1733,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester. (default 13h)
   -querier.query-store-after duration
     	The time after which a metric should be queried from storage and not just ingesters. 0 means all queries are sent to store. If this option is enabled, the time range of the query sent to the store-gateway will be manipulated to ensure the query end is not more recent than 'now - query-store-after'. (default 12h0m0s)
+  -querier.response-streaming-enabled
+    	[experimental] Enables streaming of responses from querier to query-frontend for responses that request it. This is an experimental feature and may be removed in the future.
   -querier.scheduler-address string
     	Address of the query-scheduler component, in host:port format. The host should resolve to all query-scheduler instances. This option should be set only when query-scheduler component is in use and -query-scheduler.service-discovery-mode is set to 'dns'.
   -querier.scheduler-client.backoff-max-period duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1734,7 +1734,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.query-store-after duration
     	The time after which a metric should be queried from storage and not just ingesters. 0 means all queries are sent to store. If this option is enabled, the time range of the query sent to the store-gateway will be manipulated to ensure the query end is not more recent than 'now - query-store-after'. (default 12h0m0s)
   -querier.response-streaming-enabled
-    	[experimental] Enables streaming of responses from querier to query-frontend for responses that request it. This is an experimental feature and may be removed in the future.
+    	[experimental] Enables streaming of responses from querier to query-frontend for response types that support it (currently only `active_series` responses do).
   -querier.scheduler-address string
     	Address of the query-scheduler component, in host:port format. The host should resolve to all query-scheduler instances. This option should be set only when query-scheduler component is in use and -query-scheduler.service-discovery-mode is set to 'dns'.
   -querier.scheduler-client.backoff-max-period duration

--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -149,6 +149,8 @@ frontend:
     compression: snappy
 
 frontend_worker:
+  response_streaming_enabled: true
+
   # Uncomment when using "dns" service discovery mode for query-scheduler.
   # scheduler_address: "query-scheduler:9011"
 

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -123,6 +123,7 @@ The following features are currently experimental:
   - Max concurrency for tenant federated queries (`-tenant-federation.max-concurrent`)
   - Maximum response size for active series queries (`-querier.active-series-results-max-size-bytes`)
   - Enable PromQL experimental functions (`-querier.promql-experimental-functions-enabled`)
+  - Allow streaming of `/active_series` responses to the frontend (`-querier.response-streaming-enabled`)
 - Query-frontend
   - `-query-frontend.querier-forget-delay`
   - Instant query splitting (`-query-frontend.split-instant-queries-by-interval`)

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2556,8 +2556,8 @@ The `frontend_worker` block configures the worker running within the querier, pi
 [query_scheduler_grpc_client_config: <grpc_client>]
 
 # (experimental) Enables streaming of responses from querier to query-frontend
-# for responses that request it. This is an experimental feature and may be
-# removed in the future.
+# for response types that support it (currently only `active_series` responses
+# do).
 # CLI flag: -querier.response-streaming-enabled
 [response_streaming_enabled: <boolean> | default = false]
 ```

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2555,7 +2555,9 @@ The `frontend_worker` block configures the worker running within the querier, pi
 # The CLI flags prefix for this block configuration is: querier.scheduler-client
 [query_scheduler_grpc_client_config: <grpc_client>]
 
-# (experimental) Enables streaming of responses from querier to query-frontend.
+# (experimental) Enables streaming of responses from querier to query-frontend
+# for responses that request it. This is an experimental feature and may be
+# removed in the future.
 # CLI flag: -querier.response-streaming-enabled
 [response_streaming_enabled: <boolean> | default = false]
 ```

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2554,6 +2554,10 @@ The `frontend_worker` block configures the worker running within the querier, pi
 # query-scheduler.
 # The CLI flags prefix for this block configuration is: querier.scheduler-client
 [query_scheduler_grpc_client_config: <grpc_client>]
+
+# (experimental) Enables streaming of responses from querier to query-frontend.
+# CLI flag: -querier.response-streaming-enabled
+[response_streaming_enabled: <boolean> | default = false]
 ```
 
 ### etcd

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -39,6 +39,7 @@ type queryFrontendTestConfig struct {
 	queryStatsEnabled           bool
 	setup                       func(t *testing.T, s *e2e.Scenario) (configFile string, flags map[string]string)
 	withHistograms              bool
+	shardActiveSeriesQueries    bool
 }
 
 func TestQueryFrontendWithBlocksStorageViaFlags(t *testing.T) {

--- a/pkg/frontend/transport/roundtripper.go
+++ b/pkg/frontend/transport/roundtripper.go
@@ -10,13 +10,14 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/grafana/dskit/httpgrpc"
 )
 
 // GrpcRoundTripper is similar to http.RoundTripper, but works with HTTP requests converted to protobuf messages.
 type GrpcRoundTripper interface {
-	RoundTripGRPC(context.Context, *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error)
+	RoundTripGRPC(context.Context, *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, io.ReadCloser, error)
 }
 
 func AdaptGrpcRoundTripperToHTTPRoundTripper(r GrpcRoundTripper) http.RoundTripper {
@@ -43,7 +44,7 @@ func (a *grpcRoundTripperAdapter) RoundTrip(r *http.Request) (*http.Response, er
 		return nil, err
 	}
 
-	resp, err := a.roundTripper.RoundTripGRPC(r.Context(), req)
+	resp, body, err := a.roundTripper.RoundTripGRPC(r.Context(), req)
 	if err != nil {
 		var ok bool
 		if resp, ok = httpgrpc.HTTPResponseFromError(err); !ok {
@@ -51,14 +52,32 @@ func (a *grpcRoundTripperAdapter) RoundTrip(r *http.Request) (*http.Response, er
 		}
 	}
 
+	var respBody io.ReadCloser
+	if body != nil {
+		respBody = body
+	} else {
+		respBody = &buffer{buff: resp.Body, ReadCloser: io.NopCloser(bytes.NewReader(resp.Body))}
+	}
+
 	httpResp := &http.Response{
-		StatusCode:    int(resp.Code),
-		Body:          &buffer{buff: resp.Body, ReadCloser: io.NopCloser(bytes.NewReader(resp.Body))},
-		Header:        http.Header{},
-		ContentLength: int64(len(resp.Body)),
+		StatusCode: int(resp.Code),
+		Body:       respBody,
+		Header:     http.Header{},
 	}
 	for _, h := range resp.Headers {
 		httpResp.Header[h.Key] = h.Values
 	}
+
+	contentLength := -1
+	if len(resp.Body) > 0 {
+		contentLength = len(resp.Body)
+	} else if l := httpResp.Header.Get("Content-Length"); l != "" {
+		cl, err := strconv.Atoi(l)
+		if err != nil {
+			contentLength = cl
+		}
+	}
+	httpResp.ContentLength = int64(contentLength)
+
 	return httpResp, nil
 }

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -253,7 +253,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *httpgrpc.HTTPRequest)
 
 	cleanup := func() {
 		defer cancel(errExecutingQueryRoundTripFinished)
-		f.requests.delete(freq.queryID)
+		defer f.requests.delete(freq.queryID)
 	}
 	cleanupInDefer := true
 	defer func() {

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -255,8 +255,8 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, req *httpgrpc.HTTPRequest)
 	// delete is called through the cleanup func executed either in the defer or by the caller closing the body.
 
 	cleanup := func() {
-		defer cancel(errExecutingQueryRoundTripFinished)
-		defer f.requests.delete(freq.queryID)
+		f.requests.delete(freq.queryID)
+		cancel(errExecutingQueryRoundTripFinished)
 	}
 	cleanupInDefer := true
 	defer func() {

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -411,8 +411,7 @@ func (f *Frontend) QueryResultStream(stream frontendv2pb.FrontendForQuerier_Quer
 			if req.userID != userID {
 				return fmt.Errorf("expected metadata for user: %s, got: %s", req.userID, userID)
 			}
-			select {
-			case req.response <- queryResultWithBody{
+			res := queryResultWithBody{
 				queryResult: &frontendv2pb.QueryResultRequest{
 					QueryID: resp.QueryID,
 					Stats:   d.Metadata.Stats,
@@ -422,7 +421,9 @@ func (f *Frontend) QueryResultStream(stream frontendv2pb.FrontendForQuerier_Quer
 					},
 				},
 				bodyStream: reader,
-			}: // Should always be possible unless QueryResultStream is called multiple times with the same queryID.
+			}
+			select {
+			case req.response <- res: // Should always be possible unless QueryResultStream is called multiple times with the same queryID.
 				metadataReceived = true
 			default:
 				level.Warn(f.log).Log("msg", "failed to write query result to the response channel",

--- a/pkg/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/frontend/v2/frontend_scheduler_worker.go
@@ -443,22 +443,24 @@ func (w *frontendSchedulerWorker) enqueueRequest(loop schedulerpb.SchedulerForFr
 	case schedulerpb.ERROR:
 		level.Warn(spanLogger).Log("msg", "scheduler returned error", "err", resp.Error)
 		req.enqueue <- enqueueResult{status: waitForResponse}
-		req.response <- &frontendv2pb.QueryResultRequest{
-			HttpResponse: &httpgrpc.HTTPResponse{
-				Code: http.StatusInternalServerError,
-				Body: []byte(resp.Error),
-			},
-		}
+		req.response <- queryResultWithBody{
+			wireType: &frontendv2pb.QueryResultRequest{
+				HttpResponse: &httpgrpc.HTTPResponse{
+					Code: http.StatusInternalServerError,
+					Body: []byte(resp.Error),
+				},
+			}}
 
 	case schedulerpb.TOO_MANY_REQUESTS_PER_TENANT:
 		level.Warn(spanLogger).Log("msg", "scheduler reported it has too many outstanding requests")
 		req.enqueue <- enqueueResult{status: waitForResponse}
-		req.response <- &frontendv2pb.QueryResultRequest{
-			HttpResponse: &httpgrpc.HTTPResponse{
-				Code: http.StatusTooManyRequests,
-				Body: []byte("too many outstanding requests"),
-			},
-		}
+		req.response <- queryResultWithBody{
+			wireType: &frontendv2pb.QueryResultRequest{
+				HttpResponse: &httpgrpc.HTTPResponse{
+					Code: http.StatusTooManyRequests,
+					Body: []byte("too many outstanding requests"),
+				},
+			}}
 
 	default:
 		level.Error(spanLogger).Log("msg", "unknown response status from the scheduler", "resp", resp, "queryID", req.queryID)

--- a/pkg/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/frontend/v2/frontend_scheduler_worker.go
@@ -444,7 +444,7 @@ func (w *frontendSchedulerWorker) enqueueRequest(loop schedulerpb.SchedulerForFr
 		level.Warn(spanLogger).Log("msg", "scheduler returned error", "err", resp.Error)
 		req.enqueue <- enqueueResult{status: waitForResponse}
 		req.response <- queryResultWithBody{
-			wireType: &frontendv2pb.QueryResultRequest{
+			queryResult: &frontendv2pb.QueryResultRequest{
 				HttpResponse: &httpgrpc.HTTPResponse{
 					Code: http.StatusInternalServerError,
 					Body: []byte(resp.Error),
@@ -455,7 +455,7 @@ func (w *frontendSchedulerWorker) enqueueRequest(loop schedulerpb.SchedulerForFr
 		level.Warn(spanLogger).Log("msg", "scheduler reported it has too many outstanding requests")
 		req.enqueue <- enqueueResult{status: waitForResponse}
 		req.response <- queryResultWithBody{
-			wireType: &frontendv2pb.QueryResultRequest{
+			queryResult: &frontendv2pb.QueryResultRequest{
 				HttpResponse: &httpgrpc.HTTPResponse{
 					Code: http.StatusTooManyRequests,
 					Body: []byte("too many outstanding requests"),

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -407,6 +407,19 @@ func TestFrontendStreamingResponse(t *testing.T) {
 			expectBody: "",
 		},
 		{
+			name: "metadata and empty body chunks",
+			sendResultStream: func(f *Frontend, msg *schedulerpb.FrontendToScheduler) error {
+				s := &mockQueryResultStreamServer{ctx: user.InjectOrgID(context.Background(), userID), queryID: msg.QueryID}
+				s.msgs = append(s.msgs,
+					metadataRequest(msg, http.StatusOK, []*httpgrpc.Header{{Key: "Content-Length", Values: []string{"0"}}}),
+					bodyChunkRequest(msg, nil),
+					bodyChunkRequest(msg, nil),
+				)
+				return f.QueryResultStream(s)
+			},
+			expectBody: "",
+		},
+		{
 			name: "errors on wrong message sequence",
 			sendResultStream: func(f *Frontend, msg *schedulerpb.FrontendToScheduler) error {
 				s := &mockQueryResultStreamServer{ctx: user.InjectOrgID(context.Background(), userID), queryID: msg.QueryID}

--- a/pkg/frontend/v2/frontendv2pb/frontend.pb.go
+++ b/pkg/frontend/v2/frontendv2pb/frontend.pb.go
@@ -4,6 +4,7 @@
 package frontendv2pb
 
 import (
+	bytes "bytes"
 	context "context"
 	fmt "fmt"
 	_ "github.com/gogo/protobuf/gogoproto"
@@ -90,13 +91,208 @@ func (m *QueryResultRequest) GetStats() *stats.Stats {
 	return nil
 }
 
+type QueryResultStreamRequest struct {
+	QueryID uint64 `protobuf:"varint,1,opt,name=queryID,proto3" json:"queryID,omitempty"`
+	// Types that are valid to be assigned to Data:
+	//	*QueryResultStreamRequest_Metadata
+	//	*QueryResultStreamRequest_Body
+	Data isQueryResultStreamRequest_Data `protobuf_oneof:"data"`
+}
+
+func (m *QueryResultStreamRequest) Reset()      { *m = QueryResultStreamRequest{} }
+func (*QueryResultStreamRequest) ProtoMessage() {}
+func (*QueryResultStreamRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_eca3873955a29cfe, []int{1}
+}
+func (m *QueryResultStreamRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryResultStreamRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryResultStreamRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryResultStreamRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryResultStreamRequest.Merge(m, src)
+}
+func (m *QueryResultStreamRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryResultStreamRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryResultStreamRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryResultStreamRequest proto.InternalMessageInfo
+
+type isQueryResultStreamRequest_Data interface {
+	isQueryResultStreamRequest_Data()
+	Equal(interface{}) bool
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type QueryResultStreamRequest_Metadata struct {
+	Metadata *QueryResultMetadata `protobuf:"bytes,2,opt,name=metadata,proto3,oneof"`
+}
+type QueryResultStreamRequest_Body struct {
+	Body *QueryResultBody `protobuf:"bytes,3,opt,name=body,proto3,oneof"`
+}
+
+func (*QueryResultStreamRequest_Metadata) isQueryResultStreamRequest_Data() {}
+func (*QueryResultStreamRequest_Body) isQueryResultStreamRequest_Data()     {}
+
+func (m *QueryResultStreamRequest) GetData() isQueryResultStreamRequest_Data {
+	if m != nil {
+		return m.Data
+	}
+	return nil
+}
+
+func (m *QueryResultStreamRequest) GetQueryID() uint64 {
+	if m != nil {
+		return m.QueryID
+	}
+	return 0
+}
+
+func (m *QueryResultStreamRequest) GetMetadata() *QueryResultMetadata {
+	if x, ok := m.GetData().(*QueryResultStreamRequest_Metadata); ok {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (m *QueryResultStreamRequest) GetBody() *QueryResultBody {
+	if x, ok := m.GetData().(*QueryResultStreamRequest_Body); ok {
+		return x.Body
+	}
+	return nil
+}
+
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*QueryResultStreamRequest) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
+		(*QueryResultStreamRequest_Metadata)(nil),
+		(*QueryResultStreamRequest_Body)(nil),
+	}
+}
+
+type QueryResultMetadata struct {
+	Code    int32              `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
+	Headers []*httpgrpc.Header `protobuf:"bytes,2,rep,name=headers,proto3" json:"headers,omitempty"`
+	Stats   *stats.Stats       `protobuf:"bytes,3,opt,name=stats,proto3" json:"stats,omitempty"`
+}
+
+func (m *QueryResultMetadata) Reset()      { *m = QueryResultMetadata{} }
+func (*QueryResultMetadata) ProtoMessage() {}
+func (*QueryResultMetadata) Descriptor() ([]byte, []int) {
+	return fileDescriptor_eca3873955a29cfe, []int{2}
+}
+func (m *QueryResultMetadata) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryResultMetadata) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryResultMetadata.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryResultMetadata) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryResultMetadata.Merge(m, src)
+}
+func (m *QueryResultMetadata) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryResultMetadata) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryResultMetadata.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryResultMetadata proto.InternalMessageInfo
+
+func (m *QueryResultMetadata) GetCode() int32 {
+	if m != nil {
+		return m.Code
+	}
+	return 0
+}
+
+func (m *QueryResultMetadata) GetHeaders() []*httpgrpc.Header {
+	if m != nil {
+		return m.Headers
+	}
+	return nil
+}
+
+func (m *QueryResultMetadata) GetStats() *stats.Stats {
+	if m != nil {
+		return m.Stats
+	}
+	return nil
+}
+
+type QueryResultBody struct {
+	Chunk []byte `protobuf:"bytes,1,opt,name=chunk,proto3" json:"chunk,omitempty"`
+}
+
+func (m *QueryResultBody) Reset()      { *m = QueryResultBody{} }
+func (*QueryResultBody) ProtoMessage() {}
+func (*QueryResultBody) Descriptor() ([]byte, []int) {
+	return fileDescriptor_eca3873955a29cfe, []int{3}
+}
+func (m *QueryResultBody) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryResultBody) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryResultBody.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryResultBody) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryResultBody.Merge(m, src)
+}
+func (m *QueryResultBody) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryResultBody) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryResultBody.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryResultBody proto.InternalMessageInfo
+
+func (m *QueryResultBody) GetChunk() []byte {
+	if m != nil {
+		return m.Chunk
+	}
+	return nil
+}
+
 type QueryResultResponse struct {
 }
 
 func (m *QueryResultResponse) Reset()      { *m = QueryResultResponse{} }
 func (*QueryResultResponse) ProtoMessage() {}
 func (*QueryResultResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_eca3873955a29cfe, []int{1}
+	return fileDescriptor_eca3873955a29cfe, []int{4}
 }
 func (m *QueryResultResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -127,34 +323,46 @@ var xxx_messageInfo_QueryResultResponse proto.InternalMessageInfo
 
 func init() {
 	proto.RegisterType((*QueryResultRequest)(nil), "frontendv2pb.QueryResultRequest")
+	proto.RegisterType((*QueryResultStreamRequest)(nil), "frontendv2pb.QueryResultStreamRequest")
+	proto.RegisterType((*QueryResultMetadata)(nil), "frontendv2pb.QueryResultMetadata")
+	proto.RegisterType((*QueryResultBody)(nil), "frontendv2pb.QueryResultBody")
 	proto.RegisterType((*QueryResultResponse)(nil), "frontendv2pb.QueryResultResponse")
 }
 
 func init() { proto.RegisterFile("frontend.proto", fileDescriptor_eca3873955a29cfe) }
 
 var fileDescriptor_eca3873955a29cfe = []byte{
-	// 333 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x91, 0xbf, 0x4e, 0x02, 0x41,
-	0x10, 0xc6, 0x77, 0xfd, 0x9b, 0x2c, 0xc4, 0x62, 0xfd, 0x93, 0x0b, 0xc5, 0x04, 0xaf, 0xa2, 0xba,
-	0x35, 0x98, 0x58, 0x58, 0x12, 0x43, 0xb4, 0x93, 0x93, 0xca, 0xee, 0x80, 0xe5, 0x38, 0x91, 0xdb,
-	0x63, 0x77, 0xcf, 0x84, 0xce, 0x27, 0x30, 0x3e, 0x86, 0x8f, 0x62, 0x49, 0x49, 0x29, 0x4b, 0x63,
-	0xc9, 0x23, 0x98, 0xbb, 0x05, 0xc2, 0x45, 0x63, 0xb3, 0x99, 0xc9, 0x7c, 0xbf, 0xcc, 0x37, 0xdf,
-	0x92, 0xa3, 0xbe, 0x14, 0xb1, 0xe6, 0x71, 0xcf, 0x4b, 0xa4, 0xd0, 0x82, 0x96, 0xd7, 0xfd, 0x4b,
-	0x3d, 0xe9, 0x54, 0x4e, 0x42, 0x11, 0x8a, 0x7c, 0xc0, 0xb2, 0xca, 0x6a, 0x2a, 0x17, 0x61, 0xa4,
-	0x07, 0x69, 0xc7, 0xeb, 0x8a, 0x11, 0x0b, 0x65, 0xd0, 0x0f, 0xe2, 0x80, 0xf5, 0xd4, 0x30, 0xd2,
-	0x6c, 0xa0, 0x75, 0x12, 0xca, 0xa4, 0xbb, 0x29, 0x56, 0xc4, 0xd5, 0x1f, 0xc4, 0x28, 0x1a, 0x45,
-	0x92, 0x25, 0xc3, 0x90, 0x8d, 0x53, 0x2e, 0x23, 0x2e, 0x99, 0xd2, 0x81, 0x56, 0xf6, 0xb5, 0x9c,
-	0xfb, 0x86, 0x09, 0x6d, 0xa5, 0x5c, 0x4e, 0x7c, 0xae, 0xd2, 0x67, 0xed, 0xf3, 0x71, 0xca, 0x95,
-	0xa6, 0x0e, 0x39, 0xcc, 0x98, 0xc9, 0xdd, 0x8d, 0x83, 0xab, 0xb8, 0xb6, 0xe7, 0xaf, 0x5b, 0x7a,
-	0x4d, 0xca, 0xd9, 0x6a, 0x9f, 0xab, 0x44, 0xc4, 0x8a, 0x3b, 0x3b, 0x55, 0x5c, 0x2b, 0xd5, 0xcf,
-	0xbc, 0x8d, 0x9f, 0xdb, 0x76, 0xfb, 0x7e, 0x3d, 0xf5, 0x0b, 0x5a, 0xea, 0x92, 0xfd, 0x7c, 0xb7,
-	0xb3, 0x9b, 0x43, 0x65, 0xcf, 0x3a, 0x79, 0xc8, 0x5e, 0xdf, 0x8e, 0xdc, 0x53, 0x72, 0x5c, 0xf0,
-	0x63, 0xd1, 0xfa, 0x13, 0xa1, 0xcd, 0x55, 0x6e, 0x4d, 0x21, 0x5b, 0xf6, 0x1e, 0xda, 0x26, 0xa5,
-	0x2d, 0x31, 0xad, 0x7a, 0xdb, 0xd9, 0x7a, 0xbf, 0xef, 0xaa, 0x9c, 0xff, 0xa3, 0xb0, 0x9b, 0x5c,
-	0xd4, 0x68, 0x4c, 0xe7, 0x80, 0x66, 0x73, 0x40, 0xcb, 0x39, 0xe0, 0x57, 0x03, 0xf8, 0xc3, 0x00,
-	0xfe, 0x34, 0x80, 0xa7, 0x06, 0xf0, 0x97, 0x01, 0xfc, 0x6d, 0x00, 0x2d, 0x0d, 0xe0, 0xf7, 0x05,
-	0xa0, 0xe9, 0x02, 0xd0, 0x6c, 0x01, 0xe8, 0xb1, 0xf0, 0xaf, 0x9d, 0x83, 0x3c, 0xde, 0xcb, 0x9f,
-	0x00, 0x00, 0x00, 0xff, 0xff, 0xef, 0x5d, 0x91, 0xa7, 0xfe, 0x01, 0x00, 0x00,
+	// 480 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xcf, 0x6e, 0xd3, 0x40,
+	0x10, 0xc6, 0xbd, 0x6d, 0xd2, 0xa2, 0x49, 0xc4, 0x9f, 0xa5, 0x20, 0x2b, 0x12, 0xab, 0xd4, 0x07,
+	0x88, 0x38, 0xd8, 0x28, 0x95, 0x38, 0x70, 0x41, 0x8a, 0x50, 0x15, 0x0e, 0x48, 0x74, 0x9b, 0x13,
+	0xb7, 0x75, 0xbc, 0x75, 0xac, 0x60, 0xaf, 0xbb, 0x5e, 0x23, 0xf9, 0xc6, 0x13, 0x20, 0x1e, 0x83,
+	0x33, 0x4f, 0xc1, 0x09, 0xe5, 0xd8, 0x23, 0x71, 0x2e, 0x1c, 0xfb, 0x08, 0xc8, 0x6b, 0x3b, 0x72,
+	0xa0, 0xa1, 0xb9, 0xac, 0x66, 0x34, 0xdf, 0xb7, 0xf3, 0xf3, 0x8c, 0x17, 0xee, 0x5e, 0x48, 0x11,
+	0x29, 0x1e, 0x79, 0x76, 0x2c, 0x85, 0x12, 0xb8, 0x5b, 0xe7, 0x9f, 0x86, 0xb1, 0xdb, 0x3b, 0xf2,
+	0x85, 0x2f, 0x74, 0xc1, 0x29, 0xa2, 0x52, 0xd3, 0x7b, 0xe1, 0x07, 0x6a, 0x96, 0xba, 0xf6, 0x54,
+	0x84, 0x8e, 0x2f, 0xd9, 0x05, 0x8b, 0x98, 0xe3, 0x25, 0xf3, 0x40, 0x39, 0x33, 0xa5, 0x62, 0x5f,
+	0xc6, 0xd3, 0x75, 0x50, 0x39, 0x5e, 0xde, 0xe0, 0x08, 0x83, 0x30, 0x90, 0x4e, 0x3c, 0xf7, 0x9d,
+	0xcb, 0x94, 0xcb, 0x80, 0x4b, 0x27, 0x51, 0x4c, 0x25, 0xe5, 0x59, 0xfa, 0xac, 0x2f, 0x08, 0xf0,
+	0x59, 0xca, 0x65, 0x46, 0x79, 0x92, 0x7e, 0x54, 0x94, 0x5f, 0xa6, 0x3c, 0x51, 0xd8, 0x84, 0xc3,
+	0xc2, 0x93, 0xbd, 0x7d, 0x63, 0xa2, 0x3e, 0x1a, 0xb4, 0x68, 0x9d, 0xe2, 0x57, 0xd0, 0x2d, 0x5a,
+	0x53, 0x9e, 0xc4, 0x22, 0x4a, 0xb8, 0xb9, 0xd7, 0x47, 0x83, 0xce, 0xf0, 0xb1, 0xbd, 0xe6, 0x19,
+	0x4f, 0x26, 0xef, 0xeb, 0x2a, 0xdd, 0xd0, 0x62, 0x0b, 0xda, 0xba, 0xb7, 0xb9, 0xaf, 0x4d, 0x5d,
+	0xbb, 0x24, 0x39, 0x2f, 0x4e, 0x5a, 0x96, 0xac, 0xef, 0x08, 0xcc, 0x06, 0xd0, 0xb9, 0x92, 0x9c,
+	0x85, 0xb7, 0x63, 0xbd, 0x86, 0x3b, 0x21, 0x57, 0xcc, 0x63, 0x8a, 0x55, 0x48, 0xc7, 0x76, 0x73,
+	0xd0, 0x76, 0xe3, 0xce, 0x77, 0x95, 0x70, 0x6c, 0xd0, 0xb5, 0x09, 0x9f, 0x40, 0xcb, 0x15, 0x5e,
+	0x56, 0xa1, 0x3d, 0xd9, 0x6a, 0x1e, 0x09, 0x2f, 0x1b, 0x1b, 0x54, 0x8b, 0x47, 0x07, 0xd0, 0x2a,
+	0xcc, 0x56, 0x06, 0x0f, 0x6f, 0xb8, 0x1f, 0x63, 0x68, 0x4d, 0x85, 0xc7, 0x35, 0x6b, 0x9b, 0xea,
+	0x18, 0x3f, 0x87, 0xc3, 0x19, 0x67, 0x1e, 0x97, 0x89, 0xb9, 0xd7, 0xdf, 0x1f, 0x74, 0x86, 0xf7,
+	0x1b, 0xa3, 0xd3, 0x05, 0x5a, 0x0b, 0x76, 0x9a, 0xd7, 0x33, 0xb8, 0xf7, 0x17, 0x1d, 0x3e, 0x82,
+	0xf6, 0x74, 0x96, 0x46, 0x73, 0xdd, 0xb7, 0x4b, 0xcb, 0xc4, 0x7a, 0xb4, 0xc1, 0x58, 0xef, 0x64,
+	0xf8, 0x13, 0x01, 0x3e, 0xad, 0xbe, 0xf5, 0x54, 0xc8, 0xb3, 0xf2, 0x4f, 0xc1, 0x13, 0xe8, 0x34,
+	0xd4, 0xb8, 0xbf, 0x75, 0x1e, 0xd5, 0x6a, 0x7a, 0xc7, 0xff, 0x51, 0x94, 0xad, 0x2c, 0x03, 0xbb,
+	0xf0, 0xe0, 0x9f, 0xdd, 0xe2, 0xa7, 0x5b, 0x9d, 0x1b, 0xcb, 0xdf, 0xa9, 0xc3, 0x00, 0x8d, 0x46,
+	0x8b, 0x25, 0x31, 0xae, 0x96, 0xc4, 0xb8, 0x5e, 0x12, 0xf4, 0x39, 0x27, 0xe8, 0x5b, 0x4e, 0xd0,
+	0x8f, 0x9c, 0xa0, 0x45, 0x4e, 0xd0, 0xaf, 0x9c, 0xa0, 0xdf, 0x39, 0x31, 0xae, 0x73, 0x82, 0xbe,
+	0xae, 0x88, 0xb1, 0x58, 0x11, 0xe3, 0x6a, 0x45, 0x8c, 0x0f, 0x1b, 0xaf, 0xd2, 0x3d, 0xd0, 0x8f,
+	0xe3, 0xe4, 0x4f, 0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x18, 0x1f, 0x97, 0xbc, 0x03, 0x00, 0x00,
 }
 
 func (this *QueryResultRequest) Equal(that interface{}) bool {
@@ -183,6 +391,146 @@ func (this *QueryResultRequest) Equal(that interface{}) bool {
 		return false
 	}
 	if !this.Stats.Equal(that1.Stats) {
+		return false
+	}
+	return true
+}
+func (this *QueryResultStreamRequest) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*QueryResultStreamRequest)
+	if !ok {
+		that2, ok := that.(QueryResultStreamRequest)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.QueryID != that1.QueryID {
+		return false
+	}
+	if that1.Data == nil {
+		if this.Data != nil {
+			return false
+		}
+	} else if this.Data == nil {
+		return false
+	} else if !this.Data.Equal(that1.Data) {
+		return false
+	}
+	return true
+}
+func (this *QueryResultStreamRequest_Metadata) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*QueryResultStreamRequest_Metadata)
+	if !ok {
+		that2, ok := that.(QueryResultStreamRequest_Metadata)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Metadata.Equal(that1.Metadata) {
+		return false
+	}
+	return true
+}
+func (this *QueryResultStreamRequest_Body) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*QueryResultStreamRequest_Body)
+	if !ok {
+		that2, ok := that.(QueryResultStreamRequest_Body)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Body.Equal(that1.Body) {
+		return false
+	}
+	return true
+}
+func (this *QueryResultMetadata) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*QueryResultMetadata)
+	if !ok {
+		that2, ok := that.(QueryResultMetadata)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Code != that1.Code {
+		return false
+	}
+	if len(this.Headers) != len(that1.Headers) {
+		return false
+	}
+	for i := range this.Headers {
+		if !this.Headers[i].Equal(that1.Headers[i]) {
+			return false
+		}
+	}
+	if !this.Stats.Equal(that1.Stats) {
+		return false
+	}
+	return true
+}
+func (this *QueryResultBody) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*QueryResultBody)
+	if !ok {
+		that2, ok := that.(QueryResultBody)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !bytes.Equal(this.Chunk, that1.Chunk) {
 		return false
 	}
 	return true
@@ -224,6 +572,61 @@ func (this *QueryResultRequest) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
+func (this *QueryResultStreamRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&frontendv2pb.QueryResultStreamRequest{")
+	s = append(s, "QueryID: "+fmt.Sprintf("%#v", this.QueryID)+",\n")
+	if this.Data != nil {
+		s = append(s, "Data: "+fmt.Sprintf("%#v", this.Data)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *QueryResultStreamRequest_Metadata) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&frontendv2pb.QueryResultStreamRequest_Metadata{` +
+		`Metadata:` + fmt.Sprintf("%#v", this.Metadata) + `}`}, ", ")
+	return s
+}
+func (this *QueryResultStreamRequest_Body) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&frontendv2pb.QueryResultStreamRequest_Body{` +
+		`Body:` + fmt.Sprintf("%#v", this.Body) + `}`}, ", ")
+	return s
+}
+func (this *QueryResultMetadata) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 7)
+	s = append(s, "&frontendv2pb.QueryResultMetadata{")
+	s = append(s, "Code: "+fmt.Sprintf("%#v", this.Code)+",\n")
+	if this.Headers != nil {
+		s = append(s, "Headers: "+fmt.Sprintf("%#v", this.Headers)+",\n")
+	}
+	if this.Stats != nil {
+		s = append(s, "Stats: "+fmt.Sprintf("%#v", this.Stats)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *QueryResultBody) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&frontendv2pb.QueryResultBody{")
+	s = append(s, "Chunk: "+fmt.Sprintf("%#v", this.Chunk)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
 func (this *QueryResultResponse) GoString() string {
 	if this == nil {
 		return "nil"
@@ -255,6 +658,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type FrontendForQuerierClient interface {
 	QueryResult(ctx context.Context, in *QueryResultRequest, opts ...grpc.CallOption) (*QueryResultResponse, error)
+	QueryResultStream(ctx context.Context, opts ...grpc.CallOption) (FrontendForQuerier_QueryResultStreamClient, error)
 }
 
 type frontendForQuerierClient struct {
@@ -274,9 +678,44 @@ func (c *frontendForQuerierClient) QueryResult(ctx context.Context, in *QueryRes
 	return out, nil
 }
 
+func (c *frontendForQuerierClient) QueryResultStream(ctx context.Context, opts ...grpc.CallOption) (FrontendForQuerier_QueryResultStreamClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_FrontendForQuerier_serviceDesc.Streams[0], "/frontendv2pb.FrontendForQuerier/QueryResultStream", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &frontendForQuerierQueryResultStreamClient{stream}
+	return x, nil
+}
+
+type FrontendForQuerier_QueryResultStreamClient interface {
+	Send(*QueryResultStreamRequest) error
+	CloseAndRecv() (*QueryResultResponse, error)
+	grpc.ClientStream
+}
+
+type frontendForQuerierQueryResultStreamClient struct {
+	grpc.ClientStream
+}
+
+func (x *frontendForQuerierQueryResultStreamClient) Send(m *QueryResultStreamRequest) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *frontendForQuerierQueryResultStreamClient) CloseAndRecv() (*QueryResultResponse, error) {
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	m := new(QueryResultResponse)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // FrontendForQuerierServer is the server API for FrontendForQuerier service.
 type FrontendForQuerierServer interface {
 	QueryResult(context.Context, *QueryResultRequest) (*QueryResultResponse, error)
+	QueryResultStream(FrontendForQuerier_QueryResultStreamServer) error
 }
 
 // UnimplementedFrontendForQuerierServer can be embedded to have forward compatible implementations.
@@ -285,6 +724,9 @@ type UnimplementedFrontendForQuerierServer struct {
 
 func (*UnimplementedFrontendForQuerierServer) QueryResult(ctx context.Context, req *QueryResultRequest) (*QueryResultResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method QueryResult not implemented")
+}
+func (*UnimplementedFrontendForQuerierServer) QueryResultStream(srv FrontendForQuerier_QueryResultStreamServer) error {
+	return status.Errorf(codes.Unimplemented, "method QueryResultStream not implemented")
 }
 
 func RegisterFrontendForQuerierServer(s *grpc.Server, srv FrontendForQuerierServer) {
@@ -309,6 +751,32 @@ func _FrontendForQuerier_QueryResult_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FrontendForQuerier_QueryResultStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(FrontendForQuerierServer).QueryResultStream(&frontendForQuerierQueryResultStreamServer{stream})
+}
+
+type FrontendForQuerier_QueryResultStreamServer interface {
+	SendAndClose(*QueryResultResponse) error
+	Recv() (*QueryResultStreamRequest, error)
+	grpc.ServerStream
+}
+
+type frontendForQuerierQueryResultStreamServer struct {
+	grpc.ServerStream
+}
+
+func (x *frontendForQuerierQueryResultStreamServer) SendAndClose(m *QueryResultResponse) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *frontendForQuerierQueryResultStreamServer) Recv() (*QueryResultStreamRequest, error) {
+	m := new(QueryResultStreamRequest)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 var _FrontendForQuerier_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "frontendv2pb.FrontendForQuerier",
 	HandlerType: (*FrontendForQuerierServer)(nil),
@@ -318,7 +786,13 @@ var _FrontendForQuerier_serviceDesc = grpc.ServiceDesc{
 			Handler:    _FrontendForQuerier_QueryResult_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "QueryResultStream",
+			Handler:       _FrontendForQuerier_QueryResultStream_Handler,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "frontend.proto",
 }
 
@@ -370,6 +844,167 @@ func (m *QueryResultRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i = encodeVarintFrontend(dAtA, i, uint64(m.QueryID))
 		i--
 		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryResultStreamRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryResultStreamRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryResultStreamRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Data != nil {
+		{
+			size := m.Data.Size()
+			i -= size
+			if _, err := m.Data.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	if m.QueryID != 0 {
+		i = encodeVarintFrontend(dAtA, i, uint64(m.QueryID))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryResultStreamRequest_Metadata) MarshalTo(dAtA []byte) (int, error) {
+	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+}
+
+func (m *QueryResultStreamRequest_Metadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Metadata != nil {
+		{
+			size, err := m.Metadata.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintFrontend(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *QueryResultStreamRequest_Body) MarshalTo(dAtA []byte) (int, error) {
+	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+}
+
+func (m *QueryResultStreamRequest_Body) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Body != nil {
+		{
+			size, err := m.Body.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintFrontend(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *QueryResultMetadata) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryResultMetadata) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryResultMetadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Stats != nil {
+		{
+			size, err := m.Stats.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintFrontend(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Headers) > 0 {
+		for iNdEx := len(m.Headers) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Headers[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintFrontend(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.Code != 0 {
+		i = encodeVarintFrontend(dAtA, i, uint64(m.Code))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryResultBody) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryResultBody) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryResultBody) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Chunk) > 0 {
+		i -= len(m.Chunk)
+		copy(dAtA[i:], m.Chunk)
+		i = encodeVarintFrontend(dAtA, i, uint64(len(m.Chunk)))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -428,6 +1063,80 @@ func (m *QueryResultRequest) Size() (n int) {
 	return n
 }
 
+func (m *QueryResultStreamRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.QueryID != 0 {
+		n += 1 + sovFrontend(uint64(m.QueryID))
+	}
+	if m.Data != nil {
+		n += m.Data.Size()
+	}
+	return n
+}
+
+func (m *QueryResultStreamRequest_Metadata) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Metadata != nil {
+		l = m.Metadata.Size()
+		n += 1 + l + sovFrontend(uint64(l))
+	}
+	return n
+}
+func (m *QueryResultStreamRequest_Body) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Body != nil {
+		l = m.Body.Size()
+		n += 1 + l + sovFrontend(uint64(l))
+	}
+	return n
+}
+func (m *QueryResultMetadata) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Code != 0 {
+		n += 1 + sovFrontend(uint64(m.Code))
+	}
+	if len(m.Headers) > 0 {
+		for _, e := range m.Headers {
+			l = e.Size()
+			n += 1 + l + sovFrontend(uint64(l))
+		}
+	}
+	if m.Stats != nil {
+		l = m.Stats.Size()
+		n += 1 + l + sovFrontend(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryResultBody) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Chunk)
+	if l > 0 {
+		n += 1 + l + sovFrontend(uint64(l))
+	}
+	return n
+}
+
 func (m *QueryResultResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -451,6 +1160,64 @@ func (this *QueryResultRequest) String() string {
 		`QueryID:` + fmt.Sprintf("%v", this.QueryID) + `,`,
 		`HttpResponse:` + strings.Replace(fmt.Sprintf("%v", this.HttpResponse), "HTTPResponse", "httpgrpc.HTTPResponse", 1) + `,`,
 		`Stats:` + strings.Replace(fmt.Sprintf("%v", this.Stats), "Stats", "stats.Stats", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *QueryResultStreamRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&QueryResultStreamRequest{`,
+		`QueryID:` + fmt.Sprintf("%v", this.QueryID) + `,`,
+		`Data:` + fmt.Sprintf("%v", this.Data) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *QueryResultStreamRequest_Metadata) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&QueryResultStreamRequest_Metadata{`,
+		`Metadata:` + strings.Replace(fmt.Sprintf("%v", this.Metadata), "QueryResultMetadata", "QueryResultMetadata", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *QueryResultStreamRequest_Body) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&QueryResultStreamRequest_Body{`,
+		`Body:` + strings.Replace(fmt.Sprintf("%v", this.Body), "QueryResultBody", "QueryResultBody", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *QueryResultMetadata) String() string {
+	if this == nil {
+		return "nil"
+	}
+	repeatedStringForHeaders := "[]*Header{"
+	for _, f := range this.Headers {
+		repeatedStringForHeaders += strings.Replace(fmt.Sprintf("%v", f), "Header", "httpgrpc.Header", 1) + ","
+	}
+	repeatedStringForHeaders += "}"
+	s := strings.Join([]string{`&QueryResultMetadata{`,
+		`Code:` + fmt.Sprintf("%v", this.Code) + `,`,
+		`Headers:` + repeatedStringForHeaders + `,`,
+		`Stats:` + strings.Replace(fmt.Sprintf("%v", this.Stats), "Stats", "stats.Stats", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *QueryResultBody) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&QueryResultBody{`,
+		`Chunk:` + fmt.Sprintf("%v", this.Chunk) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -590,6 +1357,377 @@ func (m *QueryResultRequest) Unmarshal(dAtA []byte) error {
 			}
 			if err := m.Stats.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipFrontend(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryResultStreamRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowFrontend
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryResultStreamRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryResultStreamRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field QueryID", wireType)
+			}
+			m.QueryID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowFrontend
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.QueryID |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowFrontend
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &QueryResultMetadata{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Data = &QueryResultStreamRequest_Metadata{v}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Body", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowFrontend
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &QueryResultBody{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Data = &QueryResultStreamRequest_Body{v}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipFrontend(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryResultMetadata) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowFrontend
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryResultMetadata: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryResultMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Code", wireType)
+			}
+			m.Code = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowFrontend
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Code |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Headers", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowFrontend
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Headers = append(m.Headers, &httpgrpc.Header{})
+			if err := m.Headers[len(m.Headers)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Stats", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowFrontend
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Stats == nil {
+				m.Stats = &stats.Stats{}
+			}
+			if err := m.Stats.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipFrontend(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryResultBody) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowFrontend
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryResultBody: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryResultBody: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Chunk", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowFrontend
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthFrontend
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Chunk = append(m.Chunk[:0], dAtA[iNdEx:postIndex]...)
+			if m.Chunk == nil {
+				m.Chunk = []byte{}
 			}
 			iNdEx = postIndex
 		default:

--- a/pkg/frontend/v2/frontendv2pb/frontend.proto
+++ b/pkg/frontend/v2/frontendv2pb/frontend.proto
@@ -19,6 +19,7 @@ option (gogoproto.unmarshaler_all) = true;
 // Frontend interface exposed to Queriers. Used by queriers to report back the result of the query.
 service FrontendForQuerier {
     rpc QueryResult (QueryResultRequest) returns (QueryResultResponse) { };
+    rpc QueryResultStream (stream QueryResultStreamRequest) returns (QueryResultResponse) { };
 }
 
 message QueryResultRequest {
@@ -28,6 +29,24 @@ message QueryResultRequest {
 
     // There is no userID field here, because Querier puts userID into the context when
     // calling QueryResult, and that is where Frontend expects to find it.
+}
+
+message QueryResultStreamRequest {
+  uint64 queryID = 1;
+  oneof data {
+    QueryResultMetadata metadata = 2;
+    QueryResultBody body = 3;
+  }
+}
+
+message QueryResultMetadata {
+    int32 code = 1;
+    repeated httpgrpc.Header headers = 2;
+    stats.Stats stats = 3;
+}
+
+message QueryResultBody {
+    bytes chunk = 1;
 }
 
 message QueryResultResponse { }

--- a/pkg/querier/cardinality_analysis_handler.go
+++ b/pkg/querier/cardinality_analysis_handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/tenant"
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/mimir/pkg/distributor"
 	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/querier/api"
+	"github.com/grafana/mimir/pkg/querier/worker"
 	"github.com/grafana/mimir/pkg/util"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -122,6 +124,8 @@ func ActiveSeriesCardinalityHandler(d Distributor, limits *validation.Overrides)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", strconv.Itoa(len(bytes)))
+		w.Header().Set(worker.ResponseStreamingEnabledHeader, "true")
 
 		// Nothing we can do about this error, so ignore it.
 		_, _ = w.Write(bytes)

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -371,11 +371,7 @@ sendBody:
 	for offset := 0; offset < len(response.Body); {
 		select {
 		case <-reqCtx.Done():
-			if cause := context.Cause(reqCtx); cause != nil {
-				level.Warn(logger).Log("msg", "response stream aborted", "cause", cause)
-			} else {
-				level.Warn(logger).Log("msg", "response stream aborted", "err", reqCtx.Err())
-			}
+			level.Warn(logger).Log("msg", "response stream aborted", "cause", context.Cause(reqCtx))
 			break sendBody
 		default:
 			err = sc.Send(&frontendv2pb.QueryResultStreamRequest{
@@ -385,7 +381,7 @@ sendBody:
 				}},
 			})
 			if err != nil {
-				level.Warn(logger).Log("msg", "error streaming response body to frontend", "err", err)
+				level.Warn(logger).Log("msg", "error streaming response body to frontend, aborting response stream", "err", err)
 				break sendBody
 			}
 			offset += responseStreamingBodyChunkSizeBytes

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -41,6 +41,10 @@ import (
 )
 
 const (
+	// ResponseStreamingEnabledHeader is the header key used by http handlers to
+	// indicate to the scheduler processor that its response should be streamed. This
+	// header is internal to the querier only and removed before the response is sent
+	// over the network.
 	ResponseStreamingEnabledHeader      = "X-Mimir-Stream-Grpc-Response"
 	responseStreamingBodyChunkSizeBytes = 1 * 1024 * 1024
 

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -300,7 +300,7 @@ func (sp *schedulerProcessor) runRequest(ctx context.Context, logger log.Logger,
 
 		var ok bool
 		response.Headers, ok = removeStreamingHeader(response.Headers)
-		if sp.streamingEnabled && ok {
+		if sp.streamingEnabled && ok && len(response.Body) > responseStreamingBodyChunkSizeBytes {
 			err = streamResponse(frontendCtx, c, queryID, response, stats)
 		} else {
 			// Response is empty and uninteresting.

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -295,7 +295,7 @@ func (sp *schedulerProcessor) runRequest(ctx context.Context, logger log.Logger,
 		}
 
 		var ok bool
-		response.Headers, ok = consumeResponseStreamingEnabledHeader(response.Headers)
+		response.Headers, ok = removeStreamingHeader(response.Headers)
 		if sp.streamingEnabled && ok {
 			err = streamResponse(frontendCtx, c, queryID, response, stats)
 		} else {
@@ -320,7 +320,7 @@ func (sp *schedulerProcessor) runRequest(ctx context.Context, logger log.Logger,
 	}
 }
 
-func consumeResponseStreamingEnabledHeader(headers []*httpgrpc.Header) ([]*httpgrpc.Header, bool) {
+func removeStreamingHeader(headers []*httpgrpc.Header) ([]*httpgrpc.Header, bool) {
 	streamEnabledViaHeader := false
 	for i, header := range headers {
 		if header.Key == ResponseStreamingEnabledHeader {

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -452,6 +452,54 @@ func TestSchedulerProcessor_ResponseStream(t *testing.T) {
 
 		workerCancel()
 	})
+
+	t.Run("should finish response stream on non-cancellation error", func(t *testing.T) {
+		sp, loopClient, requestHandler, frontend := prepareSchedulerProcessor(t)
+		sp.streamingEnabled = true
+		sp.maxMessageSize = 5 * responseStreamingBodyChunkSizeBytes
+
+		recvCount := atomic.NewInt64(0)
+		frontend.responseStreamStarted = make(chan struct{})
+
+		queryID := uint64(1)
+		loopClient.On("Recv").Return(func() (*schedulerpb.SchedulerToQuerier, error) {
+			switch recvCount.Inc() {
+			case 1:
+				return &schedulerpb.SchedulerToQuerier{
+					QueryID:         queryID,
+					FrontendAddress: frontend.addr,
+					UserID:          "test",
+				}, nil
+			default:
+				<-frontend.responseStreamStarted
+				// Simulate non-cancellation error.
+				return nil, errors.New("something went wrong")
+			}
+		})
+
+		workerCtx, workerCancel := context.WithCancel(context.Background())
+		responseBodySize := 4*responseStreamingBodyChunkSizeBytes + 1
+		requestHandler.On("Handle", mock.Anything, mock.Anything).Return(
+			&httpgrpc.HTTPResponse{Code: http.StatusOK, Headers: []*httpgrpc.Header{streamingEnabledHeader},
+				Body: bytes.Repeat([]byte("a"), responseBodySize)},
+			nil,
+		)
+
+		go func() {
+			sp.processQueriesOnSingleStream(workerCtx, nil, "127.0.0.1")
+		}()
+
+		assert.Eventually(t, func() bool {
+			return int(frontend.queryResultStreamMetadataCalls.Load()) == 1
+		}, time.Second, 10*time.Millisecond, "expected frontend to be called with response metadata once")
+		assert.Eventually(t, func() bool {
+			return int(frontend.queryResultStreamReturned.Load()) == 1
+		}, time.Second, 10*time.Millisecond, "expected frontend QueryResultStream to have returned once")
+
+		assert.Equal(t, len(frontend.responses[queryID].body), responseBodySize)
+
+		workerCancel()
+	})
 }
 
 func prepareSchedulerProcessor(t *testing.T) (*schedulerProcessor, *querierLoopClientMock, *requestHandlerMock, *frontendForQuerierMockServer) {

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -45,7 +45,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.FrontendAddress, "querier.frontend-address", "", "Address of the query-frontend component, in host:port format. If multiple query-frontends are running, the host should be a DNS resolving to all query-frontend instances. This option should be set only when query-scheduler component is not in use.")
 	f.DurationVar(&cfg.DNSLookupPeriod, "querier.dns-lookup-period", 10*time.Second, "How often to query DNS for query-frontend or query-scheduler address.")
 	f.StringVar(&cfg.QuerierID, "querier.id", "", "Querier ID, sent to the query-frontend to identify requests from the same querier. Defaults to hostname.")
-	f.BoolVar(&cfg.ResponseStreamingEnabled, "querier.response-streaming-enabled", false, "Enables streaming of responses from querier to query-frontend for responses that request it. This is an experimental feature and may be removed in the future.")
+	f.BoolVar(&cfg.ResponseStreamingEnabled, "querier.response-streaming-enabled", false, "Enables streaming of responses from querier to query-frontend for response types that support it (currently only `active_series` responses do).")
 
 	cfg.QueryFrontendGRPCClientConfig.RegisterFlagsWithPrefix("querier.frontend-client", f)
 	cfg.QuerySchedulerGRPCClientConfig.RegisterFlagsWithPrefix("querier.scheduler-client", f)

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -33,7 +33,7 @@ type Config struct {
 	QuerierID                      string            `yaml:"id" category:"advanced"`
 	QueryFrontendGRPCClientConfig  grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the querier and the query-frontend."`
 	QuerySchedulerGRPCClientConfig grpcclient.Config `yaml:"query_scheduler_grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the querier and the query-scheduler."`
-	ResponseStreamingEnabled       bool              `yaml:"response_streaming_enabled" doc:"description=Enables streaming of responses from querier to query-frontend." category:"experimental"`
+	ResponseStreamingEnabled       bool              `yaml:"response_streaming_enabled" category:"experimental"`
 
 	// This configuration is injected internally.
 	MaxConcurrentRequests   int                       `yaml:"-"` // Must be same as passed to PromQL Engine.

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -33,6 +33,7 @@ type Config struct {
 	QuerierID                      string            `yaml:"id" category:"advanced"`
 	QueryFrontendGRPCClientConfig  grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the querier and the query-frontend."`
 	QuerySchedulerGRPCClientConfig grpcclient.Config `yaml:"query_scheduler_grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the querier and the query-scheduler."`
+	ResponseStreamingEnabled       bool              `yaml:"response_streaming_enabled" doc:"description=Enables streaming of responses from querier to query-frontend." category:"experimental"`
 
 	// This configuration is injected internally.
 	MaxConcurrentRequests   int                       `yaml:"-"` // Must be same as passed to PromQL Engine.
@@ -44,6 +45,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.FrontendAddress, "querier.frontend-address", "", "Address of the query-frontend component, in host:port format. If multiple query-frontends are running, the host should be a DNS resolving to all query-frontend instances. This option should be set only when query-scheduler component is not in use.")
 	f.DurationVar(&cfg.DNSLookupPeriod, "querier.dns-lookup-period", 10*time.Second, "How often to query DNS for query-frontend or query-scheduler address.")
 	f.StringVar(&cfg.QuerierID, "querier.id", "", "Querier ID, sent to the query-frontend to identify requests from the same querier. Defaults to hostname.")
+	f.BoolVar(&cfg.ResponseStreamingEnabled, "querier.response-streaming-enabled", false, "Enables streaming of responses from querier to query-frontend for responses that request it. This is an experimental feature and may be removed in the future.")
 
 	cfg.QueryFrontendGRPCClientConfig.RegisterFlagsWithPrefix("querier.frontend-client", f)
 	cfg.QuerySchedulerGRPCClientConfig.RegisterFlagsWithPrefix("querier.scheduler-client", f)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -608,6 +608,11 @@ func (f *frontendMock) QueryResult(_ context.Context, request *frontendv2pb.Quer
 	return &frontendv2pb.QueryResultResponse{}, nil
 }
 
+// satisfy frontendv2pb.FrontendForQuerierServer interface
+func (f *frontendMock) QueryResultStream(_ frontendv2pb.FrontendForQuerier_QueryResultStreamServer) error {
+	panic("unexpected call to QueryResultStream")
+}
+
 func (f *frontendMock) getRequest(queryID uint64) *httpgrpc.HTTPResponse {
 	f.mu.Lock()
 	defer f.mu.Unlock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Some Mimir API endpoints can generate responses with a very large response body. Today, responses are transmitted from queriers to query-frontends via the non-streaming gRPC call
```
rpc QueryResult (QueryResultRequest) returns (QueryResultResponse) { };
```
In case of the `/series` and `/active_series` APIs, the (partial) responses generated by queriers can get so large that they cause the query-frontend handling the request to OOM on unmarshaling the `QueryResultRequest` containing the response. The following example profile from an internal cell demonstrates this behaviour:
![image](https://github.com/grafana/mimir/assets/16662704/4af88e41-0c42-4a0b-88fe-054654f46af9)

While queriers need to accumulate the entire response in memory to be able to deduplicate results from ingesters, query-frontends do not need to bring the full response into memory in all cases. The "active series" endpoint in particular never needs to do this and was implemented in a streaming fashion to avoid the issue of OOMs for large result sets. However, since all response bodies for all types of queries are fully loaded into query-frontend memory in today's implementation of the communication between queriers and query-frontends, this streaming is essentially useless.

To avoid this issue and enable a single query-frontend instance to process arbitrarily large responses, this PR proposes the introduction of a new (streaming) rpc 
```
rpc QueryResultStream (stream QueryResultStreamRequest) returns (QueryResultResponse) { };
```
that queriers can invoke instead of the `QueryResult` call to transmit responses to query-frontends in a streaming fashion. This essentially requires two changes:

- Lifecycle management of requests in the query-frontend needs to be handled differently. This is because a request's context and its associated `frontendRequest` data-structure can no longer be canceled/cleaned up on return from `RoundTripGRPC`. Instead, the required cleanup is captured in a closure and passed to the caller, who must invoke it through closing the response body once the transfer is complete. Because of that, we risk introducing a memory leak that could be triggered by client code not closing the response body (today not closing the response body would not lead to a leak, because the body is an `io.NopCloser`).
- Queriers need to use the new rpc to stream responses. This PR puts that behaviour behind a feature flag and also requires the response being sent to indicate it wants to use streaming via a header. In this PR, only responses to the `/active_series` endpoint request the streaming behaviour, all other responses will continue to be transmitted via the existing rpc even when the feature flag is enabled.

One less-than-obvious caveat of this streaming behaviour is that queriers participate in the handling of the request for longer than they previously would have (namely until the response body is fully streamed into the query-frontend, which itself may block on streaming to the client). Since request concurrency in queriers is limited by the `-querier.max-concurrent` flag, this may lead to slow clients and/or big requests blocking querier workers. The following pair of example traces with and without streaming illustrates this difference.

**Without response streaming**

![image](https://github.com/grafana/mimir/assets/16662704/bbc23aa9-0f9f-4c09-9049-443c10991486)


**With response streaming**

![image](https://github.com/grafana/mimir/assets/16662704/91a23396-c782-40af-8c90-8153dcdcd3e7)

If this approach proves viable, other request types might also benefit from streaming in the future (e.g. remote read).

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
