### PR TITLE
frontend: improve `shardActiveSeriesMiddleware` performance when merging responses

### DIFF
--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -423,7 +423,7 @@ func Test_shardActiveSeriesMiddleware_RoundTrip_ResponseBodyStreamed(t *testing.
 }
 
 func BenchmarkActiveSeriesMiddlewareMergeResponses(b *testing.B) {
-	bcs := []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
+	bcs := []int{2, 4, 8, 16, 32, 64, 128, 256, 512}
 
 	for _, numResponses := range bcs {
 		b.Run(fmt.Sprintf("num-responses-%d", numResponses), func(b *testing.B) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds various changes to the `shardActiveSeriesMiddleware` middleware to improve performance when merging responses if sharding is enabled.

In order to validate the changes, an additional benchmark named `BenchmarkActiveSeriesMiddlewareMergeResponses` has been included, which was executed before and after.

Below is the comparative table of these results.

```
name                                                      old time/op    new time/op    delta
ActiveSeriesMiddlewareMergeResponses/num-responses-2-8      6.12µs ± 1%    7.60µs ± 0%  +24.10%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-4-8      8.32µs ± 2%    8.81µs ± 1%   +5.86%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-8-8      11.9µs ± 1%    10.7µs ± 1%  -10.33%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-16-8     19.5µs ± 1%    14.8µs ± 1%  -23.97%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-32-8     31.9µs ± 2%    23.8µs ± 2%  -25.56%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-64-8     57.9µs ± 1%    40.4µs ± 3%  -30.27%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-128-8     107µs ± 1%      73µs ± 2%  -31.76%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-256-8     211µs ± 6%     137µs ± 3%  -35.15%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-512-8     432µs ± 6%     298µs ± 1%  -30.93%  (p=0.008 n=5+5)

name                                                      old alloc/op   new alloc/op   delta
ActiveSeriesMiddlewareMergeResponses/num-responses-2-8      5.10kB ± 0%    1.59kB ± 0%  -68.74%  (p=0.000 n=5+4)
ActiveSeriesMiddlewareMergeResponses/num-responses-4-8      8.33kB ± 0%    1.83kB ± 0%  -77.99%  (p=0.000 n=5+4)
ActiveSeriesMiddlewareMergeResponses/num-responses-8-8      14.8kB ± 0%     2.3kB ± 0%  -84.36%  (p=0.000 n=5+4)
ActiveSeriesMiddlewareMergeResponses/num-responses-16-8     30.0kB ± 0%     3.3kB ± 0%  -89.09%  (p=0.000 n=4+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-32-8     57.9kB ± 0%     5.2kB ± 0%  -91.03%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-64-8      117kB ± 0%       9kB ± 0%  -92.26%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-128-8     242kB ± 0%      17kB ± 0%  -93.08%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-256-8     478kB ± 0%      32kB ± 0%  -93.27%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-512-8     983kB ± 0%     147kB ± 0%  -85.01%  (p=0.008 n=5+5)

name                                                      old allocs/op  new allocs/op  delta
ActiveSeriesMiddlewareMergeResponses/num-responses-2-8        46.0 ± 0%      36.0 ± 0%  -21.74%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-4-8        74.0 ± 0%      54.0 ± 0%  -27.03%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-8-8         130 ± 0%        90 ± 0%  -30.77%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-16-8        244 ± 0%       162 ± 0%  -33.61%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-32-8        469 ± 0%       306 ± 0%  -34.75%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-64-8        919 ± 0%       594 ± 0%  -35.36%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-128-8     1.82k ± 0%     1.17k ± 0%  -35.64%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-256-8     3.61k ± 0%     2.32k ± 0%  -35.71%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/num-responses-512-8     7.20k ± 0%     4.64k ± 0%  -35.56%  (p=0.008 n=5+5)
```

To facilitate review, below are the various changes included in this PR:

* Implementing the use of a buffer channel to collect the results of reading two responses.
* Replacing the `io.ReadAll` calls used to drain the responses before closing them with `io.Copy(io.Discard, resp.Body)`, since the former allocates memory.
* Recycling `*jsoniter.Stream` and `*jsoniter.Iterator` types, as well as their internal buffers, through pooling.
* Replacing the use of `map[string]string` to store label/value pairs with `*labels.Builder`, allowing the latter to be reused via pooling.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
