### PR TITLE
ruler: build user-agent header at runtime

### DIFF
--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -28,11 +28,15 @@ const (
 )
 
 var (
-	UserAgent           = fmt.Sprintf("mimirtool/%s %s", version.Version, version.Info())
 	ErrResourceNotFound = errors.New("requested resource not found")
 	errConflict         = errors.New("conflict with current state of target resource")
 	errTooManyRequests  = errors.New("too many requests")
 )
+
+// UserAgent returns build information in format suitable to be used in HTTP User-Agent header.
+func UserAgent() string {
+	return fmt.Sprintf("mimirtool/%s %s", version.Version, version.Info())
+}
 
 // Config is used to configure a MimirClient.
 type Config struct {
@@ -253,6 +257,6 @@ func buildRequest(ctx context.Context, p, m string, endpoint url.URL, payload io
 	if contentLength >= 0 {
 		r.ContentLength = contentLength
 	}
-	r.Header.Add("User-Agent", UserAgent)
+	r.Header.Add("User-Agent", UserAgent())
 	return r, nil
 }

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -88,7 +88,7 @@ func (cmd *PrometheusAnalyzeCommand) parseUsedMetrics() (model.LabelValues, erro
 
 func (cmd *PrometheusAnalyzeCommand) newAPI() (v1.API, error) {
 	rt := api.DefaultRoundTripper
-	rt = config.NewUserAgentRoundTripper(client.UserAgent, rt)
+	rt = config.NewUserAgentRoundTripper(client.UserAgent(), rt)
 	if cmd.username != "" {
 		rt = &setTenantIDTransport{
 			RoundTripper: rt,

--- a/pkg/mimirtool/commands/loadgen.go
+++ b/pkg/mimirtool/commands/loadgen.go
@@ -139,7 +139,7 @@ func (c *LoadgenCommand) run(_ *kingpin.ParseContext) error {
 			URL:     &config.URL{URL: writeURL},
 			Timeout: model.Duration(c.writeTimeout),
 			Headers: map[string]string{
-				"User-Agent": client.UserAgent,
+				"User-Agent": client.UserAgent(),
 			},
 		})
 		if err != nil {

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -206,7 +206,7 @@ func (c *RemoteReadCommand) readClient() (remote.ReadClient, error) {
 			},
 		},
 		Headers: map[string]string{
-			"User-Agent": client.UserAgent,
+			"User-Agent": client.UserAgent(),
 		},
 	})
 	if err != nil {

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -52,7 +52,6 @@ const (
 	formatProtobuf = "protobuf"
 )
 
-var userAgent = fmt.Sprintf("mimir/%s", version.Version)
 var allFormats = []string{formatJSON, formatProtobuf}
 
 // QueryFrontendConfig defines query-frontend transport configuration.
@@ -168,7 +167,7 @@ func (q *RemoteQuerier) Read(ctx context.Context, query *prompb.Query) (*prompb.
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Encoding"), Values: []string{"snappy"}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Accept-Encoding"), Values: []string{"snappy"}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Type"), Values: []string{"application/x-protobuf"}},
-			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{userAgent}},
+			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{version.UserAgent()}},
 			{Key: textproto.CanonicalMIMEHeaderKey("X-Prometheus-Remote-Read-Version"), Values: []string{"0.1.0"}},
 		}),
 	}
@@ -272,7 +271,7 @@ func (q *RemoteQuerier) createRequest(ctx context.Context, query string, ts time
 		Url:    q.promHTTPPrefix + queryEndpointPath,
 		Body:   body,
 		Headers: injectHTTPGrpcReadConsistencyHeader(ctx, []*httpgrpc.Header{
-			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{userAgent}},
+			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{version.UserAgent()}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Type"), Values: []string{mimeTypeFormPost}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Content-Length"), Values: []string{strconv.Itoa(len(body))}},
 			{Key: textproto.CanonicalMIMEHeaderKey("Accept"), Values: []string{acceptHeader}},

--- a/pkg/util/version/info.go
+++ b/pkg/util/version/info.go
@@ -77,3 +77,8 @@ func Print(program string) string {
 func Info() string {
 	return fmt.Sprintf("(version=%s, branch=%s, revision=%s)", Version, Branch, Revision)
 }
+
+// UserAgent returns build information in format suitable to be used in HTTP User-Agent header.
+func UserAgent() string {
+	return fmt.Sprintf("mimir/%s", Version)
+}


### PR DESCRIPTION
#### What this PR does

We've noticed, that the requests from GEM's ruler don't include the build information in the `User-Agent` header. After an internal discussion, we think that, even though this is somewhere specific to GEM, fixing it universally on the mimir's side wouldn't hurt.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
