### PR TITLE
[Helm] Clarify error message when multiple tenant headers are present

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -58,6 +58,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Make the PSP template configurable via `rbac.podSecurityPolicy`. #7190
 * [ENHANCEMENT] Recording rules: add native histogram recording rules to `cortex_request_duration_seconds`. #7528
 * [ENHANCEMENT] Make the port used in ServiceMonitor for kube-state-metrics configurable. #7507
+* [ENHANCEMENT] Produce a clearer error messages when multiple X-Scope-OrgID headers are present. #7704
 * [BUGFIX] Metamonitoring: update dashboards to drop unsupported `step` parameter in targets. #7157
 * [BUGFIX] Recording rules: drop rules for metrics removed in 2.0: `cortex_memcache_request_duration_seconds` and `cortex_cache_request_duration_seconds`. #7514
 * [BUGFIX] Store-gateway: setting "resources.requests.memory" with a quantity that used power-of-ten SI suffix, caused an error. #7506

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2589,6 +2589,11 @@ nginx:
           "" "{{ include "mimir.noAuthTenant" . }}";
         }
 
+        map $http_x_scope_orgid $has_multiple_orgid_headers {
+          default 0;
+          "~^.+,.+$" 1;
+        }
+
         proxy_read_timeout 300;
         server {
           listen 8080;
@@ -2598,6 +2603,10 @@ nginx:
           auth_basic           "Mimir";
           auth_basic_user_file /etc/nginx/secrets/.htpasswd;
           {{- end }}
+
+          if ($has_multiple_orgid_headers = 1) {
+              return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+          }
 
           location = / {
             return 200 'OK';
@@ -2975,6 +2984,11 @@ gateway:
             "" "{{ include "mimir.noAuthTenant" . }}";
           }
 
+          map $http_x_scope_orgid $has_multiple_orgid_headers {
+            default 0;
+            "~^.+,.+$" 1;
+          }
+
           proxy_read_timeout 300;
           server {
             listen {{ include "mimir.serverHttpListenPort" . }};
@@ -2986,6 +3000,10 @@ gateway:
             auth_basic           "Mimir";
             auth_basic_user_file /etc/nginx/secrets/.htpasswd;
             {{- end }}
+
+            if ($has_multiple_orgid_headers = 1) {
+                return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+            }
 
             location = / {
               return 200 'OK';

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -45,10 +45,19 @@ data:
         "" "anonymous";
       }
     
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
       proxy_read_timeout 300;
       server {
         listen 8080;
         listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
     
         location = / {
           return 200 'OK';


### PR DESCRIPTION
#### What this PR does

This PR produces a clearer error under the circumstance when multiple X-Scope-OrgID headers are received by nginx and combined according to the [HTTP spec](https://www.rfc-editor.org/rfc/rfc9110.html).

This is valid HTTP, but Mimir does not support passing multiple tenants in this way, so the existing error is confusing:

```
tenant ID '...' contains unsupported character ...
```

After this PR, the error is:

```
Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.
```

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/7700

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
