### PR TITLE
Add config inspector to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cmd/metaconvert/metaconvert_linux_arm64
 cmd/mimir-continuous-test/mimir-continuous-test
 cmd/mimir-continuous-test/mimir-continuous-test_linux_amd64
 cmd/mimir-continuous-test/mimir-continuous-test_linux_arm64
+tools/config-inspector/config-inspector
 .bak
 .uptodate
 .pkg


### PR DESCRIPTION
The config inspector was changed to be built instead of being used in `go run`. The binary now shows up as git untracked file.
