### PR TITLE
Remove errors.Cause() usage from store-gateway and its clients

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/types"
 	"github.com/grafana/dskit/cancellation"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
@@ -34,7 +35,6 @@ import (
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	grpc_metadata "google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/storage/bucket"
@@ -927,7 +927,7 @@ func shouldStopQueryFunc(err error) bool {
 		return true
 	}
 
-	if st, ok := status.FromError(err); ok {
+	if st, ok := grpcutil.ErrorToStatus(err); ok {
 		if int(st.Code()) == http.StatusUnprocessableEntity {
 			return true
 		}

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -927,7 +927,7 @@ func shouldStopQueryFunc(err error) bool {
 		return true
 	}
 
-	if st, ok := status.FromError(errors.Cause(err)); ok {
+	if st, ok := status.FromError(err); ok {
 		if int(st.Code()) == http.StatusUnprocessableEntity {
 			return true
 		}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/gogo/protobuf/types"
 	"github.com/grafana/dskit/gate"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/runutil"
 	"github.com/oklog/ulid"
@@ -548,7 +549,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storegatewaypb.Stor
 			return
 		}
 		code := codes.Internal
-		if st, ok := status.FromError(err); ok {
+		if st, ok := grpcutil.ErrorToStatus(err); ok {
 			code = st.Code()
 		} else if errors.Is(err, context.Canceled) {
 			code = codes.Canceled

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -548,7 +548,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storegatewaypb.Stor
 			return
 		}
 		code := codes.Internal
-		if st, ok := status.FromError(errors.Cause(err)); ok {
+		if st, ok := status.FromError(err); ok {
 			code = st.Code()
 		} else if errors.Is(err, context.Canceled) {
 			code = codes.Canceled

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/grafana/dskit/services"
 	dstest "github.com/grafana/dskit/test"
 	"github.com/oklog/ulid"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -1481,9 +1480,9 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testi
 					if testData.expectedErr != nil {
 						require.Error(t, err)
 						assert.IsType(t, testData.expectedErr, err)
-						s1, ok := status.FromError(errors.Cause(err))
+						s1, ok := status.FromError(err)
 						assert.True(t, ok)
-						s2, ok := status.FromError(errors.Cause(testData.expectedErr))
+						s2, ok := status.FromError(testData.expectedErr)
 						assert.True(t, ok)
 						assert.Contains(t, s1.Message(), s2.Message())
 						assert.Equal(t, s1.Code(), s2.Code())


### PR DESCRIPTION
#### What this PR does

We have few usage of `errors.Cause()` in the store-gateway and the querier which I believe being superfluous. The usage addressed by this PR is `status.FromError(errors.Cause(err))`. The actual `status.FromError()` implementation internally uses `errors.As()` (which navigates the chain of wrapped errors), so we shouldn't need `errors.Cause()`.

The `errors.Cause()` in `shouldStopQueryFunc()` was introduced by #4100 which also introduced the integration test `Test_MaxSeriesAndChunksPerQueryLimitHit`. The integration test passes on top of this PR. As a counter proof, of we completely remove the `status.FromError()` check from `shouldStopQueryFunc()`, then the `Test_MaxSeriesAndChunksPerQueryLimitHit` integration test fails.

_Note: this PR is part of a work I'm doing to completely remove errors.Cause() from Mimir._

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
