### PR TITLE
Initialize Tanka with 1.29.

### DIFF
--- a/docs/sources/mimir/set-up/jsonnet/deploy.md
+++ b/docs/sources/mimir/set-up/jsonnet/deploy.md
@@ -41,7 +41,7 @@ You can use [Tanka](https://tanka.dev/) and [jsonnet-bundler](https://github.com
 
    # Initialise the Tanka.
    mkdir jsonnet-example && cd jsonnet-example
-   tk init --k8s=1.21
+   tk init --k8s=1.29
 
    # Install Mimir jsonnet.
    jb install github.com/grafana/mimir/operations/mimir@main

--- a/operations/mimir-tests/build.sh
+++ b/operations/mimir-tests/build.sh
@@ -8,7 +8,7 @@ rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-tk init --k8s=1.21
+tk init --k8s=1.29
 
 # Install Mimir jsonnet from this branch.
 jb install ../operations/mimir

--- a/operations/mimir/getting-started.sh
+++ b/operations/mimir/getting-started.sh
@@ -5,7 +5,7 @@ set -e
 
 # Initialise the Tanka.
 mkdir jsonnet-example && cd jsonnet-example
-tk init --k8s=1.21
+tk init --k8s=1.29
 
 # Install Mimir jsonnet.
 jb install github.com/grafana/mimir/operations/mimir@main


### PR DESCRIPTION
#### What this PR does

Initialize Tanka with 1.29, [since 1.21 is no longer available](https://github.com/jsonnet-libs/k8s-libsonnet) after [this commit.](https://github.com/jsonnet-libs/k8s-libsonnet/commit/90d0fae415cff9d0c089d60e9a478efee092c42e). This fixes `lint-jsonnet` check ([failure example](https://github.com/grafana/mimir/actions/runs/8157663593/job/22297862889?pr=7508)).

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
