### PR TITLE
Remove errors.Cause() usage from cardinality analysis handler

### DIFF
--- a/pkg/querier/cardinality_analysis_handler.go
+++ b/pkg/querier/cardinality_analysis_handler.go
@@ -129,7 +129,7 @@ func ActiveSeriesCardinalityHandler(d Distributor, limits *validation.Overrides)
 }
 
 func respondFromError(err error, w http.ResponseWriter) {
-	httpResp, ok := httpgrpc.HTTPResponseFromError(errors.Cause(err))
+	httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 	if !ok {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
#### What this PR does

In this PR I'm removing `errors.Cause()` from `respondFromError()`, which is only used by the cardinality analysis handler. The `errors.Cause()` was passed to `httpgrpc.HTTPResponseFromError()` which, in turn, passes the error to `grpcutil.ErrorToStatus()`. `grpcutil.ErrorToStatus()` ([see code](https://github.com/grafana/dskit/blob/main/grpcutil/status.go#L22-L36)) uses `errors.As()` (which navigates the chain of wrapped errors), so the `errors.Cause()` usage should be superfluous.

_Note: this PR is part of a work I'm doing to completely remove errors.Cause() from Mimir._

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
