### PR TITLE
Add dashboard UI check to all dashboards using uid based on filename hash

### DIFF
--- a/operations/mimir-mixin/dashboards/alertmanager-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager-resources.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-alertmanager-resources.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == 'a6883fb22799ac74479c7db872451092' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Alertmanager resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRowIf(

--- a/operations/mimir-mixin/dashboards/alertmanager.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager.libsonnet
@@ -6,6 +6,7 @@ local filename = 'mimir-alertmanager.json';
     local jobSelector = $.jobSelector($._config.job_names.alertmanager);
     local jobInstanceSelector = jobSelector + [utils.selector.noop($._config.per_instance_label)];
     local jobIntegrationSelector = jobSelector + [utils.selector.noop('integration')];
+    assert std.md5(filename) == 'b0d38d318bbddd80476246d4930f9e55' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Alertmanager') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(

--- a/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor-resources.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-compactor-resources.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == '09a5c49e9cdb2f2b24c6d184574a07fd' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Compactor resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -88,6 +88,7 @@ local fixTargetsForTransformations(panel, refIds) = panel {
   ],
 
   [filename]:
+    assert std.md5(filename) == '1b3443aea86db629e6efdb7d05c53823' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Compactor') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(

--- a/operations/mimir-mixin/dashboards/config.libsonnet
+++ b/operations/mimir-mixin/dashboards/config.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-config.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == '5d9d0b4724c0f80d68467088ec61e003' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Config') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(

--- a/operations/mimir-mixin/dashboards/object-store.libsonnet
+++ b/operations/mimir-mixin/dashboards/object-store.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-object-store.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == 'e1324ee2a434f4158c00a9ee279d3292' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Object Store') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(

--- a/operations/mimir-mixin/dashboards/overrides.libsonnet
+++ b/operations/mimir-mixin/dashboards/overrides.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-overrides.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == '1e2c358600ac53f09faea133f811b5bb' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Overrides') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow(

--- a/operations/mimir-mixin/dashboards/overview-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview-networking.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-overview-networking.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == 'e15c71d372cc541367a088f10d9fcd92' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Overview networking') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRowIf($._config.gateway_enabled, $.containerNetworkingRowByComponent('Gateway', 'gateway'))

--- a/operations/mimir-mixin/dashboards/overview-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview-resources.libsonnet
@@ -4,6 +4,7 @@ local filename = 'mimir-overview-resources.json';
 (import 'dashboard-utils.libsonnet') +
 (import 'dashboard-queries.libsonnet') {
   [filename]:
+    assert std.md5(filename) == 'a9b92d3c4d1af325d872a9e9a7083d71' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Overview resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
 

--- a/operations/mimir-mixin/dashboards/overview.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview.libsonnet
@@ -30,6 +30,7 @@ local filename = 'mimir-overview.json';
       writesResourcesDashboardURL: $.dashboardURL('mimir-writes-resources.json'),
     };
 
+    assert std.md5(filename) == 'ffcd83628d7d4b5a03d1cafd159e6c9c' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Overview') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
 

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-queries.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == 'b3abe8d5c040395cc36615cb4334c92d' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Queries') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(

--- a/operations/mimir-mixin/dashboards/reads-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-networking.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-reads-networking.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == '54b2a0a4748b3bd1aefa92ce5559a1c2' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Reads networking') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow($.containerNetworkingRowByComponent('Summary', 'read'))

--- a/operations/mimir-mixin/dashboards/reads-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads-resources.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-reads-resources.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == 'cc86fd5aa9301c6528986572ad974db9' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Reads resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow(

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-reads.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == 'e327503188913dc38ad571c647eef643' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Reads') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRowIf(

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads-resources.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-remote-ruler-reads-resources.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == '1940f6ef765a506a171faa2056c956c3' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Remote ruler reads resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow(

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
@@ -7,6 +7,7 @@ local filename = 'mimir-remote-ruler-reads.json';
   local rulerRoutesRegex = '/httpgrpc.HTTP/Handle|.*api_v1_query',
 
   [filename]:
+    assert std.md5(filename) == 'f103238f7f5ab2f1345ce650cbfbfe2f' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Remote ruler reads') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRowIf(

--- a/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
+++ b/operations/mimir-mixin/dashboards/rollout-progress.libsonnet
@@ -19,6 +19,7 @@ local filename = 'mimir-rollout-progress.json';
   },
 
   [filename]:
+    assert std.md5(filename) == '7f0b5567d543a1698e695b530eb7f5de' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Rollout progress') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false) + {
       // This dashboard uses the new grid system in order to place panels (using gridPos).

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -11,6 +11,7 @@ local filename = 'mimir-ruler.json';
   ],
 
   [filename]:
+    assert std.md5(filename) == '631e15d5d85afb2ca8e35d62984eeaa0' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Ruler') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(

--- a/operations/mimir-mixin/dashboards/scaling.libsonnet
+++ b/operations/mimir-mixin/dashboards/scaling.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-scaling.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == '64bbad83507b7289b514725658e10352' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Scaling') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRow(

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-slow-queries.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == '6089e1ce1e678788f46312a0a1e647e6' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Slow queries') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow(

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -17,6 +17,7 @@ local filename = 'mimir-tenants.json';
   ]),
 
   [filename]:
+    assert std.md5(filename) == '35fa247ce651ba189debf33d7ae41611' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Tenants') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addActiveUserSelectorTemplates()

--- a/operations/mimir-mixin/dashboards/top-tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/top-tenants.libsonnet
@@ -20,6 +20,7 @@ local filename = 'mimir-top-tenants.json';
   },
 
   [filename]:
+    assert std.md5(filename) == 'bc6e12d4fe540e4a1785b9d3ca0ffdd9' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Top tenants') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addCustomTemplate('limit', ['10', '50', '100'])

--- a/operations/mimir-mixin/dashboards/writes-networking.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-networking.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-writes-networking.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == '978c1cb452585c96697a238eaac7fe2d' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Writes networking') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow($.containerNetworkingRowByComponent('Summary', 'write'))

--- a/operations/mimir-mixin/dashboards/writes-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-resources.libsonnet
@@ -3,6 +3,7 @@ local filename = 'mimir-writes-resources.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    assert std.md5(filename) == 'bc9160e50b52e89e0e49c840fea3d379' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Writes resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow(

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -4,6 +4,7 @@ local filename = 'mimir-writes.json';
 (import 'dashboard-utils.libsonnet') +
 (import 'dashboard-queries.libsonnet') {
   [filename]:
+    assert std.md5(filename) == '8280707b8f16e7b87b840fc1cc92d4c5' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Writes') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
     .addRowIf(


### PR DESCRIPTION
#### What this PR does

This PR adds checks to make sure that dashboard UID hasn't changed accidentally. These UIDs are often referred to from runbooks or other internal links, and changing them accidentally can break the links. ([Mimir CHANGELOG](https://github.com/grafana/mimir/blob/1dbb5529e83930836a7da1e34940ed220fa1df7e/CHANGELOG.md?plain=1#L1878-L1898) also refers to some of them).

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
