### PR TITLE
Fix panic as a result of duplicate write request cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [BUGFIX] Querier: do not retry requests to store-gateway when a query gets canceled. #6934
 * [BUGFIX] Querier: return 499 status code instead of 500 when a request to remote read endpoint gets canceled. #6934
 * [BUGFIX] Querier: fix issue where `-querier.max-fetched-series-per-query` is not applied to `/series` endpoint if the series are loaded from ingesters. #7055
+* [BUGFIX] Distributor: fix issue where `-distributor.metric-relabeling-enabled` may cause distributors to panic and corrupt ingested data #7176
 
 ### Mixin
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -784,6 +784,7 @@ func (d *Distributor) prePushRelabelMiddleware(next PushFunc) PushFunc {
 		}
 
 		if !d.limits.MetricRelabelingEnabled(userID) {
+			cleanupInDefer = false
 			return next(ctx, pushReq)
 		}
 


### PR DESCRIPTION
#### What this PR does

This PR fixes a possible panic introduced by #6970. In `prePushRelabelMiddleware`, when `MetricRelabelingEnabled` returns true, it would call to the `next` middleware in the chain, then call `CleanUp` in a defer. This results in `CleanUp` being called twice. Two conditions result:

1. Distributors can panic during marshaling because the WriteRequest has already been reset to zero length
2. Ingesters can ingest corrupt data because the Label values in the request may be unsorted. They are then stuck failing to compact blocks.

The existing middleware test was attempting to find this condition via the `cleanupCallCount` field, but unfortunately the test is too simple to reproduce the behavior of actual distributor middleware in a running Mimir cluster. To reproduce the issue in test, we can insert a fake cleanup function after calling `CleanUp`, so that if it is called again we will catch it and fail the test.

I've reproduced this issue in a local mimir cluster via helm and verified that the proposed fix works.

#### Which issue(s) this PR fixes or relates to



#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
