### PR TITLE
mimirtool: fix panic in loadgen command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624
 
 ### Mixin
+
 * [ENHANCEMENT] Alerts: allow configuring alerts range interval via `_config.base_alerts_range_interval_minutes`. #7591
 
 ### Jsonnet
 
 ### Mimirtool
+
+* [BUGFIX] Fix panic in `loadgen` subcommand. #7629
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/commands/loadgen.go
+++ b/pkg/mimirtool/commands/loadgen.go
@@ -67,36 +67,35 @@ type LoadgenCommand struct {
 }
 
 func (c *LoadgenCommand) Register(app *kingpin.Application, _ EnvVarNames, reg prometheus.Registerer) {
-	loadgenCommand := &LoadgenCommand{}
-	cmd := app.Command("loadgen", "Simple load generator for Grafana Mimir.").PreAction(func(k *kingpin.ParseContext) error { return c.setup(k, reg) }).Action(loadgenCommand.run)
-	cmd.Flag("write-url", "").
-		Default("").StringVar(&loadgenCommand.writeURL)
+	cmd := app.Command("loadgen", "Simple load generator for Grafana Mimir.").PreAction(func(k *kingpin.ParseContext) error { return c.setup(k, reg) }).Action(c.run)
+	cmd.Flag("write-url", "Remote write URL where to push metrics to (e.g. \"http://mimir.local/api/v1/push\")").
+		Default("").StringVar(&c.writeURL)
 	cmd.Flag("series-name", "name of the metric that will be generated").
-		Default("node_cpu_seconds_total").StringVar(&loadgenCommand.metricName)
+		Default("node_cpu_seconds_total").StringVar(&c.metricName)
 	cmd.Flag("active-series", "number of active series to send").
-		Default("1000").IntVar(&loadgenCommand.activeSeries)
+		Default("1000").IntVar(&c.activeSeries)
 	cmd.Flag("scrape-interval", "period to send metrics").
-		Default("15s").DurationVar(&loadgenCommand.scrapeInterval)
+		Default("15s").DurationVar(&c.scrapeInterval)
 	cmd.Flag("parallelism", "how many metrics to send simultaneously").
-		Default("10").IntVar(&loadgenCommand.parallelism)
+		Default("10").IntVar(&c.parallelism)
 	cmd.Flag("batch-size", "how big a batch to send").
-		Default("100").IntVar(&loadgenCommand.batchSize)
+		Default("100").IntVar(&c.batchSize)
 	cmd.Flag("write-timeout", "timeout for write requests").
-		Default("500ms").DurationVar(&loadgenCommand.writeTimeout)
+		Default("500ms").DurationVar(&c.writeTimeout)
 
-	cmd.Flag("query-url", "").
-		Default("").StringVar(&loadgenCommand.queryURL)
+	cmd.Flag("query-url", "API URL to query from (e.g. \"http://mimir.local/api/v1\")").
+		Default("").StringVar(&c.queryURL)
 	cmd.Flag("query", "query to run").
-		Default("sum(node_cpu_seconds_total)").StringVar(&loadgenCommand.query)
+		Default("sum(node_cpu_seconds_total)").StringVar(&c.query)
 	cmd.Flag("query-parallelism", "number of queries to run in parallel").
-		Default("10").IntVar(&loadgenCommand.queryParallelism)
+		Default("10").IntVar(&c.queryParallelism)
 	cmd.Flag("query-timeout", "").
-		Default("20s").DurationVar(&loadgenCommand.queryTimeout)
+		Default("20s").DurationVar(&c.queryTimeout)
 	cmd.Flag("query-duration", "length of query").
-		Default("1h").DurationVar(&loadgenCommand.queryDuration)
+		Default("1h").DurationVar(&c.queryDuration)
 
 	cmd.Flag("metrics-listen-address", "address to serve metrics on").
-		Default(":8080").StringVar(&loadgenCommand.metricsListenAddress)
+		Default("127.0.0.1:8080").StringVar(&c.metricsListenAddress)
 }
 
 func (c *LoadgenCommand) setup(_ *kingpin.ParseContext, reg prometheus.Registerer) error {


### PR DESCRIPTION
#### What this PR does

This one fixes the panic in `mimirtool loadgen`

```
› go run ./cmd/mimirtool/ loadgen --write-url='http://127.0.0.1:9009/api/v1/push'
2024/03/14 20:23:59 setting up write load gen:
  url=http://127.0.0.1:9009/api/v1/push
  parallelism: 10
  active_series: 1000
 interval: 15s
2024/03/14 20:23:59 query load generation is disabled, -query-url flag has not been set
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x100c3892c]

goroutine 95 [running]:
github.com/prometheus/client_golang/prometheus.(*HistogramVec).GetMetricWithLabelValues(0x140008ef080?, {0x1400127be30?, 0x103e3f900?, 0x140015a4000?})
	/Users/v/Documents/Code/grafana/mimir-main/vendor/github.com/prometheus/client_golang/prometheus/histogram.go:1165 +0x1c
github.com/prometheus/client_golang/prometheus.(*HistogramVec).WithLabelValues(...)
	/Users/v/Documents/Code/grafana/mimir-main/vendor/github.com/prometheus/client_golang/prometheus/histogram.go:1198
github.com/grafana/mimir/pkg/mimirtool/commands.(*LoadgenCommand).runBatch(0x14000c85110, 0x2bc, 0x320)
	/Users/v/Documents/Code/grafana/mimir-main/pkg/mimirtool/commands/loadgen.go:238 +0x4a0
github.com/grafana/mimir/pkg/mimirtool/commands.(*LoadgenCommand).runScrape(0x14000c85110, 0x2bc, 0x320)
	/Users/v/Documents/Code/grafana/mimir-main/pkg/mimirtool/commands/loadgen.go:194 +0x60
github.com/grafana/mimir/pkg/mimirtool/commands.(*LoadgenCommand).runWriteShard(0x14000c85110, 0x2bc, 0x320)
	/Users/v/Documents/Code/grafana/mimir-main/pkg/mimirtool/commands/loadgen.go:186 +0x78
created by github.com/grafana/mimir/pkg/mimirtool/commands.(*LoadgenCommand).run in goroutine 1
	/Users/v/Documents/Code/grafana/mimir-main/pkg/mimirtool/commands/loadgen.go:154 +0x698
exit status 2
```

The issues that command initializes local metrics in the different instance of `LoadgenCommand` variable, than what executes the command's action. 

_I guess, the part that no one's bumped into that for the past 4 years, speaks for how popular the command is_ 🤣 

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
