### PR TITLE
Release: Build continous-test image during release

### DIFF
--- a/.github/workflows/scripts/build-images.sh
+++ b/.github/workflows/scripts/build-images.sh
@@ -16,6 +16,10 @@ for target in $@
 do
   DIRNAME="$(dirname "$target")"
   NAME="$(basename "$DIRNAME")"
-  make BUILD_IN_CONTAINER=false PUSH_MULTIARCH_TARGET="type=oci,dest=$OUTPUT/$NAME.oci" PUSH_MULTIARCH_TARGET_DISTROLESS="type=oci,dest=$OUTPUT/$NAME\-distroless.oci" \
-  PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST="type=oci,dest=$OUTPUT/$NAME\-continuous\-test.oci" push-multiarch-$target
+  make \
+    BUILD_IN_CONTAINER=false \
+    PUSH_MULTIARCH_TARGET="type=oci,dest=$OUTPUT/$NAME.oci" \
+    PUSH_MULTIARCH_TARGET_DISTROLESS="type=oci,dest=$OUTPUT/$NAME\-distroless.oci" \
+    PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST="type=oci,dest=$OUTPUT/$NAME\-continuous\-test.oci" \
+    push-multiarch-$target
 done

--- a/.github/workflows/scripts/build-images.sh
+++ b/.github/workflows/scripts/build-images.sh
@@ -16,5 +16,6 @@ for target in $@
 do
   DIRNAME="$(dirname "$target")"
   NAME="$(basename "$DIRNAME")"
-  make BUILD_IN_CONTAINER=false PUSH_MULTIARCH_TARGET="type=oci,dest=$OUTPUT/$NAME.oci" PUSH_MULTIARCH_TARGET_DISTROLESS="type=oci,dest=$OUTPUT/$NAME\-distroless.oci" push-multiarch-$target
+  make BUILD_IN_CONTAINER=false PUSH_MULTIARCH_TARGET="type=oci,dest=$OUTPUT/$NAME.oci" PUSH_MULTIARCH_TARGET_DISTROLESS="type=oci,dest=$OUTPUT/$NAME\-distroless.oci" \
+  PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST="type=oci,dest=$OUTPUT/$NAME\-continuous\-test.oci" push-multiarch-$target
 done

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 # CI workflow uses PUSH_MULTIARCH_TARGET="type=oci,dest=file.oci" to store images locally for next steps in the pipeline.
 PUSH_MULTIARCH_TARGET ?= type=registry
 PUSH_MULTIARCH_TARGET_DISTROLESS ?= type=registry
+PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST ?= type=registry
 
 # This target compiles mimir for linux/amd64 and linux/arm64 and then builds and pushes a multiarch image to the target repository.
 # We don't do separate building of single-platform and multiplatform images here (as we do for push-multiarch-build-image), as
@@ -168,7 +169,7 @@ push-multiarch-%/$(UPTODATE):
 	# Build Dockerfile.continuous-test
 	if [ -f $(DIR)/Dockerfile.continuous-test ]; then \
 		$(SUDO) docker buildx build -f $(DIR)/Dockerfile.continuous-test \
-			-o $(PUSH_MULTIARCH_TARGET) \
+			-o $(PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST) \
 			--platform linux/amd64,linux/arm64 \
 			--build-arg=revision=$(GIT_REVISION) \
 			--build-arg=goproxyValue=$(GOPROXY_VALUE) \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

After we moved the dockerfile from mimir-continuous-build to mimir folder, we no longer build the docker images during deploy, see one example https://github.com/grafana/mimir/actions/runs/8592984791/job/23563990901. Fix the issue in order to make the weekly release work.

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
