### PR TITLE
Remove technical writer as code owner for internal docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,8 +9,9 @@
 
 /docs/                                                                      @jdbaldry @grafana/mimir-maintainers
 /docs/docs.mk                                                               @grafana/docs-tooling @grafana/mimir-maintainers
+/docs/internal/                                                             @grafana/mimir-maintainers
 /docs/make-docs                                                             @grafana/docs-tooling @grafana/mimir-maintainers
-/docs/proposals                                                             @grafana/mimir-maintainers
+/docs/proposals/                                                            @grafana/mimir-maintainers
 /docs/variables.mk                                                          @grafana/docs-tooling @grafana/mimir-maintainers
 
 # Alertmanager and ruler.


### PR DESCRIPTION
#### What this PR does
Remove technical writer as code owner for internal docs. When another writer takes over, this makes sure they don't get notifications for areas that they're not responsible for.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
