### PR TITLE
Internal: remove unnecessary parameter to NoCompactionMarkFilter

### DIFF
--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -679,7 +679,7 @@ func (c *BlocksCleaner) estimateCompactionJobsFrom(ctx context.Context, userID s
 	for _, f := range []block.MetadataFilter{
 		// We don't include ShardAwareDeduplicateFilter, because it relies on list of compaction sources, which are not present in the BucketIndex.
 		// We do include NoCompactionMarkFilter to avoid computing jobs from blocks that are marked for no-compaction.
-		NewNoCompactionMarkFilter(userBucket, true),
+		NewNoCompactionMarkFilter(userBucket),
 	} {
 		err := f.Filter(ctx, metas, synced)
 		if err != nil {

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -1018,16 +1018,14 @@ var _ block.MetadataFilter = &NoCompactionMarkFilter{}
 // NoCompactionMarkFilter is a block.Fetcher filter that finds all blocks with no-compact marker files, and optionally
 // removes them from synced metas.
 type NoCompactionMarkFilter struct {
-	bkt                   objstore.InstrumentedBucketReader
-	noCompactMarkedMap    map[ulid.ULID]struct{}
-	removeNoCompactBlocks bool
+	bkt                objstore.InstrumentedBucketReader
+	noCompactMarkedMap map[ulid.ULID]struct{}
 }
 
 // NewNoCompactionMarkFilter creates NoCompactionMarkFilter.
-func NewNoCompactionMarkFilter(bkt objstore.InstrumentedBucketReader, removeNoCompactBlocks bool) *NoCompactionMarkFilter {
+func NewNoCompactionMarkFilter(bkt objstore.InstrumentedBucketReader) *NoCompactionMarkFilter {
 	return &NoCompactionMarkFilter{
-		bkt:                   bkt,
-		removeNoCompactBlocks: removeNoCompactBlocks,
+		bkt: bkt,
 	}
 }
 
@@ -1054,9 +1052,7 @@ func (f *NoCompactionMarkFilter) Filter(ctx context.Context, metas map[ulid.ULID
 				noCompactMarkedMap[blockID] = struct{}{}
 				synced.WithLabelValues(block.MarkedForNoCompactionMeta).Inc()
 
-				if f.removeNoCompactBlocks {
-					delete(metas, blockID)
-				}
+				delete(metas, blockID)
 			}
 
 		}

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -225,7 +225,7 @@ func TestGroupCompactE2E(t *testing.T) {
 		reg := prometheus.NewRegistry()
 
 		duplicateBlocksFilter := NewShardAwareDeduplicateFilter()
-		noCompactMarkerFilter := NewNoCompactionMarkFilter(objstore.WithNoopInstr(bkt), true)
+		noCompactMarkerFilter := NewNoCompactionMarkFilter(objstore.WithNoopInstr(bkt))
 		metaFetcher, err := block.NewMetaFetcher(nil, 32, objstore.WithNoopInstr(bkt), "", nil, []block.MetadataFilter{
 			duplicateBlocksFilter,
 			noCompactMarkerFilter,

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -733,7 +733,7 @@ func (c *MultitenantCompactor) compactUser(ctx context.Context, userID string) e
 		}),
 		deduplicateBlocksFilter,
 		// removes blocks that should not be compacted due to being marked so.
-		NewNoCompactionMarkFilter(userBucket, true),
+		NewNoCompactionMarkFilter(userBucket),
 	}
 
 	fetcher, err := block.NewMetaFetcher(

--- a/tools/compaction-planner/main.go
+++ b/tools/compaction-planner/main.go
@@ -100,7 +100,7 @@ func main() {
 
 	for _, f := range []block.MetadataFilter{
 		// No need to exclude blocks marked for deletion, as we did that above already.
-		compactor.NewNoCompactionMarkFilter(bucket.NewUserBucketClient(cfg.userID, bkt, nil), true),
+		compactor.NewNoCompactionMarkFilter(bucket.NewUserBucketClient(cfg.userID, bkt, nil)),
 	} {
 		log.Printf("Filtering using %T\n", f)
 		err = f.Filter(ctx, metas, synced)


### PR DESCRIPTION
#### What this PR does

This PR removes obsolete and unnecessary parameter for NoCompactionMarkFilter.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/7299#discussion_r1478280436

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
