### PR TITLE
Clarify logic around partition consumed offset

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -982,7 +982,7 @@ func TestPartitionCommitter(t *testing.T) {
 			return promtest.GatherAndCompare(reg, strings.NewReader(`
 				# HELP cortex_ingest_storage_reader_last_committed_offset The last consumed offset successfully committed by the partition reader. Set to -1 if not offset has been committed yet.
 				# TYPE cortex_ingest_storage_reader_last_committed_offset gauge
-				cortex_ingest_storage_reader_last_committed_offset{partition="1"} 124
+				cortex_ingest_storage_reader_last_committed_offset{partition="1"} 123
 
 				# HELP cortex_ingest_storage_reader_offset_commit_failures_total Total number of failed requests to commit the last consumed offset.
 				# TYPE cortex_ingest_storage_reader_offset_commit_failures_total counter
@@ -1033,7 +1033,7 @@ func TestPartitionCommitter_commit(t *testing.T) {
 		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_ingest_storage_reader_last_committed_offset The last consumed offset successfully committed by the partition reader. Set to -1 if not offset has been committed yet.
 			# TYPE cortex_ingest_storage_reader_last_committed_offset gauge
-			cortex_ingest_storage_reader_last_committed_offset{partition="1"} 124
+			cortex_ingest_storage_reader_last_committed_offset{partition="1"} 123
 
 			# HELP cortex_ingest_storage_reader_offset_commit_failures_total Total number of failed requests to commit the last consumed offset.
 			# TYPE cortex_ingest_storage_reader_offset_commit_failures_total counter


### PR DESCRIPTION
#### What this PR does

Currently, the logic around the last consumed offset which is committed to the Kafka consumer group is a bit convoluted: we don't commit the last consumed offset, but the last consumed offset + 1, which is the offset at which we should start replaying at the next startup.

In this PR I'm clarifying the logic, committing the last consumed offset. Then, when we read it back at `PartitionReader` startup, if we found the committed last consumed offset we'll start replaying from offset + 1.

The logic in this PR is expected to be unchanged, except for the metric `cortex_ingest_storage_reader_last_committed_offset` which is now fixed and track the last consumed offset, instead of the last consumed offset + 1.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
