### PR TITLE
docs: update azure blob storage account name example

### DIFF
--- a/docs/sources/mimir/configure/configure-object-storage-backend.md
+++ b/docs/sources/mimir/configure/configure-object-storage-backend.md
@@ -127,7 +127,7 @@ common:
     backend: azure
     azure:
       account_key: "${AZURE_ACCOUNT_KEY}" # This is a secret injected via an environment variable
-      account_name: mimir-prod
+      account_name: mimirprod
       endpoint_suffix: "blob.core.windows.net"
 
 blocks_storage:


### PR DESCRIPTION
Azure storage accounts can not have hyphens in their names. The field can contain only lowercase letters and numbers. Name must be between 3 and 24 characters.

#### What this PR does

Updates documentation here: https://grafana.com/docs/mimir/latest/configure/configure-object-storage-backend/#azure-blob-storage so that the storage account name does not contain any illegal characters.
