### PR TITLE
Introduce New function for DefaultCacheKeyGenerator.

### DIFF
--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -208,6 +208,13 @@ type DefaultCacheKeyGenerator struct {
 	Interval time.Duration
 }
 
+func NewDefaultCacheKeyGenerator(codec Codec, interval time.Duration) DefaultCacheKeyGenerator {
+	return DefaultCacheKeyGenerator{
+		codec:    codec,
+		Interval: interval,
+	}
+}
+
 // QueryRequest generates a cache key based on the userID, Request and Interval.
 func (g DefaultCacheKeyGenerator) QueryRequest(_ context.Context, userID string, r Request) string {
 	startInterval := r.GetStart() / g.Interval.Milliseconds()

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -204,20 +204,20 @@ type CacheKeyGenerator interface {
 
 type DefaultCacheKeyGenerator struct {
 	codec Codec
-	// Interval is a constant split Interval when determining cache keys for QueryRequest.
-	Interval time.Duration
+	// interval is a constant split interval when determining cache keys for QueryRequest.
+	interval time.Duration
 }
 
 func NewDefaultCacheKeyGenerator(codec Codec, interval time.Duration) DefaultCacheKeyGenerator {
 	return DefaultCacheKeyGenerator{
 		codec:    codec,
-		Interval: interval,
+		interval: interval,
 	}
 }
 
-// QueryRequest generates a cache key based on the userID, Request and Interval.
+// QueryRequest generates a cache key based on the userID, Request and interval.
 func (g DefaultCacheKeyGenerator) QueryRequest(_ context.Context, userID string, r Request) string {
-	startInterval := r.GetStart() / g.Interval.Milliseconds()
+	startInterval := r.GetStart() / g.interval.Milliseconds()
 	stepOffset := r.GetStart() % r.GetStep()
 
 	// Use original format for step-aligned request, so that we can use existing cached results for such requests.

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -579,7 +579,7 @@ func TestDefaultSplitter_QueryRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s - %s", tt.name, tt.interval), func(t *testing.T) {
-			if got := (DefaultCacheKeyGenerator{codec: codec, Interval: tt.interval}).QueryRequest(ctx, "fake", tt.r); got != tt.want {
+			if got := (DefaultCacheKeyGenerator{codec: codec, interval: tt.interval}).QueryRequest(ctx, "fake", tt.r); got != tt.want {
 				t.Errorf("generateKey() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -239,7 +239,7 @@ func newQueryTripperware(
 
 	cacheKeyGenerator := cfg.CacheKeyGenerator
 	if cacheKeyGenerator == nil {
-		cacheKeyGenerator = DefaultCacheKeyGenerator{codec: codec, Interval: cfg.SplitQueriesByInterval}
+		cacheKeyGenerator = NewDefaultCacheKeyGenerator(codec, cfg.SplitQueriesByInterval)
 	}
 
 	// Inject the middleware to split requests by interval + results cache (if at least one of the two is enabled).

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -244,7 +244,7 @@ func TestSplitAndCacheMiddleware_ResultsCache(t *testing.T) {
 		mockLimits{maxCacheFreshness: 10 * time.Minute, resultsCacheTTL: resultsCacheTTL, resultsCacheOutOfOrderWindowTTL: resultsCacheLowerTTL},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheKeyGenerator{Interval: day},
+		DefaultCacheKeyGenerator{interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -376,7 +376,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotLookupCacheIfStepIsNotAli
 		mockLimits{maxCacheFreshness: 10 * time.Minute},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheKeyGenerator{Interval: day},
+		DefaultCacheKeyGenerator{interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -492,7 +492,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_EnabledCachingOfStepUnalignedReque
 		limits,
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheKeyGenerator{Interval: day},
+		DefaultCacheKeyGenerator{interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -643,7 +643,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			cacheBackend := cache.NewMockCache()
-			keyGenerator := DefaultCacheKeyGenerator{Interval: day}
+			keyGenerator := DefaultCacheKeyGenerator{interval: day}
 			reg := prometheus.NewPedanticRegistry()
 
 			mw := newSplitAndCacheMiddleware(
@@ -864,7 +864,7 @@ func TestSplitAndCacheMiddleware_ResultsCacheFuzzy(t *testing.T) {
 					},
 					newTestPrometheusCodec(),
 					cache.NewMockCache(),
-					DefaultCacheKeyGenerator{Interval: day},
+					DefaultCacheKeyGenerator{interval: day},
 					PrometheusResponseExtractor{},
 					resultsCacheAlwaysEnabled,
 					log.NewNopLogger(),
@@ -1134,7 +1134,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), userID)
 			cacheBackend := cache.NewInstrumentedMockCache()
-			keyGenerator := DefaultCacheKeyGenerator{Interval: day}
+			keyGenerator := DefaultCacheKeyGenerator{interval: day}
 
 			mw := newSplitAndCacheMiddleware(
 				false, // No splitting.
@@ -1192,7 +1192,7 @@ func TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents(t *testing.T) {
 		},
 		newTestPrometheusCodec(),
 		cacheBackend,
-		DefaultCacheKeyGenerator{Interval: day},
+		DefaultCacheKeyGenerator{interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),
@@ -1273,7 +1273,7 @@ func TestSplitAndCacheMiddleware_WrapMultipleTimes(t *testing.T) {
 		mockLimits{},
 		newTestPrometheusCodec(),
 		cache.NewMockCache(),
-		DefaultCacheKeyGenerator{Interval: day},
+		DefaultCacheKeyGenerator{interval: day},
 		PrometheusResponseExtractor{},
 		resultsCacheAlwaysEnabled,
 		log.NewNopLogger(),


### PR DESCRIPTION
#### What this PR does

Our enterprise product needs to instantiate `DefaultCacheKeyGenerator`. Instead of exposing `codec`, I'm adding `NewDefaultCacheKeyGenerator` and hiding `interval`.

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
