### PR TITLE
disambiguate frontend types: rename frontend Request to MetricsQueryRequest

### DIFF
--- a/pkg/frontend/querymiddleware/blocker.go
+++ b/pkg/frontend/querymiddleware/blocker.go
@@ -40,7 +40,7 @@ func newQueryBlockerMiddleware(
 	})
 }
 
-func (qb *queryBlockerMiddleware) Do(ctx context.Context, req Request) (Response, error) {
+func (qb *queryBlockerMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 	tenants, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return qb.next.Do(ctx, req)
@@ -56,7 +56,7 @@ func (qb *queryBlockerMiddleware) Do(ctx context.Context, req Request) (Response
 	return qb.next.Do(ctx, req)
 }
 
-func (qb *queryBlockerMiddleware) isBlocked(tenant string, req Request) bool {
+func (qb *queryBlockerMiddleware) isBlocked(tenant string, req MetricsQueryRequest) bool {
 	blocks := qb.limits.BlockedQueries(tenant)
 	if len(blocks) <= 0 {
 		return false

--- a/pkg/frontend/querymiddleware/blocker.go
+++ b/pkg/frontend/querymiddleware/blocker.go
@@ -15,7 +15,7 @@ import (
 )
 
 type queryBlockerMiddleware struct {
-	next                  Handler
+	next                  MetricsQueryHandler
 	limits                Limits
 	logger                log.Logger
 	blockedQueriesCounter *prometheus.CounterVec
@@ -25,12 +25,12 @@ func newQueryBlockerMiddleware(
 	limits Limits,
 	logger log.Logger,
 	registerer prometheus.Registerer,
-) Middleware {
+) MetricsQueryMiddleware {
 	blockedQueriesCounter := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_query_frontend_rejected_queries_total",
 		Help: "Number of queries that were rejected by the cluster administrator.",
 	}, []string{"user", "reason"})
-	return MiddlewareFunc(func(next Handler) Handler {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &queryBlockerMiddleware{
 			next:                  next,
 			limits:                limits,

--- a/pkg/frontend/querymiddleware/blocker_test.go
+++ b/pkg/frontend/querymiddleware/blocker_test.go
@@ -20,7 +20,7 @@ import (
 func Test_queryBlocker_Do(t *testing.T) {
 	tests := []struct {
 		name           string
-		request        Request
+		request        MetricsQueryRequest
 		shouldContinue bool
 		limits         mockLimits
 	}{
@@ -28,7 +28,7 @@ func Test_queryBlocker_Do(t *testing.T) {
 			name:           "doesn't block queries due to empty limits",
 			limits:         mockLimits{},
 			shouldContinue: true,
-			request: Request(&PrometheusRangeQueryRequest{
+			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
 				Query: "rate(metric_counter[5m])",
 			}),
 		},
@@ -39,7 +39,7 @@ func Test_queryBlocker_Do(t *testing.T) {
 					{Pattern: "rate(metric_counter[5m])", Regex: false},
 				},
 			},
-			request: Request(&PrometheusRangeQueryRequest{
+			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
 				Query: "rate(metric_counter[5m])",
 			}),
 		},
@@ -52,7 +52,7 @@ func Test_queryBlocker_Do(t *testing.T) {
 			},
 			shouldContinue: true,
 
-			request: Request(&PrometheusRangeQueryRequest{
+			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
 				Query: "rate(metric_counter[15m])",
 			}),
 		},
@@ -64,7 +64,7 @@ func Test_queryBlocker_Do(t *testing.T) {
 rate(other_counter[5m])`, Regex: false},
 				},
 			},
-			request: Request(&PrometheusRangeQueryRequest{
+			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
 				Query: `rate(metric_counter[5m])/
 rate(other_counter[5m])`,
 			}),
@@ -78,7 +78,7 @@ rate(other_counter[5m])`,
 			},
 			shouldContinue: true,
 
-			request: Request(&PrometheusRangeQueryRequest{
+			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
 				Query: `rate(metric_counter[15m])/
 rate(other_counter[15m])`,
 			}),
@@ -90,7 +90,7 @@ rate(other_counter[15m])`,
 					{Pattern: ".*metric_counter.*", Regex: true},
 				},
 			},
-			request: Request(&PrometheusRangeQueryRequest{
+			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
 				Query: "rate(metric_counter[5m])",
 			}),
 		},
@@ -102,7 +102,7 @@ rate(other_counter[15m])`,
 					{Pattern: "(?s).*metric_counter.*", Regex: true},
 				},
 			},
-			request: Request(&PrometheusRangeQueryRequest{
+			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
 				Query: `rate(other_counter[15m])/
 		rate(metric_counter[15m])`,
 			}),
@@ -116,7 +116,7 @@ rate(other_counter[15m])`,
 			},
 			shouldContinue: true,
 
-			request: Request(&PrometheusRangeQueryRequest{
+			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
 				Query: "rate(metric_counter[5m])",
 			}),
 		},
@@ -150,7 +150,7 @@ type mockNextHandler struct {
 	shouldContinue bool
 }
 
-func (h *mockNextHandler) Do(_ context.Context, _ Request) (Response, error) {
+func (h *mockNextHandler) Do(_ context.Context, _ MetricsQueryRequest) (Response, error) {
 	if !h.shouldContinue {
 		h.t.Error("The next middleware should not be called.")
 	}

--- a/pkg/frontend/querymiddleware/cardinality.go
+++ b/pkg/frontend/querymiddleware/cardinality.go
@@ -34,23 +34,23 @@ const (
 	cacheErrorToleranceFraction = 0.1
 )
 
-// cardinalityEstimation is a Handler that caches estimates for a query's
+// cardinalityEstimation is a MetricsQueryHandler that caches estimates for a query's
 // cardinality based on similar queries seen previously.
 type cardinalityEstimation struct {
 	cache  cache.Cache
-	next   Handler
+	next   MetricsQueryHandler
 	logger log.Logger
 
 	estimationError prometheus.Histogram
 }
 
-func newCardinalityEstimationMiddleware(cache cache.Cache, logger log.Logger, registerer prometheus.Registerer) Middleware {
+func newCardinalityEstimationMiddleware(cache cache.Cache, logger log.Logger, registerer prometheus.Registerer) MetricsQueryMiddleware {
 	estimationError := promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
 		Name:    "cortex_query_frontend_cardinality_estimation_difference",
 		Help:    "Difference between estimated and actual query cardinality",
 		Buckets: prometheus.ExponentialBuckets(100, 2, 10),
 	})
-	return MiddlewareFunc(func(next Handler) Handler {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &cardinalityEstimation{
 			cache:  cache,
 			next:   next,

--- a/pkg/frontend/querymiddleware/cardinality.go
+++ b/pkg/frontend/querymiddleware/cardinality.go
@@ -63,7 +63,7 @@ func newCardinalityEstimationMiddleware(cache cache.Cache, logger log.Logger, re
 
 // Do injects a cardinality estimate into the query hints (if available) and
 // caches the actual cardinality observed for this query.
-func (c *cardinalityEstimation) Do(ctx context.Context, request Request) (Response, error) {
+func (c *cardinalityEstimation) Do(ctx context.Context, request MetricsQueryRequest) (Response, error) {
 	spanLog := spanlogger.FromContext(ctx, c.logger)
 
 	tenants, err := tenant.TenantIDs(ctx)
@@ -162,7 +162,7 @@ func isCardinalitySimilar(actualCardinality, estimatedCardinality uint64) bool {
 // with respect to both start time and range size. To avoid expiry of all
 // estimates at the bucket boundary, an offset is added based on the hash of the
 // query string.
-func generateCardinalityEstimationCacheKey(userID string, r Request, bucketSize time.Duration) string {
+func generateCardinalityEstimationCacheKey(userID string, r MetricsQueryRequest, bucketSize time.Duration) string {
 	hasher := fnv.New64a()
 	_, _ = hasher.Write([]byte(r.GetQuery()))
 

--- a/pkg/frontend/querymiddleware/cardinality_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_test.go
@@ -29,7 +29,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_keyFormat(t *testing.T) {
 	tests := []struct {
 		name     string
 		userID   string
-		r        Request
+		r        MetricsQueryRequest
 		expected string
 	}{
 		{
@@ -133,7 +133,7 @@ func Test_cardinalityEstimation_Do(t *testing.T) {
 		Query: "up",
 	}
 	addSeriesHandler := func(estimate, actual uint64) HandlerFunc {
-		return func(ctx context.Context, request Request) (Response, error) {
+		return func(ctx context.Context, request MetricsQueryRequest) (Response, error) {
 			require.NotNil(t, request.GetHints())
 			request.GetHints().GetCardinalityEstimate()
 			require.Equal(t, request.GetHints().GetEstimatedSeriesCount(), estimate)
@@ -158,7 +158,7 @@ func Test_cardinalityEstimation_Do(t *testing.T) {
 		{
 			name:     "no tenantID",
 			tenantID: "",
-			downstreamHandler: func(_ context.Context, _ Request) (Response, error) {
+			downstreamHandler: func(_ context.Context, _ MetricsQueryRequest) (Response, error) {
 				return &PrometheusResponse{}, nil
 			},
 			expectedLoads:  0,
@@ -168,7 +168,7 @@ func Test_cardinalityEstimation_Do(t *testing.T) {
 		{
 			name:     "downstream error",
 			tenantID: "1",
-			downstreamHandler: func(_ context.Context, _ Request) (Response, error) {
+			downstreamHandler: func(_ context.Context, _ MetricsQueryRequest) (Response, error) {
 				return nil, errors.New("test error")
 			},
 			expectedLoads:  1,
@@ -205,7 +205,7 @@ func Test_cardinalityEstimation_Do(t *testing.T) {
 		{
 			name:     "with empty cache",
 			tenantID: "1",
-			downstreamHandler: func(ctx context.Context, request Request) (Response, error) {
+			downstreamHandler: func(ctx context.Context, request MetricsQueryRequest) (Response, error) {
 				queryStats := stats.FromContext(ctx)
 				queryStats.AddFetchedSeries(numSeries)
 				return &PrometheusResponse{}, nil
@@ -251,8 +251,8 @@ func Test_cardinalityEstimateBucket_QueryRequest_requestEquality(t *testing.T) {
 		name          string
 		tenantA       string
 		tenantB       string
-		requestA      Request
-		requestB      Request
+		requestA      MetricsQueryRequest
+		requestB      MetricsQueryRequest
 		expectedEqual bool
 	}{
 		{

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -65,16 +65,16 @@ const (
 // Codec is used to encode/decode query requests and responses so they can be passed down to middlewares.
 type Codec interface {
 	Merger
-	// DecodeRequest decodes a MetricsQueryRequest from an http request.
-	DecodeRequest(context.Context, *http.Request) (MetricsQueryRequest, error)
+	// DecodeMetricsQueryRequest decodes a MetricsQueryRequest from an http request.
+	DecodeMetricsQueryRequest(context.Context, *http.Request) (MetricsQueryRequest, error)
 	// DecodeLabelsQueryRequest decodes a LabelsQueryRequest from an http request.
 	DecodeLabelsQueryRequest(context.Context, *http.Request) (LabelsQueryRequest, error)
 	// DecodeResponse decodes a Response from an http response.
 	// The original request is also passed as a parameter this is useful for implementation that needs the request
 	// to merge result or build the result correctly.
 	DecodeResponse(context.Context, *http.Response, MetricsQueryRequest, log.Logger) (Response, error)
-	// EncodeRequest encodes a MetricsQueryRequest into an http request.
-	EncodeRequest(context.Context, MetricsQueryRequest) (*http.Request, error)
+	// EncodeMetricsQueryRequest encodes a MetricsQueryRequest into an http request.
+	EncodeMetricsQueryRequest(context.Context, MetricsQueryRequest) (*http.Request, error)
 	// EncodeLabelsQueryRequest encodes a LabelsQueryRequest into an http request.
 	EncodeLabelsQueryRequest(context.Context, LabelsQueryRequest) (*http.Request, error)
 	// EncodeResponse encodes a Response into an http response.
@@ -246,7 +246,7 @@ func (prometheusCodec) MergeResponse(responses ...Response) (Response, error) {
 	}, nil
 }
 
-func (c prometheusCodec) DecodeRequest(_ context.Context, r *http.Request) (MetricsQueryRequest, error) {
+func (c prometheusCodec) DecodeMetricsQueryRequest(_ context.Context, r *http.Request) (MetricsQueryRequest, error) {
 	switch {
 	case IsRangeQuery(r.URL.Path):
 		return c.decodeRangeQueryRequest(r)
@@ -460,7 +460,7 @@ func decodeCacheDisabledOption(r *http.Request) bool {
 	return false
 }
 
-func (c prometheusCodec) EncodeRequest(ctx context.Context, r MetricsQueryRequest) (*http.Request, error) {
+func (c prometheusCodec) EncodeMetricsQueryRequest(ctx context.Context, r MetricsQueryRequest) (*http.Request, error) {
 	var u *url.URL
 	switch r := r.(type) {
 	case *PrometheusRangeQueryRequest:

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -65,16 +65,16 @@ const (
 // Codec is used to encode/decode query requests and responses so they can be passed down to middlewares.
 type Codec interface {
 	Merger
-	// DecodeRequest decodes a Request from an http request.
-	DecodeRequest(context.Context, *http.Request) (Request, error)
+	// DecodeRequest decodes a MetricsQueryRequest from an http request.
+	DecodeRequest(context.Context, *http.Request) (MetricsQueryRequest, error)
 	// DecodeLabelsQueryRequest decodes a LabelsQueryRequest from an http request.
 	DecodeLabelsQueryRequest(context.Context, *http.Request) (LabelsQueryRequest, error)
 	// DecodeResponse decodes a Response from an http response.
 	// The original request is also passed as a parameter this is useful for implementation that needs the request
 	// to merge result or build the result correctly.
-	DecodeResponse(context.Context, *http.Response, Request, log.Logger) (Response, error)
-	// EncodeRequest encodes a Request into an http request.
-	EncodeRequest(context.Context, Request) (*http.Request, error)
+	DecodeResponse(context.Context, *http.Response, MetricsQueryRequest, log.Logger) (Response, error)
+	// EncodeRequest encodes a MetricsQueryRequest into an http request.
+	EncodeRequest(context.Context, MetricsQueryRequest) (*http.Request, error)
 	// EncodeLabelsQueryRequest encodes a LabelsQueryRequest into an http request.
 	EncodeLabelsQueryRequest(context.Context, LabelsQueryRequest) (*http.Request, error)
 	// EncodeResponse encodes a Response into an http response.
@@ -87,8 +87,8 @@ type Merger interface {
 	MergeResponse(...Response) (Response, error)
 }
 
-// Request represents an instant or query range request that can be process by middlewares.
-type Request interface {
+// MetricsQueryRequest represents an instant or query range request that can be process by middlewares.
+type MetricsQueryRequest interface {
 	// GetId returns the ID of the request used to correlate downstream requests and responses.
 	GetId() int64
 	// GetStart returns the start timestamp of the request in milliseconds.
@@ -105,15 +105,15 @@ type Request interface {
 	// These hints can be used to optimize the query execution.
 	GetHints() *Hints
 	// WithID clones the current request with the provided ID.
-	WithID(id int64) Request
+	WithID(id int64) MetricsQueryRequest
 	// WithStartEnd clone the current request with different start and end timestamp.
-	WithStartEnd(startTime int64, endTime int64) Request
+	WithStartEnd(startTime int64, endTime int64) MetricsQueryRequest
 	// WithQuery clone the current request with a different query.
-	WithQuery(string) Request
+	WithQuery(string) MetricsQueryRequest
 	// WithTotalQueriesHint adds the number of total queries to this request's Hints.
-	WithTotalQueriesHint(int32) Request
+	WithTotalQueriesHint(int32) MetricsQueryRequest
 	// WithEstimatedSeriesCountHint WithEstimatedCardinalityHint adds a cardinality estimate to this request's Hints.
-	WithEstimatedSeriesCountHint(uint64) Request
+	WithEstimatedSeriesCountHint(uint64) MetricsQueryRequest
 	proto.Message
 	// AddSpanTags writes information about this request to an OpenTracing span
 	AddSpanTags(opentracing.Span)
@@ -246,7 +246,7 @@ func (prometheusCodec) MergeResponse(responses ...Response) (Response, error) {
 	}, nil
 }
 
-func (c prometheusCodec) DecodeRequest(_ context.Context, r *http.Request) (Request, error) {
+func (c prometheusCodec) DecodeRequest(_ context.Context, r *http.Request) (MetricsQueryRequest, error) {
 	switch {
 	case IsRangeQuery(r.URL.Path):
 		return c.decodeRangeQueryRequest(r)
@@ -257,7 +257,7 @@ func (c prometheusCodec) DecodeRequest(_ context.Context, r *http.Request) (Requ
 	}
 }
 
-func (prometheusCodec) decodeRangeQueryRequest(r *http.Request) (Request, error) {
+func (prometheusCodec) decodeRangeQueryRequest(r *http.Request) (MetricsQueryRequest, error) {
 	var result PrometheusRangeQueryRequest
 	var err error
 	reqValues, err := util.ParseRequestFormWithoutConsumingBody(r)
@@ -276,7 +276,7 @@ func (prometheusCodec) decodeRangeQueryRequest(r *http.Request) (Request, error)
 	return &result, nil
 }
 
-func (c prometheusCodec) decodeInstantQueryRequest(r *http.Request) (Request, error) {
+func (c prometheusCodec) decodeInstantQueryRequest(r *http.Request) (MetricsQueryRequest, error) {
 	var result PrometheusInstantQueryRequest
 	var err error
 	reqValues, err := util.ParseRequestFormWithoutConsumingBody(r)
@@ -460,7 +460,7 @@ func decodeCacheDisabledOption(r *http.Request) bool {
 	return false
 }
 
-func (c prometheusCodec) EncodeRequest(ctx context.Context, r Request) (*http.Request, error) {
+func (c prometheusCodec) EncodeRequest(ctx context.Context, r MetricsQueryRequest) (*http.Request, error) {
 	var u *url.URL
 	switch r := r.(type) {
 	case *PrometheusRangeQueryRequest:
@@ -594,7 +594,7 @@ func encodeOptions(req *http.Request, o Options) {
 	}
 }
 
-func (c prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ Request, logger log.Logger) (Response, error) {
+func (c prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _ MetricsQueryRequest, logger log.Logger) (Response, error) {
 	switch r.StatusCode {
 	case http.StatusServiceUnavailable:
 		return nil, apierror.New(apierror.TypeUnavailable, string(mustReadResponseBody(r)))

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -44,7 +44,7 @@ func TestMetricsQueryRequest(t *testing.T) {
 
 	for i, tc := range []struct {
 		url         string
-		expected    Request
+		expected    MetricsQueryRequest
 		expectedErr error
 	}{
 		{

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -97,14 +97,14 @@ func TestMetricsQueryRequest(t *testing.T) {
 			ctx := user.InjectOrgID(context.Background(), "1")
 			r = r.WithContext(ctx)
 
-			req, err := codec.DecodeRequest(ctx, r)
+			req, err := codec.DecodeMetricsQueryRequest(ctx, r)
 			if err != nil || tc.expectedErr != nil {
 				require.EqualValues(t, tc.expectedErr, err)
 				return
 			}
 			require.EqualValues(t, tc.expected, req)
 
-			rdash, err := codec.EncodeRequest(context.Background(), req)
+			rdash, err := codec.EncodeMetricsQueryRequest(context.Background(), req)
 			require.NoError(t, err)
 			require.EqualValues(t, tc.url, rdash.RequestURI)
 		})
@@ -282,7 +282,7 @@ func TestPrometheusCodec_EncodeRequest_AcceptHeader(t *testing.T) {
 		t.Run(queryResultPayloadFormat, func(t *testing.T) {
 			codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), queryResultPayloadFormat)
 			req := PrometheusInstantQueryRequest{}
-			encodedRequest, err := codec.EncodeRequest(context.Background(), &req)
+			encodedRequest, err := codec.EncodeMetricsQueryRequest(context.Background(), &req)
 			require.NoError(t, err)
 
 			switch queryResultPayloadFormat {
@@ -302,7 +302,7 @@ func TestPrometheusCodec_EncodeRequest_ReadConsistency(t *testing.T) {
 		t.Run(consistencyLevel, func(t *testing.T) {
 			codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), formatProtobuf)
 			ctx := api.ContextWithReadConsistency(context.Background(), consistencyLevel)
-			encodedRequest, err := codec.EncodeRequest(ctx, &PrometheusInstantQueryRequest{})
+			encodedRequest, err := codec.EncodeMetricsQueryRequest(ctx, &PrometheusInstantQueryRequest{})
 			require.NoError(t, err)
 			require.Equal(t, consistencyLevel, encodedRequest.Header.Get(api.ReadConsistencyHeader))
 		})
@@ -1133,14 +1133,14 @@ func TestPrometheusCodec_DecodeEncode(t *testing.T) {
 				expected.Header = make(http.Header)
 			}
 
-			// This header is set by EncodeRequest according to the codec's config, so we
+			// This header is set by EncodeMetricsQueryRequest according to the codec's config, so we
 			// should always expect it to be present on the re-encoded request.
 			expected.Header.Set("Accept", "application/json")
 
 			ctx := context.Background()
-			decoded, err := codec.DecodeRequest(ctx, expected)
+			decoded, err := codec.DecodeMetricsQueryRequest(ctx, expected)
 			require.NoError(t, err)
-			encoded, err := codec.EncodeRequest(ctx, decoded)
+			encoded, err := codec.EncodeMetricsQueryRequest(ctx, decoded)
 			require.NoError(t, err)
 
 			assert.Equal(t, expected.URL, encoded.URL)

--- a/pkg/frontend/querymiddleware/instrumentation.go
+++ b/pkg/frontend/querymiddleware/instrumentation.go
@@ -16,7 +16,7 @@ import (
 )
 
 // newInstrumentMiddleware can be inserted into the middleware chain to expose timing information.
-func newInstrumentMiddleware(name string, metrics *instrumentMiddlewareMetrics) Middleware {
+func newInstrumentMiddleware(name string, metrics *instrumentMiddlewareMetrics) MetricsQueryMiddleware {
 	var durationCol instrument.Collector
 
 	// Support the case metrics shouldn't be tracked (ie. unit tests).
@@ -26,7 +26,7 @@ func newInstrumentMiddleware(name string, metrics *instrumentMiddlewareMetrics) 
 		durationCol = &noopCollector{}
 	}
 
-	return MiddlewareFunc(func(next Handler) Handler {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 			var resp Response
 			err := instrument.CollectedRequest(ctx, name, durationCol, instrument.ErrorCode, func(ctx context.Context) error {

--- a/pkg/frontend/querymiddleware/instrumentation.go
+++ b/pkg/frontend/querymiddleware/instrumentation.go
@@ -27,7 +27,7 @@ func newInstrumentMiddleware(name string, metrics *instrumentMiddlewareMetrics) 
 	}
 
 	return MiddlewareFunc(func(next Handler) Handler {
-		return HandlerFunc(func(ctx context.Context, req Request) (Response, error) {
+		return HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 			var resp Response
 			err := instrument.CollectedRequest(ctx, name, durationCol, instrument.ErrorCode, func(ctx context.Context) error {
 				sp := opentracing.SpanFromContext(ctx)

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -110,13 +110,13 @@ type Limits interface {
 
 type limitsMiddleware struct {
 	Limits
-	next   Handler
+	next   MetricsQueryHandler
 	logger log.Logger
 }
 
-// newLimitsMiddleware creates a new Middleware that enforces query limits.
-func newLimitsMiddleware(l Limits, logger log.Logger) Middleware {
-	return MiddlewareFunc(func(next Handler) Handler {
+// newLimitsMiddleware creates a new MetricsQueryMiddleware that enforces query limits.
+func newLimitsMiddleware(l Limits, logger log.Logger) MetricsQueryMiddleware {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return limitsMiddleware{
 			next:   next,
 			Limits: l,
@@ -201,15 +201,15 @@ func (l limitsMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Respon
 }
 
 type limitedParallelismRoundTripper struct {
-	downstream Handler
+	downstream MetricsQueryHandler
 	limits     Limits
 
 	codec      Codec
-	middleware Middleware
+	middleware MetricsQueryMiddleware
 }
 
 // newLimitedParallelismRoundTripper creates a new roundtripper that enforces MaxQueryParallelism to the `next` roundtripper across `middlewares`.
-func newLimitedParallelismRoundTripper(next http.RoundTripper, codec Codec, limits Limits, middlewares ...Middleware) http.RoundTripper {
+func newLimitedParallelismRoundTripper(next http.RoundTripper, codec Codec, limits Limits, middlewares ...MetricsQueryMiddleware) http.RoundTripper {
 	return limitedParallelismRoundTripper{
 		downstream: roundTripperHandler{
 			next:  next,
@@ -217,7 +217,7 @@ func newLimitedParallelismRoundTripper(next http.RoundTripper, codec Codec, limi
 		},
 		codec:      codec,
 		limits:     limits,
-		middleware: MergeMiddlewares(middlewares...),
+		middleware: MergeMetricsQueryMiddlewares(middlewares...),
 	}
 }
 
@@ -261,9 +261,9 @@ func (rt limitedParallelismRoundTripper) RoundTrip(r *http.Request) (*http.Respo
 	return rt.codec.EncodeResponse(ctx, r, response)
 }
 
-// roundTripperHandler is an adapter that implements the Handler interface using a http.RoundTripper to perform
+// roundTripperHandler is an adapter that implements the MetricsQueryHandler interface using a http.RoundTripper to perform
 // the requests and a Codec to translate between http Request/Response model and this package's Request/Response model.
-// It basically encodes a MetricsQueryRequest from Handler.Do and decodes response from next roundtripper.
+// It basically encodes a MetricsQueryRequest from MetricsQueryHandler.Do and decodes response from next roundtripper.
 type roundTripperHandler struct {
 	logger log.Logger
 	next   http.RoundTripper

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -225,7 +225,7 @@ func (rt limitedParallelismRoundTripper) RoundTrip(r *http.Request) (*http.Respo
 	ctx, cancel := context.WithCancelCause(r.Context())
 	defer cancel(errExecutingParallelQueriesFinished)
 
-	request, err := rt.codec.DecodeRequest(ctx, r)
+	request, err := rt.codec.DecodeMetricsQueryRequest(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +271,7 @@ type roundTripperHandler struct {
 }
 
 func (rth roundTripperHandler) Do(ctx context.Context, r MetricsQueryRequest) (Response, error) {
-	request, err := rth.codec.EncodeRequest(ctx, r)
+	request, err := rth.codec.EncodeMetricsQueryRequest(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -122,8 +122,8 @@ func TestLimitsMiddleware_MaxQueryLookback(t *testing.T) {
 				delta := float64(5000)
 				require.Len(t, inner.Calls, 1)
 
-				assert.InDelta(t, util.TimeToMillis(testData.expectedStartTime), inner.Calls[0].Arguments.Get(1).(Request).GetStart(), delta)
-				assert.InDelta(t, util.TimeToMillis(testData.expectedEndTime), inner.Calls[0].Arguments.Get(1).(Request).GetEnd(), delta)
+				assert.InDelta(t, util.TimeToMillis(testData.expectedStartTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetStart(), delta)
+				assert.InDelta(t, util.TimeToMillis(testData.expectedEndTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetEnd(), delta)
 			}
 		})
 	}
@@ -283,8 +283,8 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 
 				// The time range of the request passed to the inner handler should have not been manipulated.
 				require.Len(t, inner.Calls, 1)
-				assert.Equal(t, util.TimeToMillis(testData.reqStartTime), inner.Calls[0].Arguments.Get(1).(Request).GetStart())
-				assert.Equal(t, util.TimeToMillis(testData.reqEndTime), inner.Calls[0].Arguments.Get(1).(Request).GetEnd())
+				assert.Equal(t, util.TimeToMillis(testData.reqStartTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetStart())
+				assert.Equal(t, util.TimeToMillis(testData.reqEndTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetEnd())
 			}
 		})
 	}
@@ -345,7 +345,7 @@ func TestLimitsMiddleware_CreationGracePeriod(t *testing.T) {
 			delta := float64(5000)
 			require.Len(t, inner.Calls, 1)
 
-			assert.InDelta(t, util.TimeToMillis(testData.expectedEndTime), inner.Calls[0].Arguments.Get(1).(Request).GetEnd(), delta)
+			assert.InDelta(t, util.TimeToMillis(testData.expectedEndTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetEnd(), delta)
 		})
 	}
 }
@@ -570,7 +570,7 @@ type mockHandler struct {
 	mock.Mock
 }
 
-func (m *mockHandler) Do(ctx context.Context, req Request) (Response, error) {
+func (m *mockHandler) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 	args := m.Called(ctx, req)
 	return args.Get(0).(Response), args.Error(1)
 }
@@ -607,7 +607,7 @@ func TestLimitedRoundTripper_MaxQueryParallelism(t *testing.T) {
 
 	_, err = newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
 		MiddlewareFunc(func(next Handler) Handler {
-			return HandlerFunc(func(c context.Context, _ Request) (Response, error) {
+			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				var wg sync.WaitGroup
 				for i := 0; i < maxQueryParallelism+20; i++ {
 					wg.Add(1)
@@ -651,7 +651,7 @@ func TestLimitedRoundTripper_MaxQueryParallelismLateScheduling(t *testing.T) {
 
 	_, err = newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
 		MiddlewareFunc(func(next Handler) Handler {
-			return HandlerFunc(func(c context.Context, _ Request) (Response, error) {
+			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				// fire up work and we don't wait.
 				for i := 0; i < 10; i++ {
 					go func() {
@@ -692,7 +692,7 @@ func TestLimitedRoundTripper_OriginalRequestContextCancellation(t *testing.T) {
 
 	_, err = newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
 		MiddlewareFunc(func(next Handler) Handler {
-			return HandlerFunc(func(c context.Context, _ Request) (Response, error) {
+			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				var wg sync.WaitGroup
 
 				// Fire up some work. Each sub-request will either be blocked in the sleep or in the queue
@@ -751,7 +751,7 @@ func BenchmarkLimitedParallelismRoundTripper(b *testing.B) {
 		for _, subRequestCount := range []int{1, 2, 5, 10, 20, 50, 100} {
 			tripper := newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxParallelism},
 				MiddlewareFunc(func(next Handler) Handler {
-					return HandlerFunc(func(c context.Context, _ Request) (Response, error) {
+					return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 						wg := sync.WaitGroup{}
 						for i := 0; i < subRequestCount; i++ {
 							wg.Add(1)

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -596,7 +596,7 @@ func TestLimitedRoundTripper_MaxQueryParallelism(t *testing.T) {
 	)
 
 	codec := newTestPrometheusCodec()
-	r, err := codec.EncodeRequest(ctx, &PrometheusRangeQueryRequest{
+	r, err := codec.EncodeMetricsQueryRequest(ctx, &PrometheusRangeQueryRequest{
 		Path:  "/api/v1/query_range",
 		Start: time.Now().Add(time.Hour).Unix(),
 		End:   util.TimeToMillis(time.Now()),
@@ -640,7 +640,7 @@ func TestLimitedRoundTripper_MaxQueryParallelismLateScheduling(t *testing.T) {
 	)
 
 	codec := newTestPrometheusCodec()
-	r, err := codec.EncodeRequest(ctx, &PrometheusRangeQueryRequest{
+	r, err := codec.EncodeMetricsQueryRequest(ctx, &PrometheusRangeQueryRequest{
 		Path:  "/api/v1/query_range",
 		Start: time.Now().Add(time.Hour).Unix(),
 		End:   util.TimeToMillis(time.Now()),
@@ -681,7 +681,7 @@ func TestLimitedRoundTripper_OriginalRequestContextCancellation(t *testing.T) {
 	)
 
 	codec := newTestPrometheusCodec()
-	r, err := codec.EncodeRequest(reqCtx, &PrometheusRangeQueryRequest{
+	r, err := codec.EncodeMetricsQueryRequest(reqCtx, &PrometheusRangeQueryRequest{
 		Path:  "/api/v1/query_range",
 		Start: time.Now().Add(time.Hour).Unix(),
 		End:   util.TimeToMillis(time.Now()),
@@ -738,7 +738,7 @@ func BenchmarkLimitedParallelismRoundTripper(b *testing.B) {
 	})
 
 	codec := newTestPrometheusCodec()
-	r, err := codec.EncodeRequest(ctx, &PrometheusRangeQueryRequest{
+	r, err := codec.EncodeMetricsQueryRequest(ctx, &PrometheusRangeQueryRequest{
 		Path:  "/api/v1/query_range",
 		Start: time.Now().Add(time.Hour).Unix(),
 		End:   util.TimeToMillis(time.Now()),

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -606,7 +606,7 @@ func TestLimitedRoundTripper_MaxQueryParallelism(t *testing.T) {
 	require.Nil(t, err)
 
 	_, err = newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
-		MiddlewareFunc(func(next Handler) Handler {
+		MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				var wg sync.WaitGroup
 				for i := 0; i < maxQueryParallelism+20; i++ {
@@ -650,7 +650,7 @@ func TestLimitedRoundTripper_MaxQueryParallelismLateScheduling(t *testing.T) {
 	require.Nil(t, err)
 
 	_, err = newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
-		MiddlewareFunc(func(next Handler) Handler {
+		MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				// fire up work and we don't wait.
 				for i := 0; i < 10; i++ {
@@ -691,7 +691,7 @@ func TestLimitedRoundTripper_OriginalRequestContextCancellation(t *testing.T) {
 	require.Nil(t, err)
 
 	_, err = newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
-		MiddlewareFunc(func(next Handler) Handler {
+		MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				var wg sync.WaitGroup
 
@@ -750,7 +750,7 @@ func BenchmarkLimitedParallelismRoundTripper(b *testing.B) {
 	for _, concurrentRequestCount := range []int{1, 10, 100} {
 		for _, subRequestCount := range []int{1, 2, 5, 10, 20, 50, 100} {
 			tripper := newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxParallelism},
-				MiddlewareFunc(func(next Handler) Handler {
+				MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 					return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 						wg := sync.WaitGroup{}
 						for i := 0; i < subRequestCount; i++ {

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -43,14 +43,14 @@ func newEmptyPrometheusResponse() *PrometheusResponse {
 }
 
 // WithID clones the current `PrometheusRangeQueryRequest` with the provided ID.
-func (q *PrometheusRangeQueryRequest) WithID(id int64) Request {
+func (q *PrometheusRangeQueryRequest) WithID(id int64) MetricsQueryRequest {
 	newRequest := *q
 	newRequest.Id = id
 	return &newRequest
 }
 
 // WithStartEnd clones the current `PrometheusRangeQueryRequest` with a new `start` and `end` timestamp.
-func (q *PrometheusRangeQueryRequest) WithStartEnd(start int64, end int64) Request {
+func (q *PrometheusRangeQueryRequest) WithStartEnd(start int64, end int64) MetricsQueryRequest {
 	newRequest := *q
 	newRequest.Start = start
 	newRequest.End = end
@@ -58,7 +58,7 @@ func (q *PrometheusRangeQueryRequest) WithStartEnd(start int64, end int64) Reque
 }
 
 // WithQuery clones the current `PrometheusRangeQueryRequest` with a new query.
-func (q *PrometheusRangeQueryRequest) WithQuery(query string) Request {
+func (q *PrometheusRangeQueryRequest) WithQuery(query string) MetricsQueryRequest {
 	newRequest := *q
 	newRequest.Query = query
 	return &newRequest
@@ -66,7 +66,7 @@ func (q *PrometheusRangeQueryRequest) WithQuery(query string) Request {
 
 // WithTotalQueriesHint clones the current `PrometheusRangeQueryRequest` with an
 // added Hint value for TotalQueries.
-func (q *PrometheusRangeQueryRequest) WithTotalQueriesHint(totalQueries int32) Request {
+func (q *PrometheusRangeQueryRequest) WithTotalQueriesHint(totalQueries int32) MetricsQueryRequest {
 	newRequest := *q
 	if newRequest.Hints == nil {
 		newRequest.Hints = &Hints{TotalQueries: totalQueries}
@@ -79,7 +79,7 @@ func (q *PrometheusRangeQueryRequest) WithTotalQueriesHint(totalQueries int32) R
 
 // WithEstimatedSeriesCountHint clones the current `PrometheusRangeQueryRequest`
 // with an added Hint value for EstimatedCardinality.
-func (q *PrometheusRangeQueryRequest) WithEstimatedSeriesCountHint(count uint64) Request {
+func (q *PrometheusRangeQueryRequest) WithEstimatedSeriesCountHint(count uint64) MetricsQueryRequest {
 	newRequest := *q
 	if newRequest.Hints == nil {
 		newRequest.Hints = &Hints{
@@ -113,25 +113,25 @@ func (r *PrometheusInstantQueryRequest) GetStep() int64 {
 	return 0
 }
 
-func (r *PrometheusInstantQueryRequest) WithID(id int64) Request {
+func (r *PrometheusInstantQueryRequest) WithID(id int64) MetricsQueryRequest {
 	newRequest := *r
 	newRequest.Id = id
 	return &newRequest
 }
 
-func (r *PrometheusInstantQueryRequest) WithStartEnd(startTime int64, _ int64) Request {
+func (r *PrometheusInstantQueryRequest) WithStartEnd(startTime int64, _ int64) MetricsQueryRequest {
 	newRequest := *r
 	newRequest.Time = startTime
 	return &newRequest
 }
 
-func (r *PrometheusInstantQueryRequest) WithQuery(s string) Request {
+func (r *PrometheusInstantQueryRequest) WithQuery(s string) MetricsQueryRequest {
 	newRequest := *r
 	newRequest.Query = s
 	return &newRequest
 }
 
-func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32) Request {
+func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32) MetricsQueryRequest {
 	newRequest := *r
 	if newRequest.Hints == nil {
 		newRequest.Hints = &Hints{TotalQueries: totalQueries}
@@ -142,7 +142,7 @@ func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32)
 	return &newRequest
 }
 
-func (r *PrometheusInstantQueryRequest) WithEstimatedSeriesCountHint(count uint64) Request {
+func (r *PrometheusInstantQueryRequest) WithEstimatedSeriesCountHint(count uint64) MetricsQueryRequest {
 	newRequest := *r
 	if newRequest.Hints == nil {
 		newRequest.Hints = &Hints{

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -96,7 +96,7 @@ func newQueryShardingMiddleware(
 	})
 }
 
-func (s *querySharding) Do(ctx context.Context, r Request) (Response, error) {
+func (s *querySharding) Do(ctx context.Context, r MetricsQueryRequest) (Response, error) {
 	log := spanlogger.FromContext(ctx, s.logger)
 
 	tenantIDs, err := tenant.TenantIDs(ctx)
@@ -171,7 +171,7 @@ func (s *querySharding) Do(ctx context.Context, r Request) (Response, error) {
 	}, nil
 }
 
-func newQuery(ctx context.Context, r Request, engine *promql.Engine, queryable storage.Queryable) (promql.Query, error) {
+func newQuery(ctx context.Context, r MetricsQueryRequest, engine *promql.Engine, queryable storage.Queryable) (promql.Query, error) {
 	switch r := r.(type) {
 	case *PrometheusRangeQueryRequest:
 		return engine.NewRangeQuery(
@@ -255,7 +255,7 @@ func (s *querySharding) shardQuery(ctx context.Context, query string, totalShard
 }
 
 // getShardsForQuery calculates and return the number of shards that should be used to run the query.
-func (s *querySharding) getShardsForQuery(ctx context.Context, tenantIDs []string, r Request, queryExpr parser.Expr, spanLog *spanlogger.SpanLogger) int {
+func (s *querySharding) getShardsForQuery(ctx context.Context, tenantIDs []string, r MetricsQueryRequest, queryExpr parser.Expr, spanLog *spanlogger.SpanLogger) int {
 	// Check if sharding is disabled for the given request.
 	if r.GetOptions().ShardingDisabled {
 		return 1

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -38,7 +38,7 @@ type querySharding struct {
 	limit Limits
 
 	engine            *promql.Engine
-	next              Handler
+	next              MetricsQueryHandler
 	logger            log.Logger
 	maxSeriesPerShard uint64
 
@@ -64,7 +64,7 @@ func newQueryShardingMiddleware(
 	limit Limits,
 	maxSeriesPerShard uint64,
 	registerer prometheus.Registerer,
-) Middleware {
+) MetricsQueryMiddleware {
 	metrics := queryShardingMetrics{
 		shardingAttempts: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_frontend_query_sharding_rewrites_attempted_total",
@@ -84,7 +84,7 @@ func newQueryShardingMiddleware(
 			Buckets: prometheus.ExponentialBuckets(2, 2, 10),
 		}),
 	}
-	return MiddlewareFunc(func(next Handler) Handler {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &querySharding{
 			next:                 next,
 			queryShardingMetrics: metrics,

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -51,7 +51,7 @@ var (
 )
 
 func mockHandlerWith(resp *PrometheusResponse, err error) Handler {
-	return HandlerFunc(func(ctx context.Context, req Request) (Response, error) {
+	return HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 		if expired := ctx.Err(); expired != nil {
 			return nil, expired
 		}
@@ -681,7 +681,7 @@ func TestQuerySharding_Correctness(t *testing.T) {
 
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
-			reqs := []Request{
+			reqs := []MetricsQueryRequest{
 				&PrometheusInstantQueryRequest{
 					Path:  "/query",
 					Time:  util.TimeToMillis(end),
@@ -1356,7 +1356,7 @@ func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
 					ResultType: string(parser.ValueTypeVector),
 				},
 			}, nil).Run(func(args mock.Arguments) {
-				req := args[1].(Request)
+				req := args[1].(MetricsQueryRequest)
 				reqShard := regexp.MustCompile(`__query_shard__="[^"]+"`).FindString(req.GetQuery())
 
 				uniqueShardsMx.Lock()
@@ -1449,7 +1449,7 @@ func TestQuerySharding_ShouldSupportMaxRegexpSizeBytes(t *testing.T) {
 					ResultType: string(parser.ValueTypeVector),
 				},
 			}, nil).Run(func(args mock.Arguments) {
-				req := args[1].(Request)
+				req := args[1].(MetricsQueryRequest)
 				reqShard := regexp.MustCompile(`__query_shard__="[^"]+"`).FindString(req.GetQuery())
 
 				uniqueShardsMx.Lock()
@@ -1681,7 +1681,7 @@ func TestQuerySharding_ShouldUseCardinalityEstimate(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		req           Request
+		req           MetricsQueryRequest
 		expectedCalls int
 	}{
 		{
@@ -2147,7 +2147,7 @@ type downstreamHandler struct {
 	queryable storage.Queryable
 }
 
-func (h *downstreamHandler) Do(ctx context.Context, r Request) (Response, error) {
+func (h *downstreamHandler) Do(ctx context.Context, r MetricsQueryRequest) (Response, error) {
 	qry, err := newQuery(ctx, r, h.engine, h.queryable)
 	if err != nil {
 		return nil, err

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -50,7 +50,7 @@ var (
 	lookbackDelta = 5 * time.Minute
 )
 
-func mockHandlerWith(resp *PrometheusResponse, err error) Handler {
+func mockHandlerWith(resp *PrometheusResponse, err error) MetricsQueryHandler {
 	return HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 		if expired := ctx.Err(); expired != nil {
 			return nil, expired

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -130,7 +130,7 @@ func TestIsRequestCachable(t *testing.T) {
 
 	for _, tc := range []struct {
 		name                      string
-		request                   Request
+		request                   MetricsQueryRequest
 		expected                  bool
 		expectedNotCachableReason string
 		cacheStepUnaligned        bool
@@ -373,9 +373,9 @@ func TestIsResponseCachable(t *testing.T) {
 func TestPartitionCacheExtents(t *testing.T) {
 	for _, tc := range []struct {
 		name                   string
-		input                  Request
+		input                  MetricsQueryRequest
 		prevCachedResponse     []Extent
-		expectedRequests       []Request
+		expectedRequests       []MetricsQueryRequest
 		expectedCachedResponse []Response
 	}{
 		{
@@ -403,7 +403,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 			prevCachedResponse: []Extent{
 				mkExtent(110, 210),
 			},
-			expectedRequests: []Request{
+			expectedRequests: []MetricsQueryRequest{
 				&PrometheusRangeQueryRequest{
 					Start: 0,
 					End:   100,
@@ -421,7 +421,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 			prevCachedResponse: []Extent{
 				mkExtent(50, 100),
 			},
-			expectedRequests: []Request{
+			expectedRequests: []MetricsQueryRequest{
 				&PrometheusRangeQueryRequest{
 					Start: 0,
 					End:   50,
@@ -443,7 +443,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 				mkExtent(50, 120),
 				mkExtent(160, 250),
 			},
-			expectedRequests: []Request{
+			expectedRequests: []MetricsQueryRequest{
 				&PrometheusRangeQueryRequest{
 					Start: 120,
 					End:   160,
@@ -466,7 +466,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 				mkExtent(50, 120),
 				mkExtent(122, 130),
 			},
-			expectedRequests: []Request{
+			expectedRequests: []MetricsQueryRequest{
 				&PrometheusRangeQueryRequest{
 					Start: 120,
 					End:   160,
@@ -487,7 +487,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 			prevCachedResponse: []Extent{
 				mkExtent(50, 90),
 			},
-			expectedRequests: []Request{
+			expectedRequests: []MetricsQueryRequest{
 				&PrometheusRangeQueryRequest{
 					Start: 100,
 					End:   100,
@@ -526,7 +526,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 			expectedCachedResponse: []Response{
 				mkAPIResponse(486, 625, 33),
 			},
-			expectedRequests: []Request{
+			expectedRequests: []MetricsQueryRequest{
 				&PrometheusRangeQueryRequest{Start: 123, End: 486, Step: 33},
 				&PrometheusRangeQueryRequest{
 					Start: 651,  // next number after 625 (end of extent) such that it is equal to input.Start + N * input.Step.
@@ -562,7 +562,7 @@ func TestDefaultSplitter_QueryRequest(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		r        Request
+		r        MetricsQueryRequest
 		interval time.Duration
 		want     string
 	}{

--- a/pkg/frontend/querymiddleware/retry.go
+++ b/pkg/frontend/querymiddleware/retry.go
@@ -64,7 +64,7 @@ func newRetryMiddleware(log log.Logger, maxRetries int, metrics prometheus.Obser
 	})
 }
 
-func (r retry) Do(ctx context.Context, req Request) (Response, error) {
+func (r retry) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 	tries := 0
 	defer func() { r.metrics.Observe(float64(tries)) }()
 

--- a/pkg/frontend/querymiddleware/retry.go
+++ b/pkg/frontend/querymiddleware/retry.go
@@ -41,7 +41,7 @@ func (m *retryMiddlewareMetrics) Observe(v float64) {
 
 type retry struct {
 	log        log.Logger
-	next       Handler
+	next       MetricsQueryHandler
 	maxRetries int
 
 	metrics prometheus.Observer
@@ -49,12 +49,12 @@ type retry struct {
 
 // newRetryMiddleware returns a middleware that retries requests if they
 // fail with 500 or a non-HTTP error.
-func newRetryMiddleware(log log.Logger, maxRetries int, metrics prometheus.Observer) Middleware {
+func newRetryMiddleware(log log.Logger, maxRetries int, metrics prometheus.Observer) MetricsQueryMiddleware {
 	if metrics == nil {
 		metrics = newRetryMiddlewareMetrics(nil)
 	}
 
-	return MiddlewareFunc(func(next Handler) Handler {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return retry{
 			log:        log,
 			next:       next,

--- a/pkg/frontend/querymiddleware/retry_test.go
+++ b/pkg/frontend/querymiddleware/retry_test.go
@@ -35,7 +35,7 @@ func TestRetry(t *testing.T) {
 
 	for _, tc := range []struct {
 		name            string
-		handler         Handler
+		handler         MetricsQueryHandler
 		resp            Response
 		err             error
 		expectedRetries int

--- a/pkg/frontend/querymiddleware/retry_test.go
+++ b/pkg/frontend/querymiddleware/retry_test.go
@@ -43,7 +43,7 @@ func TestRetry(t *testing.T) {
 		{
 			name:            "retry failures",
 			expectedRetries: 4,
-			handler: HandlerFunc(func(_ context.Context, req Request) (Response, error) {
+			handler: HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
 				if try.Inc() == 5 {
 					return &PrometheusResponse{Status: "Hello World"}, nil
 				}
@@ -54,7 +54,7 @@ func TestRetry(t *testing.T) {
 		{
 			name:            "don't retry 400s",
 			expectedRetries: 0,
-			handler: HandlerFunc(func(_ context.Context, req Request) (Response, error) {
+			handler: HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
 				return nil, errBadRequest
 			}),
 			err: errBadRequest,
@@ -62,7 +62,7 @@ func TestRetry(t *testing.T) {
 		{
 			name:            "don't retry bad-data",
 			expectedRetries: 0,
-			handler: HandlerFunc(func(_ context.Context, req Request) (Response, error) {
+			handler: HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
 				return nil, errUnprocessable
 			}),
 			err: errUnprocessable,
@@ -70,7 +70,7 @@ func TestRetry(t *testing.T) {
 		{
 			name:            "retry 500s",
 			expectedRetries: 5,
-			handler: HandlerFunc(func(_ context.Context, req Request) (Response, error) {
+			handler: HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
 				return nil, errInternal
 			}),
 			err: errInternal,
@@ -78,7 +78,7 @@ func TestRetry(t *testing.T) {
 		{
 			name:            "last error",
 			expectedRetries: 4,
-			handler: HandlerFunc(func(_ context.Context, req Request) (Response, error) {
+			handler: HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
 				if try.Inc() == 5 {
 					return nil, errBadRequest
 				}
@@ -112,7 +112,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := newRetryMiddleware(log.NewNopLogger(), 5, nil).Wrap(
-		HandlerFunc(func(c context.Context, r Request) (Response, error) {
+		HandlerFunc(func(c context.Context, r MetricsQueryRequest) (Response, error) {
 			try.Inc()
 			return nil, ctx.Err()
 		}),
@@ -122,7 +122,7 @@ func Test_RetryMiddlewareCancel(t *testing.T) {
 
 	ctx, cancel = context.WithCancel(context.Background())
 	_, err = newRetryMiddleware(log.NewNopLogger(), 5, nil).Wrap(
-		HandlerFunc(func(c context.Context, r Request) (Response, error) {
+		HandlerFunc(func(c context.Context, r MetricsQueryRequest) (Response, error) {
 			try.Inc()
 			cancel()
 			return nil, errors.New("failed")

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -116,16 +116,16 @@ func (cfg *Config) cardinalityBasedShardingEnabled() bool {
 }
 
 // HandlerFunc is like http.HandlerFunc, but for Handler.
-type HandlerFunc func(context.Context, Request) (Response, error)
+type HandlerFunc func(context.Context, MetricsQueryRequest) (Response, error)
 
 // Do implements Handler.
-func (q HandlerFunc) Do(ctx context.Context, req Request) (Response, error) {
+func (q HandlerFunc) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 	return q(ctx, req)
 }
 
 // Handler is like http.Handle, but specifically for Prometheus query_range calls.
 type Handler interface {
-	Do(context.Context, Request) (Response, error)
+	Do(context.Context, MetricsQueryRequest) (Response, error)
 }
 
 // MiddlewareFunc is like http.HandlerFunc, but for Middleware.
@@ -244,7 +244,7 @@ func newQueryTripperware(
 
 	// Inject the middleware to split requests by interval + results cache (if at least one of the two is enabled).
 	if cfg.SplitQueriesByInterval > 0 || cfg.CacheResults {
-		shouldCache := func(r Request) bool {
+		shouldCache := func(r MetricsQueryRequest) bool {
 			return !r.GetOptions().CacheDisabled
 		}
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -115,36 +115,36 @@ func (cfg *Config) cardinalityBasedShardingEnabled() bool {
 	return cfg.TargetSeriesPerShard > 0
 }
 
-// HandlerFunc is like http.HandlerFunc, but for Handler.
+// HandlerFunc is like http.HandlerFunc, but for MetricsQueryHandler.
 type HandlerFunc func(context.Context, MetricsQueryRequest) (Response, error)
 
-// Do implements Handler.
+// Do implements MetricsQueryHandler.
 func (q HandlerFunc) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 	return q(ctx, req)
 }
 
-// Handler is like http.Handle, but specifically for Prometheus query_range calls.
-type Handler interface {
+// MetricsQueryHandler is like http.Handle, but specifically for Prometheus query and query_range calls.
+type MetricsQueryHandler interface {
 	Do(context.Context, MetricsQueryRequest) (Response, error)
 }
 
-// MiddlewareFunc is like http.HandlerFunc, but for Middleware.
-type MiddlewareFunc func(Handler) Handler
+// MetricsQueryMiddlewareFunc is like http.HandlerFunc, but for MetricsQueryMiddleware.
+type MetricsQueryMiddlewareFunc func(MetricsQueryHandler) MetricsQueryHandler
 
-// Wrap implements Middleware.
-func (q MiddlewareFunc) Wrap(h Handler) Handler {
+// Wrap implements MetricsQueryMiddleware.
+func (q MetricsQueryMiddlewareFunc) Wrap(h MetricsQueryHandler) MetricsQueryHandler {
 	return q(h)
 }
 
-// Middleware is a higher order Handler.
-type Middleware interface {
-	Wrap(Handler) Handler
+// MetricsQueryMiddleware is a higher order MetricsQueryHandler.
+type MetricsQueryMiddleware interface {
+	Wrap(MetricsQueryHandler) MetricsQueryHandler
 }
 
-// MergeMiddlewares produces a middleware that applies multiple middleware in turn;
+// MergeMetricsQueryMiddlewares produces a middleware that applies multiple middleware in turn;
 // ie Merge(f,g,h).Wrap(handler) == f.Wrap(g.Wrap(h.Wrap(handler)))
-func MergeMiddlewares(middleware ...Middleware) Middleware {
-	return MiddlewareFunc(func(next Handler) Handler {
+func MergeMetricsQueryMiddlewares(middleware ...MetricsQueryMiddleware) MetricsQueryMiddleware {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		for i := len(middleware) - 1; i >= 0; i-- {
 			next = middleware[i].Wrap(next)
 		}
@@ -217,7 +217,7 @@ func newQueryTripperware(
 	queryBlockerMiddleware := newQueryBlockerMiddleware(limits, log, registerer)
 	queryStatsMiddleware := newQueryStatsMiddleware(registerer, engine)
 
-	queryRangeMiddleware := []Middleware{
+	queryRangeMiddleware := []MetricsQueryMiddleware{
 		// Track query range statistics. Added first before any subsequent middleware modifies the request.
 		queryStatsMiddleware,
 		newLimitsMiddleware(limits, log),
@@ -263,7 +263,7 @@ func newQueryTripperware(
 		))
 	}
 
-	queryInstantMiddleware := []Middleware{
+	queryInstantMiddleware := []MetricsQueryMiddleware{
 		// Track query range statistics. Added first before any subsequent middleware modifies the request.
 		queryStatsMiddleware,
 		newLimitsMiddleware(limits, log),

--- a/pkg/frontend/querymiddleware/sharded_queryable.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable.go
@@ -35,14 +35,14 @@ var (
 // shardedQueryable is an implementor of the Queryable interface.
 type shardedQueryable struct {
 	req             MetricsQueryRequest
-	handler         Handler
+	handler         MetricsQueryHandler
 	responseHeaders *responseHeadersTracker
 }
 
 // newShardedQueryable makes a new shardedQueryable. We expect a new queryable is created for each
 // query, otherwise the response headers tracker doesn't work as expected, because it merges the
 // headers for all queries run through the queryable and never reset them.
-func newShardedQueryable(req MetricsQueryRequest, next Handler) *shardedQueryable {
+func newShardedQueryable(req MetricsQueryRequest, next MetricsQueryHandler) *shardedQueryable {
 	return &shardedQueryable{
 		req:             req,
 		handler:         next,
@@ -66,7 +66,7 @@ func (q *shardedQueryable) getResponseHeaders() []*PrometheusResponseHeader {
 // through the downstream handler.
 type shardedQuerier struct {
 	req     MetricsQueryRequest
-	handler Handler
+	handler MetricsQueryHandler
 
 	// Keep track of response headers received when running embedded queries.
 	responseHeaders *responseHeadersTracker

--- a/pkg/frontend/querymiddleware/sharded_queryable.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable.go
@@ -34,7 +34,7 @@ var (
 
 // shardedQueryable is an implementor of the Queryable interface.
 type shardedQueryable struct {
-	req             Request
+	req             MetricsQueryRequest
 	handler         Handler
 	responseHeaders *responseHeadersTracker
 }
@@ -42,7 +42,7 @@ type shardedQueryable struct {
 // newShardedQueryable makes a new shardedQueryable. We expect a new queryable is created for each
 // query, otherwise the response headers tracker doesn't work as expected, because it merges the
 // headers for all queries run through the queryable and never reset them.
-func newShardedQueryable(req Request, next Handler) *shardedQueryable {
+func newShardedQueryable(req MetricsQueryRequest, next Handler) *shardedQueryable {
 	return &shardedQueryable{
 		req:             req,
 		handler:         next,
@@ -65,7 +65,7 @@ func (q *shardedQueryable) getResponseHeaders() []*PrometheusResponseHeader {
 // from the astmapper.EmbeddedQueriesMetricName metric label value and concurrently run embedded queries
 // through the downstream handler.
 type shardedQuerier struct {
-	req     Request
+	req     MetricsQueryRequest
 	handler Handler
 
 	// Keep track of response headers received when running embedded queries.

--- a/pkg/frontend/querymiddleware/sharded_queryable_test.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable_test.go
@@ -287,7 +287,7 @@ func TestShardedQueryable_GetResponseHeaders(t *testing.T) {
 	}, queryable.getResponseHeaders())
 }
 
-func mkShardedQuerier(handler Handler) *shardedQuerier {
+func mkShardedQuerier(handler MetricsQueryHandler) *shardedQuerier {
 	return &shardedQuerier{req: &PrometheusRangeQueryRequest{}, handler: handler, responseHeaders: newResponseHeadersTracker()}
 }
 

--- a/pkg/frontend/querymiddleware/sharded_queryable_test.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable_test.go
@@ -59,7 +59,7 @@ func TestShardedQuerier_Select(t *testing.T) {
 
 				// override handler func to assert new query has been substituted
 				q.handler = HandlerFunc(
-					func(ctx context.Context, req Request) (Response, error) {
+					func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 						require.Equal(t, `http_requests_total{cluster="prod"}`, req.GetQuery())
 						return expected, nil
 					},
@@ -218,7 +218,7 @@ func TestShardedQuerier_Select_ShouldConcurrentlyRunEmbeddedQueries(t *testing.T
 	downstreamWg := sync.WaitGroup{}
 	downstreamWg.Add(len(embeddedQueries))
 
-	querier := mkShardedQuerier(HandlerFunc(func(ctx context.Context, req Request) (Response, error) {
+	querier := mkShardedQuerier(HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 		// Wait until the downstream handler has been concurrently called for each embedded query.
 		downstreamWg.Done()
 		downstreamWg.Wait()

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -76,10 +76,10 @@ func newSplitAndCacheMiddlewareMetrics(reg prometheus.Registerer) *splitAndCache
 	return m
 }
 
-// splitAndCacheMiddleware is a Middleware that can (optionally) split the query by interval
+// splitAndCacheMiddleware is a MetricsQueryMiddleware that can (optionally) split the query by interval
 // and run split queries through the results cache.
 type splitAndCacheMiddleware struct {
-	next    Handler
+	next    MetricsQueryHandler
 	limits  Limits
 	merger  Merger
 	logger  log.Logger
@@ -112,10 +112,10 @@ func newSplitAndCacheMiddleware(
 	extractor Extractor,
 	shouldCacheReq shouldCacheFn,
 	logger log.Logger,
-	reg prometheus.Registerer) Middleware {
+	reg prometheus.Registerer) MetricsQueryMiddleware {
 	metrics := newSplitAndCacheMiddlewareMetrics(reg)
 
-	return MiddlewareFunc(func(next Handler) Handler {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &splitAndCacheMiddleware{
 			splitEnabled:   splitEnabled,
 			cacheEnabled:   cacheEnabled,
@@ -593,7 +593,7 @@ type requestResponse struct {
 }
 
 // doRequests executes a list of requests in parallel.
-func doRequests(ctx context.Context, downstream Handler, reqs []MetricsQueryRequest) ([]requestResponse, error) {
+func doRequests(ctx context.Context, downstream MetricsQueryHandler, reqs []MetricsQueryRequest) ([]requestResponse, error) {
 	g, ctx := errgroup.WithContext(ctx)
 	mtx := sync.Mutex{}
 	resps := make([]requestResponse, 0, len(reqs))

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -134,7 +134,7 @@ func newSplitAndCacheMiddleware(
 	})
 }
 
-func (s *splitAndCacheMiddleware) Do(ctx context.Context, req Request) (Response, error) {
+func (s *splitAndCacheMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 	spanLog := spanlogger.FromContext(ctx, s.logger)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
@@ -165,7 +165,7 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req Request) (Response
 			// Do not try to pick response from cache at all if the request is not cachable.
 			if cachable, reason := isRequestCachable(splitReq.orig, maxCacheTime, cacheUnalignedRequests, s.logger); !cachable {
 				level.Debug(spanLog).Log("msg", "skipping response cache as query is not cacheable", "query", splitReq.orig.GetQuery(), "reason", reason, "tenants", tenant.JoinTenantIDs(tenantIDs))
-				splitReq.downstreamRequests = []Request{splitReq.orig}
+				splitReq.downstreamRequests = []MetricsQueryRequest{splitReq.orig}
 				s.metrics.queryResultCacheSkippedCount.WithLabelValues(reason).Inc()
 				continue
 			}
@@ -181,7 +181,7 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req Request) (Response
 		for lookupIdx, extents := range fetchedExtents {
 			if len(extents) == 0 {
 				// We just need to run the request as is because no part of it has been cached yet.
-				lookupReqs[lookupIdx].downstreamRequests = []Request{lookupReqs[lookupIdx].orig}
+				lookupReqs[lookupIdx].downstreamRequests = []MetricsQueryRequest{lookupReqs[lookupIdx].orig}
 				continue
 			}
 
@@ -210,7 +210,7 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req Request) (Response
 	} else {
 		// Cache is disabled. We've just to execute the original request.
 		for _, splitReq := range splitReqs {
-			splitReq.downstreamRequests = []Request{splitReq.orig}
+			splitReq.downstreamRequests = []MetricsQueryRequest{splitReq.orig}
 		}
 	}
 
@@ -304,8 +304,8 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req Request) (Response
 	return s.merger.MergeResponse(responses...)
 }
 
-// splitRequestByInterval splits the given Request by configured interval. Returns the input request if splitting is disabled.
-func (s *splitAndCacheMiddleware) splitRequestByInterval(req Request) (splitRequests, error) {
+// splitRequestByInterval splits the given MetricsQueryRequest by configured interval. Returns the input request if splitting is disabled.
+func (s *splitAndCacheMiddleware) splitRequestByInterval(req MetricsQueryRequest) (splitRequests, error) {
 	if !s.splitEnabled {
 		return splitRequests{{orig: req}}, nil
 	}
@@ -468,7 +468,7 @@ func getTTLForExtent(now time.Time, ttl, ttlInOOOWindow, oooWindow time.Duration
 // splitRequest holds information about a split request.
 type splitRequest struct {
 	// The original split query.
-	orig Request
+	orig MetricsQueryRequest
 
 	// The cache key for the request.
 	cacheKey string
@@ -481,7 +481,7 @@ type splitRequest struct {
 
 	// The requests/responses we send/receive to/from downstream. For a given request, its
 	// response is stored at the same index.
-	downstreamRequests  []Request
+	downstreamRequests  []MetricsQueryRequest
 	downstreamResponses []Response
 }
 
@@ -519,7 +519,7 @@ func (s *splitRequests) countDownstreamResponseBytes() int {
 
 // prepareDownstreamRequests injects a unique ID and hints to all downstream requests and
 // initialize downstream responses slice to have the same length of requests.
-func (s *splitRequests) prepareDownstreamRequests() []Request {
+func (s *splitRequests) prepareDownstreamRequests() []MetricsQueryRequest {
 	// Count the total number of downstream requests to run and build the hints we're going
 	// to attach to each request.
 	numDownstreamRequests := s.countDownstreamRequests()
@@ -532,7 +532,7 @@ func (s *splitRequests) prepareDownstreamRequests() []Request {
 	// ID intentionally start at 1 to detect any bug in case the default zero value is used.
 	nextReqID := int64(1)
 
-	execReqs := make([]Request, 0, numDownstreamRequests)
+	execReqs := make([]MetricsQueryRequest, 0, numDownstreamRequests)
 	for _, splitReq := range *s {
 		for i := 0; i < len(splitReq.downstreamRequests); i++ {
 			splitReq.downstreamRequests[i] = splitReq.downstreamRequests[i].WithID(nextReqID).WithTotalQueriesHint(int32(numDownstreamRequests))
@@ -588,12 +588,12 @@ func (s *splitRequests) storeDownstreamResponses(responses []requestResponse) er
 
 // requestResponse contains a request response and the respective request that was used.
 type requestResponse struct {
-	Request  Request
+	Request  MetricsQueryRequest
 	Response Response
 }
 
 // doRequests executes a list of requests in parallel.
-func doRequests(ctx context.Context, downstream Handler, reqs []Request) ([]requestResponse, error) {
+func doRequests(ctx context.Context, downstream Handler, reqs []MetricsQueryRequest) ([]requestResponse, error) {
 	g, ctx := errgroup.WithContext(ctx)
 	mtx := sync.Mutex{}
 	resps := make([]requestResponse, 0, len(reqs))
@@ -626,14 +626,14 @@ func doRequests(ctx context.Context, downstream Handler, reqs []Request) ([]requ
 	return resps, g.Wait()
 }
 
-func splitQueryByInterval(r Request, interval time.Duration) ([]Request, error) {
+func splitQueryByInterval(r MetricsQueryRequest, interval time.Duration) ([]MetricsQueryRequest, error) {
 	// Replace @ modifier function to their respective constant values in the query.
 	// This way subqueries will be evaluated at the same time as the parent query.
 	query, err := evaluateAtModifierFunction(r.GetQuery(), r.GetStart(), r.GetEnd())
 	if err != nil {
 		return nil, err
 	}
-	var reqs []Request
+	var reqs []MetricsQueryRequest
 	for start := r.GetStart(); start <= r.GetEnd(); {
 		end := nextIntervalBoundary(start, r.GetStep(), interval)
 		if end > r.GetEnd() {

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -139,7 +139,7 @@ func TestSplitAndCacheMiddleware_SplitByInterval(t *testing.T) {
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				actualCount.Inc()
 
-				req, err := codec.DecodeRequest(r.Context(), r)
+				req, err := codec.DecodeMetricsQueryRequest(r.Context(), r)
 				require.NoError(t, err)
 
 				if req.GetStart() == dayOneStartTime.Unix()*1000 {
@@ -1543,7 +1543,7 @@ func newRoundTripper(next http.RoundTripper, codec Codec, logger log.Logger, mid
 }
 
 func (q roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	request, err := q.codec.DecodeRequest(r.Context(), r)
+	request, err := q.codec.DecodeMetricsQueryRequest(r.Context(), r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -28,9 +28,9 @@ const (
 	skippedReasonMappingFailed = "mapping-failed"
 )
 
-// splitInstantQueryByIntervalMiddleware is a Middleware that can (optionally) split the instant query by splitInterval
+// splitInstantQueryByIntervalMiddleware is a MetricsQueryMiddleware that can (optionally) split the instant query by splitInterval
 type splitInstantQueryByIntervalMiddleware struct {
-	next   Handler
+	next   MetricsQueryHandler
 	limits Limits
 	logger log.Logger
 
@@ -86,10 +86,10 @@ func newSplitInstantQueryByIntervalMiddleware(
 	limits Limits,
 	logger log.Logger,
 	engine *promql.Engine,
-	registerer prometheus.Registerer) Middleware {
+	registerer prometheus.Registerer) MetricsQueryMiddleware {
 	metrics := newInstantQuerySplittingMetrics(registerer)
 
-	return MiddlewareFunc(func(next Handler) Handler {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &splitInstantQueryByIntervalMiddleware{
 			next:    next,
 			limits:  limits,

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -100,7 +100,7 @@ func newSplitInstantQueryByIntervalMiddleware(
 	})
 }
 
-func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Request) (Response, error) {
+func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 	// Log the instant query and its timestamp in every error log, so that we have more information for debugging failures.
 	logger := log.With(s.logger, "query", req.GetQuery(), "query_timestamp", req.GetStart())
 
@@ -201,7 +201,7 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Requ
 }
 
 // getSplitIntervalForQuery calculates and return the split interval that should be used to run the instant query.
-func (s *splitInstantQueryByIntervalMiddleware) getSplitIntervalForQuery(tenantsIds []string, r Request, spanLog *spanlogger.SpanLogger) time.Duration {
+func (s *splitInstantQueryByIntervalMiddleware) getSplitIntervalForQuery(tenantsIds []string, r MetricsQueryRequest, spanLog *spanlogger.SpanLogger) time.Duration {
 	// Check if splitting is disabled for the given request.
 	if r.GetOptions().InstantSplitDisabled {
 		return 0

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -506,7 +506,7 @@ func TestInstantQuerySplittingCorrectness(t *testing.T) {
 
 				t.Run(testName, func(t *testing.T) {
 					t.Parallel()
-					reqs := []Request{
+					reqs := []MetricsQueryRequest{
 						&PrometheusInstantQueryRequest{
 							Path:  "/query",
 							Time:  util.TimeToMillis(end),

--- a/pkg/frontend/querymiddleware/stats.go
+++ b/pkg/frontend/querymiddleware/stats.go
@@ -25,10 +25,10 @@ type queryStatsMiddleware struct {
 	regexpMatcherCount          prometheus.Counter
 	regexpMatcherOptimizedCount prometheus.Counter
 	consistencyCounter          *prometheus.CounterVec
-	next                        Handler
+	next                        MetricsQueryHandler
 }
 
-func newQueryStatsMiddleware(reg prometheus.Registerer, engine *promql.Engine) Middleware {
+func newQueryStatsMiddleware(reg prometheus.Registerer, engine *promql.Engine) MetricsQueryMiddleware {
 	nonAlignedQueries := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "cortex_query_frontend_non_step_aligned_queries_total",
 		Help: "Total queries sent that are not step aligned.",
@@ -46,7 +46,7 @@ func newQueryStatsMiddleware(reg prometheus.Registerer, engine *promql.Engine) M
 		Help: "Total number of queries that explicitly request a level of consistency.",
 	}, []string{"user", "consistency"})
 
-	return MiddlewareFunc(func(next Handler) Handler {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &queryStatsMiddleware{
 			engine:                      engine,
 			nonAlignedQueries:           nonAlignedQueries,

--- a/pkg/frontend/querymiddleware/stats.go
+++ b/pkg/frontend/querymiddleware/stats.go
@@ -58,7 +58,7 @@ func newQueryStatsMiddleware(reg prometheus.Registerer, engine *promql.Engine) M
 	})
 }
 
-func (s queryStatsMiddleware) Do(ctx context.Context, req Request) (Response, error) {
+func (s queryStatsMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 	if !isRequestStepAligned(req) {
 		s.nonAlignedQueries.Inc()
 	}
@@ -70,7 +70,7 @@ func (s queryStatsMiddleware) Do(ctx context.Context, req Request) (Response, er
 	return s.next.Do(ctx, req)
 }
 
-func (s queryStatsMiddleware) trackRegexpMatchers(req Request) {
+func (s queryStatsMiddleware) trackRegexpMatchers(req MetricsQueryRequest) {
 	expr, err := parser.ParseExpr(req.GetQuery())
 	if err != nil {
 		return
@@ -93,7 +93,7 @@ var queryStatsErrQueryable = &storage.MockQueryable{MockQuerier: &storage.MockQu
 	return storage.ErrSeriesSet(errors.New("cannot use query stats queryable for running queries"))
 }}}
 
-func (s queryStatsMiddleware) populateQueryDetails(ctx context.Context, req Request) {
+func (s queryStatsMiddleware) populateQueryDetails(ctx context.Context, req MetricsQueryRequest) {
 	details := QueryDetailsFromContext(ctx)
 	if details == nil {
 		return

--- a/pkg/frontend/querymiddleware/stats_test.go
+++ b/pkg/frontend/querymiddleware/stats_test.go
@@ -23,7 +23,7 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 	const tenantID = "test"
 	type args struct {
 		ctx context.Context
-		req Request
+		req MetricsQueryRequest
 	}
 	tests := []struct {
 		name                 string

--- a/pkg/frontend/querymiddleware/step_align.go
+++ b/pkg/frontend/querymiddleware/step_align.go
@@ -42,7 +42,7 @@ func newStepAlignMiddleware(limits Limits, logger log.Logger, registerer prometh
 	})
 }
 
-func (s *stepAlignMiddleware) Do(ctx context.Context, r Request) (Response, error) {
+func (s *stepAlignMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Response, error) {
 	tenants, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return s.next.Do(ctx, r)
@@ -75,9 +75,9 @@ func (s *stepAlignMiddleware) Do(ctx context.Context, r Request) (Response, erro
 	return s.next.Do(ctx, r)
 }
 
-// isRequestStepAligned returns whether the Request start and end timestamps are aligned
+// isRequestStepAligned returns whether the MetricsQueryRequest start and end timestamps are aligned
 // with the step.
-func isRequestStepAligned(req Request) bool {
+func isRequestStepAligned(req MetricsQueryRequest) bool {
 	if req.GetStep() == 0 {
 		return true
 	}

--- a/pkg/frontend/querymiddleware/step_align.go
+++ b/pkg/frontend/querymiddleware/step_align.go
@@ -18,7 +18,7 @@ import (
 )
 
 type stepAlignMiddleware struct {
-	next    Handler
+	next    MetricsQueryHandler
 	limits  Limits
 	logger  log.Logger
 	aligned *prometheus.CounterVec
@@ -26,13 +26,13 @@ type stepAlignMiddleware struct {
 
 // newStepAlignMiddleware creates a middleware that aligns the start and end of request to the step to
 // improve the cacheability of the query results based on per-tenant configuration.
-func newStepAlignMiddleware(limits Limits, logger log.Logger, registerer prometheus.Registerer) Middleware {
+func newStepAlignMiddleware(limits Limits, logger log.Logger, registerer prometheus.Registerer) MetricsQueryMiddleware {
 	aligned := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_query_frontend_queries_step_aligned_total",
 		Help: "Number of queries whose start or end times have been adjusted to be step-aligned.",
 	}, []string{"user"})
 
-	return MiddlewareFunc(func(next Handler) Handler {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &stepAlignMiddleware{
 			next:    next,
 			limits:  limits,

--- a/pkg/frontend/querymiddleware/step_align_test.go
+++ b/pkg/frontend/querymiddleware/step_align_test.go
@@ -52,7 +52,7 @@ func TestStepAlignMiddleware_SingleUser(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var result *PrometheusRangeQueryRequest
 
-			next := HandlerFunc(func(_ context.Context, req Request) (Response, error) {
+			next := HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
 				result = req.(*PrometheusRangeQueryRequest)
 				return nil, nil
 			})
@@ -136,7 +136,7 @@ func TestStepAlignMiddleware_MultipleUsers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var result *PrometheusRangeQueryRequest
 
-			next := HandlerFunc(func(_ context.Context, req Request) (Response, error) {
+			next := HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
 				result = req.(*PrometheusRangeQueryRequest)
 				return nil, nil
 			})
@@ -154,7 +154,7 @@ func TestStepAlignMiddleware_MultipleUsers(t *testing.T) {
 
 func TestIsRequestStepAligned(t *testing.T) {
 	tests := map[string]struct {
-		req      Request
+		req      MetricsQueryRequest
 		expected bool
 	}{
 		"should return true if start and end are aligned to step": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

purely renaming

With the Prometheus codec completion work, we recently added the `LabelsQueryRequest` type, where previously the codec only had the `Request` type, which is only intended to represent Range and Instant query requests.

There are more similar types on the way as well (Examplars, Cardinality) & we need to disambiguate.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
