### PR TITLE
Deregister compat metrics

### DIFF
--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -187,7 +187,7 @@ func (am *MultitenantAlertmanager) DeleteUserConfig(w http.ResponseWriter, r *ht
 
 // Partially copied from: https://github.com/prometheus/alertmanager/blob/8e861c646bf67599a1704fc843c6a94d519ce312/cli/check_config.go#L65-L96
 func validateUserConfig(logger log.Logger, cfg alertspb.AlertConfigDesc, limits Limits, user string) error {
-	validateMatchersInConfigDesc(logger, compat.RegisteredMetrics, "api", cfg)
+	validateMatchersInConfigDesc(logger, compat.NewMetrics(nil), "api", cfg)
 
 	// We don't have a valid use case for empty configurations. If a tenant does not have a
 	// configuration set and issue a request to the Alertmanager, we'll a) upload an empty

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -683,7 +683,7 @@ func (am *MultitenantAlertmanager) setConfig(cfg alertspb.AlertConfigDesc) error
 	// which is correct, but Mimir uses config.Load to validate both API requests and tenant
 	// configurations. This means metrics from API requests are confused with metrics from
 	// tenant configurations. To avoid this confusion, we use a different origin.
-	validateMatchersInConfigDesc(am.logger, compat.RegisteredMetrics, "tenant", cfg)
+	validateMatchersInConfigDesc(am.logger, compat.NewMetrics(nil), "tenant", cfg)
 
 	// List existing files to keep track of the ones to be removed
 	if oldTemplateFiles, err := os.ReadDir(userTemplateDir); err == nil {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -892,7 +892,7 @@ func (t *Mimir) initAlertManager() (serv services.Service, err error) {
 	}
 	features, err := featurecontrol.NewFlags(util_log.Logger, mode)
 	util_log.CheckFatal("initializing Alertmanager feature flags", err)
-	compat.InitFromFlags(util_log.Logger, compat.RegisteredMetrics, features)
+	compat.InitFromFlags(util_log.Logger, compat.NewMetrics(nil), features)
 
 	t.Cfg.Alertmanager.ShardingRing.Common.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.Cfg.Alertmanager.CheckExternalURL(t.Cfg.API.AlertmanagerHTTPPrefix, util_log.Logger)

--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -114,7 +114,7 @@ func (a *AlertmanagerCommand) setup(_ *kingpin.ParseContext) error {
 	if err != nil {
 		return err
 	}
-	compat.InitFromFlags(l, compat.RegisteredMetrics, flags)
+	compat.InitFromFlags(l, compat.NewMetrics(nil), flags)
 
 	cli, err := client.New(a.ClientConfig)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does

This commit deregisters the compat metrics in Mimir. These metrics are not proving as useful as expected, due to the fact that the compat package is global and Mimir reloads configurations at fixed intervals. Instead, we use the logs from the compat package to learn about incompatible inputs and disagreement.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
