### PR TITLE
storegateway: Reduce number of overlapping iterator interfaces into single iterator[S]

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -670,7 +670,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storegatewaypb.Stor
 
 	start := time.Now()
 	if req.StreamingChunksBatchSize > 0 {
-		var seriesChunkIt seriesChunksSetIterator
+		var seriesChunkIt iterator[seriesChunksSet]
 		seriesChunkIt, err = s.streamingChunksSetForBlocks(ctx, req, blocks, indexReaders, readers, shardSelector, matchers, chunksLimiter, seriesLimiter, stats, reuse)
 		if err != nil {
 			return err
@@ -771,7 +771,7 @@ func (s *BucketStore) sendStreamingSeriesLabelsAndStats(
 func (s *BucketStore) sendStreamingChunks(
 	req *storepb.SeriesRequest,
 	srv storegatewaypb.StoreGateway_SeriesServer,
-	it seriesChunksSetIterator,
+	it iterator[seriesChunksSet],
 	stats *safeQueryStats,
 	totalSeriesCount int,
 ) error {
@@ -1065,7 +1065,7 @@ func (s *BucketStore) streamingChunksSetForBlocks(
 	seriesLimiter SeriesLimiter, // Rate limiter for loading series.
 	stats *safeQueryStats,
 	reuse []*reusedPostingsAndMatchers, // Should come from streamingSeriesForBlocks.
-) (seriesChunksSetIterator, error) {
+) (iterator[seriesChunksSet], error) {
 	it, err := s.getSeriesIteratorFromBlocks(ctx, req, blocks, indexReaders, shardSelector, matchers, chunksLimiter, seriesLimiter, stats, reuse, defaultStrategy)
 	if err != nil {
 		return nil, err
@@ -1086,10 +1086,10 @@ func (s *BucketStore) getSeriesIteratorFromBlocks(
 	stats *safeQueryStats,
 	reuse []*reusedPostingsAndMatchers, // Used if not empty. If not empty, len(reuse) must be len(blocks).
 	strategy seriesIteratorStrategy,
-) (seriesChunkRefsSetIterator, error) {
+) (iterator[seriesChunkRefsSet], error) {
 	var (
 		mtx                      = sync.Mutex{}
-		batches                  = make([]seriesChunkRefsSetIterator, 0, len(blocks))
+		batches                  = make([]iterator[seriesChunkRefsSet], 0, len(blocks))
 		g, _                     = errgroup.WithContext(ctx)
 		begin                    = time.Now()
 		blocksQueriedByBlockMeta = make(map[blockQueriedMeta]int)
@@ -1633,7 +1633,7 @@ func blockLabelValues(ctx context.Context, b *bucketBlock, postingsStrategy post
 }
 
 func labelValuesFromSeries(ctx context.Context, labelName string, seriesPerBatch int, pendingMatchers []*labels.Matcher, indexr *bucketIndexReader, b *bucketBlock, matchersPostings []storage.SeriesRef, stats *safeQueryStats) ([]string, error) {
-	var iterator seriesChunkRefsSetIterator
+	var iterator iterator[seriesChunkRefsSet]
 	iterator = newLoadingSeriesChunkRefsSetIterator(
 		ctx,
 		newPostingsSetsIterator(matchersPostings, seriesPerBatch),

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -531,8 +531,7 @@ func (s *seriesChunkRefsSeriesSet) Err() error {
 	return s.from.Err()
 }
 
-// deduplicatingSeriesChunkRefsSetIterator merges together consecutive series in an underlying
-// seriesChunkRefsSetIterator.
+// deduplicatingSeriesChunkRefsSetIterator merges together consecutive series in the underlying iterator.
 type deduplicatingSeriesChunkRefsSetIterator struct {
 	batchSize int
 

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -51,33 +51,6 @@ var (
 	})
 )
 
-// seriesChunkRefsSetIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefsSet.
-type seriesChunkRefsSetIterator interface {
-	Next() bool
-
-	// At returns the current seriesChunkRefsSet. The caller should (but NOT must) invoke seriesChunkRefsSet.release()
-	// on the returned set once it's guaranteed it will not be used anymore.
-	At() seriesChunkRefsSet
-
-	Err() error
-}
-
-// seriesChunkRefsIterator is the interface implemented by an iterator returning a sequence of seriesChunkRefs.
-type seriesChunkRefsIterator interface {
-	Next() bool
-	At() seriesChunkRefs
-	Err() error
-}
-
-// seriesChunkRefsSet holds a set of a set of series (sorted by labels) and their chunk references.
-type seriesChunkRefsSet struct {
-	// series sorted by labels.
-	series []seriesChunkRefs
-
-	// releasable holds whether the series slice (but not its content) can be released to a memory pool.
-	releasable bool
-}
-
 type symbolizedSeriesChunkRefsSet struct {
 	// series sorted by labels.
 	series []symbolizedSeriesChunkRefs
@@ -114,6 +87,15 @@ func (b symbolizedSeriesChunkRefsSet) release() {
 type symbolizedSeriesChunkRefs struct {
 	lset []symbolizedLabel
 	refs []seriesChunkRef
+}
+
+// seriesChunkRefsSet holds a set of series (sorted by labels) with their chunk references.
+type seriesChunkRefsSet struct {
+	// series sorted by labels.
+	series []seriesChunkRefs
+
+	// releasable holds whether the series slice (but not its content) can be released to a memory pool.
+	releasable bool
 }
 
 // newSeriesChunkRefsSet creates a new seriesChunkRefsSet with the given capacity.
@@ -198,14 +180,14 @@ func (r seriesChunkRef) ref() chunks.ChunkRef {
 	return chunkRef(r.segmentFile, r.segFileOffset)
 }
 
-// seriesChunkRefsIteratorImpl implements an iterator returning a sequence of seriesChunkRefs.
-type seriesChunkRefsIteratorImpl struct {
+// seriesChunkRefsIterator implements an iterator returning a sequence of seriesChunkRefs.
+type seriesChunkRefsIterator struct {
 	currentOffset int
 	set           seriesChunkRefsSet
 }
 
-func newSeriesChunkRefsIterator(set seriesChunkRefsSet) *seriesChunkRefsIteratorImpl {
-	c := &seriesChunkRefsIteratorImpl{}
+func newSeriesChunkRefsIterator(set seriesChunkRefsSet) *seriesChunkRefsIterator {
+	c := &seriesChunkRefsIterator{}
 	c.reset(set)
 
 	return c
@@ -216,7 +198,7 @@ func newSeriesChunkRefsIterator(set seriesChunkRefsSet) *seriesChunkRefsIterator
 //
 // This function just reset the internal state and it does NOT invoke release()
 // on the previous seriesChunkRefsSet.
-func (c *seriesChunkRefsIteratorImpl) reset(set seriesChunkRefsSet) {
+func (c *seriesChunkRefsIterator) reset(set seriesChunkRefsSet) {
 	c.set = set
 	c.currentOffset = -1
 }
@@ -224,12 +206,12 @@ func (c *seriesChunkRefsIteratorImpl) reset(set seriesChunkRefsSet) {
 // resetIteratorAndReleasePreviousSet is like reset() but also release the previous seriesChunkRefsSet
 // hold internally. Invoke this function if none else except this iterator is holding a
 // reference to the previous seriesChunkRefsSet.
-func (c *seriesChunkRefsIteratorImpl) resetIteratorAndReleasePreviousSet(set seriesChunkRefsSet) {
+func (c *seriesChunkRefsIterator) resetIteratorAndReleasePreviousSet(set seriesChunkRefsSet) {
 	c.set.release()
 	c.reset(set)
 }
 
-func (c *seriesChunkRefsIteratorImpl) Next() bool {
+func (c *seriesChunkRefsIterator) Next() bool {
 	c.currentOffset++
 	return !c.Done()
 }
@@ -237,28 +219,28 @@ func (c *seriesChunkRefsIteratorImpl) Next() bool {
 // Done returns true if the iterator trespassed the end and the item returned by At()
 // is the zero value. If the iterator is on the last item, the value returned by At()
 // is the actual item and Done() returns false.
-func (c *seriesChunkRefsIteratorImpl) Done() bool {
+func (c *seriesChunkRefsIterator) Done() bool {
 	setLength := c.set.len()
 	return setLength == 0 || c.currentOffset >= setLength
 }
 
-func (c *seriesChunkRefsIteratorImpl) At() seriesChunkRefs {
+func (c *seriesChunkRefsIterator) At() seriesChunkRefs {
 	if c.currentOffset < 0 || c.currentOffset >= c.set.len() {
 		return seriesChunkRefs{}
 	}
 	return c.set.series[c.currentOffset]
 }
 
-func (c *seriesChunkRefsIteratorImpl) Err() error {
+func (c *seriesChunkRefsIterator) Err() error {
 	return nil
 }
 
 type flattenedSeriesChunkRefsIterator struct {
-	from     seriesChunkRefsSetIterator
-	iterator *seriesChunkRefsIteratorImpl
+	from     iterator[seriesChunkRefsSet]
+	iterator *seriesChunkRefsIterator
 }
 
-func newFlattenedSeriesChunkRefsIterator(from seriesChunkRefsSetIterator) seriesChunkRefsIterator {
+func newFlattenedSeriesChunkRefsIterator(from iterator[seriesChunkRefsSet]) *flattenedSeriesChunkRefsIterator {
 	return &flattenedSeriesChunkRefsIterator{
 		from:     from,
 		iterator: newSeriesChunkRefsIterator(seriesChunkRefsSet{}), // start with an empty set and initialize on the first call to Next()
@@ -303,7 +285,7 @@ func (emptySeriesChunkRefsSetIterator) Next() bool             { return false }
 func (emptySeriesChunkRefsSetIterator) At() seriesChunkRefsSet { return seriesChunkRefsSet{} }
 func (emptySeriesChunkRefsSetIterator) Err() error             { return nil }
 
-func mergedSeriesChunkRefsSetIterators(mergedBatchSize int, all ...seriesChunkRefsSetIterator) seriesChunkRefsSetIterator {
+func mergedSeriesChunkRefsSetIterators(mergedBatchSize int, all ...iterator[seriesChunkRefsSet]) iterator[seriesChunkRefsSet] {
 	switch len(all) {
 	case 0:
 		return emptySeriesChunkRefsSetIterator{}
@@ -322,13 +304,13 @@ func mergedSeriesChunkRefsSetIterators(mergedBatchSize int, all ...seriesChunkRe
 type mergedSeriesChunkRefsSet struct {
 	batchSize int
 
-	a, b     seriesChunkRefsSetIterator
-	aAt, bAt *seriesChunkRefsIteratorImpl
+	a, b     iterator[seriesChunkRefsSet]
+	aAt, bAt *seriesChunkRefsIterator
 	current  seriesChunkRefsSet
 	done     bool
 }
 
-func newMergedSeriesChunkRefsSet(mergedBatchSize int, a, b seriesChunkRefsSetIterator) *mergedSeriesChunkRefsSet {
+func newMergedSeriesChunkRefsSet(mergedBatchSize int, a, b iterator[seriesChunkRefsSet]) *mergedSeriesChunkRefsSet {
 	return &mergedSeriesChunkRefsSet{
 		batchSize: mergedBatchSize,
 		a:         a,
@@ -400,7 +382,7 @@ func (s *mergedSeriesChunkRefsSet) Next() bool {
 // ensureItemAvailableToRead ensures curr has an item available to read, unless we reached the
 // end of all sets. If curr has no item available to read, it will advance the iterator, eventually
 // picking the next one from the set.
-func (s *mergedSeriesChunkRefsSet) ensureItemAvailableToRead(curr *seriesChunkRefsIteratorImpl, set seriesChunkRefsSetIterator) error {
+func (s *mergedSeriesChunkRefsSet) ensureItemAvailableToRead(curr *seriesChunkRefsIterator, set iterator[seriesChunkRefsSet]) error {
 	// Ensure curr has an item available, otherwise fetch the next set.
 	for curr.Done() {
 		if set.Next() {
@@ -430,7 +412,7 @@ func (s *mergedSeriesChunkRefsSet) ensureItemAvailableToRead(curr *seriesChunkRe
 
 // nextUniqueEntry returns the next unique entry from both a and b. If a.At() and b.At() have the same
 // label set, nextUniqueEntry merges their chunks refs. The merged refs are sorted by their MinTime and then by MaxTime.
-func (s *mergedSeriesChunkRefsSet) nextUniqueEntry(a, b *seriesChunkRefsIteratorImpl) (toReturn seriesChunkRefs, _ bool) {
+func (s *mergedSeriesChunkRefsSet) nextUniqueEntry(a, b *seriesChunkRefsIterator) (toReturn seriesChunkRefs, _ bool) {
 	if a.Done() && b.Done() {
 		return toReturn, false
 	} else if a.Done() {
@@ -498,21 +480,21 @@ Outer:
 }
 
 type seriesChunkRefsSeriesSet struct {
-	from seriesChunkRefsSetIterator
+	from iterator[seriesChunkRefsSet]
 
-	currentIterator *seriesChunkRefsIteratorImpl
+	currentIterator *seriesChunkRefsIterator
 }
 
-func newSeriesChunkRefsSeriesSet(from seriesChunkRefsSetIterator) storepb.SeriesSet {
+func newSeriesChunkRefsSeriesSet(from iterator[seriesChunkRefsSet]) storepb.SeriesSet {
 	return &seriesChunkRefsSeriesSet{
 		from:            from,
 		currentIterator: newSeriesChunkRefsIterator(seriesChunkRefsSet{}),
 	}
 }
 
-func newSeriesSetWithoutChunks(ctx context.Context, iterator seriesChunkRefsSetIterator, stats *safeQueryStats) storepb.SeriesSet {
-	iterator = newPreloadingAndStatsTrackingSetIterator[seriesChunkRefsSet](ctx, 1, iterator, stats)
-	return newSeriesChunkRefsSeriesSet(iterator)
+func newSeriesSetWithoutChunks(ctx context.Context, from iterator[seriesChunkRefsSet], stats *safeQueryStats) storepb.SeriesSet {
+	from = newPreloadingAndStatsTrackingSetIterator(ctx, 1, from, stats)
+	return newSeriesChunkRefsSeriesSet(from)
 }
 
 func (s *seriesChunkRefsSeriesSet) Next() bool {
@@ -549,20 +531,20 @@ func (s *seriesChunkRefsSeriesSet) Err() error {
 	return s.from.Err()
 }
 
-// deduplicatingSeriesChunkRefsSetIterator implements seriesChunkRefsSetIterator, and merges together consecutive
-// series in an underlying seriesChunkRefsSetIterator.
+// deduplicatingSeriesChunkRefsSetIterator merges together consecutive series in an underlying
+// seriesChunkRefsSetIterator.
 type deduplicatingSeriesChunkRefsSetIterator struct {
 	batchSize int
 
-	from    seriesChunkRefsIterator
+	from    iterator[seriesChunkRefs]
 	peek    *seriesChunkRefs
 	current seriesChunkRefsSet
 }
 
-func newDeduplicatingSeriesChunkRefsSetIterator(batchSize int, wrapped seriesChunkRefsSetIterator) seriesChunkRefsSetIterator {
+func newDeduplicatingSeriesChunkRefsSetIterator(batchSize int, from iterator[seriesChunkRefsSet]) *deduplicatingSeriesChunkRefsSetIterator {
 	return &deduplicatingSeriesChunkRefsSetIterator{
 		batchSize: batchSize,
-		from:      newFlattenedSeriesChunkRefsIterator(wrapped),
+		from:      newFlattenedSeriesChunkRefsIterator(from),
 	}
 }
 
@@ -615,7 +597,7 @@ func (s *deduplicatingSeriesChunkRefsSetIterator) Next() bool {
 }
 
 type limitingSeriesChunkRefsSetIterator struct {
-	from          seriesChunkRefsSetIterator
+	from          iterator[seriesChunkRefsSet]
 	chunksLimiter ChunksLimiter
 	seriesLimiter SeriesLimiter
 
@@ -623,7 +605,7 @@ type limitingSeriesChunkRefsSetIterator struct {
 	currentBatch seriesChunkRefsSet
 }
 
-func newLimitingSeriesChunkRefsSetIterator(from seriesChunkRefsSetIterator, chunksLimiter ChunksLimiter, seriesLimiter SeriesLimiter) *limitingSeriesChunkRefsSetIterator {
+func newLimitingSeriesChunkRefsSetIterator(from iterator[seriesChunkRefsSet], chunksLimiter ChunksLimiter, seriesLimiter SeriesLimiter) *limitingSeriesChunkRefsSetIterator {
 	return &limitingSeriesChunkRefsSetIterator{
 		from:          from,
 		chunksLimiter: chunksLimiter,
@@ -704,7 +686,7 @@ func openBlockSeriesChunkRefsSetsIterator(
 	stats *safeQueryStats,
 	reuse *reusedPostingsAndMatchers, // If this is not nil, these posting and matchers are used as it is without fetching new ones.
 	logger log.Logger,
-) (seriesChunkRefsSetIterator, error) {
+) (iterator[seriesChunkRefsSet], error) {
 	if batchSize <= 0 {
 		return nil, errors.New("set size must be a positive number")
 	}
@@ -730,8 +712,8 @@ func openBlockSeriesChunkRefsSetsIterator(
 		}
 	}
 
-	var iterator seriesChunkRefsSetIterator
-	iterator = newLoadingSeriesChunkRefsSetIterator(
+	var it iterator[seriesChunkRefsSet]
+	it = newLoadingSeriesChunkRefsSetIterator(
 		ctx,
 		newPostingsSetsIterator(ps, batchSize),
 		indexr,
@@ -747,10 +729,10 @@ func openBlockSeriesChunkRefsSetsIterator(
 		logger,
 	)
 	if len(pendingMatchers) > 0 {
-		iterator = newFilteringSeriesChunkRefsSetIterator(pendingMatchers, iterator, stats)
+		it = newFilteringSeriesChunkRefsSetIterator(pendingMatchers, it, stats)
 	}
 
-	return iterator, nil
+	return it, nil
 }
 
 // reusedPostings is used to share the postings and matches across function calls for re-use
@@ -1189,13 +1171,13 @@ func (s *loadingSeriesChunkRefsSetIterator) multiLookupStringify(symbolizedSet s
 
 type filteringSeriesChunkRefsSetIterator struct {
 	stats    *safeQueryStats
-	from     seriesChunkRefsSetIterator
+	from     iterator[seriesChunkRefsSet]
 	matchers []*labels.Matcher
 
 	current seriesChunkRefsSet
 }
 
-func newFilteringSeriesChunkRefsSetIterator(matchers []*labels.Matcher, from seriesChunkRefsSetIterator, stats *safeQueryStats) *filteringSeriesChunkRefsSetIterator {
+func newFilteringSeriesChunkRefsSetIterator(matchers []*labels.Matcher, from iterator[seriesChunkRefsSet], stats *safeQueryStats) *filteringSeriesChunkRefsSetIterator {
 	return &filteringSeriesChunkRefsSetIterator{
 		stats:    stats,
 		from:     from,

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -157,7 +157,7 @@ func TestFlattenedSeriesChunkRefs(t *testing.T) {
 	c := generateSeriesChunksRanges(ulid.MustNew(1, nil), 6)
 
 	testCases := map[string]struct {
-		input    seriesChunkRefsSetIterator
+		input    iterator[seriesChunkRefsSet]
 		expected []seriesChunkRefs
 	}{
 		"should iterate on no sets": {
@@ -246,7 +246,7 @@ func TestMergedSeriesChunkRefsSet(t *testing.T) {
 
 	testCases := map[string]struct {
 		batchSize    int
-		set1, set2   seriesChunkRefsSetIterator
+		set1, set2   iterator[seriesChunkRefsSet]
 		expectedSets []seriesChunkRefsSet
 		expectedErr  string
 	}{
@@ -613,7 +613,7 @@ func TestMergedSeriesChunkRefsSet_Concurrency(t *testing.T) {
 		)
 
 		// Create the iterators.
-		iterators := make([]seriesChunkRefsSetIterator, 0, numIterators)
+		iterators := make([]iterator[seriesChunkRefsSet], 0, numIterators)
 		for iteratorIdx := 0; iteratorIdx < numIterators; iteratorIdx++ {
 			// Create the sets for this iterator.
 			sets := make([]seriesChunkRefsSet, 0, numSetsPerIterator)
@@ -686,7 +686,7 @@ func BenchmarkMergedSeriesChunkRefsSetIterators(b *testing.B) {
 	for _, withDuplicatedSeries := range []bool{true, false} {
 		for numIterators := 1; numIterators <= 64; numIterators *= 2 {
 			// Create empty iterators that we can reuse in each benchmark run.
-			iterators := make([]seriesChunkRefsSetIterator, 0, numIterators)
+			iterators := make([]iterator[seriesChunkRefsSet], 0, numIterators)
 			for i := 0; i < numIterators; i++ {
 				iterators = append(iterators, newSliceSeriesChunkRefsSetIterator(nil))
 			}
@@ -746,7 +746,7 @@ func TestSeriesSetWithoutChunks(t *testing.T) {
 	c := generateSeriesChunksRanges(ulid.MustNew(1, nil), 6)
 
 	testCases := map[string]struct {
-		input              seriesChunkRefsSetIterator
+		input              iterator[seriesChunkRefsSet]
 		expectedSeries     []labels.Labels
 		expectedBatchCount int
 	}{
@@ -2405,7 +2405,7 @@ func generateSeriesChunksRanges(blockID ulid.ULID, numRefs int) []seriesChunkRef
 	return refs
 }
 
-func readAllSeriesChunkRefsSet(it seriesChunkRefsSetIterator) []seriesChunkRefsSet {
+func readAllSeriesChunkRefsSet(it iterator[seriesChunkRefsSet]) []seriesChunkRefsSet {
 	var out []seriesChunkRefsSet
 	for it.Next() {
 		out = append(out, it.At())
@@ -2413,7 +2413,7 @@ func readAllSeriesChunkRefsSet(it seriesChunkRefsSetIterator) []seriesChunkRefsS
 	return out
 }
 
-func readAllSeriesChunkRefs(it seriesChunkRefsIterator) []seriesChunkRefs {
+func readAllSeriesChunkRefs(it iterator[seriesChunkRefs]) []seriesChunkRefs {
 	var out []seriesChunkRefs
 	for it.Next() {
 		out = append(out, it.At())


### PR DESCRIPTION
#### What this PR does

While working through the `storegateway` code, I found myself being confused with how different parts rely on different "iterators", which all have somewhere similar names, e.g. `seriesChunkRefsSetIterator`, `seriesChunkRefsIterator`, and all implement the same (already defined) interface.

I understand the historic aspects of that, but since the package already has `genericIterator[S]` in some places, I wanted to clean this up a bit, and converge all iterator interfaces into a single `iterator[S]`.

This PR is a very mechanical refactor of the package, which doesn't change any of behaviours of the code.

cc @dimitarvdimitrov

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
