### PR TITLE
Block upload: include converted timestamp in the error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 * [ENHANCEMENT] Distributor: Optimize OTLP endpoint. #7475
 * [ENHANCEMENT] API: Use github.com/klauspost/compress for faster gzip and deflate compression of API responses. #7475
 * [ENHANCEMENT] Ingester: Limiting on owned series (`-ingester.use-ingester-owned-series-for-limits`) now prevents discards in cases where a tenant is sharded across all ingesters (or shuffle sharding is disabled) and the ingester count increases. #7411
+* [ENHANCEMENT] Block upload: include converted timestamps in the error message if block is from the future. #7538
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766

--- a/pkg/compactor/block_upload.go
+++ b/pkg/compactor/block_upload.go
@@ -480,8 +480,9 @@ func (c *MultitenantCompactor) sanitizeMeta(logger log.Logger, userID string, bl
 	// validate that times are in the past
 	now := time.Now()
 	if meta.MinTime > now.UnixMilli() || meta.MaxTime > now.UnixMilli() {
-		return fmt.Sprintf("block time(s) greater than the present: minTime=%d, maxTime=%d",
-			meta.MinTime, meta.MaxTime)
+		return fmt.Sprintf("block time(s) greater than the present: minTime=%d (%s), maxTime=%d (%s)",
+			meta.MinTime, formatTime(time.UnixMilli(meta.MinTime)),
+			meta.MaxTime, formatTime(time.UnixMilli(meta.MaxTime)))
 	}
 
 	// Mark block source

--- a/pkg/compactor/block_upload_test.go
+++ b/pkg/compactor/block_upload_test.go
@@ -304,7 +304,7 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 			expBadRequest: fmt.Sprintf("version must be %d", block.TSDBVersion1),
 		},
 		{
-			name:            "invalid version",
+			name:            "block in the future",
 			tenantID:        tenantID,
 			blockID:         blockID,
 			setUpBucketMock: setUpPartialBlock,

--- a/pkg/compactor/block_upload_test.go
+++ b/pkg/compactor/block_upload_test.go
@@ -304,6 +304,22 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 			expBadRequest: fmt.Sprintf("version must be %d", block.TSDBVersion1),
 		},
 		{
+			name:            "invalid version",
+			tenantID:        tenantID,
+			blockID:         blockID,
+			setUpBucketMock: setUpPartialBlock,
+			meta: &block.Meta{
+				BlockMeta: tsdb.BlockMeta{
+					ULID:    bULID,
+					Version: block.TSDBVersion1,
+					// Timestamps in microseconds will be converted to very distant future.
+					MinTime: 1704915591000000,
+					MaxTime: 1704915597000001,
+				},
+			},
+			expBadRequest: "block time(s) greater than the present: minTime=1704915591000000 (55996-08-16T08:10:00Z), maxTime=1704915597000001 (55996-08-16T09:50:00Z)",
+		},
+		{
 			name:            "ignore retention period if == 0",
 			tenantID:        tenantID,
 			blockID:         blockID,


### PR DESCRIPTION
#### What this PR does

When user tries to upload block with timestamps in microseconds instead of milliseconds, such timestamps are converted to very distant future dates. By including converted dates in the error message, we make this more clear.

(We have seen multiple support cases about this. Most recently https://github.com/grafana/mimir/discussions/7533).

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
