### PR TITLE
Encapsulating round-robin queuing logic in tree queue

### DIFF
--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -110,7 +110,7 @@ type queueBroker struct {
 
 func newQueueBroker(maxTenantQueueSize int, additionalQueueDimensionsEnabled bool, forgetDelay time.Duration) *queueBroker {
 	return &queueBroker{
-		tenantQueuesTree: NewTreeQueue("root"),
+		tenantQueuesTree: NewTreeQueue("root", roundRobin),
 		tenantQuerierAssignments: tenantQuerierAssignments{
 			queriersByID:       map[QuerierID]*querierConn{},
 			querierIDsSorted:   nil,

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -110,7 +110,7 @@ type queueBroker struct {
 
 func newQueueBroker(maxTenantQueueSize int, additionalQueueDimensionsEnabled bool, forgetDelay time.Duration) *queueBroker {
 	return &queueBroker{
-		tenantQueuesTree: NewTreeQueue("root", roundRobin),
+		tenantQueuesTree: NewTreeQueue(rootNodeName, 0),
 		tenantQuerierAssignments: tenantQuerierAssignments{
 			queriersByID:       map[QuerierID]*querierConn{},
 			querierIDsSorted:   nil,

--- a/pkg/scheduler/queue/tree_queue_queuing_functions.go
+++ b/pkg/scheduler/queue/tree_queue_queuing_functions.go
@@ -1,0 +1,65 @@
+package queue
+
+// A queueingAlgorithm determines the order that nodes are inserted into the tree,
+// and sets q.currentChildQueueIndex to the index of the next queue which will be dequeued from.
+type queueingAlgorithm string
+
+const (
+	roundRobin = queueingAlgorithm("round-robin")
+)
+
+// addNode returns a function for use in getOrAddNode. The returned function should place the child node into
+// the parent node's childQueueOrder according to the queueingAlgorithm in use.
+func addNode(e queueingAlgorithm) func(parent *TreeQueue, child *TreeQueue) {
+	switch e {
+	case roundRobin:
+		return addRoundRobinNode
+	default:
+		// We should never be able to hit this; nodes should only be created with implemented dequeue algorithms
+		panic("unrecognized queueing algorithm")
+
+	}
+}
+
+// TODO (casie): These enqueue/dequeue functions feel like they should be pointer receivers that take a child argument...
+func addRoundRobinNode(parent *TreeQueue, child *TreeQueue) {
+	// add new child queue to ordered list for round-robining;
+	// in order to maintain round-robin order as nodes are created and deleted,
+	// the new child queue should be inserted directly before the current child
+	// queue index, essentially placing the new node at the end of the line
+	if parent.currentChildQueueIndex == localQueueIndex {
+		// special case; cannot slice into childQueueOrder with index -1
+		// place at end of slice, which is the last slot before the local queue slot
+		parent.childQueueOrder = append(parent.childQueueOrder, child.name)
+	} else {
+		// insert into order behind current child queue index
+		parent.childQueueOrder = append(
+			parent.childQueueOrder[:parent.currentChildQueueIndex],
+			append(
+				[]string{child.name},
+				parent.childQueueOrder[parent.currentChildQueueIndex:]...,
+			)...,
+		)
+		// update current child queue index to its new place in the expanded slice
+		parent.currentChildQueueIndex++
+	}
+}
+
+// setNextIndex returns a function for use in Dequeue. The returned function should
+// set q.currentChildQueueIndex to the appropriate next index to be dequeued.
+func setNextIndex(d queueingAlgorithm) func(q *TreeQueue) {
+	switch d {
+	case roundRobin:
+		return roundRobinNextIndex
+	default:
+		// We should never be able to hit this; nodes should only be created with implemented dequeue algorithms
+		panic("unrecognized queueing algorithm")
+
+	}
+}
+
+// TODO (casie): Again, passing the node as an argument feels a little silly...
+func roundRobinNextIndex(q *TreeQueue) {
+	q.currentChildQueueIndex++
+	q.wrapIndex()
+}

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -238,7 +238,7 @@ func TestDequeueByPathUnbalancedTree(t *testing.T) {
 }
 
 func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
-	root := NewTreeQueue("root")
+	root := NewTreeQueue("root", roundRobin)
 
 	cache := map[string]struct{}{}
 
@@ -314,13 +314,13 @@ func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 }
 
 func TestNodeCannotDeleteItself(t *testing.T) {
-	root := NewTreeQueue("root")
+	root := NewTreeQueue("root", roundRobin)
 	require.False(t, root.deleteNode(QueuePath{}))
 	require.NotNil(t, root)
 }
 
 func makeBalancedTreeQueue(t *testing.T, firstDimensions, secondDimensions []string, itemsPerDimensions int) *TreeQueue {
-	root := NewTreeQueue("root")
+	root := NewTreeQueue("root", roundRobin)
 	require.Equal(t, 1, root.NodeCount())
 	require.Equal(t, 0, root.ItemCount())
 
@@ -373,7 +373,7 @@ func makeUnbalancedTreeQueue(t *testing.T) *TreeQueue {
 	   │		 └── localQueue
 	   └── localQueue
 	*/
-	root := NewTreeQueue("root")
+	root := NewTreeQueue("root", roundRobin)
 	require.Equal(t, 1, root.NodeCount())
 	require.Equal(t, 0, root.ItemCount())
 

--- a/pkg/scheduler/queue/tree_queue_test.go
+++ b/pkg/scheduler/queue/tree_queue_test.go
@@ -238,7 +238,7 @@ func TestDequeueByPathUnbalancedTree(t *testing.T) {
 }
 
 func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
-	root := NewTreeQueue("root", roundRobin)
+	root := NewTreeQueue(rootNodeName, 0)
 
 	cache := map[string]struct{}{}
 
@@ -314,13 +314,13 @@ func TestEnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 }
 
 func TestNodeCannotDeleteItself(t *testing.T) {
-	root := NewTreeQueue("root", roundRobin)
+	root := NewTreeQueue(rootNodeName, 0)
 	require.False(t, root.deleteNode(QueuePath{}))
 	require.NotNil(t, root)
 }
 
 func makeBalancedTreeQueue(t *testing.T, firstDimensions, secondDimensions []string, itemsPerDimensions int) *TreeQueue {
-	root := NewTreeQueue("root", roundRobin)
+	root := NewTreeQueue(rootNodeName, 0)
 	require.Equal(t, 1, root.NodeCount())
 	require.Equal(t, 0, root.ItemCount())
 
@@ -373,7 +373,7 @@ func makeUnbalancedTreeQueue(t *testing.T) *TreeQueue {
 	   │		 └── localQueue
 	   └── localQueue
 	*/
-	root := NewTreeQueue("root", roundRobin)
+	root := NewTreeQueue(rootNodeName, 0)
 	require.Equal(t, 1, root.NodeCount())
 	require.Equal(t, 0, root.ItemCount())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR is a no-op which builds on https://github.com/grafana/mimir/pull/6772, encapsulating the round-robin logic used by `TreeQueue`. We want to separate queuing logic from the tree queue itself so that we can, eventually, develop more sophisticated queuing algorithms to enable higher throughput on query components.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [n/a] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
