### PR TITLE
Added partitions support to Distributor.LabelValuesCardinality()

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1510,13 +1510,6 @@ func forReplicationSets[R any](ctx context.Context, d *Distributor, replicationS
 	})
 }
 
-// queryQuorumConfig returns the config to use with "do until quorum" functions when running queries.
-//
-// Deprecated: use queryQuorumConfigForReplicationSets() instead.
-func (d *Distributor) queryQuorumConfig(ctx context.Context, replicationSet ring.ReplicationSet) ring.DoUntilQuorumConfig {
-	return d.queryQuorumConfigForReplicationSets(ctx, []ring.ReplicationSet{replicationSet})
-}
-
 // queryQuorumConfigForReplicationSets returns the config to use with "do until quorum" functions when running queries.
 func (d *Distributor) queryQuorumConfigForReplicationSets(ctx context.Context, replicationSets []ring.ReplicationSet) ring.DoUntilQuorumConfig {
 	var zoneSorter ring.ZoneSorter

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1786,19 +1786,20 @@ func (d *Distributor) LabelValuesCardinality(ctx context.Context, labelNames []m
 // labelValuesCardinality queries ingesters for label values cardinality of a set of labelNames
 // Returns a LabelValuesCardinalityResponse where each item contains an exclusive label name and associated label values
 func (d *Distributor) labelValuesCardinality(ctx context.Context, labelNames []model.LabelName, matchers []*labels.Matcher, countMethod cardinality.CountMethod) (*ingester_client.LabelValuesCardinalityResponse, error) {
-	//nolint:staticcheck
-	replicationSet, err := d.getIngesterReplicationSetForQuery(ctx)
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// If we have a single zone, we require all ingesters to respond.
-	if replicationSet.ZoneCount() == 1 {
-		replicationSet.MaxErrors = 0
+	// When ingest storage is disabled, if ingesters are running in a single zone we can't tolerate any errors.
+	// In this case we expect exactly 1 replication set.
+	if !d.cfg.IngestStorageConfig.Enabled && len(replicationSets) == 1 && replicationSets[0].ZoneCount() == 1 {
+		replicationSets[0].MaxErrors = 0
 	}
 
 	cardinalityConcurrentMap := &labelValuesCardinalityConcurrentMap{
-		cardinalityMapByZone: make(map[string]map[string]map[string]uint64, len(labelNames)),
+		numReplicationSets:  len(replicationSets),
+		labelValuesCounters: make(map[string]map[string]countByReplicationSetAndZone, len(labelNames)),
 	}
 
 	labelValuesReq, err := toLabelValuesCardinalityRequest(labelNames, matchers, countMethod)
@@ -1806,26 +1807,46 @@ func (d *Distributor) labelValuesCardinality(ctx context.Context, labelNames []m
 		return nil, err
 	}
 
-	_, err = ring.DoUntilQuorum[struct{}](ctx, replicationSet, d.queryQuorumConfig(ctx, replicationSet), func(ctx context.Context, desc *ring.InstanceDesc) (struct{}, error) {
-		poolClient, err := d.ingesterPool.GetClientForInstance(*desc)
-		if err != nil {
-			return struct{}{}, err
-		}
+	quorumConfig := d.queryQuorumConfigForReplicationSets(ctx, replicationSets)
 
-		client := poolClient.(ingester_client.IngesterClient)
+	// Fetch labels cardinality from each ingester and collect responses by ReplicationSet.
+	//
+	// When ingest storage is enabled we expect 1 ReplicationSet for each partition. A series is sharded only to 1
+	// partition and the number of successful responses for each partition (ReplicationSet) may be different when
+	// ingesters request minimization is disabled. For this reason, we collect responses by ReplicationSet, so that
+	// we can later estimate the number of series with a higher accuracy.
+	err = concurrency.ForEachJob(ctx, len(replicationSets), 0, func(ctx context.Context, replicationSetIdx int) error {
+		replicationSet := replicationSets[replicationSetIdx]
 
-		stream, err := client.LabelValuesCardinality(ctx, labelValuesReq)
-		if err != nil {
-			return struct{}{}, err
-		}
-		defer func() { _ = util.CloseAndExhaust[*ingester_client.LabelValuesCardinalityResponse](stream) }()
+		_, err = ring.DoUntilQuorum[any](ctx, replicationSet, quorumConfig, func(ctx context.Context, desc *ring.InstanceDesc) (any, error) {
+			poolClient, err := d.ingesterPool.GetClientForInstance(*desc)
+			if err != nil {
+				return nil, err
+			}
 
-		return struct{}{}, cardinalityConcurrentMap.processLabelValuesCardinalityMessages(desc.Zone, stream)
-	}, func(struct{}) {})
+			client := poolClient.(ingester_client.IngesterClient)
+
+			stream, err := client.LabelValuesCardinality(ctx, labelValuesReq)
+			if err != nil {
+				return nil, err
+			}
+			defer func() { _ = util.CloseAndExhaust[*ingester_client.LabelValuesCardinalityResponse](stream) }()
+
+			return nil, cardinalityConcurrentMap.processMessages(replicationSetIdx, desc.Zone, stream)
+		}, func(_ any) {})
+
+		return err
+	})
+
 	if err != nil {
 		return nil, err
 	}
-	return cardinalityConcurrentMap.toLabelValuesCardinalityResponse(replicationSet.ZoneCount(), d.ingestersRing.ReplicationFactor()), nil
+
+	// When the ingest storage is enabled a partition is owned by only 1 ingester per zone,
+	// so regardless the number of zones we have it's behaving like multi-zone is always enabled.
+	isMultiZone := d.cfg.IngestStorageConfig.Enabled || (len(replicationSets) > 0 && replicationSets[0].ZoneCount() > 1)
+
+	return cardinalityConcurrentMap.toResponse(isMultiZone, d.ingestersRing.ReplicationFactor()), nil
 }
 
 func toLabelValuesCardinalityRequest(labelNames []model.LabelName, matchers []*labels.Matcher, countMethod cardinality.CountMethod) (*ingester_client.LabelValuesCardinalityRequest, error) {
@@ -1855,13 +1876,21 @@ func toIngesterCountMethod(countMethod cardinality.CountMethod) (ingester_client
 	}
 }
 
+// countByReplicationSetAndZone keeps track of a counter by replication set index and zone.
+type countByReplicationSetAndZone []map[string]uint64
+
 type labelValuesCardinalityConcurrentMap struct {
-	// cardinalityMapByZone stores a result for each zone. map[label_name]map[label_value]map[zone]
-	cardinalityMapByZone map[string]map[string]map[string]uint64
-	lock                 sync.Mutex
+	numReplicationSets int
+
+	// labelValuesCounters stores the count of label name-value pairs by replication set and zone.
+	// The map is: map[label_name]map[label_value]countByReplicationSetAndZone
+	labelValuesCountersMx sync.Mutex
+	labelValuesCounters   map[string]map[string]countByReplicationSetAndZone
 }
 
-func (cm *labelValuesCardinalityConcurrentMap) processLabelValuesCardinalityMessages(zone string, stream ingester_client.Ingester_LabelValuesCardinalityClient) error {
+// processMessages reads and processes all LabelValuesCardinalityResponse messages received from an ingester
+// via gRPC.
+func (cm *labelValuesCardinalityConcurrentMap) processMessages(replicationSetIdx int, zone string, stream ingester_client.Ingester_LabelValuesCardinalityClient) error {
 	for {
 		message, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
@@ -1869,63 +1898,70 @@ func (cm *labelValuesCardinalityConcurrentMap) processLabelValuesCardinalityMess
 		} else if err != nil {
 			return err
 		}
-		cm.processLabelValuesCardinalityMessage(zone, message)
+		cm.processMessage(replicationSetIdx, zone, message)
 	}
 	return nil
 }
 
-/*
- * Build a map from all the responses received from all the ingesters.
- * Each label name will represent a key on the cardinalityMap which will have as value a second map, containing
- * as key the label_value and value the respective series_count. This series_count will represent the cumulative result
- * of all (label_name, label_value) tuples from all ingesters, split by zone.
- *
- * Map: (label_name -> (label_value -> series_count))
- *
- * This method is called per each LabelValuesCardinalityResponse consumed from each ingester
- */
-func (cm *labelValuesCardinalityConcurrentMap) processLabelValuesCardinalityMessage(zone string, message *ingester_client.LabelValuesCardinalityResponse) {
-	cm.lock.Lock()
-	defer cm.lock.Unlock()
+// processMessage processes a single LabelValuesCardinalityResponse message received from an ingester
+// via gRPC and increment the counters of each label name-value pair.
+func (cm *labelValuesCardinalityConcurrentMap) processMessage(replicationSetIdx int, zone string, message *ingester_client.LabelValuesCardinalityResponse) {
+	cm.labelValuesCountersMx.Lock()
+	defer cm.labelValuesCountersMx.Unlock()
 
 	for _, item := range message.Items {
 
 		// Create a new map for the label name if it doesn't exist
-		if _, ok := cm.cardinalityMapByZone[item.LabelName]; !ok {
-			cm.cardinalityMapByZone[item.LabelName] = make(map[string]map[string]uint64, len(item.LabelValueSeries))
+		if _, ok := cm.labelValuesCounters[item.LabelName]; !ok {
+			cm.labelValuesCounters[item.LabelName] = make(map[string]countByReplicationSetAndZone, len(item.LabelValueSeries))
 		}
 
 		for labelValue, seriesCount := range item.LabelValueSeries {
-
-			// Create a new map for the label value if it doesn't exist
-			if _, ok := cm.cardinalityMapByZone[item.LabelName][labelValue]; !ok {
-				cm.cardinalityMapByZone[item.LabelName][labelValue] = map[string]uint64{}
+			// Lazily init the label values counters.
+			if _, ok := cm.labelValuesCounters[item.LabelName][labelValue]; !ok {
+				cm.labelValuesCounters[item.LabelName][labelValue] = make(countByReplicationSetAndZone, cm.numReplicationSets)
 			}
 
-			// Add the series count to the map
-			cm.cardinalityMapByZone[item.LabelName][labelValue][zone] += seriesCount
+			countByZone := cm.labelValuesCounters[item.LabelName][labelValue][replicationSetIdx]
+			if countByZone == nil {
+				countByZone = map[string]uint64{}
+				cm.labelValuesCounters[item.LabelName][labelValue][replicationSetIdx] = countByZone
+			}
+
+			// Accumulate the series count.
+			countByZone[zone] += seriesCount
 		}
 	}
 }
 
-// toLabelValuesCardinalityResponse adjust count of series to the replication factor and converts the map to `ingester_client.LabelValuesCardinalityResponse`.
-func (cm *labelValuesCardinalityConcurrentMap) toLabelValuesCardinalityResponse(zoneCount int, replicationFactor int) *ingester_client.LabelValuesCardinalityResponse {
+// toResponse adjust builds and returns LabelValuesCardinalityResponse containing the count of series by label name
+// and value.
+func (cm *labelValuesCardinalityConcurrentMap) toResponse(isMultiZone bool, replicationFactor int) *ingester_client.LabelValuesCardinalityResponse {
 	// we need to acquire the lock to prevent concurrent read/write to the map
-	cm.lock.Lock()
-	defer cm.lock.Unlock()
+	cm.labelValuesCountersMx.Lock()
+	defer cm.labelValuesCountersMx.Unlock()
 
-	cardinalityItems := make([]*ingester_client.LabelValueSeriesCount, 0, len(cm.cardinalityMapByZone))
-	// Adjust label values' series count to return the max value across zones
-	for labelName, labelValueSeriesCountMapByZone := range cm.cardinalityMapByZone {
-		labelValueSeriesCountMap := make(map[string]uint64, len(labelValueSeriesCountMapByZone))
+	cardinalityItems := make([]*ingester_client.LabelValueSeriesCount, 0, len(cm.labelValuesCounters))
 
-		for labelValue, seriesCountMapByZone := range labelValueSeriesCountMapByZone {
-			labelValueSeriesCountMap[labelValue] = approximateFromZones(zoneCount > 1, replicationFactor, seriesCountMapByZone)
+	for labelName, dataByLabelValues := range cm.labelValuesCounters {
+		countByLabelValue := make(map[string]uint64, len(dataByLabelValues))
+
+		// We accumulate the number of series tracked by label name-value pairs on a per replication set basis.
+		// For each replication set, we approximate the actual number of series counted by ingesters, taking in
+		// account the replication.
+		for labelValue, dataByReplicationSet := range dataByLabelValues {
+			total := uint64(0)
+
+			for _, countByZone := range dataByReplicationSet {
+				total += approximateFromZones(isMultiZone, replicationFactor, countByZone)
+			}
+
+			countByLabelValue[labelValue] = total
 		}
 
 		cardinalityItems = append(cardinalityItems, &ingester_client.LabelValueSeriesCount{
 			LabelName:        labelName,
-			LabelValueSeries: labelValueSeriesCountMap,
+			LabelValueSeries: countByLabelValue,
 		})
 	}
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1818,7 +1818,7 @@ func (d *Distributor) labelValuesCardinality(ctx context.Context, labelNames []m
 	err = concurrency.ForEachJob(ctx, len(replicationSets), 0, func(ctx context.Context, replicationSetIdx int) error {
 		replicationSet := replicationSets[replicationSetIdx]
 
-		_, err = ring.DoUntilQuorum[any](ctx, replicationSet, quorumConfig, func(ctx context.Context, desc *ring.InstanceDesc) (any, error) {
+		_, err := ring.DoUntilQuorum[any](ctx, replicationSet, quorumConfig, func(ctx context.Context, desc *ring.InstanceDesc) (any, error) {
 			poolClient, err := d.ingesterPool.GetClientForInstance(*desc)
 			if err != nil {
 				return nil, err

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -594,9 +594,9 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"single-zone": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2),
+					makeWriteRequestWith(series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 			},
 		},
@@ -606,12 +606,12 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"single-zone": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series2}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series6}},
+					makeWriteRequestWith(series1),
+					makeWriteRequestWith(series2),
+					makeWriteRequestWith(series3),
+					makeWriteRequestWith(series4),
+					makeWriteRequestWith(series5),
+					makeWriteRequestWith(series6),
 				},
 			},
 		},
@@ -622,11 +622,11 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"single-zone": {
 					nil,
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series2}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series6}},
+					makeWriteRequestWith(series2),
+					makeWriteRequestWith(series3),
+					makeWriteRequestWith(series4),
+					makeWriteRequestWith(series5),
+					makeWriteRequestWith(series6),
 				},
 			},
 			expectedErr: ring.ErrTooManyUnhealthyInstances,
@@ -637,11 +637,11 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"single-zone": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series2}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5}},
+					makeWriteRequestWith(series1),
+					makeWriteRequestWith(series2),
+					makeWriteRequestWith(series3),
+					makeWriteRequestWith(series4),
+					makeWriteRequestWith(series5),
 					nil,
 				},
 			},
@@ -654,12 +654,12 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 			},
 		},
@@ -670,12 +670,12 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 			},
 		},
@@ -686,12 +686,12 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 			},
 		},
@@ -702,12 +702,12 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 			},
 		},
@@ -718,12 +718,12 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 			},
 			expectedErr: ring.ErrTooManyUnhealthyInstances,
@@ -739,8 +739,8 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 					nil,
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 			},
 		},
@@ -751,8 +751,8 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-b": {
 					nil,
@@ -768,10 +768,10 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
 					nil,
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					makeWriteRequestWith(series1, series2, series3, series4),
 					nil,
 				},
 			},
@@ -783,11 +783,11 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					makeWriteRequestWith(series1, series2, series3, series4),
 					nil,
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					makeWriteRequestWith(series1, series2, series3, series4),
 					nil,
 				},
 			},
@@ -801,11 +801,11 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngest
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
 					nil,
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 				},
 				"zone-b": {
 					nil,
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 				},
 			},
 			shardSize: 1, // Tenant's shard made of: partition 1.

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/mimir/pkg/cardinality"
+	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/util/extract"
@@ -549,6 +550,308 @@ func TestDistributor_UserStats_ShouldSupportIngestStorage(t *testing.T) {
 
 					require.NoError(t, err)
 					assert.Equal(t, testData.expectedSeries, res.NumSeries)
+				})
+			}
+		})
+	}
+}
+
+func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistencyWithIngestStorage(t *testing.T) {
+	const preferredZone = "zone-a"
+
+	var (
+		// Define fixtures used in tests.
+		series1 = makeTimeseries([]string{labels.MetricName, "series_1", "job", "job-a", "service", "service-1"}, makeSamples(0, 0), nil)
+		series2 = makeTimeseries([]string{labels.MetricName, "series_2", "job", "job-b", "service", "service-1"}, makeSamples(0, 0), nil)
+		series3 = makeTimeseries([]string{labels.MetricName, "series_3", "job", "job-c", "service", "service-1"}, makeSamples(0, 0), nil)
+		series4 = makeTimeseries([]string{labels.MetricName, "series_4", "job", "job-a", "service", "service-1"}, makeSamples(0, 0), nil)
+		series5 = makeTimeseries([]string{labels.MetricName, "series_5", "job", "job-a", "service", "service-2"}, makeSamples(0, 0), nil)
+		series6 = makeTimeseries([]string{labels.MetricName, "series_6", "job", "job-b" /* no service label */}, makeSamples(0, 0), nil)
+
+		// To keep assertions simple, all tests push all series, and then request the cardinality of the same label names,
+		// so we expect the same response from each successful test.
+		reqLabelNames = []model.LabelName{"job", "service"}
+		expectedRes   = []*client.LabelValueSeriesCount{
+			{
+				LabelName:        "job",
+				LabelValueSeries: map[string]uint64{"job-a": 3, "job-b": 2, "job-c": 1},
+			}, {
+				LabelName:        "service",
+				LabelValueSeries: map[string]uint64{"service-1": 4, "service-2": 1},
+			},
+		}
+	)
+
+	tests := map[string]struct {
+		ingesterStateByZone map[string]ingesterZoneState
+		ingesterDataByZone  map[string][]*mimirpb.WriteRequest
+		shardSize           int
+		expectedErr         error
+	}{
+		"partitions RF=1 (1 zone), 3 ingesters": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"single-zone": {numIngesters: 3, happyIngesters: 3},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"single-zone": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+			},
+		},
+		"partitions RF=1 (1 zone), 6 ingesters": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"single-zone": {numIngesters: 6, happyIngesters: 6},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"single-zone": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series2}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series3}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series6}},
+				},
+			},
+		},
+		"partitions RF=1 (1 zone), 6 ingesters, 1 ingester in LEAVING state": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"single-zone": {numIngesters: 6, happyIngesters: 6, ringStates: []ring.InstanceState{ring.LEAVING, ring.ACTIVE, ring.ACTIVE, ring.ACTIVE, ring.ACTIVE, ring.ACTIVE}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"single-zone": {
+					nil,
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series2}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series3}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series6}},
+				},
+			},
+			expectedErr: ring.ErrTooManyUnhealthyInstances,
+		},
+		"partitions RF=1 (1 zone), 6 ingesters, 1 ingester is UNHEALTHY": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"single-zone": {numIngesters: 6, happyIngesters: 5},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"single-zone": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series2}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series3}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5}},
+					nil,
+				},
+			},
+			expectedErr: errFail,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2},
+				"zone-b": {numIngesters: 2, happyIngesters: 2},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+				"zone-b": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+			},
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, all ingesters in the preferred zone (zone-a) are in LEAVING state": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.LEAVING}},
+				"zone-b": {numIngesters: 2, happyIngesters: 2},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+				"zone-b": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+			},
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, all ingesters in the non-preferred zone (zone-b) are in LEAVING state": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2},
+				"zone-b": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.LEAVING}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+				"zone-b": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+			},
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning different partitions are in LEAVING state across both zones": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.ACTIVE}},
+				"zone-b": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.ACTIVE, ring.LEAVING}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+				"zone-b": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+			},
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning the same partition are in LEAVING state in both zones": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.ACTIVE}},
+				"zone-b": {numIngesters: 2, happyIngesters: 2, ringStates: []ring.InstanceState{ring.LEAVING, ring.ACTIVE}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+				"zone-b": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+			},
+			expectedErr: ring.ErrTooManyUnhealthyInstances,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, all ingesters in the preferred zone (zone-a) are UNHEALTHY": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 0},
+				"zone-b": {numIngesters: 2, happyIngesters: 2},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					nil,
+					nil,
+				},
+				"zone-b": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+			},
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, all ingesters in the non-preferred zone (zone-b) are UNHEALTHY": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 2, happyIngesters: 2},
+				"zone-b": {numIngesters: 2, happyIngesters: 0},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+				"zone-b": {
+					nil,
+					nil,
+				},
+			},
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning different partitions are UNHEALTHY across both zones": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {states: []ingesterState{ingesterStateFailed, ingesterStateHappy}},
+				"zone-b": {states: []ingesterState{ingesterStateHappy, ingesterStateFailed}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					nil,
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+				},
+				"zone-b": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					nil,
+				},
+			},
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning the same partition are UNHEALTHY in both zones": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {states: []ingesterState{ingesterStateHappy, ingesterStateFailed}},
+				"zone-b": {states: []ingesterState{ingesterStateHappy, ingesterStateFailed}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					nil,
+				},
+				"zone-b": {
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					nil,
+				},
+			},
+			expectedErr: errFail,
+		},
+		"partitions RF=2 (2 zones), 4 ingesters, ingesters owning the same partition are UNHEALTHY in both zones but the partition is not part of the tenant's shard": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {states: []ingesterState{ingesterStateFailed, ingesterStateHappy}},
+				"zone-b": {states: []ingesterState{ingesterStateFailed, ingesterStateHappy}},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					nil,
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+				},
+				"zone-b": {
+					nil,
+					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+				},
+			},
+			shardSize: 1, // Tenant's shard made of: partition 1.
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			for _, minimizeIngesterRequests := range []bool{false, true} {
+				minimizeIngesterRequests := minimizeIngesterRequests
+
+				t.Run(fmt.Sprintf("minimize ingester requests: %t", minimizeIngesterRequests), func(t *testing.T) {
+					t.Parallel()
+
+					// Create distributor
+					distributors, _, _, _ := prepare(t, prepConfig{
+						numDistributors:      1,
+						ingesterStateByZone:  testData.ingesterStateByZone,
+						ingesterDataByZone:   testData.ingesterDataByZone,
+						ingestStorageEnabled: true,
+						configure: func(config *Config) {
+							config.PreferAvailabilityZone = preferredZone
+							config.MinimizeIngesterRequests = minimizeIngesterRequests
+						},
+						limits: func() *validation.Limits {
+							limits := prepareDefaultLimits()
+							limits.IngestionPartitionsTenantShardSize = testData.shardSize
+							return limits
+						}(),
+					})
+
+					// Fetch label values cardinality.
+					ctx := user.InjectOrgID(context.Background(), "test")
+					_, res, err := distributors[0].LabelValuesCardinality(ctx, reqLabelNames, nil, cardinality.InMemoryMethod)
+
+					if testData.expectedErr != nil {
+						require.ErrorIs(t, err, testData.expectedErr)
+						return
+					}
+
+					require.NoError(t, err)
+					assert.ElementsMatch(t, expectedRes, res.Items)
 				})
 			}
 		})

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3858,9 +3858,17 @@ func TestDistributor_LabelValuesCardinality(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
+
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			for _, minimizeIngesterRequests := range []bool{false, true} {
+				minimizeIngesterRequests := minimizeIngesterRequests
+
 				t.Run(fmt.Sprintf("minimize ingester requests: %t", minimizeIngesterRequests), func(t *testing.T) {
+					t.Parallel()
+
 					// Create distributor
 					ds, ingesters, _, _ := prepare(t, prepConfig{
 						numIngesters:      numIngesters,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1573,9 +1573,9 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			},
 			minExemplarTS: 0,
 			maxExemplarTS: 0,
-			req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
+			req: makeWriteRequestWith(
 				makeExemplarTimeseries([]string{model.MetricNameLabel, "test1"}, 1000, []string{"foo", "bar"}),
-			}},
+			),
 			expectedExemplars: []mimirpb.PreallocTimeseries{
 				{TimeSeries: &mimirpb.TimeSeries{
 					Labels:    []mimirpb.LabelAdapter{{Name: model.MetricNameLabel, Value: "test1"}},
@@ -1589,10 +1589,10 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			},
 			minExemplarTS: 0,
 			maxExemplarTS: math.MaxInt64,
-			req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
+			req: makeWriteRequestWith(
 				makeExemplarTimeseries([]string{model.MetricNameLabel, "test1"}, 1000, []string{"foo", "bar"}),
 				makeExemplarTimeseries([]string{model.MetricNameLabel, "test2"}, 1000, []string{"foo", "bar"}),
-			}},
+			),
 			expectedExemplars: []mimirpb.PreallocTimeseries{
 				makeExemplarTimeseries([]string{model.MetricNameLabel, "test1"}, 1000, []string{"foo", "bar"}),
 				makeExemplarTimeseries([]string{model.MetricNameLabel, "test2"}, 1000, []string{"foo", "bar"}),
@@ -1604,10 +1604,10 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			},
 			minExemplarTS: 300000,
 			maxExemplarTS: math.MaxInt64,
-			req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
+			req: makeWriteRequestWith(
 				makeExemplarTimeseries([]string{model.MetricNameLabel, "test"}, 1000, []string{"foo", "bar"}),
 				makeExemplarTimeseries([]string{model.MetricNameLabel, "test"}, 601000, []string{"foo", "bar"}),
-			}},
+			),
 			expectedExemplars: []mimirpb.PreallocTimeseries{
 				{TimeSeries: &mimirpb.TimeSeries{
 					Labels:    []mimirpb.LabelAdapter{{Name: model.MetricNameLabel, Value: "test"}},
@@ -1627,17 +1627,15 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			},
 			minExemplarTS: 300000,
 			maxExemplarTS: math.MaxInt64,
-			req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
-				{
-					TimeSeries: &mimirpb.TimeSeries{
-						Labels: []mimirpb.LabelAdapter{{Name: model.MetricNameLabel, Value: "test"}},
-						Exemplars: []mimirpb.Exemplar{
-							{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar1"}}, TimestampMs: 1000},
-							{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar2"}}, TimestampMs: 601000},
-						},
+			req: makeWriteRequestWith(mimirpb.PreallocTimeseries{
+				TimeSeries: &mimirpb.TimeSeries{
+					Labels: []mimirpb.LabelAdapter{{Name: model.MetricNameLabel, Value: "test"}},
+					Exemplars: []mimirpb.Exemplar{
+						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar1"}}, TimestampMs: 1000},
+						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar2"}}, TimestampMs: 601000},
 					},
 				},
-			}},
+			}),
 			expectedExemplars: []mimirpb.PreallocTimeseries{
 				{
 					TimeSeries: &mimirpb.TimeSeries{
@@ -1660,17 +1658,15 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			},
 			minExemplarTS: 300000,
 			maxExemplarTS: math.MaxInt64,
-			req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
-				{
-					TimeSeries: &mimirpb.TimeSeries{
-						Labels: []mimirpb.LabelAdapter{{Name: model.MetricNameLabel, Value: "test"}},
-						Exemplars: []mimirpb.Exemplar{
-							{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar1"}}, TimestampMs: 1000},
-							{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar2"}}, TimestampMs: 601000},
-						},
+			req: makeWriteRequestWith(mimirpb.PreallocTimeseries{
+				TimeSeries: &mimirpb.TimeSeries{
+					Labels: []mimirpb.LabelAdapter{{Name: model.MetricNameLabel, Value: "test"}},
+					Exemplars: []mimirpb.Exemplar{
+						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar1"}}, TimestampMs: 1000},
+						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar2"}}, TimestampMs: 601000},
 					},
 				},
-			}},
+			}),
 			expectedExemplars: []mimirpb.PreallocTimeseries{
 				{
 					TimeSeries: &mimirpb.TimeSeries{
@@ -1693,17 +1689,15 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			},
 			minExemplarTS: 0,
 			maxExemplarTS: 100000,
-			req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
-				{
-					TimeSeries: &mimirpb.TimeSeries{
-						Labels: []mimirpb.LabelAdapter{{Name: model.MetricNameLabel, Value: "test"}},
-						Exemplars: []mimirpb.Exemplar{
-							{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar1"}}, TimestampMs: 1000},
-							{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar2"}}, TimestampMs: 601000},
-						},
+			req: makeWriteRequestWith(mimirpb.PreallocTimeseries{
+				TimeSeries: &mimirpb.TimeSeries{
+					Labels: []mimirpb.LabelAdapter{{Name: model.MetricNameLabel, Value: "test"}},
+					Exemplars: []mimirpb.Exemplar{
+						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar1"}}, TimestampMs: 1000},
+						{Labels: []mimirpb.LabelAdapter{{Name: "foo", Value: "bar2"}}, TimestampMs: 601000},
 					},
 				},
-			}},
+			}),
 			expectedExemplars: []mimirpb.PreallocTimeseries{
 				{
 					TimeSeries: &mimirpb.TimeSeries{
@@ -3949,9 +3943,9 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"single-zone": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 				},
 			},
 		},
@@ -3961,12 +3955,12 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"single-zone": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series4, series5, series6),
+					makeWriteRequestWith(series4, series5, series6),
+					makeWriteRequestWith(series4, series5, series6),
 				},
 			},
 		},
@@ -3976,12 +3970,12 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"single-zone": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series4, series5, series6),
+					makeWriteRequestWith(series4, series5, series6),
+					makeWriteRequestWith(series4, series5, series6),
 				},
 			},
 			expectedErr: ring.ErrTooManyUnhealthyInstances,
@@ -3992,11 +3986,11 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"single-zone": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series4, series5, series6),
+					makeWriteRequestWith(series4, series5, series6),
 					nil,
 				},
 			},
@@ -4010,13 +4004,13 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 				},
 				"zone-c": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 				},
 			},
 		},
@@ -4028,10 +4022,10 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 				},
 				"zone-c": {
 					nil,
@@ -4046,16 +4040,16 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5),
+					makeWriteRequestWith(series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-c": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series4, series5, series6),
 				},
 			},
 		},
@@ -4067,16 +4061,16 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5),
+					makeWriteRequestWith(series6),
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-c": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series4, series5, series6),
 				},
 			},
 			expectedErr: ring.ErrTooManyUnhealthyInstances,
@@ -4093,12 +4087,12 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 					nil,
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4),
+					makeWriteRequestWith(series5, series6),
 				},
 				"zone-c": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series4, series5, series6),
 				},
 			},
 		},
@@ -4110,16 +4104,16 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5),
 					nil,
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4}},
+					makeWriteRequestWith(series1, series2, series3, series4),
 					nil,
 				},
 				"zone-c": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3),
+					makeWriteRequestWith(series4, series5, series6),
 				},
 			},
 			expectedErr: errFail,
@@ -4132,16 +4126,16 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{other1}}, // Not belonging to tenant's shard.
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
+					makeWriteRequestWith(other1), // Not belonging to tenant's shard.
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{other1}}, // Not belonging to tenant's shard.
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
+					makeWriteRequestWith(other1), // Not belonging to tenant's shard.
 				},
 				"zone-c": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{other1}}, // Not belonging to tenant's shard.
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
+					makeWriteRequestWith(other1), // Not belonging to tenant's shard.
 				},
 			},
 			shardSize: 1, // Tenant's shard made of: ingester-zone-a-0, ingester-zone-b-0 and ingester-zone-c-0.
@@ -4154,15 +4148,15 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 			},
 			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
 				"zone-a": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 					nil,
 				},
 				"zone-b": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 					nil,
 				},
 				"zone-c": {
-					&mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1, series2, series3, series4, series5, series6}},
+					makeWriteRequestWith(series1, series2, series3, series4, series5, series6),
 					nil,
 				},
 			},
@@ -5303,6 +5297,14 @@ func makeWriteRequest(startTimestampMs int64, samples, metadata int, exemplars, 
 	return request
 }
 
+func makeWriteRequestWith(series ...mimirpb.PreallocTimeseries) *mimirpb.WriteRequest {
+	req := &mimirpb.WriteRequest{}
+	for _, item := range series {
+		req.Timeseries = append(req.Timeseries, item)
+	}
+	return req
+}
+
 func makeTimeseries(seriesLabels []string, samples []mimirpb.Sample, exemplars []mimirpb.Exemplar) mimirpb.PreallocTimeseries {
 	return mimirpb.PreallocTimeseries{
 		TimeSeries: &mimirpb.TimeSeries{
@@ -5465,27 +5467,15 @@ func makeWriteRequestForGenerators(series int, lsg labelSetGen, elsg labelSetGen
 }
 
 func makeWriteRequestExemplar(seriesLabels []string, timestamp int64, exemplarLabels []string) *mimirpb.WriteRequest {
-	return &mimirpb.WriteRequest{
-		Timeseries: []mimirpb.PreallocTimeseries{
-			makeExemplarTimeseries(seriesLabels, timestamp, exemplarLabels),
-		},
-	}
+	return makeWriteRequestWith(makeExemplarTimeseries(seriesLabels, timestamp, exemplarLabels))
 }
 
 func makeWriteRequestHistogram(seriesLabels []string, timestamp int64, histogram *histogram.Histogram) *mimirpb.WriteRequest {
-	return &mimirpb.WriteRequest{
-		Timeseries: []mimirpb.PreallocTimeseries{
-			makeHistogramTimeseries(seriesLabels, timestamp, histogram),
-		},
-	}
+	return makeWriteRequestWith(makeHistogramTimeseries(seriesLabels, timestamp, histogram))
 }
 
 func makeWriteRequestFloatHistogram(seriesLabels []string, timestamp int64, histogram *histogram.FloatHistogram) *mimirpb.WriteRequest {
-	return &mimirpb.WriteRequest{
-		Timeseries: []mimirpb.PreallocTimeseries{
-			makeFloatHistogramTimeseries(seriesLabels, timestamp, histogram),
-		},
-	}
+	return makeWriteRequestWith(makeFloatHistogramTimeseries(seriesLabels, timestamp, histogram))
 }
 
 func makeExemplarTimeseries(seriesLabels []string, timestamp int64, exemplarLabels []string) mimirpb.PreallocTimeseries {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -5298,11 +5298,7 @@ func makeWriteRequest(startTimestampMs int64, samples, metadata int, exemplars, 
 }
 
 func makeWriteRequestWith(series ...mimirpb.PreallocTimeseries) *mimirpb.WriteRequest {
-	req := &mimirpb.WriteRequest{}
-	for _, item := range series {
-		req.Timeseries = append(req.Timeseries, item)
-	}
-	return req
+	return &mimirpb.WriteRequest{Timeseries: series}
 }
 
 func makeTimeseries(seriesLabels []string, samples []mimirpb.Sample, exemplars []mimirpb.Exemplar) mimirpb.PreallocTimeseries {

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -113,29 +113,7 @@ func (d *Distributor) QueryStream(ctx context.Context, queryMetrics *stats.Query
 	return result, err
 }
 
-// getIngesterReplicationSetForQuery returns a ring.ReplicationSet, containing ingester instances,
-// that must be queried for a read operation. This function does NOT support the ingest storage partitions.
-//
-// Deprecated: use getIngesterReplicationSetsForQuery() instead.
-func (d *Distributor) getIngesterReplicationSetForQuery(ctx context.Context) (ring.ReplicationSet, error) {
-	userID, err := tenant.TenantID(ctx)
-	if err != nil {
-		return ring.ReplicationSet{}, err
-	}
-
-	// If tenant uses shuffle sharding, we should only query ingesters which are
-	// part of the tenant's subring.
-	shardSize := d.limits.IngestionTenantShardSize(userID)
-	lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod
-
-	if shardSize > 0 && lookbackPeriod > 0 {
-		return d.ingestersRing.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now()).GetReplicationSetForOperation(readNoExtend)
-	}
-
-	return d.ingestersRing.GetReplicationSetForOperation(readNoExtend)
-}
-
-// getIngesterReplicationSetForQuery returns a list of ring.ReplicationSet, containing ingester instances,
+// getIngesterReplicationSetsForQuery returns a list of ring.ReplicationSet, containing ingester instances,
 // that must be queried for a read operation.
 //
 // If multiple ring.ReplicationSets are returned, each must be queried separately, and results merged.

--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -132,7 +132,7 @@ func TestDistributor_QueryExemplars(t *testing.T) {
 						clonedSeries, err := clonePreallocTimeseries(series)
 						require.NoError(t, err)
 
-						_, err = ds[0].Push(ctx, &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{clonedSeries}})
+						_, err = ds[0].Push(ctx, makeWriteRequestWith(clonedSeries))
 						require.NoError(t, err)
 					}
 
@@ -315,10 +315,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReac
 			}
 
 			// Push more series to exceed the limit once we'll query back all series.
-			writeReq = &mimirpb.WriteRequest{}
-			writeReq.Timeseries = append(writeReq.Timeseries,
-				makeTimeseries([]string{model.MetricNameLabel, "another_series"}, makeSamples(0, 0), nil),
-			)
+			writeReq = makeWriteRequestWith(makeTimeseries([]string{model.MetricNameLabel, "another_series"}, makeSamples(0, 0), nil))
 
 			writeRes, err = ds[0].Push(userCtx, writeReq)
 			assert.Equal(t, &mimirpb.WriteResponse{}, writeRes)
@@ -362,10 +359,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIs
 		labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+"),
 	}
 	// Push a single series to allow us to calculate the chunk size to calculate the limit for the test.
-	writeReq := &mimirpb.WriteRequest{}
-	writeReq.Timeseries = append(writeReq.Timeseries,
-		makeTimeseries([]string{model.MetricNameLabel, "another_series"}, makeSamples(0, 0), nil),
-	)
+	writeReq := makeWriteRequestWith(makeTimeseries([]string{model.MetricNameLabel, "another_series"}, makeSamples(0, 0), nil))
 	writeRes, err := ds[0].Push(ctx, writeReq)
 	assert.Equal(t, &mimirpb.WriteResponse{}, writeRes)
 	assert.Nil(t, err)
@@ -394,10 +388,7 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIs
 	assert.Len(t, queryRes.Chunkseries, seriesToAdd)
 
 	// Push another series to exceed the chunk bytes limit once we'll query back all series.
-	writeReq = &mimirpb.WriteRequest{}
-	writeReq.Timeseries = append(writeReq.Timeseries,
-		makeTimeseries([]string{model.MetricNameLabel, "another_series_1"}, makeSamples(0, 0), nil),
-	)
+	writeReq = makeWriteRequestWith(makeTimeseries([]string{model.MetricNameLabel, "another_series_1"}, makeSamples(0, 0), nil))
 
 	writeRes, err = ds[0].Push(ctx, writeReq)
 	assert.Equal(t, &mimirpb.WriteResponse{}, writeRes)


### PR DESCRIPTION
#### What this PR does

Similarly to previous PRs https://github.com/grafana/mimir/pull/7393 and https://github.com/grafana/mimir/pull/7402, in this PR I'm adding partitions support to `Distributor.LabelValuesCardinality()`.

Similarly to `UsageStats()`, for `LabelValuesCardinality()` we should track the counters on a per replication set basis in order to get a more accurate count, which is what I did in this PR.

Note to reviewers:
- I suggest to review the diff with "hide whitespace changes"
- I renamed few data structs and functions with the aim of making them easier to read
- Since `LabelValuesCardinality()` was the last missing piece supporting partitions ring, I've been able to remove the deprecated `queryQuorumConfig()` and `getIngesterReplicationSetForQuery()`

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
