### PR TITLE
Chore: update actions depending on Node.js 16 to versions depending on Node.js 20

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -29,12 +29,12 @@ jobs:
       build_image: ${{ steps.build_image_step.outputs.build_image }}
       # Determine if we will deploy (aka push) the image to the registry.
       is_deploy: ${{ (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r')) && github.event_name == 'push' && github.repository == 'grafana/mimir' }}
-      
+
 
   goversion:
     runs-on: ubuntu-latest
     needs: prepare
-    container: 
+    container:
       image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
           mkdir -p /go/src/github.com/grafana/mimir
           ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
           version: v3.8.2
       - name: Check Helm Tests

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           echo "path=$(golangci-lint cache status | grep 'Dir: ' | cut -d ' ' -f2)" >> "$GITHUB_OUTPUT"
       - name: Cache golangci-lint cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: lint-golangci-lint-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', '.golangci.yml', 'Makefile') }}
           path: ${{ steps.golangcilintcache.outputs.path }}
@@ -78,14 +78,14 @@ jobs:
           echo "gocache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
           echo "gomodcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
       - name: Cache Go build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: lint-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
           path: ${{ steps.goenv.outputs.gocache }}
       # Although we use vendoring, this linting job downloads all modules to verify that what is vendored is correct,
       # so it'll use GOMODCACHE. Other jobs don't need this.
       - name: Cache Go module cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: lint-go-mod-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
           path: ${{ steps.goenv.outputs.gomodcache }}
@@ -222,7 +222,7 @@ jobs:
         run: |
           echo "path=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
       - name: Cache Go build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # Cache is shared between test groups.
           key: test-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
@@ -262,7 +262,7 @@ jobs:
         run: |
           echo "path=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
       - name: Cache Go build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: build-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
           path: ${{ steps.gocache.outputs.path }}
@@ -331,7 +331,7 @@ jobs:
         run: |
           echo "path=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
       - name: Cache Go build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # Cache is shared between test groups.
           key: integration-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
@@ -404,7 +404,7 @@ jobs:
         run: |
           echo "path=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
       - name: Cache Go build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # Cache is shared between test groups.
           key: integration-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}


### PR DESCRIPTION
#### What this PR does

Small chore PR to get rid of the "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20" warnings when running CI in GitHub Actions. 
For more information: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

![PS 2024-03-31 à 10 12 32](https://github.com/grafana/mimir/assets/2117580/44168a55-197a-433d-809a-86d1b7775da7)

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
