### PR TITLE
helm: Allow passing port of kube-state-metrics service to meta-monitoring

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -56,13 +56,14 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Gateway: make Ingress/Route host templateable. #7218
 * [ENHANCEMENT] Make the PSP template configurable via `rbac.podSecurityPolicy`. #7190
 * [ENHANCEMENT] Recording rules: add native histogram recording rules to `cortex_request_duration_seconds`. #7528
+* [ENHANCEMENT] Make the port used in ServiceMonitor for kube-state-metrics configurable. #7507
 * [BUGFIX] Metamonitoring: update dashboards to drop unsupported `step` parameter in targets. #7157
 * [BUGFIX] Recording rules: drop rules for metrics removed in 2.0: `cortex_memcache_request_duration_seconds` and `cortex_cache_request_duration_seconds`. #7514
 * [BUGFIX] Store-gateway: setting "resources.requests.memory" with a quantity that used power-of-ten SI suffix, caused an error. #7506
 
 ## 5.2.2
 
-* [BUGFix] Updated GEM image to v2.11.2. #7555
+* [BUGFIX] Updated GEM image to v2.11.2. #7555
 
 ## 5.2.1
 

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/kube-state-metrics-servmon.yaml
@@ -17,7 +17,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: http-metrics
+    - port: {{ $.Values.metaMonitoring.grafanaAgent.metrics.scrapeK8s.kubeStateMetrics.service.port }}
       metricRelabelings:
         - action: keep
           regex: "(^|.*;){{ include "mimir.resourceName" (dict "ctx"  $) }}.*"

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3263,6 +3263,8 @@ metaMonitoring:
           namespace: kube-system
           labelSelectors:
             app.kubernetes.io/name: kube-state-metrics
+          service:
+            port: http-metrics
 
       # -- The scrape interval for all ServiceMonitors.
       scrapeInterval: 60s


### PR DESCRIPTION
#### What this PR does

As outlined in #7474, kube-state-metrics, which runs within the k8s cluster, may not expose its service on a (named) port, that Mimir expects. This PR updates the templates in a way, so an operator could overwrite the port, used in kube-state-metrics in the values.

#### Which issue(s) this PR fixes or relates to

Fixes #7474

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
