### PR TITLE
mimir-mixin: Fix "unexpected type object, expected array"

### DIFF
--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -1416,7 +1416,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     // aliasColors was the configuration in (deprecated) graph panel; we hide it from JSON model.
     aliasColors:: super.aliasColors,
     fieldConfig+: {
-      overrides: [
+      overrides+: [
         $.overrideFieldByName(name, [
           $.overrideProperty('color', { mode: 'fixed', fixedColor: colors[name] }),
         ])

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -135,21 +135,22 @@ local filename = 'mimir-writes.json';
           |||
         ) +
         $.qpsPanel($.queries.distributor.writeRequestsPerSecond) +
-        if $._config.show_rejected_requests_on_writes_dashboard then {
-          targets: [
-                     {
-                       legendLink: null,
-                       expr: 'sum (rate(cortex_distributor_instance_rejected_requests_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.distributor)],
-                       format: 'time_series',
-                       intervalFactor: 2,
-                       legendFormat: 'rejected',
-                       refId: 'B',
-                     },
-                   ] + super.targets +
-                   $.aliasColors({
-                     rejected: '#EAB839',
-                   }),
-        } else {},
+        if $._config.show_rejected_requests_on_writes_dashboard then
+          {
+            targets: [
+              {
+                legendLink: null,
+                expr: 'sum (rate(cortex_distributor_instance_rejected_requests_total{%s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.distributor)],
+                format: 'time_series',
+                intervalFactor: 2,
+                legendFormat: 'rejected',
+                refId: 'B',
+              },
+            ] + super.targets,
+          } + $.aliasColors({
+            rejected: '#EAB839',
+          })
+        else {},
       )
       .addPanel(
         $.timeseriesPanel('Latency') +
@@ -177,21 +178,22 @@ local filename = 'mimir-writes.json';
           |||
         ) +
         $.qpsPanel('cortex_request_duration_seconds_count{%s,route="/cortex.Ingester/Push"}' % $.jobMatcher($._config.job_names.ingester)) +
-        if $._config.show_rejected_requests_on_writes_dashboard then {
-          targets: [
-                     {
-                       legendLink: null,
-                       expr: 'sum (rate(cortex_ingester_instance_rejected_requests_total{%s, reason=~"ingester_max_inflight_push_requests|ingester_max_ingestion_rate"}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester)],
-                       format: 'time_series',
-                       intervalFactor: 2,
-                       legendFormat: 'rejected',
-                       refId: 'B',
-                     },
-                   ] + super.targets +
-                   $.aliasColors({
-                     rejected: '#EAB839',
-                   }),
-        } else {},
+        if $._config.show_rejected_requests_on_writes_dashboard then
+          {
+            targets: [
+              {
+                legendLink: null,
+                expr: 'sum (rate(cortex_ingester_instance_rejected_requests_total{%s, reason=~"ingester_max_inflight_push_requests|ingester_max_ingestion_rate"}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.ingester)],
+                format: 'time_series',
+                intervalFactor: 2,
+                legendFormat: 'rejected',
+                refId: 'B',
+              },
+            ] + super.targets,
+          } + $.aliasColors({
+            rejected: '#EAB839',
+          })
+        else {},
       )
       .addPanel(
         $.timeseriesPanel('Latency') +


### PR DESCRIPTION
#### What this PR does

This is a fixup for #7413

When `show_rejected_requests_on_writes_dashboard` is set in the config, the code path in `writes.libjsonnet` fails with

```
2024/02/23 19:48:38 RUNTIME ERROR: Unexpected type object, expected array
	operations/mimir-mixin/dashboards/writes.libsonnet:(139:20)-(151:22)
	During manifestation
```

This is due to how I originally misinterpreted the `{}` in the `if C then {}` as condition C's block:

TIL (1) the `{}` is an actual object, inserted into the resulting JSON.
TIL (2) `jsonnet`'s linter doesn't catch a broken syntax, i.e. `[] + {}`, when this happens inside a dead code.

Note there are no assets to rebuild for the PR, because the mentioned config is unset in mimir. But the problem showed itself in the internal build.

#### Which issue(s) this PR fixes or relates to

Fixes n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
