### PR TITLE
ingester: Make usagestats vars package-global

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -10,7 +10,6 @@ package ingester
 
 import (
 	"context"
-	"expvar"
 	"flag"
 	"fmt"
 	"io"
@@ -129,6 +128,25 @@ var (
 	reasonIngesterMaxInMemorySeries            = globalerror.IngesterMaxInMemorySeries.LabelValue()
 	reasonIngesterMaxInflightPushRequests      = globalerror.IngesterMaxInflightPushRequests.LabelValue()
 	reasonIngesterMaxInflightPushRequestsBytes = globalerror.IngesterMaxInflightPushRequestsBytes.LabelValue()
+)
+
+// Usage-stats expvars. Initialized as package-global in order to avoid race conditions and panics
+// when initializing expvars per-ingester in multiple parallel tests at once.
+var (
+	// updated in Ingester.updateUsageStats.
+	memorySeriesStats                  = usagestats.GetAndResetInt(memorySeriesStatsName)
+	memoryTenantsStats                 = usagestats.GetAndResetInt(memoryTenantsStatsName)
+	tenantsWithOutOfOrderEnabledStat   = usagestats.GetAndResetInt(tenantsWithOutOfOrderEnabledStatName)
+	minOutOfOrderTimeWindowSecondsStat = usagestats.GetAndResetInt(minOutOfOrderTimeWindowSecondsStatName)
+	maxOutOfOrderTimeWindowSecondsStat = usagestats.GetAndResetInt(maxOutOfOrderTimeWindowSecondsStatName)
+
+	// updated in Ingester.PushWithCleanup.
+	appendedSamplesStats   = usagestats.GetAndResetCounter(appendedSamplesStatsName)
+	appendedExemplarsStats = usagestats.GetAndResetCounter(appendedExemplarsStatsName)
+
+	// Set in newIngester.
+	replicationFactor = usagestats.GetInt(replicationFactorStatsName)
+	ringStoreName     = usagestats.GetString(ringStoreStatsName)
 )
 
 // BlocksUploader interface is used to have an easy way to mock it in tests.
@@ -307,15 +325,6 @@ type Ingester struct {
 	inflightPushRequests      atomic.Int64
 	inflightPushRequestsBytes atomic.Int64
 
-	// Anonymous usage statistics tracked by ingester.
-	memorySeriesStats                  *expvar.Int
-	memoryTenantsStats                 *expvar.Int
-	appendedSamplesStats               *usagestats.Counter
-	appendedExemplarsStats             *usagestats.Counter
-	tenantsWithOutOfOrderEnabledStat   *expvar.Int
-	minOutOfOrderTimeWindowSecondsStat *expvar.Int
-	maxOutOfOrderTimeWindowSecondsStat *expvar.Int
-
 	utilizationBasedLimiter utilizationBasedLimiter
 
 	errorSamplers ingesterErrSamplers
@@ -337,8 +346,8 @@ func newIngester(cfg Config, limits *validation.Overrides, registerer prometheus
 	}
 
 	// Track constant usage stats.
-	usagestats.GetInt(replicationFactorStatsName).Set(int64(cfg.IngesterRing.ReplicationFactor))
-	usagestats.GetString(ringStoreStatsName).Set(cfg.IngesterRing.KVStore.Store)
+	replicationFactor.Set(int64(cfg.IngesterRing.ReplicationFactor))
+	ringStoreName.Set(cfg.IngesterRing.KVStore.Store)
 
 	return &Ingester{
 		cfg:    cfg,
@@ -353,14 +362,6 @@ func newIngester(cfg Config, limits *validation.Overrides, registerer prometheus
 		forceCompactTrigger: make(chan requestWithUsersAndCallback),
 		shipTrigger:         make(chan requestWithUsersAndCallback),
 		seriesHashCache:     hashcache.NewSeriesHashCache(cfg.BlocksStorageConfig.TSDB.SeriesHashCacheMaxBytes),
-
-		memorySeriesStats:                  usagestats.GetAndResetInt(memorySeriesStatsName),
-		memoryTenantsStats:                 usagestats.GetAndResetInt(memoryTenantsStatsName),
-		appendedSamplesStats:               usagestats.GetAndResetCounter(appendedSamplesStatsName),
-		appendedExemplarsStats:             usagestats.GetAndResetCounter(appendedExemplarsStatsName),
-		tenantsWithOutOfOrderEnabledStat:   usagestats.GetAndResetInt(tenantsWithOutOfOrderEnabledStatName),
-		minOutOfOrderTimeWindowSecondsStat: usagestats.GetAndResetInt(minOutOfOrderTimeWindowSecondsStatName),
-		maxOutOfOrderTimeWindowSecondsStat: usagestats.GetAndResetInt(maxOutOfOrderTimeWindowSecondsStatName),
 
 		errorSamplers: newIngesterErrSamplers(cfg.ErrorSampleRate),
 	}, nil
@@ -794,11 +795,11 @@ func (i *Ingester) updateUsageStats() {
 	}
 
 	// Track anonymous usage stats.
-	i.memorySeriesStats.Set(memorySeriesCount)
-	i.memoryTenantsStats.Set(memoryUsersCount)
-	i.tenantsWithOutOfOrderEnabledStat.Set(tenantsWithOutOfOrderEnabledCount)
-	i.minOutOfOrderTimeWindowSecondsStat.Set(int64(minOutOfOrderTimeWindow.Seconds()))
-	i.maxOutOfOrderTimeWindowSecondsStat.Set(int64(maxOutOfOrderTimeWindow.Seconds()))
+	memorySeriesStats.Set(memorySeriesCount)
+	memoryTenantsStats.Set(memoryUsersCount)
+	tenantsWithOutOfOrderEnabledStat.Set(tenantsWithOutOfOrderEnabledCount)
+	minOutOfOrderTimeWindowSecondsStat.Set(int64(minOutOfOrderTimeWindow.Seconds()))
+	maxOutOfOrderTimeWindowSecondsStat.Set(int64(maxOutOfOrderTimeWindow.Seconds()))
 }
 
 // applyTSDBSettings goes through all tenants and applies
@@ -1071,8 +1072,8 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReques
 	i.metrics.ingestedSamplesFail.WithLabelValues(userID).Add(float64(stats.failedSamplesCount))
 	i.metrics.ingestedExemplars.Add(float64(stats.succeededExemplarsCount))
 	i.metrics.ingestedExemplarsFail.Add(float64(stats.failedExemplarsCount))
-	i.appendedSamplesStats.Inc(int64(stats.succeededSamplesCount))
-	i.appendedExemplarsStats.Inc(int64(stats.succeededExemplarsCount))
+	appendedSamplesStats.Inc(int64(stats.succeededSamplesCount))
+	appendedExemplarsStats.Inc(int64(stats.succeededExemplarsCount))
 
 	group := i.activeGroups.UpdateActiveGroupTimestamp(userID, validation.GroupLabel(i.limits, userID, req.Timeseries), startAppend)
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1788,6 +1788,14 @@ func TestIngester_Push(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
+			memorySeriesStats.Set(0)
+			memoryTenantsStats.Set(0)
+			tenantsWithOutOfOrderEnabledStat.Set(0)
+			minOutOfOrderTimeWindowSecondsStat.Set(0)
+			maxOutOfOrderTimeWindowSecondsStat.Set(0)
+			appendedSamplesStatsBefore := appendedSamplesStats.Total()
+			appendedExemplarsStatsBefore := appendedExemplarsStats.Total()
+
 			registry := prometheus.NewRegistry()
 
 			// Create a mocked ingester
@@ -1903,8 +1911,8 @@ func TestIngester_Push(t *testing.T) {
 
 			assert.Equal(t, int64(len(testData.expectedIngested)), usagestats.GetInt(memorySeriesStatsName).Value())
 			assert.Equal(t, int64(expectedTenantsCount), usagestats.GetInt(memoryTenantsStatsName).Value())
-			assert.Equal(t, int64(expectedSamplesCount), usagestats.GetCounter(appendedSamplesStatsName).Total())
-			assert.Equal(t, int64(expectedExemplarsCount), usagestats.GetCounter(appendedExemplarsStatsName).Total())
+			assert.Equal(t, int64(expectedSamplesCount)+appendedSamplesStatsBefore, usagestats.GetCounter(appendedSamplesStatsName).Total())
+			assert.Equal(t, int64(expectedExemplarsCount)+appendedExemplarsStatsBefore, usagestats.GetCounter(appendedExemplarsStatsName).Total())
 			assert.Equal(t, int64(0), usagestats.GetInt(tenantsWithOutOfOrderEnabledStatName).Value())
 			assert.Equal(t, int64(0), usagestats.GetInt(minOutOfOrderTimeWindowSecondsStatName).Value())
 			assert.Equal(t, int64(0), usagestats.GetInt(maxOutOfOrderTimeWindowSecondsStatName).Value())


### PR DESCRIPTION
#### What this PR does

This PR makes usage-stats variables package-global to avoid panics when initializing them in multiple parallel tests at once.

Example panic:

```
panic: Reuse of exported var name: github.com/grafana/mimir/ingester_inmemory_series
 [recovered]
	panic: Reuse of exported var name: github.com/grafana/mimir/ingester_inmemory_series
goroutine 72 [running]:
testing.tRunner.func1.2({0x10460ac80, 0x14000a04290})
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1545 +0x1c4
testing.tRunner.func1()
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1548 +0x360
panic({0x10460ac80?, 0x14000a04290?})
	/opt/homebrew/opt/go/libexec/src/runtime/panic.go:914 +0x218
log.Panicln({0x140008e62d0?, 0x31?, 0x14000819d40?})
	/opt/homebrew/opt/go/libexec/src/log/log.go:446 +0x60
expvar.Publish({0x140004e7ec0, 0x31}, {0x104a74500?, 0x14000a19500})
	/opt/homebrew/opt/go/libexec/src/expvar/expvar.go:284 +0xc0
expvar.NewInt(...)
	/opt/homebrew/opt/go/libexec/src/expvar/expvar.go:304
github.com/grafana/mimir/pkg/usagestats.GetInt({0x103e92ea7, 0x18})
	/Users/peter/Grafana/mimir/pkg/usagestats/stats.go:60 +0xe4
github.com/grafana/mimir/pkg/usagestats.GetAndResetInt(...)
	/Users/peter/Grafana/mimir/pkg/usagestats/stats.go:65
github.com/grafana/mimir/pkg/ingester.newIngester({{{{0x103e749f7, 0xa}, {0x103e76321, 0xb}, {{...}, {...}, {...}, _}, {_, _}}, ...}, ...}, ...)
	/Users/peter/Grafana/mimir/pkg/ingester/ingester.go:357 +0x370
github.com/grafana/mimir/pkg/ingester.New({{{{0x103e749f7, 0xa}, {0x103e76321, 0xb}, {{...}, {...}, {...}, _}, {_, _}}, ...}, ...}, ...)
	/Users/peter/Grafana/mimir/pkg/ingester/ingester.go:371 +0x88
github.com/grafana/mimir/pkg/ingester.createTestIngesterWithIngestStorage({0x104aa5c10, 0x140004b7860}, 0x140008e9ed8, 0x14000820a08?, {0x104a825f0, 0x14000a249b0})
	/Users/peter/Grafana/mimir/pkg/ingester/ingester_ingest_storage_test.go:411 +0x3dc
github.com/grafana/mimir/pkg/ingester.TestIngester_PreparePartitionDownscaleHandler.func1(_, {{{{0x103e749f7, 0xa}, {0x103e76321, 0xb}, {{...}, {...}, {...}, _}, {_, ...}}, ...}, ...})
	/Users/peter/Grafana/mimir/pkg/ingester/ingester_ingest_storage_test.go:221 +0x114
github.com/grafana/mimir/pkg/ingester.TestIngester_PreparePartitionDownscaleHandler.func3(0x140004b7860?)
	/Users/peter/Grafana/mimir/pkg/ingester/ingester_ingest_storage_test.go:266 +0xa4
testing.tRunner(0x140004b7860, 0x14000768ba0)
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1595 +0xe8
created by testing.(*T).Run in goroutine 70
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1648 +0x33c
```

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
