### PR TITLE
Helm : add hpa for the ingesters

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [FEATURE] Add hpa for the ingester.
+
 ## 5.3.0-rc.0
 
 * [CHANGE] Do not render resource blocks for `initContainers`, `nodeSelector`, `affinity` and `tolerations` if they are empty.

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-hpa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-hpa.yaml
@@ -1,0 +1,51 @@
+{{- $autoscalingv2 := .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+{{- if .Values.ingester.horizontalPodAutoscaling.enabled }}
+{{- if $autoscalingv2 }}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta1
+{{- end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ingester") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "distributor") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    {{- if .Values.ingester.statefulSet.enabled }}
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ingester") }}
+    {{- end }}
+  minReplicas: {{ .Values.ingester.horizontalPodAutoscaling.minReplicas }}
+  maxReplicas: {{ .Values.ingester.horizontalPodAutoscaling.maxReplicas }}
+  {{- with .Values.ingester.horizontalPodAutoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  metrics:
+  {{- with .Values.ingester.horizontalPodAutoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if $autoscalingv2 }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
+  {{- end }}
+  {{- with .Values.ingester.horizontalPodAutoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if $autoscalingv2 }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -172,6 +172,13 @@ spec:
             {{- toYaml .Values.ingester.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.ingester.readinessProbe | nindent 12 }}
+          {{- if .Values.ingester.horizontalPodAutoscaling.enabled }}
+          lifecycle:
+            preStop:
+              httpGet:
+                path: "/ingester/flush_shutdown"
+                port: http-metrics
+          {{- end }}
           resources:
             {{- toYaml .Values.ingester.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -176,7 +176,7 @@ spec:
           lifecycle:
             preStop:
               httpGet:
-                path: "/ingester/flush_shutdown"
+                path: "/ingester/flush"
                 port: http-metrics
           {{- end }}
           resources:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -873,6 +873,20 @@ ingester:
   #   E.g. if 'replicas' is set to 4 and there are 3 zones, then 4/3=1.33 and after rounding up it means 2 pods per zone are started.
   replicas: 3
 
+  horizontalPodAutoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 95
+    targetMemoryUtilizationPercentage: 95
+    behavior:
+      scaleDown:
+        policies:
+          - type: Pods
+            value: 1
+            periodSeconds: 1800
+      stabilizationWindowSeconds: 3600
+
   statefulSet:
     enabled: true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds a hpa resource to the `ingester` component in the `mimir-distributed` helm chart.

As the scaling down process is quite tricky as if not done properly, this could come with the loss of the data stored on the disk os the scaled down replica. To avoid that, the ingester's scaled down replica must be able to flush its data to the object storage before getting terminated. To achieve this, I looked at the PR that introduced hpa for loki components [here](https://github.com/grafana/loki/pull/8684).

I'm not sure whether the path for the added lifecycle is correct so please feel free to update it if that's the case.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
