### PR TITLE
Dashboards: add more non-error colors

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -10172,6 +10172,18 @@ data:
                          {
                             "alias": "\"active series\" queries",
                             "color": "#C788DE"
+                         },
+                         {
+                            "alias": "\"label name cardinality\" queries",
+                            "color": "#3F6833"
+                         },
+                         {
+                            "alias": "\"label value cardinality\" queries",
+                            "color": "#447EBC"
+                         },
+                         {
+                            "alias": "other",
+                            "color": "#967302"
                          }
                       ],
                       "span": 3,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
@@ -812,6 +812,18 @@
                      {
                         "alias": "\"active series\" queries",
                         "color": "#C788DE"
+                     },
+                     {
+                        "alias": "\"label name cardinality\" queries",
+                        "color": "#3F6833"
+                     },
+                     {
+                        "alias": "\"label value cardinality\" queries",
+                        "color": "#447EBC"
+                     },
+                     {
+                        "alias": "other",
+                        "color": "#967302"
                      }
                   ],
                   "span": 3,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
@@ -812,6 +812,18 @@
                      {
                         "alias": "\"active series\" queries",
                         "color": "#C788DE"
+                     },
+                     {
+                        "alias": "\"label name cardinality\" queries",
+                        "color": "#3F6833"
+                     },
+                     {
+                        "alias": "\"label value cardinality\" queries",
+                        "color": "#447EBC"
+                     },
+                     {
+                        "alias": "other",
+                        "color": "#967302"
                      }
                   ],
                   "span": 3,

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -11,7 +11,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   },
 
   // Colors palette picked from Grafana UI, excluding red-ish colors which we want to keep reserved for errors / failures.
-  local nonErrorColorsPalette = ['#429D48', '#F1C731', '#2A66CF', '#9E44C1', '#FFAB57', '#C79424', '#84D586', '#A1C4FC', '#C788DE'],
+  local nonErrorColorsPalette = ['#429D48', '#F1C731', '#2A66CF', '#9E44C1', '#FFAB57', '#C79424', '#84D586', '#A1C4FC', '#C788DE', '#3F6833', '#447EBC', '#967302', '#5794F2'],
 
   local resourceRequestStyle = $.overrideFieldByName('request', [
     $.overrideProperty('color', { mode: 'fixed', fixedColor: $._colors.resourceRequest }),

--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "0098700428a0a4ee7d884d332d137caff5c52497",
-      "sum": "B49EzIY2WZsFxNMJcgRxE/gcZ9ltnS8pkOOV6Q5qioc="
+      "version": "7561fd330312538d22b00e0c7caecb4ba66321ea",
+      "sum": "+z5VY+bPBNqXcmNAV8xbJcbsRA+pro1R3IM7aIY8OlU="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "0098700428a0a4ee7d884d332d137caff5c52497",
-      "sum": "EWPd0a5uU5x1vTuyyMbH+d41wrgem7v21c2p4jekkbA="
+      "version": "7561fd330312538d22b00e0c7caecb4ba66321ea",
+      "sum": "0jg7qc3N8FtMnnQbunYCGSNcjHr9Y1krZW9OSTmWcEQ="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
#### What this PR does

Overview / Query / Sec panel uses 12 colors, but we only have 9 Adding 4 more picked from Grafana UI.
![image](https://github.com/grafana/mimir/assets/13435893/85e9998e-d3c6-4855-b6a0-7801a75d78b3)


#### Which issue(s) this PR fixes or relates to

Related to #7678 

#### Checklist

- N/A] Tests updated.
- N/A Documentation added.
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
