### PR TITLE
Packaging: remove reload from systemd file as mimir does not take into account SIGHUP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 * [BUGFIX] Fix performance regression introduced in Mimir 2.11.0 when uploading blocks to AWS S3. #7240
 * [BUGFIX] Query-frontend: fix race condition when sharding active series is enabled (see above) and response is compressed with snappy. #7290
 * [BUGFIX] Query-frontend: "query stats" log unsuccessful replies from downstream as "failed". #7296
+* [BUGFIX] Packaging: remove reload from systemd file as mimir does not take into account SIGHUP. #7345
 
 ### Mixin
 

--- a/packaging/nfpm/mimir/mimir.service
+++ b/packaging/nfpm/mimir/mimir.service
@@ -14,7 +14,6 @@ Restart=always
 User=mimir
 EnvironmentFile=$OS_ENV_DIR/mimir
 ExecStart=/usr/local/bin/mimir --config.file=/etc/mimir/config.yml --runtime-config.file=/etc/mimir/runtime_config.yml --log.level $LOG_LEVEL $CUSTOM_ARGS
-ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=20s
 SendSIGKILL=no
 WorkingDirectory=/var/lib/mimir


### PR DESCRIPTION
#### What this PR does

remove reload from systemd file as mimir does not take into account SIGHUP.
It can be unnoticied as mimir will die upon receiving SIGHUP and systemd will pick it up and restart it.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
