### PR TITLE
continuoustest: set user-agent for all requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Mimir Continuous Test
 
+* [BUGFIX] Set `User-Agent` header for all requests sent from the testing client. #7607
+
 ### Query-tee
 
 ### Documentation

--- a/pkg/continuoustest/client.go
+++ b/pkg/continuoustest/client.go
@@ -275,6 +275,8 @@ func (rt *clientRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		req.Header.Set("X-Scope-OrgID", rt.tenantID)
 	}
 
+	req.Header.Set("User-Agent", "mimir-continuous-test")
+
 	if lvl, ok := querierapi.ReadConsistencyFromContext(req.Context()); ok {
 		req.Header.Add(querierapi.ReadConsistencyHeader, lvl)
 	}

--- a/pkg/continuoustest/otlp_writer.go
+++ b/pkg/continuoustest/otlp_writer.go
@@ -49,7 +49,6 @@ func (pw *otlpHTTPWriter) sendWriteRequest(ctx context.Context, req *prompb.Writ
 	httpReq.Header.Add("Content-Encoding", "gzip")
 	httpReq.Header.Add("Accept-Encoding", "gzip")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
-	httpReq.Header.Set("User-Agent", "mimir-continuous-test")
 
 	httpResp, err := pw.httpClient.Do(httpReq)
 	if err != nil {

--- a/pkg/continuoustest/prometheus_writer.go
+++ b/pkg/continuoustest/prometheus_writer.go
@@ -42,7 +42,6 @@ func (pw *prometheusWriter) sendWriteRequest(ctx context.Context, req *prompb.Wr
 	}
 	httpReq.Header.Add("Content-Encoding", "snappy")
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
-	httpReq.Header.Set("User-Agent", "mimir-continuous-test")
 	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
 
 	httpResp, err := pw.httpClient.Do(httpReq)


### PR DESCRIPTION
#### What this PR does

I've noticed that continues-test sets `user-agents` header only on the writer side. This PR updates the client, making sure the header is set on all requests.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
