### PR TITLE
Add out of order field to block index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 * [ENHANCEMENT] Distributor: set `-distributor.reusable-ingester-push-workers=2000` by default and mark feature as `advanced`. #7128
 * [ENHANCEMENT] All: set `-server.grpc.num-workers=100` by default and mark feature as `advanced`. #7131
 * [ENHANCEMENT] Distributor: invalid metric name error message gets cleaned up to not include non-ascii strings. #7146
-* [ENHANCEMENT] Store-gateway: add `source`, `level`, and `out_or_order` to `cortex_bucket_store_series_blocks_queried` metric that indicates the number of blocks that were queried from store gateways by block metadata. #7112 #7262
+* [ENHANCEMENT] Store-gateway: add `source`, `level`, and `out_or_order` to `cortex_bucket_store_series_blocks_queried` metric that indicates the number of blocks that were queried from store gateways by block metadata. #7112 #7262 #7267
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766

--- a/pkg/storage/tsdb/bucketindex/index_test.go
+++ b/pkg/storage/tsdb/bucketindex/index_test.go
@@ -175,6 +175,7 @@ func TestBlockFromThanosMeta(t *testing.T) {
 					MaxTime: 20,
 					Compaction: tsdb.BlockMetaCompaction{
 						Level: 1,
+						Hints: []string{tsdb.CompactionHintFromOutOfOrder},
 					},
 				},
 				Thanos: block.ThanosMeta{
@@ -194,6 +195,7 @@ func TestBlockFromThanosMeta(t *testing.T) {
 				SegmentsNum:     3,
 				Source:          "test",
 				CompactionLevel: 1,
+				OutOfOrder:      true,
 			},
 		},
 		"meta.json with Files": {
@@ -355,6 +357,7 @@ func TestBlock_ThanosMeta(t *testing.T) {
 				SegmentsNum:     3,
 				Source:          "test",
 				CompactionLevel: 1,
+				OutOfOrder:      true,
 			},
 			expected: &block.Meta{
 				BlockMeta: tsdb.BlockMeta{
@@ -364,6 +367,7 @@ func TestBlock_ThanosMeta(t *testing.T) {
 					Version: block.TSDBVersion1,
 					Compaction: tsdb.BlockMetaCompaction{
 						Level: 1,
+						Hints: []string{tsdb.CompactionHintFromOutOfOrder},
 					},
 				},
 				Thanos: block.ThanosMeta{

--- a/pkg/storage/tsdb/bucketindex/updater_test.go
+++ b/pkg/storage/tsdb/bucketindex/updater_test.go
@@ -252,6 +252,7 @@ func assertBucketIndexEqual(t testing.TB, idx *Index, bkt objstore.Bucket, userI
 			CompactorShardID: b.Thanos.Labels[mimir_tsdb.CompactorShardIDExternalLabel],
 			Source:           "test",
 			CompactionLevel:  1,
+			OutOfOrder:       false,
 		})
 	}
 

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -97,7 +97,7 @@ func newBlockQueriedMeta(meta *block.Meta) blockQueriedMeta {
 	return blockQueriedMeta{
 		source:     meta.Thanos.Source,
 		level:      meta.Compaction.Level,
-		outOfOrder: meta.OutOfOrder,
+		outOfOrder: meta.Compaction.FromOutOfOrder(),
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Follow-up to #7262 that adds a `out_of_order` field to the bucket index, allowing out of order information to be visible to store gateways, via their metadata fetching, for use in metrics.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
