### PR TITLE
Modify ingester's limiter to work with ingest store.

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -368,7 +368,7 @@ func newIngester(cfg Config, limits *validation.Overrides, registerer prometheus
 }
 
 // New returns an Ingester that uses Mimir block storage.
-func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, activeGroupsCleanupService *util.ActiveGroupsCleanupService, registerer prometheus.Registerer, logger log.Logger) (*Ingester, error) {
+func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, partitionRingWatcher *ring.PartitionRingWatcher, activeGroupsCleanupService *util.ActiveGroupsCleanupService, registerer prometheus.Registerer, logger log.Logger) (*Ingester, error) {
 	i, err := newIngester(cfg, limits, registerer, logger)
 	if err != nil {
 		return nil, err
@@ -405,14 +405,8 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 		i.ownedSeriesService = newOwnedSeriesService(i.cfg.OwnedSeriesUpdateInterval, i.lifecycler.ID, ingestersRing, log.With(i.logger, "component", "owned series"), registerer, i.limits.IngestionTenantShardSize, i.getTSDBUsers, i.getTSDB)
 	}
 
-	// Init the limter and instantiate the user states which depend on it
-	i.limiter = NewLimiter(
-		limits,
-		ingestersRing,
-		cfg.IngesterRing.ReplicationFactor,
-		cfg.IngesterRing.ZoneAwarenessEnabled,
-		cfg.IngesterRing.InstanceZone,
-	)
+	var limiterStrategy limiterRingStrategy
+	limiterStrategy = newIngesterRingLimiterStrategy(ingestersRing, cfg.IngesterRing.ReplicationFactor, cfg.IngesterRing.ZoneAwarenessEnabled, cfg.IngesterRing.InstanceZone, i.limits.IngestionTenantShardSize)
 
 	if cfg.ReadPathCPUUtilizationLimit > 0 || cfg.ReadPathMemoryUtilizationLimit > 0 {
 		i.utilizationBasedLimiter = limiter.NewUtilizationBasedLimiter(cfg.ReadPathCPUUtilizationLimit,
@@ -458,8 +452,11 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 			partitionRingKV,
 			logger,
 			prometheus.WrapRegistererWithPrefix("cortex_", registerer))
+
+		limiterStrategy = newPartitionRingLimiter(partitionRingWatcher, i.limits.IngestionPartitionsTenantShardSize)
 	}
 
+	i.limiter = NewLimiter(limits, limiterStrategy)
 	i.BasicService = services.NewBasicService(i.starting, i.updateLoop, i.stopping)
 	return i, nil
 }
@@ -475,6 +472,7 @@ func NewForFlusher(cfg Config, limits *validation.Overrides, registerer promethe
 	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil, &i.inflightPushRequests, &i.inflightPushRequestsBytes)
 
 	i.shipperIngesterID = "flusher"
+	i.limiter = NewLimiter(limits, forFlushStrategy{})
 
 	// This ingester will not start any subservices (lifecycler, compaction, shipping),
 	// and will only open TSDBs, wait for Flush to be called, and then close TSDBs again.
@@ -808,9 +806,6 @@ func (i *Ingester) updateUsageStats() {
 // * The current out-of-order time window. If it changes from 0 to >0, then a new Write-Behind-Log gets created for that tenant.
 func (i *Ingester) applyTSDBSettings() {
 	for _, userID := range i.getTSDBUsers() {
-		globalValue := i.limits.MaxGlobalExemplarsPerUser(userID)
-		localValue := i.limiter.convertGlobalToLocalLimit(i.limiter.getShardSize(userID), globalValue)
-
 		oooTW := i.limits.OutOfOrderTimeWindow(userID)
 		if oooTW < 0 {
 			oooTW = 0
@@ -823,7 +818,7 @@ func (i *Ingester) applyTSDBSettings() {
 		cfg := promcfg.Config{
 			StorageConfig: promcfg.StorageConfig{
 				ExemplarsConfig: &promcfg.ExemplarsConfig{
-					MaxExemplars: int64(localValue),
+					MaxExemplars: int64(i.limiter.maxExemplarsPerUser(userID)),
 				},
 				TSDBConfig: &promcfg.TSDBConfig{
 					OutOfOrderTimeWindow: oooTW.Milliseconds(),
@@ -2413,7 +2408,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 	}
 	userDB.triggerRecomputeOwnedSeries(recomputeOwnedSeriesReasonNewUser)
 
-	maxExemplars := i.limiter.convertGlobalToLocalLimit(i.limits.IngestionTenantShardSize(userID), i.limits.MaxGlobalExemplarsPerUser(userID))
+	maxExemplars := i.limiter.maxExemplarsPerUser(userID)
 	oooTW := i.limits.OutOfOrderTimeWindow(userID)
 	// Create a new user database
 	db, err := tsdb.Open(udir, userLogger, tsdbPromReg, &tsdb.Options{

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -453,7 +453,7 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 			logger,
 			prometheus.WrapRegistererWithPrefix("cortex_", registerer))
 
-		limiterStrategy = newPartitionRingLimiter(partitionRingWatcher, i.limits.IngestionPartitionsTenantShardSize)
+		limiterStrategy = newPartitionRingLimiterStrategy(partitionRingWatcher, i.limits.IngestionPartitionsTenantShardSize)
 	}
 
 	i.limiter = NewLimiter(limits, limiterStrategy)
@@ -472,7 +472,7 @@ func NewForFlusher(cfg Config, limits *validation.Overrides, registerer promethe
 	i.metrics = newIngesterMetrics(registerer, false, i.getInstanceLimits, nil, &i.inflightPushRequests, &i.inflightPushRequestsBytes)
 
 	i.shipperIngesterID = "flusher"
-	i.limiter = NewLimiter(limits, forFlushStrategy{})
+	i.limiter = NewLimiter(limits, flusherLimiterStrategy{})
 
 	// This ingester will not start any subservices (lifecycler, compaction, shipping),
 	// and will only open TSDBs, wait for Flush to be called, and then close TSDBs again.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2409,7 +2409,6 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 	}
 	userDB.triggerRecomputeOwnedSeries(recomputeOwnedSeriesReasonNewUser)
 
-	maxExemplars := i.limiter.maxExemplarsPerUser(userID)
 	oooTW := i.limits.OutOfOrderTimeWindow(userID)
 	// Create a new user database
 	db, err := tsdb.Open(udir, userLogger, tsdbPromReg, &tsdb.Options{
@@ -2426,7 +2425,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 		SeriesLifecycleCallback:               userDB,
 		BlocksToDelete:                        userDB.blocksToDelete,
 		EnableExemplarStorage:                 true, // enable for everyone so we can raise the limit later
-		MaxExemplars:                          int64(maxExemplars),
+		MaxExemplars:                          int64(i.limiter.maxExemplarsPerUser(userID)),
 		SeriesHashCache:                       i.seriesHashCache,
 		EnableMemorySnapshotOnShutdown:        i.cfg.BlocksStorageConfig.TSDB.MemorySnapshotOnShutdown,
 		IsolationDisabled:                     true,

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -408,15 +408,7 @@ func createTestIngesterWithIngestStorage(t testing.TB, ingesterCfg *Config, over
 	// Disable TSDB head compaction jitter to have predictable tests.
 	ingesterCfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalJitterEnabled = false
 
-	// Start the ingester ring
-	rng, err := ring.New(ingesterCfg.IngesterRing.ToRingConfig(), "ingester", IngesterRingKey, log.NewNopLogger(), nil)
-	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), rng))
-	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), rng))
-	})
-
-	ingester, err := New(*ingesterCfg, overrides, rng, nil, reg, util_test.NewTestingLogger(t))
+	ingester, err := New(*ingesterCfg, overrides, nil, ring.NewPartitionRingWatcher("ingester", "partition-ring", kv, log.NewNopLogger(), nil), nil, reg, util_test.NewTestingLogger(t))
 	require.NoError(t, err)
 
 	return ingester, kafkaCluster

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -408,7 +408,8 @@ func createTestIngesterWithIngestStorage(t testing.TB, ingesterCfg *Config, over
 	// Disable TSDB head compaction jitter to have predictable tests.
 	ingesterCfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalJitterEnabled = false
 
-	ingester, err := New(*ingesterCfg, overrides, nil, ring.NewPartitionRingWatcher("ingester", "partition-ring", kv, log.NewNopLogger(), nil), nil, reg, util_test.NewTestingLogger(t))
+	prw := ring.NewPartitionRingWatcher("ingester", "partition-ring", kv, log.NewNopLogger(), nil)
+	ingester, err := New(*ingesterCfg, overrides, nil, prw, nil, reg, util_test.NewTestingLogger(t))
 	require.NoError(t, err)
 
 	return ingester, kafkaCluster

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -4604,7 +4604,7 @@ func prepareIngesterWithBlockStorageAndOverrides(t testing.TB, ingesterCfg Confi
 		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), rng))
 	})
 
-	ingester, err := New(ingesterCfg, overrides, rng, nil, registerer, noDebugNoopLogger{})
+	ingester, err := New(ingesterCfg, overrides, rng, nil, nil, registerer, noDebugNoopLogger{})
 	if err != nil {
 		return nil, err
 	}
@@ -4798,7 +4798,7 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 			// setup the tsdbs dir
 			testData.setup(t, tempDir)
 
-			ingester, err := New(ingesterCfg, overrides, nil, nil, nil, log.NewNopLogger())
+			ingester, err := New(ingesterCfg, overrides, nil, nil, nil, nil, log.NewNopLogger())
 			require.NoError(t, err)
 
 			startErr := services.StartAndAwaitRunning(context.Background(), ingester)
@@ -5938,7 +5938,7 @@ func TestHeadCompactionOnStartup(t *testing.T) {
 	ingesterCfg.BlocksStorageConfig.Bucket.S3.Endpoint = "localhost"
 	ingesterCfg.BlocksStorageConfig.TSDB.Retention = 2 * 24 * time.Hour // Make sure that no newly created blocks are deleted.
 
-	ingester, err := New(ingesterCfg, overrides, nil, nil, nil, log.NewNopLogger())
+	ingester, err := New(ingesterCfg, overrides, nil, nil, nil, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ingester))
 

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -187,12 +187,17 @@ func (is *ingesterRingLimiterStrategy) getShardSize(userID string) int {
 	return is.getIngestionTenantShardSize(userID)
 }
 
+// Interface for mocking.
+type partitionRingWatcher interface {
+	PartitionRing() *ring.PartitionRing
+}
+
 type partitionRingLimiterStrategy struct {
-	partitionRingWatcher        *ring.PartitionRingWatcher
+	partitionRingWatcher        partitionRingWatcher
 	getPartitionTenantShardSize func(userID string) int
 }
 
-func newPartitionRingLimiter(watcher *ring.PartitionRingWatcher, getPartitionTenantShardSize func(userID string) int) *partitionRingLimiterStrategy {
+func newPartitionRingLimiter(watcher partitionRingWatcher, getPartitionTenantShardSize func(userID string) int) *partitionRingLimiterStrategy {
 	return &partitionRingLimiterStrategy{
 		partitionRingWatcher:        watcher,
 		getPartitionTenantShardSize: getPartitionTenantShardSize,

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -197,7 +197,7 @@ type partitionRingLimiterStrategy struct {
 	getPartitionTenantShardSize func(userID string) int
 }
 
-func newPartitionRingLimiter(watcher partitionRingWatcher, getPartitionTenantShardSize func(userID string) int) *partitionRingLimiterStrategy {
+func newPartitionRingLimiterStrategy(watcher partitionRingWatcher, getPartitionTenantShardSize func(userID string) int) *partitionRingLimiterStrategy {
 	return &partitionRingLimiterStrategy{
 		partitionRingWatcher:        watcher,
 		getPartitionTenantShardSize: getPartitionTenantShardSize,
@@ -232,12 +232,12 @@ func (ps *partitionRingLimiterStrategy) getShardSize(userID string) int {
 	return ps.getPartitionTenantShardSize(userID)
 }
 
-type forFlushStrategy struct{}
+type flusherLimiterStrategy struct{}
 
-func (f forFlushStrategy) convertGlobalToLocalLimit(_ int, _ int) int {
+func (f flusherLimiterStrategy) convertGlobalToLocalLimit(_ int, _ int) int {
 	return 0
 }
 
-func (f forFlushStrategy) getShardSize(userID string) int {
+func (f flusherLimiterStrategy) getShardSize(userID string) int {
 	return 0
 }

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -83,6 +83,7 @@ func (l *Limiter) maxMetadataPerUser(userID string) int {
 }
 
 func (l *Limiter) maxExemplarsPerUser(userID string) int {
+	// We don't use `convertGlobalToLocalLimitOrUnlimited`, because we don't want "unlimited" part. 0 means disabled.
 	return l.ringStrategy.convertGlobalToLocalLimit(l.getShardSize(userID), l.limits.MaxGlobalExemplarsPerUser(userID))
 }
 

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -234,6 +234,6 @@ func (f flusherLimiterStrategy) convertGlobalToLocalLimit(_ int, _ int) int {
 	return 0
 }
 
-func (f flusherLimiterStrategy) getShardSize(userID string) int {
+func (f flusherLimiterStrategy) getShardSize(_ string) int {
 	return 0
 }

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -387,7 +387,7 @@ func runLimiterMaxFunctionTestWithPartitionsRing(
 			overrides, err := validation.NewOverrides(limits, nil)
 			require.NoError(t, err)
 
-			strategy := newPartitionRingLimiter(h, overrides.IngestionPartitionsTenantShardSize)
+			strategy := newPartitionRingLimiterStrategy(h, overrides.IngestionPartitionsTenantShardSize)
 			limiter := NewLimiter(overrides, strategy)
 			actual := runMaxFn(limiter)
 			assert.Equal(t, testData.expectedValue, actual)
@@ -494,7 +494,7 @@ func TestLimiter_AssertMaxSeriesPerMetric_WithPartitionsRing(t *testing.T) {
 			limits, err := validation.NewOverrides(validation.Limits{MaxGlobalSeriesPerMetric: testData.maxGlobalSeriesPerMetric}, nil)
 			require.NoError(t, err)
 
-			strategy := newPartitionRingLimiter(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
+			strategy := newPartitionRingLimiterStrategy(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxSeriesPerMetric("test", testData.series)
 
@@ -590,7 +590,7 @@ func TestLimiter_AssertMaxMetadataPerMetric_WithPartitionsRing(t *testing.T) {
 			limits, err := validation.NewOverrides(validation.Limits{MaxGlobalMetadataPerMetric: testData.maxGlobalMetadataPerMetric}, nil)
 			require.NoError(t, err)
 
-			strategy := newPartitionRingLimiter(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
+			strategy := newPartitionRingLimiterStrategy(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxMetadataPerMetric("test", testData.metadata)
 
@@ -694,7 +694,7 @@ func TestLimiter_AssertMaxSeriesPerUser_WithPartitionsRing(t *testing.T) {
 			limits, err := validation.NewOverrides(validation.Limits{MaxGlobalSeriesPerUser: testData.maxGlobalSeriesPerUser}, nil)
 			require.NoError(t, err)
 
-			strategy := newPartitionRingLimiter(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
+			strategy := newPartitionRingLimiterStrategy(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxSeriesPerUser("test", testData.series, testData.minLocalLimit)
 
@@ -790,7 +790,7 @@ func TestLimiter_AssertMaxMetricsWithMetadataPerUser_WithPartitionsRing(t *testi
 			limits, err := validation.NewOverrides(validation.Limits{MaxGlobalMetricsWithMetadataPerUser: testData.maxGlobalMetadataPerUser}, nil)
 			require.NoError(t, err)
 
-			strategy := newPartitionRingLimiter(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
+			strategy := newPartitionRingLimiterStrategy(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxMetricsWithMetadataPerUser("test", testData.metadata)
 

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -365,25 +365,25 @@ func runLimiterMaxFunctionTestWithPartitionsRing(
 			globalLimit:               1000,
 			partitionStates:           []ring.PartitionState{ring.PartitionActive, ring.PartitionInactive, ring.PartitionInactive, ring.PartitionInactive, ring.PartitionInactive},
 			tenantPartitionsShardSize: 0,
-			expectedValue:             1000, // 1000 / 1
+			expectedValue:             1000 / 1,
 		},
 		"limit is enabled, using all active partitions, only 2 are active": {
 			globalLimit:               1000,
 			partitionStates:           []ring.PartitionState{ring.PartitionActive, ring.PartitionActive, ring.PartitionInactive, ring.PartitionInactive, ring.PartitionInactive},
 			tenantPartitionsShardSize: 0,
-			expectedValue:             500, // 1000 / 2
+			expectedValue:             1000 / 2,
 		},
 		"limit is enabled, using 2 partitions out of 5, all active": {
 			globalLimit:               1000,
 			partitionStates:           []ring.PartitionState{ring.PartitionActive, ring.PartitionActive, ring.PartitionActive, ring.PartitionActive, ring.PartitionActive},
 			tenantPartitionsShardSize: 2,
-			expectedValue:             500, // 1000 / 2
+			expectedValue:             1000 / 2,
 		},
 		"limit is enabled, using 5 partitions, but only 2 are active": {
 			globalLimit:               1000,
 			partitionStates:           []ring.PartitionState{ring.PartitionActive, ring.PartitionActive, ring.PartitionInactive, ring.PartitionInactive, ring.PartitionInactive},
 			tenantPartitionsShardSize: 5,
-			expectedValue:             500, // 1000 / 2
+			expectedValue:             1000 / 2,
 		},
 		"limit is enabled, using 2 partitions, but 0 are active": {
 			globalLimit:               1000,

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -295,7 +295,8 @@ func runLimiterMaxFunctionTest(
 			overrides, err := validation.NewOverrides(limits, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(overrides, ring, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled, "zone")
+			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled, "zone", overrides.IngestionTenantShardSize)
+			limiter := NewLimiter(overrides, strategy)
 			actual := runMaxFn(limiter)
 			assert.Equal(t, testData.expectedValue, actual)
 		})
@@ -346,7 +347,8 @@ func TestLimiter_AssertMaxSeriesPerMetric(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false, "")
+			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, false, "", limits.IngestionTenantShardSize)
+			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxSeriesPerMetric("test", testData.series)
 
 			assert.Equal(t, testData.expected, actual)
@@ -397,7 +399,8 @@ func TestLimiter_AssertMaxMetadataPerMetric(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false, "")
+			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, false, "", limits.IngestionTenantShardSize)
+			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxMetadataPerMetric("test", testData.metadata)
 
 			assert.Equal(t, testData.expected, actual)
@@ -449,7 +452,8 @@ func TestLimiter_AssertMaxSeriesPerUser(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false, "")
+			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, false, "", limits.IngestionTenantShardSize)
+			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxSeriesPerUser("test", testData.series, limiter.getShardSize("test"))
 
 			assert.Equal(t, testData.expected, actual)
@@ -501,7 +505,8 @@ func TestLimiter_AssertMaxMetricsWithMetadataPerUser(t *testing.T) {
 			}, nil)
 			require.NoError(t, err)
 
-			limiter := NewLimiter(limits, ring, testData.ringReplicationFactor, false, "")
+			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, false, "", limits.IngestionTenantShardSize)
+			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxMetricsWithMetadataPerUser("test", testData.metadata)
 
 			assert.Equal(t, testData.expected, actual)

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -81,7 +81,9 @@ func TestUserMetricsMetadata(t *testing.T) {
 				MaxGlobalMetadataPerMetric:          testData.maxMetadataPerMetric,
 			}, nil)
 			require.NoError(t, err)
-			limiter := NewLimiter(limits, ring, 1, false, "")
+
+			strategy := newIngesterRingLimiterStrategy(ring, 1, false, "", limits.IngestionTenantShardSize)
+			limiter := NewLimiter(limits, strategy)
 
 			metrics := newIngesterMetrics(
 				prometheus.NewPedanticRegistry(),
@@ -134,7 +136,9 @@ func TestUserMetricsMetadataRequest(t *testing.T) {
 
 	limits, err := validation.NewOverrides(validation.Limits{}, nil)
 	require.NoError(t, err)
-	limiter := NewLimiter(limits, ring, 1, false, "")
+
+	strategy := newIngesterRingLimiterStrategy(ring, 1, false, "", limits.IngestionTenantShardSize)
+	limiter := NewLimiter(limits, strategy)
 
 	metrics := newIngesterMetrics(
 		prometheus.NewPedanticRegistry(),

--- a/pkg/ingester/user_tsdb_test.go
+++ b/pkg/ingester/user_tsdb_test.go
@@ -217,7 +217,7 @@ func TestGetSeriesAndShardsForSeriesLimit(t *testing.T) {
 
 	db := userTSDB{
 		db:                   tsdbDB,
-		limiter:              NewLimiter(overrides, nil),
+		limiter:              NewLimiter(overrides, newIngesterRingLimiterStrategy(&ringCountMock{instancesCount: 100}, 3, false, "", overrides.IngestionTenantShardSize)),
 		ownedSeriesCount:     555,
 		ownedSeriesShardSize: 333,
 	}

--- a/pkg/ingester/user_tsdb_test.go
+++ b/pkg/ingester/user_tsdb_test.go
@@ -217,7 +217,7 @@ func TestGetSeriesAndShardsForSeriesLimit(t *testing.T) {
 
 	db := userTSDB{
 		db:                   tsdbDB,
-		limiter:              NewLimiter(overrides, nil, 3, true, "zone"),
+		limiter:              NewLimiter(overrides, nil),
 		ownedSeriesCount:     555,
 		ownedSeriesShardSize: 333,
 	}

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -673,7 +673,7 @@ func (t *Mimir) initIngesterService() (serv services.Service, err error) {
 	t.Cfg.Ingester.IngestStorageConfig = t.Cfg.IngestStorage
 	t.tsdbIngesterConfig()
 
-	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Overrides, t.IngesterRing, t.ActiveGroupsCleanup, t.Registerer, util_log.Logger)
+	t.Ingester, err = ingester.New(t.Cfg.Ingester, t.Overrides, t.IngesterRing, t.IngesterPartitionRingWatcher, t.ActiveGroupsCleanup, t.Registerer, util_log.Logger)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
#### What this PR does

This PR modifies ingester's `Limiter` code to work with ingest store (partitions ring) as well as ingester ring. ~Based on top of https://github.com/grafana/mimir/pull/7411.~ Rebased on top of `main`.

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
