### PR TITLE
query-tee: override correct Host attribute

### DIFF
--- a/tools/querytee/proxy_backend.go
+++ b/tools/querytee/proxy_backend.go
@@ -81,7 +81,7 @@ func (b *ProxyBackend) createBackendRequest(orig *http.Request, body io.ReadClos
 	req.URL.Path = path.Join(b.endpoint.Path, req.URL.Path)
 
 	// Set the correct host header for the backend
-	req.Header.Set("Host", b.endpoint.Host)
+	req.Host = b.endpoint.Host
 
 	// Replace the auth:
 	// - If the endpoint has user and password, use it.


### PR DESCRIPTION
`Request.Host` takes precedence over the `Request.Header["Host"]`. Since we're cloning the request the `Request.Host` is still the Host that's ben sent by the client and even if we change the header. Changing the header doesn't affect the actual HTTP request sent since `Request.Host` takes precedence.

Credit to @pstibrany for finding this bug!