### PR TITLE
[query-frontend] `/active_series`: cancel request context when write deadline is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
 * [ENHANCEMENT] API: Use github.com/klauspost/compress for faster gzip and deflate compression of API responses. #7475
 * [ENHANCEMENT] Ingester: Limiting on owned series (`-ingester.use-ingester-owned-series-for-limits`) now prevents discards in cases where a tenant is sharded across all ingesters (or shuffle sharding is disabled) and the ingester count increases. #7411
 * [ENHANCEMENT] Block upload: include converted timestamps in the error message if block is from the future. #7538
-* [ENHANCEMENT] Query-frontend: Introduce `-query-frontend.active-series-write-timeout` to allow configuring the server-side write timeout for active series requests. #7553
+* [ENHANCEMENT] Query-frontend: Introduce `-query-frontend.active-series-write-timeout` to allow configuring the server-side write timeout for active series requests. #7553 #7569
 * [BUGFIX] Ingester: don't ignore errors encountered while iterating through chunks or samples in response to a query request. #6451
 * [BUGFIX] Fix issue where queries can fail or omit OOO samples if OOO head compaction occurs between creating a querier and reading chunks #6766
 * [BUGFIX] Fix issue where concatenatingChunkIterator can obscure errors #6766

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/tenant"
@@ -200,6 +201,9 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeError(w, apierror.New(apierror.TypeInternal, err.Error()))
 			return
 		}
+		ctx, _ := context.WithDeadlineCause(r.Context(), deadline,
+			cancellation.NewErrorf("write deadline exceeded (timeout: %v)", f.cfg.ActiveSeriesWriteTimeout))
+		r = r.WithContext(ctx)
 	}
 
 	startTime := time.Now()

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -534,24 +534,56 @@ func TestHandler_LogsFormattedQueryDetails(t *testing.T) {
 }
 
 func TestHandler_ActiveSeriesWriteTimeout(t *testing.T) {
+	const serverWriteTimeout = 50 * time.Millisecond
+	const activeSeriesWriteTimeout = 150 * time.Millisecond
+
 	for _, tt := range []struct {
-		name      string
-		path      string
-		wantError bool
+		name            string
+		path            string
+		requestDuration time.Duration
+		wantError       bool
+		wantCtxCancel   bool
 	}{
-		{name: "deadline exceeded for non-streaming endpoint", path: "/api/v1/query", wantError: true},
-		{name: "deadline not exceeded for streaming endpoint", path: "/api/v1/cardinality/active_series"},
+		{
+			name:            "deadline exceeded for non-streaming endpoint",
+			path:            "/api/v1/query",
+			requestDuration: 100 * time.Millisecond,
+			wantError:       true,
+		},
+		{
+			name:            "deadline not exceeded for active series endpoint",
+			path:            "/api/v1/cardinality/active_series",
+			requestDuration: 100 * time.Millisecond,
+		},
+		{
+			name:            "deadline exceeded for active series endpoint",
+			path:            "/api/v1/cardinality/active_series",
+			requestDuration: 200 * time.Millisecond,
+			wantError:       true,
+			wantCtxCancel:   true,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			const serverWriteTimeout = 50 * time.Millisecond
 
 			roundTripper := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				// Simulate a request that takes longer than the server write timeout.
-				time.Sleep(2 * serverWriteTimeout)
-				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))}, nil
+				select {
+				case <-req.Context().Done():
+					assert.EqualError(t, context.Cause(req.Context()),
+						fmt.Sprintf("context canceled: write deadline exceeded (timeout: %v)", activeSeriesWriteTimeout))
+					return nil, req.Context().Err()
+				case <-time.After(tt.requestDuration):
+					if tt.wantCtxCancel {
+						assert.Fail(t, "request context should have been cancelled")
+					}
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))}, nil
+				}
 			})
 
-			handler := NewHandler(HandlerConfig{ActiveSeriesWriteTimeout: time.Minute}, roundTripper, log.NewNopLogger(), nil, nil)
+			handler := NewHandler(
+				HandlerConfig{ActiveSeriesWriteTimeout: activeSeriesWriteTimeout},
+				roundTripper, log.NewNopLogger(), nil, nil,
+			)
 
 			server := httptest.NewUnstartedServer(handler)
 			server.Config.WriteTimeout = serverWriteTimeout


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This is a follow-up to #7553. I realised that the request context is not cancelled when the server write deadline is reached (see e.g. [here](https://github.com/golang/go/issues/59602)). To avoid doing unnecessary work we should cancel the request context once the deadline is reached.

This change only applies to the `/active_series` endpoint, the behaviour for other endpoints remains unchanged.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
