### PR TITLE
Require ingester zone to be configured when running ingest storage

### DIFF
--- a/integration/configs.go
+++ b/integration/configs.go
@@ -251,6 +251,9 @@ blocks_storage:
 			// Do not wait before switching an INACTIVE partition to ACTIVE.
 			"-ingester.partition-ring.min-partition-owners-count":    "0",
 			"-ingester.partition-ring.min-partition-owners-duration": "0s",
+
+			// The ingester AZ is required when running the ingest storage.
+			"-ingester.ring.instance-availability-zone": "zone-a",
 		}
 	}
 )

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -238,7 +238,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.DeprecatedReturnOnlyGRPCErrors, deprecatedReturnOnlyGRPCErrorsFlag, true, "When enabled only gRPC errors will be returned by the ingester.")
 }
 
-func (cfg *Config) Validate(logger log.Logger) error {
+func (cfg *Config) Validate(ingestStorageEnabled bool, logger log.Logger) error {
 	if cfg.ErrorSampleRate < 0 {
 		return fmt.Errorf("error sample rate cannot be a negative number")
 	}
@@ -247,7 +247,7 @@ func (cfg *Config) Validate(logger log.Logger) error {
 		util.WarnDeprecatedConfig(deprecatedReturnOnlyGRPCErrorsFlag, logger)
 	}
 
-	return cfg.IngesterRing.Validate()
+	return cfg.IngesterRing.Validate(ingestStorageEnabled)
 }
 
 func (cfg *Config) getIgnoreSeriesLimitForMetricNamesMap() map[string]struct{} {

--- a/pkg/ingester/ingester_ring_test.go
+++ b/pkg/ingester/ingester_ring_test.go
@@ -175,7 +175,7 @@ func TestRingConfig_Validate(t *testing.T) {
 		"should fail if ingest storage is enabled and no zone is configured": {
 			zone:                 "",
 			ingestStorageEnabled: true,
-			expectedError:        errors.New("the ingester instance zone must be configured when running Mimir with the ingest storage"),
+			expectedError:        errors.New("-ingester.ring.instance-availability-zone must be configured when -ingest-storage.enabled is true"),
 		},
 	}
 

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -259,7 +259,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.IngesterClient.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid ingester_client config")
 	}
-	if err := c.Ingester.Validate(log); err != nil {
+	if err := c.Ingester.Validate(c.IngestStorage.Enabled, log); err != nil {
 		return errors.Wrap(err, "invalid ingester config")
 	}
 	if err := c.Worker.Validate(); err != nil {

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -429,6 +429,7 @@ func TestConfigValidation(t *testing.T) {
 				cfg.IngestStorage.KafkaConfig.Address = "localhost:123"
 				cfg.IngestStorage.KafkaConfig.Topic = "topic"
 				cfg.Ingester.DeprecatedReturnOnlyGRPCErrors = false
+				cfg.Ingester.IngesterRing.InstanceZone = "zone-a"
 
 				return cfg
 			},
@@ -443,6 +444,7 @@ func TestConfigValidation(t *testing.T) {
 				cfg.IngestStorage.KafkaConfig.Address = "localhost:123"
 				cfg.IngestStorage.KafkaConfig.Topic = "topic"
 				cfg.Ingester.DeprecatedReturnOnlyGRPCErrors = false
+				cfg.Ingester.IngesterRing.InstanceZone = "zone-a"
 
 				return cfg
 			},

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -8,6 +8,10 @@ import (
 	"time"
 )
 
+const (
+	EnabledFlag = "ingest-storage.enabled"
+)
+
 var (
 	ErrMissingKafkaAddress = errors.New("the Kafka address has not been configured")
 	ErrMissingKafkaTopic   = errors.New("the Kafka topic has not been configured")
@@ -19,7 +23,7 @@ type Config struct {
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.BoolVar(&cfg.Enabled, "ingest-storage.enabled", false, "True to enable the ingestion via object storage.")
+	f.BoolVar(&cfg.Enabled, EnabledFlag, false, "True to enable the ingestion via object storage.")
 
 	cfg.KafkaConfig.RegisterFlagsWithPrefix("ingest-storage.kafka", f)
 }


### PR DESCRIPTION
#### What this PR does

The ingest storage requires the zone to be configured on ingesters. It's a requirement on the read path, because we always use the zone-aware tracker to handle read-path quorum. In this PR I propose to add a config validation check.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
