### PR TITLE
ruler: add more details to failures for TestRulerEvaluationDelay

### DIFF
--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -293,6 +293,7 @@ func TestRulerEvaluationDelay(t *testing.T) {
 	require.NoError(t, mimir.WaitSumMetrics(e2e.Greater(ruleEvaluationsAfterPush[0]+float64(samplesToSend)), "cortex_prometheus_rule_evaluations_total"))
 
 	// query all results to verify rules have been evaluated correctly
+	t.Log("querying from ", now.Add(-evaluationDelay), "to", now)
 	result, err = c.QueryRange("stale_nan_eval", now.Add(-evaluationDelay), now, time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, result.Type())
@@ -310,7 +311,13 @@ func TestRulerEvaluationDelay(t *testing.T) {
 			}
 
 			expectedValue := model.SampleValue(2 * (inputPos + 1))
-			require.Equal(t, expectedValue, v.Value)
+			assert.Equal(t, expectedValue, v.Value)
+			t.Log(
+				"expected value", expectedValue,
+				"actual value", v.Value,
+				"actual timestamp", v.Timestamp,
+				"expected timestamp", now.Add(-evaluationDelay).Add(time.Duration(inputPos)*time.Second),
+			)
 
 			// Look for next value
 			inputPos++
@@ -321,7 +328,7 @@ func TestRulerEvaluationDelay(t *testing.T) {
 			}
 		}
 	}
-	require.Equal(t, len(series.Samples), inputPos, "expect to have returned all evaluations")
+	assert.Equal(t, len(series.Samples), inputPos, "expect to have returned all evaluations")
 }
 
 func TestRulerSharding(t *testing.T) {


### PR DESCRIPTION
Related to https://github.com/grafana/mimir/issues/4857

This test is flaky and it's always flaky with the same failure - the first sample's value is 4 instead of 2 here: 
https://github.com/grafana/mimir/blob/9313dfc583103f202644ab10a5966efe332be5bb/integration/ruler_test.go#L314

My hypothesis is that when `now.Add(-evaluationDelay)` is done the time range `[now.Add(-evaluationDelay), now]` may becomes so very slightly smaller than `evaluationDelay` (`5m`) when taken with the `1s` step. This results in sending a query which doesn't quite include the `5m` of samples, but `4.99999(9)m` of samples, which excludes the first sample with value `2` and returns `4` instead.

I couldn't get the test to fail locally, so I'm changing the assertion type to not abort the test on the first mismatch so that we can investigate the all returned samples. Also some debug logs to verify this hypothesis with the step alignment.
