### PR TITLE
[Helm] Release 5.2.2

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/release-notes/v5.2.md
+++ b/docs/sources/helm-charts/mimir-distributed/release-notes/v5.2.md
@@ -31,4 +31,4 @@ Notable enhancements are as follows:
 
 ### 5.2.2
 
-- [PR xxx](): Update GEM to v2.11.2, see the [GEM v2.11.2 Release Notes](https://grafana.com/docs/enterprise-metrics/latest/release-notes/v2-11/#v2112) for more information.
+- [PR 7555](https://github.com/grafana/mimir/pull/7555): Update GEM to v2.11.2

--- a/docs/sources/helm-charts/mimir-distributed/release-notes/v5.2.md
+++ b/docs/sources/helm-charts/mimir-distributed/release-notes/v5.2.md
@@ -28,3 +28,7 @@ Notable enhancements are as follows:
 ### 5.2.1
 
 - [PR 7199](https://github.com/grafana/mimir/pull/7199): Revert [PR 6999](https://github.com/grafana/mimir/pull/6999), introduced in 5.2.0, which broke installations relying on the default value of `blocks_storage.backend: s3`. If `mimir.structuredConfig.blocks_storage.backend: s3` wasn't explicitly set, then Mimir would fail to connect to S3 and will instead try to read and write blocks to the local filesystem.
+
+### 5.2.2
+
+- [PR xxx](): Update GEM to v2.11.2, see the [GEM v2.11.2 Release Notes](https://grafana.com/docs/enterprise-metrics/latest/release-notes/v2-11/#v2112) for more information.

--- a/docs/sources/mimir/set-up/jsonnet/deploy.md
+++ b/docs/sources/mimir/set-up/jsonnet/deploy.md
@@ -41,7 +41,7 @@ You can use [Tanka](https://tanka.dev/) and [jsonnet-bundler](https://github.com
 
    # Initialise the Tanka.
    mkdir jsonnet-example && cd jsonnet-example
-   tk init --k8s=1.21
+   tk init --k8s=1.29
 
    # Install Mimir jsonnet.
    jb install github.com/grafana/mimir/operations/mimir@main

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+## 5.2.2
+
+* [BUGFix] Updated GEM image to v2.11.2. #7555
+
 ## 5.2.1
 
 * [BUGFIX] Revert [PR 6999](https://github.com/grafana/mimir/pull/6999), introduced in 5.2.0, which broke installations relying on the default value of `blocks_storage.backend: s3`. If `mimir.structuredConfig.blocks_storage.backend: s3` wasn't explicitly set, then Mimir would fail to connect to S3 and will instead try to read and write blocks to the local filesystem. #7199

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 5.2.1
+version: 5.2.2
 appVersion: 2.11.0
 description: "Grafana Mimir"
 home: https://grafana.com/docs/helm-charts/mimir-distributed/latest/

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/latest/)
 
 For the full documentation, visit [Grafana mimir-distributed Helm chart documentation](https://grafana.com/docs/helm-charts/mimir-distributed/latest/).
 
-> **Note:** The documentation version is derived from the Helm chart version which is 5.2.1.
+> **Note:** The documentation version is derived from the Helm chart version which is 5.2.2.
 
 When upgrading from Helm chart version 4.X, please see [Migrate the Helm chart from version 4.x to 5.0](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-helm-chart-4.x-to-5.0/).
 When upgrading from Helm chart version 3.x, please see [Migrate from single zone to zone-aware replication with Helm](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-from-single-zone-with-helm/).
@@ -14,7 +14,7 @@ When upgrading from Helm chart version 2.1, please see [Upgrade the Grafana Mimi
 
 # mimir-distributed
 
-![Version: 5.2.1](https://img.shields.io/badge/Version-5.2.1-informational?style=flat-square) ![AppVersion: 2.11.0](https://img.shields.io/badge/AppVersion-2.11.0-informational?style=flat-square)
+![Version: 5.2.2](https://img.shields.io/badge/Version-5.2.2-informational?style=flat-square) ![AppVersion: 2.11.0](https://img.shields.io/badge/AppVersion-2.11.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3133,7 +3133,7 @@ enterprise:
     # -- Grafana Enterprise Metrics container image repository. Note: for Grafana Mimir use the value 'image.repository'
     repository: grafana/enterprise-metrics
     # -- Grafana Enterprise Metrics container image tag. Note: for Grafana Mimir use the value 'image.tag'
-    tag: v2.11.1
+    tag: v2.11.2
     # Note: pullPolicy and optional pullSecrets are set in toplevel 'image' section, not here
 
 # In order to use Grafana Enterprise Metrics features, you will need to provide the contents of your Grafana Enterprise Metrics

--- a/operations/mimir-tests/build.sh
+++ b/operations/mimir-tests/build.sh
@@ -8,7 +8,7 @@ rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-tk init --k8s=1.21
+tk init --k8s=1.29
 
 # Install Mimir jsonnet from this branch.
 jb install ../operations/mimir

--- a/operations/mimir/getting-started.sh
+++ b/operations/mimir/getting-started.sh
@@ -5,7 +5,7 @@ set -e
 
 # Initialise the Tanka.
 mkdir jsonnet-example && cd jsonnet-example
-tk init --k8s=1.21
+tk init --k8s=1.29
 
 # Install Mimir jsonnet.
 jb install github.com/grafana/mimir/operations/mimir@main


### PR DESCRIPTION
#### What this PR does

Releasing Helm chart 5.2.2

- Includes GEM image bump to 2.11.2

Also cherry-picked https://github.com/grafana/mimir/pull/7544 to fix CI

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
