### PR TITLE
docs: clarify monitor-grafana-mimir/requirements.md

### DIFF
--- a/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
+++ b/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
@@ -88,7 +88,7 @@ For more information about the kubelet metrics and cAdvisor metrics exported by 
 Metrics from kubelet, kube-state-metrics, and cAdvisor must all have a `cluster` label with the same value as in the
 Mimir metrics.
 
-Metrics from node_exporter must all have an `instance` label on them that has the same value as the `instance` label on Mimir metrics.
+Metrics from node_exporter and cAdvisor must all have an `instance` label on them that has the same value as the `instance` label on Mimir metrics.
 
 ## Log labels
 

--- a/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
+++ b/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
@@ -80,7 +80,7 @@ The Grafana Mimir dashboards displaying CPU, memory, disk, and network resources
 
 - [cAdvisor](https://github.com/google/cadvisor)
 - [kubelet](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/)
-- [`node_exporter`](https://github.com/prometheus/node_exporter)
+- [Node Exporter](https://github.com/prometheus/node_exporter)
 - [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) exporter
 
 For more information about the kubelet metrics and cAdvisor metrics exported by the kubelet, refer to [Metrics For Kubernetes System Components](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/).
@@ -88,7 +88,7 @@ For more information about the kubelet metrics and cAdvisor metrics exported by 
 Metrics from kubelet, kube-state-metrics, and cAdvisor must all have a `cluster` label with the same value as in the
 Mimir metrics.
 
-Metrics from `node_exporter` and cAdvisor must all have an `instance` label on them that has the same value as the `instance` label on Mimir metrics.
+Metrics from Node Exporter and cAdvisor must all have an `instance` label on them that has the same value as the `instance` label on Mimir metrics.
 
 ## Log labels
 

--- a/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
+++ b/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
@@ -80,7 +80,7 @@ The Grafana Mimir dashboards displaying CPU, memory, disk, and network resources
 
 - [cAdvisor](https://github.com/google/cadvisor)
 - [kubelet](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/)
-- [node_exporter](https://github.com/prometheus/node_exporter)
+- [`node_exporter`](https://github.com/prometheus/node_exporter)
 - [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) exporter
 
 For more information about the kubelet metrics and cAdvisor metrics exported by the kubelet, refer to [Metrics For Kubernetes System Components](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/).
@@ -88,7 +88,7 @@ For more information about the kubelet metrics and cAdvisor metrics exported by 
 Metrics from kubelet, kube-state-metrics, and cAdvisor must all have a `cluster` label with the same value as in the
 Mimir metrics.
 
-Metrics from node_exporter and cAdvisor must all have an `instance` label on them that has the same value as the `instance` label on Mimir metrics.
+Metrics from `node_exporter` and cAdvisor must all have an `instance` label on them that has the same value as the `instance` label on Mimir metrics.
 
 ## Log labels
 


### PR DESCRIPTION
cAdvisor metrics also need the `instance` label to match what node_exporter and Mimir have

fixes https://github.com/grafana/mimir/issues/7570