### PR TITLE
Set series cache TTL different based on block metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [CHANGE] Store-gateway: remove `cortex_bucket_store_blocks_loaded_by_duration`. `cortex_bucket_store_series_blocks_queried` is better suited for detecting when compactors are not able to keep up with the number of blocks to compact. #7309
 * [CHANGE] Ingester, Distributor: the support for rejecting push requests received via gRPC before reading them into memory, enabled via `-ingester.limit-inflight-requests-using-grpc-method-limiter` and `-distributor.limit-inflight-requests-using-grpc-method-limiter`, is now stable and enabled by default. The configuration options have been deprecated and will be removed in Mimir 2.14. #7360
 * [CHANGE] Distributor: Change`-distributor.enable-otlp-metadata-storage` flag's default to true, and deprecate it. The flag will be removed in Mimir 2.14. #7366
+* [CHANGE] Store-gateway: Use a shorter TTL for cached items related to temporary blocks. #7407
 * [FEATURE] Introduce `-server.log-source-ips-full` option to log all IPs from `Forwarded`, `X-Real-IP`, `X-Forwarded-For` headers. #7250
 * [FEATURE] Introduce `-tenant-federation.max-tenants` option to limit the max number of tenants allowed for requests when federation is enabled. #6959
 * [FEATURE] Cardinality API: added a new `count_method` parameter which enables counting active label values. #7085

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	testutil "github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
@@ -131,11 +132,12 @@ func TestConfig_Validate(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
+			logger := testutil.NewTestingLogger(t)
 			cfg := &Config{}
 			flagext.DefaultValues(cfg)
 			testData.setup(cfg)
 
-			if actualErr := cfg.Validate(); testData.expected != "" {
+			if actualErr := cfg.Validate(logger); testData.expected != "" {
 				assert.EqualError(t, actualErr, testData.expected)
 			} else {
 				assert.NoError(t, actualErr)

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -271,7 +271,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.StoreGateway.Validate(c.LimitsConfig); err != nil {
 		return errors.Wrap(err, "invalid store-gateway config")
 	}
-	if err := c.Compactor.Validate(); err != nil {
+	if err := c.Compactor.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid compactor config")
 	}
 	if err := c.AlertmanagerStorage.Validate(); err != nil {

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -132,7 +132,7 @@ func (noopCache) FetchMultiPostings(_ context.Context, _ string, _ ulid.ULID, ke
 	return &indexcache.MapIterator[labels.Label]{Keys: keys}
 }
 
-func (noopCache) StoreSeriesForRef(string, ulid.ULID, storage.SeriesRef, []byte) {}
+func (noopCache) StoreSeriesForRef(string, ulid.ULID, storage.SeriesRef, []byte, time.Duration) {}
 func (noopCache) FetchMultiSeriesForRefs(_ context.Context, _ string, _ ulid.ULID, ids []storage.SeriesRef) (map[storage.SeriesRef][]byte, []storage.SeriesRef) {
 	return map[storage.SeriesRef][]byte{}, ids
 }

--- a/pkg/storegateway/indexcache/cache.go
+++ b/pkg/storegateway/indexcache/cache.go
@@ -125,7 +125,12 @@ type IndexCache interface {
 // compacted and deleted soon and a longer TTL for larger blocks that won't be deleted.
 func BlockTTL(meta *block.Meta) time.Duration {
 	duration := time.Duration(meta.MaxTime-meta.MinTime) * time.Millisecond
-	duration = max(time.Hour, duration.Round(time.Hour))
+	if duration%time.Hour != 0 {
+		duration += time.Hour - duration%time.Hour
+	}
+
+	// Pick the max of one hour or duration adjusted up to the next hour
+	duration = max(time.Hour, duration)
 
 	// Anything less than 24h is a temporary block that will eventually be compacted into
 	// a 24h block. Use a shorter TTL since otherwise these will stay in the cache long

--- a/pkg/storegateway/indexcache/cache_test.go
+++ b/pkg/storegateway/indexcache/cache_test.go
@@ -130,9 +130,21 @@ func TestBlockTTL(t *testing.T) {
 		ttl  time.Duration
 	}{
 		{
+			name: "30m block",
+			minT: 1700000000000,
+			maxT: 1700001800000,
+			ttl:  1 * time.Hour,
+		},
+		{
 			name: "1h block",
 			minT: 1700000000000,
 			maxT: 1700003600000,
+			ttl:  1 * time.Hour,
+		},
+		{
+			name: "90m block",
+			minT: 1700000000000,
+			maxT: 1700005400000,
 			ttl:  2 * time.Hour,
 		},
 		{
@@ -142,22 +154,28 @@ func TestBlockTTL(t *testing.T) {
 			ttl:  2 * time.Hour,
 		},
 		{
+			name: "3h block",
+			minT: 1700000000000,
+			maxT: 1700010800000,
+			ttl:  3 * time.Hour,
+		},
+		{
 			name: "10h block",
 			minT: 1700000000000,
 			maxT: 1700036000000,
-			ttl:  2 * time.Hour,
+			ttl:  10 * time.Hour,
 		},
 		{
 			name: "12h block",
 			minT: 1700000000000,
 			maxT: 1700043200000,
-			ttl:  2 * time.Hour,
+			ttl:  12 * time.Hour,
 		},
 		{
 			name: "20h block",
 			minT: 1700000000000,
 			maxT: 1700072000000,
-			ttl:  168 * time.Hour,
+			ttl:  20 * time.Hour,
 		},
 		{
 			name: "24h block",

--- a/pkg/storegateway/indexcache/cache_test.go
+++ b/pkg/storegateway/indexcache/cache_test.go
@@ -142,9 +142,9 @@ func TestBlockTTL(t *testing.T) {
 			ttl:  1 * time.Hour,
 		},
 		{
-			name: "90m block",
+			name: "65m block",
 			minT: 1700000000000,
-			maxT: 1700005400000,
+			maxT: 1700003900000,
 			ttl:  2 * time.Hour,
 		},
 		{
@@ -158,6 +158,12 @@ func TestBlockTTL(t *testing.T) {
 			minT: 1700000000000,
 			maxT: 1700010800000,
 			ttl:  3 * time.Hour,
+		},
+		{
+			name: "185m block",
+			minT: 1700000000000,
+			maxT: 1700011100000,
+			ttl:  4 * time.Hour,
 		},
 		{
 			name: "10h block",
@@ -184,14 +190,16 @@ func TestBlockTTL(t *testing.T) {
 			ttl:  168 * time.Hour,
 		},
 	} {
-		meta := &block.Meta{
-			BlockMeta: tsdb.BlockMeta{
-				MinTime: tt.minT,
-				MaxTime: tt.maxT,
-			},
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			meta := &block.Meta{
+				BlockMeta: tsdb.BlockMeta{
+					MinTime: tt.minT,
+					MaxTime: tt.maxT,
+				},
+			}
 
-		ttl := BlockTTL(meta)
-		assert.Equal(t, tt.ttl, ttl)
+			ttl := BlockTTL(meta)
+			assert.Equal(t, tt.ttl, ttl)
+		})
 	}
 }

--- a/pkg/storegateway/indexcache/cache_test.go
+++ b/pkg/storegateway/indexcache/cache_test.go
@@ -9,11 +9,14 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -117,4 +120,60 @@ func TestCanonicalPostingsKey(t *testing.T) {
 		_, err := base64.RawURLEncoding.DecodeString(string(key))
 		assert.NoError(t, err)
 	})
+}
+
+func TestBlockTTL(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		minT int64
+		maxT int64
+		ttl  time.Duration
+	}{
+		{
+			name: "1h block",
+			minT: 1700000000000,
+			maxT: 1700003600000,
+			ttl:  2 * time.Hour,
+		},
+		{
+			name: "2h block",
+			minT: 1700000000000,
+			maxT: 1700007200000,
+			ttl:  2 * time.Hour,
+		},
+		{
+			name: "10h block",
+			minT: 1700000000000,
+			maxT: 1700036000000,
+			ttl:  2 * time.Hour,
+		},
+		{
+			name: "12h block",
+			minT: 1700000000000,
+			maxT: 1700043200000,
+			ttl:  2 * time.Hour,
+		},
+		{
+			name: "20h block",
+			minT: 1700000000000,
+			maxT: 1700072000000,
+			ttl:  168 * time.Hour,
+		},
+		{
+			name: "24h block",
+			minT: 1700000000000,
+			maxT: 1700086400000,
+			ttl:  168 * time.Hour,
+		},
+	} {
+		meta := &block.Meta{
+			BlockMeta: tsdb.BlockMeta{
+				MinTime: tt.minT,
+				MaxTime: tt.maxT,
+			},
+		}
+
+		ttl := BlockTTL(meta)
+		assert.Equal(t, tt.ttl, ttl)
+	}
 }

--- a/pkg/storegateway/indexcache/inmemory.go
+++ b/pkg/storegateway/indexcache/inmemory.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"reflect"
 	"sync"
+	"time"
 	"unsafe"
 
 	"github.com/go-kit/log"
@@ -313,7 +314,7 @@ func (c *InMemoryIndexCache) FetchMultiPostings(_ context.Context, userID string
 
 // StoreSeriesForRef sets the series identified by the ulid and id to the value v,
 // if the series already exists in the cache it is not mutated.
-func (c *InMemoryIndexCache) StoreSeriesForRef(userID string, blockID ulid.ULID, id storage.SeriesRef, v []byte) {
+func (c *InMemoryIndexCache) StoreSeriesForRef(userID string, blockID ulid.ULID, id storage.SeriesRef, v []byte, _ time.Duration) {
 	c.set(cacheKeySeriesForRef{userID, blockID, id}, v)
 }
 

--- a/pkg/storegateway/indexcache/inmemory_test.go
+++ b/pkg/storegateway/indexcache/inmemory_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
@@ -148,7 +149,7 @@ func TestInMemoryIndexCache_UpdateItem(t *testing.T) {
 		{
 			typ: cacheTypeSeriesForRef,
 			set: func(id uint64, b []byte) {
-				cache.StoreSeriesForRef(user, uid(id), storage.SeriesRef(id), b)
+				cache.StoreSeriesForRef(user, uid(id), storage.SeriesRef(id), b, time.Hour)
 			},
 			get: func(id uint64) ([]byte, bool) {
 				seriesRef := storage.SeriesRef(id)
@@ -313,7 +314,7 @@ func TestInMemoryIndexCache_Eviction_WithMetrics(t *testing.T) {
 	testFetchMultiPostings(ctx, t, cache, user, id, []labels.Label{{Name: "test", Value: "124"}}, nil)
 
 	// Add sliceHeaderSize + 3 more bytes.
-	cache.StoreSeriesForRef(user, id, 1234, []byte{222, 223, 224})
+	cache.StoreSeriesForRef(user, id, 1234, []byte{222, 223, 224}, time.Hour)
 	assert.Equal(t, uint64(2*sliceHeaderSize+5), cache.curSize)
 	assert.Equal(t, float64(1), promtest.ToFloat64(cache.current.WithLabelValues(cacheTypePostings)))
 	assert.Equal(t, float64(sliceHeaderSize+2), promtest.ToFloat64(cache.currentSize.WithLabelValues(cacheTypePostings)))

--- a/pkg/storegateway/indexcache/remote.go
+++ b/pkg/storegateway/indexcache/remote.go
@@ -73,11 +73,6 @@ func NewRemoteIndexCache(logger log.Logger, remote cache.RemoteCacheClient, reg 
 	return c, nil
 }
 
-// set stores a value for the given key in the remote cache.
-func (c *RemoteIndexCache) set(key string, val []byte) {
-	c.remote.SetAsync(key, val, remoteDefaultTTL)
-}
-
 // get retrieves a single value from the remote cache, returned bool value indicates whether the value was found or not.
 func (c *RemoteIndexCache) get(ctx context.Context, typ string, key string) ([]byte, bool) {
 	c.requests.WithLabelValues(typ).Inc()
@@ -93,7 +88,7 @@ func (c *RemoteIndexCache) get(ctx context.Context, typ string, key string) ([]b
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
 func (c *RemoteIndexCache) StorePostings(userID string, blockID ulid.ULID, l labels.Label, v []byte) {
-	c.set(postingsCacheKey(userID, blockID.String(), l), v)
+	c.remote.SetAsync(postingsCacheKey(userID, blockID.String(), l), v, remoteDefaultTTL)
 }
 
 // FetchMultiPostings fetches multiple postings - each identified by a label.
@@ -198,8 +193,8 @@ func postingsCacheKeyLabelID(l labels.Label) (out [blake2b.Size256]byte, outLen 
 // StoreSeriesForRef sets the series identified by the ulid and id to the value v.
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
-func (c *RemoteIndexCache) StoreSeriesForRef(userID string, blockID ulid.ULID, id storage.SeriesRef, v []byte) {
-	c.set(seriesForRefCacheKey(userID, blockID, id), v)
+func (c *RemoteIndexCache) StoreSeriesForRef(userID string, blockID ulid.ULID, id storage.SeriesRef, v []byte, ttl time.Duration) {
+	c.remote.SetAsync(seriesForRefCacheKey(userID, blockID, id), v, ttl)
 }
 
 // FetchMultiSeriesForRefs fetches multiple series - each identified by ID - from the cache
@@ -262,7 +257,7 @@ func seriesForRefCacheKey(userID string, blockID ulid.ULID, id storage.SeriesRef
 
 // StoreExpandedPostings stores the encoded result of ExpandedPostings for specified matchers identified by the provided LabelMatchersKey.
 func (c *RemoteIndexCache) StoreExpandedPostings(userID string, blockID ulid.ULID, lmKey LabelMatchersKey, postingsSelectionStrategy string, v []byte) {
-	c.set(expandedPostingsCacheKey(userID, blockID, lmKey, postingsSelectionStrategy), v)
+	c.remote.SetAsync(expandedPostingsCacheKey(userID, blockID, lmKey, postingsSelectionStrategy), v, remoteDefaultTTL)
 }
 
 // FetchExpandedPostings fetches the encoded result of ExpandedPostings for specified matchers identified by the provided LabelMatchersKey.
@@ -277,7 +272,7 @@ func expandedPostingsCacheKey(userID string, blockID ulid.ULID, lmKey LabelMatch
 
 // StoreSeriesForPostings stores a series set for the provided postings.
 func (c *RemoteIndexCache) StoreSeriesForPostings(userID string, blockID ulid.ULID, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
-	c.set(seriesForPostingsCacheKey(userID, blockID, shard, postingsKey), v)
+	c.remote.SetAsync(seriesForPostingsCacheKey(userID, blockID, shard, postingsKey), v, remoteDefaultTTL)
 }
 
 // FetchSeriesForPostings fetches a series set for the provided postings.
@@ -298,7 +293,7 @@ func seriesForPostingsCacheKey(userID string, blockID ulid.ULID, shard *sharding
 
 // StoreLabelNames stores the result of a LabelNames() call.
 func (c *RemoteIndexCache) StoreLabelNames(userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, v []byte) {
-	c.set(labelNamesCacheKey(userID, blockID, matchersKey), v)
+	c.remote.SetAsync(labelNamesCacheKey(userID, blockID, matchersKey), v, remoteDefaultTTL)
 }
 
 // FetchLabelNames fetches the result of a LabelNames() call.
@@ -313,7 +308,7 @@ func labelNamesCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatch
 
 // StoreLabelValues stores the result of a LabelValues() call.
 func (c *RemoteIndexCache) StoreLabelValues(userID string, blockID ulid.ULID, labelName string, matchersKey LabelMatchersKey, v []byte) {
-	c.set(labelValuesCacheKey(userID, blockID, labelName, matchersKey), v)
+	c.remote.SetAsync(labelValuesCacheKey(userID, blockID, labelName, matchersKey), v, remoteDefaultTTL)
 }
 
 // FetchLabelValues fetches the result of a LabelValues() call.

--- a/pkg/storegateway/indexcache/remote.go
+++ b/pkg/storegateway/indexcache/remote.go
@@ -27,10 +27,6 @@ import (
 	"github.com/grafana/mimir/pkg/storage/sharding"
 )
 
-const (
-	remoteDefaultTTL = 7 * 24 * time.Hour
-)
-
 var (
 	postingsCacheKeyLabelHashBufferPool = sync.Pool{New: func() any {
 		// We assume the label name/value pair is typically not longer than 1KB.
@@ -88,7 +84,7 @@ func (c *RemoteIndexCache) get(ctx context.Context, typ string, key string) ([]b
 // The function enqueues the request and returns immediately: the entry will be
 // asynchronously stored in the cache.
 func (c *RemoteIndexCache) StorePostings(userID string, blockID ulid.ULID, l labels.Label, v []byte) {
-	c.remote.SetAsync(postingsCacheKey(userID, blockID.String(), l), v, remoteDefaultTTL)
+	c.remote.SetAsync(postingsCacheKey(userID, blockID.String(), l), v, defaultTTL)
 }
 
 // FetchMultiPostings fetches multiple postings - each identified by a label.
@@ -257,7 +253,7 @@ func seriesForRefCacheKey(userID string, blockID ulid.ULID, id storage.SeriesRef
 
 // StoreExpandedPostings stores the encoded result of ExpandedPostings for specified matchers identified by the provided LabelMatchersKey.
 func (c *RemoteIndexCache) StoreExpandedPostings(userID string, blockID ulid.ULID, lmKey LabelMatchersKey, postingsSelectionStrategy string, v []byte) {
-	c.remote.SetAsync(expandedPostingsCacheKey(userID, blockID, lmKey, postingsSelectionStrategy), v, remoteDefaultTTL)
+	c.remote.SetAsync(expandedPostingsCacheKey(userID, blockID, lmKey, postingsSelectionStrategy), v, defaultTTL)
 }
 
 // FetchExpandedPostings fetches the encoded result of ExpandedPostings for specified matchers identified by the provided LabelMatchersKey.
@@ -272,7 +268,7 @@ func expandedPostingsCacheKey(userID string, blockID ulid.ULID, lmKey LabelMatch
 
 // StoreSeriesForPostings stores a series set for the provided postings.
 func (c *RemoteIndexCache) StoreSeriesForPostings(userID string, blockID ulid.ULID, shard *sharding.ShardSelector, postingsKey PostingsKey, v []byte) {
-	c.remote.SetAsync(seriesForPostingsCacheKey(userID, blockID, shard, postingsKey), v, remoteDefaultTTL)
+	c.remote.SetAsync(seriesForPostingsCacheKey(userID, blockID, shard, postingsKey), v, defaultTTL)
 }
 
 // FetchSeriesForPostings fetches a series set for the provided postings.
@@ -293,7 +289,7 @@ func seriesForPostingsCacheKey(userID string, blockID ulid.ULID, shard *sharding
 
 // StoreLabelNames stores the result of a LabelNames() call.
 func (c *RemoteIndexCache) StoreLabelNames(userID string, blockID ulid.ULID, matchersKey LabelMatchersKey, v []byte) {
-	c.remote.SetAsync(labelNamesCacheKey(userID, blockID, matchersKey), v, remoteDefaultTTL)
+	c.remote.SetAsync(labelNamesCacheKey(userID, blockID, matchersKey), v, defaultTTL)
 }
 
 // FetchLabelNames fetches the result of a LabelNames() call.
@@ -308,7 +304,7 @@ func labelNamesCacheKey(userID string, blockID ulid.ULID, matchersKey LabelMatch
 
 // StoreLabelValues stores the result of a LabelValues() call.
 func (c *RemoteIndexCache) StoreLabelValues(userID string, blockID ulid.ULID, labelName string, matchersKey LabelMatchersKey, v []byte) {
-	c.remote.SetAsync(labelValuesCacheKey(userID, blockID, labelName, matchersKey), v, remoteDefaultTTL)
+	c.remote.SetAsync(labelValuesCacheKey(userID, blockID, labelName, matchersKey), v, defaultTTL)
 }
 
 // FetchLabelValues fetches the result of a LabelValues() call.

--- a/pkg/storegateway/indexcache/remote_test.go
+++ b/pkg/storegateway/indexcache/remote_test.go
@@ -279,7 +279,7 @@ func TestRemoteIndexCache_FetchMultiSeriesForRef(t *testing.T) {
 			// Store the series expected before running the test.
 			ctx := context.Background()
 			for _, p := range testData.setup {
-				c.StoreSeriesForRef(p.userID, p.block, p.id, p.value)
+				c.StoreSeriesForRef(p.userID, p.block, p.id, p.value, time.Hour)
 			}
 
 			// Fetch series from cached and assert on it.

--- a/pkg/storegateway/indexcache/tracing.go
+++ b/pkg/storegateway/indexcache/tracing.go
@@ -49,8 +49,8 @@ func (t *TracingIndexCache) FetchMultiPostings(ctx context.Context, userID strin
 	return hits
 }
 
-func (t *TracingIndexCache) StoreSeriesForRef(userID string, blockID ulid.ULID, id storage.SeriesRef, v []byte) {
-	t.c.StoreSeriesForRef(userID, blockID, id, v)
+func (t *TracingIndexCache) StoreSeriesForRef(userID string, blockID ulid.ULID, id storage.SeriesRef, v []byte, ttl time.Duration) {
+	t.c.StoreSeriesForRef(userID, blockID, id, v, ttl)
 }
 
 func (t *TracingIndexCache) FetchMultiSeriesForRefs(ctx context.Context, userID string, blockID ulid.ULID, ids []storage.SeriesRef) (hits map[storage.SeriesRef][]byte, misses []storage.SeriesRef) {


### PR DESCRIPTION
#### What this PR does

Instead of using a default TTL of 7d for all index-cache related entries, pick different TTLs based on metadata about the block. This allows entries related to blocks that will be deleted (OOO blocks, 2h, 12h) to expire and be eligible to be evicted sooner than they would otherwise.

This change only sets different TTLs for series entries in the cache since they account for most of the space in the cache.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
