### PR TITLE
Ensure we never use errors.Cause()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,13 @@ lint: check-makefiles
 	# Ensure all errors are report as APIError
 	faillint -paths "github.com/weaveworks/common/httpgrpc.{Errorf}=github.com/grafana/mimir/pkg/api/error.Newf" ./pkg/frontend/querymiddleware/...
 
+	# errors.Cause() only work on errors wrapped by github.com/pkg/errors, while it doesn't work
+	# on errors wrapped by golang standard errors package. In Mimir we currently use github.com/pkg/errors
+	# but other vendors we depend on (e.g. Prometheus) just uses the standard errors package.
+	# For this reason, we recommend to not use errors.Cause() anywhere, so that we don't have to
+	# question whether the usage is safe or not.
+	faillint -paths "github.com/pkg/errors.{Cause}" ./pkg/... ./cmd/... ./tools/... ./integration/...
+
 	# gogo/status allows to easily customize error details while grpc/status doesn't:
 	# for this reason we use gogo/status in several places. However, gogo/status.FromError()
 	# doesn't support wrapped errors, while grpc/status.FromError() does.

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -248,7 +248,7 @@ func (d *Distributor) doUnary(userID string, w http.ResponseWriter, r *http.Requ
 }
 
 func respondFromError(err error, w http.ResponseWriter, logger log.Logger) {
-	httpResp, ok := httpgrpc.HTTPResponseFromError(errors.Cause(err))
+	httpResp, ok := httpgrpc.HTTPResponseFromError(err)
 	if !ok {
 		level.Error(logger).Log("msg", "failed to process the request to the alertmanager", "err", err)
 		http.Error(w, "Failed to process the request to the alertmanager", http.StatusInternalServerError)


### PR DESCRIPTION
#### What this PR does

In Mimir we had very few places where we used `errors.Cause()`, which I've removed in https://github.com/grafana/mimir/pull/7212, https://github.com/grafana/mimir/pull/7213 and https://github.com/grafana/mimir/pull/7214.

In this PR I'm proposing to add a failling rule to ensure we don't use `errors.Cause()` anywhere in our codebase. I'm also addressing a last `errors.Cause()` which I've forgot earlier.

Why? `errors.Cause()` only work on errors wrapped by `github.com/pkg/errors`, while it doesn't work on errors wrapped by golang standard errors package. In Mimir we currently use `github.com/pkg/errors` but other vendors we depend on (e.g. Prometheus) just uses the standard `errors` package. I prefer to not question whether the `errors.Cause()` usage is safe or not: it's just easier to forbid it everywhere.

> other vendors we depend on (e.g. Prometheus)

This wasn't the case until recently. https://github.com/grafana/mimir/pull/7057 updated the vendored Prometheus where the `github.com/pkg/errors` usage was removed. In https://github.com/grafana/mimir/pull/7057 I proposed a follow up work to completely remove `errors.Cause()`, and this PR is the end of such work.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
