### PR TITLE
Jsonnet / Helm: improve distributors graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
   * `-compactor.ring.heartbeat-period` set to `1m`
   * `-compactor.ring.heartbeat-timeout` set to `4m`
 * [CHANGE] Ruler-querier: the topology spread constrain max skew is now configured through the configuration option `ruler_querier_topology_spread_max_skew` instead of `querier_topology_spread_max_skew`. #7204
+* [CHANGE] Distributor: `-server.grpc.keepalive.max-connection-age` lowered from `2m` to `60s` and configured `-shutdown-delay=90s` and termination grace period to `100` seconds in order to reduce the chances of failed gRPC write requests when distributors gracefully shutdown. #7361
 * [FEATURE] Added support for the following root-level settings to configure the list of matchers to apply to node affinity: #6782 #6829
   * `alertmanager_node_affinity_matchers`
   * `compactor_node_affinity_matchers`

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -44,6 +44,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add `jaegerReporterMaxQueueSize` Helm value for all components where configuring `JAEGER_REPORTER_MAX_QUEUE_SIZE` makes sense, and override the Jaeger client's default value of 100 for components expected to generate many trace spans. #7068 #7086 #7259
 * [ENHANCEMENT] Rollout-operator: upgraded to v0.10.1. #7125
 * [ENHANCEMENT] Query-frontend: configured `-shutdown-delay`, `-server.grpc.keepalive.max-connection-age` and termination grace period to reduce the likelihood of queries hitting terminated query-frontends. #7129
+* [ENHANCEMENT] Distributor: reduced `-server.grpc.keepalive.max-connection-age` from `2m` to `60s` and configured `-shutdown-delay` to `90s` in order to reduce the chances of failed gRPC write requests when distributors gracefully shutdown. #7361
 * [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the `ruler` component by setting `ruler.serivceAcount.create` to true in the values. #7132
 * [ENHANCEMENT] nginx, Gateway: set `proxy_http_version: 1.1` to proxy to HTTP 1.1. #5040
 * [ENHANCEMENT] Gateway: make Ingress/Route host templateable. #7218

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -41,6 +41,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Ruler: Set `-distributor.remote-timeout` to 10s in order to accommodate writing large rule results to the ingester. #7143
 * [CHANGE] Remove `-server.grpc.keepalive.max-connection-age` and `-server.grpc.keepalive.max-connection-age-grace` from default config. The configuration now applied directly to distributor, fixing parity with jsonnet. #7269
 * [CHANGE] Remove `-server.grpc.keepalive.max-connection-idle` from default config. The configuration now applied directly to distributor, fixing parity with jsonnet. #7298
+* [CHANGE] Distributor: termination grace period increased from 60s to 100s.
 * [ENHANCEMENT] Add `jaegerReporterMaxQueueSize` Helm value for all components where configuring `JAEGER_REPORTER_MAX_QUEUE_SIZE` makes sense, and override the Jaeger client's default value of 100 for components expected to generate many trace spans. #7068 #7086 #7259
 * [ENHANCEMENT] Rollout-operator: upgraded to v0.10.1. #7125
 * [ENHANCEMENT] Query-frontend: configured `-shutdown-delay`, `-server.grpc.keepalive.max-connection-age` and termination grace period to reduce the likelihood of queries hitting terminated query-frontends. #7129

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -47,10 +47,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           {{- if .Values.ingester.zoneAwareReplication.migration.enabled }}
             {{- if not .Values.ingester.zoneAwareReplication.migration.writePath }}
             - "-ingester.ring.zone-awareness-enabled=false"

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -49,8 +49,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -819,7 +819,8 @@ distributor:
       maxUnavailable: 0
       maxSurge: 15%
 
-  terminationGracePeriodSeconds: 60
+  # Keep the termination grace period higher than the -shutdown-delay configured on the distributor.
+  terminationGracePeriodSeconds: 100
 
   tolerations: []
   initContainers: []

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
               
             - mountPath: /certs

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -127,7 +126,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -122,7 +121,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -120,7 +119,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -122,7 +121,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -122,7 +121,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -120,7 +119,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -51,10 +51,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -53,8 +53,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -119,7 +118,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -120,7 +119,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -122,7 +121,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -55,10 +55,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -57,8 +57,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -125,7 +124,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -122,7 +121,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -51,10 +51,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -53,8 +53,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -118,7 +117,7 @@ spec:
             release: test-enterprise-legacy-label-values
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           secret:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -122,7 +121,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           secret:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -120,7 +119,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -120,7 +119,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -120,7 +119,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -120,7 +119,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -56,8 +56,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -120,7 +119,7 @@ spec:
             component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -54,10 +54,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -55,10 +55,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -57,8 +57,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -123,7 +122,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -61,10 +61,14 @@ spec:
             - "-target=distributor"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
-            # Force gRPC clients connecting to distributor to reconnect periodically in order to have them re-resolve endpoints and discover new replicas.
-            - "-server.grpc.keepalive.max-connection-age=2m"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -63,8 +63,7 @@ spec:
             - "-config.file=/etc/mimir/mimir.yaml"
             # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
             # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
-            # To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
-            # termination grace period (to give some extra buffer to the process to gracefully shutdown).
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
             - "-server.grpc.keepalive.max-connection-age=60s"
             - "-server.grpc.keepalive.max-connection-age-grace=5m"
             - "-server.grpc.keepalive.max-connection-idle=1m"
@@ -127,7 +126,7 @@ spec:
             app.kubernetes.io/component: distributor
       tolerations:
         []
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 100
       volumes:
         - name: config
           configMap:

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -521,12 +521,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -559,6 +560,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -697,12 +697,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -735,6 +736,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -636,12 +636,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -674,6 +675,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -636,12 +636,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -674,6 +675,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -908,12 +908,13 @@ spec:
         - -ingester.ring.store=consul
         - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -944,6 +945,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1073,12 +1073,13 @@ spec:
         - -ingester.ring.zone-awareness-enabled=true
         - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1109,6 +1110,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -877,12 +877,13 @@ spec:
         - -ingester.ring.store=consul
         - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -913,6 +914,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -508,12 +508,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -546,6 +547,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -454,12 +454,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -492,6 +493,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -969,12 +969,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1007,6 +1008,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -2961,12 +2963,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -3097,12 +3100,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -3233,12 +3237,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -454,12 +454,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -492,6 +493,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -528,12 +528,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml,/etc/another-config/runtimeconfig.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -568,6 +569,7 @@ spec:
           name: new-config-map
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -560,12 +560,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -598,6 +599,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -521,12 +521,13 @@ spec:
         - -memberlist.cluster-label-verification-disabled=true
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -559,6 +560,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -522,12 +522,13 @@ spec:
         - -memberlist.cluster-label-verification-disabled=true
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -560,6 +561,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -521,12 +521,13 @@ spec:
         - -memberlist.cluster-label=my-cluster-label
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -559,6 +560,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -908,12 +908,13 @@ spec:
         - -ingester.ring.store=consul
         - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -944,6 +945,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -952,12 +952,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -990,6 +991,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -952,12 +952,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -990,6 +991,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -952,12 +952,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -990,6 +991,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -952,12 +952,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -990,6 +991,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -523,12 +523,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -561,6 +562,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -697,12 +697,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -735,6 +736,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -765,12 +765,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -803,6 +804,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -697,12 +697,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -735,6 +736,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -468,12 +468,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -508,6 +509,7 @@ spec:
           name: overrides
       nodeSelector:
         workload: mimir
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -908,12 +908,13 @@ spec:
         - -ingester.ring.store=consul
         - -mem-ballast-size-bytes=1073741824
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -944,6 +945,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -655,12 +655,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -693,6 +694,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -529,12 +529,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -567,6 +568,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -526,12 +526,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -564,6 +565,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -1514,12 +1514,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1651,12 +1652,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1788,12 +1790,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -1089,12 +1089,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1226,12 +1227,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1363,12 +1365,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -1515,12 +1515,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1652,12 +1653,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -1789,12 +1791,13 @@ spec:
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
         env:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -637,12 +637,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -675,6 +676,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -637,12 +637,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -675,6 +676,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -521,12 +521,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -559,6 +560,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -521,12 +521,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -559,6 +560,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
@@ -392,12 +392,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -430,6 +431,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -520,12 +520,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -558,6 +559,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -423,12 +423,13 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc.keepalive.max-connection-age=2m
+        - -server.grpc.keepalive.max-connection-age=60s
         - -server.grpc.keepalive.max-connection-age-grace=5m
         - -server.grpc.keepalive.max-connection-idle=1m
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -shutdown-delay=90s
         - -target=distributor
         - -usage-stats.installation-mode=jsonnet
         env:
@@ -461,6 +462,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
+      terminationGracePeriodSeconds: 100
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -4,6 +4,14 @@
   local deployment = $.apps.v1.deployment,
   local service = $.core.v1.service,
 
+  // When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+  // endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+  // To achieve it, we set a shutdown delay greater than the gRPC max connection age, and we set an even higher
+  // termination grace period (to give some extra buffer to the process to gracefully shutdown).
+  local grpc_max_connection_age_seconds = 60,
+  local shutdown_delay_seconds = 90,
+  local termination_grace_period_seconds = shutdown_delay_seconds + 10,
+
   distributor_args::
     $._config.commonConfig +
     $._config.usageStatsConfig +
@@ -35,6 +43,12 @@
       // Relax pressure on KV store when running at scale.
       'distributor.ring.heartbeat-period': '1m',
       'distributor.ring.heartbeat-timeout': '4m',
+
+      // Allow DNS changes to propagate before killing off distributor
+      // to avoid connection failures in cortex-gw and therefore 5xx writes.
+      // Issue: https://github.com/grafana/mimir-squad/issues/454
+      'shutdown-delay': shutdown_delay_seconds + 's',
+      'server.grpc.keepalive.max-connection-age': grpc_max_connection_age_seconds + 's',
     } + $.mimirRuntimeConfigFile,
 
   distributor_ports:: $.util.defaultPorts,
@@ -74,7 +88,8 @@
     (if !std.isObject($._config.node_selector) then {} else deployment.mixin.spec.template.spec.withNodeSelectorMixin($._config.node_selector)) +
     $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     deployment.mixin.spec.strategy.rollingUpdate.withMaxSurge('15%') +
-    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0),
+    deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(0) +
+    deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(termination_grace_period_seconds),
 
   distributor_deployment: if !$._config.is_microservices_deployment_mode then null else
     $.newDistributorDeployment('distributor', $.distributor_container, $.distributor_node_affinity_matchers),


### PR DESCRIPTION
#### What this PR does

In this PR I'm upstreaming a change we did at Grafana Labs to reduce the likelihood of failed gRPC write requests from a gateway to distributor when a distributor gracefully shutdown. I've applied the same change both to Jsonnet and Helm. The comment in the code should be self-explanatory of the rationale behind this change.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
