### PR TITLE
Note how to run Mimir Alertmanager as part of a monolithic deployment

### DIFF
--- a/docs/sources/mimir/references/architecture/components/alertmanager.md
+++ b/docs/sources/mimir/references/architecture/components/alertmanager.md
@@ -15,7 +15,9 @@ The Mimir Alertmanager adds multi-tenancy support and horizontal scalability to 
 The Mimir Alertmanager is an optional component that accepts alert notifications from the [Mimir ruler]({{< relref "./ruler" >}}).
 The Alertmanager deduplicates and groups alert notifications, and routes them to a notification channel, such as email, PagerDuty, or OpsGenie.
 
-> **Note:** To run Mimir Alertmanager as a part of [monolithic deployment]({{< relref "/../deployment-modes/#monolithic-mode" >}})run mimir with the command `./mimir -target=all,alertmanager`.
+{{< admonition type="note" >}}
+To run Mimir Alertmanager as a part of [monolithic deployment]({{< relref "../deployment-modes#monolithic-mode" >}}), run Mimir with the option `-target=all,alertmanager`.
+{{< /admonition >}}
 
 ## Multi-tenancy
 

--- a/docs/sources/mimir/references/architecture/components/alertmanager.md
+++ b/docs/sources/mimir/references/architecture/components/alertmanager.md
@@ -15,6 +15,8 @@ The Mimir Alertmanager adds multi-tenancy support and horizontal scalability to 
 The Mimir Alertmanager is an optional component that accepts alert notifications from the [Mimir ruler]({{< relref "./ruler" >}}).
 The Alertmanager deduplicates and groups alert notifications, and routes them to a notification channel, such as email, PagerDuty, or OpsGenie.
 
+> **Note:** To run Mimir Alertmanager as a part of [monolithic deployment]({{< relref "/../deployment-modes/#monolithic-mode" >}})run mimir with the command `./mimir -target=all,alertmanager`.
+
 ## Multi-tenancy
 
 Like other Mimir components, multi-tenancy in the Mimir Alertmanager uses the tenant ID header.


### PR DESCRIPTION
Added a note about using altermanager in monolithic deployment.

PS: I did read the writers-toolkit for links https://grafana.com/docs/writers-toolkit/write/links/. However, I noticed that the rest of the content uses relref. For the sake of consistency I used relref.

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #https://github.com/grafana/mimir/issues/7405

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
