### PR TITLE
Fix TestPartitionReader_WaitReadConsistency flakyness

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -124,16 +124,15 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 		// the 2nd record consumption will be delayed.
 		consumer := consumerFunc(func(ctx context.Context, records []record) error {
 			for _, record := range records {
-				consumedRecords.Inc()
-
-				assert.Equal(t, fmt.Sprintf("record-%d", consumedRecords.Load()), string(record.content))
-				t.Logf("consumed record: %s", string(record.content))
-
 				// Introduce a delay before returning from the consume function once
 				// the 2nd record has been consumed.
-				if consumedRecords.Load() == 2 {
+				if consumedRecords.Load()+1 == 2 {
 					time.Sleep(time.Second)
 				}
+
+				consumedRecords.Inc()
+				assert.Equal(t, fmt.Sprintf("record-%d", consumedRecords.Load()), string(record.content))
+				t.Logf("consumed record: %s", string(record.content))
 			}
 
 			return nil

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -99,13 +99,10 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 		ctx = context.Background()
 	)
 
-	setup := func(t *testing.T) (testConsumer, *PartitionReader, *kgo.Client, *prometheus.Registry) {
+	setup := func(t *testing.T, consumer recordConsumer) (*PartitionReader, *kgo.Client, *prometheus.Registry) {
 		reg := prometheus.NewPedanticRegistry()
 
 		_, clusterAddr := testkafka.CreateCluster(t, 1, topicName)
-
-		// Create a consumer with no buffer capacity.
-		consumer := newTestConsumer(0)
 
 		// Configure the reader to poll the "last produced offset" frequently.
 		reader := startReader(ctx, t, clusterAddr, topicName, partitionID, consumer,
@@ -114,13 +111,35 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 
 		writeClient := newKafkaProduceClient(t, clusterAddr)
 
-		return consumer, reader, writeClient, reg
+		return reader, writeClient, reg
 	}
 
-	t.Run("should return after all produced records up have been consumed", func(t *testing.T) {
+	t.Run("should return after all produced records have been consumed", func(t *testing.T) {
 		t.Parallel()
 
-		consumer, reader, writeClient, reg := setup(t)
+		consumedRecords := atomic.NewInt64(0)
+
+		// We define a custom consume function which introduces a delay once the 2nd record
+		// has been consumed but before the function returns. From the PartitionReader perspective,
+		// the 2nd record consumption will be delayed.
+		consumer := consumerFunc(func(ctx context.Context, records []record) error {
+			for _, record := range records {
+				consumedRecords.Inc()
+
+				assert.Equal(t, fmt.Sprintf("record-%d", consumedRecords.Load()), string(record.content))
+				t.Logf("consumed record: %s", string(record.content))
+
+				// Introduce a delay before returning from the consume function once
+				// the 2nd record has been consumed.
+				if consumedRecords.Load() == 2 {
+					time.Sleep(time.Second)
+				}
+			}
+
+			return nil
+		})
+
+		reader, writeClient, reg := setup(t, consumer)
 
 		// Produce some records.
 		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
@@ -129,30 +148,12 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 
 		// WaitReadConsistency() should return after all records produced up until this
 		// point have been consumed.
-		runAsyncAndAssertCompletionOrder(t,
-			func() {
-				records, err := consumer.waitRecords(1, time.Second, 0)
-				assert.NoError(t, err)
-				assert.Equal(t, [][]byte{[]byte("record-1")}, records)
-				t.Logf("consumed records: %s", records)
+		t.Log("started waiting for read consistency")
 
-				// Wait some time before consuming next record.
-				time.Sleep(time.Second)
-
-				records, err = consumer.waitRecords(1, time.Second, 0)
-				assert.NoError(t, err)
-				assert.Equal(t, [][]byte{[]byte("record-2")}, records)
-				t.Logf("consumed records: %s", records)
-			},
-			func() {
-				t.Log("started waiting for read consistency")
-
-				err := reader.WaitReadConsistency(ctx)
-				require.NoError(t, err)
-
-				t.Log("finished waiting for read consistency")
-			},
-		)
+		err := reader.WaitReadConsistency(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), consumedRecords.Load())
+		t.Log("finished waiting for read consistency")
 
 		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested.
@@ -168,7 +169,10 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 	t.Run("should block until the context deadline exceed if produced records are not consumed", func(t *testing.T) {
 		t.Parallel()
 
-		consumer, reader, writeClient, reg := setup(t)
+		// Create a consumer with no buffer capacity.
+		consumer := newTestConsumer(0)
+
+		reader, writeClient, reg := setup(t, consumer)
 
 		// Produce some records.
 		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
@@ -200,7 +204,7 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 	t.Run("should return if no records have been produced yet", func(t *testing.T) {
 		t.Parallel()
 
-		_, reader, _, reg := setup(t)
+		reader, _, reg := setup(t, newTestConsumer(0))
 
 		err := reader.WaitReadConsistency(createTestContextWithTimeout(t, time.Second))
 		require.NoError(t, err)
@@ -219,7 +223,7 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 	t.Run("should return an error if the PartitionReader is not running", func(t *testing.T) {
 		t.Parallel()
 
-		_, reader, _, reg := setup(t)
+		reader, _, reg := setup(t, newTestConsumer(0))
 
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
 

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -364,36 +364,6 @@ func runAsyncAfter(wg *sync.WaitGroup, waitFor chan struct{}, fn func()) {
 	}()
 }
 
-// runAsyncAndAssertCompletionOrder runs all executors functions concurrently and asserts that the functions
-// completes in the given order.
-func runAsyncAndAssertCompletionOrder(t *testing.T, executors ...func()) {
-	var (
-		// Keep track of the actual execution order.
-		actualOrderMx = sync.Mutex{}
-		actualOrder   = make([]int, 0, len(executors))
-		expectedOrder = make([]int, 0, len(executors))
-		wg            = sync.WaitGroup{}
-	)
-
-	for i, executor := range executors {
-		i := i
-		executor := executor
-		expectedOrder = append(expectedOrder, i)
-
-		runAsync(&wg, func() {
-			executor()
-
-			actualOrderMx.Lock()
-			actualOrder = append(actualOrder, i)
-			actualOrderMx.Unlock()
-		})
-	}
-
-	wg.Wait()
-
-	assert.Equal(t, expectedOrder, actualOrder)
-}
-
 func createTestContextWithTimeout(t *testing.T, timeout time.Duration) context.Context {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(cancel)


### PR DESCRIPTION
#### What this PR does

@dimitarvdimitrov reported me that `TestPartitionReader_WaitReadConsistency` is flaky. We've seen it failing in [this CI run](https://github.com/grafana/mimir/actions/runs/7813347044/job/21312292344?pr=7309) because of:

```
--- FAIL: TestPartitionReader_WaitReadConsistency (0.00s)
    --- FAIL: TestPartitionReader_WaitReadConsistency/should_return_after_all_produced_records_up_have_been_consumed (1.02s)
        reader_test.go:128: produced 2 records
        reader_test.go:137: consumed records: [record-1]
        reader_test.go:148: started waiting for read consistency
        reader_test.go:153: finished waiting for read consistency
        reader_test.go:145: consumed records: [record-2]
        writer_test.go:394: 
            	Error Trace:	/__w/mimir/mimir/pkg/storage/ingest/writer_test.go:394
            	            				/__w/mimir/mimir/pkg/storage/ingest/reader_test.go:132
            	Error:      	Not equal: 
            	            	expected: []int{0, 1}
            	            	actual  : []int{1, 0}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,4 +1,4 @@
            	            	 ([]int) (len=2) {
            	            	- (int) 0,
            	            	- (int) 1
            	            	+ (int) 1,
            	            	+ (int) 0
            	            	 }
            	Test:       	TestPartitionReader_WaitReadConsistency/should_return_after_all_produced_records_up_have_been_consumed
FAIL
```

The problem is that there's a race between the 2 async functions, where the function calling `consumer.waitRecords()` may end after the one calling `reader.WaitReadConsistency(ctx)` even if `reader.WaitReadConsistency(ctx)` effectively waited for all records to be consumed.

In this PR I'm reworking the test. Instead of using `runAsyncAndAssertCompletionOrder()`, I define a custom consume function which adds a delay on the 2nd (and last) record consumption and then increases a counter of processed records. Such counter is increased after the record has been processed by consumption (processing time is simulated with the artificial delay) but before the consume function returns. Then we can just assert that the expected number of records have been consumed once `reader.WaitReadConsistency(ctx)` returns.


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
