### PR TITLE
Add partition commiter dashboard panels and alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
 ### Mixin
 
 * [ENHANCEMENT] Alerts: allow configuring alerts range interval via `_config.base_alerts_range_interval_minutes`. #7591
-* [ENHANCEMENT] Dashboards: Add panels for monitoring distributor and ingester when using ingest-storage. These panels are disabled by default, but can be enabled using `show_ingest_storage_panels: true` config option. Similarly existing panels used when distributors and ingesters use gRPC for forwarding requests can be disabled by setting `show_grpc_ingestion_panels: false`. #7670
+* [ENHANCEMENT] Dashboards: Add panels for monitoring distributor and ingester when using ingest-storage. These panels are disabled by default, but can be enabled using `show_ingest_storage_panels: true` config option. Similarly existing panels used when distributors and ingesters use gRPC for forwarding requests can be disabled by setting `show_grpc_ingestion_panels: false`. #7670 #7699
+* [ENHANCEMENT] Alerts: add the following alerts when using ingest-storage. #7699
 * [BUGFIX] Dashobards: Fix regular expression for matching read-path gRPC ingester methods to include querying of exemplars, label-related queries, or active series queries. #7676
 
 ### Jsonnet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 
 * [ENHANCEMENT] Alerts: allow configuring alerts range interval via `_config.base_alerts_range_interval_minutes`. #7591
 * [ENHANCEMENT] Dashboards: Add panels for monitoring distributor and ingester when using ingest-storage. These panels are disabled by default, but can be enabled using `show_ingest_storage_panels: true` config option. Similarly existing panels used when distributors and ingesters use gRPC for forwarding requests can be disabled by setting `show_grpc_ingestion_panels: false`. #7670 #7699
-* [ENHANCEMENT] Alerts: add the following alerts when using ingest-storage. #7699
+* [ENHANCEMENT] Alerts: add the following alerts when using ingest-storage: #7699
+  * `MimirIngesterLastConsumedOffsetCommitFailed`
 * [BUGFIX] Dashobards: Fix regular expression for matching read-path gRPC ingester methods to include querying of exemplars, label-related queries, or active series queries. #7676
 
 ### Jsonnet

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1307,6 +1307,26 @@ How to **investigate** and **fix** it:
     - Check the number of in-memory series shown on the `Mimir / Tenants` dashboard for an approximation of the number of series that will be compacted once these blocks are shipped from ingesters.
     - Check the configured `compactor_split_and_merge_shards` for the tenant. A reasonable rule of thumb is 8-10 million series per compactor shard - if the number of series per shard is above this range, increase `compactor_split_and_merge_shards` for the affected tenant(s) accordingly.
 
+## Mimir ingest storage (experimental)
+
+This section contains runbooks for alerts related to experimental Mimir ingest storage.
+In this context, any reference to Kafka means a Kafka protocol-compatible backend.
+
+### IngesterLastConsumedOffsetCommitFailed
+
+This alert is fired when an ingester is failing to commit the last consumed offset to the Kafka backend.
+
+How it **works**:
+
+- The ingester ingests data (metrics, exemplars, ...) from Kafka and periodically commits the last consumed offset back to Kafka.
+- At startup, an ingester reads the last consumed offset committed to Kafka and resume the consumption from there.
+- If the ingester fails to commit the last consumed offset to Kafka, the ingester keeps working correctly from the consumption perspective (assuming there's no other on-going issue in the cluster) but in case of a restart the ingester will resume the consumption from the last successfully committed offset. If the last offset was successfully committed several minutes ago, the ingester will re-ingest data which has already been ingested, potentially causing OOO errors, wasting resources and taking longer to startup.
+
+How to **investigate**:
+
+- Check ingester logs to find details about the error.
+- Check Kafka logs and health.
+
 ## Errors catalog
 
 Mimir has some codified error IDs that you might see in HTTP responses or logs.

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1314,12 +1314,12 @@ In this context, any reference to Kafka means a Kafka protocol-compatible backen
 
 ### MimirIngesterLastConsumedOffsetCommitFailed
 
-This alert is fired when an ingester is failing to commit the last consumed offset to the Kafka backend.
+This alert fires when an ingester is failing to commit the last consumed offset to the Kafka backend.
 
 How it **works**:
 
 - The ingester ingests data (metrics, exemplars, ...) from Kafka and periodically commits the last consumed offset back to Kafka.
-- At startup, an ingester reads the last consumed offset committed to Kafka and resume the consumption from there.
+- At startup, an ingester reads the last consumed offset committed to Kafka and resumes the consumption from there.
 - If the ingester fails to commit the last consumed offset to Kafka, the ingester keeps working correctly from the consumption perspective (assuming there's no other on-going issue in the cluster) but in case of a restart the ingester will resume the consumption from the last successfully committed offset. If the last offset was successfully committed several minutes ago, the ingester will re-ingest data which has already been ingested, potentially causing OOO errors, wasting resources and taking longer to startup.
 
 How to **investigate**:

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1312,7 +1312,7 @@ How to **investigate** and **fix** it:
 This section contains runbooks for alerts related to experimental Mimir ingest storage.
 In this context, any reference to Kafka means a Kafka protocol-compatible backend.
 
-### IngesterLastConsumedOffsetCommitFailed
+### MimirIngesterLastConsumedOffsetCommitFailed
 
 This alert is fired when an ingester is failing to commit the last consumed offset to the Kafka backend.
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -963,6 +963,21 @@ spec:
       for: 1h
       labels:
         severity: critical
+  - name: mimir_ingest_storage_alerts
+    rules:
+    - alert: MimirIngesterLastConsumedOffsetCommitFailed
+      annotations:
+        message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+          }} is failing to commit the last consumed offset.
+        runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterlastconsumedoffsetcommitfailed
+      expr: |
+        sum by(cluster, namespace, pod) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[5m]))
+        /
+        sum by(cluster, namespace, pod) (rate(cortex_ingest_storage_reader_offset_commit_requests_total[5m]))
+        > 0.2
+      for: 15m
+      labels:
+        severity: critical
   - name: mimir_continuous_test
     rules:
     - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -938,6 +938,21 @@ groups:
     for: 1h
     labels:
       severity: critical
+- name: mimir_ingest_storage_alerts
+  rules:
+  - alert: MimirIngesterLastConsumedOffsetCommitFailed
+    annotations:
+      message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} is failing to commit the last consumed offset.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterlastconsumedoffsetcommitfailed
+    expr: |
+      sum by(cluster, namespace, instance) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[5m]))
+      /
+      sum by(cluster, namespace, instance) (rate(cortex_ingest_storage_reader_offset_commit_requests_total[5m]))
+      > 0.2
+    for: 15m
+    labels:
+      severity: critical
 - name: mimir_continuous_test
   rules:
   - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -951,6 +951,21 @@ groups:
     for: 1h
     labels:
       severity: critical
+- name: mimir_ingest_storage_alerts
+  rules:
+  - alert: MimirIngesterLastConsumedOffsetCommitFailed
+    annotations:
+      message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace
+        }} is failing to commit the last consumed offset.
+      runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterlastconsumedoffsetcommitfailed
+    expr: |
+      sum by(cluster, namespace, pod) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[5m]))
+      /
+      sum by(cluster, namespace, pod) (rate(cortex_ingest_storage_reader_offset_commit_requests_total[5m]))
+      > 0.2
+    for: 15m
+    labels:
+      severity: critical
 - name: mimir_continuous_test
   rules:
   - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/mimir-mixin-tools/serve/provisioning-datasources.yaml
+++ b/operations/mimir-mixin-tools/serve/provisioning-datasources.yaml
@@ -13,6 +13,13 @@ datasources:
       basicAuthPassword: $DATASOURCE_PASSWORD
     version: 1
     editable: true
+  - name: Mimir (ingest-storage local dev env)
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://nginx:8080/prometheus
+    version: 1
+    editable: true
   - name: Loki
     type: loki
     access: proxy

--- a/operations/mimir-mixin/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts.libsonnet
@@ -6,5 +6,6 @@
     (import 'alerts/blocks.libsonnet') +
     (import 'alerts/compactor.libsonnet') +
     (import 'alerts/autoscaling.libsonnet') +
+    (import 'alerts/ingest-storage.libsonnet') +
     (import 'alerts/continuous-test.libsonnet'),
 }

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -1,0 +1,27 @@
+(import 'alerts-utils.libsonnet') {
+  local alertGroups = [
+    {
+      name: 'mimir_ingest_storage_alerts',
+      rules: [
+        {
+          alert: $.alertName('IngesterLastConsumedOffsetCommitFailed'),
+          'for': '15m',
+          expr: |||
+            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[5m]))
+            /
+            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ingest_storage_reader_offset_commit_requests_total[5m]))
+            > 0.2
+          ||| % $._config,
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s is failing to commit the last consumed offset.' % $._config,
+          },
+        },
+      ],
+    },
+  ],
+
+  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
+}


### PR DESCRIPTION
#### What this PR does

Following up https://github.com/grafana/mimir/pull/7695, in this PR:

- Added "Ingester (ingest storage - last consumed offset)" row to "Mimir / Writes" dashboard
- Added `MimirIngesterLastConsumedOffsetCommitFailed` alert

Example of the new row added to the Writes dashboard:

![Screenshot 2024-03-22 at 14 42 44](https://github.com/grafana/mimir/assets/1701904/6ae6d688-66f3-4980-bff2-3526c0cbd838)


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
