### PR TITLE
Alertmanager: Support UTF-8 characters in matchers and labels small followup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Grafana Mimir
 
-* [FEATURE] Alertmanager: Added `-alertmanager.utf8-strict-mode` to control support for any UTF-8 character as part of Alertmanager configuration/API matchers and labels. It's default value is set to `false`. #6898
 * [CHANGE] Alertmanager: Deprecates the `v1` API. All `v1` API endpoints now respond with a JSON deprecation notice and a status code of `410`. All endpoints have a `v2` equivalent. The list of endpoints is: #7103
   * `<alertmanager-web.external-url>/api/v1/alerts`
   * `<alertmanager-web.external-url>/api/v1/receivers`
@@ -41,7 +40,8 @@
 * [FEATURE] Introduce `-tenant-federation.max-tenants` option to limit the max number of tenants allowed for requests when federation is enabled. #6959
 * [FEATURE] Cardinality API: added a new `count_method` parameter which enables counting active label values. #7085
 * [FEATURE] Querier / query-frontend: added `-querier.promql-experimental-functions-enabled` CLI flag (and respective YAML config option) to enable experimental PromQL functions. The experimental functions introduced are: `mad_over_time()`, `sort_by_label()` and `sort_by_label_desc()`. #7057
-* [FEATURE] Alertmanager API: added `-alertmanager.grafana-alertmanager-compatibility-enabledd` CLI flag (and respective YAML config option) to enable an experimental API endpoints that support the migration of the Grafana Alertmanager. #7057
+* [FEATURE] Alertmanager API: added `-alertmanager.grafana-alertmanager-compatibility-enabled` CLI flag (and respective YAML config option) to enable an experimental API endpoints that support the migration of the Grafana Alertmanager. #7057
+* [FEATURE] Alertmanager: Added `-alertmanager.utf8-strict-mode-enabled` to control support for any UTF-8 character as part of Alertmanager configuration/API matchers and labels. It's default value is set to `false`. #6898
 * [ENHANCEMENT] Store-gateway: add no-compact details column on store-gateway tenants admin UI. #6848
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766
 * [ENHANCEMENT] Distributor: improve efficiency of some errors #6785

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -13623,10 +13623,10 @@
           "kind": "field",
           "name": "utf8_strict_mode",
           "required": false,
-          "desc": "Enable UTF-8 strict mode. Allows UTF-8 in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree and alertmanager_matchers_incompatible metrics before using this mode as otherwise some tenant configurations might fail to load.",
+          "desc": "Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree and alertmanager_matchers_incompatible metrics before using this mode as otherwise some tenant configurations might fail to load.",
           "fieldValue": null,
           "fieldDefaultValue": false,
-          "fieldFlag": "alertmanager.utf8-strict-mode",
+          "fieldFlag": "alertmanager.utf8-strict-mode-enabled",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
         }

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -273,8 +273,8 @@ Usage of ./cmd/mimir/mimir:
     	Directory to store Alertmanager state and temporarily configuration files. The content of this directory is not required to be persisted between restarts unless Alertmanager replication has been disabled. (default "./data-alertmanager/")
   -alertmanager.storage.retention duration
     	How long should we store stateful data (notification logs and silences). For notification log entries, refers to how long should we keep entries before they expire and are deleted. For silences, refers to how long should tenants view silences after they expire and are deleted. (default 120h0m0s)
-  -alertmanager.utf8-strict-mode
-    	[experimental] Enable UTF-8 strict mode. Allows UTF-8 in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree and alertmanager_matchers_incompatible metrics before using this mode as otherwise some tenant configurations might fail to load.
+  -alertmanager.utf8-strict-mode-enabled
+    	[experimental] Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree and alertmanager_matchers_incompatible metrics before using this mode as otherwise some tenant configurations might fail to load.
   -alertmanager.web.external-url string
     	The URL under which Alertmanager is externally reachable (eg. could be different than -http.alertmanager-http-prefix in case Alertmanager is served via a reverse proxy). This setting is used both to configure the internal requests router and to generate links in alert templates. If the external URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager, both the UI and API. (default http://localhost:8080/alertmanager)
   -api.skip-label-name-validation-header-enabled

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -49,6 +49,8 @@ The following features are currently experimental:
 - Alertmanager
   - Enable a set of experimental API endpoints to help support the migration of the Grafana Alertmanager to the Mimir Alertmanager.
     - `-alertmanager.grafana-alertmanager-compatibility-enabled`
+  - Enable support for any UTF-8 character as part of Alertmanager configuration/API matchers and labels.
+    - `-alertmanager.utf8-strict-mode-enabled`
 - Compactor
   - Enable cleanup of remaining files in the tenant bucket when there are no blocks remaining in the bucket index.
     - `-compactor.no-blocks-file-cleanup-enabled`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2252,12 +2252,12 @@ alertmanager_client:
 # CLI flag: -alertmanager.enable-state-cleanup
 [enable_state_cleanup: <boolean> | default = true]
 
-# (experimental) Enable UTF-8 strict mode. Allows UTF-8 in the matchers for
-# routes and inhibition rules, in silences, and in the labels for alerts. It is
-# recommended to check both alertmanager_matchers_disagree and
+# (experimental) Enable UTF-8 strict mode. Allows UTF-8 characters in the
+# matchers for routes and inhibition rules, in silences, and in the labels for
+# alerts. It is recommended to check both alertmanager_matchers_disagree and
 # alertmanager_matchers_incompatible metrics before using this mode as otherwise
 # some tenant configurations might fail to load.
-# CLI flag: -alertmanager.utf8-strict-mode
+# CLI flag: -alertmanager.utf8-strict-mode-enabled
 [utf8_strict_mode: <boolean> | default = false]
 ```
 

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -128,7 +128,7 @@ func TestAlertmanager(t *testing.T) {
 
 // This test asserts that in classic mode it is not possible to upload configurations,
 // create silences, or post alerts that contain UTF-8 on the left hand side of label
-// matchers or label names. It can be deleted when the -alertmanager.utf8-strict-mode
+// matchers or label names. It can be deleted when the -alertmanager.utf8-strict-mode-enabled
 // flag is removed.
 func TestAlertmanagerClassicMode(t *testing.T) {
 	s, err := e2e.NewScenario(networkName)
@@ -147,7 +147,7 @@ func TestAlertmanagerClassicMode(t *testing.T) {
 			AlertmanagerFlags(),
 			AlertmanagerS3Flags(),
 			AlertmanagerShardingFlags(consul.NetworkHTTPEndpoint(), 1),
-			map[string]string{"-alertmanager.utf8-strict-mode": "false"},
+			map[string]string{"-alertmanager.utf8-strict-mode-enabled": "false"},
 		),
 	)
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
@@ -207,7 +207,7 @@ func TestAlertmanagerClassicMode(t *testing.T) {
 // This test asserts that in UTF-8 strict mode it is possible to upload configurations,
 // create silences, and post alerts that contain UTF-8 on the left hand side of label
 // matchers and label names. It is the opposite of TestAlertmanagerClassicMode. It should
-// be merged with the TestAlertmanager test when the -alertmanager.utf8-strict-mode flag
+// be merged with the TestAlertmanager test when the -alertmanager.utf8-strict-mode-enabled flag
 // is removed.
 func TestAlertmanagerUTF8StrictMode(t *testing.T) {
 	s, err := e2e.NewScenario(networkName)
@@ -226,7 +226,7 @@ func TestAlertmanagerUTF8StrictMode(t *testing.T) {
 			AlertmanagerFlags(),
 			AlertmanagerS3Flags(),
 			AlertmanagerShardingFlags(consul.NetworkHTTPEndpoint(), 1),
-			map[string]string{"-alertmanager.utf8-strict-mode": "true"},
+			map[string]string{"-alertmanager.utf8-strict-mode-enabled": "true"},
 		),
 	)
 	require.NoError(t, s.StartAndWaitReady(alertmanager))
@@ -285,7 +285,7 @@ func TestAlertmanagerUTF8StrictMode(t *testing.T) {
 
 // This test asserts that the correct metrics are incremented when configurations are uploaded,
 // including configurations with disagreement, incompatible and invalid matchers. It can be deleted
-// when the -alertmanager.utf8-strict-mode flag is removed.
+// when the -alertmanager.utf8-strict-mode-enabled flag is removed.
 func TestAlertmanagerMatchersMetrics(t *testing.T) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -127,7 +127,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet, logger 
 
 	f.DurationVar(&cfg.PeerTimeout, "alertmanager.peer-timeout", defaultPeerTimeout, "Time to wait between peers to send notifications.")
 
-	f.BoolVar(&cfg.UTF8StrictMode, "alertmanager.utf8-strict-mode", false, "Enable UTF-8 strict mode. Allows UTF-8 in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree and alertmanager_matchers_incompatible metrics before using this mode as otherwise some tenant configurations might fail to load.")
+	f.BoolVar(&cfg.UTF8StrictMode, "alertmanager.utf8-strict-mode-enabled", false, "Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree and alertmanager_matchers_incompatible metrics before using this mode as otherwise some tenant configurations might fail to load.")
 }
 
 // Validate config and returns error on failure


### PR DESCRIPTION
Some very simplistic follow-up from #6898

- Move the changelog entry to the right place
- Add documentation about experimental features on `about-versioning`
- New boolean flags tend to be suffixed with the word "enabled" if it makes sense
- Minor fix to the flag documentation to aling with the changelog
- I fixed my own typo from #6682 in the changelog