### PR TITLE
Add guard against missing samples in KEDA queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### Jsonnet
 
+* [BUGFIX] Guard against missing samples in KEDA queries. #7691
+
 ### Mimirtool
 
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1957,6 +1957,7 @@ spec:
     name: alertmanager
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_alertmanager_cpu_hpa_default
       query: |
         max_over_time(
@@ -1966,11 +1967,20 @@ spec:
             max by (pod) (up{container="alertmanager",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1780"
     name: cortex_alertmanager_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_alertmanager_memory_hpa_default
       query: |
         max_over_time(
@@ -1990,6 +2000,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="alertmanager",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "9556302233"
@@ -2017,6 +2035,7 @@ spec:
     name: distributor
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_distributor_cpu_hpa_default
       query: |
         max_over_time(
@@ -2026,11 +2045,20 @@ spec:
             max by (pod) (up{container="distributor",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="distributor",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1780"
     name: cortex_distributor_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_distributor_memory_hpa_default
       query: |
         max_over_time(
@@ -2050,6 +2078,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="distributor",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "3058016714"
@@ -2122,6 +2158,7 @@ spec:
     name: query-frontend
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: query_frontend_cpu_hpa_default
       query: |
         max_over_time(
@@ -2131,11 +2168,20 @@ spec:
             max by (pod) (up{container="query-frontend",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2225"
     name: query_frontend_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: query_frontend_memory_hpa_default
       query: |
         max_over_time(
@@ -2155,6 +2201,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="query-frontend",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "559939584"
@@ -2182,6 +2236,7 @@ spec:
     name: ruler
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_cpu_hpa_default
       query: |
         max_over_time(
@@ -2191,11 +2246,20 @@ spec:
             max by (pod) (up{container="ruler",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="ruler",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "890"
     name: ruler_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_memory_hpa_default
       query: |
         max_over_time(
@@ -2215,6 +2279,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="ruler",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "5733781340"
@@ -2242,6 +2314,7 @@ spec:
     name: ruler-querier
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_querier_cpu_hpa_default
       query: |
         max_over_time(
@@ -2251,11 +2324,20 @@ spec:
             max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "178"
     name: ruler_querier_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_querier_memory_hpa_default
       query: |
         max_over_time(
@@ -2275,6 +2357,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="ruler-querier",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "955630223"
@@ -2302,6 +2392,7 @@ spec:
     name: ruler-query-frontend
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_query_frontend_cpu_hpa_default
       query: |
         max_over_time(
@@ -2311,11 +2402,20 @@ spec:
             max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1780"
     name: ruler_query_frontend_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_query_frontend_memory_hpa_default
       query: |
         max_over_time(
@@ -2335,6 +2435,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "559939584"

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1957,6 +1957,7 @@ spec:
     name: alertmanager
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_alertmanager_cpu_hpa_default
       query: |
         max_over_time(
@@ -1966,11 +1967,20 @@ spec:
             max by (pod) (up{container="alertmanager",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2000"
     name: cortex_alertmanager_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_alertmanager_memory_hpa_default
       query: |
         max_over_time(
@@ -1990,6 +2000,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="alertmanager",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "10737418240"
@@ -2017,6 +2035,7 @@ spec:
     name: distributor
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_distributor_cpu_hpa_default
       query: |
         max_over_time(
@@ -2026,11 +2045,20 @@ spec:
             max by (pod) (up{container="distributor",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="distributor",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2000"
     name: cortex_distributor_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_distributor_memory_hpa_default
       query: |
         max_over_time(
@@ -2050,6 +2078,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="distributor",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "3435973836"
@@ -2122,6 +2158,7 @@ spec:
     name: query-frontend
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: query_frontend_cpu_hpa_default
       query: |
         max_over_time(
@@ -2131,11 +2168,20 @@ spec:
             max by (pod) (up{container="query-frontend",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1875"
     name: query_frontend_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: query_frontend_memory_hpa_default
       query: |
         max_over_time(
@@ -2155,6 +2201,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="query-frontend",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"
@@ -2182,6 +2236,7 @@ spec:
     name: ruler
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_cpu_hpa_default
       query: |
         max_over_time(
@@ -2191,11 +2246,20 @@ spec:
             max by (pod) (up{container="ruler",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="ruler",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1000"
     name: ruler_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_memory_hpa_default
       query: |
         max_over_time(
@@ -2215,6 +2279,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="ruler",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6442450944"
@@ -2242,6 +2314,7 @@ spec:
     name: ruler-querier
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_querier_cpu_hpa_default
       query: |
         max_over_time(
@@ -2251,11 +2324,20 @@ spec:
             max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "200"
     name: ruler_querier_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_querier_memory_hpa_default
       query: |
         max_over_time(
@@ -2275,6 +2357,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="ruler-querier",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1073741824"
@@ -2302,6 +2392,7 @@ spec:
     name: ruler-query-frontend
   triggers:
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_query_frontend_cpu_hpa_default
       query: |
         max_over_time(
@@ -2311,11 +2402,20 @@ spec:
             max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
           )[15m:]
         ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2000"
     name: ruler_query_frontend_cpu_hpa_default
     type: prometheus
   - metadata:
+      ignoreNullValues: "false"
       metricName: ruler_query_frontend_memory_hpa_default
       query: |
         max_over_time(
@@ -2335,6 +2435,14 @@ spec:
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
           or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -342,6 +342,8 @@
 
           // Threshold is expected to be a string
           threshold: std.toString(std.floor(cpuToMilliCPUInt(cpu_requests) * cpu_target_utilization)),
+          // Disable ignoring null values. This allows HPAs to effectively pause when metrics are unavailable rather than scaling
+          // up or down unexpectedly. See https://keda.sh/docs/2.13/scalers/prometheus/ for more info.
           ignore_null_values: false,
         },
         {
@@ -355,6 +357,8 @@
 
           // Threshold is expected to be a string
           threshold: std.toString(std.floor($.util.siToBytes(memory_requests) * memory_target_utilization)),
+          // Disable ignoring null values. This allows HPAs to effectively pause when metrics are unavailable rather than scaling
+          // up or down unexpectedly. See https://keda.sh/docs/2.13/scalers/prometheus/ for more info.
           ignore_null_values: false,
         },
       ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds clauses to some of our KEDA queries to guard against scenarios that could cause unintended scaledowns. This happens when the prometheus targeted by KEDA is down or unresponsive for some time, which could cause data that is used in KEDA queries to be missed. Without this data, when prometheus comes back up, these queries return lower averages for a while, which can cause unintended scaledowns.

An example of what this looks like from kubectl before, during, and after prometheus going down:

```
NAME                   REFERENCE                TARGETS                                             MINPODS   MAXPODS   REPLICAS   AGE
keda-hpa-distributor   Deployment/distributor   1046561m/1k (avg), 1633790418097m/2147483648 (avg)   10        40        29         171d
keda-hpa-distributor   Deployment/distributor   <unknown>/1k (avg), 0/2147483648 (avg)               10        40        29         171d
keda-hpa-distributor   Deployment/distributor   61190m/1k (avg), 488859859863m/2147483648 (avg)      10        40        29         171d
keda-hpa-distributor   Deployment/distributor   81245m/1k (avg), 488973756911m/2147483648 (avg)      10        40        26         171d
keda-hpa-distributor   Deployment/distributor   81245m/1k (avg), 488973756911m/2147483648 (avg)      10        40        26         171d
keda-hpa-distributor   Deployment/distributor   274241m/1k (avg), 1511713092856m/2147483648 (avg)   10        40        26         171d
keda-hpa-distributor   Deployment/distributor   275528m/1k (avg), 1511747993600m/2147483648 (avg)   10        40        26         171d
keda-hpa-distributor   Deployment/distributor   307320m/1k (avg), 1686180454400m/2147483648 (avg)   10        40        26         171d
keda-hpa-distributor   Deployment/distributor   528739m/1k (avg), 1686180454400m/2147483648 (avg)   10        40        26         171d
keda-hpa-distributor   Deployment/distributor   528688m/1k (avg), 1686180454400m/2147483648 (avg)   10        40        23         171d
```

With this change, bringing prometheus down for some time and then back up does not result in an unintended scaledown:

```
NAME                   REFERENCE                TARGETS                                          MINPODS   MAXPODS   REPLICAS   AGE
keda-hpa-distributor   Deployment/distributor   965560m/1k (avg), 1626915225600m/2147483648 (avg)    10        40        32         171d
keda-hpa-distributor   Deployment/distributor   <unknown>/1k (avg), <unknown>/2147483648 (avg)   10        40        32         171d
keda-hpa-distributor   Deployment/distributor   948552m/1k (avg), 1631584217600m/2147483648 (avg)   10        40        32         171d
keda-hpa-distributor   Deployment/distributor   948046m/1k (avg), 1632766489600m/2147483648 (avg)   10        40        32         171d
keda-hpa-distributor   Deployment/distributor   947425m/1k (avg), 1632022976/2147483648 (avg)       10        40        32         171d
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
