### PR TITLE
fix: Update KEDA related information

### DIFF
--- a/docs/sources/mimir/set-up/jsonnet/configure-autoscaling.md
+++ b/docs/sources/mimir/set-up/jsonnet/configure-autoscaling.md
@@ -45,11 +45,11 @@ KEDA, as we use it, never changes the number of replicas of Mimir Deployments or
 
 However, if KEDA is not running successfully, there are consequences for Mimir autoscaling too:
 
-- `keda-operator` is down (critical): as the operator is the single point of truth, it won'r request the metrics when `keda-operator-metrics-apiserver` requests them and changes to `ScaledObject` CRD will not be reflected to the HPA until the operator will get back online. The deployment (e.g. queriers) will keep working but, in case of any surge of traffic, HPA will not be able to detect it (because of a lack of metrics) and so will not scale up.
-- `keda-operator-metrics-apiserver` is down (critical): HPA is not able to fetch updated metrics and it will stop scaling the deployment until metrics will be back. The deployment (e.g. queriers) will keep working but, in case of any surge of traffic, HPA will not be able to detect it (because of a lack of metrics) and so will not scale up.
-- `keda-admission-webhooks` is down (not critical): CRD validation won't be executed. Based on KEDA's configuration this can block changes on CRDs until the service is restored. HPA functionality is not affected.
+- `keda-operator` is down (critical): as the operator is the single point of truth, it will not request the metrics when `keda-operator-metrics-apiserver` requests them. Changes to `ScaledObject` CRD will not be reflected to the HPA until the operator is back online. The deployment (e.g. queriers) will keep working but, if there is a surge of traffic, HPA will not be able to detect it due to a lack of metrics and so will not scale up.
+- `keda-operator-metrics-apiserver` is down (critical): HPA is not able to fetch updated metrics and it will stop scaling the deployment until metrics will be back. The deployment (e.g. queriers) will keep working but, if there is a surge of traffic, HPA will not be able to detect it due to a lack of metrics and so will not scale up.
+- `keda-admission-webhooks` is down (not critical): CRD validation will not be executed. Based on KEDA's configuration, this can block changes on CRDs until the service is restored. HPA functionality is not affected.
 
-> Note: You should use [high availability](https://keda.sh/docs/latest/operate/cluster/#high-availability) configurations if the autoscaling is critical for your use case.
+> Note: Use [high availability](https://keda.sh/docs/latest/operate/cluster/#high-availability) configuration if the autoscaling is critical for your use case.
 
 The [alert `MimirAutoscalerNotActive`]({{< relref "../../manage/monitor-grafana-mimir" >}}) fires if HPA is unable to scale the deployment for any reason (e.g. unable to scrape metrics from KEDA metrics API server).
 

--- a/docs/sources/mimir/set-up/jsonnet/configure-autoscaling.md
+++ b/docs/sources/mimir/set-up/jsonnet/configure-autoscaling.md
@@ -49,7 +49,10 @@ However, if KEDA is not running successfully, there are consequences for Mimir a
 - `keda-operator-metrics-apiserver` is down (critical): HPA is not able to fetch updated metrics and it will stop scaling the deployment until metrics will be back. The deployment (e.g. queriers) will keep working but, if there is a surge of traffic, HPA will not be able to detect it due to a lack of metrics and so will not scale up.
 - `keda-admission-webhooks` is down (not critical): CRD validation will not be executed. Based on KEDA's configuration, this can block changes on CRDs until the service is restored. HPA functionality is not affected.
 
-> Note: Use [high availability](https://keda.sh/docs/latest/operate/cluster/#high-availability) configuration if the autoscaling is critical for your use case.
+{{< admonition type="note" >}}
+Use a [high availability](https://keda.sh/docs/latest/operate/cluster/#high-availability) KEDA configuration if autoscaling is critical for your use case.
+{{< /admonition >}}
+
 
 The [alert `MimirAutoscalerNotActive`]({{< relref "../../manage/monitor-grafana-mimir" >}}) fires if HPA is unable to scale the deployment for any reason (e.g. unable to scrape metrics from KEDA metrics API server).
 

--- a/docs/sources/mimir/set-up/jsonnet/configure-autoscaling.md
+++ b/docs/sources/mimir/set-up/jsonnet/configure-autoscaling.md
@@ -53,7 +53,6 @@ However, if KEDA is not running successfully, there are consequences for Mimir a
 Use a [high availability](https://keda.sh/docs/latest/operate/cluster/#high-availability) KEDA configuration if autoscaling is critical for your use case.
 {{< /admonition >}}
 
-
 The [alert `MimirAutoscalerNotActive`]({{< relref "../../manage/monitor-grafana-mimir" >}}) fires if HPA is unable to scale the deployment for any reason (e.g. unable to scrape metrics from KEDA metrics API server).
 
 ## How Kubernetes HPA works

--- a/docs/sources/mimir/set-up/jsonnet/configure-autoscaling.md
+++ b/docs/sources/mimir/set-up/jsonnet/configure-autoscaling.md
@@ -45,8 +45,11 @@ KEDA, as we use it, never changes the number of replicas of Mimir Deployments or
 
 However, if KEDA is not running successfully, there are consequences for Mimir autoscaling too:
 
-- `keda-operator` is down (not critical): changes to `ScaledObject` CRD will not be reflected to the HPA until the operator will get back online. HPA functionality is not affected.
+- `keda-operator` is down (critical): as the operator is the single point of truth, it won'r request the metrics when `keda-operator-metrics-apiserver` requests them and changes to `ScaledObject` CRD will not be reflected to the HPA until the operator will get back online. The deployment (e.g. queriers) will keep working but, in case of any surge of traffic, HPA will not be able to detect it (because of a lack of metrics) and so will not scale up.
 - `keda-operator-metrics-apiserver` is down (critical): HPA is not able to fetch updated metrics and it will stop scaling the deployment until metrics will be back. The deployment (e.g. queriers) will keep working but, in case of any surge of traffic, HPA will not be able to detect it (because of a lack of metrics) and so will not scale up.
+- `keda-admission-webhooks` is down (not critical): CRD validation won't be executed. Based on KEDA's configuration this can block changes on CRDs until the service is restored. HPA functionality is not affected.
+
+> Note: You should use [high availability](https://keda.sh/docs/latest/operate/cluster/#high-availability) configurations if the autoscaling is critical for your use case.
 
 The [alert `MimirAutoscalerNotActive`]({{< relref "../../manage/monitor-grafana-mimir" >}}) fires if HPA is unable to scale the deployment for any reason (e.g. unable to scrape metrics from KEDA metrics API server).
 


### PR DESCRIPTION
I've found by chance that this section is quite outdated: https://grafana.com/docs/mimir/latest/set-up/jsonnet/configure-autoscaling/#what-happens-if-keda-is-unhealthy

It explains how KEDA worked in the past (KEDA <= v2.8) but this behaviour change on KEDA v2.9 (released a year ago). The PR updated the info the new current one and also adds a link the the high availability configuration from official docs
#### Checklist

- [x] Documentation added.

