### PR TITLE
Get rid of -querier.prefer-streaming-chunks-from-ingesters and -querier.minimize-ingester-requests

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1812,17 +1812,6 @@
         },
         {
           "kind": "field",
-          "name": "prefer_streaming_chunks_from_ingesters",
-          "required": false,
-          "desc": "Request ingesters stream chunks. Ingesters will only respond with a stream of chunks if the target ingester supports this, and this preference will be ignored by ingesters that do not support this.",
-          "fieldValue": null,
-          "fieldDefaultValue": true,
-          "fieldFlag": "querier.prefer-streaming-chunks-from-ingesters",
-          "fieldType": "boolean",
-          "fieldCategory": "experimental"
-        },
-        {
-          "kind": "field",
           "name": "prefer_streaming_chunks_from_store_gateways",
           "required": false,
           "desc": "Request store-gateways stream chunks. Store-gateways will only respond with a stream of chunks if the target store-gateway supports this, and this preference will be ignored by store-gateways that do not support this.",
@@ -1852,17 +1841,6 @@
           "fieldDefaultValue": 256,
           "fieldFlag": "querier.streaming-chunks-per-store-gateway-buffer-size",
           "fieldType": "int",
-          "fieldCategory": "experimental"
-        },
-        {
-          "kind": "field",
-          "name": "minimize_ingester_requests",
-          "required": false,
-          "desc": "If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path.",
-          "fieldValue": null,
-          "fieldDefaultValue": true,
-          "fieldFlag": "querier.minimize-ingester-requests",
-          "fieldType": "boolean",
           "fieldCategory": "experimental"
         },
         {

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1713,12 +1713,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of split (by time) or partial (by shard) queries that will be scheduled in parallel by the query-frontend for a single input query. This limit is introduced to have a fairer query scheduling and avoid a single query over a large time range saturating all available queriers. (default 14)
   -querier.max-samples int
     	Maximum number of samples a single query can load into memory. This config option should be set on query-frontend too when query sharding is enabled. (default 50000000)
-  -querier.minimize-ingester-requests
-    	[experimental] If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path. (default true)
   -querier.minimize-ingester-requests-hedging-delay duration
     	Delay before initiating requests to further ingesters when request minimization is enabled and the initially selected set of ingesters have not all responded. Ignored if -querier.minimize-ingester-requests is not enabled. (default 3s)
-  -querier.prefer-streaming-chunks-from-ingesters
-    	[experimental] Request ingesters stream chunks. Ingesters will only respond with a stream of chunks if the target ingester supports this, and this preference will be ignored by ingesters that do not support this. (default true)
   -querier.prefer-streaming-chunks-from-store-gateways
     	[experimental] Request store-gateways stream chunks. Store-gateways will only respond with a stream of chunks if the target store-gateway supports this, and this preference will be ignored by store-gateways that do not support this.
   -querier.promql-experimental-functions-enabled

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -120,9 +120,7 @@ The following features are currently experimental:
     - `-ingester.client.circuit-breaker.cooldown-period`
 - Querier
   - Use of Redis cache backend (`-blocks-storage.bucket-store.metadata-cache.backend=redis`)
-  - Streaming chunks from ingester to querier (`-querier.prefer-streaming-chunks-from-ingesters`)
   - Streaming chunks from store-gateway to querier (`-querier.prefer-streaming-chunks-from-store-gateways`, `-querier.streaming-chunks-per-store-gateway-buffer-size`)
-  - Ingester query request minimisation (`-querier.minimize-ingester-requests`)
   - Limiting queries based on the estimated number of chunks that will be used (`-querier.max-estimated-fetched-chunks-per-query-multiplier`)
   - Max concurrency for tenant federated queries (`-tenant-federation.max-concurrent`)
   - Maximum response size for active series queries (`-querier.active-series-results-max-size-bytes`)

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1291,12 +1291,6 @@ store_gateway_client:
 # CLI flag: -querier.shuffle-sharding-ingesters-enabled
 [shuffle_sharding_ingesters_enabled: <boolean> | default = true]
 
-# (experimental) Request ingesters stream chunks. Ingesters will only respond
-# with a stream of chunks if the target ingester supports this, and this
-# preference will be ignored by ingesters that do not support this.
-# CLI flag: -querier.prefer-streaming-chunks-from-ingesters
-[prefer_streaming_chunks_from_ingesters: <boolean> | default = true]
-
 # (experimental) Request store-gateways stream chunks. Store-gateways will only
 # respond with a stream of chunks if the target store-gateway supports this, and
 # this preference will be ignored by store-gateways that do not support this.
@@ -1312,14 +1306,6 @@ store_gateway_client:
 # chunks from store-gateways.
 # CLI flag: -querier.streaming-chunks-per-store-gateway-buffer-size
 [streaming_chunks_per_store_gateway_series_buffer_size: <int> | default = 256]
-
-# (experimental) If true, when querying ingesters, only the minimum required
-# ingesters required to reach quorum will be queried initially, with other
-# ingesters queried only if needed due to failures from the initial set of
-# ingesters. Enabling this option reduces resource consumption for the happy
-# path at the cost of increased latency for the unhappy path.
-# CLI flag: -querier.minimize-ingester-requests
-[minimize_ingester_requests: <boolean> | default = true]
 
 # (advanced) Delay before initiating requests to further ingesters when request
 # minimization is enabled and the initially selected set of ingesters have not

--- a/docs/sources/mimir/release-notes/v2.12.md
+++ b/docs/sources/mimir/release-notes/v2.12.md
@@ -99,6 +99,8 @@ The default value of the following CLI flags have been changed:
 The following deprecated configuration options are removed in Grafana Mimir 2.12:
 
 - The YAML setting `frontend.cache_unaligned_requests`.
+- Experimental CLI flag `-querier.prefer-streaming-chunks-from-ingesters`.
+- Experimental CLI flag `-querier.minimize-ingester-requests`.
 
 The following configuration options are deprecated and will be removed in Grafana Mimir 2.14:
 

--- a/integration/ingester_test.go
+++ b/integration/ingester_test.go
@@ -501,9 +501,8 @@ func TestIngesterQuerying(t *testing.T) {
 					defer s.Close()
 
 					baseFlags := map[string]string{
-						"-distributor.ingestion-tenant-shard-size":        "0",
-						"-ingester.ring.heartbeat-period":                 "1s",
-						"-querier.prefer-streaming-chunks-from-ingesters": strconv.FormatBool(streamingEnabled),
+						"-distributor.ingestion-tenant-shard-size": "0",
+						"-ingester.ring.heartbeat-period":          "1s",
 					}
 
 					flags := mergeFlags(
@@ -596,12 +595,10 @@ func TestIngesterQueryingWithRequestMinimization(t *testing.T) {
 			defer s.Close()
 
 			baseFlags := map[string]string{
-				"-distributor.ingestion-tenant-shard-size":        "0",
-				"-ingester.ring.heartbeat-period":                 "1s",
-				"-ingester.ring.zone-awareness-enabled":           "true",
-				"-ingester.ring.replication-factor":               "3",
-				"-querier.minimize-ingester-requests":             "true",
-				"-querier.prefer-streaming-chunks-from-ingesters": strconv.FormatBool(streamingEnabled),
+				"-distributor.ingestion-tenant-shard-size": "0",
+				"-ingester.ring.heartbeat-period":          "1s",
+				"-ingester.ring.zone-awareness-enabled":    "true",
+				"-ingester.ring.replication-factor":        "3",
 			}
 
 			flags := mergeFlags(

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -158,7 +158,6 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, stream
 				"-store-gateway.tenant-shard-size":                             fmt.Sprintf("%d", testCfg.tenantShardSize),
 				"-query-frontend.query-stats-enabled":                          "true",
 				"-query-frontend.parallelize-shardable-queries":                strconv.FormatBool(testCfg.queryShardingEnabled),
-				"-querier.prefer-streaming-chunks-from-ingesters":              strconv.FormatBool(streamingEnabled),
 				"-querier.prefer-streaming-chunks-from-store-gateways":         strconv.FormatBool(streamingEnabled),
 			})
 
@@ -865,7 +864,6 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 				"-blocks-storage.bucket-store.sync-interval":           "1s",
 				"-blocks-storage.tsdb.retention-period":                ((blockRangePeriod * 2) - 1).String(),
 				"-querier.max-fetched-series-per-query":                "3",
-				"-querier.prefer-streaming-chunks-from-ingesters":      strconv.FormatBool(streamingEnabled),
 				"-querier.prefer-streaming-chunks-from-store-gateways": strconv.FormatBool(streamingEnabled),
 			})
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -193,9 +193,7 @@ type Config struct {
 
 	// This config is dynamically injected because it is defined in the querier config.
 	ShuffleShardingLookbackPeriod              time.Duration `yaml:"-"`
-	PreferStreamingChunksFromIngesters         bool          `yaml:"-"`
 	StreamingChunksPerIngesterSeriesBufferSize uint64        `yaml:"-"`
-	MinimizeIngesterRequests                   bool          `yaml:"-"`
 	MinimiseIngesterRequestsHedgingDelay       time.Duration `yaml:"-"`
 	PreferAvailabilityZone                     string        `yaml:"-"`
 
@@ -1525,7 +1523,7 @@ func (d *Distributor) queryQuorumConfigForReplicationSets(ctx context.Context, r
 	}
 
 	return ring.DoUntilQuorumConfig{
-		MinimizeRequests: d.cfg.MinimizeIngesterRequests,
+		MinimizeRequests: true,
 		HedgingDelay:     d.cfg.MinimiseIngesterRequestsHedgingDelay,
 		ZoneSorter:       zoneSorter,
 		Logger:           spanlogger.FromContext(ctx, d.log),

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -85,10 +85,7 @@ func (d *Distributor) QueryStream(ctx context.Context, queryMetrics *stats.Query
 			return err
 		}
 
-		if d.cfg.PreferStreamingChunksFromIngesters {
-			req.StreamingChunksBatchSize = d.cfg.StreamingChunksPerIngesterSeriesBufferSize
-		}
-
+		req.StreamingChunksBatchSize = d.cfg.StreamingChunksPerIngesterSeriesBufferSize
 		replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
 		if err != nil {
 			return err

--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -186,83 +186,71 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReac
 		t.Run(name, func(t *testing.T) {
 			for _, streamingEnabled := range []bool{true, false} {
 				t.Run(fmt.Sprintf("streaming enabled: %v", streamingEnabled), func(t *testing.T) {
-					for _, minimizeIngesterRequests := range []bool{true, false} {
-						t.Run(fmt.Sprintf("request minimization enabled: %v", minimizeIngesterRequests), func(t *testing.T) {
-							userCtx := user.InjectOrgID(context.Background(), "user")
-							limits := prepareDefaultLimits()
-							limits.MaxChunksPerQuery = limit
+					userCtx := user.InjectOrgID(context.Background(), "user")
+					limits := prepareDefaultLimits()
+					limits.MaxChunksPerQuery = limit
 
-							// Prepare distributors.
-							ds, ingesters, reg, _ := prepare(t, prepConfig{
-								numIngesters:    3,
-								happyIngesters:  3,
-								numDistributors: 1,
-								limits:          limits,
-								configure: func(config *Config) {
-									config.PreferStreamingChunksFromIngesters = streamingEnabled
-									config.MinimizeIngesterRequests = minimizeIngesterRequests
-								},
-							})
+					// Prepare distributors.
+					ds, ingesters, reg, _ := prepare(t, prepConfig{
+						numIngesters:    3,
+						happyIngesters:  3,
+						numDistributors: 1,
+						limits:          limits,
+					})
 
-							// Push a number of series below the max chunks limit. Each series has 1 sample,
-							// so expect 1 chunk per series when querying back.
-							initialSeries := limit / 3
-							writeReq := makeWriteRequest(0, initialSeries, 0, false, false, "foo")
-							writeRes, err := ds[0].Push(userCtx, writeReq)
-							require.Equal(t, &mimirpb.WriteResponse{}, writeRes)
-							require.Nil(t, err)
+					// Push a number of series below the max chunks limit. Each series has 1 sample,
+					// so expect 1 chunk per series when querying back.
+					initialSeries := limit / 3
+					writeReq := makeWriteRequest(0, initialSeries, 0, false, false, "foo")
+					writeRes, err := ds[0].Push(userCtx, writeReq)
+					require.Equal(t, &mimirpb.WriteResponse{}, writeRes)
+					require.Nil(t, err)
 
-							allSeriesMatchers := []*labels.Matcher{
-								labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+"),
-							}
-
-							queryCtx := limiter.AddQueryLimiterToContext(userCtx, limiter.NewQueryLimiter(0, 0, testCase.maxChunksLimit, testCase.maxEstimatedChunksLimit, stats.NewQueryMetrics(prometheus.NewPedanticRegistry())))
-							queryMetrics := stats.NewQueryMetrics(reg[0])
-
-							// Since the number of series (and thus chunks) is equal to the limit (but doesn't
-							// exceed it), we expect a query running on all series to succeed.
-							queryRes, err := ds[0].QueryStream(queryCtx, queryMetrics, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
-							require.NoError(t, err)
-
-							if streamingEnabled {
-								require.Len(t, queryRes.StreamingSeries, initialSeries)
-							} else {
-								require.Len(t, queryRes.Chunkseries, initialSeries)
-							}
-
-							firstRequestIngesterQueryCount := countCalls(ingesters, "QueryStream")
-
-							if minimizeIngesterRequests {
-								require.LessOrEqual(t, firstRequestIngesterQueryCount, 2, "should not call third ingester if request minimisation is enabled and first two ingesters return a successful response")
-							}
-
-							// Push more series to exceed the limit once we'll query back all series.
-							writeReq = &mimirpb.WriteRequest{}
-							for i := 0; i < limit; i++ {
-								writeReq.Timeseries = append(writeReq.Timeseries,
-									makeTimeseries([]string{model.MetricNameLabel, fmt.Sprintf("another_series_%d", i)}, makeSamples(0, 0), nil),
-								)
-							}
-
-							writeRes, err = ds[0].Push(userCtx, writeReq)
-							require.Equal(t, &mimirpb.WriteResponse{}, writeRes)
-							require.Nil(t, err)
-
-							// Reset the query limiter in the context.
-							queryCtx = limiter.AddQueryLimiterToContext(userCtx, limiter.NewQueryLimiter(0, 0, testCase.maxChunksLimit, testCase.maxEstimatedChunksLimit, stats.NewQueryMetrics(prometheus.NewPedanticRegistry())))
-
-							// Since the number of series (and thus chunks) is exceeding to the limit, we expect
-							// a query running on all series to fail.
-							_, err = ds[0].QueryStream(queryCtx, queryMetrics, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
-							require.Error(t, err)
-							require.ErrorContains(t, err, testCase.expectedError)
-
-							if minimizeIngesterRequests {
-								secondRequestIngesterQueryCallCount := countCalls(ingesters, "QueryStream") - firstRequestIngesterQueryCount
-								require.LessOrEqual(t, secondRequestIngesterQueryCallCount, 2, "should not call third ingester if request minimisation is enabled and either of first two ingesters fail with limits error")
-							}
-						})
+					allSeriesMatchers := []*labels.Matcher{
+						labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+"),
 					}
+
+					queryCtx := limiter.AddQueryLimiterToContext(userCtx, limiter.NewQueryLimiter(0, 0, testCase.maxChunksLimit, testCase.maxEstimatedChunksLimit, stats.NewQueryMetrics(prometheus.NewPedanticRegistry())))
+					queryMetrics := stats.NewQueryMetrics(reg[0])
+
+					// Since the number of series (and thus chunks) is equal to the limit (but doesn't
+					// exceed it), we expect a query running on all series to succeed.
+					queryRes, err := ds[0].QueryStream(queryCtx, queryMetrics, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+					require.NoError(t, err)
+
+					if streamingEnabled {
+						require.Len(t, queryRes.StreamingSeries, initialSeries)
+					} else {
+						require.Len(t, queryRes.Chunkseries, initialSeries)
+					}
+
+					firstRequestIngesterQueryCount := countCalls(ingesters, "QueryStream")
+
+					require.LessOrEqual(t, firstRequestIngesterQueryCount, 2, "should not call third ingester if request minimisation is enabled and first two ingesters return a successful response")
+
+					// Push more series to exceed the limit once we'll query back all series.
+					writeReq = &mimirpb.WriteRequest{}
+					for i := 0; i < limit; i++ {
+						writeReq.Timeseries = append(writeReq.Timeseries,
+							makeTimeseries([]string{model.MetricNameLabel, fmt.Sprintf("another_series_%d", i)}, makeSamples(0, 0), nil),
+						)
+					}
+
+					writeRes, err = ds[0].Push(userCtx, writeReq)
+					require.Equal(t, &mimirpb.WriteResponse{}, writeRes)
+					require.Nil(t, err)
+
+					// Reset the query limiter in the context.
+					queryCtx = limiter.AddQueryLimiterToContext(userCtx, limiter.NewQueryLimiter(0, 0, testCase.maxChunksLimit, testCase.maxEstimatedChunksLimit, stats.NewQueryMetrics(prometheus.NewPedanticRegistry())))
+
+					// Since the number of series (and thus chunks) is exceeding to the limit, we expect
+					// a query running on all series to fail.
+					_, err = ds[0].QueryStream(queryCtx, queryMetrics, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+					require.Error(t, err)
+					require.ErrorContains(t, err, testCase.expectedError)
+
+					secondRequestIngesterQueryCallCount := countCalls(ingesters, "QueryStream") - firstRequestIngesterQueryCount
+					require.LessOrEqual(t, secondRequestIngesterQueryCallCount, 2, "should not call third ingester if request minimisation is enabled and either of first two ingesters fail with limits error")
 				})
 			}
 		})
@@ -272,70 +260,59 @@ func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunksPerQueryLimitIsReac
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxSeriesPerQueryLimitIsReached(t *testing.T) {
 	const maxSeriesLimit = 10
 
-	for _, minimizeIngesterRequests := range []bool{true, false} {
-		t.Run(fmt.Sprintf("request minimization enabled: %v", minimizeIngesterRequests), func(t *testing.T) {
-			userCtx := user.InjectOrgID(context.Background(), "user")
-			limits := prepareDefaultLimits()
+	userCtx := user.InjectOrgID(context.Background(), "user")
+	limits := prepareDefaultLimits()
 
-			// Prepare distributors.
-			ds, ingesters, reg, _ := prepare(t, prepConfig{
-				numIngesters:    3,
-				happyIngesters:  3,
-				numDistributors: 1,
-				limits:          limits,
-				configure: func(config *Config) {
-					config.MinimizeIngesterRequests = minimizeIngesterRequests
-				},
-			})
+	// Prepare distributors.
+	ds, ingesters, reg, _ := prepare(t, prepConfig{
+		numIngesters:    3,
+		happyIngesters:  3,
+		numDistributors: 1,
+		limits:          limits,
+	})
 
-			// Push a number of series below the max series limit.
-			initialSeries := maxSeriesLimit
-			writeReq := makeWriteRequest(0, initialSeries, 0, false, true, "foo")
-			writeRes, err := ds[0].Push(userCtx, writeReq)
-			assert.Equal(t, &mimirpb.WriteResponse{}, writeRes)
-			assert.Nil(t, err)
+	// Push a number of series below the max series limit.
+	initialSeries := maxSeriesLimit
+	writeReq := makeWriteRequest(0, initialSeries, 0, false, true, "foo")
+	writeRes, err := ds[0].Push(userCtx, writeReq)
+	assert.Equal(t, &mimirpb.WriteResponse{}, writeRes)
+	assert.Nil(t, err)
 
-			allSeriesMatchers := []*labels.Matcher{
-				labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+"),
-			}
-
-			queryMetrics := stats.NewQueryMetrics(reg[0])
-
-			// Since the number of series is equal to the limit (but doesn't
-			// exceed it), we expect a query running on all series to succeed.
-			queryCtx := limiter.AddQueryLimiterToContext(userCtx, limiter.NewQueryLimiter(maxSeriesLimit, 0, 0, 0, stats.NewQueryMetrics(prometheus.NewPedanticRegistry())))
-			queryRes, err := ds[0].QueryStream(queryCtx, queryMetrics, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
-			require.NoError(t, err)
-			assert.Len(t, queryRes.Chunkseries, initialSeries)
-
-			firstRequestIngesterQueryCount := countCalls(ingesters, "QueryStream")
-
-			if minimizeIngesterRequests {
-				require.LessOrEqual(t, firstRequestIngesterQueryCount, 2, "should not call third ingester if request minimisation is enabled and first two ingesters return a successful response")
-			}
-
-			// Push more series to exceed the limit once we'll query back all series.
-			writeReq = makeWriteRequestWith(makeTimeseries([]string{model.MetricNameLabel, "another_series"}, makeSamples(0, 0), nil))
-
-			writeRes, err = ds[0].Push(userCtx, writeReq)
-			assert.Equal(t, &mimirpb.WriteResponse{}, writeRes)
-			assert.Nil(t, err)
-
-			// Reset the query limiter in the context.
-			queryCtx = limiter.AddQueryLimiterToContext(userCtx, limiter.NewQueryLimiter(maxSeriesLimit, 0, 0, 0, stats.NewQueryMetrics(prometheus.NewPedanticRegistry())))
-
-			// Since the number of series is exceeding the limit, we expect
-			// a query running on all series to fail.
-			_, err = ds[0].QueryStream(queryCtx, queryMetrics, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
-			require.Error(t, err)
-			assert.ErrorContains(t, err, "the query exceeded the maximum number of series")
-
-			if minimizeIngesterRequests {
-				secondRequestIngesterQueryCallCount := countCalls(ingesters, "QueryStream") - firstRequestIngesterQueryCount
-				require.LessOrEqual(t, secondRequestIngesterQueryCallCount, 2, "should not call third ingester if request minimisation is enabled and either of first two ingesters fail with limits error")
-			}
-		})
+	allSeriesMatchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+"),
 	}
+
+	queryMetrics := stats.NewQueryMetrics(reg[0])
+
+	// Since the number of series is equal to the limit (but doesn't
+	// exceed it), we expect a query running on all series to succeed.
+	queryCtx := limiter.AddQueryLimiterToContext(userCtx, limiter.NewQueryLimiter(maxSeriesLimit, 0, 0, 0, stats.NewQueryMetrics(prometheus.NewPedanticRegistry())))
+	queryRes, err := ds[0].QueryStream(queryCtx, queryMetrics, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+	require.NoError(t, err)
+	assert.Len(t, queryRes.Chunkseries, initialSeries)
+
+	firstRequestIngesterQueryCount := countCalls(ingesters, "QueryStream")
+
+	require.LessOrEqual(t, firstRequestIngesterQueryCount, 2, "should not call third ingester if request minimisation is enabled and first two ingesters return a successful response")
+
+	// Push more series to exceed the limit once we'll query back all series.
+	writeReq = makeWriteRequestWith(makeTimeseries([]string{model.MetricNameLabel, "another_series"}, makeSamples(0, 0), nil))
+
+	writeRes, err = ds[0].Push(userCtx, writeReq)
+	assert.Equal(t, &mimirpb.WriteResponse{}, writeRes)
+	assert.Nil(t, err)
+
+	// Reset the query limiter in the context.
+	queryCtx = limiter.AddQueryLimiterToContext(userCtx, limiter.NewQueryLimiter(maxSeriesLimit, 0, 0, 0, stats.NewQueryMetrics(prometheus.NewPedanticRegistry())))
+
+	// Since the number of series is exceeding the limit, we expect
+	// a query running on all series to fail.
+	_, err = ds[0].QueryStream(queryCtx, queryMetrics, math.MinInt32, math.MaxInt32, allSeriesMatchers...)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "the query exceeded the maximum number of series")
+
+	secondRequestIngesterQueryCallCount := countCalls(ingesters, "QueryStream") - firstRequestIngesterQueryCount
+	require.LessOrEqual(t, secondRequestIngesterQueryCallCount, 2, "should not call third ingester if request minimisation is enabled and either of first two ingesters fail with limits error")
 }
 
 func TestDistributor_QueryStream_ShouldReturnErrorIfMaxChunkBytesPerQueryLimitIsReached(t *testing.T) {
@@ -421,9 +398,6 @@ func TestDistributor_QueryStream_ShouldSuccessfullyRunOnSlowIngesterWithStreamin
 				replicationFactor:       1, // Use replication factor of 1 so that we always wait the response from all ingesters.
 				ingestStorageEnabled:    ingestStorageEnabled,
 				ingestStoragePartitions: 3,
-				configure: func(cfg *Config) {
-					cfg.PreferStreamingChunksFromIngesters = true
-				},
 			})
 
 			// Mock 1 ingester to be slow.

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -467,9 +467,7 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 	// ruler's dependency)
 	canJoinDistributorsRing := t.Cfg.isAnyModuleEnabled(Distributor, Write, All)
 
-	t.Cfg.Distributor.PreferStreamingChunksFromIngesters = t.Cfg.Querier.PreferStreamingChunksFromIngesters
 	t.Cfg.Distributor.StreamingChunksPerIngesterSeriesBufferSize = t.Cfg.Querier.StreamingChunksPerIngesterSeriesBufferSize
-	t.Cfg.Distributor.MinimizeIngesterRequests = t.Cfg.Querier.MinimizeIngesterRequests
 	t.Cfg.Distributor.MinimiseIngesterRequestsHedgingDelay = t.Cfg.Querier.MinimiseIngesterRequestsHedgingDelay
 	t.Cfg.Distributor.PreferAvailabilityZone = t.Cfg.Querier.PreferAvailabilityZone
 	t.Cfg.Distributor.IngestStorageConfig = t.Cfg.IngestStorage

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -48,12 +48,10 @@ type Config struct {
 
 	ShuffleShardingIngestersEnabled bool `yaml:"shuffle_sharding_ingesters_enabled" category:"advanced"`
 
-	PreferStreamingChunksFromIngesters             bool          `yaml:"prefer_streaming_chunks_from_ingesters" category:"experimental"` // Enabled by default as of Mimir 2.11, remove altogether in 2.12.
 	PreferStreamingChunksFromStoreGateways         bool          `yaml:"prefer_streaming_chunks_from_store_gateways" category:"experimental"`
 	PreferAvailabilityZone                         string        `yaml:"prefer_availability_zone" category:"experimental" doc:"hidden"`
 	StreamingChunksPerIngesterSeriesBufferSize     uint64        `yaml:"streaming_chunks_per_ingester_series_buffer_size" category:"advanced"`
 	StreamingChunksPerStoreGatewaySeriesBufferSize uint64        `yaml:"streaming_chunks_per_store_gateway_series_buffer_size" category:"experimental"`
-	MinimizeIngesterRequests                       bool          `yaml:"minimize_ingester_requests" category:"experimental"` // Enabled by default as of Mimir 2.11, remove altogether in 2.12.
 	MinimiseIngesterRequestsHedgingDelay           time.Duration `yaml:"minimize_ingester_requests_hedging_delay" category:"advanced"`
 
 	// PromQL engine config.
@@ -71,12 +69,10 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.MaxQueryIntoFuture, "querier.max-query-into-future", 10*time.Minute, "Maximum duration into the future you can query. 0 to disable.")
 	f.DurationVar(&cfg.QueryStoreAfter, queryStoreAfterFlag, 12*time.Hour, "The time after which a metric should be queried from storage and not just ingesters. 0 means all queries are sent to store. If this option is enabled, the time range of the query sent to the store-gateway will be manipulated to ensure the query end is not more recent than 'now - query-store-after'.")
 	f.BoolVar(&cfg.ShuffleShardingIngestersEnabled, "querier.shuffle-sharding-ingesters-enabled", true, fmt.Sprintf("Fetch in-memory series from the minimum set of required ingesters, selecting only ingesters which may have received series since -%s. If this setting is false or -%s is '0', queriers always query all ingesters (ingesters shuffle sharding on read path is disabled).", validation.QueryIngestersWithinFlag, validation.QueryIngestersWithinFlag))
-	f.BoolVar(&cfg.PreferStreamingChunksFromIngesters, "querier.prefer-streaming-chunks-from-ingesters", true, "Request ingesters stream chunks. Ingesters will only respond with a stream of chunks if the target ingester supports this, and this preference will be ignored by ingesters that do not support this.")
 	f.BoolVar(&cfg.PreferStreamingChunksFromStoreGateways, "querier.prefer-streaming-chunks-from-store-gateways", false, "Request store-gateways stream chunks. Store-gateways will only respond with a stream of chunks if the target store-gateway supports this, and this preference will be ignored by store-gateways that do not support this.")
 	f.StringVar(&cfg.PreferAvailabilityZone, "querier.prefer-availability-zone", "", "Preferred availability zone to query ingesters from when using the ingest storage.")
 
 	const minimiseIngesterRequestsFlagName = "querier.minimize-ingester-requests"
-	f.BoolVar(&cfg.MinimizeIngesterRequests, minimiseIngesterRequestsFlagName, true, "If true, when querying ingesters, only the minimum required ingesters required to reach quorum will be queried initially, with other ingesters queried only if needed due to failures from the initial set of ingesters. Enabling this option reduces resource consumption for the happy path at the cost of increased latency for the unhappy path.")
 	f.DurationVar(&cfg.MinimiseIngesterRequestsHedgingDelay, minimiseIngesterRequestsFlagName+"-hedging-delay", 3*time.Second, "Delay before initiating requests to further ingesters when request minimization is enabled and the initially selected set of ingesters have not all responded. Ignored if -"+minimiseIngesterRequestsFlagName+" is not enabled.")
 
 	// Why 256 series / ingester/store-gateway?


### PR DESCRIPTION
#### What this PR does
Experimental CLI flags `-querier.prefer-streaming-chunks-from-ingesters` and `-querier.minimize-ingester-requests` have been enabled by default and marked for deletion in Mimir 2.12 in https://github.com/grafana/mimir/pull/6174.
This PR gets rid of the 2 CLI flags.

#### Which issue(s) this PR fixes or relates to

Part of #7542 

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
