### PR TITLE
Improve read consistency observability

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -301,10 +301,13 @@ func (f *Handler) reportQueryStats(r *http.Request, queryString url.Values, quer
 			"results_cache_hit_bytes", details.ResultsCacheHitBytes,
 			"results_cache_miss_bytes", details.ResultsCacheMissBytes,
 		)
-		if consistency, ok := querierapi.ReadConsistencyFromContext(r.Context()); ok {
-			logMessage = append(logMessage, "read_consistency", consistency)
-		}
 	}
+
+	// Log the read consistency only when explicitly defined.
+	if consistency, ok := querierapi.ReadConsistencyFromContext(r.Context()); ok {
+		logMessage = append(logMessage, "read_consistency", consistency)
+	}
+
 	if len(f.cfg.LogQueryRequestHeaders) != 0 {
 		logMessage = append(logMessage, formatRequestHeaders(&r.Header, f.cfg.LogQueryRequestHeaders)...)
 	}

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -306,12 +306,12 @@ func DefaultTenantManagerFactory(
 		}
 
 		// Wrap the query function with our custom logic.
-		wrappedQueryFunc := WrapQueryFuncWithReadConsistency(queryFunc)
+		wrappedQueryFunc := WrapQueryFuncWithReadConsistency(queryFunc, logger)
 		wrappedQueryFunc = MetricsQueryFunc(wrappedQueryFunc, totalQueries, failedQueries)
 		wrappedQueryFunc = RecordAndReportRuleQueryMetrics(wrappedQueryFunc, queryTime, zeroFetchedSeriesCount, logger)
 
 		// Wrap the queryable with our custom logic.
-		wrappedQueryable := WrapQueryableWithReadConsistency(queryable)
+		wrappedQueryable := WrapQueryableWithReadConsistency(queryable, logger)
 
 		return rules.NewManager(&rules.ManagerOptions{
 			Appendable:                 NewPusherAppendable(p, userID, totalWrites, failedWrites),

--- a/pkg/ruler/rule_query_consistency.go
+++ b/pkg/ruler/rule_query_consistency.go
@@ -30,7 +30,7 @@ func WrapQueryFuncWithReadConsistency(fn rules.QueryFunc, logger log.Logger) rul
 		detail := rules.FromOriginContext(ctx)
 
 		// If the rule has dependencies then we should enforce strong read consistency,
-		// otherwise we'll fallback to the per-tenant default.
+		// otherwise we leave it empty to have Mimir falling back to the per-tenant default.
 		if !detail.NoDependencyRules {
 			spanLog := spanlogger.FromContext(ctx, logger)
 			spanLog.SetTag("read_consistency", api.ReadConsistencyStrong)
@@ -121,8 +121,8 @@ func isQueryingAlertsForStateMetric(metricName string, matchers ...*labels.Match
 }
 
 // forceStrongReadConsistencyIfQueryingAlertsForStateMetric enforces strong read consistency if from matchers we
-// detect that the query is querying the ALERTS_FOR_STATE metric, otherwise we don't inject any specific read
-// consistency level and we fallback to the tenant's default.
+// detect that the query is querying the ALERTS_FOR_STATE metric, otherwise we leave it empty to have Mimir falling
+// back to the per-tenant default.
 func forceStrongReadConsistencyIfQueryingAlertsForStateMetric(ctx context.Context, matchers []*labels.Matcher, logger log.Logger) context.Context {
 	if isQueryingAlertsForStateMetric("", matchers...) {
 		spanLog := spanlogger.FromContext(ctx, logger)

--- a/pkg/ruler/rule_query_consistency.go
+++ b/pkg/ruler/rule_query_consistency.go
@@ -4,8 +4,10 @@ package ruler
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
@@ -13,19 +15,26 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/grafana/mimir/pkg/querier/api"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
+
+const alertForStateMetricName = "ALERTS_FOR_STATE"
 
 // WrapQueryFuncWithReadConsistency wraps rules.QueryFunc with a function that injects strong read consistency
 // requirement in the context if the query is originated from a rule which depends on other rules in the same
 // rule group.
-func WrapQueryFuncWithReadConsistency(fn rules.QueryFunc) rules.QueryFunc {
+func WrapQueryFuncWithReadConsistency(fn rules.QueryFunc, logger log.Logger) rules.QueryFunc {
 	return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
+
 		// Get details about the rule.
 		detail := rules.FromOriginContext(ctx)
 
 		// If the rule has dependencies then we should enforce strong read consistency,
 		// otherwise we'll fallback to the per-tenant default.
 		if !detail.NoDependencyRules {
+			spanLog := spanlogger.FromContext(ctx, logger)
+			spanLog.DebugLog("msg", "forced strong read consistency because the rule depends on other rules in the same rule group")
+
 			ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
 		}
 
@@ -41,12 +50,16 @@ func WrapQueryFuncWithReadConsistency(fn rules.QueryFunc) rules.QueryFunc {
 //
 // When querying the ALERTS_FOR_STATE, ruler requires strong consistency in order to ensure we restore the state
 // from the last evaluation. Without such guarantee, the ruler may query a previous state.
-func WrapQueryableWithReadConsistency(q storage.Queryable) storage.Queryable {
-	return &readConsistencyQueryable{next: q}
+func WrapQueryableWithReadConsistency(q storage.Queryable, logger log.Logger) storage.Queryable {
+	return &readConsistencyQueryable{
+		next:   q,
+		logger: logger,
+	}
 }
 
 type readConsistencyQueryable struct {
-	next storage.Queryable
+	next   storage.Queryable
+	logger log.Logger
 }
 
 // Querier implements storage.Queryable.
@@ -56,42 +69,31 @@ func (q *readConsistencyQueryable) Querier(mint, maxt int64) (storage.Querier, e
 		return querier, err
 	}
 
-	return &readConsistencyQuerier{next: querier}, nil
+	return &readConsistencyQuerier{next: querier, logger: q.logger}, nil
 }
 
 type readConsistencyQuerier struct {
-	next storage.Querier
+	next   storage.Querier
+	logger log.Logger
 }
 
 // Select implements storage.Querier.
 func (q *readConsistencyQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	// Enforce strong read consistency if it's querying the ALERTS_FOR_STATE metric, otherwise
-	// fallback to the default.
-	if isQueryingAlertsForStateMetric("", matchers...) {
-		ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
-	}
+	ctx = forceStrongReadConsistencyIfQueryingAlertsForStateMetric(ctx, matchers, q.logger)
 
 	return q.next.Select(ctx, sortSeries, hints, matchers...)
 }
 
 // LabelValues implements storage.Querier.
 func (q *readConsistencyQuerier) LabelValues(ctx context.Context, name string, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	// Enforce strong read consistency if it's querying the ALERTS_FOR_STATE metric, otherwise
-	// fallback to the default.
-	if isQueryingAlertsForStateMetric(name, matchers...) {
-		ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
-	}
+	ctx = forceStrongReadConsistencyIfQueryingAlertsForStateMetric(ctx, matchers, q.logger)
 
 	return q.next.LabelValues(ctx, name, matchers...)
 }
 
 // LabelNames implements storage.Querier.
 func (q *readConsistencyQuerier) LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	// Enforce strong read consistency if it's querying the ALERTS_FOR_STATE metric, otherwise
-	// fallback to the default.
-	if isQueryingAlertsForStateMetric("", matchers...) {
-		ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
-	}
+	ctx = forceStrongReadConsistencyIfQueryingAlertsForStateMetric(ctx, matchers, q.logger)
 
 	return q.next.LabelNames(ctx, matchers...)
 }
@@ -104,8 +106,6 @@ func (q *readConsistencyQuerier) Close() error {
 // isQueryingAlertsForStateMetric checks whether the input metricName or matchers match the
 // ALERTS_FOR_STATE metric.
 func isQueryingAlertsForStateMetric(metricName string, matchers ...*labels.Matcher) bool {
-	const alertForStateMetricName = "ALERTS_FOR_STATE"
-
 	if metricName == alertForStateMetricName {
 		return true
 	}
@@ -117,4 +117,18 @@ func isQueryingAlertsForStateMetric(metricName string, matchers ...*labels.Match
 	}
 
 	return false
+}
+
+// forceStrongReadConsistencyIfQueryingAlertsForStateMetric enforces strong read consistency if from matchers we
+// detect that the query is querying the ALERTS_FOR_STATE metric, otherwise we don't inject any specific read
+// consistency level and we fallback to the tenant's default.
+func forceStrongReadConsistencyIfQueryingAlertsForStateMetric(ctx context.Context, matchers []*labels.Matcher, logger log.Logger) context.Context {
+	if isQueryingAlertsForStateMetric("", matchers...) {
+		spanLog := spanlogger.FromContext(ctx, logger)
+		spanLog.DebugLog("msg", fmt.Sprintf("forced strong read consistency because %s metric has been queried", alertForStateMetricName))
+
+		ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
+	}
+
+	return ctx
 }

--- a/pkg/ruler/rule_query_consistency.go
+++ b/pkg/ruler/rule_query_consistency.go
@@ -33,6 +33,7 @@ func WrapQueryFuncWithReadConsistency(fn rules.QueryFunc, logger log.Logger) rul
 		// otherwise we'll fallback to the per-tenant default.
 		if !detail.NoDependencyRules {
 			spanLog := spanlogger.FromContext(ctx, logger)
+			spanLog.SetTag("read_consistency", api.ReadConsistencyStrong)
 			spanLog.DebugLog("msg", "forced strong read consistency because the rule depends on other rules in the same rule group")
 
 			ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
@@ -125,6 +126,7 @@ func isQueryingAlertsForStateMetric(metricName string, matchers ...*labels.Match
 func forceStrongReadConsistencyIfQueryingAlertsForStateMetric(ctx context.Context, matchers []*labels.Matcher, logger log.Logger) context.Context {
 	if isQueryingAlertsForStateMetric("", matchers...) {
 		spanLog := spanlogger.FromContext(ctx, logger)
+		spanLog.SetTag("read_consistency", api.ReadConsistencyStrong)
 		spanLog.DebugLog("msg", fmt.Sprintf("forced strong read consistency because %s metric has been queried", alertForStateMetricName))
 
 		ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)

--- a/pkg/ruler/rule_query_consistency_test.go
+++ b/pkg/ruler/rule_query_consistency_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -26,7 +27,7 @@ func TestWrapQueryFuncWithReadConsistency(t *testing.T) {
 			return promql.Vector{}, nil
 		}
 
-		_, _ = WrapQueryFuncWithReadConsistency(orig)(ctx, "", time.Now())
+		_, _ = WrapQueryFuncWithReadConsistency(orig, log.NewNopLogger())(ctx, "", time.Now())
 		return
 	}
 
@@ -75,7 +76,7 @@ func TestWrapQueryableWithReadConsistency(t *testing.T) {
 			return storage.EmptySeriesSet()
 		}
 
-		wrappedQueryable := WrapQueryableWithReadConsistency(&storage.MockQueryable{MockQuerier: querier})
+		wrappedQueryable := WrapQueryableWithReadConsistency(&storage.MockQueryable{MockQuerier: querier}, log.NewNopLogger())
 		wrapperQuerier, err := wrappedQueryable.Querier(math.MinInt64, math.MaxInt64)
 		require.NoError(t, err)
 


### PR DESCRIPTION
#### What this PR does

This PR is part of the experimental ingest storage. In this PR I've done a couple of improvements to read consistency observability:

- Log read_consistency in 'query stats' even when query details are not available (the two are unrelated so I don't think we should bind them in the query-frontend middleware)
- Log in a tracing span when the ruler requests strong read consistency

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
