### PR TITLE
frontend: use zero-allocation response decoder in shard active series middleware 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [ENHANCEMENT] Store-gateway: Add `stage="wait_max_concurrent"` to `cortex_bucket_store_series_request_stage_duration_seconds` which records how long the query had to wait for its turn for `-blocks-storage.bucket-store.max-concurrent`. #7609
 * [ENHANCEMENT] Querier: add `cortex_querier_federation_upstream_query_wait_duration_seconds` to observe time from when a querier picks up a cross-tenant query to when work begins on its single-tenant counterparts. #7209
 * [ENHANCEMENT] Compactor: Add `cortex_compactor_block_compaction_delay_seconds` metric to track how long it takes to compact blocks. #7635
+* [ENHANCEMENT] Query-frontend: use zero-allocation experimental decoder for active series queries via `-query-frontend.use-shard-active-series-zero-allocation-decoder`. #7665
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [ENHANCEMENT] Store-gateway: Add `stage="wait_max_concurrent"` to `cortex_bucket_store_series_request_stage_duration_seconds` which records how long the query had to wait for its turn for `-blocks-storage.bucket-store.max-concurrent`. #7609
 * [ENHANCEMENT] Querier: add `cortex_querier_federation_upstream_query_wait_duration_seconds` to observe time from when a querier picks up a cross-tenant query to when work begins on its single-tenant counterparts. #7209
 * [ENHANCEMENT] Compactor: Add `cortex_compactor_block_compaction_delay_seconds` metric to track how long it takes to compact blocks. #7635
-* [ENHANCEMENT] Query-frontend: use zero-allocation experimental decoder for active series queries via `-query-frontend.use-shard-active-series-zero-allocation-decoder`. #7665
+* [ENHANCEMENT] Query-frontend: use zero-allocation experimental decoder for active series queries via `-query-frontend.use-active-series-decoder`. #7665
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5684,6 +5684,17 @@
         },
         {
           "kind": "field",
+          "name": "use_shard_active_series_zero_allocation_decoder",
+          "required": false,
+          "desc": "True to use the zero-allocation response decoder for active series queries.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.use-shard-active-series-zero-allocation-decoder",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "query_result_response_format",
           "required": false,
           "desc": "Format to use when retrieving query results from queriers. Supported values: json, protobuf",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5686,7 +5686,7 @@
           "kind": "field",
           "name": "use_shard_active_series_zero_allocation_decoder",
           "required": false,
-          "desc": "True to use the zero-allocation response decoder for active series queries.",
+          "desc": "Set to true to use the zero-allocation response decoder for active series queries.",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "query-frontend.use-shard-active-series-zero-allocation-decoder",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5686,7 +5686,7 @@
           "kind": "field",
           "name": "use_shard_active_series_zero_allocation_decoder",
           "required": false,
-          "desc": "Set to true to use the zero-allocation response decoder for active series queries.",
+          "desc": "True to use the zero-allocation response decoder for active series queries.",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "query-frontend.use-shard-active-series-zero-allocation-decoder",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5684,12 +5684,12 @@
         },
         {
           "kind": "field",
-          "name": "use_shard_active_series_zero_allocation_decoder",
+          "name": "use_active_series_decoder",
           "required": false,
-          "desc": "True to use the zero-allocation response decoder for active series queries.",
+          "desc": "Set to true to use the zero-allocation response decoder for active series queries.",
           "fieldValue": null,
           "fieldDefaultValue": false,
-          "fieldFlag": "query-frontend.use-shard-active-series-zero-allocation-decoder",
+          "fieldFlag": "query-frontend.use-active-series-decoder",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
         },

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2017,6 +2017,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Split instant queries by an interval and execute in parallel. 0 to disable it.
   -query-frontend.split-queries-by-interval duration
     	Split range queries by an interval and execute in parallel. You should use a multiple of 24 hours to optimize querying blocks. 0 to disable it. (default 24h0m0s)
+  -query-frontend.use-shard-active-series-zero-allocation-decoder
+    	[experimental] True to use the zero-allocation response decoder for active series queries.
   -query-scheduler.additional-query-queue-dimensions-enabled
     	[experimental] Enqueue query requests with additional queue dimensions to split tenant request queues into subqueues. This enables separate requests to proceed from a tenant's subqueues even when other subqueues are blocked on slow query requests. Must be set on both query-frontend and scheduler to take effect. (default false)
   -query-scheduler.grpc-client-config.backoff-max-period duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2017,8 +2017,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Split instant queries by an interval and execute in parallel. 0 to disable it.
   -query-frontend.split-queries-by-interval duration
     	Split range queries by an interval and execute in parallel. You should use a multiple of 24 hours to optimize querying blocks. 0 to disable it. (default 24h0m0s)
-  -query-frontend.use-shard-active-series-zero-allocation-decoder
-    	[experimental] True to use the zero-allocation response decoder for active series queries.
+  -query-frontend.use-active-series-decoder
+    	[experimental] Set to true to use the zero-allocation response decoder for active series queries.
   -query-scheduler.additional-query-queue-dimensions-enabled
     	[experimental] Enqueue query requests with additional queue dimensions to split tenant request queues into subqueues. This enables separate requests to proceed from a tenant's subqueues even when other subqueues are blocked on slow query requests. Must be set on both query-frontend and scheduler to take effect. (default false)
   -query-scheduler.grpc-client-config.backoff-max-period duration

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1504,10 +1504,10 @@ results_cache:
 # CLI flag: -query-frontend.shard-active-series-queries
 [shard_active_series_queries: <boolean> | default = false]
 
-# (experimental) True to use the zero-allocation response decoder for active
-# series queries.
-# CLI flag: -query-frontend.use-shard-active-series-zero-allocation-decoder
-[use_shard_active_series_zero_allocation_decoder: <boolean> | default = false]
+# (experimental) Set to true to use the zero-allocation response decoder for
+# active series queries.
+# CLI flag: -query-frontend.use-active-series-decoder
+[use_active_series_decoder: <boolean> | default = false]
 
 # Format to use when retrieving query results from queriers. Supported values:
 # json, protobuf

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1504,6 +1504,11 @@ results_cache:
 # CLI flag: -query-frontend.shard-active-series-queries
 [shard_active_series_queries: <boolean> | default = false]
 
+# (experimental) True to use the zero-allocation response decoder for active
+# series queries.
+# CLI flag: -query-frontend.use-shard-active-series-zero-allocation-decoder
+[use_shard_active_series_zero_allocation_decoder: <boolean> | default = false]
+
 # Format to use when retrieving query results from queriers. Supported values:
 # json, protobuf
 # CLI flag: -query-frontend.query-result-response-format

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -54,16 +54,16 @@ var (
 
 // Config for query_range middleware chain.
 type Config struct {
-	SplitQueriesByInterval               time.Duration `yaml:"split_queries_by_interval" category:"advanced"`
-	DeprecatedAlignQueriesWithStep       bool          `yaml:"align_queries_with_step" doc:"hidden"` // Deprecated: Deprecated in Mimir 2.12, remove in Mimir 2.14 (https://github.com/grafana/mimir/issues/6712)
-	ResultsCacheConfig                   `yaml:"results_cache"`
-	CacheResults                         bool          `yaml:"cache_results"`
-	MaxRetries                           int           `yaml:"max_retries" category:"advanced"`
-	NotRunningTimeout                    time.Duration `yaml:"not_running_timeout" category:"advanced"`
-	ShardedQueries                       bool          `yaml:"parallelize_shardable_queries"`
-	TargetSeriesPerShard                 uint64        `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
-	ShardActiveSeriesQueries             bool          `yaml:"shard_active_series_queries" category:"experimental"`
-	UseShardActiveSeriesZeroAllocDecoder bool          `yaml:"use_shard_active_series_zero_allocation_decoder" category:"experimental"`
+	SplitQueriesByInterval         time.Duration `yaml:"split_queries_by_interval" category:"advanced"`
+	DeprecatedAlignQueriesWithStep bool          `yaml:"align_queries_with_step" doc:"hidden"` // Deprecated: Deprecated in Mimir 2.12, remove in Mimir 2.14 (https://github.com/grafana/mimir/issues/6712)
+	ResultsCacheConfig             `yaml:"results_cache"`
+	CacheResults                   bool          `yaml:"cache_results"`
+	MaxRetries                     int           `yaml:"max_retries" category:"advanced"`
+	NotRunningTimeout              time.Duration `yaml:"not_running_timeout" category:"advanced"`
+	ShardedQueries                 bool          `yaml:"parallelize_shardable_queries"`
+	TargetSeriesPerShard           uint64        `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
+	ShardActiveSeriesQueries       bool          `yaml:"shard_active_series_queries" category:"experimental"`
+	UseActiveSeriesDecoder         bool          `yaml:"use_active_series_decoder" category:"experimental"`
 
 	// CacheKeyGenerator allows to inject a CacheKeyGenerator to use for generating cache keys.
 	// If nil, the querymiddleware package uses a DefaultCacheKeyGenerator with SplitQueriesByInterval.
@@ -82,7 +82,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Uint64Var(&cfg.TargetSeriesPerShard, "query-frontend.query-sharding-target-series-per-shard", 0, "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.")
 	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatProtobuf, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
 	f.BoolVar(&cfg.ShardActiveSeriesQueries, "query-frontend.shard-active-series-queries", false, "True to enable sharding of active series queries.")
-	f.BoolVar(&cfg.UseShardActiveSeriesZeroAllocDecoder, "query-frontend.use-shard-active-series-zero-allocation-decoder", false, "True to use the zero-allocation response decoder for active series queries.")
+	f.BoolVar(&cfg.UseActiveSeriesDecoder, "query-frontend.use-active-series-decoder", false, "Set to true to use the zero-allocation response decoder for active series queries.")
 	cfg.ResultsCacheConfig.RegisterFlags(f)
 
 	// The query-frontend.align-queries-with-step flag has been moved to the limits.go file
@@ -336,7 +336,7 @@ func newQueryTripperware(
 		}
 
 		if cfg.ShardActiveSeriesQueries {
-			activeSeries = newShardActiveSeriesMiddleware(activeSeries, cfg.UseShardActiveSeriesZeroAllocDecoder, limits, log)
+			activeSeries = newShardActiveSeriesMiddleware(activeSeries, cfg.UseActiveSeriesDecoder, limits, log)
 		}
 
 		return RoundTripFunc(func(r *http.Request) (*http.Response, error) {

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -538,7 +538,7 @@ func (s *shardActiveSeriesMiddleware) writeMergedResponseWithZeroAllocationDecod
 		}
 
 		// Reuse stream buffer.
-		reuseActiveSeriesDataChunkBuffer(streamBuf)
+		reuseActiveSeriesDataStreamBuffer(streamBuf)
 	}
 	stream.WriteArrayEnd()
 

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -530,11 +530,7 @@ func (s *shardActiveSeriesMiddleware) writeMergedResponseWithZeroAllocationDecod
 			} else {
 				stream.WriteMore()
 			}
-
-			rawStr := unsafe.String(
-				unsafe.SliceData(streamBuf.Bytes()),
-				streamBuf.Len(),
-			)
+			rawStr := unsafe.String(unsafe.SliceData(streamBuf.Bytes()), streamBuf.Len())
 
 			// Write the value as is, since it's already a JSON array.
 			stream.WriteRaw(rawStr)

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -38,6 +38,18 @@ var (
 	errShardCountTooLow = errors.New("shard count too low")
 
 	jsoniterMaxBufferSize = os.Getpagesize()
+	jsoniterBufferPool    = sync.Pool{
+		New: func() any {
+			buf := make([]byte, jsoniterMaxBufferSize)
+			return &buf
+		},
+	}
+
+	labelBuilderPool = sync.Pool{
+		New: func() any {
+			return labels.NewBuilder(labels.EmptyLabels())
+		},
+	}
 )
 
 var snappyWriterPool sync.Pool
@@ -53,16 +65,18 @@ func getSnappyWriter(w io.Writer) *s2.Writer {
 }
 
 type shardActiveSeriesMiddleware struct {
-	upstream http.RoundTripper
-	limits   Limits
-	logger   log.Logger
+	upstream                 http.RoundTripper
+	useZeroAllocationDecoder bool
+	limits                   Limits
+	logger                   log.Logger
 }
 
-func newShardActiveSeriesMiddleware(upstream http.RoundTripper, limits Limits, logger log.Logger) http.RoundTripper {
+func newShardActiveSeriesMiddleware(upstream http.RoundTripper, useZeroAllocationDecoder bool, limits Limits, logger log.Logger) http.RoundTripper {
 	return &shardActiveSeriesMiddleware{
-		upstream: upstream,
-		limits:   limits,
-		logger:   logger,
+		upstream:                 upstream,
+		useZeroAllocationDecoder: useZeroAllocationDecoder,
+		limits:                   limits,
+		logger:                   logger,
 	}
 }
 
@@ -112,8 +126,12 @@ func (s *shardActiveSeriesMiddleware) RoundTrip(r *http.Request) (*http.Response
 		}
 		return nil, apierror.New(apierror.TypeInternal, err.Error())
 	}
+	acceptEncoding := r.Header.Get("Accept-Encoding")
 
-	return s.mergeResponses(ctx, resp, r.Header.Get("Accept-Encoding")), nil
+	if s.useZeroAllocationDecoder {
+		return s.mergeResponsesWithZeroAllocationDecoder(ctx, resp, acceptEncoding), nil
+	}
+	return s.mergeResponses(ctx, resp, acceptEncoding), nil
 }
 
 func setShardCountFromHeader(origShardCount int, r *http.Request, spanLog *spanlogger.SpanLogger) int {
@@ -260,6 +278,93 @@ func shardedSelector(shardCount, currentShard int, expr parser.Expr) (parser.Exp
 func (s *shardActiveSeriesMiddleware) mergeResponses(ctx context.Context, responses []*http.Response, encoding string) *http.Response {
 	reader, writer := io.Pipe()
 
+	items := make(chan *labels.Builder, len(responses))
+
+	g := new(errgroup.Group)
+	for _, res := range responses {
+		if res == nil {
+			continue
+		}
+		r := res
+		g.Go(func() error {
+			defer func(body io.ReadCloser) {
+				// drain body reader
+				_, _ = io.Copy(io.Discard, body)
+				_ = body.Close()
+			}(r.Body)
+
+			bufPtr := jsoniterBufferPool.Get().(*[]byte)
+			defer jsoniterBufferPool.Put(bufPtr)
+
+			it := jsoniter.ConfigFastest.BorrowIterator(*bufPtr)
+			it.Reset(r.Body)
+			defer func() {
+				jsoniter.ConfigFastest.ReturnIterator(it)
+			}()
+
+			// Iterate over fields until we find data or error fields
+			foundDataField := false
+			for it.Error == nil {
+				field := it.ReadObject()
+				if field == "error" {
+					return fmt.Errorf("error in partial response: %s", it.ReadString())
+				}
+				if field == "data" {
+					foundDataField = true
+					break
+				}
+				// If the field is neither data nor error, we skip it.
+				it.ReadAny()
+			}
+			if !foundDataField {
+				return fmt.Errorf("expected data field at top level, found %s", it.CurrentBuffer())
+			}
+
+			if it.WhatIsNext() != jsoniter.ArrayValue {
+				err := errors.New("expected data field to contain an array")
+				return err
+			}
+
+			for it.ReadArray() {
+				if err := ctx.Err(); err != nil {
+					if cause := context.Cause(ctx); cause != nil {
+						return fmt.Errorf("aborted streaming because context was cancelled: %w", cause)
+					}
+					return ctx.Err()
+				}
+
+				item := labelBuilderPool.Get().(*labels.Builder)
+				it.ReadMapCB(func(iterator *jsoniter.Iterator, s string) bool {
+					item.Set(s, iterator.ReadString())
+					return true
+				})
+				items <- item
+			}
+
+			return it.Error
+		})
+	}
+
+	go func() {
+		// We ignore the error from the errgroup because it will be checked again later.
+		_ = g.Wait()
+		close(items)
+	}()
+
+	resp := &http.Response{Body: reader, StatusCode: http.StatusOK, Header: http.Header{}}
+	resp.Header.Set("Content-Type", "application/json")
+	if encoding == encodingTypeSnappyFramed {
+		resp.Header.Set("Content-Encoding", encodingTypeSnappyFramed)
+	}
+
+	go s.writeMergedResponse(ctx, g.Wait, writer, items, encoding)
+
+	return resp
+}
+
+func (s *shardActiveSeriesMiddleware) mergeResponsesWithZeroAllocationDecoder(ctx context.Context, responses []*http.Response, encoding string) *http.Response {
+	reader, writer := io.Pipe()
+
 	items := make(chan *shardActiveSeriesResponseDecoder, len(responses))
 
 	g := new(errgroup.Group)
@@ -305,15 +410,94 @@ func (s *shardActiveSeriesMiddleware) mergeResponses(ctx context.Context, respon
 		resp.Header.Set("Content-Encoding", encodingTypeSnappyFramed)
 	}
 
-	go s.writeMergedResponse(ctx, g.Wait, writer, items, encoding)
+	go s.writeMergedResponseWithZeroAllocationDecoder(ctx, g.Wait, writer, items, encoding)
 
 	return resp
 }
 
-func (s *shardActiveSeriesMiddleware) writeMergedResponse(ctx context.Context, check func() error, w io.WriteCloser, items <-chan *shardActiveSeriesResponseDecoder, encoding string) {
+func (s *shardActiveSeriesMiddleware) writeMergedResponse(ctx context.Context, check func() error, w io.WriteCloser, items <-chan *labels.Builder, encoding string) {
 	defer w.Close()
 
 	span, _ := opentracing.StartSpanFromContext(ctx, "shardActiveSeries.writeMergedResponse")
+	defer span.Finish()
+
+	var out io.Writer = w
+	if encoding == encodingTypeSnappyFramed {
+		span.LogFields(otlog.String("encoding", encodingTypeSnappyFramed))
+		enc := getSnappyWriter(w)
+		out = enc
+		defer func() {
+			enc.Close()
+			// Reset the encoder before putting it back to pool to avoid it to hold the writer.
+			enc.Reset(nil)
+			snappyWriterPool.Put(enc)
+		}()
+	} else {
+		span.LogFields(otlog.String("encoding", "none"))
+	}
+
+	stream := jsoniter.ConfigFastest.BorrowStream(out)
+	defer func(stream *jsoniter.Stream) {
+		_ = stream.Flush()
+
+		if cap(stream.Buffer()) > jsoniterMaxBufferSize {
+			return
+		}
+		jsoniter.ConfigFastest.ReturnStream(stream)
+	}(stream)
+
+	stream.WriteObjectStart()
+	stream.WriteObjectField("data")
+	stream.WriteArrayStart()
+	firstItem := true
+	for item := range items {
+		if firstItem {
+			firstItem = false
+		} else {
+			stream.WriteMore()
+		}
+		stream.WriteObjectStart()
+		firstField := true
+
+		item.Range(func(l labels.Label) {
+			if firstField {
+				firstField = false
+			} else {
+				stream.WriteMore()
+			}
+			stream.WriteObjectField(l.Name)
+			stream.WriteString(l.Value)
+		})
+		stream.WriteObjectEnd()
+
+		item.Reset(labels.EmptyLabels())
+		labelBuilderPool.Put(item)
+
+		// Flush the stream buffer if it's getting too large.
+		if stream.Buffered() > jsoniterMaxBufferSize {
+			_ = stream.Flush()
+		}
+	}
+	stream.WriteArrayEnd()
+
+	if err := check(); err != nil {
+		level.Error(s.logger).Log("msg", "error merging partial responses", "err", err.Error())
+		span.LogFields(otlog.Error(err))
+		stream.WriteMore()
+		stream.WriteObjectField("status")
+		stream.WriteString("error")
+		stream.WriteMore()
+		stream.WriteObjectField("error")
+		stream.WriteString(fmt.Sprintf("error merging partial responses: %s", err.Error()))
+	}
+
+	stream.WriteObjectEnd()
+}
+
+func (s *shardActiveSeriesMiddleware) writeMergedResponseWithZeroAllocationDecoder(ctx context.Context, check func() error, w io.WriteCloser, items <-chan *shardActiveSeriesResponseDecoder, encoding string) {
+	defer w.Close()
+
+	span, _ := opentracing.StartSpanFromContext(ctx, "shardActiveSeries.writeMergedResponseWithZeroAllocationDecoder")
 	defer span.Finish()
 
 	var out io.Writer = w

--- a/pkg/frontend/querymiddleware/shard_active_series_response_decoder.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_response_decoder.go
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Portions of this file are derived from json-iterator/go (https://github.com/json-iterator/go),
+// which is licensed under the MIT License. The specific functions derived from this source are
+// noted below in this file.
+
+package querymiddleware
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"unicode/utf16"
+	"unsafe"
+)
+
+var shardActiveSeriesDecoderMaxBuffSize = os.Getpagesize()
+
+var shardActiveSeriesResponseDecoderPool = sync.Pool{
+	New: func() any {
+		return &shardActiveSeriesResponseDecoder{
+			br:  bufio.NewReaderSize(nil, 4096),
+			out: make([]byte, 0, shardActiveSeriesDecoderMaxBuffSize),
+		}
+	},
+}
+
+func borrowShardActiveSeriesResponseDecoder(ctx context.Context, rc io.ReadCloser) *shardActiveSeriesResponseDecoder {
+	d := shardActiveSeriesResponseDecoderPool.Get().(*shardActiveSeriesResponseDecoder)
+	d.reset(ctx, rc)
+	return d
+}
+
+func reuseShardActiveSeriesResponseDecoder(d *shardActiveSeriesResponseDecoder) {
+	d.reset(context.Background(), nil)
+	if cap(d.out) > shardActiveSeriesDecoderMaxBuffSize {
+		return
+	}
+	shardActiveSeriesResponseDecoderPool.Put(d)
+}
+
+type shardActiveSeriesResponseDecoder struct {
+	ctx            context.Context
+	rc             io.ReadCloser
+	br             *bufio.Reader
+	out            []byte
+	readBytesCount int
+	foundDataValue bool
+	err            error
+}
+
+func (d *shardActiveSeriesResponseDecoder) reset(ctx context.Context, rc io.ReadCloser) {
+	d.ctx = ctx
+	d.rc = rc
+	d.br.Reset(rc)
+	d.out = d.out[:0]
+	d.readBytesCount = 0
+	d.foundDataValue = false
+	d.err = nil
+}
+
+func (d *shardActiveSeriesResponseDecoder) stickError(err error) {
+	if d.err != nil {
+		return
+	}
+	d.err = err
+}
+
+func (d *shardActiveSeriesResponseDecoder) close() {
+	_, _ = io.Copy(io.Discard, d.rc)
+	_ = d.rc.Close()
+}
+
+func (d *shardActiveSeriesResponseDecoder) hasDataValue() bool {
+	return d.foundDataValue && len(d.out) > 0
+}
+
+func (d *shardActiveSeriesResponseDecoder) dataValue() string {
+	if !d.foundDataValue {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(d.out), len(d.out))
+}
+
+func (d *shardActiveSeriesResponseDecoder) decode() error {
+	if d.foundDataValue {
+		return nil // already decoded
+	}
+
+	c := d.nextToken()
+	if d.err != nil {
+		return d.err
+	}
+	switch c {
+	case '{':
+		for d.err == nil {
+			k := d.readString()
+			switch k {
+			case "data":
+				d.readDataValue()
+				if d.err != nil {
+					return d.err
+				}
+				return d.ctx.Err()
+
+			case "error":
+				d.readErrorValue()
+				if d.err != nil {
+					return d.err
+				}
+				return d.ctx.Err()
+
+			default:
+				d.skipValue()
+			}
+
+			c = d.nextToken()
+			if c == ',' {
+				continue
+			} else if c == '}' {
+				break
+			}
+		}
+
+	default:
+		return fmt.Errorf("decode: expected {, found %c", c)
+	}
+	return errors.New("expected data field at top level")
+}
+
+func (d *shardActiveSeriesResponseDecoder) readDataValue() {
+	if c := d.nextToken(); c != ':' {
+		d.stickError(fmt.Errorf("readDataValue: expected :, found %c", c))
+		return
+	}
+	c := d.nextToken()
+	switch c {
+	case '[':
+		d.out = d.out[:0]
+
+		inner := 1
+
+		c := d.readByte()
+		for d.err == nil {
+			switch c {
+			case '[':
+				inner++
+			case ']':
+				inner--
+				if inner == 0 {
+					d.foundDataValue = true
+					return
+				}
+			default:
+				d.out = append(d.out, c)
+			}
+			c = d.readByte()
+		}
+
+	default:
+		d.stickError(errors.New("expected data field to contain an array"))
+	}
+}
+
+func (d *shardActiveSeriesResponseDecoder) nextToken() byte {
+	for {
+		c := d.readByte()
+		if d.err != nil {
+			return 0
+		}
+		switch c {
+		case ' ', '\n', '\t', '\r':
+			continue
+		default:
+			return c
+		}
+	}
+}
+
+func (d *shardActiveSeriesResponseDecoder) readString() string {
+	c := d.nextToken()
+	if c != '"' {
+		d.stickError(fmt.Errorf(`readString: expected ", found %c`, c))
+		return ""
+	}
+	d.out = d.out[:0]
+
+	for d.err == nil {
+		c = d.readByte()
+		if c == '"' {
+			return unsafe.String(
+				unsafe.SliceData(d.out), len(d.out),
+			)
+		}
+		if c == '\\' {
+			c = d.readByte()
+			d.out = d.readEscapedChar(c, d.out)
+		} else {
+			d.out = append(d.out, c)
+		}
+	}
+	d.stickError(errors.New("readString: unexpected end of input"))
+	return ""
+}
+
+func (d *shardActiveSeriesResponseDecoder) readErrorValue() {
+	if c := d.nextToken(); c != ':' {
+		d.stickError(fmt.Errorf("readErrorValue: expected :, found %c", c))
+		return
+	}
+	d.stickError(fmt.Errorf("error in partial response: %s", d.readString()))
+}
+
+func (d *shardActiveSeriesResponseDecoder) skipValue() {
+	if tk := d.nextToken(); tk != ':' {
+		d.stickError(fmt.Errorf("skipValue: expected :, found %c", tk))
+		return
+	}
+	switch d.nextToken() {
+	case '{': // object
+		d.skipObject()
+
+	case '[': // array
+		d.skipArray()
+
+	case '"': // string
+		d.skipString()
+
+	default: // number, true, false, null
+		c := d.nextToken()
+		for d.err == nil {
+			if c == ',' || c == '}' {
+				d.unreadByte()
+				break
+			}
+			c = d.nextToken()
+		}
+	}
+}
+
+func (d *shardActiveSeriesResponseDecoder) skipObject() {
+	inner := 1
+	for d.err == nil {
+		switch d.readByte() {
+		case '{':
+			inner++
+		case '}':
+			inner--
+			if inner == 0 {
+				return
+			}
+		}
+	}
+}
+
+func (d *shardActiveSeriesResponseDecoder) skipArray() {
+	inner := 1
+	for d.err == nil {
+		switch d.readByte() {
+		case '[':
+			inner++
+		case ']':
+			inner--
+			if inner == 0 {
+				return
+			}
+		}
+	}
+}
+
+func (d *shardActiveSeriesResponseDecoder) skipString() {
+	d.unreadByte()
+	_ = d.readString()
+	d.out = d.out[:0]
+}
+
+func (d *shardActiveSeriesResponseDecoder) readByte() byte {
+	b, err := d.br.ReadByte()
+	if err != nil {
+		d.stickError(err)
+		return 0
+	}
+	// Check for context cancellation every 256 bytes.
+	d.readBytesCount++
+	if d.readBytesCount%256 == 0 {
+		if err := d.ctx.Err(); err != nil {
+			if cause := context.Cause(d.ctx); cause != nil {
+				d.stickError(fmt.Errorf("decoder context cancelled: %w", cause))
+			} else {
+				d.stickError(err)
+			}
+			return 0
+		}
+	}
+	return b
+}
+
+func (d *shardActiveSeriesResponseDecoder) unreadByte() {
+	if err := d.br.UnreadByte(); err != nil {
+		d.stickError(err)
+	}
+}
+
+// Originally from json-iterator/go (https://github.com/json-iterator/go/blob/71ac16282d122fdd1e3a6d3e7f79b79b4cc3b50e/iter_str.go#L54)
+func (d *shardActiveSeriesResponseDecoder) readEscapedChar(c byte, str []byte) []byte {
+	switch c {
+	case 'u':
+		r := d.readU4()
+		if utf16.IsSurrogate(r) {
+			c = d.readByte()
+			if d.err != nil {
+				return nil
+			}
+			if c != '\\' {
+				d.unreadByte()
+				str = appendRune(str, r)
+				return str
+			}
+			c = d.readByte()
+			if d.err != nil {
+				return nil
+			}
+			if c != 'u' {
+				str = appendRune(str, r)
+				return d.readEscapedChar(c, str)
+			}
+			r2 := d.readU4()
+			if d.err != nil {
+				return nil
+			}
+			combined := utf16.DecodeRune(r, r2)
+			if combined == '\uFFFD' {
+				str = appendRune(str, r)
+				str = appendRune(str, r2)
+			} else {
+				str = appendRune(str, combined)
+			}
+		} else {
+			str = appendRune(str, r)
+		}
+	case '"':
+		str = append(str, '"')
+	case '\\':
+		str = append(str, '\\')
+	case '/':
+		str = append(str, '/')
+	case 'b':
+		str = append(str, '\b')
+	case 'f':
+		str = append(str, '\f')
+	case 'n':
+		str = append(str, '\n')
+	case 'r':
+		str = append(str, '\r')
+	case 't':
+		str = append(str, '\t')
+	default:
+		d.stickError(errors.New(`readEscapedChar: invalid escape char after \`))
+		return nil
+	}
+	return str
+}
+
+// Originally from json-iterator/go (https://github.com/json-iterator/go/blob/71ac16282d122fdd1e3a6d3e7f79b79b4cc3b50e/iter_str.go#L146)
+func (d *shardActiveSeriesResponseDecoder) readU4() (ret rune) {
+	for i := 0; i < 4; i++ {
+		c := d.readByte()
+		if d.err != nil {
+			return
+		}
+		if c >= '0' && c <= '9' {
+			ret = ret*16 + rune(c-'0')
+		} else if c >= 'a' && c <= 'f' {
+			ret = ret*16 + rune(c-'a'+10)
+		} else if c >= 'A' && c <= 'F' {
+			ret = ret*16 + rune(c-'A'+10)
+		} else {
+			d.stickError(errors.New("readU4: expects 0~9 or a~f, but found " + string([]byte{c})))
+			return
+		}
+	}
+	return ret
+}
+
+const (
+	t1 = 0x00 // 0000 0000
+	tx = 0x80 // 1000 0000
+	t2 = 0xC0 // 1100 0000
+	t3 = 0xE0 // 1110 0000
+	t4 = 0xF0 // 1111 0000
+	t5 = 0xF8 // 1111 1000
+
+	maskx = 0x3F // 0011 1111
+	mask2 = 0x1F // 0001 1111
+	mask3 = 0x0F // 0000 1111
+	mask4 = 0x07 // 0000 0111
+
+	rune1Max = 1<<7 - 1
+	rune2Max = 1<<11 - 1
+	rune3Max = 1<<16 - 1
+
+	surrogateMin = 0xD800
+	surrogateMax = 0xDFFF
+
+	maxRune   = '\U0010FFFF' // Maximum valid Unicode code point.
+	runeError = '\uFFFD'     // the "error" Rune or "Unicode replacement character"
+)
+
+// Originally from json-iterator/go (https://github.com/json-iterator/go/blob/71ac16282d122fdd1e3a6d3e7f79b79b4cc3b50e/iter_str.go#L190)
+func appendRune(p []byte, r rune) []byte {
+	// Negative values are erroneous. Making it unsigned addresses the problem.
+	switch i := uint32(r); {
+	case i <= rune1Max:
+		p = append(p, byte(r))
+		return p
+	case i <= rune2Max:
+		p = append(p, t2|byte(r>>6))
+		p = append(p, tx|byte(r)&maskx)
+		return p
+	case i > maxRune, surrogateMin <= i && i <= surrogateMax:
+		r = runeError
+		fallthrough
+	case i <= rune3Max:
+		p = append(p, t3|byte(r>>12))
+		p = append(p, tx|byte(r>>6)&maskx)
+		p = append(p, tx|byte(r)&maskx)
+		return p
+	default:
+		p = append(p, t4|byte(r>>18))
+		p = append(p, tx|byte(r>>12)&maskx)
+		p = append(p, tx|byte(r>>6)&maskx)
+		p = append(p, tx|byte(r)&maskx)
+		return p
+	}
+}

--- a/pkg/frontend/querymiddleware/shard_active_series_response_decoder.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_response_decoder.go
@@ -35,9 +35,9 @@ var shardActiveSeriesResponseDecoderPool = sync.Pool{
 	},
 }
 
-func borrowShardActiveSeriesResponseDecoder(ctx context.Context, rc io.ReadCloser, chunkCh chan<- *bytes.Buffer) *shardActiveSeriesResponseDecoder {
+func borrowShardActiveSeriesResponseDecoder(ctx context.Context, rc io.ReadCloser, streamCh chan<- *bytes.Buffer) *shardActiveSeriesResponseDecoder {
 	d := shardActiveSeriesResponseDecoderPool.Get().(*shardActiveSeriesResponseDecoder)
-	d.reset(ctx, rc, chunkCh)
+	d.reset(ctx, rc, streamCh)
 	return d
 }
 
@@ -82,7 +82,6 @@ func (d *shardActiveSeriesResponseDecoder) stickError(err error) {
 }
 
 func (d *shardActiveSeriesResponseDecoder) close() {
-	close(d.streamCh)
 	_, _ = io.Copy(io.Discard, d.rc)
 	_ = d.rc.Close()
 }

--- a/pkg/frontend/querymiddleware/shard_active_series_response_decoder_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_response_decoder_test.go
@@ -5,6 +5,7 @@ package querymiddleware
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -38,6 +39,11 @@ func TestShardActiveSeriesResponseDecoder(t *testing.T) {
 			name:           "multiple labels",
 			input:          `{"data":[{"__name__":"metric","shard":"1"},{"__name__":"metric","shard":"2"}]}`,
 			expectedOutput: `{"__name__":"metric","shard":"1"},{"__name__":"metric","shard":"2"}`,
+		},
+		{
+			name:          "unexpected comma",
+			input:         `{"data":[{"__name__":"metric","shard":"1"},,,{"__name__":"metric","shard":"2"}`,
+			expectedError: "streamData: unexpected comma",
 		},
 		{
 			name:          "unexpected end of input",
@@ -85,6 +91,7 @@ func TestShardActiveSeriesResponseDecoder(t *testing.T) {
 
 				// Drain the data channel.
 				for streamBuf := range streamCh {
+					fmt.Println(streamBuf.String())
 					dataStr.WriteString(streamBuf.String())
 				}
 			} else {

--- a/pkg/frontend/querymiddleware/shard_active_series_response_decoder_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_response_decoder_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardActiveSeriesResponseDecoder(t *testing.T) {
+	tcs := []struct {
+		name           string
+		input          string
+		expectedOutput string
+		expectedError  string
+	}{
+		{
+			name:          "empty response",
+			input:         "",
+			expectedError: "EOF",
+		},
+		{
+			name:           "empty data array",
+			input:          `{"data":[]}`,
+			expectedOutput: "",
+		},
+		{
+			name:           "skip object",
+			input:          `{"unexpected_1":3.141516, "unexpected_2":"skip me", "unexpected_3":[[{}]], "unexpected_4": {"key":[]}, "unexpected_5":null, "unexpected_6":true, "data":[{"__name__":"metric","shard":"1"}]}`,
+			expectedOutput: `{"__name__":"metric","shard":"1"}`,
+		},
+		{
+			name:           "multiple labels",
+			input:          `{"data":[{"__name__":"metric","shard":"1"},{"__name__":"metric","shard":"2"}]}`,
+			expectedOutput: `{"__name__":"metric","shard":"1"},{"__name__":"metric","shard":"2"}`,
+		},
+		{
+			name:          "unexpected end of input",
+			input:         `{"data":[{"__name__":"metric","shard":"1"},{"__name__":"metric","shard":"2"}`,
+			expectedError: "EOF",
+		},
+		{
+			name:          "error response",
+			input:         `{"status":"error","error":"some error"}`,
+			expectedError: "error in partial response: some error",
+		},
+		{
+			name:          "unicode escaped characters",
+			input:         `{"error":"\u3053\u3093\u306B\u3061\u306F"}`,
+			expectedError: "error in partial response: こんにちは",
+		},
+		{
+			name:          "wrong data type",
+			input:         `{"data":3.141516}`,
+			expectedError: "expected data field to contain an array",
+		},
+		{
+			name:          "missing 'data' and 'error' fields",
+			input:         `{"unexpected":3.141516}`,
+			expectedError: "expected data field at top level",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			r := strings.NewReader(tc.input)
+
+			d := borrowShardActiveSeriesResponseDecoder(context.Background(), io.NopCloser(r))
+			err := d.decode()
+
+			if len(tc.expectedError) > 0 {
+				require.Error(t, err)
+				require.Equal(t, tc.expectedError, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedOutput, d.dataValue())
+			}
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -311,6 +311,7 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 			// Run the request through the middleware.
 			s := newShardActiveSeriesMiddleware(
 				upstream,
+				true,
 				mockLimits{maxShardedQueries: tenantMaxShardCount, totalShards: tenantShardCount},
 				log.NewNopLogger(),
 			)
@@ -372,6 +373,7 @@ func Test_shardActiveSeriesMiddleware_RoundTrip_concurrent(t *testing.T) {
 
 	s := newShardActiveSeriesMiddleware(
 		upstream,
+		true,
 		mockLimits{maxShardedQueries: shardCount, totalShards: shardCount},
 		log.NewNopLogger(),
 	)
@@ -423,7 +425,7 @@ func Test_shardActiveSeriesMiddleware_RoundTrip_concurrent(t *testing.T) {
 }
 
 func Test_shardActiveSeriesMiddleware_mergeResponse_contextCancellation(t *testing.T) {
-	s := newShardActiveSeriesMiddleware(nil, mockLimits{}, log.NewNopLogger()).(*shardActiveSeriesMiddleware)
+	s := newShardActiveSeriesMiddleware(nil, true, mockLimits{}, log.NewNopLogger()).(*shardActiveSeriesMiddleware)
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(fmt.Errorf("test ran to completion"))
 
@@ -512,7 +514,7 @@ func benchmarkActiveSeriesMiddlewareMergeResponses(b *testing.B, encoding string
 				benchResponses[i] = responses
 			}
 
-			s := newShardActiveSeriesMiddleware(nil, mockLimits{}, log.NewNopLogger()).(*shardActiveSeriesMiddleware)
+			s := newShardActiveSeriesMiddleware(nil, true, mockLimits{}, log.NewNopLogger()).(*shardActiveSeriesMiddleware)
 
 			b.ResetTimer()
 			b.ReportAllocs()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

At certain times we've observed in ops huge spikes of allocations during the deserialization/processing of each of the query responses when merging the results in the shard active series frontend middleware, occasionally reaching values close to `~80%` of total allocations.

![Screenshot 2024-03-21 at 09 28 42](https://github.com/grafana/mimir/assets/888899/b2338344-817d-4cfa-a8aa-786c9489c430)

While this condition does not critically compromise the service, nor does imply a customer impact, such spikes translate into high CPU consumption that can negatively impact the TCO.

This PR aims to solve this problem through the implementation of a zero-allocation decoder, specifically adapted to the use case of said middleware, that borrows certain functions from the json-iter library, currently in use.

Broadly speaking, the way this new decoder works is by copying all contents of the response `data` key into an internal buffer that is subsequently reused once is received and consumed by the merger goroutine, rather than copying each of the strings associated with all label-value pairs.

_Below are the comparative benchmark results before and after the change._

```
name                                                                         old time/op    new time/op    delta
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-4-8           8.93µs ± 0%    7.51µs ± 3%   -15.94%  (p=0.016 n=4+5)
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-16-8          15.9µs ± 1%    15.9µs ± 2%      ~     (p=0.690 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-64-8          45.0µs ± 1%    43.3µs ± 2%    -3.75%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-128-8         77.8µs ± 0%    79.2µs ± 3%      ~     (p=0.222 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-4-8         14.5µs ± 1%    12.7µs ± 1%   -12.09%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-16-8        25.4µs ± 3%    24.0µs ± 1%    -5.66%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-64-8        59.9µs ± 1%    61.2µs ± 0%    +2.22%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-128-8       91.7µs ± 2%    98.7µs ± 2%    +7.58%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-4-8       1.90ms ± 0%    0.51ms ± 0%   -72.95%  (p=0.016 n=5+4)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-16-8      7.22ms ± 0%    2.10ms ± 8%   -70.95%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-64-8      28.3ms ± 1%     7.7ms ±11%   -72.63%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-128-8     56.1ms ± 1%    16.0ms ±12%   -71.52%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-4-8      18.8ms ± 0%     5.0ms ± 0%   -73.26%  (p=0.016 n=5+4)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-16-8     72.2ms ± 0%    22.6ms ±11%   -68.65%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-64-8      281ms ± 1%      81ms ± 4%   -71.23%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-128-8     558ms ± 3%     150ms ± 1%   -73.13%  (p=0.008 n=5+5)

name                                                                         old alloc/op   new alloc/op   delta
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-4-8           1.98kB ± 0%    1.80kB ± 2%    -9.07%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-16-8          3.90kB ± 0%    2.91kB ± 1%   -25.31%  (p=0.016 n=4+5)
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-64-8          11.6kB ± 0%     8.7kB ± 1%   -24.79%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-128-8         22.0kB ± 0%    19.8kB ± 1%    -9.67%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-4-8         2.75kB ± 5%    2.55kB ± 5%    -7.41%  (p=0.016 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-16-8        4.91kB ± 6%    3.92kB ± 6%   -20.26%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-64-8        13.0kB ± 4%    11.2kB ± 4%   -14.07%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-128-8       23.5kB ± 4%    24.3kB ±10%      ~     (p=0.222 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-4-8        406kB ± 0%      95kB ± 0%   -76.58%  (p=0.016 n=5+4)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-16-8      1.37MB ± 0%    0.12MB ± 2%   -91.19%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-64-8      5.25MB ± 0%    0.43MB ±24%   -91.80%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-128-8     10.5MB ± 0%     1.2MB ±59%   -88.51%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-4-8      3.29MB ± 0%    0.88MB ± 0%   -73.38%  (p=0.016 n=5+4)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-16-8     12.9MB ± 0%     2.0MB ± 3%   -84.61%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-64-8     51.7MB ± 0%     5.4MB ±12%   -89.61%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-128-8     104MB ± 0%      17MB ±14%   -83.32%  (p=0.008 n=5+5)

name                                                                         old allocs/op  new allocs/op  delta
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-4-8             60.0 ± 0%      25.0 ± 0%   -58.33%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-16-8             192 ± 0%        49 ± 0%   -74.48%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-64-8             720 ± 0%       145 ± 0%   -79.86%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=none/num-responses-128-8          1.42k ± 0%     0.27k ± 0%   -80.83%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-4-8           67.0 ± 0%      32.0 ± 0%   -52.24%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-16-8           199 ± 0%        56 ± 0%   -71.86%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-64-8           727 ± 0%       152 ± 0%   -79.09%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/encoding=snappy/num-responses-128-8        1.43k ± 0%     0.28k ± 0%   -80.43%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-4-8        32.1k ± 0%      0.0k ± 0%   -99.91%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-16-8        128k ± 0%        0k ± 0%      ~     (p=0.079 n=4+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-64-8        513k ± 0%        0k ± 0%   -99.97%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=1_000/num-responses-128-8      1.03M ± 0%     0.00M ± 1%   -99.97%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-4-8        320k ± 0%        0k ± 0%      ~     (p=0.079 n=4+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-16-8      1.28M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=5+4)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-64-8      5.12M ± 0%     0.00M ± 2%  -100.00%  (p=0.008 n=5+5)
ActiveSeriesMiddlewareMergeResponses/seriesCount=10_000/num-responses-128-8     10.2M ± 0%      0.0M ± 4%  -100.00%  (p=0.008 n=5+5)
```

_Raw benchmark results_:
* [old.bench](https://gist.github.com/ortuman/abfb50aace899ca08bf437cd0689ad12)  
* [new.bench](https://gist.github.com/ortuman/912707436a5c828d95cb493e4285d952)

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/1870

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
