### PR TITLE
Circuit breakers: add client.ErrCircuitBreakerOpen type

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
 	"github.com/go-kit/log"
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/flagext"
@@ -1042,6 +1043,21 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDistributor_PushWithCircuitBreakers(t *testing.T) {
+	ds, _, _ := prepare(t, prepConfig{
+		numIngesters:       3,
+		happyIngesters:     3,
+		numDistributors:    1,
+		circuitBreakerOpen: true,
+	})
+
+	ctx := user.InjectOrgID(context.Background(), "user")
+	err := ds[0].push(ctx, NewParsedRequest(makeWriteRequest(123456789000, 10, 0, false, true, "foo")))
+	require.Error(t, err)
+	require.ErrorIs(t, err, circuitbreaker.ErrOpen)
+	require.ErrorAs(t, err, &client.ErrCircuitBreakerOpen{})
 }
 
 func TestDistributor_PushQuery(t *testing.T) {
@@ -3511,7 +3527,8 @@ type prepConfig struct {
 
 	configure func(*Config)
 
-	timeOut bool
+	timeOut            bool
+	circuitBreakerOpen bool
 }
 
 // totalIngesters takes into account ingesterStateByZone and numIngesters.
@@ -3636,6 +3653,7 @@ func prepareIngesterZone(zone string, state ingesterZoneState, cfg prepConfig) [
 			zone:                          zone,
 			labelNamesStreamResponseDelay: labelNamesStreamResponseDelay,
 			timeOut:                       cfg.timeOut,
+			circuitBreakerOpen:            cfg.circuitBreakerOpen,
 		})
 	}
 	return ingesters
@@ -4111,6 +4129,7 @@ type mockIngester struct {
 	timeOut                       bool
 	tokens                        []uint32
 	id                            int
+	circuitBreakerOpen            bool
 }
 
 func (i *mockIngester) address() string {
@@ -4155,6 +4174,10 @@ func (i *mockIngester) Push(ctx context.Context, req *mimirpb.WriteRequest, _ ..
 
 	if i.timeOut {
 		return nil, context.DeadlineExceeded
+	}
+
+	if i.circuitBreakerOpen {
+		return nil, client.ErrCircuitBreakerOpen{}
 	}
 
 	if len(req.Timeseries) > 0 && i.timeseries == nil {

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 
+	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/globalerror"
@@ -220,6 +221,8 @@ func toGRPCError(pushErr error, serviceOverloadErrorEnabled bool) error {
 		case mimirpb.TOO_MANY_CLUSTERS:
 			errCode = codes.FailedPrecondition
 		}
+	} else if errors.As(pushErr, &client.ErrCircuitBreakerOpen{}) {
+		errCode = codes.Unavailable
 	}
 	stat := status.New(errCode, pushErr.Error())
 	if errDetails != nil {

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/opentracing/opentracing-go"
 
+	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/globalerror"
@@ -227,6 +228,8 @@ func toHTTPStatus(ctx context.Context, pushErr error, limits *validation.Overrid
 		case mimirpb.TSDB_UNAVAILABLE:
 			return http.StatusServiceUnavailable
 		}
+	} else if errors.As(pushErr, &client.ErrCircuitBreakerOpen{}) {
+		return http.StatusServiceUnavailable
 	}
 
 	return http.StatusInternalServerError

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
 	"github.com/go-kit/log"
 	"github.com/golang/snappy"
 	"github.com/grafana/dskit/flagext"
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/dskit/httpgrpc/server"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/user"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage/remote"
@@ -35,6 +36,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"google.golang.org/grpc/codes"
 
+	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/test"
@@ -1133,6 +1135,16 @@ func TestHandler_ToHTTPStatus(t *testing.T) {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, context.DeadlineExceeded.Error(), mimirpb.UNKNOWN_CAUSE), ingesterID),
 			expectedHTTPStatus: http.StatusInternalServerError,
 			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, context.DeadlineExceeded),
+		},
+		"a client.ErrCircuitBreakerOpen error gets translated into an HTTP 503": {
+			err:                client.ErrCircuitBreakerOpen{},
+			expectedHTTPStatus: http.StatusServiceUnavailable,
+			expectedErrorMsg:   circuitbreaker.ErrOpen.Error(),
+		},
+		"a wrapped client.ErrCircuitBreakerOpen error gets translated into an HTTP 503": {
+			err:                errors.Wrap(client.ErrCircuitBreakerOpen{}, fmt.Sprintf("%s %s", failedPushingToIngesterMessage, ingesterID)),
+			expectedHTTPStatus: http.StatusServiceUnavailable,
+			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, circuitbreaker.ErrOpen),
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
#### What this PR does
This PR introduces a new error type, `client.ErrCircuitBreakerOpen`, that wraps Fail-safe's `circuitbreaker.ErrOpen` error and that provides the remaining delay after which a call to the corresponding client may be retried, via the `RemainingDelay()` function. 

In case of a `client.ErrCircuitBreakerOpen` error, calls to `/distributor.Distributor/Push` and `/api/v1/push/` endpoints will return errors with gRPC code `codes.Unavailable` and HTTP status code `503` respectively.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
