### PR TITLE
Add a histogram to observe wait time when kicking off mergeQuerier jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [ENHANCEMENT] Store-gateway: merge series from different blocks concurrently. #7456
 * [ENHANCEMENT] Store-gateway: Add `stage="wait_max_concurrent"` to `cortex_bucket_store_series_request_stage_duration_seconds` which records how long the query had to wait for its turn for `-blocks-storage.bucket-store.max-concurrent`. #7609
+* [ENHANCEMENT] Querier: add histogram to observe wait times when kicking off upstream queries from mergeQuerier. #7209
+
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [ENHANCEMENT] Store-gateway: merge series from different blocks concurrently. #7456
 * [ENHANCEMENT] Store-gateway: Add `stage="wait_max_concurrent"` to `cortex_bucket_store_series_request_stage_duration_seconds` which records how long the query had to wait for its turn for `-blocks-storage.bucket-store.max-concurrent`. #7609
-* [ENHANCEMENT] Querier: add histogram to observe wait times when kicking off upstream queries from mergeQuerier. #7209
-
+* [ENHANCEMENT] Querier: add `cortex_querier_federation_upstream_query_wait_duration_seconds` to observe time from when a querier picks up a cross-tenant query to when work begins on its single-tenant counterparts. #7209
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -119,10 +119,14 @@ func NewMergeQueryable(idLabelName string, callbacks MergeQueryableCallbacks, re
 			Help:    "Number of tenants queried for a single standard query.",
 			Buckets: []float64{1, 2, 4, 8, 16, 32},
 		}),
+
+		// Experimental: Observe time to kick off upstream query jobs as a native histogram
 		upstreamQueryWaitDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "mimir_querier_federation_upstream_query_wait_duration_seconds",
-			Help:    "Time spent waiting to run upstream queries",
-			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30},
+			Name:                            "mimir_querier_federation_upstream_query_wait_duration_seconds",
+			Help:                            "Time spent waiting to run upstream queries",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}),
 	}
 }

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -122,7 +122,7 @@ func NewMergeQueryable(idLabelName string, callbacks MergeQueryableCallbacks, re
 
 		// Experimental: Observe time to kick off upstream query jobs as a native histogram
 		upstreamQueryWaitDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:                            "mimir_querier_federation_upstream_query_wait_duration_seconds",
+			Name:                            "cortex_querier_federation_upstream_query_wait_duration_seconds",
 			Help:                            "Time spent waiting to run upstream queries",
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR adds a native histogram to the mergeQuerier, which observes the time it takes for each upstream querier job to start. 

#### Which issue(s) this PR fixes or relates to
For users running many tenants, it is possible for the mergeQuerier to need to kick off many jobs ([code](https://github.com/grafana/mimir/blob/70504e61f1f0ed067a4d5a4dd24cbb82c930dc14/pkg/querier/tenantfederation/merge_queryable.go#L340)),  limited to only `tenant-federation.max-concurrent` jobs in parallel. Recording wait time at this point will hopefully give the user insight into whether `tenant-federation.max-concurrent` should be tuned.

#### Checklist

- [N/A] Tests updated.
- [N/A] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [N/A] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
