### PR TITLE
Support KEDA's ignoreNullValues field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@
 * [ENHANCEMENT] Rollout-operator: upgraded to v0.13.0. #7469
 * [ENHANCEMENT] Rollout-operator: add tracing configuration to rollout-operator container (when tracing is enabled and configured). #7469
 * [ENHANCEMENT] Query-frontend: configured `-shutdown-delay`, `-server.grpc.keepalive.max-connection-age` and termination grace period to reduce the likelihood of queries hitting terminated query-frontends. #7129
+* [ENHANCEMENT] Autoscaling: add support for KEDA's `ignoreNullValues` option for Prometheus scaler. #7471
 * [BUGFIX] Update memcached-exporter to 0.14.1 due to CVE-2023-39325. #6861
 
 ### Mimirtool

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2371,3 +2371,19 @@ spec:
     metricType: Value
     name: cortex_test_hpa_default
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_hpa_default_ignore_null_values_false
+      query: query
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "123"
+    name: cortex_test_hpa_default_ignore_null_values_false
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "true"
+      metricName: cortex_test_hpa_default_ignore_null_values_true
+      query: query
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "123"
+    name: cortex_test_hpa_default_ignore_null_values_true
+    type: prometheus

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2371,3 +2371,19 @@ spec:
     metricType: Value
     name: cortex_test_hpa_default
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_hpa_default_ignore_null_values_false
+      query: query
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "123"
+    name: cortex_test_hpa_default_ignore_null_values_false
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "true"
+      metricName: cortex_test_hpa_default_ignore_null_values_true
+      query: query
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "123"
+    name: cortex_test_hpa_default_ignore_null_values_true
+    type: prometheus

--- a/operations/mimir-tests/test-autoscaling.jsonnet
+++ b/operations/mimir-tests/test-autoscaling.jsonnet
@@ -82,7 +82,7 @@ mimir {
         metric_name: 'cortex_test_hpa_%s_ignore_null_values_true' % $._config.namespace,
         query: 'query',
         threshold: '123',
-        ignore_null_values: 'true',  // String is supported, and let as-is.
+        ignore_null_values: 'true',  // String is supported, and left as-is.
       },
     ],
   }),

--- a/operations/mimir-tests/test-autoscaling.jsonnet
+++ b/operations/mimir-tests/test-autoscaling.jsonnet
@@ -72,6 +72,18 @@ mimir {
         query: 'some_query_goes_here',
         threshold: '123',
       },
+      {
+        metric_name: 'cortex_test_hpa_%s_ignore_null_values_false' % $._config.namespace,
+        query: 'query',
+        threshold: '123',
+        ignore_null_values: false,  // Boolean is supported, and converted to string.
+      },
+      {
+        metric_name: 'cortex_test_hpa_%s_ignore_null_values_true' % $._config.namespace,
+        query: 'query',
+        threshold: '123',
+        ignore_null_values: 'true',  // String is supported, and let as-is.
+      },
     ],
   }),
 }

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -136,7 +136,20 @@
             //
             // We also have to ensure that the threshold is an integer (represented as a string)
             threshold: std.toString(std.parseInt(trigger.threshold)),
-          },
+          } + (
+            // Add support for KEDA's "ignoreNullValues" option. This defaults to "true", which means that if query
+            // returns no results, KEDA will ignore that and return value 0. By setting this value to "false",
+            // KEDA will return error in such case.
+            //
+            // Note that since our triggers use snake_case for fields, we check for "ignore_null_values", but KEDA
+            // expects camelCase (ie. "ignoreNullValues"), and string value, not boolean.
+            if std.objectHas(trigger, 'ignore_null_values') then {
+              ignoreNullValues:
+                if std.isBoolean(trigger.ignore_null_values)
+                then (if trigger.ignore_null_values then 'true' else 'false')
+                else trigger.ignore_null_values,  // not boolean
+            } else {}
+          ),
         } + (
           // Be aware that the default value for the trigger "metricType" field is "AverageValue"
           // (see https://keda.sh/docs/2.9/concepts/scaling-deployments/#triggers), which means that KEDA will


### PR DESCRIPTION
#### What this PR does

This PR adds support for KEDA's `ignoreNullValues` option for [Prometheus scalers](https://keda.sh/docs/2.13/scalers/prometheus/). This defaults to `"true"` (ie. KEDA returns 0 if query produces no results), and can be set to `"false"` to make KEDA return errors instead. (KEDA expects field value to be string, so our jsonnet converts boolean to string).

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
