### PR TITLE
Fix NPE: Multiple goroutine execute pushReq.CleanUp() concurrently

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -784,6 +784,7 @@ func (d *Distributor) prePushRelabelMiddleware(next PushFunc) PushFunc {
 		}
 
 		if !d.limits.MetricRelabelingEnabled(userID) {
+			cleanupInDefer = false
 			return next(ctx, pushReq)
 		}
 


### PR DESCRIPTION
fix https://github.com/grafana/mimir/issues/7759