### PR TITLE
Use smaller requests for TestIngester_inflightPushRequests

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -7526,7 +7526,7 @@ func testIngesterInflightPushRequests(t *testing.T, i *Ingester, reg prometheus.
 
 	startCh := make(chan struct{})
 
-	const targetRequestDuration = time.Second
+	const targetRequestDuration = 250 * time.Millisecond
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -7631,7 +7631,7 @@ func TestIngester_inflightPushRequestsBytes(t *testing.T) {
 
 			startCh := make(chan int)
 
-			const targetRequestDuration = time.Second
+			const targetRequestDuration = 250 * time.Millisecond
 
 			g, ctx := errgroup.WithContext(ctx)
 			g.Go(func() error {


### PR DESCRIPTION
#### What this PR does

The amount of data required to process for 1 second may be very large - it crashes my desktop which has a very fast processor.
Reducing the target duration to 1/10th of a second allows the test to work with much less resource.

#### Checklist

- [x] Tests updated.
- NA Documentation added.
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- NA [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
