### PR TITLE
Add partitionCommitter metrics

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -546,6 +546,7 @@ func newPartitionCommitter(kafkaCfg KafkaConfig, admClient *kadm.Client, partiti
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
+			Buckets:                         prometheus.DefBuckets,
 		}),
 		lastCommittedOffset: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name:        "cortex_ingest_storage_reader_last_committed_offset",

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -37,7 +37,7 @@ func IngesterPartitionID(ingesterID string) (int32, error) {
 }
 
 func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger) []kgo.Opt {
-	return []kgo.Opt{
+	opts := []kgo.Opt{
 		kgo.ClientID(cfg.ClientID),
 		kgo.SeedBrokers(cfg.Address),
 		kgo.AllowAutoTopicCreation(),
@@ -64,7 +64,6 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		kgo.MetadataMinAge(10 * time.Second),
 		kgo.MetadataMaxAge(10 * time.Second),
 
-		kgo.WithHooks(metrics),
 		kgo.WithLogger(newKafkaLogger(logger)),
 
 		kgo.RetryTimeoutFn(func(key int16) time.Duration {
@@ -77,6 +76,12 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 			return 30 * time.Second
 		}),
 	}
+
+	if metrics != nil {
+		opts = append(opts, kgo.WithHooks(metrics))
+	}
+
+	return opts
 }
 
 // resultPromise is a simple utility to have multiple goroutines waiting for a result from another one.

--- a/pkg/util/testkafka/cluster.go
+++ b/pkg/util/testkafka/cluster.go
@@ -13,14 +13,19 @@ import (
 
 // CreateCluster returns a fake Kafka cluster for unit testing.
 func CreateCluster(t testing.TB, numPartitions int32, topicName string) (*kfake.Cluster, string) {
+	cluster, addr := CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, topicName)
+	addSupportForConsumerGroups(t, cluster, topicName, numPartitions)
+
+	return cluster, addr
+}
+
+func CreateClusterWithoutCustomConsumerGroupsSupport(t testing.TB, numPartitions int32, topicName string) (*kfake.Cluster, string) {
 	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(numPartitions, topicName))
 	require.NoError(t, err)
 	t.Cleanup(cluster.Close)
 
 	addrs := cluster.ListenAddrs()
 	require.Len(t, addrs, 1)
-
-	addSupportForConsumerGroups(t, cluster, topicName, numPartitions)
 
 	return cluster, addrs[0]
 }


### PR DESCRIPTION
#### What this PR does

In this PR I'm adding metrics to `partitionCommitter` in order to have some visibility. The following metrics have been added:
- `cortex_ingest_storage_reader_offset_commit_requests_total`
- `cortex_ingest_storage_reader_offset_commit_failures_total`
- `cortex_ingest_storage_reader_offset_commit_request_duration_seconds` (native histogram)
- `cortex_ingest_storage_reader_last_committed_offset`

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
