### PR TITLE
mimir-continuous-test docs changes

### DIFF
--- a/docs/sources/mimir/manage/tools/mimir-continuous-test.md
+++ b/docs/sources/mimir/manage/tools/mimir-continuous-test.md
@@ -18,7 +18,7 @@ Two operating modes are supported:
 - As a continuously running deployment in your environment, mimir-continuous-test can be used to detect issues on a live Grafana Mimir cluster over time.
 - As an ad-hoc smoke test tool, mimir-continuous-test can be used to validate basic functionality after configuration changes are made to a Grafana Mimir cluster.
 
-## Download and Run mimir-continuous-test
+## Download and run mimir-continuous-test
 
 - Using Docker:
 

--- a/docs/sources/mimir/manage/tools/mimir-continuous-test.md
+++ b/docs/sources/mimir/manage/tools/mimir-continuous-test.md
@@ -11,30 +11,32 @@ weight: 30
 
 # Grafana mimir-continuous-test
 
-As a developer, you can use the standalone mimir-continuous-test tool to run smoke tests on live Grafana Mimir clusters.
+As a developer, you can use the mimir-continuous-test tool to run smoke tests on live Grafana Mimir clusters.
 This tool identifies a class of bugs that could be difficult to spot during development.
 Two operating modes are supported:
 
 - As a continuously running deployment in your environment, mimir-continuous-test can be used to detect issues on a live Grafana Mimir cluster over time.
 - As an ad-hoc smoke test tool, mimir-continuous-test can be used to validate basic functionality after configuration changes are made to a Grafana Mimir cluster.
 
-## Download mimir-continuous-test
+## Download and Run mimir-continuous-test
 
 - Using Docker:
 
 ```bash
 docker pull "grafana/mimir-continuous-test:latest"
+docker run grafana/mimir-continuous-test
 ```
 
 - Using a local binary:
 
-Download the appropriate [mimir-continuous-test binary](https://github.com/grafana/mimir/releases/latest) for your operating system and architecture, and make it executable.
+Download the appropriate [mimir binary](https://github.com/grafana/mimir/releases/latest) for your operating system and architecture, and make it executable.
 
 For Linux with the AMD64 architecture, execute the following command:
 
 ```bash
-curl -Lo mimir-continuous-test https://github.com/grafana/mimir/releases/latest/download/mimir-continuous-test-linux-amd64
-chmod +x mimir-continuous-test
+curl -Lo mimir https://github.com/grafana/mimir/releases/latest/download/mimir-linux-amd64
+chmod +x mimir
+mimir -target=continuous-test
 ```
 
 ## Configure mimir-continuous-test
@@ -50,7 +52,7 @@ Mimir-continuous-test requires the endpoints of the backend Grafana Mimir cluste
 - Set `-tests.smoke-test` to run the test once and immediately exit. In this mode, the process exit code is non-zero when the test fails.
 
 {{< admonition type="note" >}}
-You can run `mimir-continuous-test -help` to list all available configuration options.
+You can run `mimir -help` to list all available configuration options. All configuration options for mimir-continuous-test will begin with `tests`.
 {{< /admonition >}}
 
 ## How it works

--- a/docs/sources/mimir/manage/tools/mimir-continuous-test.md
+++ b/docs/sources/mimir/manage/tools/mimir-continuous-test.md
@@ -38,6 +38,9 @@ curl -Lo mimir https://github.com/grafana/mimir/releases/latest/download/mimir-l
 chmod +x mimir
 mimir -target=continuous-test
 ```
+{{< admonition type="note" >}}
+The standalone [mimir-continuous-test binary](https://github.com/grafana/mimir/releases/tag/mimir-2.12.0) is deprecated.
+{{< /admonition >}}
 
 ## Configure mimir-continuous-test
 

--- a/docs/sources/mimir/manage/tools/mimir-continuous-test.md
+++ b/docs/sources/mimir/manage/tools/mimir-continuous-test.md
@@ -56,7 +56,7 @@ Mimir-continuous-test requires the endpoints of the backend Grafana Mimir cluste
 - Set `-tests.smoke-test` to run the test once and immediately exit. In this mode, the process exit code is non-zero when the test fails.
 
 {{< admonition type="note" >}}
-You can run `mimir -help` to list all available configuration options. All configuration options for mimir-continuous-test will begin with `tests`.
+You can run `mimir -help` to list all available configuration options. All configuration options for mimir-continuous-test begin with `tests`.
 {{< /admonition >}}
 
 ## How it works

--- a/docs/sources/mimir/manage/tools/mimir-continuous-test.md
+++ b/docs/sources/mimir/manage/tools/mimir-continuous-test.md
@@ -38,6 +38,7 @@ curl -Lo mimir https://github.com/grafana/mimir/releases/latest/download/mimir-l
 chmod +x mimir
 mimir -target=continuous-test
 ```
+
 {{< admonition type="note" >}}
 The standalone [mimir-continuous-test binary](https://github.com/grafana/mimir/releases/tag/mimir-2.12.0) is deprecated.
 {{< /admonition >}}


### PR DESCRIPTION
#### What this PR does
Reflects the new way of running mimir-continuous-test since we're deprecating the individual binary.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/7747

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
