### PR TITLE
Querytee: Add metric to measure relative backend latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
 ### Query-tee
 
 * [ENHANCEMENT] Log queries that take longer than `proxy.log-slow-query-response-threshold` when compared to other backends. #7346
+* [ENHANCEMENT] Add two new metrics for measuring the relative duration between backends: #7782
+  * `cortex_querytee_backend_request_relative_duration_seconds`
+  * `cortex_querytee_backend_request_relative_duration_proportional`
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,8 @@
 
 * [ENHANCEMENT] Log queries that take longer than `proxy.log-slow-query-response-threshold` when compared to other backends. #7346
 * [ENHANCEMENT] Add two new metrics for measuring the relative duration between backends: #7782
-  * `cortex_querytee_backend_request_relative_duration_seconds`
-  * `cortex_querytee_backend_request_relative_duration_proportional`
+  * `cortex_querytee_backend_response_relative_duration_seconds`
+  * `cortex_querytee_backend_response_relative_duration_proportional`
 
 ### Documentation
 

--- a/docs/sources/mimir/manage/tools/query-tee.md
+++ b/docs/sources/mimir/manage/tools/query-tee.md
@@ -165,8 +165,8 @@ cortex_querytee_responses_compared_total{route="<route>",result="<success|fail>"
 
 Additionally, if backend results comparison is configured, two native-histograms are available:
 
-* `cortex_querytee_backend_request_relative_duration_seconds`: Time (in seconds) of preferred backend less secondary backend.
-* `cortex_querytee_backend_request_relative_duration_proportional`: Response time of preferred backend, as a proportion of secondary backend response time.
+- `cortex_querytee_backend_request_relative_duration_seconds`: Time (in seconds) of preferred backend less secondary backend.
+- `cortex_querytee_backend_request_relative_duration_proportional`: Response time of preferred backend, as a proportion of secondary backend response time.
 
 ### Ruler remote operational mode test
 

--- a/docs/sources/mimir/manage/tools/query-tee.md
+++ b/docs/sources/mimir/manage/tools/query-tee.md
@@ -163,10 +163,10 @@ cortex_querytee_responses_total{backend="<hostname>",method="<method>",route="<r
 cortex_querytee_responses_compared_total{route="<route>",result="<success|fail>"}
 ```
 
-Additionally, if backend results comparison is configured, two native-histograms are available:
+Additionally, if backend results comparison is configured, two native histograms are available:
 
-- `cortex_querytee_backend_request_relative_duration_seconds`: Time (in seconds) of preferred backend less secondary backend.
-- `cortex_querytee_backend_request_relative_duration_proportional`: Response time of preferred backend, as a proportion of secondary backend response time.
+- `cortex_querytee_backend_response_relative_duration_seconds`: Time (in seconds) of preferred backend less secondary backend.
+- `cortex_querytee_backend_response_relative_duration_proportional`: Response time of preferred backend, as a proportion of secondary backend response time.
 
 ### Ruler remote operational mode test
 

--- a/docs/sources/mimir/manage/tools/query-tee.md
+++ b/docs/sources/mimir/manage/tools/query-tee.md
@@ -163,6 +163,11 @@ cortex_querytee_responses_total{backend="<hostname>",method="<method>",route="<r
 cortex_querytee_responses_compared_total{route="<route>",result="<success|fail>"}
 ```
 
+Additionally, if backend results comparison is configured, two native-histograms are available:
+
+* `cortex_querytee_backend_request_relative_duration_seconds`: Time (in seconds) of preferred backend less secondary backend.
+* `cortex_querytee_backend_request_relative_duration_proportional`: Response time of preferred backend, as a proportion of secondary backend response time.
+
 ### Ruler remote operational mode test
 
 When the ruler is configured with the [remote evaluation mode]({{< relref "../../references/architecture/components/ruler" >}}) you can use the query-tee to compare rule evaluations too.

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -224,6 +224,8 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 			)
 		}
 
+		relativeDuration := expectedResponse.elapsedTime - actualResponse.elapsedTime
+		p.metrics.relativeDuration.WithLabelValues(req.Method, p.routeName).Observe(relativeDuration.Seconds())
 		p.metrics.responsesComparedTotal.WithLabelValues(p.routeName, string(result)).Inc()
 	}
 }

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -225,7 +225,9 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 		}
 
 		relativeDuration := expectedResponse.elapsedTime - actualResponse.elapsedTime
-		p.metrics.relativeDuration.WithLabelValues(req.Method, p.routeName).Observe(relativeDuration.Seconds())
+		proportionalDuration := expectedResponse.elapsedTime.Seconds() / actualResponse.elapsedTime.Seconds()
+		p.metrics.relativeDuration.WithLabelValues(p.routeName).Observe(relativeDuration.Seconds())
+		p.metrics.proportionalDuration.WithLabelValues(p.routeName).Observe(proportionalDuration)
 		p.metrics.responsesComparedTotal.WithLabelValues(p.routeName, string(result)).Inc()
 	}
 }

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -780,17 +780,14 @@ func (b *mockProxyBackend) Preferred() bool {
 }
 
 func (b *mockProxyBackend) ForwardRequest(_ *http.Request, _ io.ReadCloser) (time.Duration, int, []byte, *http.Response, error) {
-	statusCode := 200
-	if b.responseIndex >= len(b.fakeResponseLatencies) {
-		statusCode = 500
-	}
 	resp := &http.Response{
-		StatusCode: statusCode,
+		StatusCode: 200,
 		Header:     make(http.Header),
 		Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
 	}
 	resp.Header.Set("Content-Type", "application/json")
 	if b.responseIndex >= len(b.fakeResponseLatencies) {
+		resp.StatusCode = 500
 		return 0, 500, []byte("{}"), resp, errors.New("no more latencies available")
 	}
 	latency := b.fakeResponseLatencies[b.responseIndex]

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -455,96 +456,12 @@ func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
 		"secondary backend is 2 seconds faster than preferred": {
 			preferredResponseLatency: 3 * time.Second,
 			secondaryResponseLatency: 1 * time.Second,
-			expectedMetric: (`
-			# HELP cortex_querytee_backend_request_relative_duration_seconds Time (in seconds) of preferred backend less secondary backend.
-			# TYPE cortex_querytee_backend_request_relative_duration_seconds histogram
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-100"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-50"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-25"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-10"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-5"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-4"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-3"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-2"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-1.5"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-1"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.75"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.5"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.25"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.1"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.05"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.025"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.01"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.005"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.005"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.01"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.025"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.05"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.1"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.25"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.5"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.75"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="1"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="1.5"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="2"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="3"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="4"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="5"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="10"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="25"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="50"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="100"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="+Inf"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_sum{method="GET",route="test"} 2
-			cortex_querytee_backend_request_relative_duration_seconds_count{method="GET",route="test"} 1
-`),
+			expectedMetric:           (`todo`),
 		},
 		"preferred backend is 5 seconds faster than secondary": {
 			preferredResponseLatency: 2 * time.Second,
 			secondaryResponseLatency: 7 * time.Second,
-			expectedMetric: (`
-			# HELP cortex_querytee_backend_request_relative_duration_seconds Time (in seconds) of preferred backend less secondary backend.
-			# TYPE cortex_querytee_backend_request_relative_duration_seconds histogram
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-100"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-50"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-25"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-10"} 0
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-5"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-4"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-3"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-2"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-1.5"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-1"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.75"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.5"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.25"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.1"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.05"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.025"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.01"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.005"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.005"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.01"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.025"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.05"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.1"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.25"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.5"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.75"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="1"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="1.5"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="2"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="3"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="4"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="5"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="10"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="25"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="50"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="100"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="+Inf"} 1
-			cortex_querytee_backend_request_relative_duration_seconds_sum{method="GET",route="test"} -5
-			cortex_querytee_backend_request_relative_duration_seconds_count{method="GET",route="test"} 1
-`),
+			expectedMetric:           (`todo`),
 		},
 	}
 
@@ -572,10 +489,28 @@ func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
 			// Wait for the response comparison to complete before checking the logged messages.
 			waitForResponseComparisonMetric(t, reg, ComparisonSuccess)
 
-			require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(scenario.expectedMetric), "cortex_querytee_backend_request_relative_duration_seconds"))
-
+			//require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(scenario.expectedMetric), "cortex_querytee_backend_request_relative_duration_seconds"))
+			got, done, err := prometheus.ToTransactionalGatherer(reg).Gather()
+			defer done()
+			require.NoError(t, err, "Failed to gather metrics from registry")
+			got = filterMetrics(got, []string{"cortex_querytee_backend_request_relative_duration_seconds"})
+			require.Equal(t, 1, len(got), "Expect only one metric after filtering")
+			require.Equal(t, uint64(1), got[0].Metric[0].Histogram.GetSampleCount(), "Expect only 1 sample")
 		})
 	}
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
 }
 
 func waitForResponseComparisonMetric(t *testing.T, g prometheus.Gatherer, expectedResult ComparisonResult) {

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -525,12 +525,12 @@ func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
 			defer done()
 			require.NoError(t, err, "Failed to gather metrics from registry")
 
-			gotDuration := filterMetrics(got, []string{"cortex_querytee_backend_request_relative_duration_seconds"})
+			gotDuration := filterMetrics(got, []string{"cortex_querytee_backend_response_relative_duration_seconds"})
 			require.Equal(t, 1, len(gotDuration), "Expect only one metric after filtering")
 			require.Equal(t, scenario.expectedSampleCount, gotDuration[0].Metric[0].Histogram.GetSampleCount())
 			require.Equal(t, scenario.expectedDurationSampleSum, gotDuration[0].Metric[0].Histogram.GetSampleSum())
 
-			gotProportional := filterMetrics(got, []string{"cortex_querytee_backend_request_relative_duration_proportional"})
+			gotProportional := filterMetrics(got, []string{"cortex_querytee_backend_response_relative_duration_proportional"})
 			require.Equal(t, 1, len(gotProportional), "Expect only one metric after filtering")
 			require.Equal(t, scenario.expectedSampleCount, gotProportional[0].Metric[0].Histogram.GetSampleCount())
 			require.Equal(t, scenario.expectedProportionalSampleSum, gotProportional[0].Metric[0].Histogram.GetSampleSum())

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -446,6 +446,138 @@ func Test_ProxyEndpoint_LogSlowQueries(t *testing.T) {
 	}
 }
 
+func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
+	scenarios := map[string]struct {
+		preferredResponseLatency time.Duration
+		secondaryResponseLatency time.Duration
+		expectedMetric           string
+	}{
+		"secondary backend is 2 seconds faster than preferred": {
+			preferredResponseLatency: 3 * time.Second,
+			secondaryResponseLatency: 1 * time.Second,
+			expectedMetric: (`
+			# HELP cortex_querytee_backend_request_relative_duration_seconds Time (in seconds) of preferred backend less secondary backend.
+			# TYPE cortex_querytee_backend_request_relative_duration_seconds histogram
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-100"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-50"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-25"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-10"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-5"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-4"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-3"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-2"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-1.5"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-1"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.75"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.5"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.25"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.1"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.05"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.025"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.01"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.005"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.005"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.01"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.025"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.05"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.1"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.25"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.5"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.75"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="1"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="1.5"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="2"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="3"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="4"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="5"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="10"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="25"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="50"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="100"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="+Inf"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_sum{method="GET",route="test"} 2
+			cortex_querytee_backend_request_relative_duration_seconds_count{method="GET",route="test"} 1
+`),
+		},
+		"preferred backend is 5 seconds faster than secondary": {
+			preferredResponseLatency: 2 * time.Second,
+			secondaryResponseLatency: 7 * time.Second,
+			expectedMetric: (`
+			# HELP cortex_querytee_backend_request_relative_duration_seconds Time (in seconds) of preferred backend less secondary backend.
+			# TYPE cortex_querytee_backend_request_relative_duration_seconds histogram
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-100"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-50"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-25"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-10"} 0
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-5"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-4"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-3"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-2"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-1.5"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-1"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.75"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.5"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.25"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.1"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.05"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.025"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.01"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="-0.005"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.005"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.01"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.025"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.05"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.1"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.25"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.5"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="0.75"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="1"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="1.5"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="2"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="3"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="4"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="5"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="10"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="25"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="50"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="100"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_bucket{method="GET",route="test",le="+Inf"} 1
+			cortex_querytee_backend_request_relative_duration_seconds_sum{method="GET",route="test"} -5
+			cortex_querytee_backend_request_relative_duration_seconds_count{method="GET",route="test"} 1
+`),
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			backends := []ProxyBackendInterface{
+				newMockProxyBackend("preferred-backend", time.Second, true, scenario.preferredResponseLatency),
+				newMockProxyBackend("secondary-backend", time.Second, false, scenario.secondaryResponseLatency),
+			}
+
+			logger := newMockLogger()
+			reg := prometheus.NewPedanticRegistry()
+			comparator := &mockComparator{
+				comparisonResult: ComparisonSuccess,
+			}
+
+			endpoint := NewProxyEndpoint(backends, "test", NewProxyMetrics(reg), logger, comparator, 0)
+
+			resp := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", "http://test/api/v1/test", nil)
+			require.NoError(t, err)
+			endpoint.ServeHTTP(resp, req)
+
+			// The HTTP request above will return as soon as the primary response is received, but this doesn't guarantee that the response comparison has been completed.
+			// Wait for the response comparison to complete before checking the logged messages.
+			waitForResponseComparisonMetric(t, reg, ComparisonSuccess)
+
+			require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(scenario.expectedMetric), "cortex_querytee_backend_request_relative_duration_seconds"))
+
+		})
+	}
+}
+
 func waitForResponseComparisonMetric(t *testing.T, g prometheus.Gatherer, expectedResult ComparisonResult) {
 	started := time.Now()
 	timeoutAt := started.Add(2 * time.Second)

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -23,6 +23,7 @@ type ProxyMetrics struct {
 	requestDuration        *prometheus.HistogramVec
 	responsesTotal         *prometheus.CounterVec
 	responsesComparedTotal *prometheus.CounterVec
+	relativeDuration       *prometheus.HistogramVec
 }
 
 func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
@@ -43,6 +44,12 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 			Name:      "responses_compared_total",
 			Help:      "Total number of responses compared per route name by result.",
 		}, []string{"route", "result"}),
+		relativeDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: queryTeeMetricsNamespace,
+			Name:      "backend_request_relative_duration_seconds",
+			Help:      "Time (in seconds) of preferred backend less secondary backend.",
+			Buckets:   []float64{-100, -50, -25, -10, -5, -4, -3, -2, -1.5, -1, -.75, -.5, -.25, -.1, -.05, -.025, -.01, -.005, .005, .01, .025, .05, .1, .25, .5, 0.75, 1, 1.5, 2, 3, 4, 5, 10, 25, 50, 100},
+		}, []string{"method", "route"}),
 	}
 
 	return m

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -24,6 +24,7 @@ type ProxyMetrics struct {
 	responsesTotal         *prometheus.CounterVec
 	responsesComparedTotal *prometheus.CounterVec
 	relativeDuration       *prometheus.HistogramVec
+	proportionalDuration   *prometheus.HistogramVec
 }
 
 func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
@@ -45,11 +46,17 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 			Help:      "Total number of responses compared per route name by result.",
 		}, []string{"route", "result"}),
 		relativeDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: queryTeeMetricsNamespace,
-			Name:      "backend_request_relative_duration_seconds",
-			Help:      "Time (in seconds) of preferred backend less secondary backend.",
-			Buckets:   []float64{-100, -50, -25, -10, -5, -4, -3, -2, -1.5, -1, -.75, -.5, -.25, -.1, -.05, -.025, -.01, -.005, .005, .01, .025, .05, .1, .25, .5, 0.75, 1, 1.5, 2, 3, 4, 5, 10, 25, 50, 100},
-		}, []string{"method", "route"}),
+			Namespace:                   queryTeeMetricsNamespace,
+			Name:                        "backend_request_relative_duration_seconds",
+			Help:                        "Time (in seconds) of preferred backend less secondary backend.",
+			NativeHistogramBucketFactor: 2,
+		}, []string{"route"}),
+		proportionalDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:                   queryTeeMetricsNamespace,
+			Name:                        "backend_request_relative_duration_proportional",
+			Help:                        "Proportional time (%) of preferred backend vs secondary backend.",
+			NativeHistogramBucketFactor: 2,
+		}, []string{"route"}),
 	}
 
 	return m

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -47,13 +47,13 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 		}, []string{"route", "result"}),
 		relativeDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                   queryTeeMetricsNamespace,
-			Name:                        "backend_request_relative_duration_seconds",
+			Name:                        "backend_response_relative_duration_seconds",
 			Help:                        "Time (in seconds) of preferred backend less secondary backend.",
 			NativeHistogramBucketFactor: 2,
 		}, []string{"route"}),
 		proportionalDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                   queryTeeMetricsNamespace,
-			Name:                        "backend_request_relative_duration_proportional",
+			Name:                        "backend_response_relative_duration_proportional",
 			Help:                        "Response time of preferred backend, as a proportion of secondary backend response time.",
 			NativeHistogramBucketFactor: 2,
 		}, []string{"route"}),

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -54,7 +54,7 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 		proportionalDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                   queryTeeMetricsNamespace,
 			Name:                        "backend_request_relative_duration_proportional",
-			Help:                        "Proportional time (%) of preferred backend vs secondary backend.",
+			Help:                        "Response time of preferred backend, as a proportion of secondary backend response time.",
 			NativeHistogramBucketFactor: 2,
 		}, []string{"route"}),
 	}


### PR DESCRIPTION
This metric gives us a measurement of how individual queries compare between two backends in terms of latency (or duration).

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
