### PR TITLE
querymiddleware: Pool snappy writer in shard activity series

### DIFF
--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -52,6 +52,18 @@ var (
 	}
 )
 
+var snappyWriterPool sync.Pool
+
+func getSnappyWriter(w io.Writer) *s2.Writer {
+	sw := snappyWriterPool.Get()
+	if sw == nil {
+		return s2.NewWriter(w)
+	}
+	enc := sw.(*s2.Writer)
+	enc.Reset(w)
+	return enc
+}
+
 type shardActiveSeriesMiddleware struct {
 	upstream http.RoundTripper
 	limits   Limits
@@ -257,7 +269,7 @@ func shardedSelector(shardCount, currentShard int, expr parser.Expr) (parser.Exp
 	}, nil
 }
 
-func (s *shardActiveSeriesMiddleware) mergeResponses(ctx context.Context, responses []*http.Response, acceptEncoding string) *http.Response {
+func (s *shardActiveSeriesMiddleware) mergeResponses(ctx context.Context, responses []*http.Response, encoding string) *http.Response {
 	reader, writer := io.Pipe()
 
 	items := make(chan *labels.Builder, len(responses))
@@ -326,29 +338,34 @@ func (s *shardActiveSeriesMiddleware) mergeResponses(ctx context.Context, respon
 		close(items)
 	}()
 
-	response := &http.Response{Body: reader, StatusCode: http.StatusOK, Header: http.Header{}}
-	response.Header.Set("Content-Type", "application/json")
-	if acceptEncoding == encodingTypeSnappyFramed {
-		response.Header.Set("Content-Encoding", encodingTypeSnappyFramed)
+	resp := &http.Response{Body: reader, StatusCode: http.StatusOK, Header: http.Header{}}
+	resp.Header.Set("Content-Type", "application/json")
+	if encoding == encodingTypeSnappyFramed {
+		resp.Header.Set("Content-Encoding", encodingTypeSnappyFramed)
 	}
 
-	go s.writeMergedResponse(ctx, g.Wait, writer, items, acceptEncoding)
+	go s.writeMergedResponse(ctx, g.Wait, writer, items, encoding)
 
-	return response
+	return resp
 }
 
-func (s *shardActiveSeriesMiddleware) writeMergedResponse(ctx context.Context, check func() error, w io.WriteCloser, items <-chan *labels.Builder, encodingType string) {
+func (s *shardActiveSeriesMiddleware) writeMergedResponse(ctx context.Context, check func() error, w io.WriteCloser, items <-chan *labels.Builder, encoding string) {
 	defer w.Close()
 
 	span, _ := opentracing.StartSpanFromContext(ctx, "shardActiveSeries.writeMergedResponse")
 	defer span.Finish()
 
 	var out io.Writer = w
-	if encodingType == encodingTypeSnappyFramed {
+	if encoding == encodingTypeSnappyFramed {
 		span.LogFields(otlog.String("encoding", encodingTypeSnappyFramed))
-		enc := s2.NewWriter(w)
-		defer enc.Close()
+		enc := getSnappyWriter(w)
 		out = enc
+		defer func() {
+			enc.Close()
+			// Reset the encoder before putting it back to pool to avoid it to hold the writer.
+			enc.Reset(nil)
+			snappyWriterPool.Put(enc)
+		}()
 	} else {
 		span.LogFields(otlog.String("encoding", "none"))
 	}

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -270,12 +271,6 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 			// Stub upstream with valid or invalid responses.
 			var requestCount atomic.Int32
 			upstream := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
-				defer func(body io.ReadCloser) {
-					if body != nil {
-						_ = body.Close()
-					}
-				}(r.Body)
-
 				_, _, err := user.ExtractOrgIDFromHTTPRequest(r)
 				require.NoError(t, err)
 				_, err = user.ExtractOrgID(r.Context())
@@ -355,6 +350,74 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 			}
 			assert.Equal(t, int32(expectedCount), requestCount.Load())
 		})
+	}
+}
+
+func Test_shardActiveSeriesMiddleware_RoundTrip_concurrent(t *testing.T) {
+	const shardCount = 4
+
+	upstream := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		require.NoError(t, r.ParseForm())
+		req, err := cardinality.DecodeActiveSeriesRequestFromValues(r.Form)
+		require.NoError(t, err)
+		shard, _, err := sharding.ShardFromMatchers(req.Matchers)
+		require.NoError(t, err)
+		require.NotNil(t, shard)
+
+		resp := fmt.Sprintf(`{"data": [{"__name__": "metric-%d"}]}`, shard.ShardIndex)
+
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(resp))}, nil
+	})
+
+	s := newShardActiveSeriesMiddleware(
+		upstream,
+		mockLimits{maxShardedQueries: shardCount, totalShards: shardCount},
+		log.NewNopLogger(),
+	)
+
+	assertRoundTrip := func(t *testing.T, trip http.RoundTripper, req *http.Request) {
+		resp, err := trip.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body io.Reader = resp.Body
+		if resp.Header.Get("Content-Encoding") == encodingTypeSnappyFramed {
+			body = s2.NewReader(resp.Body)
+		}
+
+		// For this test, if we can decode the response, it is enough to guaranty it worked. We proof actual validity
+		// of all kinds of responses in the tests above.
+		var res result
+		err = json.NewDecoder(body).Decode(&res)
+		require.NoError(t, err)
+		require.Len(t, res.Data, shardCount)
+	}
+
+	const reqCount = 20
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	wg.Add(reqCount)
+
+	for n := reqCount; n > 0; n-- {
+		go func(n int) {
+			defer wg.Done()
+
+			req := httptest.NewRequest("POST", "/active_series", strings.NewReader(`selector={__name__=~"metric-.*"}`))
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+			// Send every other request as snappy to proof the middleware doesn't mess up body encoders
+			if n%2 == 0 {
+				req.Header.Add("Accept-Encoding", encodingTypeSnappyFramed)
+			}
+
+			req = req.WithContext(user.InjectOrgID(req.Context(), "test"))
+
+			assertRoundTrip(t, s, req)
+		}(n)
 	}
 }
 

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -359,6 +359,16 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 }
 
 func BenchmarkActiveSeriesMiddlewareMergeResponses(b *testing.B) {
+	b.Run("encoding=none", func(b *testing.B) {
+		benchmarkActiveSeriesMiddlewareMergeResponses(b, "")
+	})
+
+	b.Run("encoding=snappy", func(b *testing.B) {
+		benchmarkActiveSeriesMiddlewareMergeResponses(b, encodingTypeSnappyFramed)
+	})
+}
+
+func benchmarkActiveSeriesMiddlewareMergeResponses(b *testing.B, encoding string) {
 	type activeSeriesResponse struct {
 		Data []labels.Labels `json:"data"`
 	}
@@ -392,7 +402,7 @@ func BenchmarkActiveSeriesMiddlewareMergeResponses(b *testing.B) {
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
-				resp := s.mergeResponses(context.Background(), benchResponses[i], "")
+				resp := s.mergeResponses(context.Background(), benchResponses[i], encoding)
 
 				_, _ = io.Copy(io.Discard, resp.Body)
 				_ = resp.Body.Close()


### PR DESCRIPTION
#### What this PR does

In https://github.com/grafana/mimir/pull/7290#pullrequestreview-1862270232 @pracucci suggested adding snappy writer to the existing benchmarks of the middleware. This PR splits `BenchmarkActiveSeriesMiddlewareMergeResponses` into two categories: with and without snappy encoding.

After comparing the with/without results, and since it seems that, shard activity series is a part of some warm path in GEM, I decided it's worth it to pool snappy writer. Here are the results before and after the optimization:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/frontend/querymiddleware
                                                                         │ /Users/v/tmp/bench-1.txt │      /Users/v/tmp/bench-2a.txt      │
                                                                         │          sec/op          │    sec/op     vs base               │
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-2-4                 33.25µ ± ∞ ¹   13.34µ ± ∞ ¹  -59.87% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-4-4                 33.75µ ± ∞ ¹   13.86µ ± ∞ ¹  -58.95% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-8-4                 35.84µ ± ∞ ¹   15.37µ ± ∞ ¹  -57.13% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-16-4                41.02µ ± ∞ ¹   20.87µ ± ∞ ¹  -49.13% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-32-4                50.65µ ± ∞ ¹   29.13µ ± ∞ ¹  -42.48% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-64-4                71.37µ ± ∞ ¹   45.73µ ± ∞ ¹  -35.93% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-128-4              106.21µ ± ∞ ¹   73.56µ ± ∞ ¹  -30.74% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-256-4               175.9µ ± ∞ ¹   138.6µ ± ∞ ¹  -21.19% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-512-4               308.8µ ± ∞ ¹   247.4µ ± ∞ ¹  -19.88% (p=0.008 n=5)
geomean                                                                                68.77µ         38.80µ        -43.58%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                         │ /Users/v/tmp/bench-1.txt │      /Users/v/tmp/bench-2a.txt       │
                                                                         │           B/op           │     B/op       vs base               │
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-2-4             2058.624Ki ± ∞ ¹   1.940Ki ± ∞ ¹  -99.91% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-4-4             2058.843Ki ± ∞ ¹   2.132Ki ± ∞ ¹  -99.90% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-8-4             2059.312Ki ± ∞ ¹   2.627Ki ± ∞ ¹  -99.87% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-16-4            2060.255Ki ± ∞ ¹   3.674Ki ± ∞ ¹  -99.82% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-32-4            2062.128Ki ± ∞ ¹   5.537Ki ± ∞ ¹  -99.73% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-64-4            2065.896Ki ± ∞ ¹   9.436Ki ± ∞ ¹  -99.54% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-128-4            2073.57Ki ± ∞ ¹   17.32Ki ± ∞ ¹  -99.16% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-256-4             2171.1Ki ± ∞ ¹   115.9Ki ± ∞ ¹  -94.66% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-512-4             2201.7Ki ± ∞ ¹   148.5Ki ± ∞ ¹  -93.26% (p=0.008 n=5)
geomean                                                                               2.041Mi         9.485Ki        -99.55%
¹ need >= 6 samples for confidence interval at level 0.95

                                                                         │ /Users/v/tmp/bench-1.txt │      /Users/v/tmp/bench-2a.txt      │
                                                                         │        allocs/op         │  allocs/op    vs base               │
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-2-4                  47.00 ± ∞ ¹    40.00 ± ∞ ¹  -14.89% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-4-4                  65.00 ± ∞ ¹    58.00 ± ∞ ¹  -10.77% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-8-4                 101.00 ± ∞ ¹    94.00 ± ∞ ¹   -6.93% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-16-4                 173.0 ± ∞ ¹    166.0 ± ∞ ¹   -4.05% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-32-4                 317.0 ± ∞ ¹    310.0 ± ∞ ¹   -2.21% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-64-4                 605.0 ± ∞ ¹    598.0 ± ∞ ¹   -1.16% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-128-4               1.181k ± ∞ ¹   1.174k ± ∞ ¹   -0.59% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-256-4               2.346k ± ∞ ¹   2.339k ± ∞ ¹   -0.30% (p=0.008 n=5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-512-4               4.650k ± ∞ ¹   4.643k ± ∞ ¹   -0.15% (p=0.008 n=5)
geomean                                                                                 370.6          353.2         -4.69%
¹ need >= 6 samples for confidence interval at level 0.95
```

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
