### PR TITLE
Switch ingester limiter to use ingesterRing rather than lifecycler

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -408,7 +408,7 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 	// Init the limter and instantiate the user states which depend on it
 	i.limiter = NewLimiter(
 		limits,
-		i.lifecycler,
+		NewLimiterRing(ingestersRing, cfg.IngesterRing.InstanceZone),
 		cfg.IngesterRing.ReplicationFactor,
 		cfg.IngesterRing.ZoneAwarenessEnabled,
 	)

--- a/pkg/ingester/limiter.go
+++ b/pkg/ingester/limiter.go
@@ -8,6 +8,8 @@ package ingester
 import (
 	"math"
 
+	"github.com/grafana/dskit/ring"
+
 	"github.com/grafana/mimir/pkg/util"
 	util_math "github.com/grafana/mimir/pkg/util/math"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -19,6 +21,23 @@ type RingCount interface {
 	InstancesCount() int
 	InstancesInZoneCount() int
 	ZonesCount() int
+}
+
+// Wraps ring.ReadRing to implement RingCount
+type LimiterRing struct {
+	ring.ReadRing
+	zone string
+}
+
+func NewLimiterRing(ring ring.ReadRing, zone string) *LimiterRing {
+	return &LimiterRing{
+		ReadRing: ring,
+		zone:     zone,
+	}
+}
+
+func (r *LimiterRing) InstancesInZoneCount() int {
+	return r.ReadRing.InstancesInZoneCount(r.zone)
 }
 
 // Limiter implements primitives to get the maximum number of series


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Changes the ingester limiter to get information about the ingester ring from the `ring.Ring` rather than the lifecycler, to avoid issues with calling the limiter before the lifecycler is started (e.g.: during ingester startup, before the lifecycler is started).

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/7411

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
