### PR TITLE
Revert "Require ingester zone to be configured when running ingest storage"

### DIFF
--- a/integration/configs.go
+++ b/integration/configs.go
@@ -251,9 +251,6 @@ blocks_storage:
 			// Do not wait before switching an INACTIVE partition to ACTIVE.
 			"-ingester.partition-ring.min-partition-owners-count":    "0",
 			"-ingester.partition-ring.min-partition-owners-duration": "0s",
-
-			// The ingester AZ is required when running the ingest storage.
-			"-ingester.ring.instance-availability-zone": "zone-a",
 		}
 	}
 )

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -238,7 +238,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.DeprecatedReturnOnlyGRPCErrors, deprecatedReturnOnlyGRPCErrorsFlag, true, "When enabled only gRPC errors will be returned by the ingester.")
 }
 
-func (cfg *Config) Validate(ingestStorageEnabled bool, logger log.Logger) error {
+func (cfg *Config) Validate(logger log.Logger) error {
 	if cfg.ErrorSampleRate < 0 {
 		return fmt.Errorf("error sample rate cannot be a negative number")
 	}
@@ -247,7 +247,7 @@ func (cfg *Config) Validate(ingestStorageEnabled bool, logger log.Logger) error 
 		util.WarnDeprecatedConfig(deprecatedReturnOnlyGRPCErrorsFlag, logger)
 	}
 
-	return cfg.IngesterRing.Validate(ingestStorageEnabled)
+	return cfg.IngesterRing.Validate()
 }
 
 func (cfg *Config) getIgnoreSeriesLimitForMetricNamesMap() map[string]struct{} {

--- a/pkg/ingester/ingester_ring.go
+++ b/pkg/ingester/ingester_ring.go
@@ -15,8 +15,6 @@ import (
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
-
-	"github.com/grafana/mimir/pkg/storage/ingest"
 )
 
 const (
@@ -28,9 +26,6 @@ const (
 	randomTokenGeneration               = "random"
 	spreadMinimizingTokenGeneration     = "spread-minimizing"
 	spreadMinimizingJoinRingInOrderFlag = "spread-minimizing-join-ring-in-order"
-
-	ingesterRingFlagPrefix           = "ingester.ring."
-	ingesterRingAvailabilityZoneFlag = ingesterRingFlagPrefix + "instance-availability-zone"
 )
 
 type RingConfig struct {
@@ -71,7 +66,7 @@ type RingConfig struct {
 	JoinAfter time.Duration `yaml:"-"`
 }
 
-func (cfg *RingConfig) Validate(ingestStorageEnabled bool) error {
+func (cfg *RingConfig) Validate() error {
 	if cfg.TokenGenerationStrategy != randomTokenGeneration && cfg.TokenGenerationStrategy != spreadMinimizingTokenGeneration {
 		return fmt.Errorf("unsupported token generation strategy (%q) has been chosen for %s", cfg.TokenGenerationStrategy, tokenGenerationStrategyFlag)
 	}
@@ -80,20 +75,13 @@ func (cfg *RingConfig) Validate(ingestStorageEnabled bool) error {
 		if cfg.TokensFilePath != "" {
 			return fmt.Errorf("%q token generation strategy requires %q to be empty", spreadMinimizingTokenGeneration, tokensFilePathFlag)
 		}
-
-		if _, err := ring.NewSpreadMinimizingTokenGenerator(cfg.InstanceID, cfg.InstanceZone, cfg.SpreadMinimizingZones, cfg.SpreadMinimizingJoinRingInOrder); err != nil {
-			return err
-		}
+		_, err := ring.NewSpreadMinimizingTokenGenerator(cfg.InstanceID, cfg.InstanceZone, cfg.SpreadMinimizingZones, cfg.SpreadMinimizingJoinRingInOrder)
+		return err
 	}
 
-	if cfg.TokenGenerationStrategy != spreadMinimizingTokenGeneration && cfg.SpreadMinimizingJoinRingInOrder {
+	// at this point cfg.TokenGenerationStrategy is not spreadMinimizingTokenGeneration
+	if cfg.SpreadMinimizingJoinRingInOrder {
 		return fmt.Errorf("%q must be false when using %q token generation strategy", spreadMinimizingJoinRingInOrderFlag, cfg.TokenGenerationStrategy)
-	}
-
-	// Ingest storage requires the zone to be configured for ingesters, because on the read path we always use
-	// zone-aware replication tracker to compute the quorum.
-	if ingestStorageEnabled && cfg.InstanceZone == "" {
-		return fmt.Errorf("-%s must be configured when -%s is true", ingesterRingAvailabilityZoneFlag, ingest.EnabledFlag)
 	}
 
 	return nil
@@ -107,40 +95,42 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 		os.Exit(1)
 	}
 
+	prefix := "ingester.ring."
+
 	// Ring flags
 	cfg.KVStore.Store = "memberlist" // Override default value.
-	cfg.KVStore.RegisterFlagsWithPrefix(ingesterRingFlagPrefix, "collectors/", f)
+	cfg.KVStore.RegisterFlagsWithPrefix(prefix, "collectors/", f)
 
-	f.DurationVar(&cfg.HeartbeatPeriod, ingesterRingFlagPrefix+"heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
-	f.DurationVar(&cfg.HeartbeatTimeout, ingesterRingFlagPrefix+"heartbeat-timeout", time.Minute, "The heartbeat timeout after which ingesters are skipped for reads/writes. 0 = never (timeout disabled)."+sharedOptionWithRingClient)
-	f.IntVar(&cfg.ReplicationFactor, ingesterRingFlagPrefix+"replication-factor", 3, "Number of ingesters that each time series is replicated to."+sharedOptionWithRingClient)
-	f.BoolVar(&cfg.ZoneAwarenessEnabled, ingesterRingFlagPrefix+"zone-awareness-enabled", false, "True to enable the zone-awareness and replicate ingested samples across different availability zones."+sharedOptionWithRingClient)
-	f.Var(&cfg.ExcludedZones, ingesterRingFlagPrefix+"excluded-zones", "Comma-separated list of zones to exclude from the ring. Instances in excluded zones will be filtered out from the ring."+sharedOptionWithRingClient)
+	f.DurationVar(&cfg.HeartbeatPeriod, prefix+"heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
+	f.DurationVar(&cfg.HeartbeatTimeout, prefix+"heartbeat-timeout", time.Minute, "The heartbeat timeout after which ingesters are skipped for reads/writes. 0 = never (timeout disabled)."+sharedOptionWithRingClient)
+	f.IntVar(&cfg.ReplicationFactor, prefix+"replication-factor", 3, "Number of ingesters that each time series is replicated to."+sharedOptionWithRingClient)
+	f.BoolVar(&cfg.ZoneAwarenessEnabled, prefix+"zone-awareness-enabled", false, "True to enable the zone-awareness and replicate ingested samples across different availability zones."+sharedOptionWithRingClient)
+	f.Var(&cfg.ExcludedZones, prefix+"excluded-zones", "Comma-separated list of zones to exclude from the ring. Instances in excluded zones will be filtered out from the ring."+sharedOptionWithRingClient)
 
-	f.StringVar(&cfg.TokensFilePath, ingesterRingFlagPrefix+tokensFilePathFlag, "", fmt.Sprintf("File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup. Must be empty if -%s is set to %q.", ingesterRingFlagPrefix+tokenGenerationStrategyFlag, spreadMinimizingTokenGeneration))
-	f.IntVar(&cfg.NumTokens, ingesterRingFlagPrefix+"num-tokens", 128, "Number of tokens for each ingester.")
+	f.StringVar(&cfg.TokensFilePath, prefix+tokensFilePathFlag, "", fmt.Sprintf("File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup. Must be empty if -%s is set to %q.", prefix+tokenGenerationStrategyFlag, spreadMinimizingTokenGeneration))
+	f.IntVar(&cfg.NumTokens, prefix+"num-tokens", 128, "Number of tokens for each ingester.")
 
 	// Instance flags
-	f.StringVar(&cfg.InstanceID, ingesterRingFlagPrefix+"instance-id", hostname, "Instance ID to register in the ring.")
+	f.StringVar(&cfg.InstanceID, prefix+"instance-id", hostname, "Instance ID to register in the ring.")
 	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, logger)
-	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), ingesterRingFlagPrefix+"instance-interface-names", "List of network interface names to look up when finding the instance IP address.")
-	f.IntVar(&cfg.InstancePort, ingesterRingFlagPrefix+"instance-port", 0, "Port to advertise in the ring (defaults to -server.grpc-listen-port).")
-	f.StringVar(&cfg.InstanceAddr, ingesterRingFlagPrefix+"instance-addr", "", "IP address to advertise in the ring. Default is auto-detected.")
-	f.BoolVar(&cfg.EnableIPv6, ingesterRingFlagPrefix+"instance-enable-ipv6", false, "Enable using a IPv6 instance address. (default false)")
-	f.StringVar(&cfg.InstanceZone, ingesterRingAvailabilityZoneFlag, "", "The availability zone where this instance is running.")
+	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), prefix+"instance-interface-names", "List of network interface names to look up when finding the instance IP address.")
+	f.IntVar(&cfg.InstancePort, prefix+"instance-port", 0, "Port to advertise in the ring (defaults to -server.grpc-listen-port).")
+	f.StringVar(&cfg.InstanceAddr, prefix+"instance-addr", "", "IP address to advertise in the ring. Default is auto-detected.")
+	f.BoolVar(&cfg.EnableIPv6, prefix+"instance-enable-ipv6", false, "Enable using a IPv6 instance address. (default false)")
+	f.StringVar(&cfg.InstanceZone, prefix+"instance-availability-zone", "", "The availability zone where this instance is running.")
 
-	f.BoolVar(&cfg.UnregisterOnShutdown, ingesterRingFlagPrefix+"unregister-on-shutdown", true, "Unregister from the ring upon clean shutdown. It can be useful to disable for rolling restarts with consistent naming.")
+	f.BoolVar(&cfg.UnregisterOnShutdown, prefix+"unregister-on-shutdown", true, "Unregister from the ring upon clean shutdown. It can be useful to disable for rolling restarts with consistent naming.")
 
 	// Lifecycler.
-	f.DurationVar(&cfg.ObservePeriod, ingesterRingFlagPrefix+"observe-period", 0*time.Second, "Observe tokens after generating to resolve collisions. Useful when using gossiping ring.")
-	flagext.DeprecatedFlag(f, ingesterRingFlagPrefix+"join-after", "Deprecated: this setting was used to set a period of time to wait before joining the hash ring. Mimir now behaves as this setting is always set to 0s.", logger)
-	f.DurationVar(&cfg.MinReadyDuration, ingesterRingFlagPrefix+"min-ready-duration", 15*time.Second, "Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive ring updates.")
-	f.DurationVar(&cfg.FinalSleep, ingesterRingFlagPrefix+"final-sleep", 0, "Duration to sleep for before exiting, to ensure metrics are scraped.")
+	f.DurationVar(&cfg.ObservePeriod, prefix+"observe-period", 0*time.Second, "Observe tokens after generating to resolve collisions. Useful when using gossiping ring.")
+	flagext.DeprecatedFlag(f, prefix+"join-after", "Deprecated: this setting was used to set a period of time to wait before joining the hash ring. Mimir now behaves as this setting is always set to 0s.", logger)
+	f.DurationVar(&cfg.MinReadyDuration, prefix+"min-ready-duration", 15*time.Second, "Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive ring updates.")
+	f.DurationVar(&cfg.FinalSleep, prefix+"final-sleep", 0, "Duration to sleep for before exiting, to ensure metrics are scraped.")
 
 	// TokenGenerator
-	f.StringVar(&cfg.TokenGenerationStrategy, ingesterRingFlagPrefix+tokenGenerationStrategyFlag, randomTokenGeneration, fmt.Sprintf("Specifies the strategy used for generating tokens for ingesters. Supported values are: %s.", strings.Join([]string{randomTokenGeneration, spreadMinimizingTokenGeneration}, ",")))
-	f.BoolVar(&cfg.SpreadMinimizingJoinRingInOrder, ingesterRingFlagPrefix+spreadMinimizingJoinRingInOrderFlag, false, fmt.Sprintf("True to allow this ingester registering tokens in the ring only after all previous ingesters (with ID lower than the current one) have already been registered. This configuration option is supported only when the token generation strategy is set to %q.", spreadMinimizingTokenGeneration))
-	f.Var(&cfg.SpreadMinimizingZones, ingesterRingFlagPrefix+"spread-minimizing-zones", fmt.Sprintf("Comma-separated list of zones in which spread minimizing strategy is used for token generation. This value must include all zones in which ingesters are deployed, and must not change over time. This configuration is used only when %q is set to %q.", tokenGenerationStrategyFlag, spreadMinimizingTokenGeneration))
+	f.StringVar(&cfg.TokenGenerationStrategy, prefix+tokenGenerationStrategyFlag, randomTokenGeneration, fmt.Sprintf("Specifies the strategy used for generating tokens for ingesters. Supported values are: %s.", strings.Join([]string{randomTokenGeneration, spreadMinimizingTokenGeneration}, ",")))
+	f.BoolVar(&cfg.SpreadMinimizingJoinRingInOrder, prefix+spreadMinimizingJoinRingInOrderFlag, false, fmt.Sprintf("True to allow this ingester registering tokens in the ring only after all previous ingesters (with ID lower than the current one) have already been registered. This configuration option is supported only when the token generation strategy is set to %q.", spreadMinimizingTokenGeneration))
+	f.Var(&cfg.SpreadMinimizingZones, prefix+"spread-minimizing-zones", fmt.Sprintf("Comma-separated list of zones in which spread minimizing strategy is used for token generation. This value must include all zones in which ingesters are deployed, and must not change over time. This configuration is used only when %q is set to %q.", tokenGenerationStrategyFlag, spreadMinimizingTokenGeneration))
 }
 
 // ToRingConfig returns a ring.Config based on the ingester

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -259,7 +259,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.IngesterClient.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid ingester_client config")
 	}
-	if err := c.Ingester.Validate(c.IngestStorage.Enabled, log); err != nil {
+	if err := c.Ingester.Validate(log); err != nil {
 		return errors.Wrap(err, "invalid ingester config")
 	}
 	if err := c.Worker.Validate(); err != nil {

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -429,7 +429,6 @@ func TestConfigValidation(t *testing.T) {
 				cfg.IngestStorage.KafkaConfig.Address = "localhost:123"
 				cfg.IngestStorage.KafkaConfig.Topic = "topic"
 				cfg.Ingester.DeprecatedReturnOnlyGRPCErrors = false
-				cfg.Ingester.IngesterRing.InstanceZone = "zone-a"
 
 				return cfg
 			},
@@ -444,7 +443,6 @@ func TestConfigValidation(t *testing.T) {
 				cfg.IngestStorage.KafkaConfig.Address = "localhost:123"
 				cfg.IngestStorage.KafkaConfig.Topic = "topic"
 				cfg.Ingester.DeprecatedReturnOnlyGRPCErrors = false
-				cfg.Ingester.IngesterRing.InstanceZone = "zone-a"
 
 				return cfg
 			},

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -8,10 +8,6 @@ import (
 	"time"
 )
 
-const (
-	EnabledFlag = "ingest-storage.enabled"
-)
-
 var (
 	ErrMissingKafkaAddress = errors.New("the Kafka address has not been configured")
 	ErrMissingKafkaTopic   = errors.New("the Kafka topic has not been configured")
@@ -23,7 +19,7 @@ type Config struct {
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.BoolVar(&cfg.Enabled, EnabledFlag, false, "True to enable the ingestion via object storage.")
+	f.BoolVar(&cfg.Enabled, "ingest-storage.enabled", false, "True to enable the ingestion via object storage.")
 
 	cfg.KafkaConfig.RegisterFlagsWithPrefix("ingest-storage.kafka", f)
 }


### PR DESCRIPTION
grafana/mimir#7432 was done poorly, cause it requires the ingester ring AZ on every component and not just when ingester module is enabled. I will rework it, but reventing in the meanwhile.