### PR TITLE
helm: fix kedaAutoscaling CPU threshold calculation

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -43,7 +43,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Remove `-server.grpc.keepalive.max-connection-age` and `-server.grpc.keepalive.max-connection-age-grace` from default config. The configuration now applied directly to distributor, fixing parity with jsonnet. #7269
 * [CHANGE] Remove `-server.grpc.keepalive.max-connection-idle` from default config. The configuration now applied directly to distributor, fixing parity with jsonnet. #7298
 * [CHANGE] Distributor: termination grace period increased from 60s to 100s.
-* [FEATURE] Added experimental feature for deploying [KEDA](https://keda.sh) ScaledObjects as part of the helm chart for the components: distributor, querier, query-frontend and ruler. #7282 #7392
+* [FEATURE] Added experimental feature for deploying [KEDA](https://keda.sh) ScaledObjects as part of the helm chart for the components: distributor, querier, query-frontend and ruler. #7282 #7392 #7679
   * Autoscaling can be enabled via `distributor.kedaAutoscaling`, `ruler.kedaAutoscaling`, `query_frontend.kedaAutoscaling`, and `querier.kedaAutoscaling`.
   * Global configuration of `promtheusAddress`, `pollingInterval` and `customHeaders` can be found in `kedaAutoscaling`section.
   * Requires metamonitoring or custom installed Prometheus compatible solution, for more details on metamonitoring see [Monitor the health of your system](https://grafana.com/docs/helm-charts/mimir-distributed/latest/run-production-environment-with-helm/monitor-system-health/). See [grafana/mimir#7367](https://github.com/grafana/mimir/issues/7367) for a migration procedure.

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -681,3 +681,19 @@ mimir.parseCPU takes 1 argument
         {{- $value_string }}
     {{- end -}}
 {{- end -}}
+
+{{/*
+cpuToMilliCPU is used to convert Kubernetes CPU units to MilliCPU.
+The returned value is a string representation. If you need to do any math on it, please parse the string first.
+
+mimir.cpuToMilliCPU takes 1 argument
+  .value = the Kubernetes CPU request value
+*/}}
+{{- define "mimir.cpuToMilliCPU" -}}
+    {{- $value_string := .value | toString -}}
+    {{- if (hasSuffix "m" $value_string) -}}
+        {{ trimSuffix "m" $value_string -}}
+    {{- else -}}
+        {{- $value_string | float64 | mulf 1000 | toString }}
+    {{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-so.yaml
@@ -27,7 +27,7 @@ spec:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="{{ .Release.Namespace }}"}[5m])) and max by (pod) (up{container="distributor",namespace="{{ .Release.Namespace }}"}) > 0)[15m:]) * 1000
       serverAddress: {{ include "mimir.kedaPrometheusAddress" (dict "ctx" $) }} 
       {{- $cpu_request := dig "requests" "cpu" nil .Values.distributor.resources }}
-      threshold: {{ mulf (include "mimir.parseCPU" (dict "value" $cpu_request)) (divf .Values.distributor.kedaAutoscaling.targetCPUUtilizationPercentage 100) | floor | int64 | quote }}
+      threshold: {{ mulf (include "mimir.cpuToMilliCPU" (dict "value" $cpu_request)) (divf .Values.distributor.kedaAutoscaling.targetCPUUtilizationPercentage 100) | floor | int64 | quote }}
       {{- if .Values.kedaAutoscaling.customHeaders }}
       customHeaders: {{ (include "mimir.lib.mapToCSVString" (dict "map" .Values.kedaAutoscaling.customHeaders)) | quote }}
       {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
@@ -27,7 +27,7 @@ spec:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="{{ .Release.Namespace }}"}[5m])) and max by (pod) (up{container="query-frontend",namespace="{{ .Release.Namespace }}"}) > 0)[15m:]) * 1000
       serverAddress: {{ include "mimir.kedaPrometheusAddress" (dict "ctx" $) }} 
       {{- $cpu_request := dig "requests" "cpu" nil .Values.query_frontend.resources }}
-      threshold: {{ mulf (include "mimir.parseCPU" (dict "value" $cpu_request)) (divf .Values.query_frontend.kedaAutoscaling.targetCPUUtilizationPercentage 100) | floor | int64 | quote }}
+      threshold: {{ mulf (include "mimir.cpuToMilliCPU" (dict "value" $cpu_request)) (divf .Values.query_frontend.kedaAutoscaling.targetCPUUtilizationPercentage 100) | floor | int64 | quote }}
       {{- if .Values.kedaAutoscaling.customHeaders }}
       customHeaders: {{ (include "mimir.lib.mapToCSVString" (dict "map" .Values.kedaAutoscaling.customHeaders)) | quote }}
       {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-so.yaml
@@ -27,7 +27,7 @@ spec:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="{{ .Release.Namespace }}"}[5m])) and max by (pod) (up{container="ruler",namespace="{{ .Release.Namespace }}"}) > 0)[15m:]) * 1000
       serverAddress: {{ include "mimir.kedaPrometheusAddress" (dict "ctx" $) }} 
       {{- $cpu_request := dig "requests" "cpu" nil .Values.ruler.resources }}
-      threshold: {{ mulf (include "mimir.parseCPU" (dict "value" $cpu_request)) (divf .Values.ruler.kedaAutoscaling.targetCPUUtilizationPercentage 100) | floor | int64 | quote }}
+      threshold: {{ mulf (include "mimir.cpuToMilliCPU" (dict "value" $cpu_request)) (divf .Values.ruler.kedaAutoscaling.targetCPUUtilizationPercentage 100) | floor | int64 | quote }}
       {{- if .Values.kedaAutoscaling.customHeaders }}
       customHeaders: {{ (include "mimir.lib.mapToCSVString" (dict "map" .Values.kedaAutoscaling.customHeaders)) | quote }}
       {{- end }}

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/distributor/distributor-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/distributor/distributor-so.yaml
@@ -32,7 +32,7 @@ spec:
   - metadata:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="citestns"}[5m])) and max by (pod) (up{container="distributor",namespace="citestns"}) > 0)[15m:]) * 1000
       serverAddress: https://mimir.example.com/prometheus
-      threshold: "0"
+      threshold: "80"
       customHeaders: "X-Scope-OrgID=tenant"
     type: prometheus
   - metadata:

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
@@ -32,7 +32,7 @@ spec:
   - metadata:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="citestns"}[5m])) and max by (pod) (up{container="query-frontend",namespace="citestns"}) > 0)[15m:]) * 1000
       serverAddress: https://mimir.example.com/prometheus
-      threshold: "0"
+      threshold: "80"
       customHeaders: "X-Scope-OrgID=tenant"
     type: prometheus
   - metadata:

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ruler/ruler-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ruler/ruler-so.yaml
@@ -32,7 +32,7 @@ spec:
   - metadata:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="citestns"}[5m])) and max by (pod) (up{container="ruler",namespace="citestns"}) > 0)[15m:]) * 1000
       serverAddress: https://mimir.example.com/prometheus
-      threshold: "0"
+      threshold: "80"
       customHeaders: "X-Scope-OrgID=tenant"
     type: prometheus
   - metadata:

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-so.yaml
@@ -32,7 +32,7 @@ spec:
   - metadata:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="citestns"}[5m])) and max by (pod) (up{container="distributor",namespace="citestns"}) > 0)[15m:]) * 1000
       serverAddress: https://mimir.example.com/prometheus
-      threshold: "0"
+      threshold: "80"
       customHeaders: "X-Scope-OrgID=tenant-1"
     type: prometheus
   - metadata:

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
@@ -32,7 +32,7 @@ spec:
   - metadata:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="citestns"}[5m])) and max by (pod) (up{container="query-frontend",namespace="citestns"}) > 0)[15m:]) * 1000
       serverAddress: https://mimir.example.com/prometheus
-      threshold: "0"
+      threshold: "80"
       customHeaders: "X-Scope-OrgID=tenant-1"
     type: prometheus
   - metadata:

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-so.yaml
@@ -32,7 +32,7 @@ spec:
   - metadata:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="citestns"}[5m])) and max by (pod) (up{container="ruler",namespace="citestns"}) > 0)[15m:]) * 1000
       serverAddress: https://mimir.example.com/prometheus
-      threshold: "0"
+      threshold: "80"
       customHeaders: "X-Scope-OrgID=tenant-1"
     type: prometheus
   - metadata:

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/distributor/distributor-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/distributor/distributor-so.yaml
@@ -32,7 +32,7 @@ spec:
   - metadata:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="citestns"}[5m])) and max by (pod) (up{container="distributor",namespace="citestns"}) > 0)[15m:]) * 1000
       serverAddress: http://keda-autoscaling-values-mimir-nginx.citestns.svc:80/prometheus
-      threshold: "0"
+      threshold: "80"
     type: prometheus
   - metadata:
       query: max_over_time(sum((sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="citestns"}) and max by (pod) (up{container="distributor",namespace="citestns"}) > 0) or vector(0))[15m:]) + sum(sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="distributor",namespace="citestns", resource="memory"}[15m])) and max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor",namespace="citestns"}[15m]) > 0) and max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor",namespace="citestns", reason="OOMKilled"}) or vector(0))

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
@@ -32,7 +32,7 @@ spec:
   - metadata:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="citestns"}[5m])) and max by (pod) (up{container="query-frontend",namespace="citestns"}) > 0)[15m:]) * 1000
       serverAddress: http://keda-autoscaling-values-mimir-nginx.citestns.svc:80/prometheus
-      threshold: "0"
+      threshold: "80"
     type: prometheus
   - metadata:
       query: max_over_time(sum((sum by (pod) (container_memory_working_set_bytes{container="query-frontend",namespace="citestns"}) and max by (pod) (up{container="query-frontend",namespace="citestns"}) > 0) or vector(0))[15m:]) + sum(sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="query-frontend",namespace="citestns", resource="memory"}[15m])) and max by (pod) (changes(kube_pod_container_status_restarts_total{container="query-frontend",namespace="citestns"}[15m]) > 0) and max by (pod) (kube_pod_container_status_last_terminated_reason{container="query-frontend",namespace="citestns", reason="OOMKilled"}) or vector(0))

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler/ruler-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler/ruler-so.yaml
@@ -32,7 +32,7 @@ spec:
   - metadata:
       query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="citestns"}[5m])) and max by (pod) (up{container="ruler",namespace="citestns"}) > 0)[15m:]) * 1000
       serverAddress: http://keda-autoscaling-values-mimir-nginx.citestns.svc:80/prometheus
-      threshold: "0"
+      threshold: "80"
     type: prometheus
   - metadata:
       query: max_over_time(sum((sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="citestns"}) and max by (pod) (up{container="ruler",namespace="citestns"}) > 0) or vector(0))[15m:]) + sum(sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler",namespace="citestns", resource="memory"}[15m])) and max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler",namespace="citestns"}[15m]) > 0) and max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler",namespace="citestns", reason="OOMKilled"}) or vector(0))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

updates the kedaAutoscaling CPU threshold calculation to use milliCPU instead of CPU cores.

#### Which issue(s) this PR fixes or relates to

Fixes #7473
#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
