### PR TITLE
querier: fix remote read error translation

### DIFF
--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -297,6 +297,11 @@ func (c *Client) RemoteReadChunks(metricName string, start, end time.Time) (_ *h
 			Matchers:         []*prompb.LabelMatcher{{Type: prompb.LabelMatcher_EQ, Name: labels.MetricName, Value: metricName}},
 			StartTimestampMs: start.UnixMilli(),
 			EndTimestampMs:   end.UnixMilli(),
+			Hints: &prompb.ReadHints{
+				StepMs:  1,
+				StartMs: start.UnixMilli(),
+				EndMs:   end.UnixMilli(),
+			},
 		}},
 		AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_STREAMED_XOR_CHUNKS},
 	}

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -250,7 +250,8 @@ func (c *Client) QueryRangeRaw(query string, start, end time.Time, step time.Dur
 	return c.DoGetBody(addr)
 }
 
-// RemoteRead runs a remote read request against the response.
+// RemoteRead runs a remote read query against the querier.
+// RemoteRead uses samples streaming. See RemoteReadChunks as well for chunks streaming.
 // RemoteRead returns the HTTP response with consumed body, the remote read protobuf response and an error.
 // In case the response is not a protobuf, the plaintext body content is returned instead of the protobuf message.
 func (c *Client) RemoteRead(metricName string, start, end time.Time) (_ *http.Response, _ *prompb.QueryResult, plaintextResponse []byte, _ error) {
@@ -288,7 +289,8 @@ func (c *Client) RemoteRead(metricName string, start, end time.Time) (_ *http.Re
 	}
 }
 
-// RemoteReadChunks runs a remote read request against the response.
+// RemoteReadChunks runs a remote read query against the querier.
+// RemoteReadChunks uses chunks streaming. See RemoteRead as well for samples streaming.
 // RemoteReadChunks returns the HTTP response with consumed body, the remote read protobuf response and an error.
 // In case the response is not a protobuf, the plaintext body content is returned instead of the protobuf message.
 func (c *Client) RemoteReadChunks(metricName string, start, end time.Time) (_ *http.Response, _ []prompb.ChunkedReadResponse, plaintextResponse []byte, _ error) {

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -272,7 +272,7 @@ func (c *Client) RemoteRead(metricName string, start, end time.Time) (_ *http.Re
 	}
 	switch contentType := resp.Header.Get("Content-Type"); contentType {
 	case "application/x-protobuf":
-		if encoding := resp.Header.Get("Content-Encoding") != "snappy"; encoding {
+		if encoding := resp.Header.Get("Content-Encoding"); encoding != "snappy" {
 			return resp, nil, nil, fmt.Errorf("remote read should return snappy-encoded protobuf; got %s %s instead", encoding, contentType)
 		}
 		queryResult, err := parseRemoteReadSamples(resp)

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -314,7 +314,7 @@ func (c *Client) RemoteReadChunks(metricName string, start, end time.Time) (_ *h
 		return resp, nil, nil, fmt.Errorf("making remote read request: %w", err)
 	}
 	switch contentType := resp.Header.Get("Content-Type"); contentType {
-	case "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse":
+	case api.ContentTypeRemoteReadStreamedChunks:
 		if encoding := resp.Header.Get("Content-Encoding"); encoding != "" {
 			return resp, nil, nil, fmt.Errorf("remote read should not return Content-Encoding; got %s %s instead", encoding, contentType)
 		}

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -7,22 +7,15 @@
 package integration
 
 import (
-	"bytes"
-	"context"
-	"errors"
-	"io"
 	"math/rand"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
-	"github.com/golang/snappy"
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
@@ -79,68 +72,27 @@ func runTestPushSeriesForQuerierRemoteRead(t *testing.T, c *e2emimir.Client, que
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	matcher, err := labels.NewMatcher(labels.MatchEqual, "__name__", seriesName)
+	startMs := now.Add(-1 * time.Minute)
+	endMs := now.Add(time.Minute)
+
+	client, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
-
-	startMs := now.Add(-1*time.Minute).Unix() * 1000
-	endMs := now.Add(time.Minute).Unix() * 1000
-
-	q, err := remote.ToQuery(startMs, endMs, []*labels.Matcher{matcher}, &storage.SelectHints{
-		Step:  1,
-		Start: startMs,
-		End:   endMs,
-	})
-	require.NoError(t, err)
-
-	req := &prompb.ReadRequest{
-		Queries:               []*prompb.Query{q},
-		AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_SAMPLES},
-	}
-
-	data, err := proto.Marshal(req)
-	require.NoError(t, err)
-	compressed := snappy.Encode(nil, data)
-
-	// Call the remote read API endpoint with a timeout.
-	httpReqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	httpReq, err := http.NewRequestWithContext(httpReqCtx, "POST", "http://"+querier.HTTPEndpoint()+"/prometheus/api/v1/read", bytes.NewReader(compressed))
-	require.NoError(t, err)
-	httpReq.Header.Set("X-Scope-OrgID", "user-1")
-	httpReq.Header.Add("Content-Encoding", "snappy")
-	httpReq.Header.Add("Accept-Encoding", "snappy")
-	httpReq.Header.Set("Content-Type", "application/x-protobuf")
-	httpReq.Header.Set("User-Agent", "Prometheus/1.8.2")
-	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
-
-	httpResp, err := http.DefaultClient.Do(httpReq)
-	require.NoError(t, err)
+	httpResp, resp, _, err := client.RemoteRead(seriesName, startMs, endMs)
 	require.Equal(t, http.StatusOK, httpResp.StatusCode)
-
-	compressed, err = io.ReadAll(httpResp.Body)
-	require.NoError(t, err)
-
-	uncompressed, err := snappy.Decode(nil, compressed)
-	require.NoError(t, err)
-
-	var resp prompb.ReadResponse
-	err = proto.Unmarshal(uncompressed, &resp)
 	require.NoError(t, err)
 
 	// Validate the returned remote read data matches what was written
-	require.Len(t, resp.Results, 1)
-	require.Len(t, resp.Results[0].Timeseries, 1)
-	require.Len(t, resp.Results[0].Timeseries[0].Labels, 1)
-	require.Equal(t, seriesName, resp.Results[0].Timeseries[0].Labels[0].GetValue())
-	isSeriesFloat := len(resp.Results[0].Timeseries[0].Samples) == 1
-	isSeriesHistogram := len(resp.Results[0].Timeseries[0].Histograms) == 1
+	require.Len(t, resp.Timeseries, 1)
+	require.Len(t, resp.Timeseries[0].Labels, 1)
+	require.Equal(t, seriesName, resp.Timeseries[0].Labels[0].GetValue())
+	isSeriesFloat := len(resp.Timeseries[0].Samples) == 1
+	isSeriesHistogram := len(resp.Timeseries[0].Histograms) == 1
 	require.Equal(t, isSeriesFloat, !isSeriesHistogram)
 	if isSeriesFloat {
-		require.Equal(t, int64(expectedVectors[0].Timestamp), resp.Results[0].Timeseries[0].Samples[0].Timestamp)
-		require.Equal(t, float64(expectedVectors[0].Value), resp.Results[0].Timeseries[0].Samples[0].Value)
+		require.Equal(t, int64(expectedVectors[0].Timestamp), resp.Timeseries[0].Samples[0].Timestamp)
+		require.Equal(t, float64(expectedVectors[0].Value), resp.Timeseries[0].Samples[0].Value)
 	} else if isSeriesHistogram {
-		require.Equal(t, expectedVectors[0].Histogram, mimirpb.FromHistogramToPromHistogram(remote.HistogramProtoToHistogram(resp.Results[0].Timeseries[0].Histograms[0])))
+		require.Equal(t, expectedVectors[0].Histogram, mimirpb.FromHistogramToPromHistogram(remote.HistogramProtoToHistogram(resp.Timeseries[0].Histograms[0])))
 	}
 }
 
@@ -228,16 +180,16 @@ func TestQuerierStreamingRemoteRead(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate the series
-			startMs := now.Add(-time.Minute).Unix() * 1000
-			endMs := now.Add(time.Minute).Unix() * 1000
+			startMs := now.Add(-time.Minute)
+			endMs := now.Add(time.Minute)
 
 			var samples []prompb.Sample
 			if tc.floats != nil {
-				samples = tc.floats(startMs, endMs)
+				samples = tc.floats(startMs.UnixMilli(), endMs.UnixMilli())
 			}
 			var histograms []prompb.Histogram
 			if tc.histograms != nil {
-				histograms = tc.histograms(startMs, endMs)
+				histograms = tc.histograms(startMs.UnixMilli(), endMs.UnixMilli())
 			}
 
 			var series []prompb.TimeSeries
@@ -253,52 +205,11 @@ func TestQuerierStreamingRemoteRead(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, res.StatusCode)
 
-			matcher, err := labels.NewMatcher(labels.MatchEqual, "__name__", "series_1")
+			client, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 			require.NoError(t, err)
-
-			q, err := remote.ToQuery(startMs, endMs, []*labels.Matcher{matcher}, &storage.SelectHints{
-				Step:  1,
-				Start: startMs,
-				End:   endMs,
-			})
-			require.NoError(t, err)
-
-			req := &prompb.ReadRequest{
-				Queries:               []*prompb.Query{q},
-				AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_STREAMED_XOR_CHUNKS},
-			}
-
-			data, err := proto.Marshal(req)
-			require.NoError(t, err)
-			compressed := snappy.Encode(nil, data)
-
-			// Call the remote read API endpoint with a timeout.
-			httpReqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-
-			httpReq, err := http.NewRequestWithContext(httpReqCtx, "POST", "http://"+querier.HTTPEndpoint()+"/prometheus/api/v1/read", bytes.NewReader(compressed))
-			require.NoError(t, err)
-			httpReq.Header.Add("Accept-Encoding", "snappy")
-			httpReq.Header.Set("X-Scope-OrgID", "user-1")
-			httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
-
-			httpResp, err := http.DefaultClient.Do(httpReq)
-			require.NoError(t, err)
+			httpResp, results, _, err := client.RemoteReadChunks("series_1", startMs, endMs)
 			require.Equal(t, http.StatusOK, httpResp.StatusCode)
-
-			// Fetch streaming response
-			stream := remote.NewChunkedReader(httpResp.Body, remote.DefaultChunkedReadLimit, nil)
-
-			var results []prompb.ChunkedReadResponse
-			for {
-				var res prompb.ChunkedReadResponse
-				err := stream.NextProto(&res)
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				require.NoError(t, err)
-				results = append(results, res)
-			}
+			require.NoError(t, err)
 
 			// Validate the returned remote read data
 			sampleIdx := 0

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -648,6 +648,15 @@ overrides:
 			expBody:       mimirquerier.NewMaxQueryLengthError(time.Hour*24*32, 720*time.Hour).Error(),
 		},
 		{
+			name: "query remote read time range exceeds the limit (streaming chunks)",
+			query: func(c *e2emimir.Client) (*http.Response, []byte, error) {
+				httpR, _, respBytes, err := c.RemoteReadChunks(`metric`, now.Add(-time.Hour*24*32), now)
+				return httpR, respBytes, err
+			},
+			expStatusCode: http.StatusBadRequest,
+			expBody:       mimirquerier.NewMaxQueryLengthError(time.Hour*24*32, 720*time.Hour).Error(),
+		},
+		{
 			name: "execution error",
 			query: func(c *e2emimir.Client) (*http.Response, []byte, error) {
 				return c.QueryRangeRaw(`sum by (group_1) (metric{unique=~"0|1|2|3"}) * on(group_1) group_right(unique) (sum by (group_1,unique) (metric{unique=~"0|1|2|3"}))`, now.Add(-time.Minute), now, time.Minute)

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -538,10 +539,17 @@ overrides:
 	cQuerier, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "fake")
 	require.NoError(t, err)
 
+	queryClients := map[string]*e2emimir.Client{
+		"query-frontend":               cQueryFrontend,
+		"query-frontend with sharding": cQueryFrontendWithQuerySharding,
+		"querier":                      cQuerier,
+	}
+
 	for _, tc := range []struct {
 		name          string
 		query         func(*e2emimir.Client) (*http.Response, []byte, error)
 		expStatusCode int
+		expJSON       string
 		expBody       string
 	}{
 		{
@@ -550,7 +558,7 @@ overrides:
 				return c.QueryRangeRaw("unknown", now.Add(-time.Hour*24), now, time.Second)
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)", "errorType":"bad_data", "status":"error"}`,
+			expJSON:       `{"error":"exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)", "errorType":"bad_data", "status":"error"}`,
 		},
 		{
 			name: "negative step",
@@ -558,7 +566,7 @@ overrides:
 				return c.QueryRangeRaw("unknown", now.Add(-time.Hour), now, -time.Minute)
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"invalid parameter \"step\": zero or negative query resolution step widths are not accepted. Try a positive integer", "errorType":"bad_data", "status":"error"}`,
+			expJSON:       `{"error":"invalid parameter \"step\": zero or negative query resolution step widths are not accepted. Try a positive integer", "errorType":"bad_data", "status":"error"}`,
 		},
 		{
 			name: "unknown function",
@@ -566,7 +574,7 @@ overrides:
 				return c.QueryRangeRaw("unknown(up)", now.Add(-time.Hour), now, time.Minute)
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"invalid parameter \"query\": 1:1: parse error: unknown function with name \"unknown\"", "errorType":"bad_data", "status":"error"}`,
+			expJSON:       `{"error":"invalid parameter \"query\": 1:1: parse error: unknown function with name \"unknown\"", "errorType":"bad_data", "status":"error"}`,
 		},
 		{
 			name: "range vector instead of instant vector",
@@ -574,7 +582,7 @@ overrides:
 				return c.QueryRangeRaw(`sum by(grpc_method)(grpc_server_handled_total{job="cortex-dedicated-06/etcd"}[1m])`, now.Add(-time.Hour), now, time.Minute)
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"invalid parameter \"query\": 1:21: parse error: expected type instant vector in aggregation expression, got range vector", "errorType":"bad_data", "status":"error"}`,
+			expJSON:       `{"error":"invalid parameter \"query\": 1:21: parse error: expected type instant vector in aggregation expression, got range vector", "errorType":"bad_data", "status":"error"}`,
 		},
 		{
 			name: "start after end",
@@ -582,7 +590,7 @@ overrides:
 				return c.QueryRangeRaw("unknown", now, now.Add(-time.Hour), time.Minute)
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"invalid parameter \"end\": end timestamp must not be before start time", "errorType":"bad_data", "status":"error"}`,
+			expJSON:       `{"error":"invalid parameter \"end\": end timestamp must not be before start time", "errorType":"bad_data", "status":"error"}`,
 		},
 		{
 			name: "wrong duration specified in step",
@@ -597,7 +605,7 @@ overrides:
 				))
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"invalid parameter \"step\": cannot parse \"123notafloat\" to a valid duration", "errorType":"bad_data", "status":"error"}`,
+			expJSON:       `{"error":"invalid parameter \"step\": cannot parse \"123notafloat\" to a valid duration", "errorType":"bad_data", "status":"error"}`,
 		},
 		{
 			name: "wrong timestamp in start",
@@ -612,7 +620,7 @@ overrides:
 				))
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"invalid parameter \"start\": cannot parse \"depths-of-time\" to a valid timestamp", "errorType":"bad_data", "status":"error"}`,
+			expJSON:       `{"error":"invalid parameter \"start\": cannot parse \"depths-of-time\" to a valid timestamp", "errorType":"bad_data", "status":"error"}`,
 		},
 		{
 			name: "max samples limit hit",
@@ -620,7 +628,7 @@ overrides:
 				return c.QueryRangeRaw(`metric`, now.Add(-time.Minute), now, time.Minute)
 			},
 			expStatusCode: http.StatusUnprocessableEntity,
-			expBody:       `{"error":"query processing would load too many samples into memory in query execution", "errorType":"execution", "status":"error"}`,
+			expJSON:       `{"error":"query processing would load too many samples into memory in query execution", "errorType":"execution", "status":"error"}`,
 		},
 		{
 			name: "query time range exceeds the limit",
@@ -628,7 +636,16 @@ overrides:
 				return c.QueryRangeRaw(`sum_over_time(metric[31d:1s])`, now.Add(-time.Minute), now, time.Minute)
 			},
 			expStatusCode: http.StatusUnprocessableEntity,
-			expBody:       fmt.Sprintf(`{"error":"expanding series: %s", "errorType":"execution", "status":"error"}`, mimirquerier.NewMaxQueryLengthError((744*time.Hour)+(6*time.Minute), 720*time.Hour)),
+			expJSON:       fmt.Sprintf(`{"error":"expanding series: %s", "errorType":"execution", "status":"error"}`, mimirquerier.NewMaxQueryLengthError((744*time.Hour)+(6*time.Minute), 720*time.Hour)),
+		},
+		{
+			name: "query remote read time range exceeds the limit",
+			query: func(c *e2emimir.Client) (*http.Response, []byte, error) {
+				httpR, _, respBytes, err := c.RemoteRead(`metric`, now.Add(-time.Hour*24*32), now)
+				return httpR, respBytes, err
+			},
+			expStatusCode: http.StatusBadRequest,
+			expBody:       mimirquerier.NewMaxQueryLengthError(time.Hour*24*32, 720*time.Hour).Error(),
 		},
 		{
 			name: "execution error",
@@ -636,7 +653,7 @@ overrides:
 				return c.QueryRangeRaw(`sum by (group_1) (metric{unique=~"0|1|2|3"}) * on(group_1) group_right(unique) (sum by (group_1,unique) (metric{unique=~"0|1|2|3"}))`, now.Add(-time.Minute), now, time.Minute)
 			},
 			expStatusCode: http.StatusUnprocessableEntity,
-			expBody:       `{"error":"multiple matches for labels: grouping labels must ensure unique matches", "errorType":"execution", "status":"error"}`,
+			expJSON:       `{"error":"multiple matches for labels: grouping labels must ensure unique matches", "errorType":"execution", "status":"error"}`,
 		},
 		{
 			name: "range query with range vector",
@@ -644,24 +661,24 @@ overrides:
 				return c.QueryRangeRaw(`(sum(rate(up[1m])))[5m:]`, now.Add(-time.Hour), now, time.Minute)
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"invalid parameter \"query\": invalid expression type \"range vector\" for range query, must be Scalar or instant Vector", "errorType":"bad_data", "status":"error"}`,
+			expJSON:       `{"error":"invalid parameter \"query\": invalid expression type \"range vector\" for range query, must be Scalar or instant Vector", "errorType":"bad_data", "status":"error"}`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, body, err := tc.query(cQuerier)
-			require.NoError(t, err)
-			assert.Equal(t, tc.expStatusCode, resp.StatusCode, "querier returns unexpected statusCode")
-			assert.JSONEq(t, tc.expBody, string(body), "querier returns unexpected body")
+			if tc.expBody != "" && tc.expJSON != "" {
+				t.Fatalf("expected only one of expBody or expJSON to be set")
+			}
 
-			resp, body, err = tc.query(cQueryFrontend)
-			require.NoError(t, err)
-			assert.Equal(t, tc.expStatusCode, resp.StatusCode, "query-frontend returns unexpected statusCode")
-			assert.JSONEq(t, tc.expBody, string(body), "query-frontend returns unexpected body")
-
-			resp, body, err = tc.query(cQueryFrontendWithQuerySharding)
-			require.NoError(t, err)
-			assert.Equal(t, tc.expStatusCode, resp.StatusCode, "query-frontend with query-sharding returns unexpected statusCode")
-			assert.JSONEq(t, tc.expBody, string(body), "query-frontend with query-sharding returns unexpected body")
+			for name, c := range queryClients {
+				resp, body, err := tc.query(c)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expStatusCode, resp.StatusCode, "querier returns unexpected statusCode for "+name)
+				if tc.expJSON != "" {
+					assert.JSONEq(t, tc.expJSON, string(body), "querier returns unexpected body for "+name)
+				} else {
+					assert.Equal(t, tc.expBody, strings.TrimSpace(string(body)), "querier returns unexpected body for "+name)
+				}
+			}
 		})
 	}
 }

--- a/pkg/querier/api/api.go
+++ b/pkg/querier/api/api.go
@@ -5,7 +5,7 @@ package api
 import "github.com/prometheus/prometheus/model/labels"
 
 // ContentTypeRemoteReadStreamedChunks is taken from the prometheus protobuf definitions documentation.
-// At the time of writing those are at github.com/prometheus/prometheus/prompb/remote.proto.
+// See: https://github.com/prometheus/prometheus/blob/d9d51c565c622cdc7d626d3e7569652bc28abe15/prompb/remote.proto#L48
 const ContentTypeRemoteReadStreamedChunks = "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse"
 
 type LabelValuesCardinalityResponse struct {

--- a/pkg/querier/api/api.go
+++ b/pkg/querier/api/api.go
@@ -4,6 +4,10 @@ package api
 
 import "github.com/prometheus/prometheus/model/labels"
 
+// ContentTypeRemoteReadStreamedChunks is taken from the prometheus protobuf definitions documentation.
+// At the time of writing those are at github.com/prometheus/prometheus/prompb/remote.proto.
+const ContentTypeRemoteReadStreamedChunks = "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse"
+
 type LabelValuesCardinalityResponse struct {
 	SeriesCountTotal uint64                  `json:"series_count_total"`
 	Labels           []LabelNamesCardinality `json:"labels"`

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -153,7 +153,7 @@ func remoteReadStreamedXORChunks(
 			if code/100 != 4 {
 				level.Error(logger).Log("msg", "error while processing remote read request", "err", err)
 			}
-			http.Error(w, err.Error(), code) // change the Content-Type to text/plain and return a human-readable error message
+			http.Error(w, err.Error(), code)
 			return
 		}
 	}

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -138,8 +138,7 @@ func remoteReadStreamedXORChunks(
 		http.Error(w, "internal http.ResponseWriter does not implement http.Flusher interface", http.StatusBadRequest)
 		return
 	}
-
-	w.Header().Set("Content-Type", "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse")
+	w.Header().Set("Content-Type", api.ContentTypeRemoteReadStreamedChunks)
 
 	for i, qr := range req.Queries {
 		if err := processReadStreamedQueryRequest(ctx, i, qr, q, w, f, maxBytesInFrame); err != nil {

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -12,13 +12,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/util/annotations"
+
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	prom_remote "github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -26,6 +30,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/storage/series"
 	"github.com/grafana/mimir/pkg/util/test"
 )
@@ -65,6 +70,35 @@ func (m mockChunkQuerier) Select(_ context.Context, _ bool, sp *storage.SelectHi
 		panic("mockChunkQuerier: select params must be set")
 	}
 	return storage.NewSeriesSetToChunkSet(m.seriesSet)
+}
+
+type partiallyFailingSeriesSet struct {
+	ss        storage.SeriesSet
+	failAfter int
+	err       error
+}
+
+func (p *partiallyFailingSeriesSet) Next() bool {
+	if p.failAfter == 0 {
+		return false
+	}
+	p.failAfter--
+	return p.ss.Next()
+}
+
+func (p *partiallyFailingSeriesSet) At() storage.Series {
+	return p.ss.At()
+}
+
+func (p *partiallyFailingSeriesSet) Err() error {
+	if p.failAfter == 0 {
+		return p.err
+	}
+	return p.ss.Err()
+}
+
+func (p *partiallyFailingSeriesSet) Warnings() annotations.Annotations {
+	return p.ss.Warnings()
 }
 
 func TestSampledRemoteRead(t *testing.T) {
@@ -417,4 +451,140 @@ func getIndexedChunk(idx, samplesCount int, encoding chunkenc.Encoding) []byte {
 		}
 	}
 	return enc.Bytes()
+}
+
+func TestRemoteReadErrorParsing(t *testing.T) {
+	someSeries := series.NewConcreteSeriesSetFromSortedSeries([]storage.Series{
+		series.NewConcreteSeries(
+			labels.FromStrings("foo", "bar"),
+			[]model.SamplePair{{Timestamp: 0, Value: 0}, {Timestamp: 1, Value: 1}, {Timestamp: 2, Value: 2}, {Timestamp: 3, Value: 3}},
+			[]mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(4, test.GenerateTestHistogram(4))},
+		),
+		series.NewConcreteSeries(
+			labels.FromStrings("foo", "baz"),
+			[]model.SamplePair{{Timestamp: 0, Value: 0}, {Timestamp: 1, Value: 1}, {Timestamp: 2, Value: 2}, {Timestamp: 3, Value: 3}},
+			[]mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(4, test.GenerateTestHistogram(4))},
+		),
+	})
+
+	testCases := map[string]struct {
+		getQuerierErr error
+		seriesSet     storage.SeriesSet
+
+		expectedStatusCode  int
+		expectedContentType string
+	}{
+		"no error": {
+			getQuerierErr: nil,
+			seriesSet:     someSeries,
+
+			expectedStatusCode: 200,
+		},
+		"empty series set": {
+			getQuerierErr: nil,
+			seriesSet:     storage.ErrSeriesSet(nil),
+
+			expectedStatusCode: 200,
+		},
+		"validation error": {
+			getQuerierErr: NewMaxQueryLengthError(time.Hour, time.Minute),
+			seriesSet:     someSeries,
+
+			expectedStatusCode:  400,
+			expectedContentType: "text/plain; charset=utf-8",
+		},
+		"validation error while iterating samples": {
+			getQuerierErr: nil,
+			seriesSet:     &partiallyFailingSeriesSet{ss: someSeries, failAfter: 1, err: NewMaxQueryLengthError(time.Hour, time.Minute)},
+
+			expectedStatusCode:  400,
+			expectedContentType: "text/plain; charset=utf-8",
+		},
+		"promQL storage error": {
+			getQuerierErr: promql.ErrStorage{Err: errors.New("cannot reach ingesters")},
+			seriesSet:     nil,
+
+			expectedStatusCode:  500,
+			expectedContentType: "text/plain; charset=utf-8",
+		},
+		"promQL storage error while iterating samples": {
+			getQuerierErr: nil,
+			seriesSet:     &partiallyFailingSeriesSet{ss: someSeries, failAfter: 1, err: errors.New("cannot reach ingesters")},
+
+			expectedStatusCode:  500,
+			expectedContentType: "text/plain; charset=utf-8",
+		},
+	}
+
+	t.Run("samples", func(t *testing.T) {
+		for tn, tc := range testCases {
+			t.Run(tn, func(t *testing.T) {
+				q := &mockSampleAndChunkQueryable{
+					queryableFn: func(mint, maxt int64) (storage.Querier, error) {
+						return mockQuerier{
+							seriesSet: tc.seriesSet,
+						}, tc.getQuerierErr
+					},
+				}
+				handler := remoteReadHandler(q, 1024*1024, log.NewNopLogger())
+
+				requestBody, err := proto.Marshal(&client.ReadRequest{
+					Queries: []*client.QueryRequest{
+						{StartTimestampMs: 0, EndTimestampMs: 10},
+					},
+					AcceptedResponseTypes: []client.ReadRequest_ResponseType{client.SAMPLES},
+				})
+				require.NoError(t, err)
+				requestBody = snappy.Encode(nil, requestBody)
+				request, err := http.NewRequest(http.MethodPost, "/api/v1/read", bytes.NewReader(requestBody))
+				require.NoError(t, err)
+				request.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
+
+				recorder := httptest.NewRecorder()
+				handler.ServeHTTP(recorder, request)
+
+				require.Equal(t, tc.expectedStatusCode, recorder.Result().StatusCode)
+				if tc.expectedContentType == "" {
+					tc.expectedContentType = "application/x-protobuf"
+				}
+				require.Equal(t, tc.expectedContentType, recorder.Result().Header.Get("Content-Type"))
+			})
+		}
+	})
+
+	t.Run("streaming_chunks", func(t *testing.T) {
+		for tn, tc := range testCases {
+			t.Run(tn, func(t *testing.T) {
+				q := &mockSampleAndChunkQueryable{
+					chunkQueryableFn: func(mint, maxt int64) (storage.ChunkQuerier, error) {
+						return mockChunkQuerier{
+							seriesSet: tc.seriesSet,
+						}, tc.getQuerierErr
+					},
+				}
+				handler := remoteReadHandler(q, 1024*1024, log.NewNopLogger())
+
+				requestBody, err := proto.Marshal(&client.ReadRequest{
+					Queries: []*client.QueryRequest{
+						{StartTimestampMs: 0, EndTimestampMs: 10},
+					},
+					AcceptedResponseTypes: []client.ReadRequest_ResponseType{client.STREAMED_XOR_CHUNKS},
+				})
+				require.NoError(t, err)
+				requestBody = snappy.Encode(nil, requestBody)
+				request, err := http.NewRequest(http.MethodPost, "/api/v1/read", bytes.NewReader(requestBody))
+				require.NoError(t, err)
+				request.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
+
+				recorder := httptest.NewRecorder()
+				handler.ServeHTTP(recorder, request)
+
+				require.Equal(t, tc.expectedStatusCode, recorder.Result().StatusCode)
+				if tc.expectedContentType == "" {
+					tc.expectedContentType = api.ContentTypeRemoteReadStreamedChunks
+				}
+				require.Equal(t, tc.expectedContentType, recorder.Result().Header.Get("Content-Type"))
+			})
+		}
+	})
 }

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -19,13 +19,12 @@ import (
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/util/annotations"
-
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	prom_remote "github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/ingester/client"

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -327,7 +327,7 @@ func TestStreamedRemoteRead(t *testing.T) {
 			handler.ServeHTTP(recorder, request)
 
 			require.Equal(t, 200, recorder.Result().StatusCode)
-			require.Equal(t, []string{"application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse"}, recorder.Result().Header["Content-Type"])
+			require.Equal(t, []string{api.ContentTypeRemoteReadStreamedChunks}, recorder.Result().Header["Content-Type"])
 
 			stream := prom_remote.NewChunkedReader(recorder.Result().Body, prom_remote.DefaultChunkedReadLimit, nil)
 


### PR DESCRIPTION
### Problem

Currently remote-read has conflicting behaviours:
* when returning samples all internal errors are translated to HTTP 400
* when returning chunks all internal errors are translated to HTTP 500

### PR description

This PR unifies error handling such that:
* all validation errors will return HTTP 400
* all promQL storage errors and all other errors will return HTTP 500

It also adds tests for this in two places
* integration tests: this comes with moving of some code to query remote read from an endpoint
* unit tests in pkg/querier

The PR also moves the content type string to pkg/querier/api since it's a complicated string that was repeated in a few places.

### Note to reviewers


I couldn't really understand the [Prometheus docs](https://prometheus.io/docs/prometheus/latest/querying/remote_read_api/) in terms of the expected return codes and content type. The docs give a JSON example as the structure for the API, but the remote read API is based on protocol buffers. At the same time the protocol buffers do not have fields for errors. So I'm still not sure if we're compliant with the docs page.

Because of the same there are some discrepancies with HTTP status codes on the regular query and query_range APIs - they return HTTP 422 for hit limits whereas remote read returns HTTP 400
