### PR TITLE
mimirtool rules prepare: do not aggregation label to on() clause if already present in group_left() or group_right()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 * [CHANGE] Deprecated `--rule-files` flag in favor of CLI arguments. #7756
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
-* [BUGFIX] `mimirtool rules prepare`: do not aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
+* [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 
 ### Mimir Continuous Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 
 * [CHANGE] Deprecated `--rule-files` flag in favor of CLI arguments. #7756
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
+* [BUGFIX] `mimirtool rules prepare`: do not aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/rules/rules.go
+++ b/pkg/mimirtool/rules/rules.go
@@ -204,8 +204,15 @@ func prepareBinaryExpr(e *parser.BinaryExpr, label string, rule string) error {
 		return nil
 	}
 
+	// Skip if the aggregation label is already present in the on() clause.
 	for _, lbl := range e.VectorMatching.MatchingLabels {
-		// It already has the label we want to add in the expression.
+		if lbl == label {
+			return nil
+		}
+	}
+
+	// Skip if the aggregation label is already present in the group_left/right() clause.
+	for _, lbl := range e.VectorMatching.Include {
 		if lbl == label {
 			return nil
 		}

--- a/pkg/mimirtool/rules/rules_test.go
+++ b/pkg/mimirtool/rules/rules_test.go
@@ -187,6 +187,50 @@ func TestAggregateBy(t *testing.T) {
 			expectedExpr: []string{`count by (namespace, cluster) (test_series) > 1`, `count by (namespace) (test_series) > 1`},
 			count:        2, modified: 1, expect: nil,
 		},
+		{
+			name: "should not the aggregation label to on() clause if already present in group_left/right()",
+			rn: RuleNamespace{
+				Groups: []rwrulefmt.RuleGroup{
+					{
+						RuleGroup: rulefmt.RuleGroup{
+							Name: "Test",
+							Rules: []rulefmt.RuleNode{
+								{
+									Alert: yaml.Node{Value: "TestWithGroupLeft"},
+									Expr:  yaml.Node{Value: `(count by (namespace) (metric_1) > 0) * on (namespace) group_left (service) group by (service, namespace) (metric_2)`},
+								}, {
+									Alert: yaml.Node{Value: "TestWithGroupLeftAndAggregationLabelAlreadyPresentInOnClause"},
+									Expr:  yaml.Node{Value: `(count by (namespace, cluster) (metric_1) > 0) * on (namespace, cluster) group_left (service) group by (service, namespace, cluster) (metric_2)`},
+								}, {
+									Alert: yaml.Node{Value: "TestWithGroupLeftAndAggregationLabelAlreadyPresentInGroupLeftClause"},
+									Expr:  yaml.Node{Value: `(count by (namespace) (metric_1) > 0) * on (namespace) group_left (cluster) group by (cluster, namespace) (metric_2)`},
+								}, {
+									Alert: yaml.Node{Value: "TestWithGroupRight"},
+									Expr:  yaml.Node{Value: `(count by (namespace, service) (metric_1) > 0) * on (namespace) group_right (service) group by (namespace) (metric_2)`},
+								}, {
+									Alert: yaml.Node{Value: "TestWithGroupRightAndAggregationLabelAlreadyPresentInOnClause"},
+									Expr:  yaml.Node{Value: `(count by (namespace, service, cluster) (metric_1) > 0) * on (namespace, cluster) group_right (service) group by (namespace, cluster) (metric_2)`},
+								}, {
+									Alert: yaml.Node{Value: "TestWithGroupRightAndAggregationLabelAlreadyPresentInGroupRightClause"},
+									Expr:  yaml.Node{Value: `(count by (namespace, service, cluster) (metric_1) > 0) * on (namespace, service) group_right (cluster) group by (namespace, service) (metric_2)`},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedExpr: []string{
+				`(count by (namespace, cluster) (metric_1) > 0) * on (namespace, cluster) group_left (service) group by (service, namespace, cluster) (metric_2)`, // Add "cluster" label to on().
+				`(count by (namespace, cluster) (metric_1) > 0) * on (namespace, cluster) group_left (service) group by (service, namespace, cluster) (metric_2)`, // This is not modified compared to the original.
+				`(count by (namespace, cluster) (metric_1) > 0) * on (namespace) group_left (cluster) group by (cluster, namespace) (metric_2)`,                   // Do not add "cluster" label to on() because it's already present in group_left() and the same label can't be in both clauses.
+
+				`(count by (namespace, service, cluster) (metric_1) > 0) * on (namespace, cluster) group_right (service) group by (namespace, cluster) (metric_2)`,          // Add "cluster" label to on().
+				`(count by (namespace, service, cluster) (metric_1) > 0) * on (namespace, cluster) group_right (service) group by (namespace, cluster) (metric_2)`,          // This is not modified compared to the original.
+				`(count by (namespace, service, cluster) (metric_1) > 0) * on (namespace, service) group_right (cluster) group by (namespace, service, cluster) (metric_2)`, // Do not add "cluster" label to on() because it's already present in group_left() and the same label can't be in both clauses.
+			},
+			count:    6,
+			modified: 4,
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
#### What this PR does

During the weekend, while on-call, I supported an engineer at Grafana Labs which hit an edge case in `mimirtool rules prepare` command. The tool is used to add an aggregation label (defaults to `cluster`) to any aggregation and binary operator vector matcher of each rule.

The edge case we found is that when the aggregation label is already present in `group_left/right()` it shouldn't be added to `on()` too, because incorrect. A PromQL query with the same label both specified in `on()` and `group_left/right()` doesn't even parse (parsing it returns the error: `label "cluster" must not occur in ON and GROUP clause at once`).

#### Example

As an example, consider the following **original query**:

```
count by(cluster, namespace) (label_replace(cortex_build_info, "cluster", "", "cluster", "(.*)"))
* on(namespace) group_left(cluster) group by(cluster, namespace) (cortex_build_info)
```

With the code in `main`, `mimirtool rules prepare` rewrites it as follow:

```
count by(cluster, namespace) (label_replace(cortex_build_info, "cluster", "", "cluster", "(.*)"))
* on(namespace, cluster) group_left(cluster) group by(cluster, namespace) (cortex_build_info)
```

But it's invalid, and a subsequent parsing will return `label "cluster" must not occur in ON and GROUP clause at once`. With the modified code in this PR, `mimirtool rules prepare` would keep the original query as is, because `cluster` label is already part of `group_left()` and so shouldn't be added to `on()` too.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
