### PR TITLE
Update golang docker tag to v1.21.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr7561-ae15c572b6
+LATEST_BUILD_IMAGE_TAG ?= pr7562-ae15c572b6
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr7557-ae15c572b6
+LATEST_BUILD_IMAGE_TAG ?= pr7561-ae15c572b6
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr7417-94e502bf74
+LATEST_BUILD_IMAGE_TAG ?= pr7557-ae15c572b6
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/docs/sources/mimir/set-up/jsonnet/deploy.md
+++ b/docs/sources/mimir/set-up/jsonnet/deploy.md
@@ -41,7 +41,7 @@ You can use [Tanka](https://tanka.dev/) and [jsonnet-bundler](https://github.com
 
    # Initialise the Tanka.
    mkdir jsonnet-example && cd jsonnet-example
-   tk init --k8s=1.21
+   tk init --k8s=1.29
 
    # Install Mimir jsonnet.
    jb install github.com/grafana/mimir/operations/mimir@main

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -4,8 +4,8 @@
 # Provenance-includes-copyright: The Cortex Authors.
 
 FROM registry.k8s.io/kustomize/kustomize:v5.3.0 as kustomize
-FROM alpine/helm:3.14.1 as helm
-FROM golang:1.21.6-bookworm
+FROM alpine/helm:3.14.2 as helm
+FROM golang:1.21.8-bookworm
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"

--- a/operations/mimir-tests/build.sh
+++ b/operations/mimir-tests/build.sh
@@ -8,7 +8,7 @@ rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-tk init --k8s=1.21
+tk init --k8s=1.29
 
 # Install Mimir jsonnet from this branch.
 jb install ../operations/mimir

--- a/operations/mimir/getting-started.sh
+++ b/operations/mimir/getting-started.sh
@@ -5,7 +5,7 @@ set -e
 
 # Initialise the Tanka.
 mkdir jsonnet-example && cd jsonnet-example
-tk init --k8s=1.21
+tk init --k8s=1.29
 
 # Install Mimir jsonnet.
 jb install github.com/grafana/mimir/operations/mimir@main


### PR DESCRIPTION
#### What this PR does

Manually backport https://github.com/grafana/mimir/pull/7557 to `r280`.

* chore(deps): update golang docker tag to v1.21.8 (main)

* Update build image version to pr7557-ae15c572b6

* Trigger CI

---------

Co-authored-by: pr00se <pr00se@users.noreply.github.com>
Co-authored-by: Yuri Nikolic <durica.nikolic@grafana.com>
(cherry picked from commit e0a86e6c54e6467b27c638e1655fec5a7fc4d658)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
