### PR TITLE
Query-frontend activity log enhancements

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -187,7 +187,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	activityIndex := f.at.Insert(func() string { return httpRequestActivity(r, params) })
+	activityIndex := f.at.Insert(func() string { return httpRequestActivity(r, r.Header.Get("User-Agent"), params) })
 	defer f.at.Delete(activityIndex)
 
 	startTime := time.Now()
@@ -427,7 +427,7 @@ func statsValue(name string, d time.Duration) string {
 	return name + ";dur=" + durationInMs
 }
 
-func httpRequestActivity(request *http.Request, requestParams url.Values) string {
+func httpRequestActivity(request *http.Request, userAgent string, requestParams url.Values) string {
 	tenantID := "(unknown)"
 	if tenantIDs, err := tenant.TenantIDs(request.Context()); err == nil {
 		tenantID = tenant.JoinTenantIDs(tenantIDs)
@@ -439,5 +439,5 @@ func httpRequestActivity(request *http.Request, requestParams url.Values) string
 	}
 
 	// This doesn't have to be pretty, just useful for debugging, so prioritize efficiency.
-	return strings.Join([]string{tenantID, request.Method, request.URL.Path, params}, " ")
+	return fmt.Sprintf("user:%s UA:%s req:%s %s %s", tenantID, userAgent, request.Method, request.URL.Path, params)
 }

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -88,21 +88,23 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"time":  []string{"42"},
 			},
 			expectedMetrics:         5,
-			expectedActivity:        "12345 POST /api/v1/query query=some_metric&time=42",
+			expectedActivity:        "user:12345 UA:test-user-agent req:POST /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 		},
 		{
 			name: "handler with stats enabled, GET request with params",
 			cfg:  HandlerConfig{QueryStatsEnabled: true},
 			request: func() *http.Request {
-				return httptest.NewRequest("GET", "/api/v1/query?query=some_metric&time=42", nil)
+				r := httptest.NewRequest("GET", "/api/v1/query?query=some_metric&time=42", nil)
+				r.Header.Add("User-Agent", "test-user-agent")
+				return r
 			},
 			expectedParams: url.Values{
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
 			expectedMetrics:         5,
-			expectedActivity:        "12345 GET /api/v1/query query=some_metric&time=42",
+			expectedActivity:        "user:12345 UA:test-user-agent req:GET /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 		},
 		{
@@ -110,6 +112,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			cfg:  HandlerConfig{QueryStatsEnabled: true},
 			request: func() *http.Request {
 				r := httptest.NewRequest("GET", "/api/v1/query?query=some_metric&time=42", nil)
+				r.Header.Add("User-Agent", "test-user-agent")
 				return r.WithContext(api.ContextWithReadConsistency(context.Background(), api.ReadConsistencyStrong))
 			},
 			expectedParams: url.Values{
@@ -117,32 +120,36 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"time":  []string{"42"},
 			},
 			expectedMetrics:         5,
-			expectedActivity:        "12345 GET /api/v1/query query=some_metric&time=42",
+			expectedActivity:        "user:12345 UA:test-user-agent req:GET /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: api.ReadConsistencyStrong,
 		},
 		{
 			name: "handler with stats enabled, GET request without params",
 			cfg:  HandlerConfig{QueryStatsEnabled: true},
 			request: func() *http.Request {
-				return httptest.NewRequest("GET", "/api/v1/query", nil)
+				r := httptest.NewRequest("GET", "/api/v1/query", nil)
+				r.Header.Add("User-Agent", "test-user-agent")
+				return r
 			},
 			expectedParams:          url.Values{},
 			expectedMetrics:         5,
-			expectedActivity:        "12345 GET /api/v1/query (no params)",
+			expectedActivity:        "user:12345 UA:test-user-agent req:GET /api/v1/query (no params)",
 			expectedReadConsistency: "",
 		},
 		{
 			name: "handler with stats disabled, GET request with params",
 			cfg:  HandlerConfig{QueryStatsEnabled: false},
 			request: func() *http.Request {
-				return httptest.NewRequest("GET", "/api/v1/query?query=some_metric&time=42", nil)
+				r := httptest.NewRequest("GET", "/api/v1/query?query=some_metric&time=42", nil)
+				r.Header.Add("User-Agent", "test-user-agent")
+				return r
 			},
 			expectedParams: url.Values{
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
 			expectedMetrics:         0,
-			expectedActivity:        "12345 GET /api/v1/query query=some_metric&time=42",
+			expectedActivity:        "user:12345 UA:test-user-agent req:GET /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 		},
 	} {


### PR DESCRIPTION
#### What this PR does

This PR enhances format of activity log entries produced by query-frontend. I investigated a problem today using these logs, and I had to check the code to understand what the initial number means, especially because it was very short (it turned out to be tenantID). I'm also adding `User-Agent` header to the activity log, as this would have helped me to pinpoint the problem faster.

Before:

```
572 POST /prometheus/api/v1/query_range end=1707955800&query=count...
```

After:

```
user:572 UA:our-internal-query-tool POST /prometheus/api/v1/query_range end=1707955800&query=count...
```

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
