### PR TITLE
[ingester] Fix limiter logic when number of zones > replication factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
   * `active_series`: active series query
   * `other`: any other request
 * [BUGFIX] Fix performance regression introduced in Mimir 2.11.0 when uploading blocks to AWS S3. #7240
+* [BUGFIX] Ingester: fix limiter behavior when number of zones in a zone-aware cluster is greater than the configured replication factor. #7273
 
 ### Mixin
 

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -74,7 +74,6 @@ func runLimiterMaxFunctionTest(
 		ringReplicationFactor    int
 		ringZoneAwarenessEnabled bool
 		ringIngesterCount        int
-		ringZonesCount           int
 		ingestersInZoneCount     int
 		shardSize                int
 		expectedValue            int
@@ -120,13 +119,11 @@ func runLimiterMaxFunctionTest(
 			shardSize:             20,  // Greater than number of ingesters.
 			expectedValue:         300, // (1000 / 10 ingesters) * 3 replication factor
 		},
-
 		"zone-awareness enabled, limit is disabled": {
 			globalLimit:              0,
 			ringReplicationFactor:    1,
 			ringIngesterCount:        1,
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     1,
 			expectedValue:            math.MaxInt32,
 		},
@@ -135,7 +132,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        9,
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     3, // 9 ingesters / 3 zones
 			shardSize:                0,
 			expectedValue:            300, // (900 / 3 zones / 3 ingesters per zone) * 3 replication factor
@@ -145,7 +141,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        8, // ingesters are scaled down from 9 to 8
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     2, // in this zone ingesters are scaled down from 3 to 2
 			shardSize:                0,
 			expectedValue:            450, // (900 / 3 zones / 2 ingesters per zone) * 3 replication factor
@@ -155,7 +150,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        8, // ingesters are scaled down from 9 to 8
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     3, // in this zone ingesters are NOT scaled down
 			shardSize:                0,
 			expectedValue:            300, // (900 / 3 zones / 3 ingesters per zone) * 3 replication factor
@@ -165,7 +159,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        10, // ingesters are scaled up from 9 to 10
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     4, // in this zone ingesters are scaled up from 3 to 4
 			shardSize:                0,
 			expectedValue:            225, // (900 / 3 zones / 4 ingesters per zone) * 3 replication factor
@@ -175,7 +168,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        10, // ingesters are scaled up from 9 to 10
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     3, // in this zone ingesters are NOT scaled up
 			shardSize:                0,
 			expectedValue:            300, // (900 / 3 zones / 3 ingesters per zone) * 3 replication factor
@@ -185,7 +177,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        9,
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     3,   // 9 ingesters / 3 zones
 			shardSize:                5,   // the expected number of ingesters per zone is (ceil(5/3) = 2
 			expectedValue:            450, // (900 / 3 zones / 2 ingesters per zone) * 3 replication factor
@@ -195,7 +186,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        7, // ingesters are scaled down from 9 to 7
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     1,   // in this zone ingesters are scaled down from 3 to 1
 			shardSize:                5,   // the expected number of ingesters per zone is (ceil(5/3) = 2
 			expectedValue:            900, // (900 / 3 zones / 1 ingesters per zone) * 3 replication factor
@@ -205,7 +195,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        7, // ingesters are scaled down from 9 to 7
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     3,   // in this zone ingesters are NOT scaled down (ignored because of shardSize)
 			shardSize:                5,   // the expected number of ingesters per zone is (ceil(5/3) = 2
 			expectedValue:            450, // (900 / 3 zones / 2 ingesters per zone) * 3 replication factor
@@ -215,7 +204,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        11, // ingesters are scaled up from 9 to 11
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     5,   // in this zone ingesters are scaled up from 3 to 5 (ignored because of shardSize)
 			shardSize:                5,   // the expected number of ingesters per zone is (ceil(5/3) = 2
 			expectedValue:            450, // (900 / 3 zones / 2 ingesters per zone) * 3 replication factor
@@ -225,7 +213,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        11, // ingesters are scaled up from 9 to 11
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     3,   // in this zone ingesters are NOT scaled up (ignored because of shardSize)
 			shardSize:                5,   // the expected number of ingesters per zone is (ceil(5/3) = 2
 			expectedValue:            450, // (900 / 3 zones / 2 ingesters per zone) * 3 replication factor
@@ -235,7 +222,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        9,
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     3,   // 9 ingesters / 3 zones
 			shardSize:                20,  // Greater than number of ingesters.
 			expectedValue:            300, // (900 / 3 zones / 3 ingesters per zone) * 3 replication factor
@@ -245,7 +231,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        8, // ingesters are scaled down from 9 to 8
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     2,   // in this zone ingesters are scaled down from 3 to 2
 			shardSize:                20,  // Greater than number of ingesters.
 			expectedValue:            450, // (900 / 3 zones / 2 ingesters per zone) * 3 replication factor
@@ -255,7 +240,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        8, // ingesters are scaled down from 9 to 8
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     3,   // in this zone ingesters are NOT scaled down
 			shardSize:                20,  // Greater than number of ingesters.
 			expectedValue:            300, // (900 / 3 zones / 3 ingesters per zone) * 3 replication factor
@@ -265,7 +249,6 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        11, // ingesters are scaled up from 9 to 11
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     5,   // in this zone ingesters are scaled up from 3 to 5
 			shardSize:                20,  // Greater than number of ingesters.
 			expectedValue:            180, // (900 / 3 zones / 5 ingesters per zone) * 3 replication factor
@@ -275,34 +258,40 @@ func runLimiterMaxFunctionTest(
 			ringReplicationFactor:    3,
 			ringIngesterCount:        11, // ingesters are scaled up from 9 to 11
 			ringZoneAwarenessEnabled: true,
-			ringZonesCount:           3,
 			ingestersInZoneCount:     3,   // in this zone ingesters are NOT scaled up
 			shardSize:                20,  // Greater than number of ingesters.
 			expectedValue:            300, // (900 / 3 zones / 3 ingesters per zone) * 3 replication factor
 		},
 	}
 
-	for testName, testData := range tests {
-		testData := testData
+	numZonesRFMultiplier := map[string]int{
+		"num zones == replication factor":    1,
+		"num zones = 2 * replication factor": 2,
+	}
 
-		t.Run(testName, func(t *testing.T) {
-			// Mock the ring
-			ring := &ringCountMock{}
-			ring.On("InstancesCount").Return(testData.ringIngesterCount)
-			ring.On("InstancesInZoneCount").Return(testData.ingestersInZoneCount)
-			ring.On("ZonesCount").Return(testData.ringZonesCount)
+	for zoneMultiplierName, zoneMultiplier := range numZonesRFMultiplier {
+		for testName, testData := range tests {
+			testData := testData
 
-			// Mock limits
-			limits := validation.Limits{IngestionTenantShardSize: testData.shardSize}
-			applyLimits(&limits, testData.globalLimit)
+			t.Run(zoneMultiplierName+", "+testName, func(t *testing.T) {
+				// Mock the ring
+				ring := &ringCountMock{}
+				ring.On("InstancesCount").Return(testData.ringIngesterCount)
+				ring.On("InstancesInZoneCount").Return(testData.ingestersInZoneCount)
+				ring.On("ZonesCount").Return(testData.ringReplicationFactor * zoneMultiplier)
 
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+				// Mock limits
+				limits := validation.Limits{IngestionTenantShardSize: testData.shardSize}
+				applyLimits(&limits, testData.globalLimit)
 
-			limiter := NewLimiter(overrides, ring, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled)
-			actual := runMaxFn(limiter)
-			assert.Equal(t, testData.expectedValue, actual)
-		})
+				overrides, err := validation.NewOverrides(limits, nil)
+				require.NoError(t, err)
+
+				limiter := NewLimiter(overrides, ring, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled)
+				actual := runMaxFn(limiter)
+				assert.Equal(t, testData.expectedValue, actual)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

According to the [Mimir docs](https://grafana.com/docs/mimir/latest/configure/configure-zone-aware-replication/#:~:text=Deploying%20Grafana%20Mimir%20clusters%20to%20more%20zones%20than%20the%20configured%20replication%20factor%20does%20not%20have%20a%20negative%20impact.%20Deploying%20Grafana%20Mimir%20clusters%20to%20fewer%20zones%20than%20the%20configured%20replication%20factor%20can%20cause%20writes%20to%20the%20replica%20to%20be%20missed%2C%20or%20can%20cause%20writes%20to%20fail%20completely.) it is valid to deploy a cluster with zone-aware replication to `num_zones` greater than than the configured `replication_factor`:

> Deploying Grafana Mimir clusters to more zones than the configured replication factor does not have a negative impact.

However, the existing limiter logic used the total number of zones in the ring when scaling global limits, even though a tenant's series are replicated to at most `replication_factor` zones.

For example, consider:
- Zone-aware cluster with 25 ingesters across 5 zones (5 ingesters per zone)
- Replication factor = `3`
- `-ingester.max-global-series-per-user` = `10000`
- `ingestion_tenant_shard_size` = `0` (shuffle-sharding disabled)

So, the tenant's series should be replicated to all `5` ingesters in `3` different zones, with each of those ingesters having a local limit of `10000/5` = `2000` series.

The existing code:
- [calculates the `zonesCount` as the number of zones in the ring](https://github.com/grafana/mimir/blob/911fd2663aa032989ea0ec28b06601a5d29fa333/pkg/ingester/limiter.go#L145-L150), so `zonesCount` = `6`
- [initializes `ingestersInZoneCount` to the number of ingester instances in each zone](https://github.com/grafana/mimir/blob/911fd2663aa032989ea0ec28b06601a5d29fa333/pkg/ingester/limiter.go#L115), so `ingestersInZoneCount` = `5`
- [calculates the local limit](https://github.com/grafana/mimir/blob/911fd2663aa032989ea0ec28b06601a5d29fa333/pkg/ingester/limiter.go#L138) as `(10000 * 3) / 6 / 5` = `1000`

The result is that the pre-replication global limit for the tenant is effectively `1000 * 15 / 3` = `5000`.

This PR changes the `num_zones` calculation to use the configured replication factor rather than the ring zone count. I've updated the existing tests to run a second time with `num_zones` = `2 * replication_factor`, since this scenario should produce the same results as when `num_zones` = `replication_factor`. 

Note that this produces incorrect results for `num_zones` < `replication_factor` (since `num_zones` *would* then be the number of zones in the ring), but [according to the docs](https://grafana.com/docs/mimir/latest/configure/configure-zone-aware-replication/#minimum-number-of-zones:~:text=Deploying%20Grafana%20Mimir%20clusters%20to%20fewer%20zones%20than%20the%20configured%20replication%20factor%20can%20cause%20writes%20to%20the%20replica%20to%20be%20missed%2C%20or%20can%20cause%20writes%20to%20fail%20completely.) this is an unsupported mode of operation:

> Deploying Grafana Mimir clusters to fewer zones than the configured replication factor can cause writes to the replica to be missed, or can cause writes to fail completely.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
