### PR TITLE
Update requirements doc with correct frontend parameter

### DIFF
--- a/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
+++ b/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
@@ -92,7 +92,7 @@ Metrics from node_exporter must all have an `instance` label on them that has th
 
 ## Log labels
 
-The **Slow queries** dashboard uses a Loki data source with the logs from Grafana Mimir to visualize slow queries. The query-frontend component logs slow queries based on how you configured the `-query-frontend.log-queries-longer-than` parameter.
+The **Slow queries** dashboard uses a Loki data source with the logs from Grafana Mimir to visualize slow queries. The query-frontend component logs query statistics when the `-query-frontend.query-stats-enabled` parameter is set to `true`.
 These logs need to have specific labels in order for the dashboard to work.
 
 | Label name  | Configurable? | Description                                                                                                                                                                |


### PR DESCRIPTION
#### What this PR does

This PR fixes a query-frontend flag reference that in the **Log labels** section of the requirements doc. The slow queries dashboard relies on log lines associated with the `-query-frontend.query-stats-enabled` parameter, not the `-query-frontend.log-queries-longer-than` parameter.

#### Checklist

- [N/A] Tests updated.
- [X] Documentation added.
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
