### PR TITLE
Add partitions support to Distributor.ActiveSeries()

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1486,27 +1486,6 @@ func (d *Distributor) sendToStorage(ctx context.Context, userID string, partitio
 	return wrapPartitionPushError(err, int32(partitionID))
 }
 
-// forReplicationSet runs f, in parallel, for all ingesters in the input replication set.
-//
-// Deprecated: use forReplicationSets() instead.
-func forReplicationSet[T any](ctx context.Context, d *Distributor, replicationSet ring.ReplicationSet, f func(context.Context, ingester_client.IngesterClient) (T, error)) ([]T, error) {
-	wrappedF := func(ctx context.Context, ing *ring.InstanceDesc) (T, error) {
-		client, err := d.ingesterPool.GetClientForInstance(*ing)
-		if err != nil {
-			var empty T
-			return empty, err
-		}
-
-		return f(ctx, client.(ingester_client.IngesterClient))
-	}
-
-	cleanup := func(_ T) {
-		// Nothing to do.
-	}
-
-	return ring.DoUntilQuorum(ctx, replicationSet, d.queryQuorumConfig(ctx, replicationSet), wrappedF, cleanup)
-}
-
 // forReplicationSets runs f, in parallel, for all ingesters in the input replicationSets.
 // Return an error if any f fails for any of the input replicationSets.
 func forReplicationSets[R any](ctx context.Context, d *Distributor, replicationSets []ring.ReplicationSet, f func(context.Context, ingester_client.IngesterClient) (R, error)) ([]R, error) {


### PR DESCRIPTION
#### What this PR does

Similarly to previous PRs https://github.com/grafana/mimir/pull/7393 and https://github.com/grafana/mimir/pull/7402, in this PR I'm adding partitions support to `Distributor.ActiveSeries()`. This was an easy one. Just a bunch of tests.

Note to reviewers:
- I suggest to review the diff with "hide whitespace changes"
- Removed the unused `forReplicationSet()`

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
