### PR TITLE
Distributor: add bucket count validation to native histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 * [CHANGE] The configuration option `-querier.max-query-into-future` has been deprecated and will be removed in Mimir 2.14. #7496
 * [CHANGE] Distributor: the metric `cortex_distributor_sample_delay_seconds` has been deprecated and will be removed in Mimir 2.14. #7516
 * [CHANGE] Query-frontend: The deprecated YAML setting `frontend.cache_unaligned_requests` has been moved to `limits.cache_unaligned_requests`. #7519
+* [CHANGE] Distributor: validate that in native histograms the zero, negative and positive bucket counts add up to the overall count of the histogram. Such errors are now reported as 4xx and not 5xx and show up in the `cortex_discarded_samples_total` with the label `reason="native_histogram_bucket_count_mismatch"`. #7736
 * [FEATURE] Introduce `-server.log-source-ips-full` option to log all IPs from `Forwarded`, `X-Real-IP`, `X-Forwarded-For` headers. #7250
 * [FEATURE] Introduce `-tenant-federation.max-tenants` option to limit the max number of tenants allowed for requests when federation is enabled. #6959
 * [FEATURE] Cardinality API: added a new `count_method` parameter which enables counting active label names. #7085

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@
 * [CHANGE] The configuration option `-querier.max-query-into-future` has been deprecated and will be removed in Mimir 2.14. #7496
 * [CHANGE] Distributor: the metric `cortex_distributor_sample_delay_seconds` has been deprecated and will be removed in Mimir 2.14. #7516
 * [CHANGE] Query-frontend: The deprecated YAML setting `frontend.cache_unaligned_requests` has been moved to `limits.cache_unaligned_requests`. #7519
-* [CHANGE] Distributor: validate that in native histograms the zero, negative and positive bucket counts add up to the overall count of the histogram. Such errors are now reported as 4xx and not 5xx and show up in the `cortex_discarded_samples_total` with the label `reason="native_histogram_bucket_count_mismatch"`. #7736
+* [CHANGE] Distributor: validate that in integer native histograms the zero, negative and positive bucket counts add up to the overall count of the histogram. Such errors are now reported as 4xx and not 5xx and show up in the `cortex_discarded_samples_total` with the label `reason="native_histogram_bucket_count_mismatch"`. #7736
 * [FEATURE] Introduce `-server.log-source-ips-full` option to log all IPs from `Forwarded`, `X-Real-IP`, `X-Forwarded-For` headers. #7250
 * [FEATURE] Introduce `-tenant-federation.max-tenants` option to limit the max number of tenants allowed for requests when federation is enabled. #6959
 * [FEATURE] Cardinality API: added a new `count_method` parameter which enables counting active label names. #7085

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1385,6 +1385,14 @@ This non-critical error occurs when Mimir receives a write request that contains
 The series containing such samples are skipped during ingestion, and valid series within the same request are ingested.
 {{< /admonition >}}
 
+### err-mimir-native-histogram-bucket-count-mismatch
+
+This non-critical error occurs when Mimir receives a write request that contains a sample that is a native histogram where the zero, positive and negative bucket counts do not add up to the overall count of the native histogram.
+
+{{< admonition type="note" >}}
+The series containing such samples are skipped during ingestion, and valid series within the same request are ingested.
+{{< /admonition >}}
+
 ### err-mimir-label-invalid
 
 This non-critical error occurs when Mimir receives a write request that contains a series with an invalid label name.

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -259,17 +259,7 @@ func validateSampleHistogram(m *sampleValidationMetrics, now model.Time, cfg sam
 
 	// Check that bucket counts including zero bucket add up to the overall count.
 	if s.IsFloatHistogram() {
-		count := s.GetZeroCountFloat()
-		for _, c := range s.GetNegativeCounts() {
-			count += c
-		}
-		for _, c := range s.GetPositiveCounts() {
-			count += c
-		}
-		if count != s.GetCountFloat() {
-			m.bucketCountMismatch.WithLabelValues(userID, group).Inc()
-			return fmt.Errorf(bucketCountMismatchMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToString(ls), s.GetCountFloat(), count)
-		}
+		// Do nothing. Due to floating point precision issues, we don't check the bucket count.
 	} else {
 		count := s.GetZeroCountInt()
 		bucketCount := int64(0)

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -258,9 +258,8 @@ func validateSampleHistogram(m *sampleValidationMetrics, now model.Time, cfg sam
 	}
 
 	// Check that bucket counts including zero bucket add up to the overall count.
-	if s.IsFloatHistogram() {
-		// Do nothing. Due to floating point precision issues, we don't check the bucket count.
-	} else {
+	if !s.IsFloatHistogram() {
+		// Do nothing for float histograms, due to floating point precision issues, we don't check the bucket count.
 		count := s.GetZeroCountInt()
 		bucketCount := int64(0)
 		for _, c := range s.GetNegativeDeltas() {

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -654,7 +654,8 @@ func TestInvalidBucketCountHistogram(t *testing.T) {
 				ResetHint:      mimirpb.Histogram_UNKNOWN,
 				Timestamp:      0,
 			},
-			expectedError: fmt.Errorf("native histogram bucket count mismatch, timestamp: 0, series: a{a=\"a\"}, expected 4.5, got 5.5 (err-mimir-native-histogram-bucket-count-mismatch)"),
+			// Due to floating point precision issues, this case is not an error at the moment.
+			expectedError: nil,
 		},
 	}
 
@@ -672,7 +673,7 @@ func TestInvalidBucketCountHistogram(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{group="group-1",reason="native_histogram_bucket_count_mismatch",user="user-1"} 2
+			cortex_discarded_samples_total{group="group-1",reason="native_histogram_bucket_count_mismatch",user="user-1"} 1
 	`), "cortex_discarded_samples_total"))
 }
 

--- a/pkg/util/globalerror/errors.go
+++ b/pkg/util/globalerror/errors.go
@@ -20,6 +20,7 @@ const (
 	MaxNativeHistogramBuckets     ID = "max-native-histogram-buckets"
 	NotReducibleNativeHistogram   ID = "not-reducible-native-histogram"
 	InvalidSchemaNativeHistogram  ID = "invalid-native-histogram-schema"
+	BucketCountMismatch           ID = "native-histogram-bucket-count-mismatch"
 	SeriesInvalidLabel            ID = "label-invalid"
 	SeriesLabelNameTooLong        ID = "label-name-too-long"
 	SeriesLabelValueTooLong       ID = "label-value-too-long"


### PR DESCRIPTION
#### What this PR does

Otherwise the ingester performs validation and returns an untyped error which we turn into 500x with little detail on the series as well.

Inspired by https://github.com/prometheus/prometheus/blob/25a8d576717f4a69290d6f6755b4a90cfaab08ff/model/histogram/histogram.go#L366  , but not a copy of.

Only checks integer native histograms as the float histograms coming out of PromQL and being written in recording rules have precision issues. E.g.
```
mimir-1-1        | ts=2024-03-26T17:14:11.049358108Z caller=group.go:529 level=warn
trace_id=0000000000000000509674846c935631 name=cluster_job:cortex_request_duration_seconds:sum_rate
index=0 component=ruler insight=true user=anonymous file=data-ruler/anonymous/krajo group=mimir_api_1
msg="Rule sample appending failed" err="rpc error: code = FailedPrecondition 
desc = native histogram bucket count mismatch, timestamp: 1711473191044, 
series: cluster_job:cortex_request_duration_seconds:sum_rate{job=\"mimir-1\"}, 
expected 0.6889399999999999, got 0.68894 (err-mimir-native-histogram-bucket-count-mismatch)"
```

#### Which issue(s) this PR fixes or relates to

Fixes: escalation

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
