### PR TITLE
Bump prometheus version to 2.51.1 in local dev

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -309,7 +309,7 @@ std.manifestYamlDoc({
 
   prometheus:: {
     prometheus: {
-      image: 'prom/prometheus:v2.47.2',
+      image: 'prom/prometheus:v2.51.1',
       command: [
         '--config.file=/etc/prometheus/prometheus.yaml',
         '--enable-feature=exemplar-storage',

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -307,7 +307,7 @@
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--enable-feature=exemplar-storage"
       - "--enable-feature=native-histograms"
-    "image": "prom/prometheus:v2.47.2"
+    "image": "prom/prometheus:v2.51.1"
     "ports":
       - "9090:9090"
     "volumes":

--- a/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
+++ b/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   prometheus:
 
-    image: prom/prometheus:v2.50.1
+    image: prom/prometheus:v2.51.1
     command: ["--config.file=/etc/prometheus/prometheus.yaml", "--enable-feature=native-histograms"]
     volumes:
       - ./config:/etc/prometheus

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   prometheus:
     profiles:
       - prometheus
-    image: prom/prometheus:v2.50.1
+    image: prom/prometheus:v2.51.1
     command: ["--config.file=/etc/prometheus/prometheus.yaml", "--enable-feature=native-histograms"]
     volumes:
       - ./config:/etc/prometheus


### PR DESCRIPTION
#### What this PR does

Bump prometheus version in local dev

2.50.1 has a bug related to native histograms scraping. Fixed in 2.51.1:
https://github.com/prometheus/prometheus/pull/13846

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

N/A