### PR TITLE
Chore: removed unused parameter from GenerateBlockFromSpec()

### DIFF
--- a/integration/compactor_test.go
+++ b/integration/compactor_test.go
@@ -96,7 +96,7 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 		}
 		expectedSeries[i] = series{lbls: spec.Labels, samples: samples}
 
-		meta, err := block.GenerateBlockFromSpec(userID, inDir, []*block.SeriesSpec{&spec})
+		meta, err := block.GenerateBlockFromSpec(inDir, []*block.SeriesSpec{&spec})
 		require.NoError(t, err)
 
 		require.NoError(t, block.Upload(context.Background(), log.NewNopLogger(), bktClient, filepath.Join(inDir, meta.ULID.String()), meta))

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1271,11 +1271,11 @@ func TestMultitenantCompactor_ShouldFailWithInvalidTSDBCompactOutput(t *testing.
 
 	storageDir := t.TempDir()
 
-	meta1, err := block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), sourceBlock1Spec)
+	meta1, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, user), sourceBlock1Spec)
 	require.NoError(t, err)
-	meta2, err := block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), sourceBlock2Spec)
+	meta2, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, user), sourceBlock2Spec)
 	require.NoError(t, err)
-	_, err = block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), sourceBlock3Spec)
+	_, err = block.GenerateBlockFromSpec(filepath.Join(storageDir, user), sourceBlock3Spec)
 	require.NoError(t, err)
 
 	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
@@ -1291,7 +1291,7 @@ func TestMultitenantCompactor_ShouldFailWithInvalidTSDBCompactOutput(t *testing.
 	mockCall.RunFn = func(args mock.Arguments) {
 		dir := args.Get(0).(string)
 
-		compactedMeta, err := block.GenerateBlockFromSpec(user, dir, compactedBlockSpec)
+		compactedMeta, err := block.GenerateBlockFromSpec(dir, compactedBlockSpec)
 		require.NoError(t, err)
 		f, err := os.OpenFile(filepath.Join(dir, compactedMeta.ULID.String(), "tombstones"), os.O_RDONLY|os.O_CREATE, 0666)
 		require.NoError(t, err)
@@ -1460,13 +1460,13 @@ func TestMultitenantCompactor_ShouldSkipCompactionForJobsWithFirstLevelCompactio
 		}))},
 	}}
 
-	user1Meta1, err := block.GenerateBlockFromSpec("user-1", filepath.Join(storageDir, "user-1"), spec)
+	user1Meta1, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, "user-1"), spec)
 	require.NoError(t, err)
-	user1Meta2, err := block.GenerateBlockFromSpec("user-1", filepath.Join(storageDir, "user-1"), spec)
+	user1Meta2, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, "user-1"), spec)
 	require.NoError(t, err)
-	user2Meta1, err := block.GenerateBlockFromSpec("user-2", filepath.Join(storageDir, "user-2"), spec)
+	user2Meta1, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, "user-2"), spec)
 	require.NoError(t, err)
-	user2Meta2, err := block.GenerateBlockFromSpec("user-2", filepath.Join(storageDir, "user-2"), spec)
+	user2Meta2, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, "user-2"), spec)
 	require.NoError(t, err)
 
 	// Mock the last modified timestamp returned for each of the block's meta.json.
@@ -2198,9 +2198,9 @@ func TestMultitenantCompactor_OutOfOrderCompaction(t *testing.T) {
 
 	storageDir := t.TempDir()
 	// We need two blocks to start compaction.
-	meta1, err := block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), specs)
+	meta1, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, user), specs)
 	require.NoError(t, err)
-	meta2, err := block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), specs)
+	meta2, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, user), specs)
 	require.NoError(t, err)
 
 	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
@@ -2264,9 +2264,9 @@ func TestMultitenantCompactor_CriticalIssue(t *testing.T) {
 
 	storageDir := t.TempDir()
 	// We need two blocks to start compaction.
-	meta1, err := block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), specs)
+	meta1, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, user), specs)
 	require.NoError(t, err)
-	meta2, err := block.GenerateBlockFromSpec(user, filepath.Join(storageDir, user), specs)
+	meta2, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, user), specs)
 	require.NoError(t, err)
 
 	// Force chunk to fall out of the block time range by modifying MaxTime.

--- a/pkg/storage/tsdb/block/block_generator.go
+++ b/pkg/storage/tsdb/block/block_generator.go
@@ -67,7 +67,7 @@ func (s SeriesSpecs) MaxTime() int64 {
 
 // GenerateBlockFromSpec generates a TSDB block with series and chunks provided by the input specs.
 // This utility is intended just to be used for testing. Do not use it for any production code.
-func GenerateBlockFromSpec(_ string, storageDir string, specs SeriesSpecs) (_ *Meta, returnErr error) {
+func GenerateBlockFromSpec(storageDir string, specs SeriesSpecs) (_ *Meta, returnErr error) {
 	blockID := ulid.MustNew(ulid.Now(), crypto_rand.Reader)
 	blockDir := filepath.Join(storageDir, blockID.String())
 

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -498,7 +498,7 @@ func TestBucketStore_Series_ShouldQueryBlockWithOutOfOrderChunks(t *testing.T) {
 	}
 
 	storageDir := t.TempDir()
-	_, err := block.GenerateBlockFromSpec(userID, filepath.Join(storageDir, userID), specs)
+	_, err := block.GenerateBlockFromSpec(filepath.Join(storageDir, userID), specs)
 	require.NoError(t, err)
 
 	bucket, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})

--- a/tools/tsdb-chunks/main_test.go
+++ b/tools/tsdb-chunks/main_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestTSDBChunks(t *testing.T) {
-	userID := "user"
 	tmpDir := t.TempDir()
 
 	spec := block.SeriesSpec{

--- a/tools/tsdb-chunks/main_test.go
+++ b/tools/tsdb-chunks/main_test.go
@@ -37,7 +37,7 @@ func TestTSDBChunks(t *testing.T) {
 		},
 	}
 
-	meta, err := block.GenerateBlockFromSpec(userID, tmpDir, []*block.SeriesSpec{&spec})
+	meta, err := block.GenerateBlockFromSpec(tmpDir, []*block.SeriesSpec{&spec})
 	require.NoError(t, err)
 
 	co := test.CaptureOutput(t)

--- a/tools/tsdb-index-health/main_test.go
+++ b/tools/tsdb-index-health/main_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestGatherIndexHealthStats(t *testing.T) {
-	userID := "user"
 	tmpDir := t.TempDir()
 
 	spec1 := block.SeriesSpec{

--- a/tools/tsdb-index-health/main_test.go
+++ b/tools/tsdb-index-health/main_test.go
@@ -48,7 +48,7 @@ func TestGatherIndexHealthStats(t *testing.T) {
 		},
 	}
 
-	meta, err := block.GenerateBlockFromSpec(userID, tmpDir, []*block.SeriesSpec{&spec1, &spec2})
+	meta, err := block.GenerateBlockFromSpec(tmpDir, []*block.SeriesSpec{&spec1, &spec2})
 	require.NoError(t, err)
 
 	blockDir := path.Join(tmpDir, meta.ULID.String())

--- a/tools/tsdb-print-chunk/main_test.go
+++ b/tools/tsdb-print-chunk/main_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestTSDBPrintChunk(t *testing.T) {
-	userID := "user"
 	tmpDir := t.TempDir()
 
 	spec := block.SeriesSpec{

--- a/tools/tsdb-print-chunk/main_test.go
+++ b/tools/tsdb-print-chunk/main_test.go
@@ -37,7 +37,7 @@ func TestTSDBPrintChunk(t *testing.T) {
 		},
 	}
 
-	meta, err := block.GenerateBlockFromSpec(userID, tmpDir, []*block.SeriesSpec{&spec})
+	meta, err := block.GenerateBlockFromSpec(tmpDir, []*block.SeriesSpec{&spec})
 	require.NoError(t, err)
 
 	blockDir := path.Join(tmpDir, meta.ULID.String())


### PR DESCRIPTION
#### What this PR does

While working on https://github.com/grafana/mimir/pull/7293 I've noticed that the 1st parameter passed to `GenerateBlockFromSpec()` is unused. In this PR I'm removing it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
