### PR TITLE
Owned series: modify owned series lifecycle

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	integerUnavailableMsgFormat = "ingester is unavailable (current state: %s)"
-	ingesterTooBusyMsg          = "ingester is currently too busy to process queries, try again later"
-	ingesterPushGrpcDisabledMsg = "ingester is configured with Push gRPC method disabled"
+	integerUnavailableMsgFormat           = "ingester is unavailable (current state: %s)"
+	ingesterTooBusyMsg                    = "ingester is currently too busy to process queries, try again later"
+	ingesterPushGrpcDisabledMsg           = "ingester is configured with Push gRPC method disabled"
+	ingesterUnavailableForPushRequestsMsg = "ingester is unavailable for push requests"
 )
 
 var (
@@ -457,11 +458,11 @@ var _ softError = perMetricMetadataLimitReachedError{}
 
 // unavailableError is an ingesterError indicating that the ingester is unavailable.
 type unavailableError struct {
-	state services.State
+	message string
 }
 
 func (e unavailableError) Error() string {
-	return fmt.Sprintf(integerUnavailableMsgFormat, e.state.String())
+	return e.message
 }
 
 func (e unavailableError) errorCause() mimirpb.ErrorCause {
@@ -472,7 +473,11 @@ func (e unavailableError) errorCause() mimirpb.ErrorCause {
 var _ ingesterError = unavailableError{}
 
 func newUnavailableError(state services.State) unavailableError {
-	return unavailableError{state: state}
+	return unavailableError{message: fmt.Sprintf(integerUnavailableMsgFormat, state.String())}
+}
+
+func newUnavailableMsgError(msg string) unavailableError {
+	return unavailableError{message: msg}
 }
 
 type instanceLimitReachedError struct {

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -27,10 +27,9 @@ import (
 )
 
 const (
-	integerUnavailableMsgFormat           = "ingester is unavailable (current state: %s)"
-	ingesterTooBusyMsg                    = "ingester is currently too busy to process queries, try again later"
-	ingesterPushGrpcDisabledMsg           = "ingester is configured with Push gRPC method disabled"
-	ingesterUnavailableForPushRequestsMsg = "ingester is unavailable for push requests"
+	integerUnavailableMsgFormat = "ingester is unavailable (current state: %s)"
+	ingesterTooBusyMsg          = "ingester is currently too busy to process queries, try again later"
+	ingesterPushGrpcDisabledMsg = "ingester is configured with Push gRPC method disabled"
 )
 
 var (
@@ -458,11 +457,11 @@ var _ softError = perMetricMetadataLimitReachedError{}
 
 // unavailableError is an ingesterError indicating that the ingester is unavailable.
 type unavailableError struct {
-	message string
+	state services.State
 }
 
 func (e unavailableError) Error() string {
-	return e.message
+	return fmt.Sprintf(integerUnavailableMsgFormat, e.state.String())
 }
 
 func (e unavailableError) errorCause() mimirpb.ErrorCause {
@@ -473,11 +472,7 @@ func (e unavailableError) errorCause() mimirpb.ErrorCause {
 var _ ingesterError = unavailableError{}
 
 func newUnavailableError(state services.State) unavailableError {
-	return unavailableError{message: fmt.Sprintf(integerUnavailableMsgFormat, state.String())}
-}
-
-func newUnavailableMsgError(msg string) unavailableError {
-	return unavailableError{message: msg}
+	return unavailableError{state: state}
 }
 
 type instanceLimitReachedError struct {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -3526,7 +3526,7 @@ func (i *Ingester) checkAvailableForPushRequests() error {
 	}
 
 	if i.cfg.UseIngesterOwnedSeriesForLimits {
-		// Owned series service will enter Running state only after it checks for owned series at least once.
+		// Owned series service will enter Running state after initial check (if ring was empty, it skips the check).
 		if i.ownedSeriesService.State() != services.Running {
 			return newUnavailableMsgError(ingesterUnavailableForPushRequestsMsg)
 		}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -530,9 +530,8 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 
 	if i.ownedSeriesService != nil {
 		// Start owned series service asynchronously. We don't wait for ownedSeriesService to enter Running state here.
-		// This service will wait for entry in the ring, which is only created by lifecycler, and once the entry in the ring exists,
-		// ownedSeriesService will perform initial check of all tenants. While this check runs, we already allow read requests to proceed,
-		// but we block push requests (see checkAvailableForPushRequests).
+		// This service will perform initial check if ring is not empty, and switch to Running state right after.
+		// While this initial check runs, we already allow read requests to proceed, but we block push requests (see checkAvailableForPushRequests).
 		//
 		// We pass ingester's service context to ownedSeriesService, to make ownedSeriesService stop when ingester exits Running state.
 		if err := i.ownedSeriesService.StartAsync(ctx); err != nil {

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -464,7 +464,7 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 	if cfg.UseIngesterOwnedSeriesForLimits || cfg.UpdateIngesterOwnedSeries {
 		i.ownedSeriesService = newOwnedSeriesService(i.cfg.OwnedSeriesUpdateInterval, ownedSeriesStrategy, log.With(i.logger, "component", "owned series"), registerer, i.limiter.maxSeriesPerUser, i.getTSDBUsers, i.getTSDB)
 
-		// We add owned service explicitly, because ingester doesn't start it using i.subservices.
+		// We add owned series service explicitly, because ingester doesn't start it using i.subservices.
 		i.subservicesWatcher.WatchService(i.ownedSeriesService)
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -572,10 +572,6 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 		servs = append(servs, i.utilizationBasedLimiter)
 	}
 
-	if i.ownedSeriesService != nil {
-		servs = append(servs, i.ownedSeriesService)
-	}
-
 	if i.ingestReader != nil {
 		servs = append(servs, i.ingestReader)
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -462,14 +462,7 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 	i.limiter = NewLimiter(limits, limiterStrategy)
 
 	if cfg.UseIngesterOwnedSeriesForLimits || cfg.UpdateIngesterOwnedSeries {
-		i.ownedSeriesService = newOwnedSeriesService(
-			i.cfg.OwnedSeriesUpdateInterval,
-			ownedSeriesStrategy,
-			log.With(i.logger, "component", "owned series"),
-			registerer,
-			i.limiter.maxSeriesPerUser,
-			i.getTSDBUsers,
-			i.getTSDB)
+		i.ownedSeriesService = newOwnedSeriesService(i.cfg.OwnedSeriesUpdateInterval, ownedSeriesStrategy, log.With(i.logger, "component", "owned series"), registerer, i.limiter.maxSeriesPerUser, i.getTSDBUsers, i.getTSDB)
 	}
 
 	i.BasicService = services.NewBasicService(i.starting, i.updateLoop, i.stopping)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -463,6 +463,9 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 
 	if cfg.UseIngesterOwnedSeriesForLimits || cfg.UpdateIngesterOwnedSeries {
 		i.ownedSeriesService = newOwnedSeriesService(i.cfg.OwnedSeriesUpdateInterval, ownedSeriesStrategy, log.With(i.logger, "component", "owned series"), registerer, i.limiter.maxSeriesPerUser, i.getTSDBUsers, i.getTSDB)
+
+		// We add owned service explicitly, because ingester doesn't start it using i.subservices.
+		i.subservicesWatcher.WatchService(i.ownedSeriesService)
 	}
 
 	i.BasicService = services.NewBasicService(i.starting, i.updateLoop, i.stopping)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -597,7 +597,7 @@ func (i *Ingester) stopping(_ error) error {
 	if i.ownedSeriesService != nil {
 		err := services.StopAndAwaitTerminated(context.Background(), i.ownedSeriesService)
 		if err != nil {
-			// This service can't really fail, unless it never got out of Starting.
+			// This service can't really fail.
 			level.Warn(i.logger).Log("msg", "error encountered while stopping owned series service", "err", err)
 		}
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -533,7 +533,7 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 		// ACTIVE in the ring and starts to accept requests. However, because the ingester still uses the Lifecycler (rather
 		// than BasicLifecycler) there is no deterministic way to delay the ACTIVE state until we finish the calculations.
 		//
-		// Start owned series service asynchronously, and before starting lifecyclers. We wait for ownedSeriesService
+		// Start owned series service before starting lifecyclers. We wait for ownedSeriesService
 		// to enter Running state here, that is ownedSeriesService computes owned series if ring is not empty.
 		// If ring is empty, ownedSeriesService doesn't do anything.
 		// If ring is not empty, but instance is not in the ring yet, ownedSeriesService will compute 0 owned series.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -462,7 +462,20 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 	i.limiter = NewLimiter(limits, limiterStrategy)
 
 	if cfg.UseIngesterOwnedSeriesForLimits || cfg.UpdateIngesterOwnedSeries {
-		i.ownedSeriesService = newOwnedSeriesService(i.cfg.OwnedSeriesUpdateInterval, ownedSeriesStrategy, log.With(i.logger, "component", "owned series"), registerer, i.limiter.maxSeriesPerUser, i.getTSDBUsers, i.getTSDB)
+		waitForRingAndCheckSeriesInStartingState := false
+		if i.cfg.IngestStorageConfig.Enabled {
+			waitForRingAndCheckSeriesInStartingState = true
+		}
+
+		i.ownedSeriesService = newOwnedSeriesService(
+			i.cfg.OwnedSeriesUpdateInterval,
+			ownedSeriesStrategy,
+			log.With(i.logger, "component", "owned series"),
+			registerer,
+			i.limiter.maxSeriesPerUser,
+			i.getTSDBUsers,
+			i.getTSDB,
+			waitForRingAndCheckSeriesInStartingState)
 	}
 
 	i.BasicService = services.NewBasicService(i.starting, i.updateLoop, i.stopping)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -529,6 +529,10 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 	}
 
 	if i.ownedSeriesService != nil {
+		// We need to perform the initial computation of owned series after the TSDBs are opened but before the ingester becomes
+		// ACTIVE in the ring and starts to accept requests. However, because the ingester still uses the Lifecycler (rather
+		// than BasicLifecycler) there is no deterministic way to delay the ACTIVE state until we finish the calculations.
+		//
 		// Start owned series service asynchronously, and before starting lifecyclers. We wait for ownedSeriesService
 		// to enter Running state here, that is ownedSeriesService computes owned series if ring is not empty.
 		// If ring is empty, ownedSeriesService doesn't do anything.

--- a/pkg/ingester/owned_series.go
+++ b/pkg/ingester/owned_series.go
@@ -92,7 +92,7 @@ func newOwnedSeriesService(
 		}),
 	}
 
-	oss.Service = services.NewTimerService(interval, oss.starting, oss.running, nil)
+	oss.Service = services.NewBasicService(oss.starting, oss.running, nil)
 	return oss
 }
 

--- a/pkg/ingester/owned_series.go
+++ b/pkg/ingester/owned_series.go
@@ -296,7 +296,7 @@ func (ir *ownedSeriesIngesterRingStrategy) hasOwner() (bool, error) {
 		return false, err
 	}
 
-	return len(tokens) > 0, err
+	return len(tokens) > 0, nil
 }
 
 type ownedSeriesPartitionRingStrategy struct {

--- a/pkg/ingester/owned_series.go
+++ b/pkg/ingester/owned_series.go
@@ -125,7 +125,7 @@ func (oss *ownedSeriesService) starting(ctx context.Context) error {
 func (oss *ownedSeriesService) running(ctx context.Context) error {
 	tickerInterval := oss.interval
 	if !oss.initialRingCheckSucceeded {
-		tickerInterval = tickerInterval / 10
+		tickerInterval = 100 * time.Millisecond
 	}
 
 	t := time.NewTicker(tickerInterval)

--- a/pkg/ingester/owned_series.go
+++ b/pkg/ingester/owned_series.go
@@ -98,7 +98,7 @@ func newOwnedSeriesService(
 
 // This method should run as fast as possible and avoid blocking on external conditions
 // (e.g. whether lifecycler added instance to the ring or not),
-// because Ingester writes are not allowed until ownedSeriesService switches to Running state.
+// because it is started before lifecyclers.
 func (oss *ownedSeriesService) starting(ctx context.Context) error {
 	// Fetch and cache current state of the ring.
 	_, err := oss.ringStrategy.checkRingForChanges()

--- a/pkg/ingester/owned_series.go
+++ b/pkg/ingester/owned_series.go
@@ -125,7 +125,7 @@ func (oss *ownedSeriesService) starting(ctx context.Context) error {
 func (oss *ownedSeriesService) running(ctx context.Context) error {
 	tickerInterval := oss.interval
 	if !oss.initialRingCheckSucceeded {
-		tickerInterval = 100 * time.Millisecond
+		tickerInterval = 100 * time.Millisecond // Use short interval until we find non-empty ring.
 	}
 
 	t := time.NewTicker(tickerInterval)

--- a/pkg/ingester/owned_series.go
+++ b/pkg/ingester/owned_series.go
@@ -98,7 +98,7 @@ func newOwnedSeriesService(
 
 // This method should run as fast as possible and avoid blocking on external conditions
 // (e.g. whether lifecycler added instance to the ring or not),
-// because Ingester writes are not allowed until it finishes.
+// because Ingester writes are not allowed until ownedSeriesService switches to Running state.
 func (oss *ownedSeriesService) starting(ctx context.Context) error {
 	// Fetch and cache current state of the ring.
 	_, err := oss.ringStrategy.checkRingForChanges()

--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -1333,7 +1333,7 @@ func TestOwnedSeriesStartsQuicklyWithEmptyIngesterRing(t *testing.T) {
 	})
 }
 
-func TestOwnedSeriesWaitsForPartitionBeforeEnteringRunningState(t *testing.T) {
+func TestOwnedSeriesStartsQuicklyWithEmptyPartitionsRing(t *testing.T) {
 	partitionsKVStore, partitionsKVStoreCloser := consul.NewInMemoryClient(ring.GetPartitionRingCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, partitionsKVStoreCloser.Close()) })
 

--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -643,6 +643,7 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.ing.limiter.maxSeriesPerUser,
 				c.ing.getTSDBUsers,
 				c.ing.getTSDB,
+				false,
 			)
 
 			tc.testFunc(t, &c, tc.limits)
@@ -749,6 +750,7 @@ func (c *ownedSeriesWithPartitionsRingTestContext) createIngesterAndPartitionRin
 		c.ing.limiter.maxSeriesPerUser,
 		c.ing.getTSDBUsers,
 		c.ing.getTSDB,
+		true,
 	)
 }
 


### PR DESCRIPTION
#### What this PR does

This PR moves initialization of owned-series service into its own "starting" method. Ingester now fully starts this service before starting lifecyclers. Compared to the state before this PR, this change doesn't really change much -- it just moves code into the service.

We have tried various approaches in this PR, but there are constraints that we need to maintain. 

1. We cannot change ingester to ACTIVE state in the ring, and then reject read or push requests, or we risk outages -- on read path, or write path (eg. during rollouts of multiple zones).
2. Furthermore we prefer to err on under-counting owned series (when ring doesn't have our instance, owned series service will compute 0 owned series), than having incorrect high count of owned series. When we undercount, we allow extra series (and possibly hit instance limits). When we over-count, we discard new series and make this a user problem instead.

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
