### PR TITLE
Make owned series service in ingester work with partitions ring.

### DIFF
--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -65,7 +66,7 @@ func TestIngester_QueryStream_IngestStorageReadConsistency(t *testing.T) {
 			// Create the ingester.
 			overrides, err := validation.NewOverrides(limits, nil)
 			require.NoError(t, err)
-			ingester, kafkaCluster := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
+			ingester, kafkaCluster, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
 
 			// Mock the Kafka cluster to fail the Fetch operation until we unblock it later in the test.
 			// If read consistency is "eventual" then these failures shouldn't affect queries, but if it's set
@@ -153,7 +154,7 @@ func TestIngester_PrepareShutdownHandler_IngestStorageSupport(t *testing.T) {
 
 	// Start ingester.
 	cfg := defaultIngesterTestConfig(t)
-	ingester, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
+	ingester, _, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, ingester))
 	t.Cleanup(func() {
@@ -218,7 +219,7 @@ func TestIngester_PreparePartitionDownscaleHandler(t *testing.T) {
 
 	setup := func(t *testing.T, cfg Config) (*Ingester, *ring.PartitionRingWatcher) {
 		// Start ingester.
-		ingester, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, prometheus.NewPedanticRegistry())
+		ingester, _, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, prometheus.NewPedanticRegistry())
 		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(ctx, ingester))
 		t.Cleanup(func() {
@@ -347,7 +348,7 @@ func TestIngester_ShouldNotCreatePartitionIfThereIsShutdownMarker(t *testing.T) 
 	require.NoError(t, err)
 
 	cfg := defaultIngesterTestConfig(t)
-	ingester, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, prometheus.NewPedanticRegistry())
+	ingester, _, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, prometheus.NewPedanticRegistry())
 
 	// Create the shutdown marker.
 	require.NoError(t, os.MkdirAll(cfg.BlocksStorageConfig.TSDB.Dir, os.ModePerm))
@@ -376,21 +377,23 @@ func TestIngester_ShouldNotCreatePartitionIfThereIsShutdownMarker(t *testing.T) 
 	assert.Empty(t, watcher.PartitionRing().PartitionOwnerIDs(ingester.ingestPartitionID))
 }
 
-func createTestIngesterWithIngestStorage(t testing.TB, ingesterCfg *Config, overrides *validation.Overrides, reg prometheus.Registerer) (*Ingester, *kfake.Cluster) {
-	var (
-		dataDir   = t.TempDir()
-		bucketDir = t.TempDir()
-	)
+// Returned ingester and ring watcher are NOT started.
+func createTestIngesterWithIngestStorage(t testing.TB, ingesterCfg *Config, overrides *validation.Overrides, reg prometheus.Registerer) (*Ingester, *kfake.Cluster, *ring.PartitionRingWatcher) {
+	defaultIngesterConfig := defaultIngesterTestConfig(t)
 
 	ingesterCfg.IngestStorageConfig.Enabled = true
 	ingesterCfg.IngestStorageConfig.KafkaConfig.Topic = "mimir"
 	ingesterCfg.IngestStorageConfig.KafkaConfig.LastProducedOffsetPollInterval = 100 * time.Millisecond
 
 	// Create the partition ring store.
-	kv, closer := consul.NewInMemoryClient(ring.GetPartitionRingCodec(), log.NewNopLogger(), nil)
-	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+	kv := ingesterCfg.IngesterPartitionRing.kvMock
+	if kv == nil {
+		var closer io.Closer
+		kv, closer = consul.NewInMemoryClient(ring.GetPartitionRingCodec(), log.NewNopLogger(), nil)
+		t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+		ingesterCfg.IngesterPartitionRing.kvMock = kv
+	}
 
-	ingesterCfg.IngesterPartitionRing.kvMock = kv
 	ingesterCfg.IngesterPartitionRing.MinOwnersDuration = 0
 	ingesterCfg.IngesterPartitionRing.lifecyclerPollingInterval = 10 * time.Millisecond
 
@@ -398,19 +401,23 @@ func createTestIngesterWithIngestStorage(t testing.TB, ingesterCfg *Config, over
 	kafkaCluster, kafkaAddr := testkafka.CreateCluster(t, 10, ingesterCfg.IngestStorageConfig.KafkaConfig.Topic)
 	ingesterCfg.IngestStorageConfig.KafkaConfig.Address = kafkaAddr
 
-	// The ingest storage requires the ingester ID to have a well known format.
-	ingesterCfg.IngesterRing.InstanceID = "ingester-zone-a-0"
+	if ingesterCfg.IngesterRing.InstanceID == "" || ingesterCfg.IngesterRing.InstanceID == defaultIngesterConfig.IngesterRing.InstanceID {
+		// The ingest storage requires the ingester ID to have a well known format.
+		ingesterCfg.IngesterRing.InstanceID = "ingester-zone-a-0"
+	}
 
-	ingesterCfg.BlocksStorageConfig.TSDB.Dir = dataDir
+	if ingesterCfg.BlocksStorageConfig.TSDB.Dir == "" || ingesterCfg.BlocksStorageConfig.TSDB.Dir == defaultIngesterConfig.BlocksStorageConfig.TSDB.Dir { // Overwrite default values to temp dir.
+		ingesterCfg.BlocksStorageConfig.TSDB.Dir = t.TempDir()
+	}
 	ingesterCfg.BlocksStorageConfig.Bucket.Backend = "filesystem"
-	ingesterCfg.BlocksStorageConfig.Bucket.Filesystem.Directory = bucketDir
+	ingesterCfg.BlocksStorageConfig.Bucket.Filesystem.Directory = t.TempDir()
 
 	// Disable TSDB head compaction jitter to have predictable tests.
 	ingesterCfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalJitterEnabled = false
 
-	prw := ring.NewPartitionRingWatcher("ingester", "partition-ring", kv, log.NewNopLogger(), nil)
+	prw := ring.NewPartitionRingWatcher(PartitionRingName, PartitionRingKey, kv, log.NewNopLogger(), nil)
 	ingester, err := New(*ingesterCfg, overrides, nil, prw, nil, reg, util_test.NewTestingLogger(t))
 	require.NoError(t, err)
 
-	return ingester, kafkaCluster
+	return ingester, kafkaCluster, prw
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -4580,6 +4580,10 @@ func prepareIngesterWithBlocksStorageAndLimits(t testing.TB, ingesterCfg Config,
 }
 
 func prepareIngesterWithBlockStorageAndOverrides(t testing.TB, ingesterCfg Config, overrides *validation.Overrides, ingestersRing ring.ReadRing, dataDir string, bucketDir string, registerer prometheus.Registerer) (*Ingester, error) {
+	return prepareIngesterWithBlockStorageAndOverridesAndPartitionRing(t, ingesterCfg, overrides, ingestersRing, nil, dataDir, bucketDir, registerer)
+}
+
+func prepareIngesterWithBlockStorageAndOverridesAndPartitionRing(t testing.TB, ingesterCfg Config, overrides *validation.Overrides, ingestersRing ring.ReadRing, partitionsRing *ring.PartitionRingWatcher, dataDir string, bucketDir string, registerer prometheus.Registerer) (*Ingester, error) {
 	// Create a data dir if none has been provided.
 	if dataDir == "" {
 		dataDir = t.TempDir()
@@ -4600,7 +4604,7 @@ func prepareIngesterWithBlockStorageAndOverrides(t testing.TB, ingesterCfg Confi
 		ingestersRing = createAndStartRing(t, ingesterCfg.IngesterRing.ToRingConfig())
 	}
 
-	ingester, err := New(ingesterCfg, overrides, ingestersRing, nil, nil, registerer, noDebugNoopLogger{})
+	ingester, err := New(ingesterCfg, overrides, ingestersRing, partitionsRing, nil, registerer, noDebugNoopLogger{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -4604,7 +4604,7 @@ func prepareIngesterWithBlockStorageAndOverridesAndPartitionRing(t testing.TB, i
 		ingestersRing = createAndStartRing(t, ingesterCfg.IngesterRing.ToRingConfig())
 	}
 
-	ingester, err := New(ingesterCfg, overrides, ingestersRing, partitionsRing, nil, registerer, noDebugNoopLogger{})
+	ingester, err := New(ingesterCfg, overrides, ingestersRing, partitionsRing, nil, registerer, noDebugNoopLogger{}) // LOGGING: log.NewLogfmtLogger(os.Stderr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/owned_series.go
+++ b/pkg/ingester/owned_series.go
@@ -5,6 +5,8 @@ package ingester
 import (
 	"context"
 	"errors"
+	"slices"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -33,43 +35,50 @@ const (
 	recomputeOwnedSeriesReasonLocalLimitChanged    = "local series limit changed"
 )
 
+// ownedSeriesRingStrategy wraps access to the ring, to allow owned series service to be ignorant to whether it uses ingester ring or partitions ring.
+type ownedSeriesRingStrategy interface {
+	// checkRingForChanges reads current ring, stores it, and returns bool indicating whether ring has changed since last call
+	// of this method in such a way that new recomputation of token ranges is needed.
+	checkRingForChanges() (bool, error)
+
+	// shardSizeForUser returns shard size used by tenant. Size can be number of ingesters or partitions.
+	shardSizeForUser(tenant string) int
+
+	// tokenRangesForUser returns token ranges owned by this ingester for given user.
+	tokenRangesForUser(userID string, shardSize int) (ring.TokenRanges, error)
+
+	// ownerKeyAndValue returns key and value used in log message to indicate "object" that owned series operates on.
+	ownerKeyAndValue() (string, string)
+}
+
 type ownedSeriesService struct {
 	services.Service
 
-	instanceID    string
-	ingestersRing ring.ReadRing
+	logger       log.Logger
+	ringStrategy ownedSeriesRingStrategy
 
-	logger log.Logger
-
-	getIngesterShardSize func(user string) int
-	getLocalSeriesLimit  func(user string, minLocalLimit int) int
-	getTSDBUsers         func() []string
-	getTSDB              func(user string) *userTSDB
+	getLocalSeriesLimit func(user string, minLocalLimit int) int
+	getTSDBUsers        func() []string
+	getTSDB             func(user string) *userTSDB
 
 	ownedSeriesCheckDuration prometheus.Histogram
-
-	previousRing ring.ReplicationSet
 }
 
 func newOwnedSeriesService(
 	interval time.Duration,
-	instanceID string,
-	ingesterRing ring.ReadRing,
+	ringStrategy ownedSeriesRingStrategy,
 	logger log.Logger,
 	reg prometheus.Registerer,
-	getIngesterShardSize func(user string) int,
 	getLocalSeriesLimit func(user string, minLocalLimit int) int,
 	getTSDBUsers func() []string,
 	getTSDB func(user string) *userTSDB,
 ) *ownedSeriesService {
 	oss := &ownedSeriesService{
-		instanceID:           instanceID,
-		ingestersRing:        ingesterRing,
-		logger:               logger,
-		getIngesterShardSize: getIngesterShardSize,
-		getLocalSeriesLimit:  getLocalSeriesLimit,
-		getTSDBUsers:         getTSDBUsers,
-		getTSDB:              getTSDB,
+		logger:              logger,
+		ringStrategy:        ringStrategy,
+		getLocalSeriesLimit: getLocalSeriesLimit,
+		getTSDBUsers:        getTSDBUsers,
+		getTSDB:             getTSDB,
 		ownedSeriesCheckDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_owned_series_check_duration_seconds",
 			Help:    "How long does it take to check for owned series for all users.",
@@ -84,7 +93,7 @@ func newOwnedSeriesService(
 // This function runs periodically. It checks if ring has changed, and updates number of owned series for any
 // user that requires it (due to ring change, compaction, shard size change, ...).
 func (oss *ownedSeriesService) onPeriodicCheck(ctx context.Context) error {
-	ringChanged, err := oss.checkRingForChanges()
+	ringChanged, err := oss.ringStrategy.checkRingForChanges()
 	if err != nil {
 		level.Error(oss.logger).Log("msg", "can't check ring for updates", "err", err)
 		return nil // If we returned error, service would stop.
@@ -92,19 +101,6 @@ func (oss *ownedSeriesService) onPeriodicCheck(ctx context.Context) error {
 
 	oss.updateAllTenants(ctx, ringChanged)
 	return nil
-}
-
-// Reads current ring, stores it, and returns bool indicating whether ring has changed since last call of this method.
-func (oss *ownedSeriesService) checkRingForChanges() (bool, error) {
-	rs, err := oss.ingestersRing.GetAllHealthy(ownedSeriesRingOp)
-	if err != nil {
-		return false, err
-	}
-
-	// Ignore state and IP address changes, since they have no impact on token distribution
-	ringChanged := ring.HasReplicationSetChangedWithoutStateOrAddr(oss.previousRing, rs)
-	oss.previousRing = rs
-	return ringChanged, nil
 }
 
 // updateAllTenants iterates over all open TSDBs and updates owned series for all users that need it, either
@@ -150,7 +146,7 @@ func (oss *ownedSeriesService) updateAllTenants(ctx context.Context, ringChanged
 // Ring and shard size changes require new check of the ring to see if token ranges for this ingester have changed. We also need to check ring if previous ring check has failed.
 // When doing computation of owned series, we make sure to pass up-to-date number of shards.
 func (oss *ownedSeriesService) updateTenant(userID string, db *userTSDB, ringChanged bool) bool {
-	shardSize := oss.getIngesterShardSize(userID)
+	shardSize := oss.ringStrategy.shardSizeForUser(userID)
 	localLimit := oss.getLocalSeriesLimit(userID, 0)
 
 	reason := db.getAndClearReasonForRecomputeOwnedSeries() // Clear reason, so that other reasons can be set while we run update here.
@@ -172,15 +168,14 @@ func (oss *ownedSeriesService) updateTenant(userID string, db *userTSDB, ringCha
 	}
 
 	// We need to check for tokens even if ringChanged is false, because previous ring check may have failed.
-	subring := oss.ingestersRing.ShuffleShard(userID, shardSize)
-
-	ranges, err := subring.GetTokenRangesForInstance(oss.instanceID)
+	ranges, err := oss.ringStrategy.tokenRangesForUser(userID, shardSize)
 	if err != nil {
 		if errors.Is(err, ring.ErrInstanceNotFound) {
 			// This ingester doesn't own the tenant anymore, so there will be no "owned" series.
 			ranges = nil
 		} else {
-			level.Error(oss.logger).Log("msg", "failed to get token ranges from user's subring", "user", userID, "ingester", oss.instanceID, "err", err)
+			ownerKey, ownerValue := oss.ringStrategy.ownerKeyAndValue()
+			level.Error(oss.logger).Log("msg", "failed to get token ranges from user's subring", "user", userID, ownerKey, ownerValue, "err", err)
 
 			// If we failed to get token ranges, set the new reason, to make sure we do the check in next iteration.
 			if reason == "" {
@@ -208,4 +203,97 @@ func secondaryTSDBHashFunctionForUser(userID string) func(labels.Labels) uint32 
 	return func(ls labels.Labels) uint32 {
 		return mimirpb.ShardByAllLabels(userID, ls)
 	}
+}
+
+type ownedSeriesIngesterRingStrategy struct {
+	instanceID    string
+	ingestersRing ring.ReadRing
+
+	getIngesterShardSize func(user string) int
+
+	previousRing ring.ReplicationSet
+}
+
+func newOwnedSeriesIngesterRingStrategy(instanceID string, ingesterRing ring.ReadRing, getIngesterShardSize func(user string) int) *ownedSeriesIngesterRingStrategy {
+	return &ownedSeriesIngesterRingStrategy{
+		instanceID:           instanceID,
+		ingestersRing:        ingesterRing,
+		getIngesterShardSize: getIngesterShardSize,
+	}
+}
+
+func (ir *ownedSeriesIngesterRingStrategy) ownerKeyAndValue() (string, string) {
+	return "ingester", ir.instanceID
+}
+
+func (ir *ownedSeriesIngesterRingStrategy) checkRingForChanges() (bool, error) {
+	rs, err := ir.ingestersRing.GetAllHealthy(ownedSeriesRingOp)
+	if err != nil {
+		return false, err
+	}
+
+	// Ignore state and IP address changes, since they have no impact on token distribution
+	ringChanged := ring.HasReplicationSetChangedWithoutStateOrAddr(ir.previousRing, rs)
+	ir.previousRing = rs
+	return ringChanged, nil
+}
+
+func (ir *ownedSeriesIngesterRingStrategy) shardSizeForUser(userID string) int {
+	return ir.getIngesterShardSize(userID)
+}
+
+func (ir *ownedSeriesIngesterRingStrategy) tokenRangesForUser(userID string, shardSize int) (ring.TokenRanges, error) {
+	subring := ir.ingestersRing.ShuffleShard(userID, shardSize)
+
+	return subring.GetTokenRangesForInstance(ir.instanceID)
+}
+
+type ownedSeriesPartitionRingStrategy struct {
+	partitionID          int32
+	partitionRingWatcher *ring.PartitionRingWatcher
+
+	getPartitionShardSize func(user string) int
+
+	previousActivePartition []int32
+}
+
+func newOwnedSeriesPartitionRingStrategy(partitionID int32, partitionRing *ring.PartitionRingWatcher, getPartitionShardSize func(user string) int) *ownedSeriesPartitionRingStrategy {
+	return &ownedSeriesPartitionRingStrategy{
+		partitionID:           partitionID,
+		partitionRingWatcher:  partitionRing,
+		getPartitionShardSize: getPartitionShardSize,
+	}
+}
+
+func (pr *ownedSeriesPartitionRingStrategy) checkRingForChanges() (bool, error) {
+	// When using partitions ring, we consider ring to be changed if active partitions have changed.
+	r := pr.partitionRingWatcher.PartitionRing()
+	activePartitions := r.ActivePartitionIDs()
+	ringChanged := !slices.Equal(pr.previousActivePartition, activePartitions)
+	pr.previousActivePartition = activePartitions
+	return ringChanged, nil
+}
+
+func (pr *ownedSeriesPartitionRingStrategy) shardSizeForUser(userID string) int {
+	return pr.getPartitionShardSize(userID)
+}
+
+func (pr *ownedSeriesPartitionRingStrategy) tokenRangesForUser(userID string, shardSize int) (ring.TokenRanges, error) {
+	_, ok := slices.BinarySearch(pr.previousActivePartition, pr.partitionID)
+	if !ok {
+		// If our partition is not active, it has no owned series.
+		return nil, nil
+	}
+
+	r := pr.partitionRingWatcher.PartitionRing()
+	sr, err := r.ShuffleShard(userID, shardSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return sr.GetTokenRangesForPartition(pr.partitionID)
+}
+
+func (pr *ownedSeriesPartitionRingStrategy) ownerKeyAndValue() (string, string) {
+	return "partition", strconv.Itoa(int(pr.partitionID))
 }


### PR DESCRIPTION
#### What this PR does

This PR modifies "owned series" service to make it work with partitions ring (if ingest storage is configured) as well as ingester ring.

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
