### PR TITLE
Refactoring: use services.Manager to start/stop subservices in ingester

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -642,11 +642,15 @@ func (i *Ingester) stopping(_ error) error {
 		}
 	}
 
-	if err := services.StopManagerAndAwaitStopped(context.Background(), i.subservicesBeforePartitionReader); err != nil {
+	// Stop subservices.
+	i.subservicesBeforePartitionReader.StopAsync()
+	i.subservicesAfterIngesterRingLifecycler.StopAsync()
+
+	if err := i.subservicesBeforePartitionReader.AwaitStopped(context.Background()); err != nil {
 		level.Warn(i.logger).Log("msg", "failed to stop ingester subservices", "err", err)
 	}
 
-	if err := services.StopManagerAndAwaitStopped(context.Background(), i.subservicesAfterIngesterRingLifecycler); err != nil {
+	if err := i.subservicesAfterIngesterRingLifecycler.AwaitStopped(context.Background()); err != nil {
 		level.Warn(i.logger).Log("msg", "failed to stop ingester subservices", "err", err)
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -597,7 +597,10 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 	}
 
 	// Finally we start all services that should run after the ingester ring lifecycler.
-	var servs []services.Service
+	servs := []services.Service{
+		i.utilizationBasedLimiter,
+		i.ingestPartitionLifecycler,
+	}
 
 	if i.cfg.BlocksStorageConfig.TSDB.IsBlocksShippingEnabled() {
 		shippingService := services.NewBasicService(nil, i.shipBlocksLoop, nil)
@@ -611,20 +614,6 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 		}
 		closeIdleService := services.NewTimerService(interval, nil, i.closeAndDeleteIdleUserTSDBs, nil)
 		servs = append(servs, closeIdleService)
-	}
-
-	if i.utilizationBasedLimiter != nil {
-		servs = append(servs, i.utilizationBasedLimiter)
-	}
-
-	if i.ingestPartitionLifecycler != nil {
-		servs = append(servs, i.ingestPartitionLifecycler)
-	}
-
-	// Since subservices are conditional, We add an idle service if there are no subservices to
-	// guarantee there's at least 1 service to run otherwise the service manager fails to start.
-	if len(servs) == 0 {
-		servs = append(servs, services.NewIdleService(nil, nil))
 	}
 
 	i.subservicesAfterIngesterRingLifecycler, err = createManagerThenStartAndAwaitHealthy(ctx, servs...)
@@ -3935,6 +3924,16 @@ func (i *Ingester) enforceReadConsistency(ctx context.Context, tenantID string) 
 }
 
 func createManagerThenStartAndAwaitHealthy(ctx context.Context, srvs ...services.Service) (*services.Manager, error) {
+	// Filter out nil services.
+	srvs = slices.DeleteFunc(srvs, func(srv services.Service) bool {
+		return srv == nil
+	})
+
+	// Ensure there's at least 1 service otherwise the manager fails to start.
+	if len(srvs) == 0 {
+		srvs = append(srvs, services.NewIdleService(nil, nil))
+	}
+
 	manager, err := services.NewManager(srvs...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What this PR does

In this PR I'm attempting to address [a comment received here](https://github.com/grafana/mimir/pull/7486#discussion_r1533525204). The idea is to introduce another `services.Manager` in `Ingester` to "group" subservices started **before** partition reader (3 subservices).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
