### PR TITLE
Add user to log messages in the Ruler mapper when relevant

### DIFF
--- a/pkg/ruler/mapper.go
+++ b/pkg/ruler/mapper.go
@@ -138,7 +138,7 @@ func (m *mapper) MapRules(user string, ruleConfigs map[string][]rulefmt.RuleGrou
 	return anyUpdated, filenames, nil
 }
 
-func (m *mapper) writeRuleGroupsIfNewer(groups []rulefmt.RuleGroup, filename string, logger log.Logger) (bool, error) {
+func (m *mapper) writeRuleGroupsIfNewer(groups []rulefmt.RuleGroup, filename string, logger log.Logger /* contextual logger with userID */) (bool, error) {
 	sort.Slice(groups, func(i, j int) bool {
 		return groups[i].Name > groups[j].Name
 	})

--- a/pkg/ruler/mapper.go
+++ b/pkg/ruler/mapper.go
@@ -43,7 +43,7 @@ func (m *mapper) cleanupUser(userID string) {
 	dirPath := filepath.Join(m.Path, userID)
 	err := m.FS.RemoveAll(dirPath)
 	if err != nil {
-		level.Warn(m.logger).Log("msg", "unable to remove user directory", "path", dirPath, "err", err)
+		level.Warn(m.logger).Log("msg", "unable to remove user directory", "path", dirPath, "user", userID, "err", err)
 	}
 }
 
@@ -82,8 +82,7 @@ func (m *mapper) users() ([]string, error) {
 }
 
 func (m *mapper) MapRules(user string, ruleConfigs map[string][]rulefmt.RuleGroup) (bool, []string, error) {
-	anyUpdated := false
-	filenames := []string{}
+	logger := log.With(m.logger, "user", user)
 
 	// user rule files will be stored as `/<path>/<userid>/<encoded filename>`
 	path := filepath.Join(m.Path, user)
@@ -92,13 +91,16 @@ func (m *mapper) MapRules(user string, ruleConfigs map[string][]rulefmt.RuleGrou
 		return false, nil, err
 	}
 
+	anyUpdated := false
+	var filenames []string
+
 	// write all rule configs to disk
 	for filename, groups := range ruleConfigs {
 		// Store the encoded file name to better handle `/` characters
 		encodedFileName := url.PathEscape(filename)
 		fullFileName := filepath.Join(path, encodedFileName)
 
-		fileUpdated, err := m.writeRuleGroupsIfNewer(groups, fullFileName)
+		fileUpdated, err := m.writeRuleGroupsIfNewer(groups, fullFileName, logger)
 		if err != nil {
 			return false, nil, err
 		}
@@ -118,16 +120,16 @@ func (m *mapper) MapRules(user string, ruleConfigs map[string][]rulefmt.RuleGrou
 		// Ensure the namespace is decoded from a url path encoding to see if it is still required
 		decodedNamespace, err := url.PathUnescape(existingFile.Name())
 		if err != nil {
-			level.Warn(m.logger).Log("msg", "unable to remove rule file on disk", "file", fullFileName, "err", err)
+			level.Warn(logger).Log("msg", "unable to remove rule file on disk", "file", fullFileName, "err", err)
 			continue
 		}
 
-		ruleGroups := ruleConfigs[string(decodedNamespace)]
+		ruleGroups := ruleConfigs[decodedNamespace]
 
 		if ruleGroups == nil {
 			err = m.FS.Remove(fullFileName)
 			if err != nil {
-				level.Warn(m.logger).Log("msg", "unable to remove rule file on disk", "file", fullFileName, "err", err)
+				level.Warn(logger).Log("msg", "unable to remove rule file on disk", "file", fullFileName, "err", err)
 			}
 			anyUpdated = true
 		}
@@ -136,7 +138,7 @@ func (m *mapper) MapRules(user string, ruleConfigs map[string][]rulefmt.RuleGrou
 	return anyUpdated, filenames, nil
 }
 
-func (m *mapper) writeRuleGroupsIfNewer(groups []rulefmt.RuleGroup, filename string) (bool, error) {
+func (m *mapper) writeRuleGroupsIfNewer(groups []rulefmt.RuleGroup, filename string, logger log.Logger) (bool, error) {
 	sort.Slice(groups, func(i, j int) bool {
 		return groups[i].Name > groups[j].Name
 	})
@@ -163,7 +165,7 @@ func (m *mapper) writeRuleGroupsIfNewer(groups []rulefmt.RuleGroup, filename str
 		}
 	}
 
-	level.Info(m.logger).Log("msg", "updating rule file", "file", filename)
+	level.Info(logger).Log("msg", "updating rule file", "file", filename)
 	err = afero.WriteFile(m.FS, filename, d, 0777)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
#### What this PR does

Adds a `user` label to some logs emitted by the ruler when it's available.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
