### PR TITLE
Revert "fix(deps): update github.com/thanos-io/objstore digest to a8d75c5 (main)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/prometheus/procfs v0.12.0
-	github.com/thanos-io/objstore v0.0.0-20240212133125-a8d75c522f64
+	github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03
 	github.com/twmb/franz-go v1.15.4
 	github.com/twmb/franz-go/pkg/kadm v1.10.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20231206062516-c09dc92d2db1

--- a/go.sum
+++ b/go.sum
@@ -876,8 +876,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40 h1:W6vDGKCHe4wBACI1d2UgE6+50sJFhRWU4O8IB2ozzxM=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7yZxQuYwgSJM87icDaw=
-github.com/thanos-io/objstore v0.0.0-20240212133125-a8d75c522f64 h1:Ezafuq21qkPz5b/DTm0ZH4Kl4RqaD2R12bDOlYRD5VE=
-github.com/thanos-io/objstore v0.0.0-20240212133125-a8d75c522f64/go.mod h1:RMvJQnpB4QQiYGg1gF8mnPJg6IkIPY28Buh8f6b+F0c=
+github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03 h1:VEu81Atmor2RVr5iGzlLc7E8X9jd1ux0ze4Ie5Qw8n0=
+github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03/go.mod h1:RMvJQnpB4QQiYGg1gF8mnPJg6IkIPY28Buh8f6b+F0c=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twmb/franz-go v1.15.4 h1:qBCkHaiutetnrXjAUWA99D9FEcZVMt2AYwkH3vWEQTw=
 github.com/twmb/franz-go v1.15.4/go.mod h1:rC18hqNmfo8TMc1kz7CQmHL74PLNF8KVvhflxiiJZCU=

--- a/vendor/github.com/thanos-io/objstore/CHANGELOG.md
+++ b/vendor/github.com/thanos-io/objstore/CHANGELOG.md
@@ -39,8 +39,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#92](https://github.com/thanos-io/objstore/pull/92) GCS: Allow using a gRPC client.
 - [#94](https://github.com/thanos-io/objstore/pull/94) Allow timingReadCloser to be seeker 
 - [#96](https://github.com/thanos-io/objstore/pull/96) Allow nopCloserWithObjectSize to be seeker
-- [#86](https://github.com/thanos-io/objstore/pull/86) GCS: Add HTTP Config to GCS
-- [#99](https://github.com/thanos-io/objstore/pull/99) Swift: Add HTTP_Config
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/vendor/github.com/thanos-io/objstore/exthttp/transport.go
+++ b/vendor/github.com/thanos-io/objstore/exthttp/transport.go
@@ -11,16 +11,6 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-var DefaultHTTPConfig = HTTPConfig{
-	IdleConnTimeout:       model.Duration(90 * time.Second),
-	ResponseHeaderTimeout: model.Duration(2 * time.Minute),
-	TLSHandshakeTimeout:   model.Duration(10 * time.Second),
-	ExpectContinueTimeout: model.Duration(1 * time.Second),
-	MaxIdleConns:          100,
-	MaxIdleConnsPerHost:   100,
-	MaxConnsPerHost:       0,
-}
-
 // HTTPConfig stores the http.Transport configuration for the cos and s3 minio client.
 type HTTPConfig struct {
 	IdleConnTimeout       model.Duration `yaml:"idle_conn_timeout"`

--- a/vendor/github.com/thanos-io/objstore/providers/gcs/gcs.go
+++ b/vendor/github.com/thanos-io/objstore/providers/gcs/gcs.go
@@ -8,11 +8,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/go-kit/log"
@@ -21,22 +19,16 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	htransport "google.golang.org/api/transport/http"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v2"
 
 	"github.com/thanos-io/objstore"
-	"github.com/thanos-io/objstore/exthttp"
 )
 
 // DirDelim is the delimiter used to model a directory structure in an object store bucket.
 const DirDelim = "/"
-
-var DefaultConfig = Config{
-	HTTPConfig: exthttp.DefaultHTTPConfig,
-}
 
 // Config stores the configuration for gcs bucket.
 type Config struct {
@@ -47,8 +39,7 @@ type Config struct {
 	// when direct path is not enabled.
 	// See https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API for more details
 	// on how to enable direct path.
-	GRPCConnPoolSize int                `yaml:"grpc_conn_pool_size"`
-	HTTPConfig       exthttp.HTTPConfig `yaml:"http_config"`
+	GRPCConnPoolSize int `yaml:"grpc_conn_pool_size"`
 }
 
 // Bucket implements the store.Bucket and shipper.Bucket interfaces against GCS.
@@ -60,23 +51,14 @@ type Bucket struct {
 	closer io.Closer
 }
 
-// parseConfig unmarshals a buffer into a Config with default values.
-func parseConfig(conf []byte) (Config, error) {
-	config := DefaultConfig
-	if err := yaml.UnmarshalStrict(conf, &config); err != nil {
-		return Config{}, err
-	}
-
-	return config, nil
-}
-
 // NewBucket returns a new Bucket against the given bucket handle.
 func NewBucket(ctx context.Context, logger log.Logger, conf []byte, component string) (*Bucket, error) {
-	config, err := parseConfig(conf)
-	if err != nil {
+	var gc Config
+	if err := yaml.Unmarshal(conf, &gc); err != nil {
 		return nil, err
 	}
-	return NewBucketWithConfig(ctx, logger, config, component)
+
+	return NewBucketWithConfig(ctx, logger, gc, component)
 }
 
 // NewBucketWithConfig returns a new Bucket with gcs Config struct.
@@ -94,37 +76,11 @@ func NewBucketWithConfig(ctx context.Context, logger log.Logger, gc Config, comp
 			return nil, errors.Wrap(err, "failed to create credentials from JSON")
 		}
 		opts = append(opts, option.WithCredentials(credentials))
-	} else {
-		opts = append(opts, option.WithoutAuthentication())
 	}
 
 	opts = append(opts,
 		option.WithUserAgent(fmt.Sprintf("thanos-%s/%s (%s)", component, version.Version, runtime.Version())),
 	)
-
-	// Check if a roundtripper has been set in the config
-	// otherwise build the default transport.
-	var rt http.RoundTripper
-	if gc.HTTPConfig.Transport != nil {
-		rt = gc.HTTPConfig.Transport
-	} else {
-		var err error
-		rt, err = exthttp.DefaultTransport(gc.HTTPConfig)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	gRT, err := htransport.NewTransport(context.Background(), rt, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	httpCli := &http.Client{
-		Transport: gRT,
-		Timeout:   time.Duration(gc.HTTPConfig.IdleConnTimeout),
-	}
-	opts = append(opts, option.WithHTTPClient(httpCli))
 
 	return newBucket(ctx, logger, gc, opts)
 }

--- a/vendor/github.com/thanos-io/objstore/providers/s3/s3.go
+++ b/vendor/github.com/thanos-io/objstore/providers/s3/s3.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/efficientgo/core/logerrcapture"
 	"github.com/go-kit/log"
@@ -22,6 +23,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 	"gopkg.in/yaml.v2"
 
@@ -99,8 +101,16 @@ const (
 )
 
 var DefaultConfig = Config{
-	PutUserMetadata:  map[string]string{},
-	HTTPConfig:       exthttp.DefaultHTTPConfig,
+	PutUserMetadata: map[string]string{},
+	HTTPConfig: exthttp.HTTPConfig{
+		IdleConnTimeout:       model.Duration(90 * time.Second),
+		ResponseHeaderTimeout: model.Duration(2 * time.Minute),
+		TLSHandshakeTimeout:   model.Duration(10 * time.Second),
+		ExpectContinueTimeout: model.Duration(1 * time.Second),
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
+		MaxConnsPerHost:       0,
+	},
 	PartSize:         1024 * 1024 * 64, // 64MB.
 	BucketLookupType: AutoLookup,
 	SendContentMd5:   true, // Default to using MD5.

--- a/vendor/github.com/thanos-io/objstore/providers/swift/swift.go
+++ b/vendor/github.com/thanos-io/objstore/providers/swift/swift.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -22,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore"
-	"github.com/thanos-io/objstore/exthttp"
 	"gopkg.in/yaml.v2"
 )
 
@@ -39,35 +37,33 @@ var DefaultConfig = Config{
 	Retries:        3,
 	ConnectTimeout: model.Duration(10 * time.Second),
 	Timeout:        model.Duration(5 * time.Minute),
-	HTTPConfig:     exthttp.DefaultHTTPConfig,
 }
 
 type Config struct {
-	AuthVersion                 int                `yaml:"auth_version"`
-	AuthUrl                     string             `yaml:"auth_url"`
-	Username                    string             `yaml:"username"`
-	UserDomainName              string             `yaml:"user_domain_name"`
-	UserDomainID                string             `yaml:"user_domain_id"`
-	UserId                      string             `yaml:"user_id"`
-	Password                    string             `yaml:"password"`
-	DomainId                    string             `yaml:"domain_id"`
-	DomainName                  string             `yaml:"domain_name"`
-	ApplicationCredentialID     string             `yaml:"application_credential_id"`
-	ApplicationCredentialName   string             `yaml:"application_credential_name"`
-	ApplicationCredentialSecret string             `yaml:"application_credential_secret"`
-	ProjectID                   string             `yaml:"project_id"`
-	ProjectName                 string             `yaml:"project_name"`
-	ProjectDomainID             string             `yaml:"project_domain_id"`
-	ProjectDomainName           string             `yaml:"project_domain_name"`
-	RegionName                  string             `yaml:"region_name"`
-	ContainerName               string             `yaml:"container_name"`
-	ChunkSize                   int64              `yaml:"large_object_chunk_size"`
-	SegmentContainerName        string             `yaml:"large_object_segments_container_name"`
-	Retries                     int                `yaml:"retries"`
-	ConnectTimeout              model.Duration     `yaml:"connect_timeout"`
-	Timeout                     model.Duration     `yaml:"timeout"`
-	UseDynamicLargeObjects      bool               `yaml:"use_dynamic_large_objects"`
-	HTTPConfig                  exthttp.HTTPConfig `yaml:"http_config"`
+	AuthVersion                 int            `yaml:"auth_version"`
+	AuthUrl                     string         `yaml:"auth_url"`
+	Username                    string         `yaml:"username"`
+	UserDomainName              string         `yaml:"user_domain_name"`
+	UserDomainID                string         `yaml:"user_domain_id"`
+	UserId                      string         `yaml:"user_id"`
+	Password                    string         `yaml:"password"`
+	DomainId                    string         `yaml:"domain_id"`
+	DomainName                  string         `yaml:"domain_name"`
+	ApplicationCredentialID     string         `yaml:"application_credential_id"`
+	ApplicationCredentialName   string         `yaml:"application_credential_name"`
+	ApplicationCredentialSecret string         `yaml:"application_credential_secret"`
+	ProjectID                   string         `yaml:"project_id"`
+	ProjectName                 string         `yaml:"project_name"`
+	ProjectDomainID             string         `yaml:"project_domain_id"`
+	ProjectDomainName           string         `yaml:"project_domain_name"`
+	RegionName                  string         `yaml:"region_name"`
+	ContainerName               string         `yaml:"container_name"`
+	ChunkSize                   int64          `yaml:"large_object_chunk_size"`
+	SegmentContainerName        string         `yaml:"large_object_segments_container_name"`
+	Retries                     int            `yaml:"retries"`
+	ConnectTimeout              model.Duration `yaml:"connect_timeout"`
+	Timeout                     model.Duration `yaml:"timeout"`
+	UseDynamicLargeObjects      bool           `yaml:"use_dynamic_large_objects"`
 }
 
 func parseConfig(conf []byte) (*Config, error) {
@@ -105,7 +101,6 @@ func configFromEnv() (*Config, error) {
 		ConnectTimeout:              model.Duration(c.ConnectTimeout),
 		Timeout:                     model.Duration(c.Timeout),
 		UseDynamicLargeObjects:      false,
-		HTTPConfig:                  DefaultConfig.HTTPConfig,
 	}
 	if os.Getenv("SWIFT_CHUNK_SIZE") != "" {
 		var err error
@@ -120,7 +115,7 @@ func configFromEnv() (*Config, error) {
 	return &config, nil
 }
 
-func connectionFromConfig(sc *Config, rt http.RoundTripper) *swift.Connection {
+func connectionFromConfig(sc *Config) *swift.Connection {
 	connection := swift.Connection{
 		AuthVersion:                 sc.AuthVersion,
 		AuthUrl:                     sc.AuthUrl,
@@ -140,7 +135,6 @@ func connectionFromConfig(sc *Config, rt http.RoundTripper) *swift.Connection {
 		Retries:                     sc.Retries,
 		ConnectTimeout:              time.Duration(sc.ConnectTimeout),
 		Timeout:                     time.Duration(sc.Timeout),
-		Transport:                   rt,
 	}
 	return &connection
 }
@@ -179,21 +173,7 @@ func ensureContainer(connection *swift.Connection, name string, createIfNotExist
 }
 
 func NewContainerFromConfig(logger log.Logger, sc *Config, createContainer bool) (*Container, error) {
-
-	// Check if a roundtripper has been set in the config
-	// otherwise build the default transport.
-	var rt http.RoundTripper
-	if sc.HTTPConfig.Transport != nil {
-		rt = sc.HTTPConfig.Transport
-	} else {
-		var err error
-		rt, err = exthttp.DefaultTransport(sc.HTTPConfig)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	connection := connectionFromConfig(sc, rt)
+	connection := connectionFromConfig(sc)
 	if err := connection.Authenticate(); err != nil {
 		return nil, errors.Wrap(err, "authentication")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1012,7 +1012,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/objstore v0.0.0-20240212133125-a8d75c522f64
+# github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03
 ## explicit; go 1.20
 github.com/thanos-io/objstore
 github.com/thanos-io/objstore/exthttp


### PR DESCRIPTION
Reverts grafana/mimir#7351.

The above PR introduced https://github.com/thanos-io/objstore/pull/86, which changes authentication behaviour for GCS to set `option.WithoutAuthentication` whenever a service account is not configured for the bucket client ([diff](https://github.com/thanos-io/objstore/pull/86/files#diff-6f1f01a82332f5074843c222ea2e28118de43aa1a516848fe5b7ef3ac18f8470R97-R98)). As a consequence, auth config set via `GOOGLE_APPLICATION_CREDENTIALS` is ignored.