### PR TITLE
Fix type error in autoscaling jsonnet

### DIFF
--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -843,7 +843,7 @@ spec:
           limits:
             memory: 1200Mi
           requests:
-            cpu: "2"
+            cpu: 2500m
             memory: 600Mi
         volumeMounts:
         - mountPath: /etc/mimir
@@ -2134,7 +2134,7 @@ spec:
           )[15m:]
         ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "1780"
+      threshold: "2225"
     name: query_frontend_cpu_hpa_default
     type: prometheus
   - metadata:

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -843,7 +843,7 @@ spec:
           limits:
             memory: 1200Mi
           requests:
-            cpu: "2"
+            cpu: 2500m
             memory: 600Mi
         volumeMounts:
         - mountPath: /etc/mimir
@@ -2134,7 +2134,7 @@ spec:
           )[15m:]
         ) * 1000
       serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "1500"
+      threshold: "1875"
     name: query_frontend_cpu_hpa_default
     type: prometheus
   - metadata:

--- a/operations/mimir-tests/test-autoscaling.jsonnet
+++ b/operations/mimir-tests/test-autoscaling.jsonnet
@@ -50,6 +50,10 @@ mimir {
     // the KEDA threshold
     k.util.resourcesRequests(2, '3.2Gi') +
     k.util.resourcesLimits(null, '6Gi'),
+  query_frontend_container+::
+    // Test a CPU request set in milli-CPUs to verify this gets converted into an integer for
+    // the KEDA threshold.
+    k.util.resourcesRequests('2500m', '600Mi'),
   ruler_querier_container+::
     // Test a <1 non-integer CPU request, to verify that this gets converted into an integer for
     // the KEDA threshold

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -354,7 +354,7 @@
     // This is due to KEDA requiring an integer.
 
     if (std.isString(str) && std.endsWith(str, 'm')) then (
-      std.rstripChars(str, 'm')
+      std.parseInt(std.rstripChars(str, 'm'))
     ) else (
       std.parseJson(str + '') * 1000
     )


### PR DESCRIPTION
#### What this PR does

Fixes an issue where the CPU parsing method sometimes returns an integer and sometimes returns a string.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
