### PR TITLE
Update about-grafana-mimir-architecture

### DIFF
--- a/docs/sources/mimir/get-started/about-grafana-mimir-architecture/index.md
+++ b/docs/sources/mimir/get-started/about-grafana-mimir-architecture/index.md
@@ -44,7 +44,7 @@ This gives [queriers]({{< relref "../../references/architecture/components/queri
 To effectively use the WAL, and to be able to recover the in-memory series if an ingester abruptly terminates, store the WAL to a persistent disk that can survive an ingester failure.
 For example, when running in the cloud, include an AWS EBS volume or a GCP persistent disk.
 If you are running the Grafana Mimir cluster in Kubernetes, you can use a StatefulSet with a persistent volume claim for the ingesters.
-The location on the filesystem where the WAL is stored is the same location where local TSDB blocks (compacted from head) are stored. The location of the filesystem and the location of the local TSDB blocks cannot be decoupled.
+The location on the filesystem where the WAL is stored is the same location where local TSDB blocks (compacted from head) are stored. The locations of the WAL and the local TSDB blocks cannot be decoupled.
 
 For more information, refer to [timeline of block uploads]({{< relref "../../manage/run-production-environment/production-tips#how-to-estimate--querierquery-store-after" >}}) and [Ingester]({{< relref "../../references/architecture/components/ingester" >}}).
 


### PR DESCRIPTION
#### What this PR does

While reading through the docs, I've bumped into this phrase, that doesn't look right to me. 

> The location of the filesystem and the location of the local TSDB blocks cannot be decoupled.

I don't understand what "the location of the filesystem" could mean, in the context of the document. I wonder if maybe this is a typo.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
