### PR TITLE
Deprecate metric cortex_distributor_sample_delay_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [CHANGE] Store-gateway: Use a shorter TTL for cached items related to temporary blocks. #7407
 * [CHANGE] Standardise exemplar label as "trace_id". #7475
 * [CHANGE] The configuration option `-querier.max-query-into-future` has been deprecated and will be removed in Mimir 2.14. #7496
+* [CHANGE] Distributor: the metric `cortex_distributor_sample_delay_seconds` is now deprecated and will be removed in Mimir 2.14. #7516
 * [FEATURE] Introduce `-server.log-source-ips-full` option to log all IPs from `Forwarded`, `X-Real-IP`, `X-Forwarded-For` headers. #7250
 * [FEATURE] Introduce `-tenant-federation.max-tenants` option to limit the max number of tenants allowed for requests when federation is enabled. #6959
 * [FEATURE] Cardinality API: added a new `count_method` parameter which enables counting active label values. #7085

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [CHANGE] Store-gateway: Use a shorter TTL for cached items related to temporary blocks. #7407
 * [CHANGE] Standardise exemplar label as "trace_id". #7475
 * [CHANGE] The configuration option `-querier.max-query-into-future` has been deprecated and will be removed in Mimir 2.14. #7496
-* [CHANGE] Distributor: the metric `cortex_distributor_sample_delay_seconds` is now deprecated and will be removed in Mimir 2.14. #7516
+* [CHANGE] Distributor: the metric `cortex_distributor_sample_delay_seconds` has been deprecated and will be removed in Mimir 2.14. #7516
 * [FEATURE] Introduce `-server.log-source-ips-full` option to log all IPs from `Forwarded`, `X-Real-IP`, `X-Forwarded-For` headers. #7250
 * [FEATURE] Introduce `-tenant-federation.max-tenants` option to limit the max number of tenants allowed for requests when federation is enabled. #6959
 * [FEATURE] Cardinality API: added a new `count_method` parameter which enables counting active label values. #7085

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -184,6 +184,8 @@ The following features or configuration parameters are currently deprecated and 
 
 The following features or configuration parameters are currently deprecated and will be **removed in Mimir 2.14**:
 
+- Distributor
+  - the metric `cortex_distributor_sample_delay_seconds`
 - Ingester
   - `-ingester.return-only-grpc-errors`
 - Ingester client


### PR DESCRIPTION
#### What this PR does

Deprecate the metric cortex_distributor_sample_delay_seconds

cortex_distributor_sample_delay_seconds has served it's purpose
in developing out of order ingestion, however the metric is not
useful in a multi tenant environment.

We'll remove it in 2.14 and may reintroduce it as a
native histogram / tenant if needed later.

#### Which issue(s) this PR fixes or relates to

Related to: #7154 

#### Checklist

- [X] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
