### PR TITLE
chunkIterator: optimize caching and AtT() calculation

### DIFF
--- a/pkg/querier/iterators/chunk_iterator.go
+++ b/pkg/querier/iterators/chunk_iterator.go
@@ -41,7 +41,7 @@ func (i *chunkIterator) Seek(t int64) chunkenc.ValueType {
 	if int64(i.Through) < t || i.isExhausted {
 		i.valType = chunkenc.ValNone
 		i.isExhausted = true
-		i.cachedTime = int64(i.Through)
+		i.cachedTime = -1
 		return chunkenc.ValNone
 	}
 


### PR DESCRIPTION
#### What this PR does
This PR improves the current implementation of `iterators.chunkIterator.AtT()`. Namely, if a cached value is not valid, the current implementation returns the timestamp obtained as a result of loading an appropriate value from the underlying iterator (of type `chunk.Iterator`). In order to retrieve the current timestamp it is, though, not necessary to load a new value, since the timestamp can be taken directly by calling the underlying iterator's `Timestamp()` function.

For example:
```
var it chunkIterator = ... // we create an instance of type chunkIterator

it.Next() // we initialize the iterator, but we don't load any value
ts := it.AtT() // we get the current timestamp from the underlying iterator, although we have never loaded a value

t, h := it.AtHistogram(nil) // we load and cahce a histogram
ts = it.AtT() // we get the current timestamp, which has been cached, i.e., t == ts

it.Next() // this call invalidates the cache, but moves to the next position in the underlying iterator
ts = it.AtT() // we get the new timestamp from the underlying iterator, without loading its value. t != ts
```

Moreover, this PR simplifies the checking whether the cached value is valid: auxiliary fields `cachedValueValid`, `cachedHistogramValid` and `cachedFloatHistogramValid` have been replaced with just one field `cacheValid`.

A comparison between the old and the new way of fetching the current timestamp showed that the latter requires less CPU:
```
                                        │   old.txt   │              new.txt               │
                                        │   sec/op    │   sec/op     vs base               │
ChunkIterator_AtT/float_chunk             44.90µ ± 4%   44.68µ ± 1%       ~ (p=0.190 n=10)
ChunkIterator_AtT/histogram_chunk         52.01µ ± 2%   46.99µ ± 2%  -9.65% (p=0.000 n=10)
ChunkIterator_AtT/float_histogram_chunk   54.04µ ± 1%   49.61µ ± 1%  -8.20% (p=0.000 n=10)
geomean                                                50.16µ        47.05µ       -6.20%

```

#### Which issue(s) this PR fixes or relates to

Part of #7235 

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
