### PR TITLE
Native histogram: validate schema number before reducing resolution

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1286,6 +1286,12 @@ This non-critical error occurs when Mimir receives a write request that contains
 
 > **Note:** The series containing such samples are skipped during ingestion, and valid series within the same request are ingested.
 
+### err-mimir-invalid-native-histogram-schema
+
+This non-critical error occurs when Mimir receives a write request that contains a sample that is a native histogram with an invalid schema number. Currently, valid schema numbers are from the range [-4, 8].
+
+> **Note:** The series containing such samples are skipped during ingestion, and valid series within the same request are ingested.
+
 ### err-mimir-label-invalid
 
 This non-critical error occurs when Mimir receives a write request that contains a series with an invalid label name.

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -30,15 +30,16 @@ const (
 
 var (
 	// Discarded series / samples reasons.
-	reasonMissingMetricName         = globalerror.MissingMetricName.LabelValue()
-	reasonInvalidMetricName         = globalerror.InvalidMetricName.LabelValue()
-	reasonMaxLabelNamesPerSeries    = globalerror.MaxLabelNamesPerSeries.LabelValue()
-	reasonInvalidLabel              = globalerror.SeriesInvalidLabel.LabelValue()
-	reasonLabelNameTooLong          = globalerror.SeriesLabelNameTooLong.LabelValue()
-	reasonLabelValueTooLong         = globalerror.SeriesLabelValueTooLong.LabelValue()
-	reasonMaxNativeHistogramBuckets = globalerror.MaxNativeHistogramBuckets.LabelValue()
-	reasonDuplicateLabelNames       = globalerror.SeriesWithDuplicateLabelNames.LabelValue()
-	reasonTooFarInFuture            = globalerror.SampleTooFarInFuture.LabelValue()
+	reasonMissingMetricName            = globalerror.MissingMetricName.LabelValue()
+	reasonInvalidMetricName            = globalerror.InvalidMetricName.LabelValue()
+	reasonMaxLabelNamesPerSeries       = globalerror.MaxLabelNamesPerSeries.LabelValue()
+	reasonInvalidLabel                 = globalerror.SeriesInvalidLabel.LabelValue()
+	reasonLabelNameTooLong             = globalerror.SeriesLabelNameTooLong.LabelValue()
+	reasonLabelValueTooLong            = globalerror.SeriesLabelValueTooLong.LabelValue()
+	reasonMaxNativeHistogramBuckets    = globalerror.MaxNativeHistogramBuckets.LabelValue()
+	reasonInvalidNativeHistogramSchema = globalerror.InvalidSchemaNativeHistogram.LabelValue()
+	reasonDuplicateLabelNames          = globalerror.SeriesWithDuplicateLabelNames.LabelValue()
+	reasonTooFarInFuture               = globalerror.SampleTooFarInFuture.LabelValue()
 
 	// Discarded exemplars reasons.
 	reasonExemplarLabelsMissing    = globalerror.ExemplarLabelsMissing.LabelValue()
@@ -73,17 +74,12 @@ var (
 		"received a series whose number of labels exceeds the limit (actual: %d, limit: %d) series: '%.200s%s'",
 		validation.MaxLabelNamesPerSeriesFlag,
 	)
-	noMetricNameMsgFormat              = globalerror.MissingMetricName.Message("received series has no metric name")
-	invalidMetricNameMsgFormat         = globalerror.InvalidMetricName.Message("received a series with invalid metric name: '%.200s'")
-	maxNativeHistogramBucketsMsgFormat = fmt.Sprintf(
-		"received a native histogram sample with too many buckets, timestamp: %%d series: %%s, buckets: %%d, limit: %%d (%s)",
-		globalerror.MaxNativeHistogramBuckets,
-	)
-	notReducibleNativeHistogramMsgFormat = fmt.Sprintf(
-		"received a native histogram sample with too many buckets and cannot reduce, timestamp: %%d series: %%s, buckets: %%d, limit: %%d (%s)",
-		globalerror.NotReducibleNativeHistogram,
-	)
-	sampleTimestampTooNewMsgFormat = globalerror.SampleTooFarInFuture.MessageWithPerTenantLimitConfig(
+	noMetricNameMsgFormat                 = globalerror.MissingMetricName.Message("received series has no metric name")
+	invalidMetricNameMsgFormat            = globalerror.InvalidMetricName.Message("received a series with invalid metric name: '%.200s'")
+	maxNativeHistogramBucketsMsgFormat    = globalerror.MaxNativeHistogramBuckets.Message("received a native histogram sample with too many buckets, timestamp: %d series: %s, buckets: %d, limit: %d")
+	notReducibleNativeHistogramMsgFormat  = globalerror.NotReducibleNativeHistogram.Message("received a native histogram sample with too many buckets and cannot reduce, timestamp: %d series: %s, buckets: %d, limit: %d")
+	invalidSchemaNativeHistogramMsgFormat = globalerror.InvalidSchemaNativeHistogram.Message("received a native histogram sample with an invalid schema %d: valid schema numbers are %d <= n <= %d")
+	sampleTimestampTooNewMsgFormat        = globalerror.SampleTooFarInFuture.MessageWithPerTenantLimitConfig(
 		"received a sample whose timestamp is too far in the future, timestamp: %d series: '%.200s'",
 		validation.CreationGracePeriodFlag,
 	)
@@ -117,15 +113,16 @@ type sampleValidationConfig interface {
 
 // sampleValidationMetrics is a collection of metrics used during sample validation.
 type sampleValidationMetrics struct {
-	missingMetricName         *prometheus.CounterVec
-	invalidMetricName         *prometheus.CounterVec
-	maxLabelNamesPerSeries    *prometheus.CounterVec
-	invalidLabel              *prometheus.CounterVec
-	labelNameTooLong          *prometheus.CounterVec
-	labelValueTooLong         *prometheus.CounterVec
-	maxNativeHistogramBuckets *prometheus.CounterVec
-	duplicateLabelNames       *prometheus.CounterVec
-	tooFarInFuture            *prometheus.CounterVec
+	missingMetricName            *prometheus.CounterVec
+	invalidMetricName            *prometheus.CounterVec
+	maxLabelNamesPerSeries       *prometheus.CounterVec
+	invalidLabel                 *prometheus.CounterVec
+	labelNameTooLong             *prometheus.CounterVec
+	labelValueTooLong            *prometheus.CounterVec
+	maxNativeHistogramBuckets    *prometheus.CounterVec
+	invalidNativeHistogramSchema *prometheus.CounterVec
+	duplicateLabelNames          *prometheus.CounterVec
+	tooFarInFuture               *prometheus.CounterVec
 }
 
 func (m *sampleValidationMetrics) deleteUserMetrics(userID string) {
@@ -137,6 +134,7 @@ func (m *sampleValidationMetrics) deleteUserMetrics(userID string) {
 	m.labelNameTooLong.DeletePartialMatch(filter)
 	m.labelValueTooLong.DeletePartialMatch(filter)
 	m.maxNativeHistogramBuckets.DeletePartialMatch(filter)
+	m.invalidNativeHistogramSchema.DeletePartialMatch(filter)
 	m.duplicateLabelNames.DeletePartialMatch(filter)
 	m.tooFarInFuture.DeletePartialMatch(filter)
 }
@@ -149,21 +147,23 @@ func (m *sampleValidationMetrics) deleteUserMetricsForGroup(userID, group string
 	m.labelNameTooLong.DeleteLabelValues(userID, group)
 	m.labelValueTooLong.DeleteLabelValues(userID, group)
 	m.maxNativeHistogramBuckets.DeleteLabelValues(userID, group)
+	m.invalidNativeHistogramSchema.DeleteLabelValues(userID, group)
 	m.duplicateLabelNames.DeleteLabelValues(userID, group)
 	m.tooFarInFuture.DeleteLabelValues(userID, group)
 }
 
 func newSampleValidationMetrics(r prometheus.Registerer) *sampleValidationMetrics {
 	return &sampleValidationMetrics{
-		missingMetricName:         validation.DiscardedSamplesCounter(r, reasonMissingMetricName),
-		invalidMetricName:         validation.DiscardedSamplesCounter(r, reasonInvalidMetricName),
-		maxLabelNamesPerSeries:    validation.DiscardedSamplesCounter(r, reasonMaxLabelNamesPerSeries),
-		invalidLabel:              validation.DiscardedSamplesCounter(r, reasonInvalidLabel),
-		labelNameTooLong:          validation.DiscardedSamplesCounter(r, reasonLabelNameTooLong),
-		labelValueTooLong:         validation.DiscardedSamplesCounter(r, reasonLabelValueTooLong),
-		maxNativeHistogramBuckets: validation.DiscardedSamplesCounter(r, reasonMaxNativeHistogramBuckets),
-		duplicateLabelNames:       validation.DiscardedSamplesCounter(r, reasonDuplicateLabelNames),
-		tooFarInFuture:            validation.DiscardedSamplesCounter(r, reasonTooFarInFuture),
+		missingMetricName:            validation.DiscardedSamplesCounter(r, reasonMissingMetricName),
+		invalidMetricName:            validation.DiscardedSamplesCounter(r, reasonInvalidMetricName),
+		maxLabelNamesPerSeries:       validation.DiscardedSamplesCounter(r, reasonMaxLabelNamesPerSeries),
+		invalidLabel:                 validation.DiscardedSamplesCounter(r, reasonInvalidLabel),
+		labelNameTooLong:             validation.DiscardedSamplesCounter(r, reasonLabelNameTooLong),
+		labelValueTooLong:            validation.DiscardedSamplesCounter(r, reasonLabelValueTooLong),
+		maxNativeHistogramBuckets:    validation.DiscardedSamplesCounter(r, reasonMaxNativeHistogramBuckets),
+		invalidNativeHistogramSchema: validation.DiscardedSamplesCounter(r, reasonInvalidNativeHistogramSchema),
+		duplicateLabelNames:          validation.DiscardedSamplesCounter(r, reasonDuplicateLabelNames),
+		tooFarInFuture:               validation.DiscardedSamplesCounter(r, reasonTooFarInFuture),
 	}
 }
 
@@ -232,6 +232,12 @@ func validateSampleHistogram(m *sampleValidationMetrics, now model.Time, cfg sam
 				m.maxNativeHistogramBuckets.WithLabelValues(userID, group).Inc()
 				return fmt.Errorf(maxNativeHistogramBucketsMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToString(ls), bucketCount, bucketLimit)
 			}
+
+			if s.Schema < mimirpb.MinimumHistogramSchema || s.Schema > mimirpb.MaximumHistogramSchema {
+				m.invalidNativeHistogramSchema.WithLabelValues(userID, group).Inc()
+				return fmt.Errorf(invalidSchemaNativeHistogramMsgFormat, s.Schema, mimirpb.MinimumHistogramSchema, mimirpb.MaximumHistogramSchema)
+			}
+
 			for {
 				bc, err := s.ReduceResolution()
 				if err != nil {

--- a/pkg/mimirpb/custom.go
+++ b/pkg/mimirpb/custom.go
@@ -58,12 +58,20 @@ func (h *Histogram) ReduceResolution() (int, error) {
 	return h.reduceIntResolution()
 }
 
-// The minimum schema for a histogram is -4. Currently this is hardcoded and
-// not exported from Prometheus or client_golang, so we define it here.
-const minimumHistogramSchema = -4
+const (
+	// MinimumHistogramSchema is the minimum schema for a histogram.
+	// Currently, it is -4, hardcoded and not exported from either
+	// Prometheus or client_golang, so we define it here.
+	MinimumHistogramSchema = -4
+
+	// MaximumHistogramSchema is the minimum schema for a histogram.
+	// Currently, it is 8, hardcoded and not exported from either
+	// Prometheus or client_golang, so we define it here.
+	MaximumHistogramSchema = 8
+)
 
 func (h *Histogram) reduceFloatResolution() (int, error) {
-	if h.Schema == minimumHistogramSchema {
+	if h.Schema == MinimumHistogramSchema {
 		return 0, fmt.Errorf("cannot reduce resolution of histogram with schema %d", h.Schema)
 	}
 	h.PositiveSpans, h.PositiveCounts = reduceResolution(h.PositiveSpans, h.PositiveCounts, h.Schema, h.Schema-1, false)
@@ -73,7 +81,7 @@ func (h *Histogram) reduceFloatResolution() (int, error) {
 }
 
 func (h *Histogram) reduceIntResolution() (int, error) {
-	if h.Schema == minimumHistogramSchema {
+	if h.Schema == MinimumHistogramSchema {
 		return 0, fmt.Errorf("cannot reduce resolution of histogram with schema %d", h.Schema)
 	}
 	h.PositiveSpans, h.PositiveDeltas = reduceResolution(h.PositiveSpans, h.PositiveDeltas, h.Schema, h.Schema-1, true)

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -19,6 +19,7 @@ const (
 	MaxLabelNamesPerSeries        ID = "max-label-names-per-series"
 	MaxNativeHistogramBuckets     ID = "max-native-histogram-buckets"
 	NotReducibleNativeHistogram   ID = "not-reducible-native-histogram"
+	InvalidSchemaNativeHistogram  ID = "invalid-native-histogram-schema"
 	SeriesInvalidLabel            ID = "label-invalid"
 	SeriesLabelNameTooLong        ID = "label-name-too-long"
 	SeriesLabelValueTooLong       ID = "label-value-too-long"


### PR DESCRIPTION
#### What this PR does

Currently, distributor's sample histogram validation does not check the schema number before reducing resolution. However, histogram samples with schemas outside the [-4..8] range should be rejected. This PR introduces that check.

#### Which issue(s) this PR fixes or relates to

Fixes #7230 

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
