### PR TITLE
Revert "helm: omit `backend: s3` when minio is disabled"

### DIFF
--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -175,6 +175,7 @@ mimir:
 
     # This configures how the store-gateway synchronizes blocks stored in the bucket. It uses Minio by default for getting started (configured via flags) but this should be changed for production deployments.
     blocks_storage:
+      backend: s3
       bucket_store:
         {{- if index .Values "chunks-cache" "enabled" }}
         chunks_cache:
@@ -204,7 +205,6 @@ mimir:
         {{- end }}
         sync_dir: /data/tsdb-sync
       {{- if .Values.minio.enabled }}
-      backend: s3
       s3:
         access_key_id: {{ .Values.minio.rootUser }}
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-tsdb

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -20,6 +20,7 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     blocks_storage:
+      backend: s3
       bucket_store:
         chunks_cache:
           backend: memcached

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -30,6 +30,7 @@ data:
     auth:
       type: enterprise
     blocks_storage:
+      backend: s3
       bucket_store:
         sync_dir: /data/tsdb-sync
       tsdb:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -20,6 +20,7 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     blocks_storage:
+      backend: s3
       bucket_store:
         sync_dir: /data/tsdb-sync
       tsdb:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -20,6 +20,7 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     blocks_storage:
+      backend: s3
       bucket_store:
         chunks_cache:
           backend: memcached


### PR DESCRIPTION
Reverts grafana/mimir#6999

The default is actually `filesystem`. So omitting `s3` results in a breaking change as reported in https://github.com/grafana/mimir/issues/7196