### PR TITLE
prepare-partition-downscale: Switch to Active state only if partition is currently Inactive.

### DIFF
--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -313,6 +313,31 @@ func TestIngester_PreparePartitionDownscaleHandler(t *testing.T) {
 			return slices.Equal(watcher.PartitionRing().PendingPartitionIDs(), []int32{0})
 		}, time.Second, 10*time.Millisecond)
 	})
+
+	t.Run("DELETE is ignored if the partition is in PENDING state", func(t *testing.T) {
+		t.Parallel()
+
+		// To keep the partition in PENDING state we set a minimum number of owners
+		// higher than the actual number of ingesters we're going to run.
+		cfg := defaultIngesterTestConfig(t)
+		cfg.IngesterPartitionRing.MinOwnersCount = 2
+
+		ingester, watcher := setup(t, cfg)
+
+		// Pre-condition: the partition is PENDING.
+		require.Eventually(t, func() bool {
+			return slices.Equal(watcher.PartitionRing().PendingPartitionIDs(), []int32{0})
+		}, time.Second, 10*time.Millisecond)
+
+		res := httptest.NewRecorder()
+		ingester.PreparePartitionDownscaleHandler(res, httptest.NewRequest(http.MethodDelete, "/ingester/prepare-partition-downscale", nil))
+		require.Equal(t, http.StatusOK, res.Code)
+
+		// We expect the partition to be in PENDING state.
+		require.Eventually(t, func() bool {
+			return slices.Equal(watcher.PartitionRing().PendingPartitionIDs(), []int32{0})
+		}, time.Second, 10*time.Millisecond)
+	})
 }
 
 func TestIngester_ShouldNotCreatePartitionIfThereIsShutdownMarker(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

This PR fixes tiny bug in `/ingester/prepare-partition-downscale` endpoint: `DELETE` method (= cancellation of downscale) will switch partition to `Active` state only if it was `Inactive`. Previously this could switch `Pending` -> `Active` too early, which is undesired.

This endpoint is supposed to work together with rollout-operator, and rollout-operator calls this endpoint with `DELETE` method regularly.

During tests, unrelated problem was discovered with initialization of usage stats metrics. This will be fixed in separate PR.

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
