### PR TITLE
Do not register compat metrics in mimirtool

### DIFF
--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -114,7 +114,7 @@ func (a *AlertmanagerCommand) setup(_ *kingpin.ParseContext) error {
 	if err != nil {
 		return err
 	}
-	compat.InitFromFlags(l, compat.RegisteredMetrics, flags)
+	compat.InitFromFlags(l, compat.NewMetrics(nil), flags)
 
 	cli, err := client.New(a.ClientConfig)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does

This commit does the same as we did for amtool in prometheus/alertmanager#3713. There is no need to register these metrics, so we use `compat.NewMetrics(nil)` instead of `compat.RegisteredMetrics`.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
