### PR TITLE
Add first level compaction delay to compactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * [ENHANCEMENT] Distributor: invalid metric name error message gets cleaned up to not include non-ascii strings. #7146
 * [ENHANCEMENT] Store-gateway: add `source`, `level`, and `out_or_order` to `cortex_bucket_store_series_blocks_queried` metric that indicates the number of blocks that were queried from store gateways by block metadata. #7112 #7262 #7267
 * [ENHANCEMENT] Compactor: After updating bucket-index, compactor now also computes estimated number of compaction jobs based on current bucket-index, and reports the result in `cortex_bucket_index_estimated_compaction_jobs` metric. If computation of jobs fails, `cortex_bucket_index_estimated_compaction_jobs_errors_total` is updated instead. #7299
+* [ENHANCEMENT] Compactor: Add `first_level_compaction_delay` setting and deprecate `first_level_compaction_wait_period`.  #7311
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8887,7 +8887,7 @@
           "kind": "field",
           "name": "first_level_compaction_delay",
           "required": false,
-          "desc": "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters, relative to the current time and the block's maxT. This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. This setting replaces first-level-compaction-wait-period when enabled.",
+          "desc": "How long the compactor delays before compacting first-level blocks that are uploaded by the ingesters, comparing the current time to the block's maxT. This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. This setting replaces first-level-compaction-wait-period when enabled.",
           "fieldValue": null,
           "fieldDefaultValue": 0,
           "fieldFlag": "compactor.first-level-compaction-delay",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8876,10 +8876,21 @@
           "kind": "field",
           "name": "first_level_compaction_wait_period",
           "required": false,
-          "desc": "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage.",
+          "desc": "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. first-level-compaction-delay should be used instead of this setting.",
           "fieldValue": null,
           "fieldDefaultValue": 1500000000000,
           "fieldFlag": "compactor.first-level-compaction-wait-period",
+          "fieldType": "duration",
+          "fieldCategory": "deprecated"
+        },
+        {
+          "kind": "field",
+          "name": "first_level_compaction_delay",
+          "required": false,
+          "desc": "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters, relative to the current time and the block's maxT. This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. This setting replaces first-level-compaction-wait-period when enabled.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "compactor.first-level-compaction-delay",
           "fieldType": "duration"
         },
         {

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -958,7 +958,7 @@ Usage of ./cmd/mimir/mimir:
   -compactor.enabled-tenants comma-separated-list-of-strings
     	Comma separated list of tenants that can be compacted. If specified, only these tenants will be compacted by compactor, otherwise all tenants can be compacted. Subject to sharding.
   -compactor.first-level-compaction-delay duration
-    	How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters, relative to the current time and the block's maxT. This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. This setting replaces first-level-compaction-wait-period when enabled.
+    	How long the compactor delays before compacting first-level blocks that are uploaded by the ingesters, comparing the current time to the block's maxT. This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. This setting replaces first-level-compaction-wait-period when enabled.
   -compactor.first-level-compaction-wait-period duration
     	[deprecated] How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. first-level-compaction-delay should be used instead of this setting. (default 25m0s)
   -compactor.max-block-upload-validation-concurrency int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -957,8 +957,10 @@ Usage of ./cmd/mimir/mimir:
     	Comma separated list of tenants that cannot be compacted by this compactor. If specified, and compactor would normally pick given tenant for compaction (via -compactor.enabled-tenants or sharding), it will be ignored instead.
   -compactor.enabled-tenants comma-separated-list-of-strings
     	Comma separated list of tenants that can be compacted. If specified, only these tenants will be compacted by compactor, otherwise all tenants can be compacted. Subject to sharding.
+  -compactor.first-level-compaction-delay duration
+    	How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters, relative to the current time and the block's maxT. This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. This setting replaces first-level-compaction-wait-period when enabled.
   -compactor.first-level-compaction-wait-period duration
-    	How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. (default 25m0s)
+    	[deprecated] How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. first-level-compaction-delay should be used instead of this setting. (default 25m0s)
   -compactor.max-block-upload-validation-concurrency int
     	Max number of uploaded blocks that can be validated concurrently. 0 = no limit. (default 1)
   -compactor.max-closing-blocks-concurrency int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -313,8 +313,8 @@ Usage of ./cmd/mimir/mimir:
     	Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
   -compactor.data-dir string
     	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor/")
-  -compactor.first-level-compaction-wait-period duration
-    	How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. (default 25m0s)
+  -compactor.first-level-compaction-delay duration
+    	How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters, relative to the current time and the block's maxT. This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. This setting replaces first-level-compaction-wait-period when enabled.
   -compactor.partial-block-deletion-delay duration
     	If a partial block (unfinished block without meta.json file) hasn't been modified for this time, it will be marked for deletion. The minimum accepted value is 4h0m0s: a lower value will be ignored and the feature disabled. 0 to disable. (default 1d)
   -compactor.ring.consul.hostname string

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -314,7 +314,7 @@ Usage of ./cmd/mimir/mimir:
   -compactor.data-dir string
     	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor/")
   -compactor.first-level-compaction-delay duration
-    	How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters, relative to the current time and the block's maxT. This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. This setting replaces first-level-compaction-wait-period when enabled.
+    	How long the compactor delays before compacting first-level blocks that are uploaded by the ingesters, comparing the current time to the block's maxT. This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. This setting replaces first-level-compaction-wait-period when enabled.
   -compactor.partial-block-deletion-delay duration
     	If a partial block (unfinished block without meta.json file) hasn't been modified for this time, it will be marked for deletion. The minimum accepted value is 4h0m0s: a lower value will be ignored and the feature disabled. 0 to disable. (default 1d)
   -compactor.ring.consul.hostname string

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3977,8 +3977,8 @@ The `compactor` block configures the compactor component.
 # CLI flag: -compactor.first-level-compaction-wait-period
 [first_level_compaction_wait_period: <duration> | default = 25m]
 
-# How long the compactor waits before compacting first-level blocks that are
-# uploaded by the ingesters, relative to the current time and the block's maxT.
+# How long the compactor delays before compacting first-level blocks that are
+# uploaded by the ingesters, comparing the current time to the block's maxT.
 # This setting allows for the reduction of cases where the compactor begins to
 # compact blocks before all ingesters have uploaded their blocks to the storage.
 # This setting replaces first-level-compaction-wait-period when enabled.

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3969,12 +3969,21 @@ The `compactor` block configures the compactor component.
 # CLI flag: -compactor.compaction-concurrency
 [compaction_concurrency: <int> | default = 1]
 
-# How long the compactor waits before compacting first-level blocks that are
-# uploaded by the ingesters. This configuration option allows for the reduction
-# of cases where the compactor begins to compact blocks before all ingesters
-# have uploaded their blocks to the storage.
+# (deprecated) How long the compactor waits before compacting first-level blocks
+# that are uploaded by the ingesters. This configuration option allows for the
+# reduction of cases where the compactor begins to compact blocks before all
+# ingesters have uploaded their blocks to the storage.
+# first-level-compaction-delay should be used instead of this setting.
 # CLI flag: -compactor.first-level-compaction-wait-period
 [first_level_compaction_wait_period: <duration> | default = 25m]
+
+# How long the compactor waits before compacting first-level blocks that are
+# uploaded by the ingesters, relative to the current time and the block's maxT.
+# This setting allows for the reduction of cases where the compactor begins to
+# compact blocks before all ingesters have uploaded their blocks to the storage.
+# This setting replaces first-level-compaction-wait-period when enabled.
+# CLI flag: -compactor.first-level-compaction-delay
+[first_level_compaction_delay: <duration> | default = 0s]
 
 # (advanced) How frequently compactor should run blocks cleanup and maintenance,
 # as well as update the bucket index.

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -238,7 +238,7 @@ func TestGroupCompactE2E(t *testing.T) {
 		planner := NewSplitAndMergePlanner([]int64{1000, 3000})
 		grouper := NewSplitAndMergeGrouper("user-1", []int64{1000, 3000}, 0, 0, logger)
 		metrics := NewBucketCompactorMetrics(blocksMarkedForDeletion, prometheus.NewPedanticRegistry())
-		bComp, err := NewBucketCompactor(logger, sy, grouper, planner, comp, dir, bkt, 2, true, ownAllJobs, sortJobsByNewestBlocksFirst, 0, 4, metrics)
+		bComp, err := NewBucketCompactor(logger, sy, grouper, planner, comp, dir, bkt, 2, true, ownAllJobs, sortJobsByNewestBlocksFirst, 0, 0, 4, metrics)
 		require.NoError(t, err)
 
 		// Compaction on empty should not fail.

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -140,7 +140,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.IntVar(&cfg.CompactionConcurrency, "compactor.compaction-concurrency", 1, "Max number of concurrent compactions running.")
 	f.DurationVar(&cfg.CompactionWaitPeriod, "compactor.first-level-compaction-wait-period", 25*time.Minute, "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. "+
 		"first-level-compaction-delay should be used instead of this setting.")
-	f.DurationVar(&cfg.FirstLevelCompactionDelay, "compactor.first-level-compaction-delay", 0, "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters, relative to the current time and the block's maxT. "+
+	f.DurationVar(&cfg.FirstLevelCompactionDelay, "compactor.first-level-compaction-delay", 0, "How long the compactor delays before compacting first-level blocks that are uploaded by the ingesters, comparing the current time to the block's maxT. "+
 		"This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. "+
 		"This setting replaces first-level-compaction-wait-period when enabled.",
 	)

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -88,7 +88,8 @@ type Config struct {
 	CompactionInterval         time.Duration           `yaml:"compaction_interval" category:"advanced"`
 	CompactionRetries          int                     `yaml:"compaction_retries" category:"advanced"`
 	CompactionConcurrency      int                     `yaml:"compaction_concurrency" category:"advanced"`
-	CompactionWaitPeriod       time.Duration           `yaml:"first_level_compaction_wait_period"`
+	CompactionWaitPeriod       time.Duration           `yaml:"first_level_compaction_wait_period" category:"deprecated"` // Deprecated. TODO: Remove in Mimir 2.13.
+	FirstLevelCompactionDelay  time.Duration           `yaml:"first_level_compaction_delay"`
 	CleanupInterval            time.Duration           `yaml:"cleanup_interval" category:"advanced"`
 	CleanupConcurrency         int                     `yaml:"cleanup_concurrency" category:"advanced"`
 	DeletionDelay              time.Duration           `yaml:"deletion_delay" category:"advanced"`
@@ -137,7 +138,12 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.DurationVar(&cfg.MaxCompactionTime, "compactor.max-compaction-time", time.Hour, "Max time for starting compactions for a single tenant. After this time no new compactions for the tenant are started before next compaction cycle. This can help in multi-tenant environments to avoid single tenant using all compaction time, but also in single-tenant environments to force new discovery of blocks more often. 0 = disabled.")
 	f.IntVar(&cfg.CompactionRetries, "compactor.compaction-retries", 3, "How many times to retry a failed compaction within a single compaction run.")
 	f.IntVar(&cfg.CompactionConcurrency, "compactor.compaction-concurrency", 1, "Max number of concurrent compactions running.")
-	f.DurationVar(&cfg.CompactionWaitPeriod, "compactor.first-level-compaction-wait-period", 25*time.Minute, "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage.")
+	f.DurationVar(&cfg.CompactionWaitPeriod, "compactor.first-level-compaction-wait-period", 25*time.Minute, "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. "+
+		"first-level-compaction-delay should be used instead of this setting.")
+	f.DurationVar(&cfg.FirstLevelCompactionDelay, "compactor.first-level-compaction-delay", 0, "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters, relative to the current time and the block's maxT. "+
+		"This setting allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. "+
+		"This setting replaces first-level-compaction-wait-period when enabled.",
+	)
 	f.DurationVar(&cfg.CleanupInterval, "compactor.cleanup-interval", 15*time.Minute, "How frequently compactor should run blocks cleanup and maintenance, as well as update the bucket index.")
 	f.IntVar(&cfg.CleanupConcurrency, "compactor.cleanup-concurrency", 20, "Max number of tenants for which blocks cleanup and maintenance should run concurrently.")
 	f.StringVar(&cfg.CompactionJobsOrder, "compactor.compaction-jobs-order", CompactionOrderOldestFirst, fmt.Sprintf("The sorting to use when deciding which compaction jobs should run first for a given tenant. Supported values are: %s.", strings.Join(CompactionOrders, ", ")))
@@ -773,6 +779,7 @@ func (c *MultitenantCompactor) compactUser(ctx context.Context, userID string) e
 		c.shardingStrategy.ownJob,
 		c.jobsOrder,
 		c.compactorCfg.CompactionWaitPeriod,
+		c.compactorCfg.FirstLevelCompactionDelay,
 		c.compactorCfg.BlockSyncConcurrency,
 		c.bucketCompactorMetrics,
 	)


### PR DESCRIPTION
#### What this PR does

This PR introduces a new compactor setting: `first_level_compaction_delay`, and deprecates `first_level_compaction_wait_period`. The goal of this new setting is to allow compaction to proceed or not relative to the maxT of the job, along with some delay. This avoids the problem described in #7279 where blocks that are uploaded late for earlier time periods can prevent L1 compaction from happening.

The new setting is only applied when configured, which it is not by default. Since `first_level_compaction_delay` allows blocks to be considered for compaction that normally wouldn't be using `first_level_compaction_wait_period`, only the new setting is evaluated when enabled, else the previous setting is still evaluated.

#### Which issue(s) this PR fixes or relates to

Fixes #7279

#### Follow-up PRs

- Update helm chart

#### Future PRs

- Set a default value for `first_level_compaction_delay`, such as `90m`

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
