### PR TITLE
WIP: mimir-build-image: Upgrade golangci-lint to v1.57.2

### DIFF
--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -35,7 +35,7 @@ RUN GOARCH=$(go env GOARCH) && \
     curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.54.1
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.57.2
 
 ENV SKOPEO_VERSION=v1.15.1
 RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \

--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -8,7 +8,6 @@ package mimirpb
 import (
 	stdlibjson "encoding/json"
 	"math"
-	"reflect"
 	"strconv"
 	"testing"
 	"unsafe"
@@ -197,9 +196,7 @@ func TestFromLabelAdaptersToLabelsWithCopy(t *testing.T) {
 
 	// All strings must be copied.
 	actualValue := actual.Get("hello")
-	hInputValue := (*reflect.StringHeader)(unsafe.Pointer(&input[0].Value))
-	hActualValue := (*reflect.StringHeader)(unsafe.Pointer(&actualValue))
-	assert.NotEqual(t, hInputValue.Data, hActualValue.Data)
+	assert.NotSame(t, unsafe.StringData(input[0].Value), unsafe.StringData(actualValue))
 }
 
 func BenchmarkFromLabelAdaptersToLabelsWithCopy(b *testing.B) {


### PR DESCRIPTION
#### What this PR does
Upgrade golangci-lint to v1.57.2 in the build image.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
