### PR TITLE
downgrade integration test certificate elliptic curve algo for boringcrypto FIPS-only compatibility

### DIFF
--- a/integration/ca/ca.go
+++ b/integration/ca/ca.go
@@ -26,7 +26,7 @@ type CA struct {
 }
 
 func New(name string) *CA {
-	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		panic(err)
 	}
@@ -71,7 +71,7 @@ func (ca *CA) WriteCACertificate(path string) error {
 }
 
 func (ca *CA) WriteCertificate(template *x509.Certificate, certPath string, keyPath string) error {
-	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
downgrade to P384 from P521

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
