### PR TITLE
Fix linting issues: Part 2

### DIFF
--- a/cmd/mimirtool/main.go
+++ b/cmd/mimirtool/main.go
@@ -49,7 +49,7 @@ func main() {
 	remoteReadCommand.Register(app, envVars)
 	ruleCommand.Register(app, envVars, prometheus.DefaultRegisterer)
 
-	app.Command("version", "Get the version of the mimirtool CLI").Action(func(k *kingpin.ParseContext) error {
+	app.Command("version", "Get the version of the mimirtool CLI").Action(func(*kingpin.ParseContext) error {
 		fmt.Fprintln(os.Stdout, mimirversion.Print("Mimirtool"))
 		version.CheckLatest(mimirversion.Version)
 		return nil

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -407,7 +407,7 @@ func WithConfigFile(configFile string) Option {
 }
 
 // WithNoopOption returns an option that doesn't change anything.
-func WithNoopOption() Option { return func(options *Options) {} }
+func WithNoopOption() Option { return func(*Options) {} }
 
 // FlagMapper is the type of function that maps flags, just to reduce some verbosity.
 type FlagMapper func(flags map[string]string) map[string]string

--- a/integration/kv_test.go
+++ b/integration/kv_test.go
@@ -31,7 +31,7 @@ func TestKVList(t *testing.T) {
 		// Create keys to list back
 		keysToCreate := []string{"key-a", "key-b", "key-c"}
 		for _, key := range keysToCreate {
-			err := client.CAS(context.Background(), key, func(in interface{}) (out interface{}, retry bool, err error) {
+			err := client.CAS(context.Background(), key, func(interface{}) (out interface{}, retry bool, err error) {
 				return key, false, nil
 			})
 			require.NoError(t, err, "could not create key")
@@ -53,7 +53,7 @@ func TestKVList(t *testing.T) {
 func TestKVDelete(t *testing.T) {
 	testKVs(t, func(t *testing.T, client kv.Client, reg *prometheus.Registry) {
 		// Create a key
-		err := client.CAS(context.Background(), "key-to-delete", func(in interface{}) (out interface{}, retry bool, err error) {
+		err := client.CAS(context.Background(), "key-to-delete", func(interface{}) (out interface{}, retry bool, err error) {
 			return "key-to-delete", false, nil
 		})
 		require.NoError(t, err, "object could not be created")
@@ -76,11 +76,11 @@ func TestKVDelete(t *testing.T) {
 }
 
 func TestKVWatchAndDelete(t *testing.T) {
-	testKVs(t, func(t *testing.T, client kv.Client, reg *prometheus.Registry) {
+	testKVs(t, func(t *testing.T, client kv.Client, _ *prometheus.Registry) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		err := client.CAS(context.Background(), "key-before-watch", func(in interface{}) (out interface{}, retry bool, err error) {
+		err := client.CAS(context.Background(), "key-before-watch", func(interface{}) (out interface{}, retry bool, err error) {
 			return "value-before-watch", false, nil
 		})
 		require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestKVWatchAndDelete(t *testing.T) {
 			w.watch(ctx, client)
 		}()
 
-		err = client.CAS(context.Background(), "key-to-delete", func(in interface{}) (out interface{}, retry bool, err error) {
+		err = client.CAS(context.Background(), "key-to-delete", func(interface{}) (out interface{}, retry bool, err error) {
 			return "value-to-delete", false, nil
 		})
 		require.NoError(t, err, "object could not be created")

--- a/operations/compare-helm-with-jsonnet/plugins/resolve-config/main.go
+++ b/operations/compare-helm-with-jsonnet/plugins/resolve-config/main.go
@@ -114,7 +114,7 @@ func (c *ConfigExtractor) ResolveConfigs() ([]*yaml.RNode, error) {
 		return nil, err
 	}
 
-	err = concurrency.ForEachJob(context.Background(), len(c.allItems), runtime.NumCPU(), func(ctx context.Context, idx int) error {
+	err = concurrency.ForEachJob(context.Background(), len(c.allItems), runtime.NumCPU(), func(_ context.Context, idx int) error {
 		pod, ok, err := extractPodSpec(c.allItems[idx])
 		if err != nil {
 			return err

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -304,7 +304,7 @@ func TestBlockQuerierSeriesSet(t *testing.T) {
 		t.Run(fmt.Sprintf("consume with .Next() method, perform .At() after every %dth call to .Next()", callAtEvery), func(t *testing.T) {
 			t.Parallel()
 
-			advance := func(it chunkenc.Iterator, wantTs int64) chunkenc.ValueType { return it.Next() }
+			advance := func(it chunkenc.Iterator, _ int64) chunkenc.ValueType { return it.Next() }
 			ss := getSeriesSet()
 
 			verifyNextSeries(t, ss, labels.FromStrings("__name__", "first", "a", "a"), 3*time.Millisecond, []timeRange{

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1046,7 +1046,7 @@ func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhile
 
 		srv, q := prepareTestCase(t)
 
-		srv.onSeries = func(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer) error {
+		srv.onSeries = func(*storepb.SeriesRequest, storegatewaypb.StoreGateway_SeriesServer) error {
 			if numExecutions.Inc() == 1 {
 				close(waitExecution)
 				<-continueExecution
@@ -1082,7 +1082,7 @@ func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhile
 
 		srv, q := prepareTestCase(t)
 
-		srv.onLabelNames = func(ctx context.Context, req *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
+		srv.onLabelNames = func(context.Context, *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
 			if numExecutions.Inc() == 1 {
 				close(waitExecution)
 				<-continueExecution
@@ -1117,7 +1117,7 @@ func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhile
 
 		srv, q := prepareTestCase(t)
 
-		srv.onLabelValues = func(ctx context.Context, req *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
+		srv.onLabelValues = func(context.Context, *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
 			if numExecutions.Inc() == 1 {
 				close(waitExecution)
 				<-continueExecution

--- a/pkg/querier/blocks_store_replicated_set_test.go
+++ b/pkg/querier/blocks_store_replicated_set_test.go
@@ -322,7 +322,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor(t *testing.T) {
 			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-			require.NoError(t, ringStore.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
+			require.NoError(t, ringStore.CAS(ctx, "test", func(interface{}) (interface{}, bool, error) {
 				d := ring.NewDesc()
 				testData.setup(d)
 				return d, true, nil
@@ -389,7 +389,7 @@ func TestBlocksStoreReplicationSet_GetClientsFor_ShouldSupportRandomLoadBalancin
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	require.NoError(t, ringStore.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
+	require.NoError(t, ringStore.CAS(ctx, "test", func(interface{}) (interface{}, bool, error) {
 		d := ring.NewDesc()
 		for n := 1; n <= numInstances; n++ {
 			d.AddIngester(fmt.Sprintf("instance-%d", n), fmt.Sprintf("127.0.0.%d", n), "", []uint32{uint32(n)}, ring.ACTIVE, registeredAt)

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1284,10 +1284,10 @@ func TestConfig_ValidateLimits(t *testing.T) {
 		expected error
 	}{
 		"should pass with default config": {
-			setup: func(cfg *Config, limits *validation.Limits) {},
+			setup: func(*Config, *validation.Limits) {},
 		},
 		"should pass if 'query store after' is enabled and shuffle-sharding is disabled": {
-			setup: func(cfg *Config, limits *validation.Limits) {
+			setup: func(cfg *Config, _ *validation.Limits) {
 				cfg.QueryStoreAfter = time.Hour
 			},
 		},

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -102,7 +102,7 @@ func (p *partiallyFailingSeriesSet) Warnings() annotations.Annotations {
 
 func TestSampledRemoteRead(t *testing.T) {
 	q := &mockSampleAndChunkQueryable{
-		queryableFn: func(mint, maxt int64) (storage.Querier, error) {
+		queryableFn: func(int64, int64) (storage.Querier, error) {
 			return mockQuerier{
 				seriesSet: series.NewConcreteSeriesSetFromUnsortedSeries([]storage.Series{
 					series.NewConcreteSeries(
@@ -326,7 +326,7 @@ func TestStreamedRemoteRead(t *testing.T) {
 	for tn, tc := range tcs {
 		t.Run(tn, func(t *testing.T) {
 			q := &mockSampleAndChunkQueryable{
-				chunkQueryableFn: func(mint, maxt int64) (storage.ChunkQuerier, error) {
+				chunkQueryableFn: func(int64, int64) (storage.ChunkQuerier, error) {
 					return mockChunkQuerier{
 						seriesSet: series.NewConcreteSeriesSetFromUnsortedSeries([]storage.Series{
 							series.NewConcreteSeries(
@@ -519,7 +519,7 @@ func TestRemoteReadErrorParsing(t *testing.T) {
 		for tn, tc := range testCases {
 			t.Run(tn, func(t *testing.T) {
 				q := &mockSampleAndChunkQueryable{
-					queryableFn: func(mint, maxt int64) (storage.Querier, error) {
+					queryableFn: func(int64, int64) (storage.Querier, error) {
 						return mockQuerier{
 							seriesSet: tc.seriesSet,
 						}, tc.getQuerierErr
@@ -555,7 +555,7 @@ func TestRemoteReadErrorParsing(t *testing.T) {
 		for tn, tc := range testCases {
 			t.Run(tn, func(t *testing.T) {
 				q := &mockSampleAndChunkQueryable{
-					chunkQueryableFn: func(mint, maxt int64) (storage.ChunkQuerier, error) {
+					chunkQueryableFn: func(int64, int64) (storage.ChunkQuerier, error) {
 						return mockChunkQuerier{
 							seriesSet: tc.seriesSet,
 						}, tc.getQuerierErr

--- a/pkg/querier/tenantfederation/merge_exemplar_queryable.go
+++ b/pkg/querier/tenantfederation/merge_exemplar_queryable.go
@@ -176,7 +176,7 @@ func (m *mergeExemplarQuerier) Select(start, end int64, matchers ...[]*labels.Ma
 	// Each task grabs a job object from the slice and stores its results in the corresponding
 	// index in the results slice. The job handles performing a tenant-specific exemplar query
 	// and adding a tenant ID label to each of the results.
-	run := func(ctx context.Context, idx int) error {
+	run := func(_ context.Context, idx int) error {
 		job := jobs[idx]
 
 		res, err := job.querier.Select(start, end, job.matchers...)
@@ -217,7 +217,7 @@ func filterTenantsAndRewriteMatchers(idLabelName string, ids []string, allMatche
 		return sliceToSet(ids), allMatchers
 	}
 
-	outIds := make(map[string]struct{})
+	outIDs := make(map[string]struct{})
 	outMatchers := make([][]*labels.Matcher, len(allMatchers))
 
 	// The ExemplarQuerier.Select method accepts a slice of slices of matchers. The matchers within
@@ -225,13 +225,13 @@ func filterTenantsAndRewriteMatchers(idLabelName string, ids []string, allMatche
 	// In order to support that, we start with a set of 0 tenant IDs and add any tenant IDs that remain
 	// after filtering (based on the inner slice of matchers), for each outer slice.
 	for i, matchers := range allMatchers {
-		filteredIds, unrelatedMatchers := filterValuesByMatchers(idLabelName, ids, matchers...)
-		for k := range filteredIds {
-			outIds[k] = struct{}{}
+		filteredIDs, unrelatedMatchers := filterValuesByMatchers(idLabelName, ids, matchers...)
+		for k := range filteredIDs {
+			outIDs[k] = struct{}{}
 		}
 
 		outMatchers[i] = unrelatedMatchers
 	}
 
-	return outIds, outMatchers
+	return outIDs, outMatchers
 }

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -72,12 +72,12 @@ func TestFrontendProcessor_processQueriesOnSingleStream(t *testing.T) {
 
 		workerCtx, workerCancel := context.WithCancel(context.Background())
 
-		requestHandler.On("Handle", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		requestHandler.On("Handle", mock.Anything, mock.Anything).Run(func(mock.Arguments) {
 			// Cancel the worker context while the query execution is in progress.
 			workerCancel()
 
 			// Ensure the execution context hasn't been canceled yet.
-			require.Nil(t, processClient.Context().Err())
+			require.NoError(t, processClient.Context().Err())
 
 			// Intentionally slow down the query execution, to double check the worker waits until done.
 			time.Sleep(time.Second)

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -83,7 +83,7 @@ func TestSchedulerProcessor_processQueriesOnSingleStream(t *testing.T) {
 
 		workerCtx, workerCancel := context.WithCancel(context.Background())
 
-		requestHandler.On("Handle", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		requestHandler.On("Handle", mock.Anything, mock.Anything).Run(func(mock.Arguments) {
 			// Cancel the worker context while the query execution is in progress.
 			workerCancel()
 
@@ -405,7 +405,7 @@ func TestSchedulerProcessor_ResponseStream(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 
 			requestHandler.On("Handle", mock.Anything, mock.Anything).Run(
-				func(arguments mock.Arguments) { cancel() },
+				func(mock.Arguments) { cancel() },
 			).Return(returnResponses(responses)())
 
 			reqProcessor.processQueriesOnSingleStream(ctx, nil, "127.0.0.1")

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -29,7 +29,7 @@ func TestConfig_Validate(t *testing.T) {
 		expectedErr string
 	}{
 		"should pass with default config": {
-			setup: func(cfg *Config) {},
+			setup: func(*Config) {},
 		},
 		"should pass if frontend address is configured, but not scheduler address": {
 			setup: func(cfg *Config) {

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -298,7 +298,7 @@ func TestRuler_PrometheusRules(t *testing.T) {
 				},
 			},
 			expectedConfigured: 1,
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
 				tenantLimits[userID] = validation.MockDefaultLimits()
 				tenantLimits[userID].RulerRecordingRulesEvaluationEnabled = true
 				tenantLimits[userID].RulerAlertingRulesEvaluationEnabled = false
@@ -330,7 +330,7 @@ func TestRuler_PrometheusRules(t *testing.T) {
 				},
 			},
 			expectedConfigured: 1,
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
 				tenantLimits[userID] = validation.MockDefaultLimits()
 				tenantLimits[userID].RulerRecordingRulesEvaluationEnabled = false
 				tenantLimits[userID].RulerAlertingRulesEvaluationEnabled = true
@@ -364,7 +364,7 @@ func TestRuler_PrometheusRules(t *testing.T) {
 				},
 			},
 			expectedConfigured: 0,
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
 				tenantLimits[userID] = validation.MockDefaultLimits()
 				tenantLimits[userID].RulerRecordingRulesEvaluationEnabled = false
 				tenantLimits[userID].RulerAlertingRulesEvaluationEnabled = false

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -379,7 +379,7 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 			queries := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
 			failures := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
 
-			mockFunc := func(ctx context.Context, q string, t time.Time) (promql.Vector, error) {
+			mockFunc := func(context.Context, string, time.Time) (promql.Vector, error) {
 				return promql.Vector{}, tc.returnedError
 			}
 			qf := MetricsQueryFunc(mockFunc, queries, failures, tc.remoteQuerier)
@@ -397,7 +397,7 @@ func TestRecordAndReportRuleQueryMetrics(t *testing.T) {
 	queryTime := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"})
 	zeroFetchedSeriesCount := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"})
 
-	mockFunc := func(ctx context.Context, q string, t time.Time) (promql.Vector, error) {
+	mockFunc := func(context.Context, string, time.Time) (promql.Vector, error) {
 		time.Sleep(1 * time.Second)
 		return promql.Vector{}, nil
 	}

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -42,7 +42,7 @@ func TestRemoteQuerier_Read(t *testing.T) {
 	setup := func() (mockHTTPGRPCClient, *httpgrpc.HTTPRequest) {
 		var inReq httpgrpc.HTTPRequest
 
-		mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+		mockClientFn := func(_ context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 			inReq = *req
 
 			b, err := proto.Marshal(&prompb.ReadResponse{
@@ -97,7 +97,7 @@ func TestRemoteQuerier_Read(t *testing.T) {
 }
 
 func TestRemoteQuerier_ReadReqTimeout(t *testing.T) {
-	mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+	mockClientFn := func(ctx context.Context, _ *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
@@ -117,7 +117,7 @@ func TestRemoteQuerier_Query(t *testing.T) {
 	setup := func() (mockHTTPGRPCClient, *httpgrpc.HTTPRequest) {
 		var inReq httpgrpc.HTTPRequest
 
-		mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+		mockClientFn := func(_ context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 			inReq = *req
 
 			return &httpgrpc.HTTPResponse{
@@ -266,7 +266,7 @@ func TestRemoteQuerier_QueryRetryOnFailure(t *testing.T) {
 			var count atomic.Int64
 
 			ctx, cancel := context.WithCancel(context.Background())
-			mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+			mockClientFn := func(context.Context, *httpgrpc.HTTPRequest, ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 				count.Add(1)
 				if testCase.err != nil {
 					if grpcutil.IsCanceled(testCase.err) {
@@ -396,7 +396,7 @@ func TestRemoteQuerier_QueryJSONDecoding(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+			mockClientFn := func(context.Context, *httpgrpc.HTTPRequest, ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 				return &httpgrpc.HTTPResponse{
 					Code: http.StatusOK,
 					Headers: []*httpgrpc.Header{
@@ -664,7 +664,7 @@ func TestRemoteQuerier_QueryProtobufDecoding(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+			mockClientFn := func(context.Context, *httpgrpc.HTTPRequest, ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 				b, err := scenario.body.Marshal()
 				if err != nil {
 					return nil, err
@@ -692,7 +692,7 @@ func TestRemoteQuerier_QueryProtobufDecoding(t *testing.T) {
 }
 
 func TestRemoteQuerier_QueryUnknownResponseContentType(t *testing.T) {
-	mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+	mockClientFn := func(context.Context, *httpgrpc.HTTPRequest, ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 		return &httpgrpc.HTTPResponse{
 			Code: http.StatusOK,
 			Headers: []*httpgrpc.Header{
@@ -709,7 +709,7 @@ func TestRemoteQuerier_QueryUnknownResponseContentType(t *testing.T) {
 }
 
 func TestRemoteQuerier_QueryReqTimeout(t *testing.T) {
-	mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+	mockClientFn := func(ctx context.Context, _ *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
@@ -767,7 +767,7 @@ func TestRemoteQuerier_StatusErrorResponses(t *testing.T) {
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			mockClientFn := func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+			mockClientFn := func(context.Context, *httpgrpc.HTTPRequest, ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
 				return testCase.resp, testCase.err
 			}
 			logger := newLoggerWithCounter()

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -1290,7 +1290,7 @@ func (r *Ruler) notifySyncRules(ctx context.Context, userIDs []string) {
 	// the client-side gRPC instrumentation fails.
 	ctx = user.InjectOrgID(ctx, "")
 
-	errs.Add(r.forEachRulerInTheRing(ctx, r.ring, RuleSyncRingOp, func(ctx context.Context, inst *ring.InstanceDesc, rulerClient RulerClient, rulerClientErr error) error {
+	errs.Add(r.forEachRulerInTheRing(ctx, r.ring, RuleSyncRingOp, func(ctx context.Context, _ *ring.InstanceDesc, rulerClient RulerClient, rulerClientErr error) error {
 		var err error
 
 		if rulerClientErr != nil {

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -224,10 +224,10 @@ func prepareRuler(t *testing.T, cfg Config, storage rulestore.RuleStore, opts ..
 func prepareRulerManager(t *testing.T, cfg Config, opts ...prepareOption) *DefaultMultiTenantManager {
 	options := applyPrepareOptions(t, cfg.Ring.Common.InstanceID, opts...)
 
-	noopQueryable := storage.QueryableFunc(func(mint, maxt int64) (storage.Querier, error) {
+	noopQueryable := storage.QueryableFunc(func(int64, int64) (storage.Querier, error) {
 		return storage.NoopQuerier(), nil
 	})
-	noopQueryFunc := func(ctx context.Context, q string, t time.Time) (promql.Vector, error) {
+	noopQueryFunc := func(context.Context, string, time.Time) (promql.Vector, error) {
 		return nil, nil
 	}
 
@@ -249,7 +249,7 @@ func TestNotifierSendsUserIDHeader(t *testing.T) {
 
 	// We do expect 1 API call for the user create with the getOrCreateNotifier()
 	wg.Add(1)
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		userID, _, err := tenant.ExtractTenantIDFromHTTPRequest(r)
 		require.NoError(t, err)
 		assert.Equal(t, "1", userID)
@@ -1019,7 +1019,7 @@ func TestRuler_NotifySyncRulesAsync_ShouldTriggerRulesSyncingOnAllRulersWhenEnab
 				rulerCfg.Ring.Common.InstanceAddr = rulerAddr
 				rulerCfg.Ring.Common.KVStore = kv.Config{Mock: kvStore}
 
-				limits := validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				limits := validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 					defaults.RulerTenantShardSize = rulerShardSize
 				})
 
@@ -1674,7 +1674,7 @@ func TestFilterRuleGroupsByEnabled(t *testing.T) {
 					createRuleGroup("group-3", "user-2", createAlertingRule("alert-6", "6"), createAlertingRule("alert-7", "7")),
 				},
 			},
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
 				tenantLimits["user-1"] = validation.MockDefaultLimits()
 				tenantLimits["user-1"].RulerRecordingRulesEvaluationEnabled = true
 				tenantLimits["user-1"].RulerAlertingRulesEvaluationEnabled = false
@@ -1704,7 +1704,7 @@ func TestFilterRuleGroupsByEnabled(t *testing.T) {
 					createRuleGroup("group-3", "user-2", createAlertingRule("alert-6", "6"), createAlertingRule("alert-7", "7")),
 				},
 			},
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
 				tenantLimits["user-1"] = validation.MockDefaultLimits()
 				tenantLimits["user-1"].RulerRecordingRulesEvaluationEnabled = false
 				tenantLimits["user-1"].RulerAlertingRulesEvaluationEnabled = true
@@ -1734,7 +1734,7 @@ func TestFilterRuleGroupsByEnabled(t *testing.T) {
 					createRuleGroup("group-3", "user-2", createAlertingRule("alert-6", "6"), createAlertingRule("alert-7", "7")),
 				},
 			},
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
 				tenantLimits["user-1"] = validation.MockDefaultLimits()
 				tenantLimits["user-1"].RulerRecordingRulesEvaluationEnabled = false
 				tenantLimits["user-1"].RulerAlertingRulesEvaluationEnabled = false
@@ -1760,7 +1760,7 @@ func TestFilterRuleGroupsByEnabled(t *testing.T) {
 					createRuleGroup("group-3", "user-2", createAlertingRule("alert-6", "6"), createAlertingRule("alert-7", "7")),
 				},
 			},
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 				defaults.RulerRecordingRulesEvaluationEnabled = false
 				defaults.RulerAlertingRulesEvaluationEnabled = false
 			}),
@@ -1909,17 +1909,17 @@ func BenchmarkFilterRuleGroupsByEnabled(b *testing.B) {
 			limits: validation.MockDefaultOverrides(),
 		},
 		"recording rules disabled": {
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 				defaults.RulerRecordingRulesEvaluationEnabled = false
 			}),
 		},
 		"alerting rules disabled": {
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 				defaults.RulerAlertingRulesEvaluationEnabled = false
 			}),
 		},
 		"all rules disabled": {
-			limits: validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+			limits: validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 				defaults.RulerRecordingRulesEvaluationEnabled = false
 				defaults.RulerAlertingRulesEvaluationEnabled = false
 			}),

--- a/pkg/ruler/rulestore/config_test.go
+++ b/pkg/ruler/rulestore/config_test.go
@@ -24,7 +24,7 @@ func TestIsDefaults(t *testing.T) {
 			expected: true,
 		},
 		"should return false if the config contains zero values": {
-			setup:    func(cfg *Config) {},
+			setup:    func(*Config) {},
 			expected: false,
 		},
 		"should return false if the config contains default values and some overrides": {

--- a/pkg/scheduler/schedulerdiscovery/config_test.go
+++ b/pkg/scheduler/schedulerdiscovery/config_test.go
@@ -16,7 +16,7 @@ func TestConfig_Validate(t *testing.T) {
 		expectedErr string
 	}{
 		"should pass with default config": {
-			setup: func(cfg *Config) {},
+			setup: func(*Config) {},
 		},
 		"should fail if service discovery mode is invalid": {
 			setup: func(cfg *Config) {

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -141,7 +141,7 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 		expectedOffset := int64(1)
 
 		// Slow down the 1st ListOffsets request.
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
 			if firstRequest.CompareAndSwap(true, false) {
 				close(firstRequestReceived)
 				time.Sleep(2 * firstRequestTimeout)
@@ -187,7 +187,7 @@ func TestPartitionOffsetReader_FetchLastProducedOffset(t *testing.T) {
 
 		// Make the ListOffsets request failing.
 		actualTries := atomic.NewInt64(0)
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			actualTries.Inc()
 			return nil, errors.New("mocked error"), true
@@ -305,7 +305,7 @@ func TestPartitionOffsetReader_FetchPartitionStartOffset(t *testing.T) {
 		expectedStartOffset := int64(1)
 
 		// Slow down the 1st ListOffsets request.
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
 			if firstRequest.CompareAndSwap(true, false) {
 				close(firstRequestReceived)
 				time.Sleep(2 * firstRequestTimeout)
@@ -351,7 +351,7 @@ func TestPartitionOffsetReader_FetchPartitionStartOffset(t *testing.T) {
 
 		// Make the ListOffsets request failing.
 		actualTries := atomic.NewInt64(0)
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			actualTries.Inc()
 			return nil, errors.New("mocked error"), true

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -203,7 +203,7 @@ func TestPusherConsumer_consume_ShouldLogErrorsHonoringOptionalLogging(t *testin
 
 	// Utility function used to setup the test.
 	setupTest := func(pusherErr error) (*pusherConsumer, *concurrency.SyncBuffer, *prometheus.Registry) {
-		pusher := pusherFunc(func(ctx context.Context, request *mimirpb.WriteRequest) error {
+		pusher := pusherFunc(func(context.Context, *mimirpb.WriteRequest) error {
 			return pusherErr
 		})
 

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -174,7 +174,7 @@ func TestPartitionReader_WaitReadConsistency(t *testing.T) {
 		// We define a custom consume function which introduces a delay once the 2nd record
 		// has been consumed but before the function returns. From the PartitionReader perspective,
 		// the 2nd record consumption will be delayed.
-		consumer := consumerFunc(func(ctx context.Context, records []record) error {
+		consumer := consumerFunc(func(_ context.Context, records []record) error {
 			for _, record := range records {
 				// Introduce a delay before returning from the consume function once
 				// the 2nd record has been consumed.
@@ -306,7 +306,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		var (
 			_, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-			consumer       = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+			consumer       = consumerFunc(func(context.Context, []record) error { return nil })
 			reg            = prometheus.NewPedanticRegistry()
 		)
 
@@ -328,12 +328,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		var (
 			cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-			consumer             = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+			consumer             = consumerFunc(func(context.Context, []record) error { return nil })
 			reg                  = prometheus.NewPedanticRegistry()
 		)
 
 		// Mock Kafka to fail the Fetch request.
-		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 
 			return nil, errors.New("mocked error"), true
@@ -368,12 +368,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 			consumedRecordsCount = atomic.NewInt64(0)
 		)
 
-		consumer := consumerFunc(func(ctx context.Context, records []record) error {
+		consumer := consumerFunc(func(_ context.Context, records []record) error {
 			consumedRecordsCount.Add(int64(len(records)))
 			return nil
 		})
 
-		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			fetchRequestsCount.Inc()
 
@@ -438,12 +438,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 			consumedRecordsCount     = atomic.NewInt64(0)
 		)
 
-		consumer := consumerFunc(func(ctx context.Context, records []record) error {
+		consumer := consumerFunc(func(_ context.Context, records []record) error {
 			consumedRecordsCount.Add(int64(len(records)))
 			return nil
 		})
 
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			listOffsetsRequestsCount.Inc()
 
@@ -510,7 +510,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 			consumedRecords      []string
 		)
 
-		consumer := consumerFunc(func(ctx context.Context, records []record) error {
+		consumer := consumerFunc(func(_ context.Context, records []record) error {
 			consumedRecordsMx.Lock()
 			defer consumedRecordsMx.Unlock()
 
@@ -520,7 +520,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 			return nil
 		})
 
-		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 
 			fetchRequestsCount.Inc()
@@ -591,7 +591,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 			consumedRecords      []string
 		)
 
-		consumer := consumerFunc(func(ctx context.Context, records []record) error {
+		consumer := consumerFunc(func(_ context.Context, records []record) error {
 			consumedRecordsMx.Lock()
 			defer consumedRecordsMx.Unlock()
 
@@ -601,7 +601,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 			return nil
 		})
 
-		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			fetchRequestsCount.Inc()
 
@@ -683,7 +683,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 			consumedRecords      []string
 		)
 
-		consumer := consumerFunc(func(ctx context.Context, records []record) error {
+		consumer := consumerFunc(func(_ context.Context, records []record) error {
 			consumedRecordsMx.Lock()
 			defer consumedRecordsMx.Unlock()
 
@@ -693,7 +693,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 			return nil
 		})
 
-		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			fetchRequestsCount.Inc()
 
@@ -769,12 +769,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		var (
 			cluster, clusterAddr     = testkafka.CreateCluster(t, partitionID+1, topicName)
-			consumer                 = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+			consumer                 = consumerFunc(func(context.Context, []record) error { return nil })
 			listOffsetsRequestsCount = atomic.NewInt64(0)
 		)
 
 		// Mock Kafka to always fail the ListOffsets request.
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 
 			listOffsetsRequestsCount.Inc()
@@ -806,12 +806,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		var (
 			cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-			consumer             = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+			consumer             = consumerFunc(func(context.Context, []record) error { return nil })
 			fetchRequestsCount   = atomic.NewInt64(0)
 		)
 
 		// Mock Kafka to always fail the Fetch request.
-		cluster.ControlKey(int16(kmsg.Fetch), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 
 			fetchRequestsCount.Inc()
@@ -856,12 +856,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				t.Cleanup(cancel)
 
-				consumer := consumerFunc(func(ctx context.Context, records []record) error {
+				consumer := consumerFunc(func(context.Context, []record) error {
 					return nil
 				})
 
 				cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-				cluster.ControlKey(int16(kmsg.Fetch), func(req kmsg.Request) (kmsg.Response, error, bool) {
+				cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
 					cluster.KeepControl()
 
 					// Throttle the Fetch request.
@@ -938,7 +938,7 @@ func TestPartitionReader_fetchLastCommittedOffset(t *testing.T) {
 
 		var (
 			cluster, clusterAddr = testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitionID+1, topicName)
-			consumer             = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+			consumer             = consumerFunc(func(context.Context, []record) error { return nil })
 			reader               = createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
 		)
 
@@ -968,7 +968,7 @@ func TestPartitionReader_fetchLastCommittedOffset(t *testing.T) {
 
 		var (
 			cluster, clusterAddr = testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitionID+1, topicName)
-			consumer             = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+			consumer             = consumerFunc(func(context.Context, []record) error { return nil })
 			reader               = createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
 		)
 
@@ -1008,7 +1008,7 @@ func TestPartitionReader_fetchLastCommittedOffset(t *testing.T) {
 
 		var (
 			cluster, clusterAddr = testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitionID+1, topicName)
-			consumer             = consumerFunc(func(ctx context.Context, records []record) error { return nil })
+			consumer             = consumerFunc(func(context.Context, []record) error { return nil })
 			reader               = createReader(t, clusterAddr, topicName, partitionID, consumer, withMaxConsumerLagAtStartup(time.Second))
 		)
 
@@ -1189,7 +1189,7 @@ func TestPartitionCommitter_commit(t *testing.T) {
 		cluster, clusterAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitionID+1, topicName)
 
 		// Mock the cluster to fail any offset commit request.
-		cluster.ControlKey(kmsg.OffsetCommit.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(kmsg.OffsetCommit.Int16(), func(kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			return nil, errors.New("mocked error"), true
 		})

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -55,7 +55,7 @@ func TestWriter_WriteSync(t *testing.T) {
 
 		produceRequestProcessed := atomic.NewBool(false)
 
-		cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
 			// Add a delay, so that if WriteSync() will not wait then the test will fail.
 			time.Sleep(time.Second)
 			produceRequestProcessed.Store(true)
@@ -238,7 +238,7 @@ func TestWriter_WriteSync(t *testing.T) {
 		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
 		writer, _ := createTestWriter(t, kafkaCfg)
 
-		cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
 			// Keep failing every request.
 			cluster.KeepControl()
 			return nil, errors.New("mock error"), true
@@ -267,7 +267,7 @@ func TestWriter_WriteSync(t *testing.T) {
 		)
 
 		wg.Add(1)
-		cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
 			// Ensure the test waits for this too, since the client request will fail earlier
 			// (if we don't wait, the test will end before this function and then goleak will
 			// report a goroutine leak).

--- a/pkg/storage/tsdb/block/block_test.go
+++ b/pkg/storage/tsdb/block/block_test.go
@@ -330,7 +330,7 @@ func TestMarkForDeletion(t *testing.T) {
 	}{
 		{
 			name:         "block marked for deletion",
-			preUpload:    func(t testing.TB, id ulid.ULID, bkt objstore.Bucket) {},
+			preUpload:    func(testing.TB, ulid.ULID, objstore.Bucket) {},
 			blocksMarked: 1,
 		},
 		{
@@ -379,7 +379,7 @@ func TestMarkForNoCompact(t *testing.T) {
 	}{
 		{
 			name:         "block marked",
-			preUpload:    func(t testing.TB, id ulid.ULID, bkt objstore.Bucket) {},
+			preUpload:    func(testing.TB, ulid.ULID, objstore.Bucket) {},
 			blocksMarked: 1,
 		},
 		{
@@ -440,7 +440,7 @@ func TestUnMarkForNoCompact(t *testing.T) {
 			},
 		},
 		"unmark non-existing block should fail": {
-			setupTest: func(t testing.TB, id ulid.ULID, bkt objstore.Bucket) {},
+			setupTest: func(testing.TB, ulid.ULID, objstore.Bucket) {},
 			expectedError: func(id ulid.ULID) error {
 				return errors.Errorf("deletion of no-compaction marker for block %s has failed: inmem: object not found", id.String())
 			},

--- a/pkg/storage/tsdb/block/index_test.go
+++ b/pkg/storage/tsdb/block/index_test.go
@@ -63,7 +63,7 @@ func TestRewrite(t *testing.T) {
 
 	totalChunks := 0
 	ignoredChunks := 0
-	require.NoError(t, rewrite(ctx, log.NewNopLogger(), ir, cr, iw, cw, m, []ignoreFnType{func(mint, maxt int64, prev *chunks.Meta, curr *chunks.Meta) (bool, error) {
+	require.NoError(t, rewrite(ctx, log.NewNopLogger(), ir, cr, iw, cw, m, []ignoreFnType{func(_, _ int64, _ *chunks.Meta, curr *chunks.Meta) (bool, error) {
 		totalChunks++
 		if curr.OverlapsClosedInterval(excludeTime, excludeTime) {
 			// Ignores all chunks that overlap with the excludeTime. excludeTime was randomly selected inside the block.

--- a/pkg/storage/tsdb/config_test.go
+++ b/pkg/storage/tsdb/config_test.go
@@ -25,98 +25,98 @@ func TestConfig_Validate(t *testing.T) {
 		expectedErr error
 	}{
 		"should pass on S3 backend": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.Bucket.Backend = "s3"
 			},
 			expectedErr: nil,
 		},
 		"should pass on GCS backend": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.Bucket.Backend = "gcs"
 			},
 			expectedErr: nil,
 		},
 		"should fail on unknown storage backend": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.Bucket.Backend = "unknown"
 			},
 			expectedErr: bucket.ErrUnsupportedStorageBackend,
 		},
 		"should fail on invalid ship concurrency": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.ShipConcurrency = 0
 			},
 			expectedErr: errInvalidShipConcurrency,
 		},
 		"should pass on invalid ship concurrency but shipping is disabled": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.ShipConcurrency = 0
 				cfg.TSDB.ShipInterval = 0
 			},
 			expectedErr: nil,
 		},
 		"should fail on invalid compaction interval": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.HeadCompactionInterval = 0
 			},
 			expectedErr: errInvalidCompactionInterval,
 		},
 		"should fail on too high compaction interval": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.HeadCompactionInterval = 20 * time.Minute
 			},
 			expectedErr: errInvalidCompactionInterval,
 		},
 		"should fail on invalid compaction concurrency": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.HeadCompactionConcurrency = 0
 			},
 			expectedErr: errInvalidCompactionConcurrency,
 		},
 		"should pass on valid compaction concurrency": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.HeadCompactionConcurrency = 10
 			},
 			expectedErr: nil,
 		},
 		"should fail on negative stripe size": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.StripeSize = -2
 			},
 			expectedErr: errInvalidStripeSize,
 		},
 		"should fail on stripe size 0": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.StripeSize = 0
 			},
 			expectedErr: errInvalidStripeSize,
 		},
 		"should fail on stripe size 1": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.StripeSize = 1
 			},
 			expectedErr: errInvalidStripeSize,
 		},
 		"should pass on valid stripe size": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.StripeSize = 1 << 14
 			},
 			expectedErr: nil,
 		},
 		"should fail on empty block ranges": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.BlockRanges = nil
 			},
 			expectedErr: errEmptyBlockranges,
 		},
 		"should fail on invalid TSDB WAL segment size": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.WALSegmentSizeBytes = 0
 			},
 			expectedErr: errInvalidWALSegmentSizeBytes,
 		},
 		"should fail on invalid store-gateway streaming batch size": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.BucketStore.StreamingBatchSize = 0
 			},
 			expectedErr: errInvalidStreamingBatchSize,
@@ -129,7 +129,7 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: errEarlyCompactionRequiresActiveSeries,
 		},
 		"should fail on invalid forced compaction min series reduction percentage": {
-			setup: func(cfg *BlocksStorageConfig, activeSeriesCfg *activeseries.Config) {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
 				cfg.TSDB.EarlyHeadCompactionMinEstimatedSeriesReductionPercentage = 101
 			},
 			expectedErr: errInvalidEarlyHeadCompactionMinSeriesReduction,

--- a/pkg/storage/tsdb/users_scanner_test.go
+++ b/pkg/storage/tsdb/users_scanner_test.go
@@ -43,7 +43,7 @@ func TestUsersScanner_ScanUsers_ShouldReturnUsersForWhichOwnerCheckOrTenantDelet
 	bucketClient.MockExists(path.Join("user-1", TenantDeletionMarkPath), false, nil)
 	bucketClient.MockExists(path.Join("user-2", TenantDeletionMarkPath), false, errors.New("fail"))
 
-	isOwned := func(userID string) (bool, error) {
+	isOwned := func(string) (bool, error) {
 		return false, errors.New("failed to check if user is owned")
 	}
 

--- a/pkg/storegateway/bucket_chunk_reader_test.go
+++ b/pkg/storegateway/bucket_chunk_reader_test.go
@@ -54,12 +54,12 @@ func TestBucketChunkReader_refetchChunks(t *testing.T) {
 
 	// Each func takes the estimated length and returns a new length.
 	chunkLengthSkewingFuncs := map[string]func(uint32) uint32{
-		"tsdb.EstimatedMaxChunkSize":    func(chunkLength uint32) uint32 { return tsdb.EstimatedMaxChunkSize },
-		"10xtsdb.EstimatedMaxChunkSize": func(chunkLength uint32) uint32 { return 10 * tsdb.EstimatedMaxChunkSize },
+		"tsdb.EstimatedMaxChunkSize":    func(uint32) uint32 { return tsdb.EstimatedMaxChunkSize },
+		"10xtsdb.EstimatedMaxChunkSize": func(uint32) uint32 { return 10 * tsdb.EstimatedMaxChunkSize },
 		"size-1":                        func(chunkLength uint32) uint32 { return chunkLength - 1 },
 		"size/2":                        func(chunkLength uint32) uint32 { return chunkLength / 2 },
-		"1":                             func(chunkLength uint32) uint32 { return 1 },
-		"0":                             func(chunkLength uint32) uint32 { return 0 },
+		"1":                             func(uint32) uint32 { return 1 },
+		"0":                             func(uint32) uint32 { return 0 },
 	}
 
 	for name, skewChunkLen := range chunkLengthSkewingFuncs {

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -323,7 +323,7 @@ func TestBucketStores_syncUsersBlocks(t *testing.T) {
 
 			// Sync user stores and count the number of times the callback is called.
 			var storesCount atomic.Int32
-			err = stores.syncUsersBlocks(context.Background(), func(ctx context.Context, bs *BucketStore) error {
+			err = stores.syncUsersBlocks(context.Background(), func(context.Context, *BucketStore) error {
 				storesCount.Inc()
 				return nil
 			})

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -340,7 +340,7 @@ func TestBlockLabelNames(t *testing.T) {
 			onLabelNamesCalled: func() error {
 				return fmt.Errorf("not expected the LabelNames() calls with matchers")
 			},
-			onLabelValuesOffsetsCalled: func(name string) error {
+			onLabelValuesOffsetsCalled: func(string) error {
 				expectedCalls--
 				if expectedCalls < 0 {
 					return fmt.Errorf("didn't expect another index.Reader.LabelValues() call")
@@ -392,7 +392,7 @@ func TestBlockLabelValues(t *testing.T) {
 		b := newTestBucketBlock()
 		b.indexHeaderReader = &interceptedIndexReader{
 			Reader:                     b.indexHeaderReader,
-			onLabelValuesOffsetsCalled: func(name string) error { return context.DeadlineExceeded },
+			onLabelValuesOffsetsCalled: func(string) error { return context.DeadlineExceeded },
 		}
 		b.indexCache = cacheNotExpectingToStoreLabelValues{t: t}
 
@@ -405,7 +405,7 @@ func TestBlockLabelValues(t *testing.T) {
 		b := newTestBucketBlock()
 		b.indexHeaderReader = &interceptedIndexReader{
 			Reader: b.indexHeaderReader,
-			onLabelValuesOffsetsCalled: func(name string) error {
+			onLabelValuesOffsetsCalled: func(string) error {
 				expectedCalls--
 				if expectedCalls < 0 {
 					return fmt.Errorf("didn't expect another index.Reader.LabelValues() call")
@@ -1904,7 +1904,7 @@ func TestBucketStore_Series_RequestAndResponseHints(t *testing.T) {
 	tb, store, seriesSet1, seriesSet2, block1, block2, cleanup := setupStoreForHintsTest(t, 5000)
 	tb.Cleanup(cleanup)
 	for _, streamingBatchSize := range []int{0, 1, 5} {
-		t.Run(fmt.Sprintf("streamingBatchSize=%d", streamingBatchSize), func(t *testing.T) {
+		t.Run(fmt.Sprintf("streamingBatchSize=%d", streamingBatchSize), func(*testing.T) {
 			runTestServerSeries(tb, store, streamingBatchSize, newTestCases(seriesSet1, seriesSet2, block1, block2)...)
 		})
 	}

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -63,17 +63,17 @@ func TestConfig_Validate(t *testing.T) {
 		expected error
 	}{
 		"should pass by default": {
-			setup:    func(cfg *Config, limits *validation.Limits) {},
+			setup:    func(*Config, *validation.Limits) {},
 			expected: nil,
 		},
 		"should fail if shard size is negative": {
-			setup: func(cfg *Config, limits *validation.Limits) {
+			setup: func(_ *Config, limits *validation.Limits) {
 				limits.StoreGatewayTenantShardSize = -3
 			},
 			expected: errInvalidTenantShardSize,
 		},
 		"should pass if shard size has been set": {
-			setup: func(cfg *Config, limits *validation.Limits) {
+			setup: func(_ *Config, limits *validation.Limits) {
 				limits.StoreGatewayTenantShardSize = 3
 			},
 			expected: nil,
@@ -193,7 +193,7 @@ func TestStoreGateway_InitialSyncFailure(t *testing.T) {
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
-	bucketClient := &bucket.ErrorInjectedBucketClient{Injector: func(operation bucket.Operation, s string) error { return assert.AnError }}
+	bucketClient := &bucket.ErrorInjectedBucketClient{Injector: func(bucket.Operation, string) error { return assert.AnError }}
 
 	g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, defaultLimitsOverrides(t), log.NewLogfmtLogger(os.Stdout), nil, nil)
 	require.NoError(t, err)

--- a/pkg/storegateway/indexcache/remote_test.go
+++ b/pkg/storegateway/indexcache/remote_test.go
@@ -215,7 +215,7 @@ func TestRemoteIndexCache_FetchMultiSeriesForRef(t *testing.T) {
 		mockedErr      error
 		fetchUserID    string
 		fetchBlockID   ulid.ULID
-		fetchIds       []storage.SeriesRef
+		fetchIDs       []storage.SeriesRef
 		expectedHits   map[storage.SeriesRef][]byte
 		expectedMisses []storage.SeriesRef
 	}{
@@ -223,7 +223,7 @@ func TestRemoteIndexCache_FetchMultiSeriesForRef(t *testing.T) {
 			setup:          []mockedSeriesForRef{},
 			fetchUserID:    user1,
 			fetchBlockID:   block1,
-			fetchIds:       []storage.SeriesRef{1, 2},
+			fetchIDs:       []storage.SeriesRef{1, 2},
 			expectedHits:   nil,
 			expectedMisses: []storage.SeriesRef{1, 2},
 		},
@@ -237,7 +237,7 @@ func TestRemoteIndexCache_FetchMultiSeriesForRef(t *testing.T) {
 			},
 			fetchUserID:  user1,
 			fetchBlockID: block1,
-			fetchIds:     []storage.SeriesRef{1, 2},
+			fetchIDs:     []storage.SeriesRef{1, 2},
 			expectedHits: map[storage.SeriesRef][]byte{
 				1: value1,
 				2: value2,
@@ -251,7 +251,7 @@ func TestRemoteIndexCache_FetchMultiSeriesForRef(t *testing.T) {
 			},
 			fetchUserID:    user1,
 			fetchBlockID:   block1,
-			fetchIds:       []storage.SeriesRef{1, 2},
+			fetchIDs:       []storage.SeriesRef{1, 2},
 			expectedHits:   map[storage.SeriesRef][]byte{1: value1},
 			expectedMisses: []storage.SeriesRef{2},
 		},
@@ -264,7 +264,7 @@ func TestRemoteIndexCache_FetchMultiSeriesForRef(t *testing.T) {
 			mockedErr:      errors.New("mocked error"),
 			fetchUserID:    user1,
 			fetchBlockID:   block1,
-			fetchIds:       []storage.SeriesRef{1, 2},
+			fetchIDs:       []storage.SeriesRef{1, 2},
 			expectedHits:   nil,
 			expectedMisses: []storage.SeriesRef{1, 2},
 		},
@@ -283,12 +283,12 @@ func TestRemoteIndexCache_FetchMultiSeriesForRef(t *testing.T) {
 			}
 
 			// Fetch series from cached and assert on it.
-			hits, misses := c.FetchMultiSeriesForRefs(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchIds)
+			hits, misses := c.FetchMultiSeriesForRefs(ctx, testData.fetchUserID, testData.fetchBlockID, testData.fetchIDs)
 			assert.Equal(t, testData.expectedHits, hits)
 			assert.Equal(t, testData.expectedMisses, misses)
 
 			// Assert on metrics.
-			assert.Equal(t, float64(len(testData.fetchIds)), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeriesForRef)))
+			assert.Equal(t, float64(len(testData.fetchIDs)), prom_testutil.ToFloat64(c.requests.WithLabelValues(cacheTypeSeriesForRef)))
 			assert.Equal(t, float64(len(testData.expectedHits)), prom_testutil.ToFloat64(c.hits.WithLabelValues(cacheTypeSeriesForRef)))
 			for _, typ := range remove(allCacheTypes, cacheTypeSeriesForRef) {
 				assert.Equal(t, 0.0, prom_testutil.ToFloat64(c.requests.WithLabelValues(typ)))

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -34,7 +34,7 @@ func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) 
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, bkt.Close()) })
 
-	testLazyBinaryReader(t, bkt, tmpDir, ulid.ULID{}, func(t *testing.T, r *LazyBinaryReader, err error) {
+	testLazyBinaryReader(t, bkt, tmpDir, ulid.ULID{}, func(t *testing.T, _ *LazyBinaryReader, err error) {
 		require.Error(t, err)
 	})
 }

--- a/pkg/storegateway/indexheader/reader_benchmarks_test.go
+++ b/pkg/storegateway/indexheader/reader_benchmarks_test.go
@@ -177,7 +177,7 @@ func BenchmarkLabelValuesOffsetsIndexV1(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			name := names[i%len(names)]
 
-			values, err := br.LabelValuesOffsets(name, "", func(s string) bool {
+			values, err := br.LabelValuesOffsets(name, "", func(string) bool {
 				return true
 			})
 
@@ -221,7 +221,7 @@ func BenchmarkLabelValuesOffsetsIndexV2(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			name := names[i%len(names)]
 
-			values, err := br.LabelValuesOffsets(name, "", func(s string) bool {
+			values, err := br.LabelValuesOffsets(name, "", func(string) bool {
 				return true
 			})
 

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1489,7 +1489,7 @@ func TestOpenBlockSeriesChunkRefsSetsIterator(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	newTestBlock := prepareTestBlock(test.NewTB(t), func(tb testing.TB, appenderFactory func() storage.Appender) {
+	newTestBlock := prepareTestBlock(test.NewTB(t), func(_ testing.TB, appenderFactory func() storage.Appender) {
 		const (
 			samplesFor1Chunk   = 100                  // not a complete chunk
 			samplesFor2Chunks  = samplesFor1Chunk * 2 // not a complete chunk
@@ -2008,10 +2008,10 @@ func TestOpenBlockSeriesChunkRefsSetsIterator_SeriesCaching(t *testing.T) {
 		for ts := int64(0); ts < 10; ts++ {
 			for _, s := range existingSeries {
 				_, err := appender.Append(0, s, ts, 0)
-				assert.NoError(t, err)
+				assert.NoError(tb, err)
 			}
 		}
-		assert.NoError(t, appender.Commit())
+		assert.NoError(tb, appender.Commit())
 	})
 
 	mockedSeriesHashes := map[string]uint64{

--- a/pkg/storegateway/sharding_strategy_test.go
+++ b/pkg/storegateway/sharding_strategy_test.go
@@ -363,7 +363,7 @@ func TestShuffleShardingStrategy(t *testing.T) {
 			t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 			// Initialize the ring state.
-			require.NoError(t, store.CAS(ctx, "test", func(in interface{}) (interface{}, bool, error) {
+			require.NoError(t, store.CAS(ctx, "test", func(interface{}) (interface{}, bool, error) {
 				d := ring.NewDesc()
 				testData.setupRing(d)
 				return d, true, nil

--- a/pkg/usagestats/seed_test.go
+++ b/pkg/usagestats/seed_test.go
@@ -127,14 +127,14 @@ func TestWaitSeedFileStability(t *testing.T) {
 	}
 
 	tests := map[string]func(t *testing.T, bucketClient *bucket.ClientMock) testExpectations{
-		"should immediately return if seed file does not exist": func(t *testing.T, bucketClient *bucket.ClientMock) testExpectations {
+		"should immediately return if seed file does not exist": func(_ *testing.T, bucketClient *bucket.ClientMock) testExpectations {
 			bucketClient.MockGet(ClusterSeedFileName, "", bucket.ErrObjectDoesNotExist)
 
 			return testExpectations{
 				expectedErr: bucket.ErrObjectDoesNotExist,
 			}
 		},
-		"should immediately return if seed file is corrupted": func(t *testing.T, bucketClient *bucket.ClientMock) testExpectations {
+		"should immediately return if seed file is corrupted": func(_ *testing.T, bucketClient *bucket.ClientMock) testExpectations {
 			bucketClient.MockGet(ClusterSeedFileName, "xxx", nil)
 
 			return testExpectations{
@@ -224,7 +224,7 @@ func TestInitSeedFile(t *testing.T) {
 				expectedMinDuration: minStability,
 			}
 		},
-		"should create the seed file if doesn't exist and then wait for 'min stability'": func(t *testing.T, bucketClient objstore.Bucket) testExpectations {
+		"should create the seed file if doesn't exist and then wait for 'min stability'": func(*testing.T, objstore.Bucket) testExpectations {
 			return testExpectations{
 				expectedMinDuration: minStability,
 			}

--- a/pkg/util/flags_test.go
+++ b/pkg/util/flags_test.go
@@ -19,7 +19,7 @@ func TestTrackRegisteredFlags(t *testing.T) {
 	var previous, registered, nonPrefixed string
 	fs.StringVar(&previous, "previous.flag", "previous", "")
 
-	rf := TrackRegisteredFlags(prefix, fs, func(prefix string, f *flag.FlagSet) {
+	rf := TrackRegisteredFlags(prefix, fs, func(prefix string, _ *flag.FlagSet) {
 		fs.StringVar(&registered, prefix+flagName, "registered", "")
 		fs.StringVar(&nonPrefixed, flagName, "non-prefixed", "")
 	})

--- a/pkg/util/instrumentation/tracer_transport_test.go
+++ b/pkg/util/instrumentation/tracer_transport_test.go
@@ -26,7 +26,7 @@ func TestTracerTransportPropagatesTrace(t *testing.T) {
 	}{
 		{
 			name:          "no next transport",
-			handlerAssert: func(t *testing.T, req *http.Request) {},
+			handlerAssert: func(*testing.T, *http.Request) {},
 		},
 		{
 			name: "with next transport",
@@ -45,7 +45,7 @@ func TestTracerTransportPropagatesTrace(t *testing.T) {
 			defer closer.Close()
 
 			observedTraceID := make(chan string, 2)
-			handler := middleware.Tracer{}.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler := middleware.Tracer{}.Wrap(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				sp := opentracing.SpanFromContext(r.Context())
 				defer sp.Finish()
 

--- a/pkg/util/noauth/no_auth.go
+++ b/pkg/util/noauth/no_auth.go
@@ -45,7 +45,7 @@ func SetupAuthMiddleware(config *server.Config, multitenancyEnabled bool, noMult
 	}
 
 	config.GRPCMiddleware = append(config.GRPCMiddleware,
-		func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 			ctx = user.InjectOrgID(ctx, noMultitenancyTenant)
 			return handler(ctx, req)
 		},

--- a/pkg/util/pool/fast_releasing_pool_test.go
+++ b/pkg/util/pool/fast_releasing_pool_test.go
@@ -151,7 +151,7 @@ func TestFastReleasingSlabPool(t *testing.T) {
 		require.Greater(t, int(delegatePool.Gets.Load()), 0)
 	})
 
-	t.Run("releasing slabID 0", func(t *testing.T) {
+	t.Run("releasing slabID 0", func(*testing.T) {
 		delegatePool := &TrackedPool{Parent: &sync.Pool{}}
 		slabPool := NewFastReleasingSlabPool[byte](delegatePool, 10)
 

--- a/pkg/util/validation/exporter/exporter_test.go
+++ b/pkg/util/validation/exporter/exporter_test.go
@@ -284,7 +284,7 @@ func TestOverridesExporter_withRing(t *testing.T) {
 
 	// Create an empty ring.
 	ctx := context.Background()
-	require.NoError(t, ringStore.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	require.NoError(t, ringStore.CAS(ctx, ringKey, func(interface{}) (out interface{}, retry bool, err error) {
 		return ring.NewDesc(), true, nil
 	}))
 

--- a/pkg/util/validation/exporter/ring_test.go
+++ b/pkg/util/validation/exporter/ring_test.go
@@ -22,7 +22,7 @@ func TestOverridesExporter_emptyRing(t *testing.T) {
 
 	// Create an empty ring.
 	ctx := context.Background()
-	require.NoError(t, ringStore.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	require.NoError(t, ringStore.CAS(ctx, ringKey, func(interface{}) (out interface{}, retry bool, err error) {
 		return ring.NewDesc(), true, nil
 	}))
 
@@ -66,7 +66,7 @@ func TestOverridesExporterRing_scaleDown(t *testing.T) {
 
 	// Register instances in the ring (manually, to be able to assign tokens).
 	ctx := context.Background()
-	require.NoError(t, ringStore.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
+	require.NoError(t, ringStore.CAS(ctx, ringKey, func(interface{}) (out interface{}, retry bool, err error) {
 		desc := ring.NewDesc()
 		desc.AddIngester(l1.GetInstanceID(), l1.GetInstanceAddr(), "", []uint32{leaderToken + 1}, ring.ACTIVE, time.Now())
 		desc.AddIngester(l2.GetInstanceID(), l2.GetInstanceAddr(), "", []uint32{leaderToken + 2}, ring.ACTIVE, time.Now())

--- a/pkg/util/version/info_handler.go
+++ b/pkg/util/version/info_handler.go
@@ -30,8 +30,7 @@ type BuildInfoFeatures struct {
 }
 
 func BuildInfoHandler(application string, features interface{}) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := BuildInfoResponse{
 			Status: "success",
 			BuildInfo: BuildInfo{

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -212,7 +212,7 @@ func Test_ProxyEndpoint_Requests(t *testing.T) {
 			wg.Add(2)
 
 			if tc.handler == nil {
-				testHandler = func(w http.ResponseWriter, r *http.Request) {
+				testHandler = func(w http.ResponseWriter, _ *http.Request) {
 					_, _ = w.Write([]byte("ok"))
 				}
 
@@ -288,7 +288,7 @@ func Test_ProxyEndpoint_Comparison(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			preferredBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			preferredBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", scenario.preferredResponseContentType)
 				w.WriteHeader(scenario.preferredResponseStatusCode)
 				_, err := w.Write([]byte("preferred response"))
@@ -299,7 +299,7 @@ func Test_ProxyEndpoint_Comparison(t *testing.T) {
 			preferredBackendURL, err := url.Parse(preferredBackend.URL)
 			require.NoError(t, err)
 
-			secondaryBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			secondaryBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", scenario.secondaryResponseContentType)
 				w.WriteHeader(scenario.secondaryResponseStatusCode)
 				_, err := w.Write([]byte("secondary response"))


### PR DESCRIPTION
#### What this PR does
Fix linting issues caught by golangci-lint v1.57.2, mostly unused arguments. This fixes the remaining trivial issues :) A few issues remain, but they're non-trivial and need to be tackled on their own (hint: deprecated stdlib API).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
