### PR TITLE
Wait ingester to replay partition at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Querier: the CLI flag `-querier.minimize-ingester-requests` has been moved from "experimental" to "advanced". #7638
+* [CHANGE] Ingester: `/ingester/flush` endpoint is now only allowed to execute only while the ingester is in `Running` state. The 503 status code is returned if the endpoint is called while the ingester is not in `Running` state. #7486
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [ENHANCEMENT] Store-gateway: merge series from different blocks concurrently. #7456
 * [ENHANCEMENT] Store-gateway: Add `stage="wait_max_concurrent"` to `cortex_bucket_store_series_request_stage_duration_seconds` which records how long the query had to wait for its turn for `-blocks-storage.bucket-store.max-concurrent`. #7609

--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -16,7 +16,8 @@ ingest_storage:
     topic:   mimir-ingest
 
 ingester:
-  return_only_grpc_errors: true
+  return_only_grpc_errors:     true
+  track_ingester_owned_series: true
 
   partition_ring:
     min_partition_owners_count:       2

--- a/pkg/ingester/active_series.go
+++ b/pkg/ingester/active_series.go
@@ -24,7 +24,7 @@ const activeSeriesMaxSizeBytes = 1 * 1024 * 1024
 // series that match the given matchers.
 func (i *Ingester) ActiveSeries(request *client.ActiveSeriesRequest, stream client.Ingester_ActiveSeriesServer) (err error) {
 	defer func() { err = i.mapReadErrorToErrorWithStatus(err) }()
-	if err := i.checkAvailable(); err != nil {
+	if err := i.checkAvailableForRead(); err != nil {
 		return err
 	}
 	if err := i.checkReadOverloaded(); err != nil {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -346,7 +346,6 @@ type Ingester struct {
 	ingestReader              *ingest.PartitionReader
 	ingestPartitionID         int32
 	ingestPartitionLifecycler *ring.PartitionInstanceLifecycler
-	ingestPartitionWatcher    *ring.PartitionRingWatcher
 }
 
 func newIngester(cfg Config, limits *validation.Overrides, registerer prometheus.Registerer, logger log.Logger) (*Ingester, error) {
@@ -462,8 +461,6 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 			partitionRingKV,
 			logger,
 			prometheus.WrapRegistererWithPrefix("cortex_", registerer))
-
-		i.ingestPartitionWatcher = partitionRingWatcher
 
 		limiterStrategy = newPartitionRingLimiterStrategy(partitionRingWatcher, i.limits.IngestionPartitionsTenantShardSize)
 		ownedSeriesStrategy = newOwnedSeriesPartitionRingStrategy(i.ingestPartitionID, partitionRingWatcher, i.limits.IngestionPartitionsTenantShardSize)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -3329,7 +3329,7 @@ func (i *Ingester) FlushHandler(w http.ResponseWriter, r *http.Request) {
 		level.Warn(i.logger).Log("msg", "flushing TSDB blocks is not allowed", "err", err)
 
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte(err.Error()))
+		_, _ = w.Write([]byte(err.Error()))
 		return
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2985,7 +2985,7 @@ func (i *Ingester) compactionServiceRunning(ctx context.Context) error {
 				// Stop the previous ticker before creating a new one.
 				stopTicker()
 
-				firstInterval, standardInterval = newFirstInterval, newStandardInterval
+				standardInterval = newStandardInterval
 				stopTicker, tickerChan = util.NewVariableTicker(newFirstInterval, newStandardInterval)
 			}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -571,7 +571,7 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 	}
 
 	// Start the following services before starting the ingest storage reader, in order to have them
-	// running while replacying the partition (if ingest storage is enabled).
+	// running while replaying the partition (if ingest storage is enabled).
 	if err := services.StartAndAwaitRunning(ctx, i.compactionService); err != nil {
 		return errors.Wrap(err, "failed to start TSDB Head compaction service")
 	}
@@ -586,7 +586,7 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 
 	// When ingest storage is enabled, we have to make sure that reader catches up replaying the partition
 	// BEFORE the ingester ring lifecycler is started, because once the ingester ring lifecycler will start
-	// it will switch the ingester state to ACTIVE.
+	// it will switch the ingester state in the ring to ACTIVE.
 	if i.ingestReader != nil {
 		if err := services.StartAndAwaitRunning(ctx, i.ingestReader); err != nil {
 			return errors.Wrap(err, "failed to start partition reader")

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -598,8 +598,10 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 		return errors.Wrap(err, "failed to start lifecycler")
 	}
 
-	// let's start the rest of subservices via manager
-	servs := []services.Service(nil)
+	// Finally we start all services that should run after the ingester ring lifecycler.
+	// We add an idle service because all other services are conditional but we need to
+	// guarantee there's at least 1 service to run otherwise the service manager fails to start.
+	servs := []services.Service{services.NewIdleService(nil, nil)}
 
 	if i.cfg.BlocksStorageConfig.TSDB.IsBlocksShippingEnabled() {
 		shippingService := services.NewBasicService(nil, i.shipBlocksLoop, nil)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -3011,7 +3011,6 @@ func (i *Ingester) compactionServiceRunning(ctx context.Context) error {
 
 // compactionServiceInterval returns how frequently the TSDB Head should be checked for compaction.
 // The returned value may change over time.
-// TODO unit test
 func (i *Ingester) compactionServiceInterval() (firstInterval, standardInterval time.Duration) {
 	if i.State() == services.Starting {
 		// Trigger TSDB Head compaction frequently when starting up, because we may replay data from the partition

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -43,6 +43,8 @@ import (
 )
 
 func TestIngester_Start(t *testing.T) {
+	util_test.VerifyNoLeak(t)
+
 	t.Run("should replay the partition at startup and then join the ingesters and partitions ring", func(t *testing.T) {
 		var (
 			ctx                = context.Background()

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -78,7 +78,7 @@ func TestIngester_Start(t *testing.T) {
 		// Mock the Kafka cluster to:
 		// - Count the Fetch requests.
 		// - Mock the ListOffsets response, returning the offset expected once the ingester can be
-		//   considered having successfully catched up.
+		//   considered having successfully caught up.
 		kafkaCluster.ControlKey(int16(kmsg.Fetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			kafkaCluster.KeepControl()
 			fetchRequestsCount.Inc()

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -7259,7 +7259,7 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 		cfg.InstanceLimitsFn = func() *InstanceLimits { return &limits }
 
 		reg := prometheus.NewPedanticRegistry()
-		i, _, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
+		i, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
 
 		// Re-enable push gRPC method to simulate migration period, when ingester can receive requests from gRPC
 		i.cfg.PushGrpcMethodEnabled = true
@@ -10269,7 +10269,9 @@ func TestIngester_lastUpdatedTimeIsNotInTheFuture(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, i))
-	defer services.StopAndAwaitTerminated(ctx, i) //nolint:errcheck
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, i))
+	})
 
 	// Wait until it's healthy
 	test.Poll(t, 1*time.Second, 1, func() interface{} {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -10423,7 +10423,7 @@ func newFailingIngester(t *testing.T, cfg Config, kvStore kv.Client, failingCaus
 	if kvStore != nil {
 		fI.kvStore = kvStore
 	}
-	fI.BasicService = services.NewBasicService(fI.starting, fI.running, fI.stopping)
+	fI.BasicService = services.NewBasicService(fI.starting, fI.ingesterRunning, fI.stopping)
 	return fI
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -10400,7 +10400,7 @@ func newFailingIngester(t *testing.T, cfg Config, kvStore kv.Client, failingCaus
 	if kvStore != nil {
 		fI.kvStore = kvStore
 	}
-	fI.BasicService = services.NewBasicService(fI.starting, fI.updateLoop, fI.stopping)
+	fI.BasicService = services.NewBasicService(fI.starting, fI.running, fI.stopping)
 	return fI
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -7259,7 +7259,7 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 		cfg.InstanceLimitsFn = func() *InstanceLimits { return &limits }
 
 		reg := prometheus.NewPedanticRegistry()
-		i, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
+		i, _, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
 
 		// Re-enable push gRPC method to simulate migration period, when ingester can receive requests from gRPC
 		i.cfg.PushGrpcMethodEnabled = true

--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -718,9 +718,9 @@ func (c *ownedSeriesWithPartitionsRingTestContext) createIngesterAndPartitionRin
 		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), c.partitionsRing))
 	}
 
-	ing, _ := createTestIngesterWithIngestStorage(t, &c.cfg, c.overrides, nil)
+	ing, _, prw := createTestIngesterWithIngestStorage(t, &c.cfg, c.overrides, nil)
 	c.ing = ing
-	c.partitionsRing = ing.ingestPartitionWatcher
+	c.partitionsRing = prw
 
 	// Ingester is not started yet.
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c.ing))
@@ -730,7 +730,7 @@ func (c *ownedSeriesWithPartitionsRingTestContext) createIngesterAndPartitionRin
 
 	// Make sure that partition is now registered in the ring, and is active. This takes at least 1 sec.
 	test.Poll(t, 2*time.Second, true, func() interface{} {
-		p := c.partitionsRing.PartitionRing().ActivePartitionIDs()
+		p := prw.PartitionRing().ActivePartitionIDs()
 		return slices.Contains(p, c.partitionID)
 	})
 

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -48,6 +48,7 @@ type KafkaConfig struct {
 
 	LastProducedOffsetPollInterval time.Duration `yaml:"last_produced_offset_poll_interval"`
 	LastProducedOffsetRetryTimeout time.Duration `yaml:"last_produced_offset_retry_timeout"`
+	MaxConsumerLagAtStartup        time.Duration `yaml:"max_consumer_lag_at_startup"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
@@ -63,6 +64,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 
 	f.DurationVar(&cfg.LastProducedOffsetPollInterval, prefix+".last-produced-offset-poll-interval", time.Second, "How frequently to poll the last produced offset, used to enforce strong read consistency.")
 	f.DurationVar(&cfg.LastProducedOffsetRetryTimeout, prefix+".last-produced-offset-retry-timeout", 10*time.Second, "How long to retry a failed request to get the last produced offset.")
+	f.DurationVar(&cfg.MaxConsumerLagAtStartup, prefix+".max-consumer-lag-at-startup", 15*time.Second, "The maximum tolerated lag before a consumer is being considered to have catched up reading from a partition at startup. Set 0 to disable.")
 }
 
 func (cfg *KafkaConfig) Validate() error {

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -64,7 +64,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 
 	f.DurationVar(&cfg.LastProducedOffsetPollInterval, prefix+".last-produced-offset-poll-interval", time.Second, "How frequently to poll the last produced offset, used to enforce strong read consistency.")
 	f.DurationVar(&cfg.LastProducedOffsetRetryTimeout, prefix+".last-produced-offset-retry-timeout", 10*time.Second, "How long to retry a failed request to get the last produced offset.")
-	f.DurationVar(&cfg.MaxConsumerLagAtStartup, prefix+".max-consumer-lag-at-startup", 15*time.Second, "The maximum tolerated lag before a consumer is being considered to have catched up reading from a partition at startup. Set 0 to disable.")
+	f.DurationVar(&cfg.MaxConsumerLagAtStartup, prefix+".max-consumer-lag-at-startup", 15*time.Second, "The maximum tolerated lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set 0 to disable waiting for maximum consumer lag being honored at startup.")
 }
 
 func (cfg *KafkaConfig) Validate() error {

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -123,8 +123,6 @@ func (p *partitionOffsetReader) getAndNotifyLastProducedOffset(ctx context.Conte
 // RequestLastProducedOffset fetches and returns the last produced offset for a partition, or -1 if the
 // partition is empty. This function issues a single request, but the Kafka client used under the
 // hood may retry a failed request until the retry timeout is hit.
-//
-// This function may be directly called from outside the partitionOffsetReader.
 func (p *partitionOffsetReader) RequestLastProducedOffset(ctx context.Context) (_ int64, returnErr error) {
 	startTime := time.Now()
 

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -108,10 +108,10 @@ func (p *partitionOffsetReader) getAndNotifyLastProducedOffset(ctx context.Conte
 	p.nextResultPromise = newResultPromise[int64]()
 	p.nextResultPromiseMx.Unlock()
 
-	// We call RequestLastProducedOffset() even if there are no goroutines waiting on the result in order to get
+	// We call FetchLastProducedOffset() even if there are no goroutines waiting on the result in order to get
 	// a constant load on the Kafka backend. In other words, the load produced on Kafka by this component is
 	// constant, regardless the number of received queries with strong consistency enabled.
-	offset, err := p.RequestLastProducedOffset(ctx)
+	offset, err := p.FetchLastProducedOffset(ctx)
 	if err != nil {
 		level.Warn(p.logger).Log("msg", "failed to fetch the last produced offset", "err", err)
 	}
@@ -120,10 +120,10 @@ func (p *partitionOffsetReader) getAndNotifyLastProducedOffset(ctx context.Conte
 	promise.notify(offset, err)
 }
 
-// RequestLastProducedOffset fetches and returns the last produced offset for a partition, or -1 if the
+// FetchLastProducedOffset fetches and returns the last produced offset for a partition, or -1 if the
 // partition is empty. This function issues a single request, but the Kafka client used under the
 // hood may retry a failed request until the retry timeout is hit.
-func (p *partitionOffsetReader) RequestLastProducedOffset(ctx context.Context) (_ int64, returnErr error) {
+func (p *partitionOffsetReader) FetchLastProducedOffset(ctx context.Context) (_ int64, returnErr error) {
 	startTime := time.Now()
 
 	p.lastProducedOffsetRequestsTotal.Inc()
@@ -191,12 +191,12 @@ func (p *partitionOffsetReader) RequestLastProducedOffset(ctx context.Context) (
 	return listRes.Topics[0].Partitions[0].Offset - 1, nil
 }
 
-// FetchLastProducedOffset returns the result of the *next* "last produced offset" request
+// WaitNextFetchLastProducedOffset returns the result of the *next* "last produced offset" request
 // that will be issued.
 //
 // The "last produced offset" is the offset of the last message written to the partition (starting from 0), or -1 if no
 // message has been written yet.
-func (p *partitionOffsetReader) FetchLastProducedOffset(ctx context.Context) (int64, error) {
+func (p *partitionOffsetReader) WaitNextFetchLastProducedOffset(ctx context.Context) (int64, error) {
 	// Get the promise for the result of the next request that will be issued.
 	p.nextResultPromiseMx.RLock()
 	promise := p.nextResultPromise

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -48,7 +48,7 @@ func TestPartitionOffsetReader(t *testing.T) {
 
 		for i := 0; i < 2; i++ {
 			runAsync(&wg, func() {
-				_, err := reader.FetchLastProducedOffset(ctx)
+				_, err := reader.WaitNextFetchLastProducedOffset(ctx)
 				assert.Equal(t, errPartitionOffsetReaderStopped, err)
 			})
 		}
@@ -59,13 +59,13 @@ func TestPartitionOffsetReader(t *testing.T) {
 		// At the point we expect the waiting goroutines to be unblocked.
 		wg.Wait()
 
-		// The next call to FetchLastProducedOffset() should return immediately.
-		_, err := reader.FetchLastProducedOffset(ctx)
+		// The next call to WaitNextFetchLastProducedOffset() should return immediately.
+		_, err := reader.WaitNextFetchLastProducedOffset(ctx)
 		assert.Equal(t, errPartitionOffsetReaderStopped, err)
 	})
 }
 
-func TestPartitionOffsetReader_RequestLastProducedOffset(t *testing.T) {
+func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 	const (
 		numPartitions = 1
 		userID        = "user-1"
@@ -90,21 +90,21 @@ func TestPartitionOffsetReader_RequestLastProducedOffset(t *testing.T) {
 			reader         = newPartitionOffsetReader(client, topicName, partitionID, pollInterval, reg, logger)
 		)
 
-		offset, err := reader.RequestLastProducedOffset(ctx)
+		offset, err := reader.FetchLastProducedOffset(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, int64(-1), offset)
 
 		// Write the 1st message.
 		produceRecord(ctx, t, client, topicName, partitionID, []byte("message 1"))
 
-		offset, err = reader.RequestLastProducedOffset(ctx)
+		offset, err = reader.FetchLastProducedOffset(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), offset)
 
 		// Write the 2nd message.
 		produceRecord(ctx, t, client, topicName, partitionID, []byte("message 2"))
 
-		offset, err = reader.RequestLastProducedOffset(ctx)
+		offset, err = reader.FetchLastProducedOffset(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), offset)
 
@@ -151,20 +151,20 @@ func TestPartitionOffsetReader_RequestLastProducedOffset(t *testing.T) {
 
 		wg := sync.WaitGroup{}
 
-		// Run the 1st RequestLastProducedOffset() with a timeout which is expected to expire
+		// Run the 1st FetchLastProducedOffset() with a timeout which is expected to expire
 		// before the request will succeed.
 		runAsync(&wg, func() {
 			ctxWithTimeout, cancel := context.WithTimeout(ctx, firstRequestTimeout)
 			defer cancel()
 
-			_, err := reader.RequestLastProducedOffset(ctxWithTimeout)
+			_, err := reader.FetchLastProducedOffset(ctxWithTimeout)
 			require.ErrorIs(t, err, context.DeadlineExceeded)
 		})
 
-		// Run a 2nd RequestLastProducedOffset() once the 1st request is received. This request
+		// Run a 2nd FetchLastProducedOffset() once the 1st request is received. This request
 		// is expected to succeed.
 		runAsyncAfter(&wg, firstRequestReceived, func() {
-			offset, err := reader.RequestLastProducedOffset(ctx)
+			offset, err := reader.FetchLastProducedOffset(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, expectedOffset, offset)
 		})
@@ -194,7 +194,7 @@ func TestPartitionOffsetReader_RequestLastProducedOffset(t *testing.T) {
 		})
 
 		startTime := time.Now()
-		_, err := reader.RequestLastProducedOffset(ctx)
+		_, err := reader.FetchLastProducedOffset(ctx)
 		elapsedTime := time.Since(startTime)
 
 		require.Error(t, err)
@@ -208,7 +208,7 @@ func TestPartitionOffsetReader_RequestLastProducedOffset(t *testing.T) {
 	})
 }
 
-func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
+func TestPartitionOffsetReader_WaitNextFetchLastProducedOffset(t *testing.T) {
 	const (
 		numPartitions = 1
 		topicName     = "test"
@@ -256,18 +256,18 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 
 		wg := sync.WaitGroup{}
 
-		// The 1st FetchLastProducedOffset() is called before the service start so it's expected
+		// The 1st WaitNextFetchLastProducedOffset() is called before the service start so it's expected
 		// to wait the result of the 1st request.
 		runAsync(&wg, func() {
-			actual, err := reader.FetchLastProducedOffset(ctx)
+			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, int64(1), actual)
 		})
 
-		// The 2nd FetchLastProducedOffset() is called while the 1st request is running, so it's expected
+		// The 2nd WaitNextFetchLastProducedOffset() is called while the 1st request is running, so it's expected
 		// to wait the result of the 2nd request.
 		runAsyncAfter(&wg, firstRequestReceived, func() {
-			actual, err := reader.FetchLastProducedOffset(ctx)
+			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, int64(2), actual)
 		})
@@ -294,7 +294,7 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 		canceledCtx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		_, err := reader.FetchLastProducedOffset(canceledCtx)
+		_, err := reader.WaitNextFetchLastProducedOffset(canceledCtx)
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/pkg/storage/ingest/partition_offset_watcher.go
+++ b/pkg/storage/ingest/partition_offset_watcher.go
@@ -163,6 +163,14 @@ func (w *partitionOffsetWatcher) Wait(ctx context.Context, waitForOffset int64) 
 	}
 }
 
+// LastConsumedOffset returns the last consumed offset.
+func (w *partitionOffsetWatcher) LastConsumedOffset() int64 {
+	w.mx.Lock()
+	defer w.mx.Unlock()
+
+	return w.lastConsumedOffset
+}
+
 // waitingGoroutinesCount returns the number of active watch groups (an active group has at least
 // 1 goroutine waiting). This function is useful for testing.
 func (w *partitionOffsetWatcher) watchGroupsCount() int {

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -176,9 +176,9 @@ func (r *PartitionReader) processNextFetchesUntilMaxLagHonored(ctx context.Conte
 
 	for boff.Ongoing() {
 		// Send a direct request to the Kafka backend to fetch the last produced offset.
-		// We intentionally don't use FetchLastProducedOffset() to not introduce further
+		// We intentionally don't use WaitNextFetchLastProducedOffset() to not introduce further
 		// latency.
-		lastProducedOffset, err := r.offsetReader.RequestLastProducedOffset(ctx)
+		lastProducedOffset, err := r.offsetReader.FetchLastProducedOffset(ctx)
 		if err != nil {
 			level.Warn(r.logger).Log("msg", "partition reader failed to fetch last produced offset", "err", err)
 			boff.Wait()
@@ -446,7 +446,7 @@ func (r *PartitionReader) WaitReadConsistency(ctx context.Context) (returnErr er
 	}
 
 	// Get the last produced offset.
-	lastProducedOffset, err := r.offsetReader.FetchLastProducedOffset(ctx)
+	lastProducedOffset, err := r.offsetReader.WaitNextFetchLastProducedOffset(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -207,7 +207,7 @@ func (r *PartitionReader) processNextFetchesUntilMaxLagHonored(ctx context.Conte
 		// If it took less than the max desired lag to replay the partition
 		// then we can stop here, otherwise we'll have to redo it.
 		if currLag := time.Since(lastProducedOffsetFetchedAt); currLag <= maxLag {
-			level.Info(r.logger).Log("msg", "partition reader consumed partition and current lag is less than configured max consumer lag", "current_lag", currLag, "max_lag", maxLag)
+			level.Info(r.logger).Log("msg", "partition reader consumed partition and current lag is less than configured max consumer lag", "last_consumed_offset", r.consumedOffsetWatcher.LastConsumedOffset(), "current_lag", currLag, "max_lag", maxLag)
 			return nil
 		}
 	}

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -12,11 +12,14 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/test"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/util/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/util/testkafka"
@@ -36,7 +39,7 @@ func TestPartitionReader(t *testing.T) {
 	content := []byte("special content")
 	consumer := newTestConsumer(2)
 
-	startReader(ctx, t, clusterAddr, topicName, partitionID, consumer)
+	createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer)
 
 	writeClient := newKafkaProduceClient(t, clusterAddr)
 
@@ -48,7 +51,7 @@ func TestPartitionReader(t *testing.T) {
 	assert.Equal(t, [][]byte{content, content}, records)
 }
 
-func TestReader_ConsumerError(t *testing.T) {
+func TestPartitionReader_ConsumerError(t *testing.T) {
 	const (
 		topicName   = "test"
 		partitionID = 1
@@ -71,7 +74,7 @@ func TestReader_ConsumerError(t *testing.T) {
 		assert.Equal(t, "1", string(records[0].content))
 		return errors.New("consumer error")
 	})
-	startReader(ctx, t, clusterAddr, topicName, partitionID, consumer)
+	createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer)
 
 	// Write to Kafka.
 	writeClient := newKafkaProduceClient(t, clusterAddr)
@@ -105,7 +108,7 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, 1, topicName)
 
 		// Configure the reader to poll the "last produced offset" frequently.
-		reader := startReader(ctx, t, clusterAddr, topicName, partitionID, consumer,
+		reader := createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer,
 			withLastProducedOffsetPollInterval(100*time.Millisecond),
 			withRegistry(reg))
 
@@ -241,6 +244,250 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 	})
 }
 
+func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
+	const (
+		topicName   = "test"
+		partitionID = 1
+	)
+
+	ctx := context.Background()
+
+	t.Run("should immediately switch to Running state if partition is empty", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			_, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
+			consumer       = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+		)
+
+		// Create and start the reader. We expect the reader to start even if partition is empty.
+		reader := createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
+		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+	})
+
+	t.Run("should immediately switch to Running state if configured max lag is 0", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
+			consumer             = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+		)
+
+		// Mock Kafka to fail the Fetch request.
+		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			return nil, errors.New("mocked error"), true
+		})
+
+		// Produce some records.
+		writeClient := newKafkaProduceClient(t, clusterAddr)
+		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+		t.Log("produced 2 records")
+
+		// Create and start the reader. We expect the reader to start even if Fetch is failing.
+		reader := createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
+		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+	})
+
+	t.Run("should wait until max lag is honored", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
+			fetchRequestsCount   = atomic.NewInt64(0)
+			fetchShouldFail      = atomic.NewBool(true)
+			consumedRecordsCount = atomic.NewInt64(0)
+		)
+
+		consumer := consumerFunc(func(ctx context.Context, records []record) error {
+			consumedRecordsCount.Add(int64(len(records)))
+			return nil
+		})
+
+		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+			fetchRequestsCount.Inc()
+
+			if fetchShouldFail.Load() {
+				return nil, errors.New("mocked error"), true
+			}
+
+			return nil, nil, false
+		})
+
+		// Produce some records.
+		writeClient := newKafkaProduceClient(t, clusterAddr)
+		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+		t.Log("produced 2 records")
+
+		// Create and start the reader.
+		reader := createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
+		require.NoError(t, reader.StartAsync(ctx))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		})
+
+		// Wait until the Kafka cluster received few Fetch requests.
+		test.Poll(t, 5*time.Second, true, func() interface{} {
+			return fetchRequestsCount.Load() > 2
+		})
+
+		// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
+		// catched up yet, and it's still in Starting state.
+		assert.Equal(t, services.Starting, reader.State())
+		assert.Equal(t, int64(0), consumedRecordsCount.Load())
+
+		// Unblock the Fetch requests. Now they will succeed.
+		fetchShouldFail.Store(false)
+
+		// We expect the reader to catch up, and then switch to Running state.
+		test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+			return reader.State()
+		})
+
+		assert.Equal(t, int64(2), consumedRecordsCount.Load())
+	})
+
+	t.Run("should wait until max lag is honored and retry if a failure occurs when fetching last produced offset", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			cluster, clusterAddr     = testkafka.CreateCluster(t, partitionID+1, topicName)
+			listOffsetsRequestsCount = atomic.NewInt64(0)
+			listOffsetsShouldFail    = atomic.NewBool(true)
+			consumedRecordsCount     = atomic.NewInt64(0)
+		)
+
+		consumer := consumerFunc(func(ctx context.Context, records []record) error {
+			consumedRecordsCount.Add(int64(len(records)))
+			return nil
+		})
+
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+			listOffsetsRequestsCount.Inc()
+
+			if listOffsetsShouldFail.Load() {
+				return nil, errors.New("mocked error"), true
+			}
+
+			return nil, nil, false
+		})
+
+		// Produce some records.
+		writeClient := newKafkaProduceClient(t, clusterAddr)
+		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+		t.Log("produced 2 records")
+
+		// Create and start the reader.
+		reader := createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
+		require.NoError(t, reader.StartAsync(ctx))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		})
+
+		// Wait until the Kafka cluster received few ListOffsets requests.
+		test.Poll(t, 5*time.Second, true, func() interface{} {
+			return listOffsetsRequestsCount.Load() > 2
+		})
+
+		// Since the mocked Kafka cluster is configured to fail any ListOffsets request we expect the reader hasn't
+		// catched up yet, and it's still in Starting state.
+		assert.Equal(t, services.Starting, reader.State())
+		assert.Equal(t, int64(0), consumedRecordsCount.Load())
+
+		// Unblock the ListOffsets requests. Now they will succeed.
+		listOffsetsShouldFail.Store(false)
+
+		// We expect the reader to catch up, and then switch to Running state.
+		test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+			return reader.State()
+		})
+
+		assert.Equal(t, int64(2), consumedRecordsCount.Load())
+	})
+
+	t.Run("should not wait indefinitely if context is cancelled while fetching last produced offset", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			cluster, clusterAddr     = testkafka.CreateCluster(t, partitionID+1, topicName)
+			consumer                 = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+			listOffsetsRequestsCount = atomic.NewInt64(0)
+		)
+
+		// Mock Kafka to always fail the ListOffsets request.
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			listOffsetsRequestsCount.Inc()
+			return nil, errors.New("mocked error"), true
+		})
+
+		// Create and start the reader.
+		reader := createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
+
+		readerCtx, cancelReaderCtx := context.WithCancel(ctx)
+		require.NoError(t, reader.StartAsync(readerCtx))
+
+		// Wait until the Kafka cluster received at least 1 ListOffsets request.
+		test.Poll(t, 5*time.Second, true, func() interface{} {
+			return listOffsetsRequestsCount.Load() > 0
+		})
+
+		// Cancelling the context should cause the service to switch to a terminal state.
+		assert.Equal(t, services.Starting, reader.State())
+		cancelReaderCtx()
+
+		test.Poll(t, 5*time.Second, services.Failed, func() interface{} {
+			return reader.State()
+		})
+	})
+
+	t.Run("should not wait indefinitely if context is cancelled while fetching records", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
+			consumer             = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+			fetchRequestsCount   = atomic.NewInt64(0)
+		)
+
+		// Mock Kafka to always fail the Fetch request.
+		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			fetchRequestsCount.Inc()
+			return nil, errors.New("mocked error"), true
+		})
+
+		// Produce some records.
+		writeClient := newKafkaProduceClient(t, clusterAddr)
+		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+		t.Log("produced 2 records")
+
+		// Create and start the reader.
+		reader := createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
+
+		readerCtx, cancelReaderCtx := context.WithCancel(ctx)
+		require.NoError(t, reader.StartAsync(readerCtx))
+
+		// Wait until the Kafka cluster received at least 1 Fetch request.
+		test.Poll(t, 5*time.Second, true, func() interface{} {
+			return fetchRequestsCount.Load() > 0
+		})
+
+		// Cancelling the context should cause the service to switch to a terminal state.
+		assert.Equal(t, services.Starting, reader.State())
+		cancelReaderCtx()
+
+		test.Poll(t, 5*time.Second, services.Failed, func() interface{} {
+			return reader.State()
+		})
+	})
+}
+
 func newKafkaProduceClient(t *testing.T, addrs string) *kgo.Client {
 	writeClient, err := kgo.NewClient(
 		kgo.SeedBrokers(addrs),
@@ -285,16 +532,22 @@ func withLastProducedOffsetPollInterval(i time.Duration) func(cfg *readerTestCfg
 	}
 }
 
+func withMaxConsumerLagAtStartup(maxLag time.Duration) func(cfg *readerTestCfg) {
+	return func(cfg *readerTestCfg) {
+		cfg.kafka.MaxConsumerLagAtStartup = maxLag
+	}
+}
+
 func withRegistry(reg prometheus.Registerer) func(cfg *readerTestCfg) {
 	return func(cfg *readerTestCfg) {
 		cfg.registry = reg
 	}
 }
 
-func defaultReaderTestConfig(addr string, topicName string, partitionID int32, consumer recordConsumer) *readerTestCfg {
+func defaultReaderTestConfig(t *testing.T, addr string, topicName string, partitionID int32, consumer recordConsumer) *readerTestCfg {
 	return &readerTestCfg{
 		registry:       prometheus.NewPedanticRegistry(),
-		logger:         log.NewNopLogger(),
+		logger:         testutil.NewLogger(t),
 		kafka:          createTestKafkaConfig(addr, topicName),
 		partitionID:    partitionID,
 		consumer:       consumer,
@@ -302,14 +555,20 @@ func defaultReaderTestConfig(addr string, topicName string, partitionID int32, c
 	}
 }
 
-func startReader(ctx context.Context, t *testing.T, addr string, topicName string, partitionID int32, consumer recordConsumer, opts ...readerTestCfgOtp) *PartitionReader {
-	cfg := defaultReaderTestConfig(addr, topicName, partitionID, consumer)
+func createReader(t *testing.T, addr string, topicName string, partitionID int32, consumer recordConsumer, opts ...readerTestCfgOtp) *PartitionReader {
+	cfg := defaultReaderTestConfig(t, addr, topicName, partitionID, consumer)
 	for _, o := range opts {
 		o(cfg)
 	}
 	reader, err := newPartitionReader(cfg.kafka, cfg.partitionID, "test-group", cfg.consumer, cfg.logger, cfg.registry)
 	require.NoError(t, err)
 	reader.commitInterval = cfg.commitInterval
+
+	return reader
+}
+
+func createAndStartReader(ctx context.Context, t *testing.T, addr string, topicName string, partitionID int32, consumer recordConsumer, opts ...readerTestCfgOtp) *PartitionReader {
+	reader := createReader(t, addr, topicName, partitionID, consumer, opts...)
 
 	require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
 	t.Cleanup(func() {
@@ -335,7 +594,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 
 		consumer := newTestConsumer(3)
-		reader := startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+		reader := createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
 
 		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("1"))
 		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("2"))
@@ -349,7 +608,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 		recordsSentAfterShutdown := []byte("4")
 		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, recordsSentAfterShutdown)
 
-		startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+		createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
 
 		records, err := consumer.waitRecords(1, time.Second, 0)
 		assert.NoError(t, err)
@@ -367,7 +626,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 
 		consumer := newTestConsumer(4)
-		reader := startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+		reader := createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
 
 		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("1"))
 		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("2"))
@@ -378,7 +637,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
 		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("4"))
-		startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+		createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
 
 		// There should be only one record - the one produced after the shutdown.
 		// The offset of record "3" should have been committed at shutdown and the reader should have resumed from there.
@@ -396,7 +655,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 
 		consumer := newTestConsumer(4)
-		reader := startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+		reader := createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
 
 		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("1"))
 		produceRecord(ctx, t, newKafkaProduceClient(t, clusterAddr), topicName, partitionID, []byte("2"))
@@ -406,7 +665,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-		reader = startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+		reader = createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
 
 		// No new records since the last commit.
 		_, err = consumer.waitRecords(0, time.Second, 0)
@@ -414,7 +673,7 @@ func TestPartitionReader_Commit(t *testing.T) {
 
 		// Shut down without having consumed any records.
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-		_ = startReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
+		_ = createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer, withCommitInterval(commitInterval))
 
 		// No new records since the last commit (2 shutdowns ago).
 		_, err = consumer.waitRecords(0, time.Second, 0)

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -264,6 +264,9 @@ type TSDBConfig struct {
 	// HeadCompactionIntervalJitterEnabled is enabled by default, but allows to disable it in tests.
 	HeadCompactionIntervalJitterEnabled bool `yaml:"-"`
 
+	// HeadCompactionIntervalWhileStarting setting is hardcoded, but allowed to overwrite it in tests.
+	HeadCompactionIntervalWhileStarting time.Duration `yaml:"-"`
+
 	// TimelyHeadCompaction allows head compaction to happen when min block range can no longer be appended,
 	// without requiring 1.5x the chunk range worth of data in the head.
 	TimelyHeadCompaction bool `yaml:"timely_head_compaction_enabled" category:"experimental"`
@@ -314,6 +317,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.TimelyHeadCompaction, "blocks-storage.tsdb.timely-head-compaction-enabled", false, "Allows head compaction to happen when the min block range can no longer be appended, without requiring 1.5x the chunk range worth of data in the head.")
 
 	cfg.HeadCompactionIntervalJitterEnabled = true
+	cfg.HeadCompactionIntervalWhileStarting = 30 * time.Second
 }
 
 // Validate the config.

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/grafana/dskit/httpgrpc"
@@ -156,9 +157,12 @@ func NewVariableTicker(durations ...time.Duration) (func(), <-chan time.Time) {
 		}
 	}()
 
+	stopOnce := sync.Once{}
 	stop := func() {
-		ticker.Stop()
-		close(stopped)
+		stopOnce.Do(func() {
+			ticker.Stop()
+			close(stopped)
+		})
 	}
 
 	return stop, ticks

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -127,6 +127,11 @@ func NewVariableTicker(durations ...time.Duration) (func(), <-chan time.Time) {
 	ticker := time.NewTicker(durations[0])
 	durations = durations[1:]
 
+	// If there was only 1 duration we can simply return the built-in ticker.
+	if len(durations) == 0 {
+		return ticker.Stop, ticker.C
+	}
+
 	// Create a channel over which our ticks will be sent.
 	ticks := make(chan time.Time, 1)
 

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -204,3 +204,46 @@ func TestUnixSecondsJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestVariableTicker(t *testing.T) {
+	t.Run("should tick at configured durations", func(t *testing.T) {
+		t.Parallel()
+
+		startTime := time.Now()
+		stop, tickerChan := NewVariableTicker(time.Second, 2*time.Second)
+		t.Cleanup(stop)
+
+		// Capture the timing of 3 ticks.
+		var ticks []time.Time
+		for len(ticks) < 3 {
+			ticks = append(ticks, <-tickerChan)
+		}
+
+		tolerance := 250 * time.Millisecond
+		assert.InDelta(t, ticks[0].Sub(startTime).Seconds(), 1*time.Second.Seconds(), float64(tolerance))
+		assert.InDelta(t, ticks[1].Sub(startTime).Seconds(), 3*time.Second.Seconds(), float64(tolerance))
+		assert.InDelta(t, ticks[2].Sub(startTime).Seconds(), 5*time.Second.Seconds(), float64(tolerance))
+	})
+
+	t.Run("should close the channel on Close()", func(t *testing.T) {
+		t.Parallel()
+
+		for _, durations := range [][]time.Duration{{time.Second}, {time.Second, 2 * time.Second}} {
+			durations := durations
+
+			t.Run(fmt.Sprintf("durations: %v", durations), func(t *testing.T) {
+				t.Parallel()
+
+				stop, tickerChan := NewVariableTicker(durations...)
+				stop()
+
+				select {
+				case <-tickerChan:
+					t.Error("should not close the channel and not send any further tick")
+				case <-time.After(2 * time.Second):
+					// All good.
+				}
+			})
+		}
+	})
+}

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -14,6 +14,8 @@ import (
 	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 const (
@@ -206,6 +208,8 @@ func TestUnixSecondsJSON(t *testing.T) {
 }
 
 func TestVariableTicker(t *testing.T) {
+	test.VerifyNoLeak(t)
+
 	t.Run("should tick at configured durations", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -225,7 +225,7 @@ func TestVariableTicker(t *testing.T) {
 		assert.InDelta(t, ticks[2].Sub(startTime).Seconds(), 5*time.Second.Seconds(), float64(tolerance))
 	})
 
-	t.Run("should close the channel on Close()", func(t *testing.T) {
+	t.Run("should not close the channel on Close()", func(t *testing.T) {
 		t.Parallel()
 
 		for _, durations := range [][]time.Duration{{time.Second}, {time.Second, 2 * time.Second}} {


### PR DESCRIPTION
#### What this PR does

In this PR I'm proposing to have ingester replaying its partition at startup before it will join the ring and add itself as owner in the partition ring.

##### How it works

When an ingester starts up, either because it was scaled out or a restart occurred (crash, rescheduling, rolling update, …) it performs the following operations in order:

1. Replay its own partition from Kafka, until it’s guaranteed a maximum lag of X seconds
   - To guarantee a maximum lag of `-ingest-storage.max-consumer-lag-at-startup` (max lag) seconds, the ingester loops on:
     - Get the last committed offset and current local timestamp (CT) when last committed offset has been fetched (response got from Kafka)
     - Replay up until the last committed offset
     - Stop iterating if “now - CT” <= max lag
1. Start the ingesters lifecycler
   - This will either register the ingester to the ring, or switch the ingester from LEAVING to ACTIVE in case it was previously gracefully shutdown.
1. Start the partitions lifecycler
   - This will add the ingester to the partition’s owners in the partitions ring.

While replaying the partition, the ingester should do TSDB Head compaction and update metrics, so I've changed the order of internal services started in `Ingester.starting()` so that they're started before starting replaying partitions. Added unit tests assert on such ordering too.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
