### PR TITLE
helm: clarify keda docs

### DIFF
--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3242,11 +3242,11 @@ metaMonitoring:
       # configuration to push metrics to this Prometheus-compatible remote. Optional.
       # Note that you need to configure serviceMonitor in order to have some metrics available.
       #
-      # If you leave the metamMnitoring.grafanaAgent.metrics.remote.url field empty,
+      # If you leave the metaMonitoring.grafanaAgent.metrics.remote.url field empty,
       # then the chart automatically fills in the address of the GEM gateway Service
       # or the Mimir NGINX Service.
       #
-      # If you have deployed Mimir, and metamMnitoring.grafanaAgent.metrics.remote.url is not set,
+      # If you have deployed Mimir, and metaMonitoring.grafanaAgent.metrics.remote.url is not set,
       # then the metamonitoring metrics are be sent to the Mimir cluster.
       # You can query these metrics using the HTTP header X-Scope-OrgID: metamonitoring
       #

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -507,7 +507,10 @@ rbac:
 
 # -- KEDA Autoscaling configuration
 kedaAutoscaling:
-  # -- A Prometheus-compatible URL. Cadvisor and Mimir metrics for the Mimir pods are expected in this server. For more information on the required metrics see [Monitor system health](https://grafana.com/docs/helm-charts/mimir-distributed/latest/run-production-environment-with-helm/monitor-system-health/) If empty, the helm chart uses the metamonitoring URL from metaMonitoring.grafanaAgent.metrics.remote.url. If that is empty, then the Mimir cluster is used.
+  # -- A Prometheus-compatible URL. Cadvisor and Mimir metrics for the Mimir pods are expected in this server.
+  # For more information on the required metrics see [Monitor system health](https://grafana.com/docs/helm-charts/mimir-distributed/latest/run-production-environment-with-helm/monitor-system-health/).
+  # If empty, the helm chart uses the metamonitoring URL from metaMonitoring.grafanaAgent.metrics.remote.url.
+  # If that is empty, then the Mimir cluster is used.
   prometheusAddress: ""
   customHeaders: {}
   pollingInterval: 10
@@ -767,8 +770,8 @@ distributor:
 
   # -- [Experimental] Configure autoscaling via KEDA (https://keda.sh). This requires having
   # KEDA already installed in the Kubernetes cluster. The metrics for scaling are read
-  # from the metamonitoring setup (metamonitoring.grafanaAgent.metrics.remote).
-  # Basic auth and extra HTTP headers from metamonitoring are ignored, please use customHeaders.
+  # according to top-level kedaAutoscaling.prometheusAddress (defaulting to metamonitoring remote-write destination).
+  # Basic auth and extra HTTP headers from metaMonitoring are ignored, please use customHeaders.
   # The remote URL is used even if metamonitoring is disabled.
   # See https://github.com/grafana/mimir/issues/7367 for more details on how to migrate to autoscaled resources without disruptions.
   kedaAutoscaling:
@@ -1165,8 +1168,8 @@ ruler:
 
   # -- [Experimental] Configure autoscaling via KEDA (https://keda.sh). This requires having
   # KEDA already installed in the Kubernetes cluster. The metrics for scaling are read
-  # from the metamonitoring setup (metamonitoring.grafanaAgent.metrics.remote).
-  # Basic auth and extra HTTP headers from metamonitoring are ignored, please use customHeaders.
+  # according to top-level kedaAutoscaling.prometheusAddress (defaulting to metamonitoring remote-write destination).
+  # Basic auth and extra HTTP headers from metaMonitoring are ignored, please use customHeaders.
   # The remote URL is used even if metamonitoring is disabled.
   # See https://github.com/grafana/mimir/issues/7367 for more details on how to migrate to autoscaled resources without disruptions.
   kedaAutoscaling:
@@ -1274,8 +1277,8 @@ querier:
 
   # -- [Experimental] Configure autoscaling via KEDA (https://keda.sh). This requires having
   # KEDA already installed in the Kubernetes cluster. The metrics for scaling are read
-  # from the metamonitoring setup (metamonitoring.grafanaAgent.metrics.remote).
-  # Basic auth and extra HTTP headers from metamonitoring are ignored, please use customHeaders.
+  # according to top-level kedaAutoscaling.prometheusAddress (defaulting to metamonitoring remote-write destination).
+  # Basic auth and extra HTTP headers from metaMonitoring are ignored, please use customHeaders.
   # The remote URL is used even if metamonitoring is disabled.
   # See https://github.com/grafana/mimir/issues/7367 for more details on how to migrate to autoscaled resources without disruptions.
   kedaAutoscaling:
@@ -1384,8 +1387,8 @@ query_frontend:
 
   # -- [Experimental] Configure autoscaling via KEDA (https://keda.sh). This requires having
   # KEDA already installed in the Kubernetes cluster. The metrics for scaling are read
-  # from the metamonitoring setup (metamonitoring.grafanaAgent.metrics.remote).
-  # Basic auth and extra HTTP headers from metamonitoring are ignored, please use customHeaders.
+  # according to top-level kedaAutoscaling.prometheusAddress (defaulting to metamonitoring remote-write destination).
+  # Basic auth and extra HTTP headers from metaMonitoring are ignored, please use customHeaders.
   # The remote URL is used even if metamonitoring is disabled.
   # See https://github.com/grafana/mimir/issues/7367 for more details on how to migrate to autoscaled resources without disruptions.
   kedaAutoscaling:
@@ -3239,11 +3242,11 @@ metaMonitoring:
       # configuration to push metrics to this Prometheus-compatible remote. Optional.
       # Note that you need to configure serviceMonitor in order to have some metrics available.
       #
-      # If you leave the metamonitoring.grafanaAgent.metrics.remote.url field empty,
+      # If you leave the metamMnitoring.grafanaAgent.metrics.remote.url field empty,
       # then the chart automatically fills in the address of the GEM gateway Service
       # or the Mimir NGINX Service.
       #
-      # If you have deployed Mimir, and metamonitoring.grafanaAgent.metrics.remote.url is not set,
+      # If you have deployed Mimir, and metamMnitoring.grafanaAgent.metrics.remote.url is not set,
       # then the metamonitoring metrics are be sent to the Mimir cluster.
       # You can query these metrics using the HTTP header X-Scope-OrgID: metamonitoring
       #


### PR DESCRIPTION
The per-component docs were wrong in that the metrics aren't always read from the metamonitoring prometheus. THis used to be the case when autoscaling was first implemented but since then kedaAutoscaling.prometheusAddress has been added.
