### PR TITLE
mimir: don't export null "ingestion_partitions_tenant_shard_size" fields

### DIFF
--- a/operations/mimir/shuffle-sharding.libsonnet
+++ b/operations/mimir/shuffle-sharding.libsonnet
@@ -76,84 +76,84 @@
       extra_small_user+:: {},
 
       // Target 300K active series.
-      medium_small_user+:: {
+      medium_small_user+:: std.prune({
         local series = 300e3,
 
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(3, $._config.shuffle_sharding.store_gateway_shard_size),
         ruler_tenant_shard_size: std.max(2, $._config.shuffle_sharding.ruler_shard_size),
-      },
+      }),
 
       // Target 1M active series.
-      small_user+:: {
+      small_user+:: std.prune({
         local series = 1e6,
 
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(6, $._config.shuffle_sharding.store_gateway_shard_size),
         ruler_tenant_shard_size: std.max(2, $._config.shuffle_sharding.ruler_shard_size),
-      },
+      }),
 
       // Target 3M active series.
-      medium_user+:: {
+      medium_user+:: std.prune({
         local series = 3e6,
 
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(9, $._config.shuffle_sharding.store_gateway_shard_size),
         ruler_tenant_shard_size: std.max(2, $._config.shuffle_sharding.ruler_shard_size),
-      },
+      }),
 
       // Target 6M active series.
-      big_user+:: {
+      big_user+:: std.prune({
         local series = 6e6,
 
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(12, $._config.shuffle_sharding.store_gateway_shard_size),
         ruler_tenant_shard_size: std.max(3, $._config.shuffle_sharding.ruler_shard_size),
-      },
+      }),
 
       // Target 12M active series.
-      super_user+:: {
+      super_user+:: std.prune({
         local series = 12e6,
 
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(18, $._config.shuffle_sharding.store_gateway_shard_size),
         ruler_tenant_shard_size: std.max(6, $._config.shuffle_sharding.ruler_shard_size),
-      },
+      }),
 
       // Target 16M active series.
-      mega_user+:: {
+      mega_user+:: std.prune({
         local series = 16e6,
 
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(24, $._config.shuffle_sharding.store_gateway_shard_size),
         ruler_tenant_shard_size: std.max(8, $._config.shuffle_sharding.ruler_shard_size),
-      },
+      }),
 
       // Target 24M active series.
-      user_24M+:: {
+      user_24M+:: std.prune({
         local series = 24e6,
 
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(30, $._config.shuffle_sharding.store_gateway_shard_size),
         ruler_tenant_shard_size: std.max(8, $._config.shuffle_sharding.ruler_shard_size),
-      },
+      }),
 
       // Target 32M active series.
-      user_32M+:: {
+      user_32M+:: std.prune({
         local series = 32e6,
 
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(42, $._config.shuffle_sharding.store_gateway_shard_size),
         ruler_tenant_shard_size: std.max(12, $._config.shuffle_sharding.ruler_shard_size),
-      },
+      }),
     },
   },
 


### PR DESCRIPTION
#### What this PR does

This is a follow-up to #7804

We've noticed that the previous version always updated the generated ConfigMaps, with a `null` value of `ingestion_partitions_tenant_shard_size`, even when the `$._config.shuffle_sharding.ingest_storage_partitions_enabled` was unset. This PR improves this by making sure the nulls aren't end up in the resulting configs.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
