### PR TITLE
Do not use grpc/status.FromError() and gogo/status.FromError()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,10 @@ lint: check-makefiles
 	# Ensure all errors are report as APIError
 	faillint -paths "github.com/weaveworks/common/httpgrpc.{Errorf}=github.com/grafana/mimir/pkg/api/error.Newf" ./pkg/frontend/querymiddleware/...
 
+	# Do not use grpc/status.FromError() because doesn't support wrapped errors.
+	# Use grpcutil.ErrorToStatus() instead.
+	faillint -paths "google.golang.org/grpc/status.{FromError}=github.com/grafana/dskit/grpcutil.ErrorToStatus" ./pkg/... ./cmd/... ./tools/... ./integration/...
+
 	# Ensure the query path is supporting multiple tenants
 	faillint -paths "\
 		github.com/grafana/mimir/pkg/tenant.{TenantID}=github.com/grafana/mimir/pkg/tenant.{TenantIDs}" \

--- a/Makefile
+++ b/Makefile
@@ -306,9 +306,17 @@ lint: check-makefiles
 	# Ensure all errors are report as APIError
 	faillint -paths "github.com/weaveworks/common/httpgrpc.{Errorf}=github.com/grafana/mimir/pkg/api/error.Newf" ./pkg/frontend/querymiddleware/...
 
-	# Do not use grpc/status.FromError() because doesn't support wrapped errors.
-	# Use grpcutil.ErrorToStatus() instead.
-	faillint -paths "google.golang.org/grpc/status.{FromError}=github.com/grafana/dskit/grpcutil.ErrorToStatus" ./pkg/... ./cmd/... ./tools/... ./integration/...
+	# gogo/status allows to easily customize error details while grpc/status doesn't:
+	# for this reason we use gogo/status in several places. However, gogo/status.FromError()
+	# doesn't support wrapped errors, while grpc/status.FromError() does.
+	#
+	# Since we want support for errors wrapping everywhere, to avoid subtle bugs depending
+	# on which status package is imported, we don't allow .FromError() from both packages
+	# and we require to use grpcutil.ErrorToStatus() instead.
+	faillint -paths "\
+		google.golang.org/grpc/status.{FromError}=github.com/grafana/dskit/grpcutil.ErrorToStatus,\
+		github.com/gogo/status.{FromError}=github.com/grafana/dskit/grpcutil.ErrorToStatus" \
+		./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Ensure the query path is supporting multiple tenants
 	faillint -paths "\

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1398,7 +1398,7 @@ func TestDistributor_Push_LabelNameValidation(t *testing.T) {
 			req.SkipLabelNameValidation = tc.skipLabelNameValidationReq
 			_, err := ds[0].Push(ctx, req)
 			if tc.errExpected {
-				fromError, _ := status.FromError(err)
+				fromError, _ := grpcutil.ErrorToStatus(err)
 				assert.Equal(t, tc.errMessage, fromError.Message())
 			} else {
 				assert.Nil(t, err)
@@ -1468,7 +1468,7 @@ func TestDistributor_Push_ExemplarValidation(t *testing.T) {
 			})
 			_, err := ds[0].Push(ctx, tc.req)
 			if tc.errMsg != "" {
-				fromError, _ := status.FromError(err)
+				fromError, _ := grpcutil.ErrorToStatus(err)
 				assert.Contains(t, fromError.Message(), tc.errMsg)
 				assert.Contains(t, fromError.Message(), tc.errID)
 			} else {
@@ -5538,7 +5538,7 @@ func searchToken(tokens []uint32, key uint32) int {
 }
 
 func checkGRPCError(t *testing.T, expectedStatus *status.Status, expectedDetails *mimirpb.ErrorDetails, err error) {
-	stat, ok := status.FromError(err)
+	stat, ok := grpcutil.ErrorToStatus(err)
 	require.True(t, ok)
 	require.Equal(t, expectedStatus.Code(), stat.Code())
 	require.Equal(t, expectedStatus.Message(), stat.Message())
@@ -5748,7 +5748,7 @@ func TestStartFinishRequest(t *testing.T) {
 					// Verify that errors returned by StartPushRequest method are NOT gRPC status errors.
 					// They will be converted to gRPC status by grpcInflightMethodLimiter.
 					require.Error(t, err)
-					_, ok := status.FromError(err)
+					_, ok := grpcutil.ErrorToStatus(err)
 					require.False(t, ok)
 				}
 			}

--- a/pkg/distributor/errors_test.go
+++ b/pkg/distributor/errors_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gogo/status"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
 	"github.com/pkg/errors"
@@ -333,7 +334,7 @@ func TestToGRPCError(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := toGRPCError(tc.err, tc.serviceOverloadErrorEnabled)
 
-			stat, ok := status.FromError(err)
+			stat, ok := grpcutil.ErrorToStatus(err)
 			require.True(t, ok)
 			require.Equal(t, tc.expectedGRPCCode, stat.Code())
 			require.Equal(t, tc.expectedErrorMsg, stat.Message())

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/status"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/munnerz/goautoneg"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -692,7 +692,7 @@ func encodeDurationMs(d int64) string {
 
 func decorateWithParamName(err error, field string) error {
 	errTmpl := "invalid parameter %q: %v"
-	if status, ok := status.FromError(err); ok {
+	if status, ok := grpcutil.ErrorToStatus(err); ok {
 		return apierror.Newf(apierror.TypeBadData, errTmpl, field, status.Message())
 	}
 	return apierror.Newf(apierror.TypeBadData, errTmpl, field, err)

--- a/pkg/ingester/client/circuitbreaker_test.go
+++ b/pkg/ingester/client/circuitbreaker_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/failsafe-go/failsafe-go/circuitbreaker"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/ring"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -78,7 +79,7 @@ func TestNewCircuitBreaker(t *testing.T) {
 
 	// Failed request that should put the circuit breaker into "open"
 	err = breaker(context.Background(), "/cortex.Ingester/Push", "", "", &conn, failure)
-	s, ok := status.FromError(err)
+	s, ok := grpcutil.ErrorToStatus(err)
 	require.True(t, ok, "expected to get gRPC status from error")
 	require.Equal(t, codes.Unavailable, s.Code())
 

--- a/pkg/ingester/client/mimir_util_test.go
+++ b/pkg/ingester/client/mimir_util_test.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -79,7 +78,7 @@ func TestSendQueryStream(t *testing.T) {
 	// Try to receive the response and assert the error we get is the context.Canceled
 	// wrapped within a gRPC error.
 	_, err = stream.Recv()
-	s, ok := status.FromError(err)
+	s, ok := grpcutil.ErrorToStatus(err)
 	require.True(t, ok)
 	require.Equal(t, codes.Canceled, s.Code())
 

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gogo/status"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
@@ -80,7 +81,7 @@ func newErrorWithStatus(originalErr error, code codes.Code) errorWithStatus {
 // and containing the given HTTP status code.
 func newErrorWithHTTPStatus(err error, code int) errorWithStatus {
 	errWithHTTPStatus := httpgrpc.Errorf(code, err.Error())
-	stat, _ := status.FromError(errWithHTTPStatus)
+	stat, _ := grpcutil.ErrorToStatus(errWithHTTPStatus)
 	return errorWithStatus{
 		err:    err,
 		status: stat,

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -285,6 +285,7 @@ func TestErrorWithStatus(t *testing.T) {
 			require.Errorf(t, errWithStatus, data.expectedErrorMessage)
 
 			// Ensure gogo's status.FromError recognizes errWithStatus.
+			//lint:ignore faillint We want to explicitly assert on status.FromError()
 			stat, ok := status.FromError(errWithStatus)
 			require.True(t, ok)
 			require.Equal(t, codes.Unimplemented, stat.Code())
@@ -326,6 +327,7 @@ func TestErrorWithHTTPStatus(t *testing.T) {
 	require.Error(t, errWithHTTPStatus)
 
 	// Ensure gogo's status.FromError recognizes errWithHTTPStatus.
+	//lint:ignore faillint We want to explicitly assert on status.FromError()
 	stat, ok := status.FromError(errWithHTTPStatus)
 	require.True(t, ok)
 	require.Equal(t, http.StatusBadRequest, int(stat.Code()))
@@ -526,7 +528,7 @@ func TestMapPushErrorToErrorWithStatus(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			handledErr := mapPushErrorToErrorWithStatus(tc.err)
-			stat, ok := status.FromError(handledErr)
+			stat, ok := grpcutil.ErrorToStatus(handledErr)
 			require.True(t, ok)
 			require.Equal(t, tc.expectedCode, stat.Code())
 			require.Equal(t, tc.expectedMessage, stat.Message())
@@ -745,7 +747,7 @@ func TestMapReadErrorToErrorWithStatus(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			handledErr := mapReadErrorToErrorWithStatus(tc.err)
-			stat, ok := status.FromError(handledErr)
+			stat, ok := grpcutil.ErrorToStatus(handledErr)
 			require.True(t, ok)
 			require.Equal(t, tc.expectedCode, stat.Code())
 			require.Equal(t, tc.expectedMessage, stat.Message())

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gogo/status"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
@@ -290,7 +291,15 @@ func TestErrorWithStatus(t *testing.T) {
 			require.Equal(t, stat.Message(), data.expectedErrorMessage)
 			checkErrorWithStatusDetails(t, stat.Details(), data.expectedErrorDetails)
 
+			// Ensure dskit's grpcutil.ErrorToStatus recognizes errWithHTTPStatus.
+			stat, ok = grpcutil.ErrorToStatus(errWithStatus)
+			require.True(t, ok)
+			require.Equal(t, codes.Unimplemented, stat.Code())
+			require.Equal(t, stat.Message(), data.expectedErrorMessage)
+			checkErrorWithStatusDetails(t, stat.Details(), data.expectedErrorDetails)
+
 			// Ensure grpc's status.FromError recognizes errWithStatus.
+			//lint:ignore faillint We want to explicitly assert on status.FromError()
 			st, ok := grpcstatus.FromError(errWithStatus)
 			require.True(t, ok)
 			require.Equal(t, codes.Unimplemented, st.Code())
@@ -315,6 +324,7 @@ func TestErrorWithHTTPStatus(t *testing.T) {
 	err := newSampleTimestampTooOldError(timestamp, metricLabelAdapters)
 	errWithHTTPStatus := newErrorWithHTTPStatus(err, http.StatusBadRequest)
 	require.Error(t, errWithHTTPStatus)
+
 	// Ensure gogo's status.FromError recognizes errWithHTTPStatus.
 	stat, ok := status.FromError(errWithHTTPStatus)
 	require.True(t, ok)
@@ -322,7 +332,14 @@ func TestErrorWithHTTPStatus(t *testing.T) {
 	require.Errorf(t, err, stat.Message())
 	require.NotEmpty(t, stat.Details())
 
+	// Ensure dskit's grpcutil.ErrorToStatus recognizes errWithHTTPStatus.
+	stat, ok = grpcutil.ErrorToStatus(errWithHTTPStatus)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, int(stat.Code()))
+	require.Errorf(t, err, stat.Message())
+
 	// Ensure grpc's status.FromError recognizes errWithHTTPStatus.
+	//lint:ignore faillint We want to explicitly assert on status.FromError()
 	st, ok := grpcstatus.FromError(errWithHTTPStatus)
 	require.True(t, ok)
 	require.Equal(t, http.StatusBadRequest, int(st.Code()))

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/failsafe-go/failsafe-go/circuitbreaker"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/gogo/status"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/kv"
 	dslog "github.com/grafana/dskit/log"
 	dskit_metrics "github.com/grafana/dskit/metrics"
@@ -2526,7 +2526,7 @@ func Test_Ingester_LabelNames(t *testing.T) {
 		i.utilizationBasedLimiter = &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
 
 		_, err := i.LabelNames(ctx, &client.LabelNamesRequest{})
-		stat, ok := status.FromError(err)
+		stat, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Equal(t, codes.ResourceExhausted, stat.Code())
 		require.Equal(t, tooBusyErrorMsg, stat.Message())
@@ -2590,7 +2590,7 @@ func Test_Ingester_LabelValues(t *testing.T) {
 		i.utilizationBasedLimiter = &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
 
 		_, err := i.LabelValues(ctx, &client.LabelValuesRequest{})
-		stat, ok := status.FromError(err)
+		stat, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Equal(t, codes.ResourceExhausted, stat.Code())
 		require.Equal(t, tooBusyErrorMsg, stat.Message())
@@ -2791,7 +2791,7 @@ func TestIngester_LabelNamesAndValues(t *testing.T) {
 		i.utilizationBasedLimiter = &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
 
 		err := i.LabelNamesAndValues(&client.LabelNamesAndValuesRequest{}, nil)
-		stat, ok := status.FromError(err)
+		stat, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Equal(t, codes.ResourceExhausted, stat.Code())
 		require.Equal(t, tooBusyErrorMsg, stat.Message())
@@ -2911,7 +2911,7 @@ func TestIngester_LabelValuesCardinality(t *testing.T) {
 		i.utilizationBasedLimiter = &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
 
 		err := i.LabelValuesCardinality(&client.LabelValuesCardinalityRequest{}, nil)
-		stat, ok := status.FromError(err)
+		stat, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Equal(t, codes.ResourceExhausted, stat.Code())
 		require.Equal(t, tooBusyErrorMsg, stat.Message())
@@ -3443,7 +3443,7 @@ func Test_Ingester_MetricsForLabelMatchers(t *testing.T) {
 		i.utilizationBasedLimiter = &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
 
 		_, err := i.MetricsForLabelMatchers(ctx, &client.MetricsForLabelMatchersRequest{})
-		stat, ok := status.FromError(err)
+		stat, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Equal(t, codes.ResourceExhausted, stat.Code())
 		require.Equal(t, tooBusyErrorMsg, stat.Message())
@@ -3841,7 +3841,7 @@ func TestIngester_QueryStream(t *testing.T) {
 		i.utilizationBasedLimiter = &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
 
 		err = i.QueryStream(&client.QueryRequest{}, nil)
-		stat, ok := status.FromError(err)
+		stat, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Equal(t, codes.ResourceExhausted, stat.Code())
 		require.Equal(t, tooBusyErrorMsg, stat.Message())
@@ -4300,7 +4300,7 @@ func TestIngester_QueryExemplars(t *testing.T) {
 		i.utilizationBasedLimiter = &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
 
 		_, err := i.QueryExemplars(ctx, &client.ExemplarQueryRequest{})
-		stat, ok := status.FromError(err)
+		stat, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Equal(t, codes.ResourceExhausted, stat.Code())
 		require.Equal(t, tooBusyErrorMsg, stat.Message())
@@ -5615,7 +5615,7 @@ func Test_Ingester_UserStats(t *testing.T) {
 		i.utilizationBasedLimiter = &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
 
 		_, err := i.UserStats(ctx, &client.UserStatsRequest{})
-		stat, ok := status.FromError(err)
+		stat, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Equal(t, codes.ResourceExhausted, stat.Code())
 		require.Equal(t, tooBusyErrorMsg, stat.Message())
@@ -6504,7 +6504,7 @@ func TestIngester_PushInstanceLimits(t *testing.T) {
 							assert.ErrorIs(t, err, testData.expectedErr)
 							var optional middleware.OptionalLogging
 							assert.ErrorAs(t, err, &optional)
-							s, ok := status.FromError(err)
+							s, ok := grpcutil.ErrorToStatus(err)
 							require.True(t, ok, "expected to be able to convert to gRPC status")
 							assert.Equal(t, codes.Unavailable, s.Code())
 						} else {
@@ -6690,7 +6690,7 @@ func TestIngester_PushInstanceLimitsWithCircuitBreaker(t *testing.T) {
 						_, err := client.Push(ctx, req)
 						require.Error(t, err)
 						require.NotErrorIs(t, err, circuitbreaker.ErrCircuitBreakerOpen)
-						s, ok := status.FromError(err)
+						s, ok := grpcutil.ErrorToStatus(err)
 						require.True(t, ok, "expected to be able to convert to gRPC status")
 						require.Equal(t, codes.Unavailable, s.Code())
 						require.ErrorContains(t, s.Err(), testData.expectedErr.Error())
@@ -6824,7 +6824,7 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 		require.ErrorAs(t, err, &optional)
 		require.False(t, optional.ShouldLog(ctx, time.Duration(0)), "expected not to log via .ShouldLog()")
 
-		s, ok := status.FromError(err)
+		s, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok, "expected to be able to convert to gRPC status")
 		require.Equal(t, codes.Unavailable, s.Code())
 
@@ -6931,7 +6931,7 @@ func TestIngester_inflightPushRequestsBytes(t *testing.T) {
 		require.ErrorAs(t, err, &optional)
 		require.False(t, optional.ShouldLog(ctx, time.Duration(0)), "expected not to log via .ShouldLog()")
 
-		s, ok := status.FromError(err)
+		s, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok, "expected to be able to convert to gRPC status")
 		require.Equal(t, codes.Unavailable, s.Code())
 
@@ -9436,13 +9436,13 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					for i := 0; i < errorSampleRate-1; i++ {
 						_, err = client.Push(ctxs[0], req)
 						require.Error(t, err)
-						status, ok := status.FromError(err)
+						status, ok := grpcutil.ErrorToStatus(err)
 						require.True(t, ok)
 						require.ErrorContains(t, status.Err(), testData.expectedErrs[0].err.Error())
 					}
 					_, err = client.Push(ctxs[1], req)
 					require.Error(t, err)
-					status, ok := status.FromError(err)
+					status, ok := grpcutil.ErrorToStatus(err)
 					require.True(t, ok)
 					require.ErrorContains(t, status.Err(), testData.expectedErrs[1].err.Error())
 				}
@@ -9549,7 +9549,7 @@ func TestIngester_SampledUserLimitExceeded(t *testing.T) {
 		// Append 2 series first, expect max-series-per-user error.
 		_, err = client.Push(ctx, mimirpb.ToWriteRequest([][]mimirpb.LabelAdapter{metricLabelAdapters1, metricLabelAdapters2}, []mimirpb.Sample{sample2, sample3}, nil, nil, mimirpb.API))
 		require.Error(t, err)
-		status, ok := status.FromError(err)
+		status, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Errorf(t, expectedError, status.Message())
 	}
@@ -9653,7 +9653,7 @@ func TestIngester_SampledMetricLimitExceeded(t *testing.T) {
 		// Append 2 series first, expect max-series-per-user error.
 		_, err = client.Push(ctx, mimirpb.ToWriteRequest([][]mimirpb.LabelAdapter{metricLabelAdapters1, metricLabelAdapters2}, []mimirpb.Sample{sample2, sample3}, nil, nil, mimirpb.API))
 		require.Error(t, err)
-		status, ok := status.FromError(err)
+		status, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Errorf(t, expectedError, status.Message())
 	}

--- a/pkg/mimir/grpc_push_check_test.go
+++ b/pkg/mimir/grpc_push_check_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/api"
 )
@@ -63,7 +62,7 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 		m.returnError = errors.New("hello there")
 		ctx, err := l.RPCCallStarting(context.Background(), ingesterPushMethod, nil)
 		require.Error(t, err)
-		_, ok := status.FromError(err)
+		_, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Nil(t, ctx.Value(pushTypeCtxKey)) // Original context expected in case of errors.
 	})
@@ -170,7 +169,7 @@ func TestGrpcInflightMethodLimiter(t *testing.T) {
 			grpcutil.MetadataMessageSize: "123456",
 		}))
 		require.Error(t, err)
-		_, ok := status.FromError(err)
+		_, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
 		require.Nil(t, ctx.Value(pushTypeCtxKey)) // Original context expected in case of errors.
 	})

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/gogo/status"
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/grpcclient"
@@ -127,7 +126,7 @@ func (sp *schedulerProcessor) processQueriesOnSingleStream(workerCtx context.Con
 		if err := sp.querierLoop(execCtx, c, address, inflightQuery); err != nil {
 			if !isErrCancel(err, log.With(sp.log, "addr", address)) {
 				// Do not log an error if the query-scheduler is shutting down.
-				if s, ok := status.FromError(err); !ok || !strings.Contains(s.Message(), schedulerpb.ErrSchedulerIsNotRunning.Error()) {
+				if s, ok := grpcutil.ErrorToStatus(err); !ok || !strings.Contains(s.Message(), schedulerpb.ErrSchedulerIsNotRunning.Error()) {
 					level.Error(sp.log).Log("msg", "error processing requests from scheduler", "err", err, "addr", address)
 				}
 				backoff.Wait()

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/gogo/status"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
@@ -180,7 +180,7 @@ func MetricsQueryFunc(qf rules.QueryFunc, queries, failedQueries prometheus.Coun
 			return result, origErr
 		} else if err != nil {
 			// When remote querier enabled, consider anything an error except those with 4xx status code.
-			st, ok := status.FromError(err)
+			st, ok := grpcutil.ErrorToStatus(err)
 			if !(ok && st.Code()/100 == 4) {
 				failedQueries.Inc()
 			}

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/gogo/status"
+	"github.com/grafana/dskit/grpcutil"
 	dskit_metrics "github.com/grafana/dskit/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -664,7 +664,7 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 					} else {
 						assert.Error(t, err)
 						assert.Contains(t, err.Error(), testData.expectedErr)
-						status, ok := status.FromError(err)
+						status, ok := grpcutil.ErrorToStatus(err)
 						assert.Equal(t, true, ok)
 						assert.Equal(t, testData.expectedCode, status.Code())
 					}

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/grafana/dskit/gate"
+	"github.com/grafana/dskit/grpcutil"
 	dskit_metrics "github.com/grafana/dskit/metrics"
 	"github.com/grafana/regexp"
 	"github.com/oklog/ulid"
@@ -50,7 +51,6 @@ import (
 	"github.com/thanos-io/objstore/providers/filesystem"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/bucket"
@@ -2033,14 +2033,14 @@ func TestBucketStore_Series_CanceledRequest(t *testing.T) {
 	srv := newStoreGatewayTestServer(t, store)
 	_, _, _, _, err = srv.Series(ctx, req)
 	assert.Error(t, err)
-	s, ok := status.FromError(err)
+	s, ok := grpcutil.ErrorToStatus(err)
 	assert.True(t, ok)
 	assert.Equal(t, codes.Canceled, s.Code())
 
 	req.StreamingChunksBatchSize = 10
 	_, _, _, _, err = srv.Series(ctx, req)
 	assert.Error(t, err)
-	s, ok = status.FromError(err)
+	s, ok = grpcutil.ErrorToStatus(err)
 	assert.True(t, ok)
 	assert.Equal(t, codes.Canceled, s.Code())
 }
@@ -2096,7 +2096,7 @@ func TestBucketStore_Series_InvalidRequest(t *testing.T) {
 	srv := newStoreGatewayTestServer(t, store)
 	_, _, _, _, err = srv.Series(context.Background(), req)
 	assert.Error(t, err)
-	s, ok := status.FromError(err)
+	s, ok := grpcutil.ErrorToStatus(err)
 	assert.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, s.Code())
 	assert.ErrorContains(t, s.Err(), "error parsing regexp: missing closing )")
@@ -2747,7 +2747,7 @@ func TestLabelNames_Cancelled(t *testing.T) {
 
 	_, err := store.LabelNames(ctx, req)
 	assert.Error(t, err)
-	s, ok := status.FromError(err)
+	s, ok := grpcutil.ErrorToStatus(err)
 	assert.True(t, ok)
 	assert.Equal(t, codes.Canceled, s.Code())
 }
@@ -2774,7 +2774,7 @@ func TestLabelValues_Cancelled(t *testing.T) {
 
 	_, err := store.LabelValues(ctx, req)
 	assert.Error(t, err)
-	s, ok := status.FromError(err)
+	s, ok := grpcutil.ErrorToStatus(err)
 	assert.True(t, ok)
 	assert.Equal(t, codes.Canceled, s.Code())
 }

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/kv/consul"
 	dskit_metrics "github.com/grafana/dskit/metrics"
 	"github.com/grafana/dskit/ring"
@@ -1480,9 +1481,9 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testi
 					if testData.expectedErr != nil {
 						require.Error(t, err)
 						assert.IsType(t, testData.expectedErr, err)
-						s1, ok := status.FromError(err)
+						s1, ok := grpcutil.ErrorToStatus(err)
 						assert.True(t, ok)
-						s2, ok := status.FromError(testData.expectedErr)
+						s2, ok := grpcutil.ErrorToStatus(testData.expectedErr)
 						assert.True(t, ok)
 						assert.Contains(t, s1.Message(), s2.Message())
 						assert.Equal(t, s1.Code(), s2.Code())

--- a/pkg/storegateway/limiter_test.go
+++ b/pkg/storegateway/limiter_test.go
@@ -10,11 +10,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -43,7 +43,7 @@ func TestLimiter(t *testing.T) {
 }
 
 func checkErrorStatusCode(t *testing.T, err error) {
-	st, ok := status.FromError(err)
+	st, ok := grpcutil.ErrorToStatus(err)
 	assert.True(t, ok)
 	assert.Equal(t, uint32(http.StatusUnprocessableEntity), uint32(st.Code()))
 }

--- a/pkg/util/grpc_error_test.go
+++ b/pkg/util/grpc_error_test.go
@@ -79,6 +79,11 @@ func TestWrapContextError(t *testing.T) {
 				require.True(t, ok)
 				assert.Equal(t, testData.expectedGrpcCode, gogoStatus.Code())
 
+				gogoStatus, ok = grpcutil.ErrorToStatus(wrapped)
+				require.True(t, ok)
+				assert.Equal(t, testData.expectedGrpcCode, gogoStatus.Code())
+
+				//lint:ignore faillint We want to explicitly assert on status.FromError()
 				grpcStatus, ok := grpcstatus.FromError(wrapped)
 				require.True(t, ok)
 				assert.Equal(t, testData.expectedGrpcCode, grpcStatus.Code())

--- a/pkg/util/grpc_error_test.go
+++ b/pkg/util/grpc_error_test.go
@@ -75,6 +75,7 @@ func TestWrapContextError(t *testing.T) {
 				assert.True(t, errors.Is(wrapped, testData.expectedContextErr))
 				assert.Equal(t, testData.expectedGrpcCode, grpcutil.ErrorToStatusCode(wrapped))
 
+				//lint:ignore faillint We want to explicitly assert on status.FromError()
 				gogoStatus, ok := gogostatus.FromError(wrapped)
 				require.True(t, ok)
 				assert.Equal(t, testData.expectedGrpcCode, gogoStatus.Code())


### PR DESCRIPTION
#### What this PR does

In the review of https://github.com/grafana/mimir/pull/7213 I've learned from @duricanikolic that:

> I have worked on the error handling improvement on the write path, and I ensured that most of the usages of the `status` packages there were from `gogo` instead of `grpc`. 
> What is the difference? 
> On one side, `gogo`'s `status` package allows you to easily add custom error details, which are crucial for the error handling on the write path. On another side, `status.FromError()` **doesn't use** `errors.As()` internally.
> Related to `grpc`'s `status` package, it is not easy to add custom error details, but `status.FromError()` uses `errors.As()` internally.
> In order to minimizes differences between different packages used, I then implemented `[grpcutil.ErrorToStatus()](https://github.com/grafana/dskit/blob/main/grpcutil/status.go#L12-L36)` in `dskit` that, independently from whether the status is created by `gogo` or `grpc` uses `errors.As()`.
> I'd recommend using `grpcutil.ErrorToStatus()` instead of `status.FromError()`.

Since we want support for errors wrapping everywhere, to avoid subtle bugs depending on which status package is imported, I propose to never allow `.FromError()`, replace it with `grpcutil.ErrorToStatus()` and add a `faillint` rule to enforce it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
