### PR TITLE
Chore: remove superfluous errors.Cause() usage in pkg/storage

### DIFF
--- a/pkg/storage/tsdb/block/fetcher.go
+++ b/pkg/storage/tsdb/block/fetcher.go
@@ -309,11 +309,11 @@ func (f *MetaFetcher) fetchMetadata(ctx context.Context, excludeMarkedForDeletio
 					continue
 				}
 
-				if errors.Is(errors.Cause(err), ErrorSyncMetaNotFound) {
+				if errors.Is(err, ErrorSyncMetaNotFound) {
 					mtx.Lock()
 					resp.noMetasCount++
 					mtx.Unlock()
-				} else if errors.Is(errors.Cause(err), ErrorSyncMetaCorrupted) {
+				} else if errors.Is(err, ErrorSyncMetaCorrupted) {
 					mtx.Lock()
 					resp.corruptedMetasCount++
 					mtx.Unlock()
@@ -549,10 +549,10 @@ func (f *IgnoreDeletionMarkFilter) Filter(ctx context.Context, metas map[ulid.UL
 			for id := range ch {
 				m := &DeletionMark{}
 				if err := ReadMarker(ctx, f.logger, f.bkt, id.String(), m); err != nil {
-					if errors.Is(errors.Cause(err), ErrorMarkerNotFound) {
+					if errors.Is(err, ErrorMarkerNotFound) {
 						continue
 					}
-					if errors.Is(errors.Cause(err), ErrorUnmarshalMarker) {
+					if errors.Is(err, ErrorUnmarshalMarker) {
 						level.Warn(f.logger).Log("msg", "found partial deletion-mark.json; if we will see it happening often for the same block, consider manually deleting deletion-mark.json from the object storage", "block", id, "err", err)
 						continue
 					}


### PR DESCRIPTION
#### What this PR does

In this PR I'm removing superfluous `errors.Cause()` usage in `pkg/storage`. This usage of `errors.Is(errors.Cause(), ...)` was introduced in https://github.com/grafana/mimir/pull/3288 when removing Thanos dependency.

The reason why `errors.Cause()` is superfluous is because `errors.Is()` already navigates the chain of wrapped errors, so we don't have to look at the `Cause()` of an error. I've checked all places where these errors are returned, and they're all correctly wrapped with `errors.Wrap()` (so `errors.Is()` is enough). In addition, for the errors returned by `ReadMarker()`, in other places in the code we just check the same errors using only `errors.Is()`, another signal that `errors.Cause()` is not needed.

_Note: this PR is part of a work I'm doing to completely remove `errors.Cause()` from Mimir._

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
