### PR TITLE
Improve compaction of sporadic blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 * [BUGFIX] Compactor: do not allow out-of-order blocks to prevent timely compaction. #7342
 * [BUGFIX] Update `google.golang.org/grpc` to resolve occasional issues with gRPC server closing its side of connection before it was drained by the client. #7380
 * [BUGFIX] Query-frontend: abort response streaming for `active_series` requests when the request context is canceled. #7378
+* [BUGFIX] Compactor: improve compaction of sporadic blocks. #7329
 
 ### Mixin
 

--- a/integration/store_gateway_limits_hit_test.go
+++ b/integration/store_gateway_limits_hit_test.go
@@ -42,6 +42,7 @@ func Test_MaxSeriesAndChunksPerQueryLimitHit(t *testing.T) {
 			"-blocks-storage.tsdb.retention-period":             blockRangePeriod.String(), // We want blocks to be immediately deleted from ingesters.
 			"-blocks-storage.tsdb.ship-interval":                "1s",
 			"-blocks-storage.tsdb.head-compaction-interval":     "500ms",
+			"-compactor.first-level-compaction-wait-period":     "1m", // Do not compact aggressively
 		},
 	)
 

--- a/pkg/compactor/split_merge_compactor_test.go
+++ b/pkg/compactor/split_merge_compactor_test.go
@@ -142,10 +142,6 @@ func TestMultitenantCompactor_ShouldSupportSplitAndMergeCompactor(t *testing.T) 
 				block1 := createTSDBBlock(t, bkt, userID, 0, (5 * time.Minute).Milliseconds(), numSeries, externalLabels(""))
 				block2 := createTSDBBlock(t, bkt, userID, time.Minute.Milliseconds(), (7 * time.Minute).Milliseconds(), numSeries, externalLabels(""))
 
-				// Add another block as "most recent one" otherwise the previous blocks are not compacted
-				// because the most recent blocks must cover the full range to be compacted.
-				block3 := createTSDBBlock(t, bkt, userID, blockRangeMillis, blockRangeMillis+time.Minute.Milliseconds(), numSeries, externalLabels(""))
-
 				return []block.Meta{
 					{
 						BlockMeta: tsdb.BlockMeta{
@@ -172,18 +168,6 @@ func TestMultitenantCompactor_ShouldSupportSplitAndMergeCompactor(t *testing.T) 
 							Labels: map[string]string{
 								mimir_tsdb.CompactorShardIDExternalLabel: "2_of_2",
 							},
-						},
-					}, {
-						// Not compacted.
-						BlockMeta: tsdb.BlockMeta{
-							MinTime: blockRangeMillis,
-							MaxTime: blockRangeMillis + time.Minute.Milliseconds(),
-							Compaction: tsdb.BlockMetaCompaction{
-								Sources: []ulid.ULID{block3},
-							},
-						},
-						Thanos: block.ThanosMeta{
-							Labels: map[string]string{},
 						},
 					},
 				}
@@ -195,10 +179,6 @@ func TestMultitenantCompactor_ShouldSupportSplitAndMergeCompactor(t *testing.T) 
 				block1 := createTSDBBlock(t, bkt, userID, 0, (5 * time.Minute).Milliseconds(), numSeries, externalLabels(""))
 				block2 := createTSDBBlock(t, bkt, userID, (5 * time.Minute).Milliseconds(), (10 * time.Minute).Milliseconds(), numSeries, externalLabels(""))
 
-				// Add another block as "most recent one" otherwise the previous blocks are not compacted
-				// because the most recent blocks must cover the full range to be compacted.
-				block3 := createTSDBBlock(t, bkt, userID, blockRangeMillis, blockRangeMillis+time.Minute.Milliseconds(), numSeries, externalLabels(""))
-
 				return []block.Meta{
 					{
 						BlockMeta: tsdb.BlockMeta{
@@ -225,18 +205,6 @@ func TestMultitenantCompactor_ShouldSupportSplitAndMergeCompactor(t *testing.T) 
 							Labels: map[string]string{
 								mimir_tsdb.CompactorShardIDExternalLabel: "2_of_2",
 							},
-						},
-					}, {
-						// Not compacted.
-						BlockMeta: tsdb.BlockMeta{
-							MinTime: blockRangeMillis,
-							MaxTime: blockRangeMillis + time.Minute.Milliseconds(),
-							Compaction: tsdb.BlockMetaCompaction{
-								Sources: []ulid.ULID{block3},
-							},
-						},
-						Thanos: block.ThanosMeta{
-							Labels: map[string]string{},
 						},
 					},
 				}
@@ -248,10 +216,6 @@ func TestMultitenantCompactor_ShouldSupportSplitAndMergeCompactor(t *testing.T) 
 				block1 := createTSDBBlock(t, bkt, userID, 0, (5 * time.Minute).Milliseconds(), numSeries, externalLabels(""))
 				block2 := createTSDBBlock(t, bkt, userID, (7 * time.Minute).Milliseconds(), (10 * time.Minute).Milliseconds(), numSeries, externalLabels(""))
 
-				// Add another block as "most recent one" otherwise the previous blocks are not compacted
-				// because the most recent blocks must cover the full range to be compacted.
-				block3 := createTSDBBlock(t, bkt, userID, blockRangeMillis, blockRangeMillis+time.Minute.Milliseconds(), numSeries, externalLabels(""))
-
 				return []block.Meta{
 					{
 						BlockMeta: tsdb.BlockMeta{
@@ -278,18 +242,6 @@ func TestMultitenantCompactor_ShouldSupportSplitAndMergeCompactor(t *testing.T) 
 							Labels: map[string]string{
 								mimir_tsdb.CompactorShardIDExternalLabel: "2_of_2",
 							},
-						},
-					}, {
-						// Not compacted.
-						BlockMeta: tsdb.BlockMeta{
-							MinTime: blockRangeMillis,
-							MaxTime: blockRangeMillis + time.Minute.Milliseconds(),
-							Compaction: tsdb.BlockMetaCompaction{
-								Sources: []ulid.ULID{block3},
-							},
-						},
-						Thanos: block.ThanosMeta{
-							Labels: map[string]string{},
 						},
 					},
 				}
@@ -492,10 +444,6 @@ func TestMultitenantCompactor_ShouldSupportSplitAndMergeCompactor(t *testing.T) 
 				block1 := createTSDBBlock(t, bkt, userID, 0, (5 * time.Minute).Milliseconds(), numSeries, externalLabels(""))
 				block2 := createTSDBBlock(t, bkt, userID, (5 * time.Minute).Milliseconds(), (10 * time.Minute).Milliseconds(), numSeries, externalLabels(""))
 
-				// Add another block as "most recent one" otherwise the previous blocks are not compacted
-				// because the most recent blocks must cover the full range to be compacted.
-				block3 := createTSDBBlock(t, bkt, userID, blockRangeMillis, blockRangeMillis+time.Minute.Milliseconds(), numSeries, externalLabels(""))
-
 				return []block.Meta{
 					// Compacted but not split.
 					{
@@ -504,18 +452,6 @@ func TestMultitenantCompactor_ShouldSupportSplitAndMergeCompactor(t *testing.T) 
 							MaxTime: (10 * time.Minute).Milliseconds(),
 							Compaction: tsdb.BlockMetaCompaction{
 								Sources: []ulid.ULID{block1, block2},
-							},
-						},
-						Thanos: block.ThanosMeta{
-							Labels: map[string]string{},
-						},
-					}, {
-						// Not compacted.
-						BlockMeta: tsdb.BlockMeta{
-							MinTime: blockRangeMillis,
-							MaxTime: blockRangeMillis + time.Minute.Milliseconds(),
-							Compaction: tsdb.BlockMetaCompaction{
-								Sources: []ulid.ULID{block3},
 							},
 						},
 						Thanos: block.ThanosMeta{

--- a/pkg/compactor/split_merge_job.go
+++ b/pkg/compactor/split_merge_job.go
@@ -131,6 +131,19 @@ func (g blocksGroup) maxTime() int64 {
 	return max
 }
 
+// maxCompactionLevel returns the highest Compaction.Level across all blocks in the group.
+func (g blocksGroup) maxCompactionLevel() int {
+	maxLevel := g.blocks[0].Compaction.Level
+
+	for _, b := range g.blocks[1:] {
+		if b.Compaction.Level > maxLevel {
+			maxLevel = b.Compaction.Level
+		}
+	}
+
+	return maxLevel
+}
+
 // getNonShardedBlocks returns the list of non-sharded blocks.
 func (g blocksGroup) getNonShardedBlocks() []*block.Meta {
 	var out []*block.Meta

--- a/pkg/compactor/split_merge_job_test.go
+++ b/pkg/compactor/split_merge_job_test.go
@@ -257,3 +257,23 @@ func TestBlocksGroup_getNonShardedBlocks(t *testing.T) {
 		assert.Equal(t, tc.expected, tc.input.getNonShardedBlocks())
 	}
 }
+
+func TestBlocksGroup_MaxTime(t *testing.T) {
+	bg := blocksGroup{blocks: []*block.Meta{
+		{BlockMeta: tsdb.BlockMeta{MaxTime: 10}},
+		{BlockMeta: tsdb.BlockMeta{MaxTime: 20}},
+		{BlockMeta: tsdb.BlockMeta{MaxTime: 30}},
+	}}
+
+	assert.Equal(t, int64(30), bg.maxTime())
+}
+
+func TestBlocksGroup_MaxCompactionLevel(t *testing.T) {
+	bg := blocksGroup{blocks: []*block.Meta{
+		{BlockMeta: tsdb.BlockMeta{Compaction: tsdb.BlockMetaCompaction{Level: 1}}},
+		{BlockMeta: tsdb.BlockMeta{Compaction: tsdb.BlockMetaCompaction{Level: 3}}},
+		{BlockMeta: tsdb.BlockMeta{Compaction: tsdb.BlockMetaCompaction{Level: 2}}},
+	}}
+
+	assert.Equal(t, 3, bg.maxCompactionLevel())
+}


### PR DESCRIPTION
#### What this PR does

This PR changes the split_merge_grouper's check that's meant to filter recent blocks based on the `highestMaxTime`, to allow jobs where either the:

- maxTime is at least 1 full job range in the past, since users may not have uploaded recent blocks (described in [#7265](https://github.com/grafana/mimir/issues/7265)), but we don't want that to stop compaction from happening.
- max compaction level is 1, since filtering level 1 jobs is [handled separately](https://github.com/grafana/mimir/blob/015ddf691df2488d49013475c1c542a01dbcc3e6/pkg/compactor/bucket_compactor.go#L1002-L1018). This condition allows compaction to proceed more quickly than waiting on the above condition to be met for L1 blocks.

Together, these conditions address users who upload blocks sporadically, where currently compaction does not occur as expected (as described in #7265).

#### Which issue(s) this PR fixes or relates to

Fixes #7265

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
