### PR TITLE
Add partitions ring support to Distributor.UserStats()

### DIFF
--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -519,19 +519,12 @@ func TestDistributor_UserStats_ShouldSupportIngestStorage(t *testing.T) {
 				t.Run(fmt.Sprintf("minimize ingester requests: %t", minimizeIngesterRequests), func(t *testing.T) {
 					t.Parallel()
 
-					// Find the max number of ingesters in a zone. It will be used as the number of partitions.
-					numPartitions := 0
-					for _, state := range testData.ingesterStateByZone {
-						numPartitions = max(numPartitions, max(state.numIngesters, len(state.states)))
-					}
-
 					// Create distributor
 					distributors, _, _, _ := prepare(t, prepConfig{
-						numDistributors:         1,
-						ingesterStateByZone:     testData.ingesterStateByZone,
-						ingesterDataByZone:      testData.ingesterDataByZone,
-						ingestStorageEnabled:    true,
-						ingestStoragePartitions: int32(numPartitions),
+						numDistributors:      1,
+						ingesterStateByZone:  testData.ingesterStateByZone,
+						ingesterDataByZone:   testData.ingesterDataByZone,
+						ingestStorageEnabled: true,
 						configure: func(config *Config) {
 							config.PreferAvailabilityZone = preferredZone
 							config.MinimizeIngesterRequests = minimizeIngesterRequests

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/grafana/mimir/pkg/cardinality"
 	"github.com/grafana/mimir/pkg/mimirpb"
-	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/util/extract"
 	"github.com/grafana/mimir/pkg/util/testkafka"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -544,11 +543,8 @@ func TestDistributor_UserStats_ShouldSupportIngestStorage(t *testing.T) {
 						}(),
 					})
 
-					// Ensure strong read consistency, required to have no flaky tests when ingest storage is enabled.
-					ctx := user.InjectOrgID(context.Background(), "test")
-					ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
-
 					// Fetch user stats.
+					ctx := user.InjectOrgID(context.Background(), "test")
 					res, err := distributors[0].UserStats(ctx, cardinality.InMemoryMethod)
 
 					if testData.expectedErr != nil {

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/mtime"
+	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
@@ -22,9 +23,12 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"google.golang.org/grpc/codes"
 
+	"github.com/grafana/mimir/pkg/cardinality"
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/util/extract"
 	"github.com/grafana/mimir/pkg/util/testkafka"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 // kafkaTopic is the Kafka topic used for ingest storage tests.
@@ -256,6 +260,306 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 				"cortex_distributor_latest_seen_sample_timestamp_seconds",
 				"cortex_distributor_sample_delay_seconds",
 			))
+		})
+	}
+}
+
+func TestDistributor_UserStats_ShouldSupportIngestStorage(t *testing.T) {
+	const preferredZone = "zone-a"
+
+	tests := map[string]struct {
+		ingesterStateByZone map[string]ingesterZoneState
+		ingesterDataByZone  map[string][]*mimirpb.WriteRequest
+		shardSize           int
+		expectedSeries      uint64
+		expectedErr         error
+	}{
+		"partitions RF=1 (1 zone), 3 ingesters": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"single-zone": {numIngesters: 3, happyIngesters: 3},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"single-zone": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1"),
+					makeWriteRequest(0, 1, 0, false, false, "series_2"),
+					makeWriteRequest(0, 1, 0, false, false, "series_3"),
+				},
+			},
+			expectedSeries: 3,
+		},
+		"partitions RF=1 (1 zone), 6 ingesters": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"single-zone": {numIngesters: 6, happyIngesters: 6},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"single-zone": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1"),
+					makeWriteRequest(0, 1, 0, false, false, "series_2"),
+					makeWriteRequest(0, 1, 0, false, false, "series_3", "series_4"),
+					makeWriteRequest(0, 1, 0, false, false, "series_5", "series_7"),
+					makeWriteRequest(0, 1, 0, false, false, "series_7"),
+					makeWriteRequest(0, 1, 0, false, false, "series_8", "series_9"),
+				},
+			},
+			expectedSeries: 9,
+		},
+		"partitions RF=1 (1 zone), 6 ingesters, 1 ingester in LEAVING state": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"single-zone": {numIngesters: 6, happyIngesters: 6, ringStates: []ring.InstanceState{ring.LEAVING, ring.ACTIVE, ring.ACTIVE, ring.ACTIVE, ring.ACTIVE, ring.ACTIVE}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"single-zone": {
+					nil,
+					makeWriteRequest(0, 1, 0, false, false, "series_2"),
+					makeWriteRequest(0, 1, 0, false, false, "series_3", "series_4"),
+					makeWriteRequest(0, 1, 0, false, false, "series_5", "series_7"),
+					makeWriteRequest(0, 1, 0, false, false, "series_7"),
+					makeWriteRequest(0, 1, 0, false, false, "series_8", "series_9"),
+				},
+			},
+			expectedErr: ring.ErrTooManyUnhealthyInstances,
+		},
+		"partitions RF=1 (1 zone), 6 ingesters, 1 ingester is UNHEALTHY": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"single-zone": {numIngesters: 6, happyIngesters: 5},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"single-zone": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1"),
+					makeWriteRequest(0, 1, 0, false, false, "series_2"),
+					makeWriteRequest(0, 1, 0, false, false, "series_3", "series_4"),
+					makeWriteRequest(0, 1, 0, false, false, "series_5", "series_7"),
+					makeWriteRequest(0, 1, 0, false, false, "series_7"),
+					nil,
+				},
+			},
+			expectedErr: errFail,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2},
+				"zone-b": {numIngesters: 2, happyIngesters: 2},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+			},
+			expectedSeries: 5,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, all ingesters in the preferred zone (zone-a) are in LEAVING state": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.LEAVING}},
+				"zone-b": {numIngesters: 2, happyIngesters: 2},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+			},
+			expectedSeries: 5,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, all ingesters in the non-preferred zone (zone-b) are in LEAVING state": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2},
+				"zone-b": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.LEAVING}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+			},
+			expectedSeries: 5,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning different partitions are in LEAVING state across both zones": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.ACTIVE}},
+				"zone-b": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.ACTIVE, ring.LEAVING}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+			},
+			expectedSeries: 5,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning the same partition are in LEAVING state in both zones": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.ACTIVE}},
+				"zone-b": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.ACTIVE}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+			},
+			expectedErr: ring.ErrTooManyUnhealthyInstances,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, all ingesters in the preferred zone (zone-a) are UNHEALTHY": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 0},
+				"zone-b": {numIngesters: 2, happyIngesters: 2},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					nil,
+					nil,
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+			},
+			expectedSeries: 5,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, all ingesters in the non-preferred zone (zone-b) are UNHEALTHY": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2},
+				"zone-b": {numIngesters: 2, happyIngesters: 0},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+				"zone-b": {
+					nil,
+					nil,
+				},
+			},
+			expectedSeries: 5,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning different partitions are UNHEALTHY across both zones": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {states: []ingesterState{ingesterStateFailed, ingesterStateHappy}},
+				"zone-b": {states: []ingesterState{ingesterStateHappy, ingesterStateFailed}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					nil,
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5"),
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					nil,
+				},
+			},
+			expectedSeries: 5,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning the same partition are UNHEALTHY in both zones": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {states: []ingesterState{ingesterStateHappy, ingesterStateFailed}},
+				"zone-b": {states: []ingesterState{ingesterStateHappy, ingesterStateFailed}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					nil,
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+					nil,
+				},
+			},
+			expectedErr: errFail,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning the same partition are UNHEALTHY in both zones but the partition is not part of the tenant's shard": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {states: []ingesterState{ingesterStateFailed, ingesterStateHappy}},
+				"zone-b": {states: []ingesterState{ingesterStateFailed, ingesterStateHappy}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					nil,
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+				},
+				"zone-b": {
+					nil,
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+				},
+			},
+			shardSize:      1, // Tenant's shard made of: partition 1.
+			expectedSeries: 3,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			for _, minimizeIngesterRequests := range []bool{false, true} {
+				minimizeIngesterRequests := minimizeIngesterRequests
+
+				t.Run(fmt.Sprintf("minimize ingester requests: %t", minimizeIngesterRequests), func(t *testing.T) {
+					t.Parallel()
+
+					// Find the max number of ingesters in a zone. It will be used as the number of partitions.
+					numPartitions := 0
+					for _, state := range testData.ingesterStateByZone {
+						numPartitions = max(numPartitions, max(state.numIngesters, len(state.states)))
+					}
+
+					// Create distributor
+					distributors, _, _, _ := prepare(t, prepConfig{
+						numDistributors:         1,
+						ingesterStateByZone:     testData.ingesterStateByZone,
+						ingesterDataByZone:      testData.ingesterDataByZone,
+						ingestStorageEnabled:    true,
+						ingestStoragePartitions: int32(numPartitions),
+						configure: func(config *Config) {
+							config.PreferAvailabilityZone = preferredZone
+							config.MinimizeIngesterRequests = minimizeIngesterRequests
+						},
+						limits: func() *validation.Limits {
+							limits := prepareDefaultLimits()
+							limits.IngestionPartitionsTenantShardSize = testData.shardSize
+							return limits
+						}(),
+					})
+
+					// Ensure strong read consistency, required to have no flaky tests when ingest storage is enabled.
+					ctx := user.InjectOrgID(context.Background(), "test")
+					ctx = api.ContextWithReadConsistency(ctx, api.ReadConsistencyStrong)
+
+					// Fetch user stats.
+					res, err := distributors[0].UserStats(ctx, cardinality.InMemoryMethod)
+
+					if testData.expectedErr != nil {
+						require.ErrorIs(t, err, testData.expectedErr)
+						return
+					}
+
+					require.NoError(t, err)
+					assert.Equal(t, testData.expectedSeries, res.NumSeries)
+				})
+			}
 		})
 	}
 }

--- a/pkg/distributor/query_ingest_storage_test.go
+++ b/pkg/distributor/query_ingest_storage_test.go
@@ -21,7 +21,6 @@ import (
 	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
-	util_math "github.com/grafana/mimir/pkg/util/math"
 )
 
 func TestDistributor_QueryStream_ShouldSupportIngestStorage(t *testing.T) {
@@ -510,11 +509,6 @@ func TestDistributor_QueryStream_ShouldSupportIngestStorage(t *testing.T) {
 					config.PreferAvailabilityZone = testData.preferZone
 					config.MinimizeIngesterRequests = testData.minimizeIngesterRequests
 				},
-			}
-
-			// Detect the number of partitions from test scenario.
-			for _, zone := range testData.ingesterStateByZone {
-				cfg.ingestStoragePartitions = util_math.Max(cfg.ingestStoragePartitions, int32(util_math.Max(zone.numIngesters, len(zone.states))))
 			}
 
 			distributors, ingesters, distributorRegistries, _ := prepare(t, cfg)

--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -114,7 +114,6 @@ func TestDistributor_QueryExemplars(t *testing.T) {
 
 					if ingestStorageEnabled {
 						testConfig.ingestStorageEnabled = true
-						testConfig.ingestStoragePartitions = numIngesters
 						testConfig.limits.IngestionPartitionsTenantShardSize = testData.shuffleShardSize
 					} else {
 						testConfig.shuffleShardSize = testData.shuffleShardSize


### PR DESCRIPTION
#### What this PR does

In this PR I'm adding partitions ring support to `Distributor.UserStats()`. Contrary to https://github.com/grafana/mimir/pull/7393 (which was straightforward) the main difference here is that with the ingest storage we have to account for replication in a slightly different way (see comments in the code).

Note to reviewers:
- I suggest to review with "hide whitespace changes" enabled

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
