### PR TITLE
Add page for displaying compaction jobs computed from bucket-index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 * [FEATURE] Alertmanager: Added `-alertmanager.utf8-strict-mode-enabled` to control support for any UTF-8 character as part of Alertmanager configuration/API matchers and labels. It's default value is set to `false`. #6898
 * [FEATURE] Querier: added `histogram_avg()` function support to PromQL. #7293
 * [FEATURE] Ingester: added `-blocks-storage.tsdb.timely-head-compaction` flag, which enables more timely head compaction, and defaults to `false`. #7372
-* [FEATURE] Compactor: Added `/compactor/tenants` and `/compactor/tenant/{tenant}/planned_jobs` endpoints that provide functionality that was provided by `tools/compaction-planner` -- listing of planned compaction jobs based on tenants' bucket index.
+* [FEATURE] Compactor: Added `/compactor/tenants` and `/compactor/tenant/{tenant}/planned_jobs` endpoints that provide functionality that was provided by `tools/compaction-planner` -- listing of planned compaction jobs based on tenants' bucket index. #7381
 * [ENHANCEMENT] Vault: add lifecycle manager for token used to authenticate to Vault. This ensures the client token is always valid. Includes a gauge (`cortex_vault_token_lease_renewal_active`) to check whether token renewal is active, and the counters `cortex_vault_token_lease_renewal_success_total` and `cortex_vault_auth_success_total` to see the total number of successful lease renewals / authentications. #7337
 * [ENHANCEMENT] Store-gateway: add no-compact details column on store-gateway tenants admin UI. #6848
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [FEATURE] Alertmanager: Added `-alertmanager.utf8-strict-mode-enabled` to control support for any UTF-8 character as part of Alertmanager configuration/API matchers and labels. It's default value is set to `false`. #6898
 * [FEATURE] Querier: added `histogram_avg()` function support to PromQL. #7293
 * [FEATURE] Ingester: added `-blocks-storage.tsdb.timely-head-compaction` flag, which enables more timely head compaction, and defaults to `false`. #7372
+* [FEATURE] Compactor: Added `/compactor/tenants` and `/compactor/tenant/{tenant}/planned_jobs` endpoints that provide functionality that was provided by `tools/compaction-planner` -- listing of planned compaction jobs based on tenants' bucket index.
 * [ENHANCEMENT] Vault: add lifecycle manager for token used to authenticate to Vault. This ensures the client token is always valid. Includes a gauge (`cortex_vault_token_lease_renewal_active`) to check whether token renewal is active, and the counters `cortex_vault_token_lease_renewal_success_total` and `cortex_vault_auth_success_total` to see the total number of successful lease renewals / authentications. #7337
 * [ENHANCEMENT] Store-gateway: add no-compact details column on store-gateway tenants admin UI. #6848
 * [ENHANCEMENT] PromQL: ignore small errors for bucketQuantile #6766

--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -97,6 +97,8 @@ This document groups API endpoints by service. Note that the API endpoints are e
 | [Check block upload](#check-block-upload) | Compactor | `GET /api/v1/upload/block/{block}/check` |
 | [Tenant delete request](#tenant-delete-request) | Compactor | `POST /compactor/delete_tenant` |
 | [Tenant delete status](#tenant-delete-status) | Compactor | `GET /compactor/delete_tenant_status` |
+| [Compactor tenants](#compactor-tenants) | Compactor | `GET /compactor/tenants` |
+| [Compactor tenant planned jobs](#compactor-tenant-planned-jobs) | Compactor | `GET /compactor/tenant/{tenant}/planned_jobs` |
 | [Overrides-exporter ring status](#overrides-exporter-ring-status) | Overrides-exporter | `GET /overrides-exporter/ring` |
 {{% /responsive-table %}}
 
@@ -1222,6 +1224,22 @@ Returns status of tenant deletion.
 The `blocks_deleted` field will be set to `true` if all the tenant's blocks have been deleted.
 
 Requires [authentication](#authentication).
+
+### Compactor tenants
+
+```
+GET /compactor/tenants
+```
+
+Displays a web page with the list of tenants with blocks in the storage configured for compactor.
+
+### Compactor tenant planned jobs
+
+```
+GET /compactor/tenant/{tenant}/planned_jobs
+```
+
+Displays a web page listing planned compaction jobs computed from current bucket-index for a given tenant.
 
 ## Overrides-exporter
 

--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -1239,7 +1239,7 @@ Displays a web page with the list of tenants with blocks in the storage configur
 GET /compactor/tenant/{tenant}/planned_jobs
 ```
 
-Displays a web page listing planned compaction jobs computed from current bucket-index for a given tenant.
+Displays a web page listing planned compaction jobs computed from the bucket index for the given tenant.
 
 ## Overrides-exporter
 

--- a/docs/sources/mimir/references/http-api/index.md
+++ b/docs/sources/mimir/references/http-api/index.md
@@ -1231,7 +1231,7 @@ Requires [authentication](#authentication).
 GET /compactor/tenants
 ```
 
-Displays a web page with the list of tenants with blocks in the storage configured for compactor.
+Displays a web page with the list of tenants that have blocks in the storage configured for the compactor.
 
 ### Compactor tenant planned jobs
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -380,7 +380,7 @@ func (a *API) RegisterStoreGateway(s *storegateway.StoreGateway) {
 func (a *API) RegisterCompactor(c *compactor.MultitenantCompactor) {
 	a.indexPage.AddLinks(defaultWeight, "Compactor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/compactor/ring"},
-		{Desc: "Tenants & Compaction Jobs", Path: "/compactor/tenants"},
+		{Desc: "Tenants & compaction jobs", Path: "/compactor/tenants"},
 	})
 	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/api/v1/upload/block/{block}/start", http.HandlerFunc(c.StartBlockUpload), true, false, http.MethodPost)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -380,6 +380,7 @@ func (a *API) RegisterStoreGateway(s *storegateway.StoreGateway) {
 func (a *API) RegisterCompactor(c *compactor.MultitenantCompactor) {
 	a.indexPage.AddLinks(defaultWeight, "Compactor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/compactor/ring"},
+		{Desc: "Tenants & Compaction Jobs", Path: "/compactor/tenants"},
 	})
 	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), false, true, "GET", "POST")
 	a.RegisterRoute("/api/v1/upload/block/{block}/start", http.HandlerFunc(c.StartBlockUpload), true, false, http.MethodPost)
@@ -388,6 +389,8 @@ func (a *API) RegisterCompactor(c *compactor.MultitenantCompactor) {
 	a.RegisterRoute("/api/v1/upload/block/{block}/check", http.HandlerFunc(c.GetBlockUploadStateHandler), true, false, http.MethodGet)
 	a.RegisterRoute("/compactor/delete_tenant", http.HandlerFunc(c.DeleteTenant), true, true, "POST")
 	a.RegisterRoute("/compactor/delete_tenant_status", http.HandlerFunc(c.DeleteTenantStatus), true, true, "GET")
+	a.RegisterRoute("/compactor/tenants", http.HandlerFunc(c.TenantsHandler), false, true, "GET")
+	a.RegisterRoute("/compactor/tenant/{tenant}/planned_jobs", http.HandlerFunc(c.PlannedJobsHandler), false, true, "GET")
 }
 
 func (a *API) DisableServerHTTPTimeouts(next http.Handler) http.Handler {

--- a/pkg/compactor/compactor_tenants.gohtml
+++ b/pkg/compactor/compactor_tenants.gohtml
@@ -1,0 +1,26 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/compactor.tenantsPageContents */ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Compactor: bucket tenants</title>
+</head>
+<body>
+<h1>Store-gateway: bucket tenants</h1>
+<p>Current time: {{ .Now }}</p>
+<table border="1" cellpadding="5" style="border-collapse: collapse">
+    <thead>
+    <tr>
+        <th>Tenant</th>
+    </tr>
+    </thead>
+    <tbody style="font-family: monospace;">
+    {{ range .Tenants }}
+        <tr>
+            <td><a href="tenant/{{ . }}/planned_jobs">{{ . }}</a></td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>

--- a/pkg/compactor/compactor_tenants.gohtml
+++ b/pkg/compactor/compactor_tenants.gohtml
@@ -6,7 +6,7 @@
     <title>Compactor: bucket tenants</title>
 </head>
 <body>
-<h1>Store-gateway: bucket tenants</h1>
+<h1>Compactor: bucket tenants</h1>
 <p>Current time: {{ .Now }}</p>
 <table border="1" cellpadding="5" style="border-collapse: collapse">
     <thead>

--- a/pkg/compactor/planned_jobs.gohtml
+++ b/pkg/compactor/planned_jobs.gohtml
@@ -8,8 +8,8 @@
 <body style="padding: 1em;">
 <h1>Compaction jobs based on bucket-index</h1>
 <p>
-    This page shows compaction jobs computed from bucket index. This is not up-to-date view of compaction jobs.
-    Compactors owning the job are computed using current <a href="/compactor/ring">compactor ring</a>, and ignore <code>-compactor.enabled-tenants</code> and <code>-compactor.disabled-tenants</code> configuration.
+    This page shows compaction jobs computed from the bucket index. This is not an up-to-date view of compaction jobs.
+    Compactors owning the job are computed using the current <a href="/compactor/ring">compactor ring</a>, and ignore <code>-compactor.enabled-tenants</code> and <code>-compactor.disabled-tenants</code> configuration.
 </p>
 <ul>
     <li>Current time: {{ .Now }}</li>

--- a/pkg/compactor/planned_jobs.gohtml
+++ b/pkg/compactor/planned_jobs.gohtml
@@ -1,0 +1,79 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/compactor.plannerJobsContent */ -}}
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/html">
+<head>
+    <meta charset="UTF-8">
+    <title>Compactor: compaction jobs based on bucket-index</title>
+</head>
+<body style="padding: 1em;">
+<h1>Compaction jobs based on bucket-index</h1>
+<p>
+    This page shows compaction jobs computed from bucket index. This is not up-to-date view of compaction jobs.
+    Compactors owning the job are computed using current <a href="/compactor/ring">compactor ring</a>, and ignore <code>-compactor.enabled-tenants</code> and <code>-compactor.disabled-tenants</code> configuration.
+</p>
+<ul>
+    <li>Current time: {{ .Now }}</li>
+    <li>Tenant: <strong>{{ .Tenant }}</strong></li>
+    <li>Bucket index last updated: {{ .BucketIndexUpdated }}</li>
+    <li>Tenant Split groups: {{ .TenantSplitGroups }}</li>
+    <li>Tenant Merge shards: {{ .TenantMergeShards }}</li>
+</ul>
+
+<hr />
+
+<form>
+    <input type="checkbox" id="show-blocks" name="show_blocks" {{ if .ShowBlocks }} checked {{ end }}>&nbsp;<label for="show-blocks">Show Blocks</label>&nbsp;&nbsp;
+    <input type="checkbox" id="show-compactors" name="show_compactors" {{ if .ShowCompactors }} checked {{ end }}>&nbsp;<label for="show-compactors">Show Compactors</label>&nbsp;&nbsp;
+    <label for="split-groups">Split groups:</label>&nbsp;<input id="split-groups" name="split_groups" type="text" value="{{ .SplitGroups }}" style="width: 6em;"/>&nbsp;&nbsp;
+    <label for="merge-shards">Merge shards:</label>&nbsp;<input id="merge-shards" name="merge_shards" type="text" value="{{ .MergeShards }}" style="width: 6em;"/>&nbsp;&nbsp;
+    <button type="submit" style="background-color: lightgrey;">
+        <span style="padding: 0.5em 1em; font-size: 125%;">Reload</span>
+    </button>
+</form>
+
+<hr />
+<p>Total jobs:</p>
+<ul>
+    <li>Split jobs: {{ .SplitJobsCount }}</li>
+    <li>Merge jobs: {{ .MergeJobsCount }}</li>
+</ul>
+
+<table border="1" cellpadding="5" style="border-collapse: collapse;">
+    <thead>
+    <tr>
+        <th>Job Number</th>
+        <th>Start Time</th>
+        <th>End Time</th>
+        <th>Number of Blocks</th>
+        <th>Job Key</th>
+        {{ if .ShowCompactors }}
+        <th title="Compactor that owns this job based on ring">Compactor</th>{{ end }}
+        {{ if .ShowBlocks }}
+        <th>Blocks</th>{{ end }}
+    </tr>
+    </thead>
+    <tbody style="font-family: monospace;">
+    {{ $page := . }}
+    {{ range $index, $job := .PlannedJobs }}
+        <tr>
+            <td>{{ add $index 1}}</td>
+            <td>{{ .MinTime }}</td>
+            <td>{{ .MaxTime }}</td>
+            <td>{{ len .Blocks }}</td>
+            <td>{{ $job.Key }}</td>
+            {{ if $page.ShowCompactors }}
+            <td>{{ .Compactor }}</td>{{ end }}
+            {{ if $page.ShowBlocks }}
+                <td>
+                    {{ range $i, $b := .Blocks }}
+                        {{ if $i }}<br>{{ end }}
+                        {{ $b }}
+                    {{ end }}
+                </td>
+            {{ end }}
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>

--- a/pkg/compactor/planned_jobs_http.go
+++ b/pkg/compactor/planned_jobs_http.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package compactor
 
 import (

--- a/pkg/compactor/planned_jobs_http.go
+++ b/pkg/compactor/planned_jobs_http.go
@@ -1,0 +1,178 @@
+package compactor
+
+import (
+	_ "embed"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/gorilla/mux"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/timestamp"
+
+	"github.com/grafana/mimir/pkg/storage/bucket"
+	"github.com/grafana/mimir/pkg/storage/tsdb"
+	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
+	"github.com/grafana/mimir/pkg/util"
+)
+
+//go:embed compactor_tenants.gohtml
+var tenantsPageHTML string
+var tenantsTemplate = template.Must(template.New("webpage").Parse(tenantsPageHTML))
+
+type tenantsPageContents struct {
+	Now     time.Time `json:"now"`
+	Tenants []string  `json:"tenants,omitempty"`
+}
+
+func (c *MultitenantCompactor) TenantsHandler(w http.ResponseWriter, req *http.Request) {
+	tenants, err := tsdb.ListUsers(req.Context(), c.bucketClient)
+	if err != nil {
+		util.WriteTextResponse(w, fmt.Sprintf("Can't read tenants: %s", err))
+		return
+	}
+
+	util.RenderHTTPResponse(w, tenantsPageContents{
+		Now:     time.Now(),
+		Tenants: tenants,
+	}, tenantsTemplate, req)
+}
+
+//go:embed planned_jobs.gohtml
+var plannerJobsHTML string
+var plannerJobsTemplateFuncs = template.FuncMap{"add": func(x, y int) int { return x + y }}
+var plannerJobsTemplate = template.Must(template.New("webpage").Funcs(plannerJobsTemplateFuncs).Parse(plannerJobsHTML))
+
+type plannerJobsContent struct {
+	Now                string `json:"now"`
+	BucketIndexUpdated string `json:"bucket_index_updated"`
+
+	Tenant      string                 `json:"tenant"`
+	PlannedJobs []plannedCompactionJob `json:"jobs"`
+
+	ShowBlocks     bool `json:"-"`
+	ShowCompactors bool `json:"-"`
+
+	SplitJobsCount int `json:"split_jobs_count"`
+	MergeJobsCount int `json:"merge_jobs_count"`
+
+	TenantSplitGroups int `json:"tenant_split_groups"`
+	TenantMergeShards int `json:"tenant_merge_shards"`
+	SplitGroups       int `json:"-"`
+	MergeShards       int `json:"-"`
+}
+
+type plannedCompactionJob struct {
+	Key       string      `json:"key"`
+	MinTime   string      `json:"min_time"`
+	MaxTime   string      `json:"max_time"`
+	Blocks    []ulid.ULID `json:"blocks"`
+	Compactor string      `json:"compactor,omitempty"`
+}
+
+func (c *MultitenantCompactor) PlannedJobsHandler(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	tenantID := vars["tenant"]
+	if tenantID == "" {
+		util.WriteTextResponse(w, "Tenant ID can't be empty")
+		return
+	}
+
+	if err := req.ParseForm(); err != nil {
+		util.WriteTextResponse(w, fmt.Sprintf("Can't parse form: %s", err))
+		return
+	}
+
+	showBlocks := req.Form.Get("show_blocks") == "on"
+	showCompactors := req.Form.Get("show_compactors") == "on"
+	tenantSplitGroups := c.cfgProvider.CompactorSplitGroups(tenantID)
+
+	tenantMergeShards := c.cfgProvider.CompactorSplitAndMergeShards(tenantID)
+
+	mergeShards := tenantMergeShards
+	if sc := req.Form.Get("merge_shards"); sc != "" {
+		mergeShards, _ = strconv.Atoi(sc)
+		if mergeShards < 0 {
+			mergeShards = 0
+		}
+	}
+
+	splitGroups := tenantSplitGroups
+	if sc := req.Form.Get("split_groups"); sc != "" {
+		splitGroups, _ = strconv.Atoi(sc)
+		if splitGroups < 0 {
+			splitGroups = 0
+		}
+	}
+
+	idx, err := bucketindex.ReadIndex(req.Context(), c.bucketClient, tenantID, nil, c.logger)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to read bucket index for tenant while listing compaction jobs", "user", tenantID, "err", err)
+		util.WriteTextResponse(w, "Failed to read bucket index for tenant")
+		return
+	}
+
+	jobs, err := estimateCompactionJobsFromBucketIndex(req.Context(), tenantID, bucket.NewUserBucketClient(tenantID, c.bucketClient, c.cfgProvider), idx, c.compactorCfg.BlockRanges, mergeShards, splitGroups)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to compute compaction jobs from bucket index for tenant while listing compaction jobs", "user", tenantID, "err", err)
+		util.WriteTextResponse(w, "Failed to compute compaction jobs from bucket index")
+		return
+	}
+
+	jobs = c.jobsOrder(jobs)
+
+	plannedJobs := make([]plannedCompactionJob, 0, len(jobs))
+
+	splitJobs, mergeJobs := 0, 0
+
+	for _, j := range jobs {
+		pj := plannedCompactionJob{
+			Key:     j.Key(),
+			MinTime: formatTime(timestamp.Time(j.MinTime())),
+			MaxTime: formatTime(timestamp.Time(j.MaxTime())),
+			Blocks:  j.IDs(),
+		}
+
+		if j.UseSplitting() {
+			splitJobs++
+		} else {
+			mergeJobs++
+		}
+
+		if showCompactors {
+			inst, err := c.shardingStrategy.instanceOwningJob(j)
+			if err != nil {
+				pj.Compactor = err.Error()
+			} else {
+				pj.Compactor = fmt.Sprintf("%s %s", inst.Id, inst.Addr)
+			}
+		}
+
+		plannedJobs = append(plannedJobs, pj)
+	}
+
+	util.RenderHTTPResponse(w, plannerJobsContent{
+		Now:                formatTime(time.Now()),
+		BucketIndexUpdated: formatTime(idx.GetUpdatedAt()),
+		Tenant:             tenantID,
+		PlannedJobs:        plannedJobs,
+
+		ShowBlocks:     showBlocks,
+		ShowCompactors: showCompactors,
+
+		TenantSplitGroups: tenantSplitGroups,
+		TenantMergeShards: tenantMergeShards,
+		SplitGroups:       splitGroups,
+		MergeShards:       mergeShards,
+
+		SplitJobsCount: splitJobs,
+		MergeJobsCount: mergeJobs,
+	}, plannerJobsTemplate, req)
+}
+
+func formatTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}

--- a/pkg/compactor/planned_jobs_http_test.go
+++ b/pkg/compactor/planned_jobs_http_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package compactor
 
 import (

--- a/pkg/compactor/planned_jobs_http_test.go
+++ b/pkg/compactor/planned_jobs_http_test.go
@@ -61,8 +61,8 @@ func TestPlannedJobsHandler(t *testing.T) {
 	// Mark block for no-compaction.
 	require.NoError(t, block.MarkForNoCompact(context.Background(), log.NewNopLogger(), userBucket, blockMarkedForNoCompact, block.CriticalNoCompactReason, "testing", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
 
-	headersWithJsonAccept := http.Header{}
-	headersWithJsonAccept.Set("Accept", "application/json")
+	headersWithJSONAccept := http.Header{}
+	headersWithJSONAccept.Set("Accept", "application/json")
 
 	t.Run("tenants handler html", func(t *testing.T) {
 		resp := httptest.NewRecorder()
@@ -74,7 +74,7 @@ func TestPlannedJobsHandler(t *testing.T) {
 
 	t.Run("tenants handler json", func(t *testing.T) {
 		resp := httptest.NewRecorder()
-		c.TenantsHandler(resp, &http.Request{Header: headersWithJsonAccept})
+		c.TenantsHandler(resp, &http.Request{Header: headersWithJSONAccept})
 
 		require.Equal(t, http.StatusOK, resp.Code)
 		require.Contains(t, resp.Body.String(), `"tenants":["testuser"]`)
@@ -100,7 +100,7 @@ func TestPlannedJobsHandler(t *testing.T) {
 	t.Run("compaction jobs json", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 
-		req := mux.SetURLVars(&http.Request{Header: headersWithJsonAccept}, map[string]string{
+		req := mux.SetURLVars(&http.Request{Header: headersWithJSONAccept}, map[string]string{
 			"tenant":       user,
 			"split_count":  "0",
 			"merge_shards": "3",

--- a/pkg/compactor/planned_jobs_http_test.go
+++ b/pkg/compactor/planned_jobs_http_test.go
@@ -1,0 +1,116 @@
+package compactor
+
+import (
+	"context"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/storage/bucket"
+	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
+	mimir_testutil "github.com/grafana/mimir/pkg/storage/tsdb/testutil"
+)
+
+func TestPlannedJobsHandler(t *testing.T) {
+	const user = "testuser"
+
+	bucketClient, _ := mimir_testutil.PrepareFilesystemBucket(t)
+	bucketClient = block.BucketWithGlobalMarkers(bucketClient)
+
+	cfg := prepareConfig(t)
+	c, _, _, _, _ := prepare(t, cfg, bucketClient)
+	c.bucketClient = bucketClient // this is normally done in starting, but we these tests don't require running compactor. (TODO: check if we can get rid of bucketClientFactory)
+
+	twoHoursMS := 2 * time.Hour.Milliseconds()
+	dayMS := 24 * time.Hour.Milliseconds()
+
+	blockMarkedForNoCompact := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	index := bucketindex.Index{}
+	index.Blocks = bucketindex.Blocks{
+		// Some 2h blocks that should be compacted together and split.
+		&bucketindex.Block{ID: ulid.MustNew(ulid.Now(), rand.Reader), MinTime: 0, MaxTime: twoHoursMS},
+		&bucketindex.Block{ID: ulid.MustNew(ulid.Now(), rand.Reader), MinTime: 0, MaxTime: twoHoursMS},
+		&bucketindex.Block{ID: ulid.MustNew(ulid.Now(), rand.Reader), MinTime: 0, MaxTime: twoHoursMS},
+
+		// Some merge jobs.
+		&bucketindex.Block{ID: ulid.MustNew(ulid.Now(), rand.Reader), MinTime: dayMS, MaxTime: 2 * dayMS, CompactorShardID: "1_of_3"},
+		&bucketindex.Block{ID: ulid.MustNew(ulid.Now(), rand.Reader), MinTime: dayMS, MaxTime: 2 * dayMS, CompactorShardID: "1_of_3"},
+
+		&bucketindex.Block{ID: ulid.MustNew(ulid.Now(), rand.Reader), MinTime: dayMS, MaxTime: 2 * dayMS, CompactorShardID: "2_of_3"},
+		&bucketindex.Block{ID: ulid.MustNew(ulid.Now(), rand.Reader), MinTime: dayMS, MaxTime: 2 * dayMS, CompactorShardID: "2_of_3"},
+
+		// This merge job is skipped, as block is marked for no-compaction.
+		&bucketindex.Block{ID: ulid.MustNew(ulid.Now(), rand.Reader), MinTime: dayMS, MaxTime: 2 * dayMS, CompactorShardID: "3_of_3"},
+		&bucketindex.Block{ID: blockMarkedForNoCompact, MinTime: dayMS, MaxTime: 2 * dayMS, CompactorShardID: "3_of_3"},
+	}
+
+	require.NoError(t, bucketindex.WriteIndex(context.Background(), bucketClient, user, nil, &index))
+
+	userBucket := bucket.NewUserBucketClient(user, bucketClient, nil)
+	// Mark block for no-compaction.
+	require.NoError(t, block.MarkForNoCompact(context.Background(), log.NewNopLogger(), userBucket, blockMarkedForNoCompact, block.CriticalNoCompactReason, "testing", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
+
+	headersWithJsonAccept := http.Header{}
+	headersWithJsonAccept.Set("Accept", "application/json")
+
+	t.Run("tenants handler html", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		c.TenantsHandler(resp, &http.Request{})
+
+		require.Equal(t, http.StatusOK, resp.Code)
+		require.Contains(t, resp.Body.String(), "/"+user+"/planned_jobs")
+	})
+
+	t.Run("tenants handler json", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		c.TenantsHandler(resp, &http.Request{Header: headersWithJsonAccept})
+
+		require.Equal(t, http.StatusOK, resp.Code)
+		require.Contains(t, resp.Body.String(), `"tenants":["testuser"]`)
+	})
+
+	t.Run("compaction jobs html", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+
+		req := mux.SetURLVars(&http.Request{}, map[string]string{
+			"tenant":       user,
+			"split_count":  "0",
+			"merge_shards": "3",
+		})
+		c.PlannedJobsHandler(resp, req)
+
+		require.Equal(t, http.StatusOK, resp.Code)
+
+		require.Contains(t, resp.Body.String(), "<td>0@17241709254077376921-merge--0-7200000</td>")
+		require.Contains(t, resp.Body.String(), "<td>0@17241709254077376921-merge-1_of_3-86400000-172800000</td>")
+		require.Contains(t, resp.Body.String(), "<td>0@17241709254077376921-merge-2_of_3-86400000-172800000</td>")
+	})
+
+	t.Run("compaction jobs json", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+
+		req := mux.SetURLVars(&http.Request{Header: headersWithJsonAccept}, map[string]string{
+			"tenant":       user,
+			"split_count":  "0",
+			"merge_shards": "3",
+		})
+		c.PlannedJobsHandler(resp, req)
+
+		require.Equal(t, http.StatusOK, resp.Code)
+
+		require.Contains(t, resp.Body.String(), `"key":"0@17241709254077376921-merge--0-7200000"`)
+		require.Contains(t, resp.Body.String(), `"key":"0@17241709254077376921-merge-1_of_3-86400000-172800000"`)
+		require.Contains(t, resp.Body.String(), `"key":"0@17241709254077376921-merge-2_of_3-86400000-172800000"`)
+	})
+}


### PR DESCRIPTION
#### What this PR does

This PR adds admin page that displays compaction jobs computed from bucket index. This is same output as produced by `tools/compaction-planner` tool, without the need to provide all necessary configuration via CLI flags, since compactor already has all the required configuration.

Page allows to experiment with different merge shards and split counts, and it can also show which compactor is expected to own (and run) the job based on current state of the ring. (Screenshot was created with only one compactor in the ring)

<img width="2180" alt="screenshot" src="https://github.com/grafana/mimir/assets/895919/1e6bb325-9d4e-4aaf-95ad-39801fa14d2f">

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
