### PR TITLE
Fix TestPartitionReader_ConsumeAtStartup flakyness

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -294,6 +294,8 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		// Mock Kafka to fail the Fetch request.
 		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+
 			return nil, errors.New("mocked error"), true
 		})
 
@@ -304,7 +306,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 		t.Log("produced 2 records")
 
 		// Create and start the reader. We expect the reader to start even if Fetch is failing.
-		reader := createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
+		reader := createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(0))
 		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
 	})
@@ -675,6 +677,8 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		// Mock Kafka to always fail the ListOffsets request.
 		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+
 			listOffsetsRequestsCount.Inc()
 			return nil, errors.New("mocked error"), true
 		})
@@ -710,6 +714,8 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		// Mock Kafka to always fail the Fetch request.
 		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
+
 			fetchRequestsCount.Inc()
 			return nil, errors.New("mocked error"), true
 		})

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -434,6 +434,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		var (
 			cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
+			fetchRequestsCount   = atomic.NewInt64(0)
 			fetchShouldFail      = atomic.NewBool(true)
 			consumedRecordsMx    sync.Mutex
 			consumedRecords      []string
@@ -452,6 +453,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 
+			fetchRequestsCount.Inc()
 			if fetchShouldFail.Load() {
 				return nil, errors.New("mocked error"), true
 			}
@@ -480,13 +482,19 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 		// Make Fetch working.
 		fetchShouldFail.Store(false)
 
+		// Wait until Fetch request has been issued at least once, in order to avoid any race condition
+		// (the problem is that we may produce the next record before the client fetched the partition end position).
+		require.Eventually(t, func() bool {
+			return fetchRequestsCount.Load() > 0
+		}, 5*time.Second, 10*time.Millisecond)
+
 		// Produce one more record.
 		produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
 		t.Log("produced 1 record after starting the reader")
 
 		// Since the reader has been configured with position=end we expect to consume only
 		// the record produced after reader has been started.
-		test.Poll(t, time.Second, []string{"record-3"}, func() interface{} {
+		test.Poll(t, 5*time.Second, []string{"record-3"}, func() interface{} {
 			consumedRecordsMx.Lock()
 			defer consumedRecordsMx.Unlock()
 			return slices.Clone(consumedRecords)


### PR DESCRIPTION
#### What this PR does

I've seen a flaky run of `TestPartitionReader_ConsumeAtStartup`:

```
--- FAIL: TestPartitionReader_ConsumeAtStartup (0.00s)
    --- FAIL: TestPartitionReader_ConsumeAtStartup/should_consume_partition_from_end_if_position=end,_and_skip_honoring_max_lag (1.03s)
        reader_test.go:466: produced 2 records before starting the reader
        logging.go:33: level warn partition 1 msg starting consumption from partition end (may cause data loss) consumer_group test-group
        logging.go:33: level info partition 1 component kafka_client msg immediate metadata update triggered why querying metadata for consumer initialization
        logging.go:33: level info partition 1 msg partition reader is skipping to consume partition until max consumer lag is honored because it's going to consume the partition from the end
        reader_test.go:485: produced 1 record after starting the reader
        logging.go:33: level info partition 1 component kafka_client msg assigning partitions why new assignments from direct consumer how assigning everything new, keeping current assignment input test[1{-1 e-1 ce0}]
        reader_test.go:489: expected [record-3], got []
        logging.go:33: level error partition 1 msg encountered error while fetching err topic "", partition 0: context canceled
        logging.go:33: level info partition 1 msg stopping partition reader
FAIL
FAIL	github.com/grafana/mimir/pkg/storage/ingest	19.453s
```

I haven't been able to reproduce it locally after many tries, but I think there may be a race condition with the Kafka client. This PR should fix the potential race condition (see comment in the test).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
