### PR TITLE
Add Dockerfile for tools/copyblocks

### DIFF
--- a/tools/copyblocks/Dockerfile
+++ b/tools/copyblocks/Dockerfile
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+FROM       alpine:3.19.0
+ARG        EXTRA_PACKAGES
+RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
+# Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
+ARG        TARGETOS
+ARG        TARGETARCH
+ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
+# Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
+ARG        USE_BINARY_SUFFIX
+COPY       copyblocks${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /copyblocks
+EXPOSE     8080
+ENTRYPOINT ["/copyblocks"]
+
+ARG revision
+LABEL org.opencontainers.image.title="copyblocks" \
+      org.opencontainers.image.source="https://github.com/grafana/mimir/tree/main/tools/copyblocks" \
+      org.opencontainers.image.revision="${revision}"


### PR DESCRIPTION
#### What this PR does

This PR adds Dockerfile for `tools/copyblocks`. This allows manual builds of docker image, eg.:

```
make tools/copyblocks/.uptodate
```

or

```
make BUILD_IMAGE=grafana/mimir-build-image IMAGE_PREFIX=myrepo/ push-multiarch-tools/copyblocks/.uptodate
```

This also enabled building of docker image during releases or weekly builds.

(Asked internal IT to create new grafana/copyblocks repository for this to work.)

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
