### PR TITLE
Ingest-storage: control auto-creation of topic, and setting of default number of partitions for auto-created topics.

### DIFF
--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -64,8 +64,8 @@ type KafkaConfig struct {
 	ConsumeFromPositionAtStartup string        `yaml:"consume_from_position_at_startup"`
 	MaxConsumerLagAtStartup      time.Duration `yaml:"max_consumer_lag_at_startup"`
 
-	AutoCreateTopicEnabled                bool `yaml:"auto_create_topic_enabled"`
-	DefaultPartitionsForAutocreatedTopics int  `yaml:"default_partitions_for_autocreated_topics"`
+	AutoCreateTopicEnabled           bool `yaml:"auto_create_topic_enabled"`
+	AutoCreateTopicDefaultPartitions int  `yaml:"auto_create_topic_default_partitions"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
@@ -85,7 +85,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.StringVar(&cfg.ConsumeFromPositionAtStartup, prefix+".consume-from-position-at-startup", consumeFromLastOffset, fmt.Sprintf("From which position to start consuming the partition at startup. Supported options: %s.", strings.Join(consumeFromPositionOptions, ", ")))
 	f.DurationVar(&cfg.MaxConsumerLagAtStartup, prefix+".max-consumer-lag-at-startup", 15*time.Second, "The maximum tolerated lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set 0 to disable waiting for maximum consumer lag being honored at startup.")
 	f.BoolVar(&cfg.AutoCreateTopicEnabled, prefix+".auto-create-topic-enabled", true, "Enable auto-creation of Kafka topic if it doesn't exist.")
-	f.IntVar(&cfg.DefaultPartitionsForAutocreatedTopics, prefix+".default-partitions-for-autocreated-topics", 0, "When positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that Kafka broker will use for auto-created topics. Note that this is Kafka-cluster wide setting, and applies to any auto-created topic.")
+	f.IntVar(&cfg.AutoCreateTopicDefaultPartitions, prefix+".auto-create-topic-default-partitions", 0, "When auto-creation of Kafka topic is enabled and this value is positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that Kafka broker will use for auto-created topics. Note that this is Kafka-cluster wide setting, and applies to any auto-created topic. If setting of num.partitions fails, Mimir will proceed anyway, but auto-created topic may have incorrect number of partitions.")
 }
 
 func (cfg *KafkaConfig) Validate() error {

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -63,6 +63,9 @@ type KafkaConfig struct {
 
 	ConsumeFromPositionAtStartup string        `yaml:"consume_from_position_at_startup"`
 	MaxConsumerLagAtStartup      time.Duration `yaml:"max_consumer_lag_at_startup"`
+
+	AutoCreateTopicEnabled                bool `yaml:"auto_create_topic_enabled"`
+	DefaultPartitionsForAutocreatedTopics int  `yaml:"default_partitions_for_autocreated_topics"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
@@ -81,6 +84,8 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 
 	f.StringVar(&cfg.ConsumeFromPositionAtStartup, prefix+".consume-from-position-at-startup", consumeFromLastOffset, fmt.Sprintf("From which position to start consuming the partition at startup. Supported options: %s.", strings.Join(consumeFromPositionOptions, ", ")))
 	f.DurationVar(&cfg.MaxConsumerLagAtStartup, prefix+".max-consumer-lag-at-startup", 15*time.Second, "The maximum tolerated lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set 0 to disable waiting for maximum consumer lag being honored at startup.")
+	f.BoolVar(&cfg.AutoCreateTopicEnabled, prefix+".auto-create-topic-enabled", true, "Enable auto-creation of Kafka topic if it doesn't exist.")
+	f.IntVar(&cfg.DefaultPartitionsForAutocreatedTopics, prefix+".default-partitions-for-autocreated-topics", 0, "When positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that Kafka broker will use for auto-created topics. Note that this is Kafka-cluster wide setting, and applies to any auto-created topic.")
 }
 
 func (cfg *KafkaConfig) Validate() error {

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -90,7 +90,7 @@ func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, consumerGroup s
 }
 
 func (r *PartitionReader) start(ctx context.Context) (returnErr error) {
-	if r.kafkaCfg.DefaultPartitionsForAutocreatedTopics > 0 {
+	if r.kafkaCfg.AutoCreateTopicEnabled {
 		setDefaultNumberOfPartitionsForAutocreatedTopics(r.kafkaCfg, r.logger)
 	}
 

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -90,6 +90,10 @@ func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, consumerGroup s
 }
 
 func (r *PartitionReader) start(ctx context.Context) (returnErr error) {
+	if r.kafkaCfg.DefaultPartitionsForAutocreatedTopics > 0 {
+		setDefaultNumberOfPartitionsForAutocreatedTopics(r.kafkaCfg, r.logger)
+	}
+
 	// Stop dependencies if the start() fails.
 	defer func() {
 		if returnErr != nil {

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -134,8 +134,10 @@ func shouldLog(ctx context.Context, err error) (bool, string) {
 	return optional.ShouldLog(ctx)
 }
 
+// setDefaultNumberOfPartitionsForAutocreatedTopics tries to set num.partitions config option on brokers.
+// This is best-effort, if setting the option fails, error is logged, but not returned.
 func setDefaultNumberOfPartitionsForAutocreatedTopics(cfg KafkaConfig, logger log.Logger) {
-	if cfg.DefaultPartitionsForAutocreatedTopics <= 0 {
+	if cfg.AutoCreateTopicDefaultPartitions <= 0 {
 		return
 	}
 
@@ -148,7 +150,7 @@ func setDefaultNumberOfPartitionsForAutocreatedTopics(cfg KafkaConfig, logger lo
 	adm := kadm.NewClient(cl)
 	defer adm.Close()
 
-	defaultNumberOfPartitions := fmt.Sprintf("%d", cfg.DefaultPartitionsForAutocreatedTopics)
+	defaultNumberOfPartitions := fmt.Sprintf("%d", cfg.AutoCreateTopicDefaultPartitions)
 	_, err = adm.AlterBrokerConfigsState(context.Background(), []kadm.AlterConfig{
 		{
 			Op:    kadm.SetConfig,
@@ -162,5 +164,5 @@ func setDefaultNumberOfPartitionsForAutocreatedTopics(cfg KafkaConfig, logger lo
 		return
 	}
 
-	level.Info(logger).Log("msg", "configured Kafka-wide default number of partitions for auto-created topics (num.partitions)", "value", cfg.DefaultPartitionsForAutocreatedTopics)
+	level.Info(logger).Log("msg", "configured Kafka-wide default number of partitions for auto-created topics (num.partitions)", "value", cfg.AutoCreateTopicDefaultPartitions)
 }

--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -9,8 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 func TestIngesterPartitionID(t *testing.T) {
@@ -123,4 +126,35 @@ func TestResultPromise(t *testing.T) {
 		require.Equal(t, context.DeadlineExceeded, err)
 		require.Equal(t, 0, actual)
 	})
+}
+
+func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	addrs := cluster.ListenAddrs()
+	require.Len(t, addrs, 1)
+
+	cfg := KafkaConfig{
+		Address:                               addrs[0],
+		DefaultPartitionsForAutocreatedTopics: 100,
+	}
+
+	cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		r := request.(*kmsg.AlterConfigsRequest)
+
+		require.Len(t, r.Resources, 1)
+		res := r.Resources[0]
+		require.Equal(t, kmsg.ConfigResourceTypeBroker, res.ResourceType)
+		require.Len(t, res.Configs, 1)
+		cfg := res.Configs[0]
+		require.Equal(t, "num.partitions", cfg.Name)
+		require.NotNil(t, *cfg.Value)
+		require.Equal(t, "100", *cfg.Value)
+
+		return &kmsg.AlterConfigsResponse{}, nil, true
+	})
+
+	setDefaultNumberOfPartitionsForAutocreatedTopics(cfg, log.NewNopLogger())
 }

--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -137,8 +137,8 @@ func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
 	require.Len(t, addrs, 1)
 
 	cfg := KafkaConfig{
-		Address:                               addrs[0],
-		DefaultPartitionsForAutocreatedTopics: 100,
+		Address:                          addrs[0],
+		AutoCreateTopicDefaultPartitions: 100,
 	}
 
 	cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -71,9 +71,16 @@ func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registere
 		}),
 	}
 
-	w.Service = services.NewIdleService(nil, w.stopping)
+	w.Service = services.NewIdleService(w.starting, w.stopping)
 
 	return w
+}
+
+func (w *Writer) starting(_ context.Context) error {
+	if w.kafkaCfg.DefaultPartitionsForAutocreatedTopics > 0 {
+		setDefaultNumberOfPartitionsForAutocreatedTopics(w.kafkaCfg, w.logger)
+	}
+	return nil
 }
 
 func (w *Writer) stopping(_ error) error {

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -77,7 +77,7 @@ func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registere
 }
 
 func (w *Writer) starting(_ context.Context) error {
-	if w.kafkaCfg.DefaultPartitionsForAutocreatedTopics > 0 {
+	if w.kafkaCfg.AutoCreateTopicEnabled {
 		setDefaultNumberOfPartitionsForAutocreatedTopics(w.kafkaCfg, w.logger)
 	}
 	return nil


### PR DESCRIPTION
#### What this PR does

This PR introduces two options:
* `-ingest-storage.kafka.auto-create-topic-enabled` (default true) to control whether Mimir can auto-create topic
* `-ingest-storage.kafka.auto-create-topic-default-partitions` (default 0) -- when `auto-create-topic-enabled` is true and ` auto-create-topic-default-partitions` is set to positive number, Mimir updates `num.partitions` setting on Kafka brokers before starting reading or writing to topic (and possibly auto-create the topic).

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
