### PR TITLE
Allow decoding metrics requests twice

### DIFF
--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -268,7 +268,7 @@ func (prometheusCodec) decodeRangeQueryRequest(r *http.Request) (MetricsQueryReq
 		return nil, err
 	}
 
-	result.Query = r.FormValue("query")
+	result.Query = reqValues.Get("query")
 	result.Path = r.URL.Path
 	decodeOptions(r, &result.Options)
 	return &result, nil

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -1149,6 +1149,58 @@ func TestPrometheusCodec_DecodeEncode(t *testing.T) {
 	}
 }
 
+func TestPrometheusCodec_DecodeMultipleTimes(t *testing.T) {
+	const query = "sum by (namespace) (container_memory_rss)"
+	t.Run("instant query", func(t *testing.T) {
+		params := url.Values{
+			"query": []string{query},
+			"time":  []string{"1000000000.011"},
+		}
+		req, err := http.NewRequest("POST", "/api/v1/query?", strings.NewReader(params.Encode()))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Accept", "application/json")
+
+		ctx := context.Background()
+		codec := newTestPrometheusCodec()
+		decoded, err := codec.DecodeMetricsQueryRequest(ctx, req)
+		require.NoError(t, err)
+		require.Equal(t, query, decoded.GetQuery())
+
+		// Decode the same request again.
+		decoded2, err := codec.DecodeMetricsQueryRequest(ctx, req)
+		require.NoError(t, err)
+		require.Equal(t, query, decoded2.GetQuery())
+
+		require.Equal(t, decoded, decoded2)
+	})
+	t.Run("range query", func(t *testing.T) {
+		params := url.Values{
+			"query": []string{query},
+			"start": []string{"1000000000.011"},
+			"end":   []string{"1000000010.022"},
+			"step":  []string{"1s"},
+		}
+		req, err := http.NewRequest("POST", "/api/v1/query_range?", strings.NewReader(params.Encode()))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Accept", "application/json")
+
+		ctx := context.Background()
+		codec := newTestPrometheusCodec()
+		decoded, err := codec.DecodeMetricsQueryRequest(ctx, req)
+		require.NoError(t, err)
+		require.Equal(t, query, decoded.GetQuery())
+
+		// Decode the same request again.
+		decoded2, err := codec.DecodeMetricsQueryRequest(ctx, req)
+		require.NoError(t, err)
+		require.Equal(t, query, decoded2.GetQuery())
+
+		require.Equal(t, decoded, decoded2)
+	})
+}
+
 func newTestPrometheusCodec() Codec {
 	return NewPrometheusCodec(prometheus.NewPedanticRegistry(), formatJSON)
 }


### PR DESCRIPTION
In a downstream implementation a middleware peeks into the request by calling the `PrometheusCodec.DecodeMetricsQueryRquest()` method, and sometimes ignores and just passes the request to the next handler.

However, the call to `r.Form()` has left the body consumed and the body can't be decoded again.

Fixed that and added a test to make sure this doesn't happen again.

This doesn't change any behavior in Mimir itself, so no changelog entry is needed.
