### PR TITLE
Switch back to upstream faillint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr7356-96b108aa4f
+LATEST_BUILD_IMAGE_TAG ?= pr7776-bae88f6be5
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -42,13 +42,12 @@ RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers
     DISABLE_DOCS=1 make -C /go/src/github.com/containers/skopeo install && \
     rm -rf /go/pkg /go/src /root/.cache
 
-# github.com/pstibrany/faillint@update-deps-and-rename-mod is a fork of github.com/fatih/faillint with PR https://github.com/fatih/faillint/pull/41. Once it's merged, we should switch back.
 RUN GO111MODULE=on \
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 && \
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 && \
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
-	go install github.com/pstibrany/faillint@update-deps-and-rename-mod && \
+    go install github.com/fatih/faillint@v1.12.0 && \
 	go install github.com/campoy/embedmd@v1.0.0 && \
 	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0 && \
 	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066 && \

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -47,7 +47,7 @@ RUN GO111MODULE=on \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 && \
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 && \
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
-    go install github.com/fatih/faillint@v1.12.0 && \
+	go install github.com/fatih/faillint@v1.12.0 && \
 	go install github.com/campoy/embedmd@v1.0.0 && \
 	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0 && \
 	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@bca3066 && \


### PR DESCRIPTION
#### What this PR does

This PR switches back to upstream faillint, since there's a [new release](https://github.com/fatih/faillint/pull/41#issuecomment-2032333247) that works with Go 1.22.

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
