### PR TITLE
Chunk iterators: Optimize histogram memory allocations

### DIFF
--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -166,7 +166,7 @@ func (a *iteratorAdapter) AtHistogram(h *histogram.Histogram) (int64, *histogram
 	if h == nil {
 		h = &histogram.Histogram{}
 	}
-	fromH := a.curr.Histograms[a.curr.Index]
+	fromH := (*histogram.Histogram)(a.curr.PointerValues[a.curr.Index])
 	fromH.CopyTo(h)
 	return a.curr.Timestamps[a.curr.Index], h
 }
@@ -181,12 +181,12 @@ func (a *iteratorAdapter) AtFloatHistogram(fh *histogram.FloatHistogram) (int64,
 	// The promQL engine works on Float Histograms even if the underlying data is an integer histogram
 	// and will call AtFloatHistogram on a Histogram
 	if a.curr.ValueType == chunkenc.ValFloatHistogram {
-		fromFH := a.curr.FloatHistograms[a.curr.Index]
+		fromFH := (*histogram.FloatHistogram)(a.curr.PointerValues[a.curr.Index])
 		fromFH.CopyTo(fh)
 		return a.curr.Timestamps[a.curr.Index], fh
 	}
 	if a.curr.ValueType == chunkenc.ValHistogram {
-		fromH := a.curr.Histograms[a.curr.Index]
+		fromH := (*histogram.Histogram)(a.curr.PointerValues[a.curr.Index])
 		fromH.ToFloat(fh)
 		return a.curr.Timestamps[a.curr.Index], fh
 	}

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -163,34 +163,32 @@ func (a *iteratorAdapter) AtHistogram(h *histogram.Histogram) (int64, *histogram
 	if a.curr.ValueType != chunkenc.ValHistogram {
 		panic(fmt.Sprintf("Cannot read histogram from batch %v", a.curr.ValueType))
 	}
-	toH := h
-	if toH == nil {
-		toH = &histogram.Histogram{}
+	if h == nil {
+		h = &histogram.Histogram{}
 	}
 	fromH := a.curr.Histograms[a.curr.Index]
-	fromH.CopyTo(toH)
-	return a.curr.Timestamps[a.curr.Index], toH
+	fromH.CopyTo(h)
+	return a.curr.Timestamps[a.curr.Index], h
 }
 
 // AtFloatHistogram implements chunkenc.Iterator. It copies and returns the underlying float histogram.
 // If a pointer to a float histogram is passed as parameter, the underlying float histogram is copied there.
 // Otherwise, a new float histogram is created.
 func (a *iteratorAdapter) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
-	toFH := fh
-	if toFH == nil {
-		toFH = &histogram.FloatHistogram{}
+	if fh == nil {
+		fh = &histogram.FloatHistogram{}
 	}
 	// The promQL engine works on Float Histograms even if the underlying data is an integer histogram
 	// and will call AtFloatHistogram on a Histogram
 	if a.curr.ValueType == chunkenc.ValFloatHistogram {
 		fromFH := a.curr.FloatHistograms[a.curr.Index]
-		fromFH.CopyTo(toFH)
-		return a.curr.Timestamps[a.curr.Index], toFH
+		fromFH.CopyTo(fh)
+		return a.curr.Timestamps[a.curr.Index], fh
 	}
 	if a.curr.ValueType == chunkenc.ValHistogram {
 		fromH := a.curr.Histograms[a.curr.Index]
-		fromH.ToFloat(toFH)
-		return a.curr.Timestamps[a.curr.Index], toFH
+		fromH.ToFloat(fh)
+		return a.curr.Timestamps[a.curr.Index], fh
 	}
 	panic(fmt.Sprintf("Cannot read floathistogram from batch %v", a.curr.ValueType))
 }

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -167,7 +167,7 @@ func (a *iteratorAdapter) AtHistogram(h *histogram.Histogram) (int64, *histogram
 	if toH == nil {
 		toH = &histogram.Histogram{}
 	}
-	fromH := (*histogram.Histogram)(a.curr.PointerValues[a.curr.Index])
+	fromH := a.curr.Histograms[a.curr.Index]
 	fromH.CopyTo(toH)
 	return a.curr.Timestamps[a.curr.Index], toH
 }
@@ -183,12 +183,12 @@ func (a *iteratorAdapter) AtFloatHistogram(fh *histogram.FloatHistogram) (int64,
 	// The promQL engine works on Float Histograms even if the underlying data is an integer histogram
 	// and will call AtFloatHistogram on a Histogram
 	if a.curr.ValueType == chunkenc.ValFloatHistogram {
-		fromFH := (*histogram.FloatHistogram)(a.curr.PointerValues[a.curr.Index])
+		fromFH := a.curr.FloatHistograms[a.curr.Index]
 		fromFH.CopyTo(toFH)
 		return a.curr.Timestamps[a.curr.Index], toFH
 	}
 	if a.curr.ValueType == chunkenc.ValHistogram {
-		fromH := (*histogram.Histogram)(a.curr.PointerValues[a.curr.Index])
+		fromH := a.curr.Histograms[a.curr.Index]
 		fromH.ToFloat(toFH)
 		return a.curr.Timestamps[a.curr.Index], toFH
 	}

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -7,7 +7,9 @@ package batch
 
 import (
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/zeropool"
 
 	"github.com/grafana/mimir/pkg/storage/chunk"
 )
@@ -17,16 +19,17 @@ import (
 type chunkIterator struct {
 	chunk GenericChunk
 	it    chunk.Iterator
-	batch *chunk.Batch
+	batch chunk.Batch
+
+	hPool  *zeropool.Pool[*histogram.Histogram]
+	fhPool *zeropool.Pool[*histogram.FloatHistogram]
 }
 
 func (i *chunkIterator) reset(chunk GenericChunk) {
 	i.chunk = chunk
 	i.it = chunk.Iterator(i.it)
-	if i.batch != nil {
-		i.batch.Length = 0
-		i.batch.Index = 0
-	}
+	i.batch.Length = 0
+	i.batch.Index = 0
 }
 
 // Seek advances the iterator forward to the value at or after
@@ -40,20 +43,17 @@ func (i *chunkIterator) Seek(t int64, size int) chunkenc.ValueType {
 
 	// If the seek is to the middle of the current batch, and size fits, we can
 	// shortcut.
-	if i.batch != nil {
-		if i.batch.Length > 0 && t >= i.batch.Timestamps[0] && t <= i.batch.Timestamps[i.batch.Length-1] {
-			i.batch.Index = 0
-			for i.batch.Index < i.batch.Length && t > i.batch.Timestamps[i.batch.Index] {
-				i.batch.Index++
-			}
-			if i.batch.Index+size < i.batch.Length {
-				return i.batch.ValueType
-			}
+	if i.batch.Length > 0 && t >= i.batch.Timestamps[0] && t <= i.batch.Timestamps[i.batch.Length-1] {
+		i.batch.Index = 0
+		for i.batch.Index < i.batch.Length && t > i.batch.Timestamps[i.batch.Index] {
+			i.batch.Index++
+		}
+		if i.batch.Index+size < i.batch.Length {
+			return i.batch.ValueType
 		}
 	}
-
 	if typ := i.it.FindAtOrAfter(model.Time(t)); typ != chunkenc.ValNone {
-		i.batch = i.it.Batch(size, typ, i.batch)
+		i.batch = i.it.Batch(size, typ, i.hPool, i.fhPool)
 		if i.batch.Length > 0 {
 			return typ
 		}
@@ -63,7 +63,7 @@ func (i *chunkIterator) Seek(t int64, size int) chunkenc.ValueType {
 
 func (i *chunkIterator) Next(size int) chunkenc.ValueType {
 	if typ := i.it.Scan(); typ != chunkenc.ValNone {
-		i.batch = i.it.Batch(size, typ, i.batch)
+		i.batch = i.it.Batch(size, typ, i.hPool, i.fhPool)
 		if i.batch.Length > 0 {
 			return typ
 		}
@@ -76,7 +76,7 @@ func (i *chunkIterator) AtTime() int64 {
 }
 
 func (i *chunkIterator) Batch() chunk.Batch {
-	return *i.batch
+	return i.batch
 }
 
 func (i *chunkIterator) Err() error {

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/zeropool"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/chunk"
@@ -207,13 +208,11 @@ func (i *mockIterator) Timestamp() int64 {
 	return 0
 }
 
-func (i *mockIterator) Batch(_ int, valueType chunkenc.ValueType, b *chunk.Batch) *chunk.Batch {
-	batch := b
-	if batch == nil {
-		batch = &chunk.Batch{}
+func (i *mockIterator) Batch(_ int, valueType chunkenc.ValueType, _ *zeropool.Pool[*histogram.Histogram], _ *zeropool.Pool[*histogram.FloatHistogram]) chunk.Batch {
+	batch := chunk.Batch{
+		Length:    chunk.BatchSize,
+		ValueType: valueType,
 	}
-	batch.Length = chunk.BatchSize
-	batch.ValueType = valueType
 	for i := 0; i < chunk.BatchSize; i++ {
 		batch.Timestamps[i] = int64(i)
 	}

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -153,7 +153,7 @@ func testSeek(t require.TestingT, points int, iter chunkenc.Iterator, encoding c
 		expectedTS := int64(i * int(step/time.Millisecond))
 		assertPoint(expectedTS, iter.Seek(expectedTS))
 
-		for j := i + 1; j < i+points/10; j++ {
+		for j := i + 1; j < i+points/10 && j < points; j++ {
 			expectedTS := int64(j * int(step/time.Millisecond))
 			assertPoint(expectedTS, iter.Next())
 		}
@@ -207,11 +207,13 @@ func (i *mockIterator) Timestamp() int64 {
 	return 0
 }
 
-func (i *mockIterator) Batch(_ int, valueType chunkenc.ValueType) chunk.Batch {
-	batch := chunk.Batch{
-		Length:    chunk.BatchSize,
-		ValueType: valueType,
+func (i *mockIterator) Batch(_ int, valueType chunkenc.ValueType, b *chunk.Batch) *chunk.Batch {
+	batch := b
+	if batch == nil {
+		batch = &chunk.Batch{}
 	}
+	batch.Length = chunk.BatchSize
+	batch.ValueType = valueType
 	for i := 0; i < chunk.BatchSize; i++ {
 		batch.Timestamps[i] = int64(i)
 	}

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -155,7 +155,7 @@ func (c *mergeIterator) buildNextBatch(size int) chunkenc.ValueType {
 	// is before all iterators next entry.
 	for len(c.h) > 0 && (len(c.batches) == 0 || c.nextBatchEndTime() >= c.h[0].AtTime()) {
 		c.nextBatchBuf[0] = c.h[0].Batch()
-		c.batchesBuf = mergeStreams(c.batches, c.nextBatchBuf[:], c.batchesBuf, size)
+		c.batchesBuf = mergeStreams(c.batches, c.nextBatchBuf[:], c.batchesBuf, size, &c.hPool, &c.fhPool)
 		c.batches = append(c.batches[:0], c.batchesBuf...)
 
 		if c.h[0].Next(size) != chunkenc.ValNone {

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -58,7 +58,7 @@ func newMergeIterator(it iterator, cs []GenericChunk) *mergeIterator {
 		c.batchesBuf = make(batchStream, len(c.its))
 	}
 	for i, cs := range css {
-		c.its[i] = newNonOverlappingIterator(c.its[i], cs)
+		c.its[i] = newNonOverlappingIterator(c.its[i], cs, &c.hPool, &c.fhPool)
 	}
 
 	for _, iter := range c.its {
@@ -155,7 +155,7 @@ func (c *mergeIterator) buildNextBatch(size int) chunkenc.ValueType {
 	// is before all iterators next entry.
 	for len(c.h) > 0 && (len(c.batches) == 0 || c.nextBatchEndTime() >= c.h[0].AtTime()) {
 		c.nextBatchBuf[0] = c.h[0].Batch()
-		c.batchesBuf = mergeStreams(c.batches, c.nextBatchBuf[:], c.batchesBuf, size, false, true, &c.hPool, &c.fhPool)
+		c.batchesBuf = mergeStreams(c.batches, c.nextBatchBuf[:], c.batchesBuf, size)
 		c.batches = append(c.batches[:0], c.batchesBuf...)
 
 		if c.h[0].Next(size) != chunkenc.ValNone {

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -79,11 +79,11 @@ func newMergeIterator(it iterator, cs []GenericChunk) *mergeIterator {
 func (c *mergeIterator) putPointerValuesToThePool(b chunk.Batch) {
 	if b.ValueType == chunkenc.ValHistogram {
 		for i := 0; i < b.Length; i++ {
-			c.hPool.Put(b.Histograms[i])
+			c.hPool.Put((*histogram.Histogram)(b.PointerValues[i]))
 		}
 	} else if b.ValueType == chunkenc.ValFloatHistogram {
 		for i := 0; i < b.Length; i++ {
-			c.fhPool.Put(b.FloatHistograms[i])
+			c.fhPool.Put((*histogram.FloatHistogram)(b.PointerValues[i]))
 		}
 	}
 }

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -15,40 +15,48 @@ import (
 )
 
 func TestMergeIter(t *testing.T) {
-	chunk1 := mkGenericChunk(t, 0, 100, chunk.PrometheusXorChunk)
-	chunk2 := mkGenericChunk(t, model.TimeFromUnix(25), 100, chunk.PrometheusXorChunk)
-	chunk3 := mkGenericChunk(t, model.TimeFromUnix(50), 100, chunk.PrometheusXorChunk)
-	chunk4 := mkGenericChunk(t, model.TimeFromUnix(75), 100, chunk.PrometheusXorChunk)
-	chunk5 := mkGenericChunk(t, model.TimeFromUnix(100), 100, chunk.PrometheusXorChunk)
+	for _, enc := range []chunk.Encoding{chunk.PrometheusXorChunk, chunk.PrometheusHistogramChunk, chunk.PrometheusFloatHistogramChunk} {
+		t.Run(enc.String(), func(t *testing.T) {
+			chunk1 := mkGenericChunk(t, 0, 100, enc)
+			chunk2 := mkGenericChunk(t, model.TimeFromUnix(25), 100, enc)
+			chunk3 := mkGenericChunk(t, model.TimeFromUnix(50), 100, enc)
+			chunk4 := mkGenericChunk(t, model.TimeFromUnix(75), 100, enc)
+			chunk5 := mkGenericChunk(t, model.TimeFromUnix(100), 100, enc)
 
-	iter := NewGenericChunkMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testIter(t, 200, iter, chunk.PrometheusXorChunk)
-	iter = NewGenericChunkMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testSeek(t, 200, iter, chunk.PrometheusXorChunk)
+			iter := NewGenericChunkMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+			testIter(t, 200, iter, enc)
+			iter = NewGenericChunkMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+			testSeek(t, 200, iter, enc)
 
-	// Re-use iterator.
-	iter = NewGenericChunkMergeIterator(iter, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testIter(t, 200, iter, chunk.PrometheusXorChunk)
-	iter = NewGenericChunkMergeIterator(iter, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
-	testSeek(t, 200, iter, chunk.PrometheusXorChunk)
-
+			// Re-use iterator.
+			iter = NewGenericChunkMergeIterator(iter, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+			testIter(t, 200, iter, enc)
+			iter = NewGenericChunkMergeIterator(iter, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+			testSeek(t, 200, iter, enc)
+		})
+	}
 }
 
 func TestMergeHarder(t *testing.T) {
 	var (
 		numChunks = 24 * 15
 		chunks    = make([]GenericChunk, 0, numChunks)
-		from      = model.Time(0)
 		offset    = 30
 		samples   = 100
 	)
-	for i := 0; i < numChunks; i++ {
-		chunks = append(chunks, mkGenericChunk(t, from, samples, chunk.PrometheusXorChunk))
-		from = from.Add(time.Duration(offset) * time.Second)
-	}
-	iter := newMergeIterator(nil, chunks)
-	testIter(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter), chunk.PrometheusXorChunk)
+	for _, enc := range []chunk.Encoding{chunk.PrometheusXorChunk, chunk.PrometheusHistogramChunk, chunk.PrometheusFloatHistogramChunk} {
+		t.Run(enc.String(), func(t *testing.T) {
+			chunks = chunks[:0]
+			from := model.Time(0)
+			for i := 0; i < numChunks; i++ {
+				chunks = append(chunks, mkGenericChunk(t, from, samples, enc))
+				from = from.Add(time.Duration(offset) * time.Second)
+			}
+			iter := newMergeIterator(nil, chunks)
+			testIter(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter), enc)
 
-	iter = newMergeIterator(nil, chunks)
-	testSeek(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter), chunk.PrometheusXorChunk)
+			iter = newMergeIterator(nil, chunks)
+			testSeek(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter), enc)
+		})
+	}
 }

--- a/pkg/querier/batch/non_overlapping.go
+++ b/pkg/querier/batch/non_overlapping.go
@@ -6,7 +6,9 @@
 package batch
 
 import (
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/zeropool"
 
 	"github.com/grafana/mimir/pkg/storage/chunk"
 )
@@ -19,12 +21,14 @@ type nonOverlappingIterator struct {
 
 // newNonOverlappingIterator returns a single iterator over a slice of sorted,
 // non-overlapping iterators.
-func newNonOverlappingIterator(it *nonOverlappingIterator, chunks []GenericChunk) *nonOverlappingIterator {
+func newNonOverlappingIterator(it *nonOverlappingIterator, chunks []GenericChunk, hPool *zeropool.Pool[*histogram.Histogram], fhPool *zeropool.Pool[*histogram.FloatHistogram]) *nonOverlappingIterator {
 	if it == nil {
 		it = &nonOverlappingIterator{}
 	}
 	it.chunks = chunks
 	it.curr = 0
+	it.iter.hPool = hPool
+	it.iter.fhPool = fhPool
 	it.iter.reset(it.chunks[0])
 	return it
 }

--- a/pkg/querier/batch/non_overlapping_test.go
+++ b/pkg/querier/batch/non_overlapping_test.go
@@ -18,16 +18,16 @@ func TestNonOverlappingIter(t *testing.T) {
 	for i := int64(0); i < 100; i++ {
 		cs = append(cs, mkGenericChunk(t, model.TimeFromUnix(i*10), 10, chunk.PrometheusXorChunk))
 	}
-	testIter(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs)), chunk.PrometheusXorChunk)
-	it := newNonOverlappingIterator(nil, cs)
+	testIter(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil)), chunk.PrometheusXorChunk)
+	it := newNonOverlappingIterator(nil, cs, nil, nil)
 	adapter := newIteratorAdapter(nil, it)
 	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk)
 
 	// Do the same operations while re-using the iterators.
-	it = newNonOverlappingIterator(it, cs)
+	it = newNonOverlappingIterator(it, cs, nil, nil)
 	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it)
 	testIter(t, 10*100, adapter, chunk.PrometheusXorChunk)
-	it = newNonOverlappingIterator(it, cs)
+	it = newNonOverlappingIterator(it, cs, nil, nil)
 	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it)
 	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk)
 }
@@ -41,6 +41,6 @@ func TestNonOverlappingIterSparse(t *testing.T) {
 		mkGenericChunk(t, model.TimeFromUnix(95), 1, chunk.PrometheusXorChunk),
 		mkGenericChunk(t, model.TimeFromUnix(96), 4, chunk.PrometheusXorChunk),
 	}
-	testIter(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs)), chunk.PrometheusXorChunk)
-	testSeek(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs)), chunk.PrometheusXorChunk)
+	testIter(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil)), chunk.PrometheusXorChunk)
+	testSeek(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil)), chunk.PrometheusXorChunk)
 }

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -128,11 +128,11 @@ func mergeStreams(left, right, result batchStream, size int, hPool *zeropool.Poo
 				populate(right, rt)
 			} else {
 				populate(left, lt)
-				if hPool != nil && rt == chunkenc.ValHistogram {
+				if rt == chunkenc.ValHistogram && hPool != nil {
 					_, h := right.atHistogram()
 					hPool.Put((*histogram.Histogram)(h))
 				}
-				if fhPool != nil && rt == chunkenc.ValFloatHistogram {
+				if rt == chunkenc.ValFloatHistogram && fhPool != nil {
 					_, fh := right.atFloatHistogram()
 					fhPool.Put((*histogram.FloatHistogram)(fh))
 				}

--- a/pkg/querier/batch/stream_test.go
+++ b/pkg/querier/batch/stream_test.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
 
@@ -87,7 +86,7 @@ func TestStream(t *testing.T) {
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			result := make(batchStream, len(tc.input1)+len(tc.input2))
-			result = mergeStreams(tc.input1, tc.input2, result, chunk.BatchSize, false, false, nil, nil)
+			result = mergeStreams(tc.input1, tc.input2, result, chunk.BatchSize)
 			require.Equal(t, len(tc.output), len(result))
 			for i, batch := range tc.output {
 				other := result[i]
@@ -97,7 +96,7 @@ func TestStream(t *testing.T) {
 	}
 }
 
-func TestStreamWithCopiedPointerValues(t *testing.T) {
+/*func TestStreamWithCopiedPointerValues(t *testing.T) {
 	tests := map[string]struct {
 		left, right batchStream
 	}{
@@ -195,7 +194,7 @@ func seek(bs batchStream, ts int64, t chunkenc.ValueType) (*histogram.Histogram,
 		}
 	}
 	return nil, nil
-}
+}*/
 
 func mkFloatBatch(from int64) chunk.Batch {
 	return mkGenericFloatBatch(from, chunk.BatchSize)
@@ -205,9 +204,9 @@ func mkHistogramBatch(from int64) chunk.Batch {
 	return mkGenericHistogramBatch(from, chunk.BatchSize)
 }
 
-func mkFloatHistogramBatch(from int64) chunk.Batch {
+/*func mkFloatHistogramBatch(from int64) chunk.Batch {
 	return mkGenericFloatHistogramBatch(from, chunk.BatchSize)
-}
+}*/
 
 func mkGenericFloatBatch(from int64, size int) chunk.Batch {
 	batch := chunk.Batch{ValueType: chunkenc.ValFloat}

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -396,7 +396,7 @@ func TestBatchMergeChunks(t *testing.T) {
 	require.ElementsMatch(t, m[0].Histograms, m[1].Histograms)
 }
 
-func BenchmarkExecute(b *testing.B) {
+func BenchmarkQueryExecute(b *testing.B) {
 	var (
 		logger    = log.NewNopLogger()
 		queryStep = time.Second
@@ -424,7 +424,11 @@ func BenchmarkExecute(b *testing.B) {
 	}
 
 	for _, scenario := range scenarios {
-		for _, encoding := range []chunk.Encoding{chunk.PrometheusXorChunk, chunk.PrometheusHistogramChunk, chunk.PrometheusFloatHistogramChunk} {
+		for _, encoding := range []chunk.Encoding{
+			chunk.PrometheusXorChunk,
+			chunk.PrometheusHistogramChunk,
+			chunk.PrometheusFloatHistogramChunk,
+		} {
 			name := fmt.Sprintf("chunks: %d samples per chunk: %d duplication factor: %d encoding: %s", scenario.numChunks, scenario.numSamplesPerChunk, scenario.duplicationFactor, encoding)
 			queryStart := time.Now().Add(-time.Second * time.Duration(scenario.numChunks*scenario.numSamplesPerChunk))
 			queryEnd := time.Now()
@@ -524,7 +528,7 @@ func mockTSDB(t *testing.T, mint model.Time, samples int, step, chunkOffset time
 	return queryable, ts
 }
 
-func createChunks(b *testing.B, numChunks, numSamplesPerChunk, duplicationFactor int, queryStart time.Time, step time.Duration, enc chunk.Encoding) []client.Chunk {
+func createChunks(b require.TestingT, numChunks, numSamplesPerChunk, duplicationFactor int, queryStart time.Time, step time.Duration, enc chunk.Encoding) []client.Chunk {
 	result := make([]chunk.Chunk, 0, numChunks)
 
 	for d := 0; d < duplicationFactor; d++ {

--- a/pkg/storage/chunk/chunk.go
+++ b/pkg/storage/chunk/chunk.go
@@ -8,7 +8,6 @@ package chunk
 import (
 	"fmt"
 	"io"
-	"unsafe"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -99,15 +98,15 @@ const BatchSize = 12
 // Batch is intended to be small, and passed by value!
 type Batch struct {
 	Timestamps [BatchSize]int64
-	Values     [BatchSize]float64
-	// PointerValues store pointers to non-float complex values like histograms, float histograms or future additions.
-	// Since Batch is expected to be passed by value, the array needs to be constant sized,
-	// however increasing the size of the Batch also adds memory management overhead. Using the unsafe.Pointer
-	// combined with the ValueType implements a kind of "union" type to keep the memory use down.
-	PointerValues [BatchSize]unsafe.Pointer
-	ValueType     chunkenc.ValueType
-	Index         int
-	Length        int
+	// Values stores float values related to this batch if ValueType is chunkenc.ValFloat.
+	Values [BatchSize]float64
+	// Histograms stores histogram values related to this batch if ValueType is chunkenc.ValHistogram.
+	Histograms [BatchSize]*histogram.Histogram
+	// Histograms stores float histogram values related to this batch if ValueType is chunkenc.ValFloatHistogram.
+	FloatHistograms [BatchSize]*histogram.FloatHistogram
+	ValueType       chunkenc.ValueType
+	Index           int
+	Length          int
 }
 
 // Chunk contains encoded timeseries data

--- a/pkg/storage/chunk/chunk.go
+++ b/pkg/storage/chunk/chunk.go
@@ -107,11 +107,10 @@ type Batch struct {
 	// Since Batch is expected to be passed by value, the array needs to be constant sized,
 	// however increasing the size of the Batch also adds memory management overhead. Using the unsafe.Pointer
 	// combined with the ValueType implements a kind of "union" type to keep the memory use down.
-	PointerValues   [BatchSize]unsafe.Pointer
-	FloatHistograms [BatchSize]*histogram.FloatHistogram
-	ValueType       chunkenc.ValueType
-	Index           int
-	Length          int
+	PointerValues [BatchSize]unsafe.Pointer
+	ValueType     chunkenc.ValueType
+	Index         int
+	Length        int
 }
 
 // Chunk contains encoded timeseries data

--- a/pkg/storage/chunk/chunk.go
+++ b/pkg/storage/chunk/chunk.go
@@ -77,9 +77,14 @@ type Iterator interface {
 	AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram)
 	AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram)
 	Timestamp() int64
-	// Returns a batch of the provisded size; NB not idempotent!  Should only be called
+	// Batch returns a batch of the provisded size; NB not idempotent!  Should only be called
 	// once per Scan.
-	Batch(size int, valueType chunkenc.ValueType) Batch
+	// When the optional *Batch argument is passed, it will be replaced with the content
+	// of the new batch. Depending on the implementation, the optional *Batch argument can
+	// also be used to optimize memory allocations. For example, if it already contains
+	// pointers to objects of type histogram.Histogram or histogram.FloatHistogram,
+	// the latter can be reused for the object of the new Batch.
+	Batch(size int, valueType chunkenc.ValueType, b *Batch) *Batch
 	// Returns the last error encountered. In general, an error signals data
 	// corruption in the chunk and requires quarantining.
 	Err() error

--- a/pkg/storage/chunk/chunk_test.go
+++ b/pkg/storage/chunk/chunk_test.go
@@ -314,11 +314,11 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 	iter := chunk.NewIterator(nil)
 	for i := 0; i < samples; {
 		chunkType := iter.Scan()
-		var batch *Batch
+		var batch Batch
 		switch encoding {
 		case PrometheusXorChunk:
 			require.Equal(t, chunkenc.ValFloat, chunkType)
-			batch = iter.Batch(BatchSize, chunkenc.ValFloat, batch)
+			batch = iter.Batch(BatchSize, chunkenc.ValFloat, nil, nil)
 			require.Equal(t, chunkenc.ValFloat, batch.ValueType, "Batch contains floats")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])
@@ -326,7 +326,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			}
 		case PrometheusHistogramChunk:
 			require.Equal(t, chunkenc.ValHistogram, chunkType)
-			batch = iter.Batch(BatchSize, chunkenc.ValHistogram, batch)
+			batch = iter.Batch(BatchSize, chunkenc.ValHistogram, nil, nil)
 			require.Equal(t, chunkenc.ValHistogram, batch.ValueType, "Batch contains histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])
@@ -334,7 +334,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			}
 		case PrometheusFloatHistogramChunk:
 			require.Equal(t, chunkenc.ValFloatHistogram, chunkType)
-			batch = iter.Batch(BatchSize, chunkenc.ValFloatHistogram, batch)
+			batch = iter.Batch(BatchSize, chunkenc.ValFloatHistogram, nil, nil)
 			require.Equal(t, chunkenc.ValFloatHistogram, batch.ValueType, "Batch contains float histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])

--- a/pkg/storage/chunk/chunk_test.go
+++ b/pkg/storage/chunk/chunk_test.go
@@ -330,7 +330,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			require.Equal(t, chunkenc.ValHistogram, batch.ValueType, "Batch contains histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])
-				require.EqualValues(t, expectedHistogram(i+j), (*histogram.Histogram)(batch.PointerValues[j]))
+				require.EqualValues(t, expectedHistogram(i+j), batch.Histograms[j])
 			}
 		case PrometheusFloatHistogramChunk:
 			require.Equal(t, chunkenc.ValFloatHistogram, chunkType)
@@ -338,7 +338,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			require.Equal(t, chunkenc.ValFloatHistogram, batch.ValueType, "Batch contains float histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])
-				require.EqualValues(t, expectedFloatHistogram(i+j), (*histogram.FloatHistogram)(batch.PointerValues[j]))
+				require.EqualValues(t, expectedFloatHistogram(i+j), batch.FloatHistograms[j])
 			}
 		default:
 			require.FailNowf(t, "Unexpected encoding", "%v", encoding)

--- a/pkg/storage/chunk/chunk_test.go
+++ b/pkg/storage/chunk/chunk_test.go
@@ -314,11 +314,11 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 	iter := chunk.NewIterator(nil)
 	for i := 0; i < samples; {
 		chunkType := iter.Scan()
-		var batch Batch
+		var batch *Batch
 		switch encoding {
 		case PrometheusXorChunk:
 			require.Equal(t, chunkenc.ValFloat, chunkType)
-			batch = iter.Batch(BatchSize, chunkenc.ValFloat)
+			batch = iter.Batch(BatchSize, chunkenc.ValFloat, batch)
 			require.Equal(t, chunkenc.ValFloat, batch.ValueType, "Batch contains floats")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])
@@ -326,7 +326,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			}
 		case PrometheusHistogramChunk:
 			require.Equal(t, chunkenc.ValHistogram, chunkType)
-			batch = iter.Batch(BatchSize, chunkenc.ValHistogram)
+			batch = iter.Batch(BatchSize, chunkenc.ValHistogram, batch)
 			require.Equal(t, chunkenc.ValHistogram, batch.ValueType, "Batch contains histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])
@@ -334,7 +334,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			}
 		case PrometheusFloatHistogramChunk:
 			require.Equal(t, chunkenc.ValFloatHistogram, chunkType)
-			batch = iter.Batch(BatchSize, chunkenc.ValFloatHistogram)
+			batch = iter.Batch(BatchSize, chunkenc.ValFloatHistogram, batch)
 			require.Equal(t, chunkenc.ValFloatHistogram, batch.ValueType, "Batch contains float histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])

--- a/pkg/storage/chunk/chunk_test.go
+++ b/pkg/storage/chunk/chunk_test.go
@@ -330,7 +330,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			require.Equal(t, chunkenc.ValHistogram, batch.ValueType, "Batch contains histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])
-				require.EqualValues(t, expectedHistogram(i+j), batch.Histograms[j])
+				require.EqualValues(t, expectedHistogram(i+j), (*histogram.Histogram)(batch.PointerValues[j]))
 			}
 		case PrometheusFloatHistogramChunk:
 			require.Equal(t, chunkenc.ValFloatHistogram, chunkType)
@@ -338,7 +338,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			require.Equal(t, chunkenc.ValFloatHistogram, batch.ValueType, "Batch contains float histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.EqualValues(t, int64((i+j)*step), batch.Timestamps[j])
-				require.EqualValues(t, expectedFloatHistogram(i+j), batch.FloatHistograms[j])
+				require.EqualValues(t, expectedFloatHistogram(i+j), (*histogram.FloatHistogram)(batch.PointerValues[j]))
 			}
 		default:
 			require.FailNowf(t, "Unexpected encoding", "%v", encoding)


### PR DESCRIPTION
#### What this PR does

Prometheus introduced a possibility to optionally reuse the memory area of the given histogram or float histogram to reduce allocation (https://github.com/prometheus/prometheus/pull/13340). 

In #7274  we adapted Mimir's `chunk.Iterator` interface in such a way that its `AtHistogram()` and `AtFloatHistogram()` methods follow the signature of the corresponding methods of Prometheus' `chunkenc.Iterator`, i.e., they now also contain optional arguments of type `*histogram.Histogram` and `*histogram.FloatHistogram` that allow memory allocation optimization. 

### Changes in `batch.iteratorAdapter` 
In #7219 we adapter signatures of `batch.iteratorAdapter.AtHistogram()` and `batch.iteratorAdapter.AtFloatHistogram()` by adding the optional argument of type `*histogram.Histogram` and `*histogram.FloatHistogram` needed for memory allocation optimization, but these arguments were not used. This PR changes the two implementations as it is explained in their documentations. Namely, the PR changes them from
```
	...
	// AtHistogram implements chunkenc.Iterator. It does not copy the underlying histogram as that optimization is left to the caller / higher level.
	func (a *iteratorAdapter) AtHistogram(h *histogram.Histogram) (int64, *histogram.Histogram) {
		...
	}
	...
	// AtFloatHistogram implements chunkenc.Iterator. It does not copy the underlying histogram as that optimization is left to the caller / higher level.
	func (a *iteratorAdapter) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
		...
	}
```
to
```
	...
	// AtHistogram implements chunkenc.Iterator. It copies and returns the underlying histogram.
	// If a pointer to a histogram is passed as parameter, the underlying histogram is copied there.
	// Otherwise, a new histogram is created.
	func (a *iteratorAdapter) AtHistogram(h *histogram.Histogram) (int64, *histogram.Histogram) {
		...
	}
	...
	// AtFloatHistogram implements chunkenc.Iterator. It copies and returns the underlying float histogram.
	// If a pointer to a float histogram is passed as parameter, the underlying float histogram is copied there.
	// Otherwise, a new float histogram is created.
	func (a *iteratorAdapter) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
		...
	}
```

### Changes in `chunk.Iterator` and  `chunk.prometheusChunkIterator`

In this PR we additionally modify `chunk.Iterator` interface by allowing its `Batch()` method to optimize memory allocations. The signature of the method is changed from 
```
	// Returns a batch of the provisded size; NB not idempotent!  Should only be called
	// once per Scan.
	Batch(size int, valueType chunkenc.ValueType) Batch
```
to
```
	// Batch returns a batch of the provisded size; NB not idempotent!  Should only be called
	// once per Scan.
	// When the optional *zeropool.Pool arguments hPool and fhPool are passed, they will be
	// used to optimize memory allocations for histogram.Histogram and histogram.FloatHistogram
	// objects.
	// For example, when creating a batch of chunkenc.ValHistogram or chunkenc.ValFloatHistogram
	// objects, the histogram.Histogram or histogram.FloatHistograms objects already present in
	// the hPool or fhPool pool will be used instead of creating new ones.
	Batch(size int, valueType chunkenc.ValueType, hPool *zeropool.Pool[*histogram.Histogram], fhPool *zeropool.Pool[*histogram.FloatHistogram]) Batch
```
Namely, `chunk.Iterator.Batch()` now accepts optional `*zeropool.Pool[*histogram.Histogram]` and `*zeropool.Pool[*histogram.FloatHistogram]` arguments that, when not nil, will avoid creation of new `histogram.Histogram` and `histogram.FloatHistogram` objects, if some already created objects of the same type already exist in the pools. The only known implementation of `chunk.Iterator`, `chunk.prometheusChunkIterator`, has been modified in such a way that it doesn't create new `histogram.Histogram` and `histogram.FloatHistogram` objects, when they can be reused.

### Changes in `batch.mergeIterator` 

Additionally, this PR modifies the implementation of `batch.mergeIterator` in such a way that it uses the benefits of the new `chunk.Iterator.Batch()` method, and further optimizes the memory allocations. Previously, new `histogram.Histogram` and `histogram.FloatHistogram` objects were created every time a new `Batch` was built by `batch.mergeIterator.buildNextBatch()`. With the present implementation, this situation changes: namely , when `batch.mergeIterator.build` is called, new `histogram.Histogram` and `histogram.FloatHistogram` will be created only if the pools (of type `zeropool.Pool`) storing pointers to unused `histogram.Histogram` and `histogram.FloatHistogram` objects are empty. Unused `histogram.Histogram` and `histogram.FloatHistogram` are the ones that get discarded on `batch.mergeIterator.Next()` and `batch.mergeIterator.Seek()`.

### Benchmark
```
                                                                                                                 │ old2602c.txt │             new2602c.txt             │
                                                                                                                 │    sec/op    │    sec/op     vs base                │
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-8              11.53m ±  3%   12.07m ±  5%   +4.69% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusHistogramChunk-8        89.05m ± 36%   69.81m ±  4%  -21.60% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusFloatHistogramChunk-8   81.34m ± 12%   70.21m ± 57%        ~ (p=0.123 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-8              43.31m ± 17%   22.50m ± 21%  -48.06% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusHistogramChunk-8        244.0m ±  7%   104.3m ± 12%  -57.23% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusFloatHistogramChunk-8   214.1m ±  7%   120.5m ± 12%  -43.69% (p=0.000 n=10)
geomean                                                                                                            75.75m         50.58m        -33.23%

                                                                                                                 │ old2602c.txt  │             new2602c.txt             │
                                                                                                                 │     B/op      │     B/op      vs base                │
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-8               8.585Mi ± 0%   8.585Mi ± 0%        ~ (p=0.796 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusHistogramChunk-8         75.81Mi ± 0%   33.09Mi ± 0%  -56.36% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusFloatHistogramChunk-8    52.91Mi ± 0%   33.08Mi ± 0%  -37.48% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-8               9.030Mi ± 0%   9.026Mi ± 0%   -0.05% (p=0.003 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusHistogramChunk-8        116.02Mi ± 0%   33.64Mi ± 0%  -71.00% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusFloatHistogramChunk-8    93.12Mi ± 0%   33.62Mi ± 0%  -63.89% (p=0.000 n=10)
geomean                                                                                                             38.70Mi        21.40Mi       -44.72%

                                                                                                                 │ old2602c.txt │            new2602c.txt             │
                                                                                                                 │  allocs/op   │  allocs/op   vs base                │
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusXorChunk-8               3.376k ± 0%   3.377k ± 0%        ~ (p=0.221 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusHistogramChunk-8        1407.5k ± 0%   607.8k ± 0%  -56.82% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_1_encoding:_PrometheusFloatHistogramChunk-8    907.5k ± 0%   607.7k ± 0%  -33.03% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusXorChunk-8               9.395k ± 0%   9.395k ± 0%        ~ (p=0.865 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusHistogramChunk-8        2021.5k ± 0%   622.1k ± 0%  -69.23% (p=0.000 n=10)
QueryExecute/chunks:_1000_samples_per_chunk:_100_duplication_factor:_3_encoding:_PrometheusFloatHistogramChunk-8   1521.5k ± 0%   622.1k ± 0%  -59.11% (p=0.000 n=10)
geomean                                                                                                             223.5k        128.7k       -42.43%
```

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/7235

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
