### PR TITLE
Fix 'op' label values for cortex_query_frontend_queries_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@
 * [BUGFIX] Querier: return 499 status code instead of 500 when a request to remote read endpoint gets canceled. #6934
 * [BUGFIX] Querier: fix issue where `-querier.max-fetched-series-per-query` is not applied to `/series` endpoint if the series are loaded from ingesters. #7055
 * [BUGFIX] Distributor: fix issue where `-distributor.metric-relabeling-enabled` may cause distributors to panic and corrupt ingested data #7176
+* [BUGFIX] Query-frontend: the `cortex_query_frontend_queries_total` report incorrectly reported `op="query"` for any request which wasn't a range query. Now the `op` label value can be one of the following: #7207
+  * `query`: instant query
+  * `query_range`: range query
+  * `cardinality`: cardinality query
+  * `label_names_and_values`: label names / values query
+  * `active_series`: active series query
+  * `other`: any other request
 
 ### Mixin
 

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -164,9 +164,13 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 	require.Equal(t, 500, res.StatusCode)
 
 	// check metric label values for total queries in the query frontend
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_query_frontend_queries_total"}, e2e.WithLabelMatchers(
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_query_frontend_queries_total"}, e2e.WithLabelMatchers(
 		labels.MustNewMatcher(labels.MatchEqual, "user", strings.Join(tenantIDs, "|")),
 		labels.MustNewMatcher(labels.MatchEqual, "op", "query"))))
+
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_query_frontend_queries_total"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "user", strings.Join(tenantIDs, "|")),
+		labels.MustNewMatcher(labels.MatchEqual, "op", "other"))))
 
 	// check metric label values for query queue length in either query frontend or query scheduler
 	queueComponent := queryFrontend

--- a/pkg/frontend/querymiddleware/cardinality_query_cache.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache.go
@@ -28,7 +28,7 @@ func newCardinalityQueryCacheRoundTripper(cache cache.Cache, generator CacheKeyG
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, generator.LabelValuesCardinality, ttl, next, logger, newResultsCacheMetrics("cardinality", reg))
+	return newGenericQueryCacheRoundTripper(cache, generator.LabelValuesCardinality, ttl, next, logger, newResultsCacheMetrics(queryTypeCardinality, reg))
 }
 
 type cardinalityQueryTTL struct {

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -34,7 +34,7 @@ func newLabelsQueryCacheRoundTripper(cache cache.Cache, generator CacheKeyGenera
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, generator.LabelValues, ttl, next, logger, newResultsCacheMetrics("label_names_and_values", reg))
+	return newGenericQueryCacheRoundTripper(cache, generator.LabelValues, ttl, next, logger, newResultsCacheMetrics(queryTypeLabels, reg))
 }
 
 type labelsQueryTTL struct {

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -8,7 +8,6 @@ package querymiddleware
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -251,22 +250,118 @@ func TestInstantTripperware(t *testing.T) {
 
 func TestTripperware_Metrics(t *testing.T) {
 	tests := map[string]struct {
-		path                    string
-		expectedNotAlignedCount int
-		stepAlignEnabled        bool
+		path             string
+		stepAlignEnabled bool
+		expectedMetrics  string
 	}{
-		"start/end is aligned to step": {
-			path:                    "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=120",
-			expectedNotAlignedCount: 0,
+		"range query, start/end is aligned to step": {
+			path: "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=120",
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="query_range",user="user-1"} 1
+			`,
 		},
-		"start/end is not aligned to step, aligning disabled": {
-			path:                    "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7",
-			expectedNotAlignedCount: 1,
+		"range query, start/end is not aligned to step, aligning disabled": {
+			path: "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7",
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 1
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="query_range",user="user-1"} 1
+			`,
 		},
-		"start/end is not aligned to step, aligning enabled": {
-			path:                    "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7",
-			expectedNotAlignedCount: 1,
-			stepAlignEnabled:        true,
+		"range query, start/end is not aligned to step, aligning enabled": {
+			path:             "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7",
+			stepAlignEnabled: true,
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 1
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="query_range",user="user-1"} 1
+			`,
+		},
+		"instant query": {
+			path: "/api/v1/query?query=up&time=1536673680",
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="query",user="user-1"} 1
+			`,
+		},
+		"label names": {
+			path: "/api/v1/labels?start=1536673680&end=1536716880",
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="label_names_and_values",user="user-1"} 1
+			`,
+		},
+		"label values": {
+			path: "/api/v1/label/test/values?start=1536673680&end=1536716880",
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="label_names_and_values",user="user-1"} 1
+			`,
+		},
+		"cardinality label names": {
+			path: "/api/v1/cardinality/label_names?selector=%7Bjob%3D%22test%22%7D",
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="cardinality",user="user-1"} 1
+			`,
+		},
+		"cardinality active series": {
+			path: "/api/v1/cardinality/active_series?selector=%7Bjob%3D%22test%22%7D",
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="active_series",user="user-1"} 1
+			`,
+		},
+		"unknown query type": {
+			path: "/api/v1/unknown",
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="other",user="user-1"} 1
+			`,
 		},
 	}
 
@@ -320,16 +415,9 @@ func TestTripperware_Metrics(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.StatusCode)
 
-			body, err := io.ReadAll(resp.Body)
-			require.NoError(t, err)
-			require.Equal(t, `{"status":""}`, string(body))
-
-			assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
-				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
-				cortex_query_frontend_non_step_aligned_queries_total %d
-			`, testData.expectedNotAlignedCount)),
+			assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(testData.expectedMetrics),
 				"cortex_query_frontend_non_step_aligned_queries_total",
+				"cortex_query_frontend_queries_total",
 			))
 		})
 	}


### PR DESCRIPTION
#### What this PR does

Today I noticed that the `op` label value reported by `cortex_query_frontend_queries_total` may be wrong because it uses `op="query"` for any non range query. This PR fixes it, using the same label values we use for caching metrics.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
