### PR TITLE
User circuit breaker remaining delay to calculate the Retry-After delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [FEATURE] Alertmanager API: added `-alertmanager.grafana-alertmanager-compatibility-enabled` CLI flag (and respective YAML config option) to enable an experimental API endpoints that support the migration of the Grafana Alertmanager. #7057
 * [FEATURE] Alertmanager: Added `-alertmanager.utf8-strict-mode-enabled` to control support for any UTF-8 character as part of Alertmanager configuration/API matchers and labels. It's default value is set to `false`. #6898
 * [FEATURE] Querier: added `histogram_avg()` function support to PromQL. #7293
+* [FEATURE] Distributor: added option `-distributor.retry-after-header.circuit-breaker-awareness-enabled` that, when enabled, makes the `Retry-After` delay calculation take into account the remaining time a circuit breaker will be open, so that the failed request doesn't get retried before. #7347
 * [ENHANCEMENT] Vault: add lifecycle manager for token used to authenticate to Vault. This ensures the client token is always valid. Includes a gauge (`cortex_vault_token_lease_renewal_active`) to check whether token renewal is active, and the counters `cortex_vault_token_lease_renewal_success_total` and `cortex_vault_auth_success_total` to see the total number of successful lease renewals / authentications. #7337
 * [ENHANCEMENT] Store-gateway: add no-compact details column on store-gateway tenants admin UI. #6848
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -785,6 +785,16 @@
               "fieldFlag": "distributor.retry-after-header.max-backoff-exponent",
               "fieldType": "int",
               "fieldCategory": "experimental"
+            },
+            {
+              "kind": "field",
+              "name": "circuit_breaker_awareness_enabled",
+              "required": false,
+              "desc": "",
+              "fieldValue": null,
+              "fieldDefaultValue": false,
+              "fieldType": "boolean",
+              "fieldCategory": "experimental"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1167,6 +1167,8 @@ Usage of ./cmd/mimir/mimir:
     	Per-tenant push request rate limit in requests per second. 0 to disable.
   -distributor.retry-after-header.base-seconds int
     	[experimental] Base duration in seconds for calculating the Retry-After header in responses to 429/5xx errors. (default 3)
+  -distributor.retry-after-header.circuit-breaker-awareness-enabled
+    	[experimental] When enabled, calculates the Retry-After delay taking into account circuit breaker's remaining delay. In this case the Retry-After delay must be greater or equal to the circuit breaker's remaining delay, if that value doesn't exceed the maximum allowed retry duration calculated as base-seconds * 2^max-backoff-exponent.
   -distributor.retry-after-header.enabled
     	[experimental] Enabled controls inclusion of the Retry-After header in the response: true includes it for client retry guidance, false omits it.
   -distributor.retry-after-header.max-backoff-exponent int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -763,6 +763,9 @@ retry_after_header:
   # CLI flag: -distributor.retry-after-header.max-backoff-exponent
   [max_backoff_exponent: <int> | default = 5]
 
+  # (experimental)
+  [circuit_breaker_awareness_enabled: <boolean> | default = ]
+
 ha_tracker:
   # Enable the distributors HA tracker so that it can accept samples from
   # Prometheus HA replicas gracefully (requires labels).

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -53,9 +54,10 @@ const (
 )
 
 type RetryConfig struct {
-	Enabled            bool `yaml:"enabled" category:"experimental"`
-	BaseSeconds        int  `yaml:"base_seconds" category:"experimental"`
-	MaxBackoffExponent int  `yaml:"max_backoff_exponent" category:"experimental"`
+	Enabled                        bool `yaml:"enabled" category:"experimental"`
+	BaseSeconds                    int  `yaml:"base_seconds" category:"experimental"`
+	MaxBackoffExponent             int  `yaml:"max_backoff_exponent" category:"experimental"`
+	CircuitBreakerAwarenessEnabled bool `yaml:"circuit_breaker_awareness_enabled" category:"experimental"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -63,6 +65,7 @@ func (cfg *RetryConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.Enabled, "distributor.retry-after-header.enabled", false, "Enabled controls inclusion of the Retry-After header in the response: true includes it for client retry guidance, false omits it.")
 	f.IntVar(&cfg.BaseSeconds, "distributor.retry-after-header.base-seconds", 3, "Base duration in seconds for calculating the Retry-After header in responses to 429/5xx errors.")
 	f.IntVar(&cfg.MaxBackoffExponent, "distributor.retry-after-header.max-backoff-exponent", 5, "Sets the upper limit on the number of Retry-Attempt considered for calculation. It caps the Retry-Attempt header without rejecting additional attempts, controlling exponential backoff calculations. For example, when the base-seconds is set to 3 and max-backoff-exponent to 5, the maximum retry duration would be 3 * 2^5 = 96 seconds.")
+	f.BoolVar(&cfg.Enabled, "distributor.retry-after-header.circuit-breaker-awareness-enabled", false, "When enabled, calculates the Retry-After delay taking into account circuit breaker's remaining delay. In this case the Retry-After delay must be greater or equal to the circuit breaker's remaining delay, if that value doesn't exceed the maximum allowed retry duration calculated as base-seconds * 2^max-backoff-exponent.")
 }
 
 func (cfg *RetryConfig) Validate() error {
@@ -176,7 +179,7 @@ func handler(
 	})
 }
 
-func calculateRetryAfter(retryAttemptHeader string, baseSeconds int, maxBackoffExponent int) string {
+func calculateRetryAfter(retryAttemptHeader string, baseSeconds int, maxBackoffExponent int, circuitBreakerDelaySeconds float64) string {
 	retryAttempt, err := strconv.Atoi(retryAttemptHeader)
 	// If retry-attempt is not valid, set it to default 1
 	if err != nil || retryAttempt < 1 {
@@ -185,12 +188,15 @@ func calculateRetryAfter(retryAttemptHeader string, baseSeconds int, maxBackoffE
 	if retryAttempt > maxBackoffExponent {
 		retryAttempt = maxBackoffExponent
 	}
-	var minSeconds, maxSeconds int64
+	var (
+		minSeconds, maxSeconds int64
+		maxAllowedDelay        = baseSeconds << maxBackoffExponent
+	)
 	minSeconds = int64(baseSeconds) << (retryAttempt - 1)
-	maxSeconds = int64(minSeconds) << 1
+	maxSeconds = minSeconds << 1
 
 	delaySeconds := minSeconds + rand.Int63n(maxSeconds-minSeconds)
-
+	delaySeconds = int64(math.Min(math.Max(float64(delaySeconds), circuitBreakerDelaySeconds), float64(maxAllowedDelay)))
 	return strconv.FormatInt(delaySeconds, 10)
 }
 
@@ -243,7 +249,15 @@ func addHeaders(w http.ResponseWriter, err error, r *http.Request, responseCode 
 	if responseCode == http.StatusTooManyRequests || responseCode/100 == 5 {
 		if retryCfg.Enabled {
 			retryAttemptHeader := r.Header.Get("Retry-Attempt")
-			retrySeconds := calculateRetryAfter(retryAttemptHeader, retryCfg.BaseSeconds, retryCfg.MaxBackoffExponent)
+			circuitBreakerDelaySeconds := 0.0
+			if retryCfg.CircuitBreakerAwarenessEnabled {
+				var errCircuitBreakerOpen circuitBreakerOpenError
+				if errors.As(err, &errCircuitBreakerOpen) {
+					circuitBreakerDelaySeconds = errCircuitBreakerOpen.RemainingDelay().Seconds()
+				}
+			}
+			retrySeconds := calculateRetryAfter(retryAttemptHeader, retryCfg.BaseSeconds, retryCfg.MaxBackoffExponent, circuitBreakerDelaySeconds)
+
 			w.Header().Set("Retry-After", retrySeconds)
 			if sp := opentracing.SpanFromContext(r.Context()); sp != nil {
 				sp.SetTag("retry-after", retrySeconds)

--- a/pkg/ingester/client/circuitbreaker.go
+++ b/pkg/ingester/client/circuitbreaker.go
@@ -46,6 +46,10 @@ type ErrCircuitBreakerOpen struct {
 	remainingDelay time.Duration
 }
 
+func NewErrCircuitBreakerOpen(remainingDelay time.Duration) ErrCircuitBreakerOpen {
+	return ErrCircuitBreakerOpen{remainingDelay: remainingDelay}
+}
+
 func (e ErrCircuitBreakerOpen) RemainingDelay() time.Duration {
 	return e.remainingDelay
 }
@@ -105,7 +109,7 @@ func NewCircuitBreaker(inst ring.InstanceDesc, cfg CircuitBreakerConfig, metrics
 
 		if err != nil && errors.Is(err, circuitbreaker.ErrOpen) {
 			countOpen.Inc()
-			return ErrCircuitBreakerOpen{remainingDelay: breaker.RemainingDelay()}
+			return NewErrCircuitBreakerOpen(breaker.RemainingDelay())
 		}
 
 		return err


### PR DESCRIPTION
#### What this PR does
This PR changes the current procedure for calculating the `Retry-After` delay by taking into account the remaining circuit breaker delay. Currently the `Retry-After` delay is calculated this way:
- we select a random value `r` between `baseSeconds * 2^(retryAttempt - 1)` (inclusive) and `baseSeconds * 2^retryAttempt)` (exclusive),
- we return the minimium between `r` and `baseSeconds * 2^maxBackoffExponent`, because the delay must never be higher than the latter, 
 
where `retryAttempt` is the current retry attempt present in the request's header, while `baseSeconds` and `maxBackoffExponent` are configured values of CLI flags `-distributor.retry-after-header.base-seconds` and `distributor.retry-after-header.max-backoff-exponent`.

This PR introduces a possibility to force the `Retry-After` calculation to wait at least until an open circuit breaker retries, i.e.,
- we select a random value `r` between `baseSeconds * 2^(retryAttempt - 1)` (inclusive) and `baseSeconds * 2^retryAttempt)` (exclusive),
- we choose the maximum between `r` and `circuitBreakerRemainingDelay`
- if the value calculated at the previous step is higher than the maximum allowed value `baseSeconds * 2^maxBackoffExponent`, we return the latter, 

where `circuitBreakerRemainingDelay` is the remaining time in seconds an open circuit breaker will remain in the open state before it retries. 

In order to allow the new way of calculation, the newly added CLI flag `-distributor.retry-after-header.circuit-breaker-awareness-enabled` must be set to `true`.
 
#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
