### PR TITLE
Do not consider out-of-order blocks when filtering compactable jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [BUGFIX] Query-frontend: fix race condition when sharding active series is enabled (see above) and response is compressed with snappy. #7290
 * [BUGFIX] Query-frontend: "query stats" log unsuccessful replies from downstream as "failed". #7296
 * [BUGFIX] Packaging: remove reload from systemd file as mimir does not take into account SIGHUP. #7345
+* [BUGFIX] Compactor: do not allow out-of-order blocks to prevent timely compaction. #7342
 
 ### Mixin
 

--- a/pkg/compactor/job.go
+++ b/pkg/compactor/job.go
@@ -165,11 +165,15 @@ func jobWaitPeriodElapsed(ctx context.Context, job *Job, waitPeriod time.Duratio
 		return true, nil, nil
 	}
 
-	// Check if the job contains any source block uploaded more recently
-	// than "wait period" ago.
+	// Check if the job contains any source block uploaded more recently than "wait period" ago,
+	// ignoring out of order blocks.
 	threshold := time.Now().Add(-waitPeriod)
 
 	for _, meta := range job.Metas() {
+		if meta.OutOfOrder || meta.Compaction.FromOutOfOrder() {
+			continue
+		}
+
 		metaPath := path.Join(meta.ULID.String(), block.MetaFilename)
 
 		attrs, err := userBucket.Attributes(ctx, metaPath)

--- a/pkg/compactor/job_test.go
+++ b/pkg/compactor/job_test.go
@@ -100,7 +100,7 @@ func TestJobWaitPeriodElapsed(t *testing.T) {
 			waitPeriod: 10 * time.Minute,
 			jobBlocks: []jobBlock{
 				{meta: meta5, attrs: objstore.ObjectAttributes{LastModified: time.Now().Add(-20 * time.Minute)}},
-				{meta: meta6, attrs: objstore.ObjectAttributes{LastModified: time.Now().Add(-15 * time.Minute)}},
+				{meta: meta6, attrs: objstore.ObjectAttributes{LastModified: time.Now().Add(-5 * time.Minute)}},
 			},
 			expectedElapsed: true,
 			expectedMeta:    nil,

--- a/pkg/compactor/job_test.go
+++ b/pkg/compactor/job_test.go
@@ -47,6 +47,12 @@ func TestJobWaitPeriodElapsed(t *testing.T) {
 	meta3 := &block.Meta{BlockMeta: tsdb.BlockMeta{ULID: ulid.MustNew(3, nil), Compaction: tsdb.BlockMetaCompaction{Level: 2}}}
 	meta4 := &block.Meta{BlockMeta: tsdb.BlockMeta{ULID: ulid.MustNew(4, nil), Compaction: tsdb.BlockMetaCompaction{Level: 2}}}
 
+	// OOO blocks
+	meta5 := &block.Meta{BlockMeta: tsdb.BlockMeta{ULID: ulid.MustNew(5, nil), Compaction: tsdb.BlockMetaCompaction{Level: 1}}}
+	meta6 := &block.Meta{BlockMeta: tsdb.BlockMeta{ULID: ulid.MustNew(6, nil), Compaction: tsdb.BlockMetaCompaction{Level: 1}}}
+	meta5.Compaction.SetOutOfOrder()
+	meta6.Compaction.SetOutOfOrder()
+
 	tests := map[string]struct {
 		waitPeriod      time.Duration
 		jobBlocks       []jobBlock
@@ -86,6 +92,15 @@ func TestJobWaitPeriodElapsed(t *testing.T) {
 			jobBlocks: []jobBlock{
 				{meta: meta3, attrs: objstore.ObjectAttributes{LastModified: time.Now().Add(-4 * time.Minute)}},
 				{meta: meta4, attrs: objstore.ObjectAttributes{LastModified: time.Now().Add(-5 * time.Minute)}},
+			},
+			expectedElapsed: true,
+			expectedMeta:    nil,
+		},
+		"out of order block": {
+			waitPeriod: 10 * time.Minute,
+			jobBlocks: []jobBlock{
+				{meta: meta5, attrs: objstore.ObjectAttributes{LastModified: time.Now().Add(-20 * time.Minute)}},
+				{meta: meta6, attrs: objstore.ObjectAttributes{LastModified: time.Now().Add(-15 * time.Minute)}},
 			},
 			expectedElapsed: true,
 			expectedMeta:    nil,


### PR DESCRIPTION
#### What this PR does

This PR excludes out-of-order blocks when deciding if a job should be filtered based on whether the first level compaction wait period has elapsed. This ensures that out-of-order blocks, which may be uploaded late, do not prevent compaction for a job containing blocks that were uploaded earlier.

#### Which issue(s) this PR fixes or relates to

Fixes #7279

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

### Testing

I ran this for a day with many OOO blocks being created, and did not observe any compactions being skipped due to OOO blocks.
