### PR TITLE
Reuse Histogram objects in tools/tsdb-chunks and tools/tsdb-print-chunk

### DIFF
--- a/tools/tsdb-chunks/main.go
+++ b/tools/tsdb-chunks/main.go
@@ -73,6 +73,7 @@ func printChunksFile(filename string, printSamples bool) error {
 	var (
 		h  *histogram.Histogram      // reused in iteration as we just dump the value and move on
 		fh *histogram.FloatHistogram // reused in iteration as we just dump the value and move on
+		ts int64                     // we declare ts here to prevent shadowing of h and fh within the loop
 	)
 	for c, err := nextChunk(cix, file); err == nil; c, err = nextChunk(cix, file) {
 		if printSamples {
@@ -94,7 +95,7 @@ func printChunksFile(filename string, printSamples bool) error {
 
 					fmt.Printf("Chunk #%d, sample #%d: ts: %d (%s), val: %g\n", cix, six, ts, formatTimestamp(ts), val)
 				case chunkenc.ValHistogram:
-					ts, h := it.AtHistogram(h)
+					ts, h = it.AtHistogram(h)
 					if ts < minTS {
 						minTS = ts
 					}
@@ -104,7 +105,7 @@ func printChunksFile(filename string, printSamples bool) error {
 
 					fmt.Printf("Chunk #%d, sample #%d: ts: %d (%s), val: %s\n", cix, six, ts, formatTimestamp(ts), h.String())
 				case chunkenc.ValFloatHistogram:
-					ts, fh := it.AtFloatHistogram(fh)
+					ts, fh = it.AtFloatHistogram(fh)
 					if ts < minTS {
 						minTS = ts
 					}

--- a/tools/tsdb-print-chunk/main.go
+++ b/tools/tsdb-print-chunk/main.go
@@ -65,6 +65,7 @@ func printChunks(blockDir string, chunkRefs []string) {
 		var (
 			h  *histogram.Histogram      // reused in iteration as we just dump the value and move on
 			fh *histogram.FloatHistogram // reused in iteration as we just dump the value and move on
+			ts int64                     // we declare ts here to prevent shadowing of h and fh within the loop
 		)
 		for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
 			switch valType {
@@ -72,10 +73,10 @@ func printChunks(blockDir string, chunkRefs []string) {
 				ts, v := it.At()
 				fmt.Printf("%g\t%d (%s)\n", v, ts, timestamp.Time(ts).UTC().Format(time.RFC3339Nano))
 			case chunkenc.ValHistogram:
-				ts, h := it.AtHistogram(h)
+				ts, h = it.AtHistogram(h)
 				fmt.Printf("%s\t%d (%s)\n", h.String(), ts, timestamp.Time(ts).UTC().Format(time.RFC3339Nano))
 			case chunkenc.ValFloatHistogram:
-				ts, fh := it.AtFloatHistogram(fh)
+				ts, fh = it.AtFloatHistogram(fh)
 				fmt.Printf("%s\t%d (%s)\n", fh.String(), ts, timestamp.Time(ts).UTC().Format(time.RFC3339Nano))
 			default:
 				fmt.Printf("skipping unsupported value type %v\n", valType)


### PR DESCRIPTION
#### What this PR does
In #7219 we updated `mimir-prometheus` to https://github.com/grafana/mimir-prometheus/commit/c2a5e1599c5678514ab70be1723a1ebd0d6287da. Additionally, the PR adapted calls to prometheus' `chunkenc.Iterator.AtHistogram()` and `chunkenc.Iterator.AtFloatHistogram()` in `tools/tsdb-chunks` and `tools/tsdb-print-chunk` to reuse the memory of a histogram provided as an argument. Unfortunately, a bug illustrated by the following code was introduced:
```
it := ch.Iterator(nil) // an instance of chunkenc.Iterator
var (
	h  *histogram.Histogram      // supposed to be reused in the loop, but it is never assigned a value
	fh *histogram.FloatHistogram // supposed to be reused in the loop, but it is never assigned a value
)
for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
	switch valType {
	case chunkenc.ValFloat:
		ts, v := it.At()
		...
	case chunkenc.ValHistogram:
		ts, h := it.AtHistogram(h) // this cretes a new variable h that shadows the one declared outside of the loop
		...
	case chunkenc.ValFloatHistogram:
		ts, fh := it.AtFloatHistogram(fh) // this cretes a new variable fh that shadows the one declared outside of the loop
		...
	default:
		...
	}
}
...
```

This PR fixes the bug introduced above.

#### Which issue(s) this PR fixes or relates to

Part of [#<issue number>](https://github.com/grafana/mimir/issues/7235)

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
