### PR TITLE
rulestore/local: add support for GetRuleGroup endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766
 * [ENHANCEMENT] Distributor: improve efficiency of some errors #6785
 * [ENHANCEMENT] Ruler: exclude vector queries from being tracked in `cortex_ruler_queries_zero_fetched_series_total`. #6544
+* [ENHANCEMENT] Ruler: local storage backend now supports reading a rule group via `/config/api/v1/rules/{namespace}/{groupName}` configuration API endpoint. #6632
 * [ENHANCEMENT] Query-Frontend and Query-Scheduler: split tenant query request queues by query component with `query-frontend.additional-query-queue-dimensions-enabled` and `query-scheduler.additional-query-queue-dimensions-enabled`. #6772
 * [ENHANCEMENT] Distributor: support disabling metric relabel rules per-tenant via the flag `-distributor.metric-relabeling-enabled` or associated YAML. #6970
 * [ENHANCEMENT] Distributor: `-distributor.remote-timeout` is now accounted from the first ingester push request being sent. #6972

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -62,7 +62,6 @@ import (
 	"github.com/grafana/mimir/pkg/ruler"
 	"github.com/grafana/mimir/pkg/ruler/rulestore"
 	rulebucketclient "github.com/grafana/mimir/pkg/ruler/rulestore/bucketclient"
-	rulestorelocal "github.com/grafana/mimir/pkg/ruler/rulestore/local"
 	"github.com/grafana/mimir/pkg/scheduler"
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/ingest"
@@ -333,7 +332,7 @@ func (c *Config) validateBucketConfigs() error {
 	}
 
 	// Validate ruler bucket config.
-	if c.isAnyModuleEnabled(All, Ruler, Backend) && c.RulerStorage.Backend != rulestorelocal.Name {
+	if c.isAnyModuleEnabled(All, Ruler, Backend) && c.RulerStorage.Backend != rulestore.BackendLocal {
 		errs.Add(errors.Wrap(validateBucketConfig(c.RulerStorage.Config, c.BlocksStorage.Bucket), "ruler storage"))
 	}
 
@@ -441,7 +440,7 @@ func (c *Config) validateFilesystemPaths(logger log.Logger) error {
 				checkValue: filepath.Join(c.RulerStorage.Filesystem.Directory, rulebucketclient.RulesPrefix),
 			})
 		}
-		if c.RulerStorage.Backend == rulestorelocal.Name {
+		if c.RulerStorage.Backend == rulestore.BackendLocal {
 			paths = append(paths, pathConfig{
 				name:       "ruler storage local directory",
 				cfgValue:   c.RulerStorage.Local.Directory,

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -780,7 +780,7 @@ func (t *Mimir) initRulerStorage() (serv services.Service, err error) {
 
 func (t *Mimir) initRuler() (serv services.Service, err error) {
 	if t.RulerDirectStorage == nil {
-		level.Info(util_log.Logger).Log("msg", "The ruler storage has not been configured.  Not starting the ruler.")
+		level.Info(util_log.Logger).Log("msg", "The ruler storage has not been configured. Not starting the ruler.")
 		return nil, nil
 	}
 

--- a/pkg/mimir/sanity_check.go
+++ b/pkg/mimir/sanity_check.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 
 	alertstorelocal "github.com/grafana/mimir/pkg/alertmanager/alertstore/local"
-	rulestorelocal "github.com/grafana/mimir/pkg/ruler/rulestore/local"
+	"github.com/grafana/mimir/pkg/ruler/rulestore"
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/util/fs"
 )
@@ -137,7 +137,7 @@ func checkObjectStoresConfig(ctx context.Context, cfg Config, logger log.Logger)
 	}
 
 	// Check ruler storage config.
-	if cfg.isAnyModuleEnabled(All, Ruler, Backend) && cfg.RulerStorage.Backend != rulestorelocal.Name {
+	if cfg.isAnyModuleEnabled(All, Ruler, Backend) && cfg.RulerStorage.Backend != rulestore.BackendLocal {
 		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.RulerStorage.Config, logger), "ruler storage"))
 	}
 

--- a/pkg/ruler/rulestore/config.go
+++ b/pkg/ruler/rulestore/config.go
@@ -15,8 +15,11 @@ import (
 	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/flagext"
 
-	"github.com/grafana/mimir/pkg/ruler/rulestore/local"
 	"github.com/grafana/mimir/pkg/storage/bucket"
+)
+
+const (
+	BackendLocal = "local"
 )
 
 var supportedCacheBackends = []string{cache.BackendMemcached, cache.BackendRedis}
@@ -24,7 +27,7 @@ var supportedCacheBackends = []string{cache.BackendMemcached, cache.BackendRedis
 // Config configures a rule store.
 type Config struct {
 	bucket.Config `yaml:",inline"`
-	Local         local.Config `yaml:"local"`
+	Local         LocalStoreConfig `yaml:"local"`
 
 	// Cache holds the configuration used for the ruler storage cache.
 	Cache cache.BackendConfig `yaml:"cache"`
@@ -34,11 +37,11 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	prefix := "ruler-storage."
 
-	cfg.StorageBackendConfig.ExtraBackends = []string{local.Name}
+	cfg.StorageBackendConfig.ExtraBackends = []string{BackendLocal}
 	cfg.Local.RegisterFlagsWithPrefix(prefix, f)
 	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "ruler", f)
 
-	f.StringVar(&cfg.Cache.Backend, prefix+"cache.backend", "", fmt.Sprintf("Backend for ruler storage cache, if not empty. The cache is supported for any storage backend except %q. Supported values: %s.", local.Name, strings.Join(supportedCacheBackends, ", ")))
+	f.StringVar(&cfg.Cache.Backend, prefix+"cache.backend", "", fmt.Sprintf("Backend for ruler storage cache, if not empty. The cache is supported for any storage backend except %q. Supported values: %s.", BackendLocal, strings.Join(supportedCacheBackends, ", ")))
 	cfg.Cache.Memcached.RegisterFlagsWithPrefix(prefix+"cache.memcached.", f)
 	cfg.Cache.Redis.RegisterFlagsWithPrefix(prefix+"cache.redis.", f)
 }
@@ -58,6 +61,15 @@ func (cfg *Config) IsDefaults() bool {
 
 	// Note: cmp.Equal will panic if it encounters anything it cannot handle.
 	return cmp.Equal(*cfg, defaults, cmp.FilterPath(filterNonYaml, cmp.Ignore()), cmp.Comparer(equalSecrets))
+}
+
+type LocalStoreConfig struct {
+	Directory string `yaml:"directory"`
+}
+
+// RegisterFlagsWithPrefix registers flags with the input prefix.
+func (cfg *LocalStoreConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.Directory, prefix+"local.directory", "", "Directory to scan for rules")
 }
 
 // Return true if the path contains a struct field with tag `yaml:"-"`.

--- a/pkg/ruler/rulestore/local/local.go
+++ b/pkg/ruler/rulestore/local/local.go
@@ -7,38 +7,26 @@ package local
 
 import (
 	"context"
-	"flag"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/rulefmt"
 	promRules "github.com/prometheus/prometheus/rules"
 
 	"github.com/grafana/mimir/pkg/ruler/rulespb"
+	"github.com/grafana/mimir/pkg/ruler/rulestore"
 )
-
-const (
-	Name = "local"
-)
-
-type Config struct {
-	Directory string `yaml:"directory"`
-}
-
-// RegisterFlagsWithPrefix registers flags with the input prefix.
-func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.StringVar(&cfg.Directory, prefix+"local.directory", "", "Directory to scan for rules")
-}
 
 // Client expects to load already existing rules located at:
 //
 //	cfg.Directory / userID / namespace
 type Client struct {
-	cfg    Config
+	cfg    rulestore.LocalStoreConfig
 	loader promRules.GroupLoader
 }
 
-func NewLocalRulesClient(cfg Config, loader promRules.GroupLoader) (*Client, error) {
+func NewLocalRulesClient(cfg rulestore.LocalStoreConfig, loader promRules.GroupLoader) (*Client, error) {
 	if cfg.Directory == "" {
 		return nil, errors.New("directory required for local rules config")
 	}
@@ -82,11 +70,21 @@ func (l *Client) ListAllUsers(_ context.Context) ([]string, error) {
 
 // ListRuleGroupsForUserAndNamespace implements rules.RuleStore. This method also loads the rules.
 func (l *Client) ListRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string) (rulespb.RuleGroupList, error) {
-	if namespace != "" {
-		return l.loadAllRulesGroupsForUserAndNamespace(ctx, userID, namespace)
+	if namespace == "" {
+		return l.loadAllRulesGroupsForUser(ctx, userID)
 	}
 
-	return l.loadAllRulesGroupsForUser(ctx, userID)
+	rulegroups, err := l.loadRawRulesGroupsForUserAndNamespace(ctx, userID, namespace)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load rule group for user %s and namespace %s", userID, namespace)
+	}
+
+	var list rulespb.RuleGroupList
+	for _, rg := range rulegroups.Groups {
+		desc := rulespb.ToProto(userID, namespace, rg)
+		list = append(list, desc)
+	}
+	return list, nil
 }
 
 func (l *Client) LoadRuleGroups(_ context.Context, _ map[string]rulespb.RuleGroupList) (rulespb.RuleGroupList, error) {
@@ -95,8 +93,22 @@ func (l *Client) LoadRuleGroups(_ context.Context, _ map[string]rulespb.RuleGrou
 }
 
 // GetRuleGroup implements RuleStore
-func (l *Client) GetRuleGroup(_ context.Context, _, _, _ string) (*rulespb.RuleGroupDesc, error) {
-	return nil, errors.New("GetRuleGroup unsupported in rule local store")
+func (l *Client) GetRuleGroup(ctx context.Context, userID string, namespace string, group string) (*rulespb.RuleGroupDesc, error) {
+	if namespace == "" {
+		return nil, errors.New("empty namespace")
+	}
+
+	rulegroups, err := l.loadRawRulesGroupsForUserAndNamespace(ctx, userID, namespace)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load rule group for user %s and namespace %s", userID, namespace)
+	}
+
+	for _, rg := range rulegroups.Groups {
+		if rg.Name == group {
+			return rulespb.ToProto(userID, namespace, rg), nil
+		}
+	}
+	return nil, rulestore.ErrGroupNotFound
 }
 
 // SetRuleGroup implements RuleStore
@@ -115,7 +127,7 @@ func (l *Client) DeleteNamespace(_ context.Context, _, _ string) error {
 }
 
 func (l *Client) loadAllRulesGroupsForUser(ctx context.Context, userID string) (rulespb.RuleGroupList, error) {
-	var allLists rulespb.RuleGroupList
+	var list rulespb.RuleGroupList
 
 	root := filepath.Join(l.cfg.Directory, userID)
 	infos, err := os.ReadDir(root)
@@ -143,31 +155,25 @@ func (l *Client) loadAllRulesGroupsForUser(ctx context.Context, userID string) (
 			continue
 		}
 
-		list, err := l.loadAllRulesGroupsForUserAndNamespace(ctx, userID, namespace)
+		rulegroups, err := l.loadRawRulesGroupsForUserAndNamespace(ctx, userID, namespace)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to list rule group for user %s and namespace %s", userID, namespace)
+			return nil, errors.Wrapf(err, "failed to load rule group for user %s and namespace %s", userID, namespace)
 		}
-
-		allLists = append(allLists, list...)
-	}
-
-	return allLists, nil
-}
-
-func (l *Client) loadAllRulesGroupsForUserAndNamespace(_ context.Context, userID string, namespace string) (rulespb.RuleGroupList, error) {
-	filename := filepath.Join(l.cfg.Directory, userID, namespace)
-
-	rulegroups, allErrors := l.loader.Load(filename)
-	if len(allErrors) > 0 {
-		return nil, errors.Wrapf(allErrors[0], "error parsing %s", filename)
-	}
-
-	var list rulespb.RuleGroupList
-
-	for _, group := range rulegroups.Groups {
-		desc := rulespb.ToProto(userID, namespace, group)
-		list = append(list, desc)
+		for _, rg := range rulegroups.Groups {
+			desc := rulespb.ToProto(userID, namespace, rg)
+			list = append(list, desc)
+		}
 	}
 
 	return list, nil
+}
+
+func (l *Client) loadRawRulesGroupsForUserAndNamespace(_ context.Context, userID string, namespace string) (*rulefmt.RuleGroups, error) {
+	filename := filepath.Join(l.cfg.Directory, userID, namespace)
+
+	rulegroups, errs := l.loader.Load(filename)
+	if len(errs) > 0 {
+		return nil, errors.Wrapf(errs[0], "error parsing %s", filename)
+	}
+	return rulegroups, nil
 }

--- a/pkg/ruler/rulestore/local/local_test.go
+++ b/pkg/ruler/rulestore/local/local_test.go
@@ -19,9 +19,10 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/ruler/rulespb"
+	"github.com/grafana/mimir/pkg/ruler/rulestore"
 )
 
-func TestClient_LoadAllRuleGroups(t *testing.T) {
+func TestClient_LoadRuleGroups(t *testing.T) {
 	user1 := "user"
 	user2 := "second-user"
 
@@ -69,27 +70,45 @@ func TestClient_LoadAllRuleGroups(t *testing.T) {
 	err = os.Symlink(namespace1, path.Join(dir, user1, namespace2))
 	require.NoError(t, err)
 
-	client, err := NewLocalRulesClient(Config{
+	client, err := NewLocalRulesClient(rulestore.LocalStoreConfig{
 		Directory: dir,
 	}, promRules.FileLoader{})
 	require.NoError(t, err)
 
-	ctx := context.Background()
-	userMap := map[string]rulespb.RuleGroupList{}
+	t.Run("all rule groups", func(t *testing.T) {
+		ctx := context.Background()
 
-	for _, u := range []string{user1, user2} {
-		rgl, err := client.ListRuleGroupsForUserAndNamespace(ctx, u, "") // Client loads rules in its List method.
+		for _, u := range []string{user1, user2} {
+			rgs, err := client.ListRuleGroupsForUserAndNamespace(ctx, u, "") // Client loads rules in its List method.
+			require.NoError(t, err)
+
+			require.Equal(t, 2, len(rgs))
+			// We rely on the fact that files are parsed in alphabetical order, and our namespace1 < namespace2.
+			require.Equal(t, rulespb.ToProto(u, namespace1, ruleGroups.Groups[0]), rgs[0])
+			require.Equal(t, rulespb.ToProto(u, namespace2, ruleGroups.Groups[0]), rgs[1])
+		}
+	})
+
+	t.Run("all rule groups in namespace", func(t *testing.T) {
+		ctx := context.Background()
+
+		for _, u := range []string{user1, user2} {
+			rgs, err := client.ListRuleGroupsForUserAndNamespace(ctx, u, namespace2) // Client loads rules in its List method.
+			require.NoError(t, err)
+
+			require.Equal(t, 1, len(rgs))
+			require.Equal(t, rulespb.ToProto(u, namespace2, ruleGroups.Groups[0]), rgs[0])
+		}
+	})
+
+	t.Run("single rule group in namespace", func(t *testing.T) {
+		rg, err := client.GetRuleGroup(context.Background(), user1, namespace1, "rule")
 		require.NoError(t, err)
-		userMap[u] = rgl
-	}
+		require.Equal(t, rulespb.ToProto(user1, namespace1, ruleGroups.Groups[0]), rg)
+	})
 
-	for _, u := range []string{user1, user2} {
-		actual, found := userMap[u]
-		require.True(t, found)
-
-		require.Equal(t, 2, len(actual))
-		// We rely on the fact that files are parsed in alphabetical order, and our namespace1 < namespace2.
-		require.Equal(t, rulespb.ToProto(u, namespace1, ruleGroups.Groups[0]), actual[0])
-		require.Equal(t, rulespb.ToProto(u, namespace2, ruleGroups.Groups[0]), actual[1])
-	}
+	t.Run("single rule group that not exists", func(t *testing.T) {
+		_, err := client.GetRuleGroup(context.Background(), user1, namespace1, "unknown-rule")
+		require.ErrorIs(t, err, rulestore.ErrGroupNotFound)
+	})
 }

--- a/pkg/ruler/storage.go
+++ b/pkg/ruler/storage.go
@@ -26,7 +26,7 @@ import (
 
 // NewRuleStore returns a rule store backend client based on the provided cfg.
 func NewRuleStore(ctx context.Context, cfg rulestore.Config, cfgProvider bucket.TenantConfigProvider, loader promRules.GroupLoader, cacheTTL time.Duration, logger log.Logger, reg prometheus.Registerer) (directStore, cachedStore rulestore.RuleStore, _ error) {
-	if cfg.Backend == local.Name {
+	if cfg.Backend == rulestore.BackendLocal {
 		store, err := local.NewLocalRulesClient(cfg.Local, loader)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
#### What this PR does

Add support for the `/config/api/v1/rules/{namespace}/{groupName}` in the ruler's "local" store.

Note, the changes ended up a bit more involved, than what we anticipated originally. That is, in order for "local" store to follow the `rulestore.RuleStore` interface, the backend must return the sentinel errors, defined along with the interface. This created a circular dependency between the `rulestore` and `local` packages due to how the configs were laid out. The choice the PR made to resolve that, is to move the `local`'s config outside the package, close to `rulestore.Config` (see the actual changes).

#### Which issue(s) this PR fixes or relates to

Fixes #6632

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
