### PR TITLE
helm 5.3: release notes suggestions

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/release-notes/v5.3.md
+++ b/docs/sources/helm-charts/mimir-distributed/release-notes/v5.3.md
@@ -17,13 +17,13 @@ A number of timeout settings have been improved upon:
 
 - Relaxed the hash ring heartbeat period and timeout for distributor, ingester, store-gateway and compactor. This means a reduced load in intra component communication with the tradeoff that abrupt component failures will take longer to detect. The new values are taken from Grafana Cloud Metrics operations.
 - The timeout for writing recording rule results has been increased to 10 seconds to accommodate large result sets.
-- The distributor termination grace period was increased from 60s to 100s to give more time for a clean termination.
-- The read timeout for chunks and index caches using memcached has been increased to `750ms` from `450ms` due to measurements.
+- The distributor termination grace period was increased from `60s` to `100s` to give more time for a clean termination.
+- The read timeout for chunks and index caches using memcached has been increased to from `450ms` to `750ms`.
 - For the distributor and query-frontend components the GRPC maximum connection age and the component shutdown delay has been tuned to avoid invoking components that are shutting down.
 
 ## Features and enhancements
 
 Notable enhancements are as follows:
 
-- Added experimental feature for deploying [KEDA](https://keda.sh) ScaledObjects as part of the helm chart for the components: distributor, querier, query-frontend and ruler. For more details please see the [Helm chart changelog](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/CHANGELOG.md).
-- GEM gateway: Allow to configure whether or not NGINX binds IPv6 via `gateway.nginx.config.enableIPv6`.
+- Added experimental feature for deploying [KEDA](https://keda.sh) ScaledObjects as part of the helm chart for the components: distributor, querier, query-frontend and ruler. For more details please see the values sections `kedaAutoscaling`, `distributor.kedaAutoscaling`, `ruler.kedaAutoscaling`, `query_frontend.kedaAutoscaling`, and `querier.kedaAutoscaling`, and the [Helm chart changelog](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/CHANGELOG.md).
+- Gateway: Allow to configure whether or not NGINX binds IPv6 via `gateway.nginx.config.enableIPv6`.

--- a/docs/sources/helm-charts/mimir-distributed/release-notes/v5.3.md
+++ b/docs/sources/helm-charts/mimir-distributed/release-notes/v5.3.md
@@ -26,4 +26,4 @@ A number of timeout settings have been improved upon:
 Notable enhancements are as follows:
 
 - Added experimental feature for deploying [KEDA](https://keda.sh) ScaledObjects as part of the helm chart for the components: distributor, querier, query-frontend and ruler. For more details please see the values sections `kedaAutoscaling`, `distributor.kedaAutoscaling`, `ruler.kedaAutoscaling`, `query_frontend.kedaAutoscaling`, and `querier.kedaAutoscaling`, and the [Helm chart changelog](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/CHANGELOG.md).
-- Gateway: Allow to configure whether or not NGINX binds IPv6 via `gateway.nginx.config.enableIPv6`.
+- Gateway: Added option for configuring whether or not NGINX binds IPv6: `gateway.nginx.config.enableIPv6`.


### PR DESCRIPTION
* use consistent formatting for durations
* use "from X to Y" structure for consistency
* remove neutral reason for increasing cache timeouts; it doesn't provide any valuable information
* remove clarification for GEM gateway; the mentioned change applies to non-GEM gateway as well
