### PR TITLE
Dashboards: renamed rows in the "Remote ruler reads" and "Remote ruler reads resources" dashboards to match the actual component names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
   * `MimirIngesterFailsToProcessRecordsFromKafka`
   * `MimirIngesterFailsEnforceStrongConsistencyOnReadPath`
 * [ENHANCEMENT] Dashboards: add in-flight queries scaling metric panel for ruler-querier. #7749
+* [ENHANCEMENT] Dashboards: renamed rows in the "Remote ruler reads" and "Remote ruler reads resources" dashboards to match the actual component names. #7750
 * [BUGFIX] Dashboards: Fix regular expression for matching read-path gRPC ingester methods to include querying of exemplars, label-related queries, or active series queries. #7676
 * [BUGFIX] Dashboards: Fix user id abbreviations and column heads for Top Tenants dashboard. #7724
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -23638,7 +23638,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Query-frontend (dedicated to ruler)",
+                "title": "Ruler-query-frontend",
                 "titleSize": "h6"
              },
              {
@@ -23920,7 +23920,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Query-scheduler (dedicated to ruler)",
+                "title": "Ruler-query-scheduler",
                 "titleSize": "h6"
              },
              {
@@ -24202,7 +24202,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Querier (dedicated to ruler)",
+                "title": "Ruler-querier",
                 "titleSize": "h6"
              }
           ],
@@ -24772,7 +24772,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Query-frontend (dedicated to ruler)",
+                "title": "Ruler-query-frontend",
                 "titleSize": "h6"
              },
              {
@@ -25100,7 +25100,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Query-scheduler (dedicated to ruler)",
+                "title": "Ruler-query-scheduler",
                 "titleSize": "h6"
              },
              {
@@ -25262,7 +25262,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Query-scheduler Latency (Time in Queue) Breakout by Additional Queue Dimensions",
+                "title": "Ruler-query-scheduler Latency (Time in Queue) Breakout by Additional Queue Dimensions",
                 "titleSize": "h6"
              },
              {
@@ -25569,7 +25569,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Querier (dedicated to ruler)",
+                "title": "Ruler-querier",
                 "titleSize": "h6"
              },
              {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads-resources.json
@@ -285,7 +285,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-frontend (dedicated to ruler)",
+            "title": "Ruler-query-frontend",
             "titleSize": "h6"
          },
          {
@@ -543,7 +543,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-scheduler (dedicated to ruler)",
+            "title": "Ruler-query-scheduler",
             "titleSize": "h6"
          },
          {
@@ -801,7 +801,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Querier (dedicated to ruler)",
+            "title": "Ruler-querier",
             "titleSize": "h6"
          }
       ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -445,7 +445,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-frontend (dedicated to ruler)",
+            "title": "Ruler-query-frontend",
             "titleSize": "h6"
          },
          {
@@ -773,7 +773,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-scheduler (dedicated to ruler)",
+            "title": "Ruler-query-scheduler",
             "titleSize": "h6"
          },
          {
@@ -935,7 +935,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-scheduler Latency (Time in Queue) Breakout by Additional Queue Dimensions",
+            "title": "Ruler-query-scheduler Latency (Time in Queue) Breakout by Additional Queue Dimensions",
             "titleSize": "h6"
          },
          {
@@ -1242,7 +1242,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Querier (dedicated to ruler)",
+            "title": "Ruler-querier",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-resources.json
@@ -309,7 +309,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-frontend (dedicated to ruler)",
+            "title": "Ruler-query-frontend",
             "titleSize": "h6"
          },
          {
@@ -591,7 +591,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-scheduler (dedicated to ruler)",
+            "title": "Ruler-query-scheduler",
             "titleSize": "h6"
          },
          {
@@ -873,7 +873,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Querier (dedicated to ruler)",
+            "title": "Ruler-querier",
             "titleSize": "h6"
          }
       ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -445,7 +445,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-frontend (dedicated to ruler)",
+            "title": "Ruler-query-frontend",
             "titleSize": "h6"
          },
          {
@@ -773,7 +773,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-scheduler (dedicated to ruler)",
+            "title": "Ruler-query-scheduler",
             "titleSize": "h6"
          },
          {
@@ -935,7 +935,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-scheduler Latency (Time in Queue) Breakout by Additional Queue Dimensions",
+            "title": "Ruler-query-scheduler Latency (Time in Queue) Breakout by Additional Queue Dimensions",
             "titleSize": "h6"
          },
          {
@@ -1242,7 +1242,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Querier (dedicated to ruler)",
+            "title": "Ruler-querier",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads-resources.libsonnet
@@ -7,7 +7,7 @@ local filename = 'mimir-remote-ruler-reads-resources.json';
     ($.dashboard('Remote ruler reads resources') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates(false)
     .addRow(
-      $.row('Query-frontend (dedicated to ruler)')
+      $.row('Ruler-query-frontend')
       .addPanel(
         $.containerCPUUsagePanelByComponent('ruler_query_frontend'),
       )
@@ -19,7 +19,7 @@ local filename = 'mimir-remote-ruler-reads-resources.json';
       )
     )
     .addRow(
-      $.row('Query-scheduler (dedicated to ruler)')
+      $.row('Ruler-query-scheduler')
       .addPanel(
         $.containerCPUUsagePanelByComponent('ruler_query_scheduler'),
       )
@@ -31,7 +31,7 @@ local filename = 'mimir-remote-ruler-reads-resources.json';
       )
     )
     .addRow(
-      $.row('Querier (dedicated to ruler)')
+      $.row('Ruler-querier')
       .addPanel(
         $.containerCPUUsagePanelByComponent('ruler_querier'),
       )

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
@@ -54,7 +54,7 @@ local filename = 'mimir-remote-ruler-reads.json';
       )
     )
     .addRow(
-      $.row('Query-frontend (dedicated to ruler)')
+      $.row('Ruler-query-frontend')
       .addPanel(
         $.timeseriesPanel('Requests / sec') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.ruler_query_frontend), rulerRoutesRegex])
@@ -80,7 +80,7 @@ local filename = 'mimir-remote-ruler-reads.json';
           these panels will show "No data."
         </p>
       |||;
-      $.row('Query-scheduler (dedicated to ruler)')
+      $.row('Ruler-query-scheduler')
       .addPanel(
         local title = 'Requests / sec';
         $.timeseriesPanel(title) +
@@ -127,7 +127,7 @@ local filename = 'mimir-remote-ruler-reads.json';
           regex: '^$',
         },
       ];
-      $.row('Query-scheduler Latency (Time in Queue) Breakout by Additional Queue Dimensions')
+      $.row('Ruler-query-scheduler Latency (Time in Queue) Breakout by Additional Queue Dimensions')
       .addPanel(
         local title = '99th Percentile Latency by Queue Dimension';
         $.timeseriesPanel(title) +
@@ -169,7 +169,7 @@ local filename = 'mimir-remote-ruler-reads.json';
       )
     )
     .addRow(
-      $.row('Querier (dedicated to ruler)')
+      $.row('Ruler-querier')
       .addPanel(
         $.timeseriesPanel('Requests / sec') +
         $.qpsPanel('cortex_querier_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.ruler_querier), $.queries.read_http_routes_regex])


### PR DESCRIPTION
#### What this PR does

I'm working on some improvements to "Remote ruler" dashboards and I noticed the row titles are a bit confusing. The Mimir components have a specific name (e.g. ruler-query-frontend, ruler-query-scheduler, ...) so I think we should just use it.

Example of dashboards after these changes are applied:

![screencapture-localhost-3001-d-1940f6ef765a506a171faa2056c956c3-mimir-remote-ruler-reads-resources-2024-03-29-10_24_26](https://github.com/grafana/mimir/assets/1701904/f16eaaa0-077b-468c-958b-00274021037c)

![screencapture-localhost-3001-d-f103238f7f5ab2f1345ce650cbfbfe2f-mimir-remote-ruler-reads-2024-03-29-10_24_17](https://github.com/grafana/mimir/assets/1701904/d13358a7-4b8a-470d-89de-b8587dd21237)



#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
