### PR TITLE
Helm: align terminationGracePeriodSeconds with Jsonnet

### DIFF
--- a/operations/compare-helm-with-jsonnet/components/pods/standard-pod-changes.yaml
+++ b/operations/compare-helm-with-jsonnet/components/pods/standard-pod-changes.yaml
@@ -23,7 +23,6 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
       serviceAccount:
       serviceAccountName:
-      terminationGracePeriodSeconds: # TODO(logiraptor): We set a different terminationGracePeriodSeconds in Helm v Jsonnet
       securityContext: # TODO(logiraptor): We set a pod security context only in Jsonnet
       containers:
       - name: mimir # This section applies to the first container in all mimir components

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -41,7 +41,20 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Ruler: Set `-distributor.remote-timeout` to 10s in order to accommodate writing large rule results to the ingester. #7143
 * [CHANGE] Remove `-server.grpc.keepalive.max-connection-age` and `-server.grpc.keepalive.max-connection-age-grace` from default config. The configuration now applied directly to distributor, fixing parity with jsonnet. #7269
 * [CHANGE] Remove `-server.grpc.keepalive.max-connection-idle` from default config. The configuration now applied directly to distributor, fixing parity with jsonnet. #7298
-* [CHANGE] Distributor: termination grace period increased from 60s to 100s.
+* [CHANGE] Fine-tuned `terminationGracePeriodSeconds` for the following components: #7361
+  * Alertmanager: changed from `60` to `900`
+  * Distributor: changed from `60` to `100`
+  * Ingester: changed from `240` to `1200`
+  * Overrides-exporter: changed from `60` to `30`
+  * Ruler: changed from `180` to `600`
+  * Querier: changed from `180` to `30`
+  * Query-scheduler: changed from `180` to `30`
+  * Store-gateway: changed from `240` to `120`
+  * Compactor: changed from `240` to `900`
+  * Chunks-cache: changed from `60` to `30`
+  * Index-cache: changed from `60` to `30`
+  * Metadata-cache: changed from `60` to `30`
+  * Results-cache: changed from `60` to `30`
 * [ENHANCEMENT] Add `jaegerReporterMaxQueueSize` Helm value for all components where configuring `JAEGER_REPORTER_MAX_QUEUE_SIZE` makes sense, and override the Jaeger client's default value of 100 for components expected to generate many trace spans. #7068 #7086 #7259
 * [ENHANCEMENT] Rollout-operator: upgraded to v0.10.1. #7125
 * [ENHANCEMENT] Query-frontend: configured `-shutdown-delay`, `-server.grpc.keepalive.max-connection-age` and termination grace period to reduce the likelihood of queries hitting terminated query-frontends. #7129

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -638,7 +638,7 @@ alertmanager:
   statefulStrategy:
     type: RollingUpdate
 
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 900
 
   initContainers: []
   # Init containers to be added to the alertmanager pod.
@@ -950,7 +950,7 @@ ingester:
   statefulStrategy:
     type: RollingUpdate
 
-  terminationGracePeriodSeconds: 240
+  terminationGracePeriodSeconds: 1200
 
   tolerations: []
   initContainers: []
@@ -1118,7 +1118,7 @@ overrides_exporter:
       cpu: 100m
       memory: 128Mi
 
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 30
 
   tolerations: []
   extraContainers: []
@@ -1205,7 +1205,7 @@ ruler:
       maxSurge: 50%
       maxUnavailable: 0
 
-  terminationGracePeriodSeconds: 180
+  terminationGracePeriodSeconds: 600
 
   tolerations: []
   initContainers: []
@@ -1283,7 +1283,7 @@ querier:
       maxUnavailable: 0
       maxSurge: 15%
 
-  terminationGracePeriodSeconds: 180
+  terminationGracePeriodSeconds: 30
 
   tolerations: []
   initContainers: []
@@ -1441,7 +1441,7 @@ query_scheduler:
       maxUnavailable: 0
       maxSurge: 1
 
-  terminationGracePeriodSeconds: 180
+  terminationGracePeriodSeconds: 30
 
   tolerations: []
   initContainers: []
@@ -1573,7 +1573,7 @@ store_gateway:
   strategy:
     type: RollingUpdate
 
-  terminationGracePeriodSeconds: 240
+  terminationGracePeriodSeconds: 120
 
   tolerations: []
   initContainers: []
@@ -1766,7 +1766,7 @@ compactor:
   strategy:
     type: RollingUpdate
 
-  terminationGracePeriodSeconds: 240
+  terminationGracePeriodSeconds: 900
 
   tolerations: []
   initContainers: []
@@ -1883,7 +1883,7 @@ chunks-cache:
   # -- Management policy for chunks-cache pods
   podManagementPolicy: Parallel
   # -- Grace period to allow the chunks-cache to shutdown before it is killed
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 30
 
   # -- Stateful chunks-cache strategy
   statefulStrategy:
@@ -1975,7 +1975,7 @@ index-cache:
   # -- Management policy for index-cache pods
   podManagementPolicy: Parallel
   # -- Grace period to allow the index-cache to shutdown before it is killed
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 30
 
   # -- Stateful index-cache strategy
   statefulStrategy:
@@ -2067,7 +2067,7 @@ metadata-cache:
   # -- Management policy for metadata-cache pods
   podManagementPolicy: Parallel
   # -- Grace period to allow the metadata-cache to shutdown before it is killed
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 30
 
   # -- Stateful metadata-cache strategy
   statefulStrategy:
@@ -2159,7 +2159,7 @@ results-cache:
   # -- Management policy for results-cache pods
   podManagementPolicy: Parallel
   # -- Grace period to allow the results-cache to shutdown before it is killed
-  terminationGracePeriodSeconds: 60
+  terminationGracePeriodSeconds: 30
 
   # -- Stateful results-cache strategy
   statefulStrategy:


### PR DESCRIPTION
#### What this PR does

Jsonnet and Helm `terminationGracePeriodSeconds` is unaligned. In this PR I'm proposing to align them, so that assert on differences between the two and easily spot when they diverge. As usual, I'm taking Jsonnet as leader and Helm as follower.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
