### PR TITLE
Update Alertmanager to cab8ecb (#7254)

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -13623,7 +13623,7 @@
           "kind": "field",
           "name": "utf8_strict_mode",
           "required": false,
-          "desc": "Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree and alertmanager_matchers_incompatible metrics before using this mode as otherwise some tenant configurations might fail to load.",
+          "desc": "Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree_total and alertmanager_matchers_incompatible_total metrics before using this mode as otherwise some tenant configurations might fail to load.",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "alertmanager.utf8-strict-mode-enabled",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -274,7 +274,7 @@ Usage of ./cmd/mimir/mimir:
   -alertmanager.storage.retention duration
     	How long should we store stateful data (notification logs and silences). For notification log entries, refers to how long should we keep entries before they expire and are deleted. For silences, refers to how long should tenants view silences after they expire and are deleted. (default 120h0m0s)
   -alertmanager.utf8-strict-mode-enabled
-    	[experimental] Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree and alertmanager_matchers_incompatible metrics before using this mode as otherwise some tenant configurations might fail to load.
+    	[experimental] Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree_total and alertmanager_matchers_incompatible_total metrics before using this mode as otherwise some tenant configurations might fail to load.
   -alertmanager.web.external-url string
     	The URL under which Alertmanager is externally reachable (eg. could be different than -http.alertmanager-http-prefix in case Alertmanager is served via a reverse proxy). This setting is used both to configure the internal requests router and to generate links in alert templates. If the external URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager, both the UI and API. (default http://localhost:8080/alertmanager)
   -api.skip-label-name-validation-header-enabled

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2254,9 +2254,9 @@ alertmanager_client:
 
 # (experimental) Enable UTF-8 strict mode. Allows UTF-8 characters in the
 # matchers for routes and inhibition rules, in silences, and in the labels for
-# alerts. It is recommended to check both alertmanager_matchers_disagree and
-# alertmanager_matchers_incompatible metrics before using this mode as otherwise
-# some tenant configurations might fail to load.
+# alerts. It is recommended to check both alertmanager_matchers_disagree_total
+# and alertmanager_matchers_incompatible_total metrics before using this mode as
+# otherwise some tenant configurations might fail to load.
 # CLI flag: -alertmanager.utf8-strict-mode-enabled
 [utf8_strict_mode: <boolean> | default = false]
 ```

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/opentracing-contrib/go-stdlib v1.0.0
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/alertmanager v0.26.1-0.20240119104350-f92a08d07386
+	github.com/prometheus/alertmanager v0.26.1-0.20240130102200-cab8ecbc95c4
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/client_model v0.5.0
 	github.com/prometheus/common v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -830,8 +830,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/prometheus/alertmanager v0.26.1-0.20240119104350-f92a08d07386 h1:jcyYvVOHEllcJsH23+TU7MFPUaNHga4TJ43v+Zt4Zts=
-github.com/prometheus/alertmanager v0.26.1-0.20240119104350-f92a08d07386/go.mod h1:pT85bjw8Hkt/ZfVpa/b0gLWQc015Yjbi02eCYD0yRl4=
+github.com/prometheus/alertmanager v0.26.1-0.20240130102200-cab8ecbc95c4 h1:2QqZsz1XYxCMOC7Siw6bU5E8dAa0Z5DNSyd1w262oHM=
+github.com/prometheus/alertmanager v0.26.1-0.20240130102200-cab8ecbc95c4/go.mod h1:pT85bjw8Hkt/ZfVpa/b0gLWQc015Yjbi02eCYD0yRl4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -318,10 +318,10 @@ func TestAlertmanagerMatchersMetrics(t *testing.T) {
 
 	// The metrics should all be zero as no configurations contain matchers.
 	metricNames := []string{
-		"alertmanager_matchers_parse",
-		"alertmanager_matchers_disagree",
-		"alertmanager_matchers_incompatible",
-		"alertmanager_matchers_invalid",
+		"alertmanager_matchers_parse_total",
+		"alertmanager_matchers_disagree_total",
+		"alertmanager_matchers_incompatible_total",
+		"alertmanager_matchers_invalid_total",
 	}
 	metrics, err := alertmanager.SumMetrics(metricNames, e2e.SkipMissingMetrics)
 	require.NoError(t, err)
@@ -334,7 +334,7 @@ func TestAlertmanagerMatchersMetrics(t *testing.T) {
 	require.NoError(t, c1.SetAlertmanagerConfig(ctx, mimirAlertmanagerUserClassicConfigYaml, nil))
 	metrics, err = alertmanager.SumMetrics(metricNames, e2e.SkipMissingMetrics)
 	require.NoError(t, err)
-	// The sum for alertmanager_matchers_parse should be 4 as there are two matchers for origin=api
+	// The sum for alertmanager_matchers_parse_total should be 4 as there are two matchers for origin=api
 	// and another two matchers for origin=config.
 	require.Equal(t, []float64{4, 0, 0, 0}, metrics)
 
@@ -342,7 +342,7 @@ func TestAlertmanagerMatchersMetrics(t *testing.T) {
 	require.NoError(t, c2.SetAlertmanagerConfig(ctx, mimirAlertmanagerUserClassicConfigYaml, nil))
 	metrics, err = alertmanager.SumMetrics(metricNames, e2e.SkipMissingMetrics)
 	require.NoError(t, err)
-	// The sum for alertmanager_matchers_parse should be 8 as there are two matchers for origin=api
+	// The sum for alertmanager_matchers_parse_total should be 8 as there are two matchers for origin=api
 	// and another two matchers for origin=config, and 4 from the previous sum.
 	require.Equal(t, []float64{8, 0, 0, 0}, metrics)
 

--- a/pkg/alertmanager/alertmanager_config_test.go
+++ b/pkg/alertmanager/alertmanager_config_test.go
@@ -119,7 +119,7 @@ inhibit_rules:
 	}
 }
 
-func requireMetric(t *testing.T, expected float64, m *prometheus.GaugeVec) {
+func requireMetric(t *testing.T, expected float64, m *prometheus.CounterVec) {
 	if expected == 0 {
 		require.Equal(t, 0, testutil.CollectAndCount(m))
 	} else {

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -127,7 +127,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet, logger 
 
 	f.DurationVar(&cfg.PeerTimeout, "alertmanager.peer-timeout", defaultPeerTimeout, "Time to wait between peers to send notifications.")
 
-	f.BoolVar(&cfg.UTF8StrictMode, "alertmanager.utf8-strict-mode-enabled", false, "Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree and alertmanager_matchers_incompatible metrics before using this mode as otherwise some tenant configurations might fail to load.")
+	f.BoolVar(&cfg.UTF8StrictMode, "alertmanager.utf8-strict-mode-enabled", false, "Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended to check both alertmanager_matchers_disagree_total and alertmanager_matchers_incompatible_total metrics before using this mode as otherwise some tenant configurations might fail to load.")
 }
 
 // Validate config and returns error on failure

--- a/vendor/github.com/prometheus/alertmanager/matchers/compat/metrics.go
+++ b/vendor/github.com/prometheus/alertmanager/matchers/compat/metrics.go
@@ -31,28 +31,28 @@ var DefaultOrigins = []string{
 var RegisteredMetrics = NewMetrics(prometheus.DefaultRegisterer)
 
 type Metrics struct {
-	Total             *prometheus.GaugeVec
-	DisagreeTotal     *prometheus.GaugeVec
-	IncompatibleTotal *prometheus.GaugeVec
-	InvalidTotal      *prometheus.GaugeVec
+	Total             *prometheus.CounterVec
+	DisagreeTotal     *prometheus.CounterVec
+	IncompatibleTotal *prometheus.CounterVec
+	InvalidTotal      *prometheus.CounterVec
 }
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
 	m := &Metrics{
-		Total: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "alertmanager_matchers_parse",
+		Total: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "alertmanager_matchers_parse_total",
 			Help: "Total number of matcher inputs parsed, including invalid inputs.",
 		}, []string{"origin"}),
-		DisagreeTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "alertmanager_matchers_disagree",
+		DisagreeTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "alertmanager_matchers_disagree_total",
 			Help: "Total number of matcher inputs which produce different parsings (disagreement).",
 		}, []string{"origin"}),
-		IncompatibleTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "alertmanager_matchers_incompatible",
+		IncompatibleTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "alertmanager_matchers_incompatible_total",
 			Help: "Total number of matcher inputs that are incompatible with the UTF-8 parser.",
 		}, []string{"origin"}),
-		InvalidTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "alertmanager_matchers_invalid",
+		InvalidTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Name: "alertmanager_matchers_invalid_total",
 			Help: "Total number of matcher inputs that could not be parsed.",
 		}, []string{"origin"}),
 	}

--- a/vendor/github.com/prometheus/alertmanager/matchers/compat/parse.go
+++ b/vendor/github.com/prometheus/alertmanager/matchers/compat/parse.go
@@ -170,7 +170,7 @@ func FallbackMatcherParser(l log.Logger, m *Metrics) ParseMatcher {
 			// parser. This means the input is not forwards compatible.
 			m.IncompatibleTotal.With(lbs).Inc()
 			suggestion := cMatcher.String()
-			level.Warn(l).Log("msg", "Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the old matchers parser as a fallback. To make this input compatible with the new parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue.", "input", input, "origin", origin, "err", err, "suggestion", suggestion)
+			level.Warn(l).Log("msg", "Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the old matchers parser as a fallback. To make this input compatible with the new parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue.", "input", input, "origin", origin, "err", nErr, "suggestion", suggestion)
 			return cMatcher, nil
 		}
 		// If the input is valid in both parsers, but produces different results,
@@ -219,7 +219,7 @@ func FallbackMatchersParser(l log.Logger, m *Metrics) ParseMatchers {
 			suggestion := sb.String()
 			// The input is valid in the pkg/labels parser, but not the
 			// new matchers/parse parser.
-			level.Warn(l).Log("msg", "Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the old matchers parser as a fallback. To make this input compatible with the new parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue.", "input", input, "origin", origin, "err", err, "suggestion", suggestion)
+			level.Warn(l).Log("msg", "Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the old matchers parser as a fallback. To make this input compatible with the new parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue.", "input", input, "origin", origin, "err", nErr, "suggestion", suggestion)
 			return cMatchers, nil
 		}
 		// If the input is valid in both parsers, but produces different results,

--- a/vendor/github.com/prometheus/alertmanager/notify/email/email.go
+++ b/vendor/github.com/prometheus/alertmanager/notify/email/email.go
@@ -368,7 +368,7 @@ func (n *Email) getPassword() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("could not read %s: %w", n.conf.AuthPasswordFile, err)
 		}
-		return string(content), nil
+		return strings.TrimSpace(string(content)), nil
 	}
 	return string(n.conf.AuthPassword), nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -822,7 +822,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/prometheus/alertmanager v0.26.1-0.20240119104350-f92a08d07386
+# github.com/prometheus/alertmanager v0.26.1-0.20240130102200-cab8ecbc95c4
 ## explicit; go 1.21
 github.com/prometheus/alertmanager/api
 github.com/prometheus/alertmanager/api/metrics


### PR DESCRIPTION
#### What this PR does

This pull request updates the r275 branch with https://github.com/grafana/mimir/pull/7254 as discussed on Slack [here](https://raintank-corp.slack.com/archives/C9KL8THCY/p1706611104496719).

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
