### PR TITLE
[query-frontend] Close response body in request handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [BUGFIX] querier: Don't cache context.Canceled errors for bucket index. #7620
 * [BUGFIX] Store-gateway: account for `"other"` time in LabelValues and LabelNames requests. #7622
 * [BUGFIX] Query-frontend: Don't panic when using the `-query-frontend.downstream-url` flag. #7651
+* [BUGFIX] Query-frontend: close the response body upon completion of the request. #7654
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [BUGFIX] querier: Don't cache context.Canceled errors for bucket index. #7620
 * [BUGFIX] Store-gateway: account for `"other"` time in LabelValues and LabelNames requests. #7622
 * [BUGFIX] Query-frontend: Don't panic when using the `-query-frontend.downstream-url` flag. #7651
-* [BUGFIX] Query-frontend: close the response body upon completion of the request. #7654
+* [BUGFIX] Query-frontend: Fix memory leak on every request. #7654
 
 ### Mixin
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -216,6 +216,14 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Make sure to close the response body to release resources associated with this request.
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			level.Warn(f.log).Log("msg", "failed to close response body", "err", err)
+		}
+	}()
+
 	hs := w.Header()
 	for h, vs := range resp.Header {
 		hs[h] = vs

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -218,9 +218,11 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Make sure to close the response body to release resources associated with this request.
 	defer func() {
-		err = resp.Body.Close()
-		if err != nil {
-			level.Warn(f.log).Log("msg", "failed to close response body", "err", err)
+		if resp.Body != nil {
+			err = resp.Body.Close()
+			if err != nil {
+				level.Warn(f.log).Log("msg", "failed to close response body", "err", err)
+			}
 		}
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This closes the response body received by the frontend handler to free the resources associated with it. If this isn't done and the `response.Body` contains a non-noop `io.ReadCloser` it causes a memory leak.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
