### PR TITLE
dashboards: overview: reduce number of queries by 10

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -10123,7 +10123,217 @@ data:
                             },
                             "unit": "reqps"
                          },
-                         "overrides": [ ]
+                         "overrides": [
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_query($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "instant queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#429D48",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_query_range($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "range queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#F1C731",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_labels($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "\"label names\" queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#2A66CF",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_label_name_values($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "\"label values\" queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#9E44C1",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_series($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "series queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#FFAB57",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_read($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "remote read queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#C79424",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_metadata($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "metadata queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#84D586",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_query_exemplars($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "exemplar queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#A1C4FC",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_cardinality_active_series($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "\"active series\" queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#C788DE",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_cardinality_label_names($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "\"label name cardinality\" queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#3F6833",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/.*_api_v1_cardinality_label_values($|[^_])/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "displayName",
+                                     "value": "\"label value cardinality\" queries"
+                                  },
+                                  {
+                                     "id": "color",
+                                     "value": {
+                                        "fixedColor": "#447EBC",
+                                        "mode": "fixed"
+                                     }
+                                  }
+                               ]
+                            }
+                         ]
                       },
                       "id": 11,
                       "links": [ ],
@@ -10136,126 +10346,15 @@ data:
                             "sort": "none"
                          }
                       },
-                      "seriesOverrides": [
-                         {
-                            "alias": "instant queries",
-                            "color": "#429D48"
-                         },
-                         {
-                            "alias": "range queries",
-                            "color": "#F1C731"
-                         },
-                         {
-                            "alias": "\"label names\" queries",
-                            "color": "#2A66CF"
-                         },
-                         {
-                            "alias": "\"label values\" queries",
-                            "color": "#9E44C1"
-                         },
-                         {
-                            "alias": "series queries",
-                            "color": "#FFAB57"
-                         },
-                         {
-                            "alias": "remote read queries",
-                            "color": "#C79424"
-                         },
-                         {
-                            "alias": "metadata queries",
-                            "color": "#84D586"
-                         },
-                         {
-                            "alias": "exemplar queries",
-                            "color": "#A1C4FC"
-                         },
-                         {
-                            "alias": "\"active series\" queries",
-                            "color": "#C788DE"
-                         },
-                         {
-                            "alias": "\"label name cardinality\" queries",
-                            "color": "#3F6833"
-                         },
-                         {
-                            "alias": "\"label value cardinality\" queries",
-                            "color": "#447EBC"
-                         },
-                         {
-                            "alias": "other",
-                            "color": "#967302"
-                         }
-                      ],
                       "span": 3,
                       "targets": [
                          {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_query\"}[$__rate_interval]))",
+                            "expr": "sum by (route) (rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))",
                             "format": "time_series",
-                            "legendFormat": "instant queries",
                             "legendLink": null
                          },
                          {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_query_range\"}[$__rate_interval]))",
-                            "format": "time_series",
-                            "legendFormat": "range queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_labels\"}[$__rate_interval]))",
-                            "format": "time_series",
-                            "legendFormat": "\"label names\" queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_label_name_values\"}[$__rate_interval]))",
-                            "format": "time_series",
-                            "legendFormat": "\"label values\" queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_series\"}[$__rate_interval]))",
-                            "format": "time_series",
-                            "legendFormat": "series queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_read\"}[$__rate_interval]))",
-                            "format": "time_series",
-                            "legendFormat": "remote read queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_metadata\"}[$__rate_interval]))",
-                            "format": "time_series",
-                            "legendFormat": "metadata queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_query_exemplars\"}[$__rate_interval]))",
-                            "format": "time_series",
-                            "legendFormat": "exemplar queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=\"prometheus_api_v1_cardinality_active_series\"}[$__rate_interval])) > 0",
-                            "format": "time_series",
-                            "legendFormat": "\"active series\" queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=\"prometheus_api_v1_cardinality_label_names\"}[$__rate_interval])) > 0",
-                            "format": "time_series",
-                            "legendFormat": "\"label name cardinality\" queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=\"prometheus_api_v1_cardinality_label_values\"}[$__rate_interval])) > 0",
-                            "format": "time_series",
-                            "legendFormat": "\"label value cardinality\" queries",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\".*(query|query_range|label.*|series|read|metadata|query_exemplars|cardinality_.*)\"}[$__rate_interval]))",
+                            "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))",
                             "format": "time_series",
                             "legendFormat": "other",
                             "legendLink": null

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
@@ -763,7 +763,217 @@
                         },
                         "unit": "reqps"
                      },
-                     "overrides": [ ]
+                     "overrides": [
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_query($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "instant queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#429D48",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_query_range($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "range queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#F1C731",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_labels($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"label names\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#2A66CF",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_label_name_values($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"label values\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#9E44C1",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_series($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "series queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#FFAB57",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_read($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "remote read queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#C79424",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_metadata($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "metadata queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#84D586",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_query_exemplars($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "exemplar queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#A1C4FC",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_cardinality_active_series($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"active series\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#C788DE",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_cardinality_label_names($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"label name cardinality\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#3F6833",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_cardinality_label_values($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"label value cardinality\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#447EBC",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
                   },
                   "id": 11,
                   "links": [ ],
@@ -776,126 +986,15 @@
                         "sort": "none"
                      }
                   },
-                  "seriesOverrides": [
-                     {
-                        "alias": "instant queries",
-                        "color": "#429D48"
-                     },
-                     {
-                        "alias": "range queries",
-                        "color": "#F1C731"
-                     },
-                     {
-                        "alias": "\"label names\" queries",
-                        "color": "#2A66CF"
-                     },
-                     {
-                        "alias": "\"label values\" queries",
-                        "color": "#9E44C1"
-                     },
-                     {
-                        "alias": "series queries",
-                        "color": "#FFAB57"
-                     },
-                     {
-                        "alias": "remote read queries",
-                        "color": "#C79424"
-                     },
-                     {
-                        "alias": "metadata queries",
-                        "color": "#84D586"
-                     },
-                     {
-                        "alias": "exemplar queries",
-                        "color": "#A1C4FC"
-                     },
-                     {
-                        "alias": "\"active series\" queries",
-                        "color": "#C788DE"
-                     },
-                     {
-                        "alias": "\"label name cardinality\" queries",
-                        "color": "#3F6833"
-                     },
-                     {
-                        "alias": "\"label value cardinality\" queries",
-                        "color": "#447EBC"
-                     },
-                     {
-                        "alias": "other",
-                        "color": "#967302"
-                     }
-                  ],
                   "span": 3,
                   "targets": [
                      {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_query\"}[$__rate_interval]))",
+                        "expr": "sum by (route) (rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))",
                         "format": "time_series",
-                        "legendFormat": "instant queries",
                         "legendLink": null
                      },
                      {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_query_range\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "range queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_labels\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "\"label names\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_label_name_values\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "\"label values\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_series\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "series queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_read\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "remote read queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_metadata\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "metadata queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_query_exemplars\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "exemplar queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=\"prometheus_api_v1_cardinality_active_series\"}[$__rate_interval])) > 0",
-                        "format": "time_series",
-                        "legendFormat": "\"active series\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=\"prometheus_api_v1_cardinality_label_names\"}[$__rate_interval])) > 0",
-                        "format": "time_series",
-                        "legendFormat": "\"label name cardinality\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=\"prometheus_api_v1_cardinality_label_values\"}[$__rate_interval])) > 0",
-                        "format": "time_series",
-                        "legendFormat": "\"label value cardinality\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\".*(query|query_range|label.*|series|read|metadata|query_exemplars|cardinality_.*)\"}[$__rate_interval]))",
+                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))",
                         "format": "time_series",
                         "legendFormat": "other",
                         "legendLink": null

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
@@ -763,7 +763,217 @@
                         },
                         "unit": "reqps"
                      },
-                     "overrides": [ ]
+                     "overrides": [
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_query($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "instant queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#429D48",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_query_range($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "range queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#F1C731",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_labels($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"label names\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#2A66CF",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_label_name_values($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"label values\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#9E44C1",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_series($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "series queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#FFAB57",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_read($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "remote read queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#C79424",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_metadata($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "metadata queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#84D586",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_query_exemplars($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "exemplar queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#A1C4FC",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_cardinality_active_series($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"active series\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#C788DE",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_cardinality_label_names($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"label name cardinality\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#3F6833",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/.*_api_v1_cardinality_label_values($|[^_])/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "displayName",
+                                 "value": "\"label value cardinality\" queries"
+                              },
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "#447EBC",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
                   },
                   "id": 11,
                   "links": [ ],
@@ -776,126 +986,15 @@
                         "sort": "none"
                      }
                   },
-                  "seriesOverrides": [
-                     {
-                        "alias": "instant queries",
-                        "color": "#429D48"
-                     },
-                     {
-                        "alias": "range queries",
-                        "color": "#F1C731"
-                     },
-                     {
-                        "alias": "\"label names\" queries",
-                        "color": "#2A66CF"
-                     },
-                     {
-                        "alias": "\"label values\" queries",
-                        "color": "#9E44C1"
-                     },
-                     {
-                        "alias": "series queries",
-                        "color": "#FFAB57"
-                     },
-                     {
-                        "alias": "remote read queries",
-                        "color": "#C79424"
-                     },
-                     {
-                        "alias": "metadata queries",
-                        "color": "#84D586"
-                     },
-                     {
-                        "alias": "exemplar queries",
-                        "color": "#A1C4FC"
-                     },
-                     {
-                        "alias": "\"active series\" queries",
-                        "color": "#C788DE"
-                     },
-                     {
-                        "alias": "\"label name cardinality\" queries",
-                        "color": "#3F6833"
-                     },
-                     {
-                        "alias": "\"label value cardinality\" queries",
-                        "color": "#447EBC"
-                     },
-                     {
-                        "alias": "other",
-                        "color": "#967302"
-                     }
-                  ],
                   "span": 3,
                   "targets": [
                      {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_query\"}[$__rate_interval]))",
+                        "expr": "sum by (route) (rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))",
                         "format": "time_series",
-                        "legendFormat": "instant queries",
                         "legendLink": null
                      },
                      {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_query_range\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "range queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_labels\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "\"label names\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_label_name_values\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "\"label values\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_series\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "series queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_read\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "remote read queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_metadata\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "metadata queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_query_exemplars\"}[$__rate_interval]))",
-                        "format": "time_series",
-                        "legendFormat": "exemplar queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=\"prometheus_api_v1_cardinality_active_series\"}[$__rate_interval])) > 0",
-                        "format": "time_series",
-                        "legendFormat": "\"active series\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=\"prometheus_api_v1_cardinality_label_names\"}[$__rate_interval])) > 0",
-                        "format": "time_series",
-                        "legendFormat": "\"label name cardinality\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=\"prometheus_api_v1_cardinality_label_values\"}[$__rate_interval])) > 0",
-                        "format": "time_series",
-                        "legendFormat": "\"label value cardinality\" queries",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\".*(query|query_range|label.*|series|read|metadata|query_exemplars|cardinality_.*)\"}[$__rate_interval]))",
+                        "expr": "sum(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((query-frontend.*|cortex|mimir|mimir-read.*))\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))",
                         "format": "time_series",
                         "legendFormat": "other",
                         "legendLink": null

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -77,28 +77,25 @@
       // These query routes are used in the overview and other dashboard, everythign else is considered "other" queries.
       // Has to be a list to keep the same colors as before, see overridesNonErrorColorsPalette.
       local overviewRoutes = [
-        r { routeStr: std.strReplace(r.route, '/', '_') }
-        for r in [
-          { name: 'instantQuery', displayName: 'instant queries', route: '/api/v1/query' },
-          { name: 'rangeQuery', displayName: 'range queries', route: '/api/v1/query_range' },
-          { name: 'labelNames', displayName: '"label names" queries', route: '/api/v1/labels' },
-          { name: 'labelValues', displayName: '"label values" queries', route: '/api/v1/label_name_values' },
-          { name: 'series', displayName: 'series queries', route: '/api/v1/series' },
-          { name: 'remoteRead', displayName: 'remote read queries', route: '/api/v1/read' },
-          { name: 'metadata', displayName: 'metadata queries', route: '/api/v1/metadata' },
-          { name: 'exemplars', displayName: 'exemplar queries', route: '/api/v1/query_exemplars' },
-          { name: 'activeSeries', displayName: '"active series" queries', route: '/api/v1/cardinality_active_series' },
-          { name: 'labelNamesCardinality', displayName: '"label name cardinality" queries', route: '/api/v1/cardinality_label_names' },
-          { name: 'labelValuesCardinality', displayName: '"label value cardinality" queries', route: '/api/v1/cardinality_label_values' },
-        ]
+        { name: 'instantQuery', displayName: 'instant queries', route: '/api/v1/query', routeLabel: '_api_v1_query' },
+        { name: 'rangeQuery', displayName: 'range queries', route: '/api/v1/query_range', routeLabel: '_api_v1_query_range' },
+        { name: 'labelNames', displayName: '"label names" queries', route: '/api/v1/labels', routeLabel: '_api_v1_labels' },
+        { name: 'labelValues', displayName: '"label values" queries', route: '/api/v1/label_name_values', routeLabel: '_api_v1_label_name_values' },
+        { name: 'series', displayName: 'series queries', route: '/api/v1/series', routeLabel: '_api_v1_series' },
+        { name: 'remoteRead', displayName: 'remote read queries', route: '/api/v1/read', routeLabel: '_api_v1_read' },
+        { name: 'metadata', displayName: 'metadata queries', route: '/api/v1/metadata', routeLabel: '_api_v1_metadata' },
+        { name: 'exemplars', displayName: 'exemplar queries', route: '/api/v1/query_exemplars', routeLabel: '_api_v1_query_exemplars' },
+        { name: 'activeSeries', displayName: '"active series" queries', route: '/api/v1/cardinality_active_series', routeLabel: '_api_v1_cardinality_active_series' },
+        { name: 'labelNamesCardinality', displayName: '"label name cardinality" queries', route: '/api/v1/cardinality_label_names', routeLabel: '_api_v1_cardinality_label_names' },
+        { name: 'labelValuesCardinality', displayName: '"label value cardinality" queries', route: '/api/v1/cardinality_label_values', routeLabel: '_api_v1_cardinality_label_values' },
       ],
-      local overviewRoutesRegex = '(prometheus|api_prom)(%s)' % std.join('|', [r.routeStr for r in overviewRoutes]),
+      local overviewRoutesRegex = '(prometheus|api_prom)(%s)' % std.join('|', [r.routeLabel for r in overviewRoutes]),
       overviewRoutesOverrides: [
         {
           matcher: {
             id: 'byRegexp',
             // To distinguish between query and query_range, we need to match the route with a negative lookahead.
-            options: '/.*%s($|[^_])/' % r.routeStr,
+            options: '/.*%s($|[^_])/' % r.routeLabel,
           },
           properties: [
             {
@@ -113,7 +110,7 @@
       nonOverviewRoutesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_.*",route!~"%(overviewRoutesRegex)s"}[$__rate_interval]))' % (variables { overviewRoutesRegex: overviewRoutesRegex }),
 
       local queryPerSecond(name) = 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)%(route)s"}[$__rate_interval]))' %
-                                   (variables { route: std.filter(function(r) r.name == name, overviewRoutes)[0].routeStr }),
+                                   (variables { route: std.filter(function(r) r.name == name, overviewRoutes)[0].routeLabel }),
       instantQueriesPerSecond: queryPerSecond('instantQuery'),
       rangeQueriesPerSecond: queryPerSecond('rangeQuery'),
       labelNamesQueriesPerSecond: queryPerSecond('labelNames'),

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -74,18 +74,57 @@
 
     query_frontend: {
       readRequestsPerSecond: 'cortex_request_duration_seconds_count{%(queryFrontendMatcher)s, route=~"%(readHTTPRoutesRegex)s"}' % variables,
-      instantQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_query"}[$__rate_interval]))' % variables,
-      rangeQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_query_range"}[$__rate_interval]))' % variables,
-      labelNamesQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_labels"}[$__rate_interval]))' % variables,
-      labelValuesQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_label_name_values"}[$__rate_interval]))' % variables,
-      seriesQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_series"}[$__rate_interval]))' % variables,
-      remoteReadQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_read"}[$__rate_interval]))' % variables,
-      metadataQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_metadata"}[$__rate_interval]))' % variables,
-      exemplarsQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_query_exemplars"}[$__rate_interval]))' % variables,
-      activeSeriesQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route="prometheus_api_v1_cardinality_active_series"}[$__rate_interval])) > 0' % variables,
-      labelNamesCardinalityQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route="prometheus_api_v1_cardinality_label_names"}[$__rate_interval])) > 0' % variables,
-      labelValuesCardinalityQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route="prometheus_api_v1_cardinality_label_values"}[$__rate_interval])) > 0' % variables,
-      otherQueriesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_.*",route!~".*(query|query_range|label.*|series|read|metadata|query_exemplars|cardinality_.*)"}[$__rate_interval]))' % variables,
+      // These query routes are used in the overview and other dashboard, everythign else is considered "other" queries.
+      // Has to be a list to keep the same colors as before, see overridesNonErrorColorsPalette.
+      local overviewRoutes = [
+        r { routeStr: std.strReplace(r.route, '/', '_') }
+        for r in [
+          { name: 'instantQuery', displayName: 'instant queries', route: '/api/v1/query' },
+          { name: 'rangeQuery', displayName: 'range queries', route: '/api/v1/query_range' },
+          { name: 'labelNames', displayName: '"label names" queries', route: '/api/v1/labels' },
+          { name: 'labelValues', displayName: '"label values" queries', route: '/api/v1/label_name_values' },
+          { name: 'series', displayName: 'series queries', route: '/api/v1/series' },
+          { name: 'remoteRead', displayName: 'remote read queries', route: '/api/v1/read' },
+          { name: 'metadata', displayName: 'metadata queries', route: '/api/v1/metadata' },
+          { name: 'exemplars', displayName: 'exemplar queries', route: '/api/v1/query_exemplars' },
+          { name: 'activeSeries', displayName: '"active series" queries', route: '/api/v1/cardinality_active_series' },
+          { name: 'labelNamesCardinality', displayName: '"label name cardinality" queries', route: '/api/v1/cardinality_label_names' },
+          { name: 'labelValuesCardinality', displayName: '"label value cardinality" queries', route: '/api/v1/cardinality_label_values' },
+        ]
+      ],
+      local overviewRoutesRegex = '(prometheus|api_prom)(%s)' % std.join('|', [r.routeStr for r in overviewRoutes]),
+      overviewRoutesOverrides: [
+        {
+          matcher: {
+            id: 'byRegexp',
+            // To distinguish between query and query_range, we need to match the route with a negative lookahead.
+            options: '/.*%s($|[^_])/' % r.routeStr,
+          },
+          properties: [
+            {
+              id: 'displayName',
+              value: r.displayName,
+            },
+          ],
+        }
+        for r in overviewRoutes
+      ],
+      overviewRoutesPerSecond: 'sum by (route) (rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"%(overviewRoutesRegex)s"}[$__rate_interval]))' % (variables { overviewRoutesRegex: overviewRoutesRegex }),
+      nonOverviewRoutesPerSecond: 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_.*",route!~"%(overviewRoutesRegex)s"}[$__rate_interval]))' % (variables { overviewRoutesRegex: overviewRoutesRegex }),
+
+      local queryPerSecond(name) = 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)%(route)s"}[$__rate_interval]))' %
+                                   (variables { route: std.filter(function(r) r.name == name, overviewRoutes)[0].routeStr }),
+      instantQueriesPerSecond: queryPerSecond('instantQuery'),
+      rangeQueriesPerSecond: queryPerSecond('rangeQuery'),
+      labelNamesQueriesPerSecond: queryPerSecond('labelNames'),
+      labelValuesQueriesPerSecond: queryPerSecond('labelValues'),
+      seriesQueriesPerSecond: queryPerSecond('series'),
+      remoteReadQueriesPerSecond: queryPerSecond('remoteRead'),
+      metadataQueriesPerSecond: queryPerSecond('metadata'),
+      exemplarsQueriesPerSecond: queryPerSecond('exemplars'),
+      activeSeriesQueriesPerSecond: queryPerSecond('activeSeries'),
+      labelNamesCardinalityQueriesPerSecond: queryPerSecond('labelNamesCardinality'),
+      labelValuesCardinalityQueriesPerSecond: queryPerSecond('labelValuesCardinality'),
 
       // Read failures rate as percentage of total requests.
       readFailuresRate: |||

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -1346,6 +1346,24 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ), legends)),
   },
 
+  overridesNonErrorColorsPalette(overrides):: std.mapWithIndex(function(idx, override) (
+    // Do not define an override if we exausted the colors in the palette.
+    // Grafana will automatically choose another color.
+    if idx >= std.length(nonErrorColorsPalette) then override else
+      {
+        matcher: override.matcher,
+        properties: override.properties + [
+          {
+            id: 'color',
+            value: {
+              fixedColor: nonErrorColorsPalette[idx],
+              mode: 'fixed',
+            },
+          },
+        ],
+      }
+  ), overrides),
+
   // Panel query override functions
   overrideField(matcherId, options, overrideProperties):: {
     matcher: {

--- a/operations/mimir-mixin/dashboards/overview.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview.libsonnet
@@ -175,42 +175,29 @@ local filename = 'mimir-overview.json';
         )
       )
       .addPanel(
-        local legends = [
-          'instant queries',
-          'range queries',
-          '"label names" queries',
-          '"label values" queries',
-          'series queries',
-          'remote read queries',
-          'metadata queries',
-          'exemplar queries',
-          '"active series" queries',
-          '"label name cardinality" queries',
-          '"label value cardinality" queries',
-          'other',
-        ];
-
         $.timeseriesPanel('Queries / sec') +
-        $.queryPanel(
-          [
-            $.queries.query_frontend.instantQueriesPerSecond,
-            $.queries.query_frontend.rangeQueriesPerSecond,
-            $.queries.query_frontend.labelNamesQueriesPerSecond,
-            $.queries.query_frontend.labelValuesQueriesPerSecond,
-            $.queries.query_frontend.seriesQueriesPerSecond,
-            $.queries.query_frontend.remoteReadQueriesPerSecond,
-            $.queries.query_frontend.metadataQueriesPerSecond,
-            $.queries.query_frontend.exemplarsQueriesPerSecond,
-            $.queries.query_frontend.activeSeriesQueriesPerSecond,
-            $.queries.query_frontend.labelNamesCardinalityQueriesPerSecond,
-            $.queries.query_frontend.labelValuesCardinalityQueriesPerSecond,
-            $.queries.query_frontend.otherQueriesPerSecond,
+        {
+          targets: [
+            {
+              expr: $.queries.query_frontend.overviewRoutesPerSecond,
+              format: 'time_series',
+              legendLink: null,
+            },
+            {
+              expr: $.queries.query_frontend.nonOverviewRoutesPerSecond,
+              format: 'time_series',
+              legendFormat: 'other',
+              legendLink: null,
+            },
           ],
-          legends,
-        ) +
-        $.panelSeriesNonErrorColorsPalette(legends) +
-        $.stack +
-        { fieldConfig+: { defaults+: { unit: 'reqps' } } },
+        } +
+        {
+          fieldConfig+: {
+            defaults+: { unit: 'reqps' },
+            overrides+: $.overridesNonErrorColorsPalette($.queries.query_frontend.overviewRoutesOverrides),
+          },
+        } +
+        $.stack
       )
     )
 


### PR DESCRIPTION
#### What this PR does

Instead of 12 different queries, use 2 in the "Queries / sec" panel. One for known routes combined with overrides for legend and color and one for "other".

This will help introducing native histogram version.

#### Which issue(s) this PR fixes or relates to

Related to #7154 

#### Checklist

- N/A Tests updated.
- N/A Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
