### PR TITLE
Distinguish between starting and running phases of ingest reader.

### DIFF
--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -350,12 +350,12 @@ local filename = 'mimir-writes.json';
         },
       )
       .addPanel(
-        $.timeseriesPanel('Kafka record end-to-end latency when catching-up') +
+        $.timeseriesPanel('Kafka record end-to-end latency when starting') +
         $.panelDescription(
-          'Kafka record end-to-end latency when catching-up',
+          'Kafka record end-to-end latency when starting',
           |||
             Time between writing request by distributor to Kafka and reading the record by ingester during catch-up phase, when ingesters are starting.
-            If ingesters are not cathing up in selected time range, this panel will be empty.
+            If ingesters are not starting and catching up in the selected time range, this panel will be empty.
           |||
         ) +
         $.queryPanel(


### PR DESCRIPTION
#### What this PR does

This PR adds `phase` label to `cortex_ingest_storage_reader_receive_delay_seconds` metric to differentiate end-to-end lag when ingesters are starting and catching up

<img width="2250" alt="image" src="https://github.com/grafana/mimir/assets/895919/ef7b9364-b9b3-4c1b-b9a1-8e0cee192c0b">

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
