### PR TITLE
Update versions used for backwards compatibility tests

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -11,12 +11,11 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
 		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 	),
-	"grafana/mimir:2.4.0":  e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
-	"grafana/mimir:2.5.0":  e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 	"grafana/mimir:2.6.0":  e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 	"grafana/mimir:2.7.1":  e2emimir.NoopFlagMapper,
 	"grafana/mimir:2.8.0":  e2emimir.NoopFlagMapper,
 	"grafana/mimir:2.9.1":  e2emimir.NoopFlagMapper,
 	"grafana/mimir:2.10.0": e2emimir.NoopFlagMapper,
 	"grafana/mimir:2.11.0": e2emimir.NoopFlagMapper,
+	"grafana/mimir:2.12.0": e2emimir.NoopFlagMapper,
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Add 2.12 to backwards compatibility tests, and removes pre-2023 releases.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/7542

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
