### PR TITLE
query-tee: use X-Scope-OrgID for basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@
 ### Query-tee
 
 * [BUGFIX] Fix issue where `Host` HTTP header was not being correctly changed for the proxy targets. #7386
+* [ENHANCEMENT] Allow using the value of X-Scope-OrgID for basic auth username in the forwarded request if URL username is set as `__REQUEST_HEADER_X_SCOPE_ORGID__`. #7452
 
 ### Documentation
 

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -46,7 +46,12 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.ServerHTTPServicePort, "server.http-service-port", 80, "The HTTP port where the query-tee service listens for HTTP requests.")
 	f.StringVar(&cfg.ServerGRPCServiceAddress, "server.grpc-service-address", "", "Bind address for server where query-tee service listens for HTTP over gRPC requests.")
 	f.IntVar(&cfg.ServerGRPCServicePort, "server.grpc-service-port", 9095, "The GRPC port where the query-tee service listens for HTTP over gRPC messages.")
-	f.StringVar(&cfg.BackendEndpoints, "backend.endpoints", "", "Comma separated list of backend endpoints to query.")
+	f.StringVar(&cfg.BackendEndpoints, "backend.endpoints", "",
+		"Comma-separated list of backend endpoints to query. If the client request contains basic auth, it will be forwarded to the backend. "+
+			"Basic auth is also accepted as part of the endpoint URL and takes precedence over the basic auth in the client request. "+
+			"If the endpoint URL doesn't contain basic auth password, then the basic auth password from the client request is used. "+
+			"If the endpoint basic auth username is __REQUEST_HEADER_X_SCOPE_ORGID__, then the value of the X-Scope-OrgID header will be used as the username.",
+	)
 	f.BoolVar(&cfg.BackendSkipTLSVerify, "backend.skip-tls-verify", false, "Skip TLS verification on backend targets.")
 	f.StringVar(&cfg.PreferredBackend, "backend.preferred", "", "The hostname of the preferred backend when selecting the response to send back to the client. If no preferred backend is configured then the query-tee will send back to the client the first successful response received without waiting for other backends.")
 	f.DurationVar(&cfg.BackendReadTimeout, "backend.read-timeout", 150*time.Second, "The timeout when reading the response from a backend.")

--- a/tools/querytee/proxy_backend.go
+++ b/tools/querytee/proxy_backend.go
@@ -87,8 +87,12 @@ func (b *ProxyBackend) createBackendRequest(orig *http.Request, body io.ReadClos
 	// - If the endpoint has user and password, use it.
 	// - If the endpoint has user only, keep it and use the request password (if any).
 	// - If the endpoint has no user and no password, use the request auth (if any).
+	// - If the endpoint has __REQUEST_HEADER_X_SCOPE_ORGID__ as the user, then replace it with the X-Scope-OrgID header value from the request.
 	clientUser, clientPass, clientAuth := orig.BasicAuth()
 	endpointUser := b.endpoint.User.Username()
+	if endpointUser == "__REQUEST_HEADER_X_SCOPE_ORGID__" {
+		endpointUser = orig.Header.Get("X-Scope-OrgID")
+	}
 	endpointPass, _ := b.endpoint.User.Password()
 
 	req.Header.Del("Authorization")

--- a/tools/querytee/proxy_backend_test.go
+++ b/tools/querytee/proxy_backend_test.go
@@ -20,6 +20,7 @@ func Test_ProxyBackend_createBackendRequest_HTTPBasicAuthentication(t *testing.T
 	tests := map[string]struct {
 		clientUser   string
 		clientPass   string
+		clientTenant string
 		backendUser  string
 		backendPass  string
 		expectedUser string
@@ -30,31 +31,44 @@ func Test_ProxyBackend_createBackendRequest_HTTPBasicAuthentication(t *testing.T
 			expectedPass: "",
 		},
 		"if the request is authenticated and the backend has no auth it should forward the request auth": {
-			clientUser:   "marco",
-			clientPass:   "marco-secret",
+			clientUser: "marco",
+			clientPass: "marco-secret",
+
 			expectedUser: "marco",
 			expectedPass: "marco-secret",
 		},
 		"if the request is authenticated and the backend has an username set it should forward the request password only": {
-			clientUser:   "marco",
-			clientPass:   "marco-secret",
-			backendUser:  "backend",
+			clientUser:  "marco",
+			clientPass:  "marco-secret",
+			backendUser: "backend",
+
 			expectedUser: "backend",
 			expectedPass: "marco-secret",
 		},
 		"if the request is authenticated and the backend is authenticated it should use the backend auth": {
-			clientUser:   "marco",
-			clientPass:   "marco-secret",
-			backendUser:  "backend",
-			backendPass:  "backend-secret",
+			clientUser:  "marco",
+			clientPass:  "marco-secret",
+			backendUser: "backend",
+			backendPass: "backend-secret",
+
 			expectedUser: "backend",
 			expectedPass: "backend-secret",
 		},
 		"if the request is NOT authenticated and the backend is authenticated it should use the backend auth": {
-			backendUser:  "backend",
-			backendPass:  "backend-secret",
+			backendUser: "backend",
+			backendPass: "backend-secret",
+
 			expectedUser: "backend",
 			expectedPass: "backend-secret",
+		},
+		"if the request is NOT authenticated and the backend has __REQUEST_HEADER_X_SCOPE_ORGID__ as the user, it should use the tenant ID from the request as the user": {
+			clientUser:   "dimitar",
+			clientTenant: "123",
+			backendUser:  "__REQUEST_HEADER_X_SCOPE_ORGID__",
+			backendPass:  "123-secret",
+
+			expectedUser: "123",
+			expectedPass: "123-secret",
 		},
 	}
 
@@ -65,6 +79,9 @@ func Test_ProxyBackend_createBackendRequest_HTTPBasicAuthentication(t *testing.T
 
 			orig := httptest.NewRequest("GET", "/test", nil)
 			orig.SetBasicAuth(testData.clientUser, testData.clientPass)
+			if testData.clientTenant != "" {
+				orig.Header.Set("X-Scope-OrgID", testData.clientTenant)
+			}
 
 			b := NewProxyBackend("test", u, time.Second, false, false)
 			r, err := b.createBackendRequest(orig, nil)


### PR DESCRIPTION
Allow using the value of X-Scope-OrgID for basic auth username in the forwarded request if URL username is set as `__REQUEST_HEADER_X_SCOPE_ORGID__`

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
