### PR TITLE
Slow queries dashboard: bug fixes and a new panel

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33171,7 +33171,7 @@ data:
                       "span": 12,
                       "targets": [
                          {
-                            "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{ duration .response_time }}\",param_step_seconds=\"{{ div .param_step 1000 }}\",length_seconds=\"{{ duration .length }}\"",
+                            "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{ if .response_time }} {{ duration .response_time }} {{ end }}\",param_step_seconds=\"{{ if .param_step }} {{ div .param_step 1000 }} {{ end }}\",length_seconds=\"{{ if .length }} {{ duration .length }} {{ end }}\"",
                             "instant": false,
                             "legendFormat": "",
                             "range": true,

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -32239,6 +32239,87 @@ data:
                             "show": false
                          }
                       ]
+                   },
+                   {
+                      "aliasColors": { },
+                      "bars": false,
+                      "dashLength": 10,
+                      "dashes": false,
+                      "datasource": "${loki_datasource}",
+                      "description": "### Query wall time\nSeconds per second spent by queriers evaluating queries.\nThis is roughly the product of the number of subqueries for a query and how long they took.\nIn increase in this metric means that queries take more resources from the query path to evaluate.\n\n",
+                      "fill": 1,
+                      "id": 6,
+                      "legend": {
+                         "avg": false,
+                         "current": false,
+                         "max": false,
+                         "min": false,
+                         "show": true,
+                         "total": false,
+                         "values": false
+                      },
+                      "lines": true,
+                      "linewidth": 1,
+                      "links": [ ],
+                      "nullPointMode": "null as zero",
+                      "percentage": false,
+                      "pointradius": 5,
+                      "points": false,
+                      "renderer": "flot",
+                      "seriesOverrides": [ ],
+                      "spaceLength": 10,
+                      "span": 2,
+                      "stack": false,
+                      "steppedLine": false,
+                      "targets": [
+                         {
+                            "expr": "quantile_over_time(0.99, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()",
+                            "format": "time_series",
+                            "legendFormat": "p99",
+                            "legendLink": null
+                         },
+                         {
+                            "expr": "quantile_over_time(0.5, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()",
+                            "format": "time_series",
+                            "legendFormat": "p50",
+                            "legendLink": null
+                         }
+                      ],
+                      "thresholds": [ ],
+                      "timeFrom": null,
+                      "timeShift": null,
+                      "title": "Query wall time",
+                      "tooltip": {
+                         "shared": false,
+                         "sort": 0,
+                         "value_type": "individual"
+                      },
+                      "type": "graph",
+                      "xaxis": {
+                         "buckets": null,
+                         "mode": "time",
+                         "name": null,
+                         "show": true,
+                         "values": [ ]
+                      },
+                      "yaxes": [
+                         {
+                            "format": "s",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                         },
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                         }
+                      ]
                    }
                 ],
                 "repeat": null,
@@ -32259,7 +32340,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 6,
+                      "id": 7,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32333,7 +32414,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 7,
+                      "id": 8,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32407,7 +32488,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 8,
+                      "id": 9,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32481,7 +32562,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 9,
+                      "id": 10,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32555,7 +32636,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 10,
+                      "id": 11,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32621,6 +32702,81 @@ data:
                             "show": false
                          }
                       ]
+                   },
+                   {
+                      "aliasColors": { },
+                      "bars": false,
+                      "dashLength": 10,
+                      "dashes": false,
+                      "datasource": "${loki_datasource}",
+                      "description": "### Query wall time\nSeconds per second spent by queriers evaluating queries.\nThis is roughly the product of the number of subqueries for a query and how long they took.\nIn increase in this metric means that queries take more resources from the query path to evaluate.\n\n",
+                      "fill": 1,
+                      "id": 12,
+                      "legend": {
+                         "avg": false,
+                         "current": false,
+                         "max": false,
+                         "min": false,
+                         "show": true,
+                         "total": false,
+                         "values": false
+                      },
+                      "lines": true,
+                      "linewidth": 1,
+                      "links": [ ],
+                      "nullPointMode": "null as zero",
+                      "percentage": false,
+                      "pointradius": 5,
+                      "points": false,
+                      "renderer": "flot",
+                      "seriesOverrides": [ ],
+                      "spaceLength": 10,
+                      "span": 2,
+                      "stack": false,
+                      "steppedLine": false,
+                      "targets": [
+                         {
+                            "expr": "topk(10, quantile_over_time(0.99, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user))",
+                            "format": "time_series",
+                            "legendFormat": "{{user}}",
+                            "legendLink": null
+                         }
+                      ],
+                      "thresholds": [ ],
+                      "timeFrom": null,
+                      "timeShift": null,
+                      "title": "P99 query wall time",
+                      "tooltip": {
+                         "shared": false,
+                         "sort": 0,
+                         "value_type": "individual"
+                      },
+                      "type": "graph",
+                      "xaxis": {
+                         "buckets": null,
+                         "mode": "time",
+                         "name": null,
+                         "show": true,
+                         "values": [ ]
+                      },
+                      "yaxes": [
+                         {
+                            "format": "s",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                         },
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                         }
+                      ]
                    }
                 ],
                 "repeat": null,
@@ -32641,7 +32797,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 11,
+                      "id": 13,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32715,7 +32871,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 12,
+                      "id": 14,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32789,7 +32945,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 13,
+                      "id": 15,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32863,7 +33019,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 14,
+                      "id": 16,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32937,7 +33093,7 @@ data:
                       "dashes": false,
                       "datasource": "${loki_datasource}",
                       "fill": 1,
-                      "id": 15,
+                      "id": 17,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -32972,6 +33128,81 @@ data:
                       "timeFrom": null,
                       "timeShift": null,
                       "title": "P99 time span",
+                      "tooltip": {
+                         "shared": false,
+                         "sort": 0,
+                         "value_type": "individual"
+                      },
+                      "type": "graph",
+                      "xaxis": {
+                         "buckets": null,
+                         "mode": "time",
+                         "name": null,
+                         "show": true,
+                         "values": [ ]
+                      },
+                      "yaxes": [
+                         {
+                            "format": "s",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": 0,
+                            "show": true
+                         },
+                         {
+                            "format": "short",
+                            "label": null,
+                            "logBase": 1,
+                            "max": null,
+                            "min": null,
+                            "show": false
+                         }
+                      ]
+                   },
+                   {
+                      "aliasColors": { },
+                      "bars": false,
+                      "dashLength": 10,
+                      "dashes": false,
+                      "datasource": "${loki_datasource}",
+                      "description": "### Query wall time\nSeconds per second spent by queriers evaluating queries.\nThis is roughly the product of the number of subqueries for a query and how long they took.\nIn increase in this metric means that queries take more resources from the query path to evaluate.\n\n",
+                      "fill": 1,
+                      "id": 18,
+                      "legend": {
+                         "avg": false,
+                         "current": false,
+                         "max": false,
+                         "min": false,
+                         "show": true,
+                         "total": false,
+                         "values": false
+                      },
+                      "lines": true,
+                      "linewidth": 1,
+                      "links": [ ],
+                      "nullPointMode": "null as zero",
+                      "percentage": false,
+                      "pointradius": 5,
+                      "points": false,
+                      "renderer": "flot",
+                      "seriesOverrides": [ ],
+                      "spaceLength": 10,
+                      "span": 2,
+                      "stack": false,
+                      "steppedLine": false,
+                      "targets": [
+                         {
+                            "expr": "topk(10, quantile_over_time(0.99, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user_agent))",
+                            "format": "time_series",
+                            "legendFormat": "{{user_agent}}",
+                            "legendLink": null
+                         }
+                      ],
+                      "thresholds": [ ],
+                      "timeFrom": null,
+                      "timeShift": null,
+                      "title": "P99 query wall time",
                       "tooltip": {
                          "shared": false,
                          "sort": 0,
@@ -33179,7 +33410,7 @@ data:
                          ]
                       },
                       "height": "500px",
-                      "id": 16,
+                      "id": 19,
                       "span": 12,
                       "targets": [
                          {

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33163,6 +33163,18 @@ data:
                                      "value": "s"
                                   }
                                ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "query_wall_time_seconds"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "unit",
+                                     "value": "s"
+                                  }
+                               ]
                             }
                          ]
                       },
@@ -33212,7 +33224,6 @@ data:
                                   "path": true,
                                   "pod": true,
                                   "pod_template_hash": true,
-                                  "query_wall_time_seconds": true,
                                   "response_time": true,
                                   "stream": true,
                                   "traceID": true,
@@ -33251,7 +33262,11 @@ data:
                                "conversions": [
                                   {
                                      "destinationType": "number",
-                                     "targetField": "estimated_series_count"
+                                     "targetField": "sharded_queries"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "split_queries"
                                   },
                                   {
                                      "destinationType": "number",
@@ -33259,19 +33274,7 @@ data:
                                   },
                                   {
                                      "destinationType": "number",
-                                     "targetField": "fetched_chunks_count"
-                                  },
-                                  {
-                                     "destinationType": "number",
                                      "targetField": "fetched_index_bytes"
-                                  },
-                                  {
-                                     "destinationType": "number",
-                                     "targetField": "fetched_series_count"
-                                  },
-                                  {
-                                     "destinationType": "number",
-                                     "targetField": "queue_time_seconds"
                                   },
                                   {
                                      "destinationType": "number",
@@ -33287,11 +33290,15 @@ data:
                                   },
                                   {
                                      "destinationType": "number",
-                                     "targetField": "sharded_queries"
+                                     "targetField": "estimated_series_count"
                                   },
                                   {
                                      "destinationType": "number",
-                                     "targetField": "split_queries"
+                                     "targetField": "fetched_chunks_count"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "fetched_series_count"
                                   },
                                   {
                                      "destinationType": "number",
@@ -33308,6 +33315,10 @@ data:
                                   {
                                      "destinationType": "number",
                                      "targetField": "queue_time_seconds"
+                                  },
+                                  {
+                                     "destinationType": "number",
+                                     "targetField": "query_wall_time_seconds"
                                   }
                                ]
                             }

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -433,6 +433,87 @@
                         "show": false
                      }
                   ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${loki_datasource}",
+                  "description": "### Query wall time\nSeconds per second spent by queriers evaluating queries.\nThis is roughly the product of the number of subqueries for a query and how long they took.\nIn increase in this metric means that queries take more resources from the query path to evaluate.\n\n",
+                  "fill": 1,
+                  "id": 6,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "quantile_over_time(0.99, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()",
+                        "format": "time_series",
+                        "legendFormat": "p99",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "quantile_over_time(0.5, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()",
+                        "format": "time_series",
+                        "legendFormat": "p50",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Query wall time",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
                }
             ],
             "repeat": null,
@@ -453,7 +534,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 6,
+                  "id": 7,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -527,7 +608,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 7,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -601,7 +682,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 8,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -675,7 +756,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 9,
+                  "id": 10,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -749,7 +830,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 10,
+                  "id": 11,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -815,6 +896,81 @@
                         "show": false
                      }
                   ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${loki_datasource}",
+                  "description": "### Query wall time\nSeconds per second spent by queriers evaluating queries.\nThis is roughly the product of the number of subqueries for a query and how long they took.\nIn increase in this metric means that queries take more resources from the query path to evaluate.\n\n",
+                  "fill": 1,
+                  "id": 12,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "topk(10, quantile_over_time(0.99, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user))",
+                        "format": "time_series",
+                        "legendFormat": "{{user}}",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "P99 query wall time",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
                }
             ],
             "repeat": null,
@@ -835,7 +991,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 11,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -909,7 +1065,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 12,
+                  "id": 14,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -983,7 +1139,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 13,
+                  "id": 15,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1057,7 +1213,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 14,
+                  "id": 16,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1131,7 +1287,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 15,
+                  "id": 17,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1166,6 +1322,81 @@
                   "timeFrom": null,
                   "timeShift": null,
                   "title": "P99 time span",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${loki_datasource}",
+                  "description": "### Query wall time\nSeconds per second spent by queriers evaluating queries.\nThis is roughly the product of the number of subqueries for a query and how long they took.\nIn increase in this metric means that queries take more resources from the query path to evaluate.\n\n",
+                  "fill": 1,
+                  "id": 18,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "topk(10, quantile_over_time(0.99, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user_agent))",
+                        "format": "time_series",
+                        "legendFormat": "{{user_agent}}",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "P99 query wall time",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -1373,7 +1604,7 @@
                      ]
                   },
                   "height": "500px",
-                  "id": 16,
+                  "id": 19,
                   "span": 12,
                   "targets": [
                      {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -1365,7 +1365,7 @@
                   "span": 12,
                   "targets": [
                      {
-                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{ duration .response_time }}\",param_step_seconds=\"{{ div .param_step 1000 }}\",length_seconds=\"{{ duration .length }}\"",
+                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{ if .response_time }} {{ duration .response_time }} {{ end }}\",param_step_seconds=\"{{ if .param_step }} {{ div .param_step 1000 }} {{ end }}\",length_seconds=\"{{ if .length }} {{ duration .length }} {{ end }}\"",
                         "instant": false,
                         "legendFormat": "",
                         "range": true,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -1357,6 +1357,18 @@
                                  "value": "s"
                               }
                            ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "query_wall_time_seconds"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "s"
+                              }
+                           ]
                         }
                      ]
                   },
@@ -1406,7 +1418,6 @@
                               "path": true,
                               "pod": true,
                               "pod_template_hash": true,
-                              "query_wall_time_seconds": true,
                               "response_time": true,
                               "stream": true,
                               "traceID": true,
@@ -1445,7 +1456,11 @@
                            "conversions": [
                               {
                                  "destinationType": "number",
-                                 "targetField": "estimated_series_count"
+                                 "targetField": "sharded_queries"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "split_queries"
                               },
                               {
                                  "destinationType": "number",
@@ -1453,19 +1468,7 @@
                               },
                               {
                                  "destinationType": "number",
-                                 "targetField": "fetched_chunks_count"
-                              },
-                              {
-                                 "destinationType": "number",
                                  "targetField": "fetched_index_bytes"
-                              },
-                              {
-                                 "destinationType": "number",
-                                 "targetField": "fetched_series_count"
-                              },
-                              {
-                                 "destinationType": "number",
-                                 "targetField": "queue_time_seconds"
                               },
                               {
                                  "destinationType": "number",
@@ -1481,11 +1484,15 @@
                               },
                               {
                                  "destinationType": "number",
-                                 "targetField": "sharded_queries"
+                                 "targetField": "estimated_series_count"
                               },
                               {
                                  "destinationType": "number",
-                                 "targetField": "split_queries"
+                                 "targetField": "fetched_chunks_count"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_series_count"
                               },
                               {
                                  "destinationType": "number",
@@ -1502,6 +1509,10 @@
                               {
                                  "destinationType": "number",
                                  "targetField": "queue_time_seconds"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "query_wall_time_seconds"
                               }
                            ]
                         }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -433,6 +433,87 @@
                         "show": false
                      }
                   ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${loki_datasource}",
+                  "description": "### Query wall time\nSeconds per second spent by queriers evaluating queries.\nThis is roughly the product of the number of subqueries for a query and how long they took.\nIn increase in this metric means that queries take more resources from the query path to evaluate.\n\n",
+                  "fill": 1,
+                  "id": 6,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "quantile_over_time(0.99, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()",
+                        "format": "time_series",
+                        "legendFormat": "p99",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "quantile_over_time(0.5, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()",
+                        "format": "time_series",
+                        "legendFormat": "p50",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Query wall time",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
                }
             ],
             "repeat": null,
@@ -453,7 +534,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 6,
+                  "id": 7,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -527,7 +608,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 7,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -601,7 +682,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 8,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -675,7 +756,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 9,
+                  "id": 10,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -749,7 +830,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 10,
+                  "id": 11,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -815,6 +896,81 @@
                         "show": false
                      }
                   ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${loki_datasource}",
+                  "description": "### Query wall time\nSeconds per second spent by queriers evaluating queries.\nThis is roughly the product of the number of subqueries for a query and how long they took.\nIn increase in this metric means that queries take more resources from the query path to evaluate.\n\n",
+                  "fill": 1,
+                  "id": 12,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "topk(10, quantile_over_time(0.99, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user))",
+                        "format": "time_series",
+                        "legendFormat": "{{user}}",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "P99 query wall time",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
                }
             ],
             "repeat": null,
@@ -835,7 +991,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 11,
+                  "id": 13,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -909,7 +1065,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 12,
+                  "id": 14,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -983,7 +1139,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 13,
+                  "id": 15,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1057,7 +1213,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 14,
+                  "id": 16,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1131,7 +1287,7 @@
                   "dashes": false,
                   "datasource": "${loki_datasource}",
                   "fill": 1,
-                  "id": 15,
+                  "id": 17,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1166,6 +1322,81 @@
                   "timeFrom": null,
                   "timeShift": null,
                   "title": "P99 time span",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "s",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "${loki_datasource}",
+                  "description": "### Query wall time\nSeconds per second spent by queriers evaluating queries.\nThis is roughly the product of the number of subqueries for a query and how long they took.\nIn increase in this metric means that queries take more resources from the query path to evaluate.\n\n",
+                  "fill": 1,
+                  "id": 18,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "topk(10, quantile_over_time(0.99, {cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user_agent))",
+                        "format": "time_series",
+                        "legendFormat": "{{user_agent}}",
+                        "legendLink": null
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "P99 query wall time",
                   "tooltip": {
                      "shared": false,
                      "sort": 0,
@@ -1373,7 +1604,7 @@
                      ]
                   },
                   "height": "500px",
-                  "id": 16,
+                  "id": 19,
                   "span": 12,
                   "targets": [
                      {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -1365,7 +1365,7 @@
                   "span": 12,
                   "targets": [
                      {
-                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{ duration .response_time }}\",param_step_seconds=\"{{ div .param_step 1000 }}\",length_seconds=\"{{ duration .length }}\"",
+                        "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",name=~\"query-frontend.*\"} |= \"query stats\" != \"/api/v1/read\" | logfmt | user=~\"${tenant_id}\" | user_agent=~\"${user_agent}\" | response_time > ${min_duration} | label_format response_time_seconds=\"{{ if .response_time }} {{ duration .response_time }} {{ end }}\",param_step_seconds=\"{{ if .param_step }} {{ div .param_step 1000 }} {{ end }}\",length_seconds=\"{{ if .length }} {{ duration .length }} {{ end }}\"",
                         "instant": false,
                         "legendFormat": "",
                         "range": true,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -1357,6 +1357,18 @@
                                  "value": "s"
                               }
                            ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "query_wall_time_seconds"
+                           },
+                           "properties": [
+                              {
+                                 "id": "unit",
+                                 "value": "s"
+                              }
+                           ]
                         }
                      ]
                   },
@@ -1406,7 +1418,6 @@
                               "path": true,
                               "pod": true,
                               "pod_template_hash": true,
-                              "query_wall_time_seconds": true,
                               "response_time": true,
                               "stream": true,
                               "traceID": true,
@@ -1445,7 +1456,11 @@
                            "conversions": [
                               {
                                  "destinationType": "number",
-                                 "targetField": "estimated_series_count"
+                                 "targetField": "sharded_queries"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "split_queries"
                               },
                               {
                                  "destinationType": "number",
@@ -1453,19 +1468,7 @@
                               },
                               {
                                  "destinationType": "number",
-                                 "targetField": "fetched_chunks_count"
-                              },
-                              {
-                                 "destinationType": "number",
                                  "targetField": "fetched_index_bytes"
-                              },
-                              {
-                                 "destinationType": "number",
-                                 "targetField": "fetched_series_count"
-                              },
-                              {
-                                 "destinationType": "number",
-                                 "targetField": "queue_time_seconds"
                               },
                               {
                                  "destinationType": "number",
@@ -1481,11 +1484,15 @@
                               },
                               {
                                  "destinationType": "number",
-                                 "targetField": "sharded_queries"
+                                 "targetField": "estimated_series_count"
                               },
                               {
                                  "destinationType": "number",
-                                 "targetField": "split_queries"
+                                 "targetField": "fetched_chunks_count"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "fetched_series_count"
                               },
                               {
                                  "destinationType": "number",
@@ -1502,6 +1509,10 @@
                               {
                                  "destinationType": "number",
                                  "targetField": "queue_time_seconds"
+                              },
+                              {
+                                 "destinationType": "number",
+                                 "targetField": "query_wall_time_seconds"
                               }
                            ]
                         }

--- a/operations/mimir-mixin-tools/serve/provisioning-datasources.yaml
+++ b/operations/mimir-mixin-tools/serve/provisioning-datasources.yaml
@@ -13,3 +13,14 @@ datasources:
       basicAuthPassword: $DATASOURCE_PASSWORD
     version: 1
     editable: true
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: $LOKI_DATASOURCE_URL
+    basicAuth: true
+    basicAuthUser: $LOKI_DATASOURCE_USERNAME
+    secureJsonData:
+      basicAuthPassword: $LOKI_DATASOURCE_PASSWORD
+    version: 1
+    editable: true

--- a/operations/mimir-mixin-tools/serve/run.sh
+++ b/operations/mimir-mixin-tools/serve/run.sh
@@ -38,6 +38,9 @@ if [ ! -e "${SCRIPT_DIR}/.config" ]; then
   echo "DATASOURCE_URL=\"<grafana-cloud-url ending with /prometheus>\""
   echo "DATASOURCE_USERNAME=\"<grafana-cloud-instance-id>\""
   echo "DATASOURCE_PASSWORD=\"<grafana-cloud-api-key>\""
+  echo "LOKI_DATASOURCE_URL=\"<grafana-cloud-url ending with (optional)>\""
+  echo "LOKI_DATASOURCE_USERNAME=\"<grafana-cloud-instance-id (optional)>\""
+  echo "LOKI_DATASOURCE_PASSWORD=\"<grafana-cloud-api-key (optional)>\""
   echo "GRAFANA_PUBLISHED_PORT=\"<grafana-port-on-the-host>\""
   echo ""
   exit 1
@@ -72,10 +75,12 @@ docker run \
   --env "DATASOURCE_URL=${DATASOURCE_URL}" \
   --env "DATASOURCE_USERNAME=${DATASOURCE_USERNAME}" \
   --env "DATASOURCE_PASSWORD=${DATASOURCE_PASSWORD}" \
+  --env "LOKI_DATASOURCE_URL=${LOKI_DATASOURCE_URL}" \
+  --env "LOKI_DATASOURCE_USERNAME=${LOKI_DATASOURCE_USERNAME}" \
+  --env "LOKI_DATASOURCE_PASSWORD=${LOKI_DATASOURCE_PASSWORD}" \
   -v "${SCRIPT_DIR}/../../mimir-mixin-compiled/dashboards:/var/lib/grafana/dashboards" \
   -v "${SCRIPT_DIR}/provisioning-dashboards.yaml:/etc/grafana/provisioning/dashboards/provisioning-dashboards.yaml" \
   -v "${SCRIPT_DIR}/provisioning-datasources.yaml:/etc/grafana/provisioning/datasources/provisioning-datasources.yaml" \
-  --network=host \
   --expose 3000 \
   --publish "${GRAFANA_PUBLISHED_PORT}:3000" \
   grafana/grafana:latest

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -61,6 +61,25 @@ local filename = 'mimir-slow-queries.json';
           unit='s',
         )
       )
+      .addPanel(
+        $.panel('Query wall time') +
+        $.lokiMetricsQueryPanel(
+          [
+            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
+          ],
+          ['p99', 'p50'],
+          unit='s',
+        )
+        + $.panelDescription(
+          'Query wall time',
+          |||
+            Seconds per second spent by queriers evaluating queries.
+            This is roughly the product of the number of subqueries for a query and how long they took.
+            In increase in this metric means that queries take more resources from the query path to evaluate.
+          |||
+        ),
+      )
     )
     .addRow(
       $.row('Top 10 tenants') { collapse: true }
@@ -102,6 +121,22 @@ local filename = 'mimir-slow-queries.json';
           '{{user}}',
           unit='s',
         )
+      )
+      .addPanel(
+        $.panel('P99 query wall time') +
+        $.lokiMetricsQueryPanel(
+          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+          '{{user}}',
+          unit='s',
+        )
+        + $.panelDescription(
+          'Query wall time',
+          |||
+            Seconds per second spent by queriers evaluating queries.
+            This is roughly the product of the number of subqueries for a query and how long they took.
+            In increase in this metric means that queries take more resources from the query path to evaluate.
+          |||
+        ),
       )
     )
     .addRow(
@@ -145,6 +180,22 @@ local filename = 'mimir-slow-queries.json';
             '{{user_agent}}',
             unit='s',
           )
+        )
+        .addPanel(
+          $.panel('P99 query wall time') +
+          $.lokiMetricsQueryPanel(
+            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            '{{user_agent}}',
+            unit='s',
+          )
+          + $.panelDescription(
+            'Query wall time',
+            |||
+              Seconds per second spent by queriers evaluating queries.
+              This is roughly the product of the number of subqueries for a query and how long they took.
+              In increase in this metric means that queries take more resources from the query path to evaluate.
+            |||
+          ),
         )
       )
     )

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -161,9 +161,9 @@ local filename = 'mimir-slow-queries.json';
           targets: [
             {
               local extraFields = [
-                'response_time_seconds="{{ duration .response_time }}"',
-                'param_step_seconds="{{ div .param_step 1000 }}"',
-                'length_seconds="{{ duration .length }}"',
+                'response_time_seconds="{{ if .response_time }} {{ duration .response_time }} {{ end }}"',
+                'param_step_seconds="{{ if .param_step }} {{ div .param_step 1000 }} {{ end }}"',
+                'length_seconds="{{ if .length }} {{ duration .length }} {{ end }}"',
               ],
               // Filter out the remote read endpoint.
               expr: '{%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | label_format %s' % [$._config.per_cluster_label, $._config.per_namespace_label, std.join(',', extraFields)],

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -174,6 +174,10 @@ local filename = 'mimir-slow-queries.json';
             },
           ],
 
+          local bytesFields = ['fetched_chunk_bytes', 'fetched_index_bytes', 'response_size_bytes', 'results_cache_hit_bytes', 'results_cache_miss_bytes'],
+          local shortFields = ['estimated_series_count', 'fetched_chunks_count', 'fetched_series_count'],
+          local secondsFields = ['Time span', 'Duration', 'Step', 'queue_time_seconds', 'query_wall_time_seconds'],
+
           // Use Grafana transformations to display fields in a table.
           transformations: [
             {
@@ -187,7 +191,7 @@ local filename = 'mimir-slow-queries.json';
               id: 'organize',
               options: {
                 // Hide fields we don't care.
-                local hiddenFields = ['caller', 'cluster', 'container', 'host', 'id', 'job', 'level', 'line', 'method', 'msg', 'name', 'namespace', 'path', 'pod', 'pod_template_hash', 'query_wall_time_seconds', 'stream', 'traceID', 'tsNs', 'labels', 'Line', 'Time', 'gossip_ring_member', 'component', 'response_time', 'param_step', 'length'],
+                local hiddenFields = ['caller', 'cluster', 'container', 'host', 'id', 'job', 'level', 'line', 'method', 'msg', 'name', 'namespace', 'path', 'pod', 'pod_template_hash', 'stream', 'traceID', 'tsNs', 'labels', 'Line', 'Time', 'gossip_ring_member', 'component', 'response_time', 'param_step', 'length'],
 
                 excludeByName: {
                   [field]: true
@@ -221,7 +225,7 @@ local filename = 'mimir-slow-queries.json';
               // Transforma some fields into numbers so sorting in the table doesn't sort them lexicographically.
               id: 'convertFieldType',
               options: {
-                local numericFields = ['estimated_series_count', 'fetched_chunk_bytes', 'fetched_chunks_count', 'fetched_index_bytes', 'fetched_series_count', 'queue_time_seconds', 'response_size_bytes', 'results_cache_hit_bytes', 'results_cache_miss_bytes', 'sharded_queries', 'split_queries', 'Time span', 'Duration', 'Step', 'queue_time_seconds'],
+                local numericFields = ['sharded_queries', 'split_queries'] + bytesFields + shortFields + secondsFields,
 
                 conversions: [
                   {
@@ -237,7 +241,6 @@ local filename = 'mimir-slow-queries.json';
           fieldConfig: {
             // Configure overrides to nicely format field values.
             overrides:
-              local bytesFields = ['fetched_chunk_bytes', 'fetched_index_bytes', 'response_size_bytes', 'results_cache_hit_bytes', 'results_cache_miss_bytes'];
               [
                 {
                   matcher: { id: 'byName', options: fieldName },
@@ -245,7 +248,6 @@ local filename = 'mimir-slow-queries.json';
                 }
                 for fieldName in bytesFields
               ] +
-              local shortFields = ['estimated_series_count', 'fetched_chunks_count', 'fetched_series_count'];
               [
                 {
                   matcher: { id: 'byName', options: fieldName },
@@ -253,7 +255,6 @@ local filename = 'mimir-slow-queries.json';
                 }
                 for fieldName in shortFields
               ] +
-              local secondsFields = ['Time span', 'Duration', 'Step', 'queue_time_seconds'];
               [
                 {
                   matcher: { id: 'byName', options: fieldName },


### PR DESCRIPTION
This fixes two issues with the dashboard and adds a new panel: Query wall time 

1. Some parsing errors in the logs table showed as columns. This PR prevents the parsing errors

**Previously**
<img width="1776" alt="Screenshot 2024-01-23 at 17 41 53" src="https://github.com/grafana/mimir/assets/21020035/d447664b-1273-445b-a7e5-4041164d2459">

**Now**
<img width="1782" alt="Screenshot 2024-01-23 at 17 41 59" src="https://github.com/grafana/mimir/assets/21020035/a93f6c2d-aa6a-4ebb-af39-79fd259bce65">

2. `query_wall_time_seconds` was hidden from the table
3. Adds three panels for query wall time

<img width="1781" alt="Screenshot 2024-01-23 at 18 05 03" src="https://github.com/grafana/mimir/assets/21020035/4e1f096a-13c6-425f-96ce-7c5b44653743">

#### mixin-serve

This also adds the ability to set up a Loki datasource for the local dashboards in `make mixin-serve`