### PR TITLE
test: fix `Test_shardActiveSeriesMiddleware_mergeResponse_contextCancellation` flakiness

### DIFF
--- a/pkg/frontend/querymiddleware/shard_active_series_response_decoder.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_response_decoder.go
@@ -129,9 +129,7 @@ func (d *shardActiveSeriesResponseDecoder) decode() error {
 
 func (d *shardActiveSeriesResponseDecoder) readData() {
 	defer func() {
-		if err := d.ctx.Err(); err != nil {
-			d.stickError(err)
-		}
+		d.checkContextCanceled()
 	}()
 
 	if c := d.nextToken(); c != ':' {
@@ -149,9 +147,7 @@ func (d *shardActiveSeriesResponseDecoder) readData() {
 
 func (d *shardActiveSeriesResponseDecoder) readError() {
 	defer func() {
-		if err := d.ctx.Err(); err != nil {
-			d.stickError(err)
-		}
+		d.checkContextCanceled()
 	}()
 
 	if c := d.nextToken(); c != ':' {


### PR DESCRIPTION
#### What this PR does

Return context cancellation cause when reading `data`/`error` fields content in shard active series decoder. 

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/7861
