### PR TITLE
Update Vault token renewal test to use e2e.GreaterOrEqual

### DIFF
--- a/integration/vault_test.go
+++ b/integration/vault_test.go
@@ -78,5 +78,5 @@ func TestVaultTokenRenewal(t *testing.T) {
 	// Check that the token lease has been updated before hitting max_ttl
 	require.NoError(t, mimir.WaitSumMetrics(e2e.GreaterOrEqual(2), "cortex_vault_token_lease_renewal_success_total"))
 	// Check that re-authentication occurred
-	require.NoError(t, mimir.WaitSumMetrics(e2e.Equals(2), "cortex_vault_auth_success_total"))
+	require.NoError(t, mimir.WaitSumMetrics(e2e.GreaterOrEqual(2), "cortex_vault_auth_success_total"))
 }


### PR DESCRIPTION
#### What this PR does
Updates `TestVaultTokenRenewal` test to use `e2e.GreaterOrEqual` instead of `e2e.Equal` - `cortex_vault_auth_success_total` was being incremented past the value the equality was looking for, and `WaitSumMetric` kept looping until timeout.

As `cortex_vault_auth_success_total` gets updated frequently during token renewal, `e2e.GreaterOrEqual` is a more appropriate check.

Fixes #7397 

#### Checklist

- [ ] Tests updated.
