### PR TITLE
feat: add possibility to configure memberlist via helm values

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -52,6 +52,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Gateway: make Ingress/Route host templateable. #7218
 * [BUGFIX] Metamonitoring: update dashboards to drop unsupported `step` parameter in targets. #7157
 * [ENHANCEMENT] Make the PSP template configurable via `rbac.podSecurityPolicy`. #7190
+* [ENHANCEMENT] Add possibility to configure `memberlist` config via helm values. #7379
 
 ## 5.2.1
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -80,6 +80,11 @@ serviceAccount:
 # -- Configuration is loaded from the secret called 'externalConfigSecretName'. If 'useExternalConfig' is true, then the configuration is not generated, just consumed.
 useExternalConfig: false
 
+# -- Memberlist configuration. Please refer to https://grafana.com/docs/mimir/latest/references/configuration-parameters/#memberlist
+memberlist:
+  abort_if_cluster_join_fails: false
+  compression_enabled: false
+
 # -- Defines what kind of object stores the configuration, a ConfigMap or a Secret.
 # In order to move sensitive information (such as credentials) from the ConfigMap/Secret to a more secure location (e.g. vault), it is possible to use [environment variables in the configuration](https://grafana.com/docs/mimir/latest/reference-configuration-parameters/#use-environment-variables-in-the-configuration).
 # Such environment variables can be then stored in a separate Secret and injected via the global.extraEnvFrom value. For details about environment injection from a Secret please see [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables).
@@ -331,8 +336,9 @@ mimir:
       max_cache_freshness: 10m
 
     memberlist:
-      abort_if_cluster_join_fails: false
-      compression_enabled: false
+    {{- with .Values.memberlist }}
+      {{- toYaml . | nindent 2 }}
+    {{- end }}
       join_members:
       - dns+{{ include "mimir.fullname" . }}-gossip-ring.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.memberlistBindPort" . }}
 


### PR DESCRIPTION
#### What this PR does

Adds the possibility to configure `memberlist` configuration via Helm values. 
A similar PR has been done for the grafana/tempo-distributed Helm chart: https://github.com/grafana/helm-charts/pull/2326

This can be useful when users have to overwrite specific memberlist configuration only.
Today the only possibility to do this, is to completely copy & paste the entire `mimir.config` values and modifying the `memberlist` section.

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
