### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,3 +26,4 @@ CHANGELOG.md
 go.mod @grafana/mimir-maintainers @grafanabot
 go.sum @grafana/mimir-maintainers @grafanabot
 /vendor/ @grafana/mimir-maintainers @grafanabot
+/vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers @grafanabot


### PR DESCRIPTION
#### What this PR does

This commit updates CODEOWNERS to add
@grafana/mimir-ruler-and-alertmanager-maintainers as codeowners for vendor/github.com/prometheus/alertmanager. This will give the Alerting team permissions to approve and merge updates to Alertmanager without having to be in the larger Mimir maintainers group.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
