### PR TITLE
Do not check for ingester ring state before creating TSDB, or compacting / shipping blocks

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -948,7 +948,7 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReques
 		return nil
 	}
 
-	db, err := i.getOrCreateTSDB(userID, false)
+	db, err := i.getOrCreateTSDB(userID)
 	if err != nil {
 		return wrapOrAnnotateWithUser(err, userID)
 	}
@@ -2317,7 +2317,7 @@ func (i *Ingester) getTSDBUsers() []string {
 	return ids
 }
 
-func (i *Ingester) getOrCreateTSDB(userID string, force bool) (*userTSDB, error) {
+func (i *Ingester) getOrCreateTSDB(userID string) (*userTSDB, error) {
 	db := i.getTSDB(userID)
 	if db != nil {
 		return db, nil

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -4814,7 +4814,7 @@ func TestIngester_shipBlocks(t *testing.T) {
 	// Create the TSDB for 3 users and then replace the shipper with the mocked one
 	mocks := []*uploaderMock{}
 	for _, userID := range []string{"user-1", "user-2", "user-3"} {
-		userDB, err := i.getOrCreateTSDB(userID, false)
+		userDB, err := i.getOrCreateTSDB(userID)
 		require.NoError(t, err)
 		require.NotNil(t, userDB)
 
@@ -4985,7 +4985,7 @@ func TestIngester_closingAndOpeningTsdbConcurrently(t *testing.T) {
 		return i.lifecycler.HealthyInstancesCount()
 	})
 
-	_, err = i.getOrCreateTSDB(userID, false)
+	_, err = i.getOrCreateTSDB(userID)
 	require.NoError(t, err)
 
 	iterations := 5000
@@ -4998,7 +4998,7 @@ func TestIngester_closingAndOpeningTsdbConcurrently(t *testing.T) {
 			case <-quit:
 				return
 			default:
-				_, err = i.getOrCreateTSDB(userID, false)
+				_, err = i.getOrCreateTSDB(userID)
 				if err != nil {
 					chanErr <- err
 				}
@@ -5038,7 +5038,7 @@ func TestIngester_idleCloseEmptyTSDB(t *testing.T) {
 		return i.lifecycler.HealthyInstancesCount()
 	})
 
-	db, err := i.getOrCreateTSDB(userID, true)
+	db, err := i.getOrCreateTSDB(userID)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 
@@ -5054,7 +5054,7 @@ func TestIngester_idleCloseEmptyTSDB(t *testing.T) {
 	require.Nil(t, db)
 
 	// And we can recreate it again, if needed.
-	db, err = i.getOrCreateTSDB(userID, true)
+	db, err = i.getOrCreateTSDB(userID)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 }
@@ -5493,7 +5493,7 @@ func TestIngester_ForFlush(t *testing.T) {
 
 func mockUserShipper(t *testing.T, i *Ingester) *uploaderMock {
 	m := &uploaderMock{}
-	userDB, err := i.getOrCreateTSDB(userID, false)
+	userDB, err := i.getOrCreateTSDB(userID)
 	require.NoError(t, err)
 	require.NotNil(t, userDB)
 
@@ -9701,7 +9701,7 @@ func TestIngester_lastUpdatedTimeIsNotInTheFuture(t *testing.T) {
 		return i.lifecycler.HealthyInstancesCount()
 	})
 
-	db, err := i.getOrCreateTSDB(userID, true)
+	db, err := i.getOrCreateTSDB(userID)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 	require.InDelta(t, time.Now().Unix(), db.getLastUpdate().Unix(), 5) // within 5 seconds of "now"
@@ -9714,7 +9714,7 @@ func TestIngester_lastUpdatedTimeIsNotInTheFuture(t *testing.T) {
 	i.closeAllTSDB()
 
 	// and open it again (it must exist)
-	db, err = i.getOrCreateTSDB(userID, false)
+	db, err = i.getOrCreateTSDB(userID)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 


### PR DESCRIPTION
#### What this PR does

While reviewing the usage of the ingesters ring lifecycler, as part of the work we're doing to introduce an experimental ingest storage based on Kafka, I've noticed that we still have checks that were originally introduced (in Cortex) as part of the blocks transfer feature we had. The blocks transfer was a feature that allowed a shutting down ingester to transfer its blocks to another ingester before terminating the process. This feature was soon removed from Cortex and never existed in Mimir.

In this PR I propose to remove the checks we do on the ingester's state, that were introduced for the blocks transfer. This means that, after this PR, blocks can be compacted and shipper whatever is the state of the ingester in the ring (which shouldn't be an issue IMO) and same for the TSDB creation. However, in practice TSDB can only be created when ingester is in Running state, due to another check (preserved) on the ingester service state (see updated test).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
