### PR TITLE
store-gateway: record request ambient time for LabelNames and LabelValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [ENHANCEMENT] Store-gateway: merge series from different blocks concurrently. #7456
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
-* [BUGFIX] Store-gateway: account for `"other"` time in LabelValues and LabelNames requests. #7622 
+* [BUGFIX] Store-gateway: account for `"other"` time in LabelValues and LabelNames requests. #7622
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [ENHANCEMENT] Store-gateway: merge series from different blocks concurrently. #7456
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
+* [BUGFIX] Store-gateway: account for `"other"` time in LabelValues and LabelNames requests. #7622 
 
 ### Mixin
 


### PR DESCRIPTION
The ambient time (`queryStats.streamingSeriesAmbientTime`) is used to observe the `"other"` stage duration in `BucketStore.recordStreamingSeriesStats` after running LabelNames, LabelValues and Series requests.

But `queryStats.streamingSeriesAmbientTime` is only populated for `Series` requests. This results in skewed `"other"` timings.
