### PR TITLE
Distributor: add support to tee writes to ingesters and partitions

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1438,7 +1438,6 @@ func (d *Distributor) sendWriteRequestToBackends(ctx context.Context, tenantID s
 	// Ingester errors could be soft (e.g. 4xx) or hard errors (e.g. 5xx) errors, while partition errors are always hard
 	// errors. For this reason, it's important to give precedence to partition errors, otherwise the distributor may return
 	// a 4xx (ingester error) when it should actually be a 5xx (partition error).
-	// TODO unit test
 	if partitionsErr != nil {
 		return partitionsErr
 	}

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1327,17 +1327,23 @@ func (d *Distributor) push(ctx context.Context, pushReq *Request) error {
 	// Get both series and metadata keys in one slice.
 	keys, initialMetadataIndex := getSeriesAndMetadataTokens(userID, req)
 
+	var (
+		ingestersSubring  ring.DoBatchRing
+		partitionsSubring ring.DoBatchRing
+	)
+
 	// Get the tenant's subring to use to either write to ingesters or partitions.
-	var tenantRing ring.DoBatchRing
 	if d.cfg.IngestStorageConfig.Enabled {
 		subring, err := d.partitionsRing.ShuffleShard(userID, d.limits.IngestionPartitionsTenantShardSize(userID))
 		if err != nil {
 			return err
 		}
 
-		tenantRing = ring.NewActivePartitionBatchRing(subring.PartitionRing())
-	} else {
-		tenantRing = d.ingestersRing.ShuffleShard(userID, d.limits.IngestionTenantShardSize(userID))
+		partitionsSubring = ring.NewActivePartitionBatchRing(subring.PartitionRing())
+	}
+
+	if !d.cfg.IngestStorageConfig.Enabled || d.cfg.IngestStorageConfig.Migration.DistributorSendToIngestersEnabled {
+		ingestersSubring = d.ingestersRing.ShuffleShard(userID, d.limits.IngestionTenantShardSize(userID))
 	}
 
 	// we must not re-use buffers now until all writes to backends (e.g. ingesters) have completed, which can happen
@@ -1345,13 +1351,27 @@ func (d *Distributor) push(ctx context.Context, pushReq *Request) error {
 	// once all backend requests have completed (see cleanup function passed to sendWriteRequestToBackends()).
 	cleanupInDefer = false
 
-	return d.sendWriteRequestToBackends(ctx, userID, req, keys, initialMetadataIndex, tenantRing, pushReq.CleanUp)
+	return d.sendWriteRequestToBackends(ctx, userID, req, keys, initialMetadataIndex, ingestersSubring, partitionsSubring, pushReq.CleanUp)
 }
 
-// sendWriteRequestToBackends sends the input req data to backends (i.e. ingesters or partitions).
+// sendWriteRequestToBackends sends the input req data to backends. The backends could be:
+// - Ingesters, when ingestersSubring is not nil
+// - Ingest storage partitions, when partitionsSubring is not nil
 //
 // The input cleanup function is guaranteed to be called after all requests to all backends have completed.
-func (d *Distributor) sendWriteRequestToBackends(ctx context.Context, tenantID string, req *mimirpb.WriteRequest, keys []uint32, initialMetadataIndex int, tenantRing ring.DoBatchRing, cleanup func()) error {
+func (d *Distributor) sendWriteRequestToBackends(ctx context.Context, tenantID string, req *mimirpb.WriteRequest, keys []uint32, initialMetadataIndex int, ingestersSubring, partitionsSubring ring.DoBatchRing, cleanup func()) error {
+	var (
+		wg            = sync.WaitGroup{}
+		partitionsErr error
+		ingestersErr  error
+	)
+
+	// Ensure at least one ring has been provided.
+	if ingestersSubring == nil && partitionsSubring == nil {
+		// It should never happen. If it happens, it's a logic bug.
+		panic("no tenant subring has been provided to sendWriteRequestToBackends()")
+	}
+
 	// Use an independent context to make sure all backend instances (e.g. ingesters) get samples even if we return early.
 	// It will still take a while to lookup the ring and calculate which instance gets which series,
 	// so we'll start the remote timeout once the first callback is called.
@@ -1380,14 +1400,53 @@ func (d *Distributor) sendWriteRequestToBackends(ctx context.Context, tenantID s
 		Go:            d.doBatchPushWorkers,
 	}
 
-	if d.cfg.IngestStorageConfig.Enabled {
-		return d.sendWriteRequestToPartitions(ctx, tenantID, tenantRing, req, keys, initialMetadataIndex, remoteRequestContext, batchOptions)
+	// Keep it easy if there's only 1 backend to write to.
+	if partitionsSubring == nil {
+		return d.sendWriteRequestToIngesters(ctx, ingestersSubring, req, keys, initialMetadataIndex, remoteRequestContext, batchOptions)
 	}
-	return d.sendWriteRequestToIngesters(ctx, tenantRing, req, keys, initialMetadataIndex, remoteRequestContext, batchOptions)
+	if ingestersSubring == nil {
+		return d.sendWriteRequestToPartitions(ctx, tenantID, partitionsSubring, req, keys, initialMetadataIndex, remoteRequestContext, batchOptions)
+	}
+
+	// Prepare a callback function that will call the input cleanup callback function only after
+	// the cleanup has been done for all backends.
+	cleanupWaitBackends := atomic.NewInt64(2)
+	batchOptions.Cleanup = func() {
+		if cleanupWaitBackends.Dec() == 0 {
+			batchCleanup()
+		}
+	}
+
+	// Write both to ingesters and partitions.
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		ingestersErr = d.sendWriteRequestToIngesters(ctx, ingestersSubring, req, keys, initialMetadataIndex, remoteRequestContext, batchOptions)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		partitionsErr = d.sendWriteRequestToPartitions(ctx, tenantID, partitionsSubring, req, keys, initialMetadataIndex, remoteRequestContext, batchOptions)
+	}()
+
+	// Wait until all backends have done.
+	wg.Wait()
+
+	// Ingester errors could be soft (e.g. 4xx) or hard errors (e.g. 5xx) errors, while partition errors are always hard
+	// errors. For this reason, it's important to give precedence to partition errors, otherwise the distributor may return
+	// a 4xx (ingester error) when it should actually be a 5xx (partition error).
+	// TODO unit test
+	if partitionsErr != nil {
+		return partitionsErr
+	}
+	return ingestersErr
 }
 
 func (d *Distributor) sendWriteRequestToIngesters(ctx context.Context, tenantRing ring.DoBatchRing, req *mimirpb.WriteRequest, keys []uint32, initialMetadataIndex int, remoteRequestContext func() context.Context, batchOptions ring.DoBatchOptions) error {
-	return ring.DoBatchWithOptions(ctx, ring.WriteNoExtend, tenantRing, keys,
+	err := ring.DoBatchWithOptions(ctx, ring.WriteNoExtend, tenantRing, keys,
 		func(ingester ring.InstanceDesc, indexes []int) error {
 			req := req.ForIndexes(indexes, initialMetadataIndex)
 
@@ -1406,10 +1465,13 @@ func (d *Distributor) sendWriteRequestToIngesters(ctx context.Context, tenantRin
 
 			return err
 		}, batchOptions)
+
+	// Since data may be written to different backends it may be helpful to clearly identify which backend failed.
+	return errors.Wrap(err, "send data to ingesters")
 }
 
 func (d *Distributor) sendWriteRequestToPartitions(ctx context.Context, tenantID string, tenantRing ring.DoBatchRing, req *mimirpb.WriteRequest, keys []uint32, initialMetadataIndex int, remoteRequestContext func() context.Context, batchOptions ring.DoBatchOptions) error {
-	return ring.DoBatchWithOptions(ctx, ring.WriteNoExtend, tenantRing, keys,
+	err := ring.DoBatchWithOptions(ctx, ring.WriteNoExtend, tenantRing, keys,
 		func(partition ring.InstanceDesc, indexes []int) error {
 			req := req.ForIndexes(indexes, initialMetadataIndex)
 
@@ -1427,6 +1489,9 @@ func (d *Distributor) sendWriteRequestToPartitions(ctx context.Context, tenantID
 			return err
 		}, batchOptions,
 	)
+
+	// Since data may be written to different backends it may be helpful to clearly identify which backend failed.
+	return errors.Wrap(err, "send data to partitions")
 }
 
 // getSeriesAndMetadataTokens returns a slice of tokens for the series and metadata from the request in this specific order.

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/grpcutil"
+	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/mtime"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/test"
@@ -422,15 +424,6 @@ func TestDistributor_Push_ShouldCleanupWriteRequestAfterWritingBothToIngestersAn
 	ctx := user.InjectOrgID(context.Background(), "user")
 	now := time.Now()
 
-	// To keep assertions simple, all tests send the same request.
-	createRequest := func() *mimirpb.WriteRequest {
-		return &mimirpb.WriteRequest{
-			Timeseries: []mimirpb.PreallocTimeseries{
-				makeTimeseries([]string{model.MetricNameLabel, "series_one"}, makeSamples(now.UnixMilli(), 1), nil),
-			},
-		}
-	}
-
 	testConfig := prepConfig{
 		numDistributors:         1,
 		numIngesters:            3,
@@ -471,7 +464,11 @@ func TestDistributor_Push_ShouldCleanupWriteRequestAfterWritingBothToIngestersAn
 	}
 
 	// Send write request.
-	_, err := distributors[0].Push(ctx, createRequest())
+	_, err := distributors[0].Push(ctx, &mimirpb.WriteRequest{
+		Timeseries: []mimirpb.PreallocTimeseries{
+			makeTimeseries([]string{model.MetricNameLabel, "series_one"}, makeSamples(now.UnixMilli(), 1), nil),
+		},
+	})
 	require.NoError(t, err)
 
 	// Since there's still 1 ingester in-flight request, we expect the cleanup function not being called yet.
@@ -495,6 +492,67 @@ func TestDistributor_Push_ShouldCleanupWriteRequestAfterWritingBothToIngestersAn
 	for _, ingester := range ingesters {
 		assert.Equal(t, []string{"series_one"}, ingester.metricNames(), "ingester ID: %s", ingester.instanceID())
 	}
+}
+
+func TestDistributor_Push_ShouldGivePrecedenceToPartitionsErrorWhenWritingBothToIngestersAndPartitions(t *testing.T) {
+	t.Parallel()
+
+	ctx := user.InjectOrgID(context.Background(), "user")
+	now := time.Now()
+
+	testConfig := prepConfig{
+		numDistributors:         1,
+		numIngesters:            1,
+		happyIngesters:          1,
+		replicationFactor:       1,
+		ingesterIngestionType:   ingesterIngestionTypeGRPC, // Do not consume from Kafka in this test.
+		ingestStorageEnabled:    true,
+		ingestStoragePartitions: 1,
+		limits:                  prepareDefaultLimits(),
+		configure: func(cfg *Config) {
+			cfg.IngestStorageConfig.Migration.DistributorSendToIngestersEnabled = true
+		},
+	}
+
+	distributors, ingesters, regs, kafkaCluster := prepare(t, testConfig)
+	require.Len(t, distributors, 1)
+	require.Len(t, ingesters, 1)
+	require.Len(t, regs, 1)
+
+	// Mock Kafka to return an hard error.
+	releaseProduceRequest := make(chan struct{})
+	kafkaCluster.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
+		kafkaCluster.KeepControl()
+
+		// Wait until released, then add an extra sleep to increase the likelihood this error
+		// will be returned after the ingester one.
+		<-releaseProduceRequest
+		time.Sleep(time.Second)
+
+		partitionID := req.(*kmsg.ProduceRequest).Topics[0].Partitions[0].Partition
+		res := testkafka.CreateProduceResponseError(req.GetVersion(), kafkaTopic, partitionID, kerr.InvalidTopicException)
+
+		return res, nil, true
+	})
+
+	// Mock ingester to return a soft error.
+	ingesters[0].registerBeforePushHook(func(_ context.Context, _ *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error, bool) {
+		// Release the Kafka produce request once the push to ingester has been received.
+		close(releaseProduceRequest)
+
+		ingesterErr := httpgrpc.Errorf(http.StatusBadRequest, "ingester error")
+		return &mimirpb.WriteResponse{}, ingesterErr, true
+	})
+
+	// Send write request.
+	_, err := distributors[0].Push(ctx, &mimirpb.WriteRequest{
+		Timeseries: []mimirpb.PreallocTimeseries{
+			makeTimeseries([]string{model.MetricNameLabel, "series_one"}, makeSamples(now.UnixMilli(), 1), nil),
+		},
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "send data to partitions")
 }
 
 func TestDistributor_UserStats_ShouldSupportIngestStorage(t *testing.T) {

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/mtime"
 	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/test"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
@@ -22,12 +25,14 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/mimir/pkg/cardinality"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/storage/ingest"
 	"github.com/grafana/mimir/pkg/util/extract"
 	"github.com/grafana/mimir/pkg/util/testkafka"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -70,7 +75,7 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 		"should shard series across all partitions when shuffle sharding is disabled": {
 			shardSize: 0,
 			expectedSeriesByPartition: map[int32][]string{
-				0: {"series_one", "series_three", "series_four"},
+				0: {"series_four", "series_one", "series_three"},
 				1: {"series_two"},
 				2: {"series_five"},
 			},
@@ -78,8 +83,8 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 		"should shard series across the number of configured partitions when shuffle sharding is enabled": {
 			shardSize: 2,
 			expectedSeriesByPartition: map[int32][]string{
-				1: {"series_one", "series_two", "series_three"},
-				2: {"series_four", "series_five"},
+				1: {"series_one", "series_three", "series_two"},
+				2: {"series_five", "series_four"},
 			},
 		},
 		"should return gRPC error if writing to 1 out of N partitions fail with a non-retryable error": {
@@ -91,7 +96,7 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 			expectedErr: fmt.Errorf(fmt.Sprintf("%s %d", failedPushingToPartitionMessage, 1)),
 			expectedSeriesByPartition: map[int32][]string{
 				// Partition 1 is missing because it failed.
-				0: {"series_one", "series_three", "series_four"},
+				0: {"series_four", "series_one", "series_three"},
 				2: {"series_five"},
 			},
 		},
@@ -108,7 +113,7 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 			expectedErr: context.DeadlineExceeded,
 			expectedSeriesByPartition: map[int32][]string{
 				// Partition 1 is missing because it failed.
-				0: {"series_one", "series_three", "series_four"},
+				0: {"series_four", "series_one", "series_three"},
 				2: {"series_five"},
 			},
 		},
@@ -175,21 +180,8 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 				assert.Equal(t, emptyResponse, res)
 			}
 
-			// Read all requests written to Kafka.
-			requestsByPartition := readAllRequestsByPartitionFromKafka(t, kafkaCluster.ListenAddrs(), testConfig.ingestStoragePartitions, time.Second)
-
 			// Ensure series has been sharded as expected.
-			actualSeriesByPartition := map[int32][]string{}
-
-			for partitionID, requests := range requestsByPartition {
-				for _, req := range requests {
-					for _, series := range req.Timeseries {
-						metricName, _ := extract.UnsafeMetricNameFromLabelAdapters(series.Labels)
-						actualSeriesByPartition[partitionID] = append(actualSeriesByPartition[partitionID], metricName)
-					}
-				}
-			}
-
+			actualSeriesByPartition := readAllMetricNamesByPartitionFromKafka(t, kafkaCluster.ListenAddrs(), testConfig.ingestStoragePartitions, time.Second)
 			assert.Equal(t, testData.expectedSeriesByPartition, actualSeriesByPartition)
 
 			// Asserts on tracked metrics.
@@ -263,6 +255,245 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 				"cortex_distributor_sample_delay_seconds",
 			))
 		})
+	}
+}
+
+func TestDistributor_Push_ShouldSupportWriteBothToIngestersAndPartitions(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), "user")
+	now := time.Now()
+
+	// To keep assertions simple, all tests send the same request.
+	createRequest := func() *mimirpb.WriteRequest {
+		return &mimirpb.WriteRequest{
+			Timeseries: []mimirpb.PreallocTimeseries{
+				makeTimeseries([]string{model.MetricNameLabel, "series_one"}, makeSamples(now.UnixMilli(), 1), nil),
+				makeTimeseries([]string{model.MetricNameLabel, "series_two"}, makeSamples(now.UnixMilli(), 2), nil),
+				makeTimeseries([]string{model.MetricNameLabel, "series_three"}, makeSamples(now.UnixMilli(), 3), nil),
+				makeTimeseries([]string{model.MetricNameLabel, "series_four"}, makeSamples(now.UnixMilli(), 4), nil),
+				makeTimeseries([]string{model.MetricNameLabel, "series_five"}, makeSamples(now.UnixMilli(), 5), nil),
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		shardSize                     int
+		shouldFailWritingToPartitions bool
+		shouldFailWritingToIngesters  bool
+		expectedErr                   string
+		expectedMetricsByPartition    map[int32][]string
+		expectedMetricsByIngester     map[string][]string
+	}{
+		"should shard series across all partitions when shuffle sharding is disabled": {
+			shardSize: 0,
+			expectedMetricsByPartition: map[int32][]string{
+				0: {"series_four", "series_one", "series_three"},
+				1: {"series_two"},
+				2: {"series_five"},
+			},
+			expectedMetricsByIngester: map[string][]string{
+				"ingester-0": {"series_four", "series_five"},
+				"ingester-1": {"series_one", "series_two", "series_three"},
+				"ingester-2": {},
+			},
+		},
+		"should shard series across the number of configured partitions / ingesters when shuffle sharding is enabled": {
+			shardSize: 2,
+			expectedMetricsByPartition: map[int32][]string{
+				1: {"series_one", "series_three", "series_two"},
+				2: {"series_five", "series_four"},
+			},
+			expectedMetricsByIngester: map[string][]string{
+				"ingester-0": {"series_four", "series_five"},
+				"ingester-1": {"series_one", "series_two", "series_three"},
+			},
+		},
+		"should return gRPC error if fails to write to ingesters": {
+			shouldFailWritingToIngesters: true,
+			expectedErr:                  failedPushingToIngesterMessage,
+		},
+		"should return gRPC error if fails to write to partitions": {
+			shouldFailWritingToPartitions: true,
+			expectedErr:                   failedPushingToPartitionMessage,
+		},
+	}
+
+	for testName, testData := range tests {
+		testData := testData
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			// Pre-condition: ensure that sharding is different between ingesters and partitions.
+			// This is required to ensure series are correctly sharded based on ingesters and partitions ring.
+			// If the sharding is the same, then we have no guarantee it's actually working as expected.
+			if len(testData.expectedMetricsByIngester) > 0 && len(testData.expectedMetricsByPartition) > 0 {
+				actualPartitionsSharding := map[string][]string{}
+				actualIngestersSharding := map[string][]string{}
+
+				for partitionID, partitionMetrics := range testData.expectedMetricsByPartition {
+					actualPartitionsSharding[strconv.Itoa(int(partitionID))] = slices.Clone(partitionMetrics)
+					slices.Sort(actualPartitionsSharding[strconv.Itoa(int(partitionID))])
+				}
+				for ingesterID, ingesterMetrics := range testData.expectedMetricsByIngester {
+					partitionID, err := ingest.IngesterPartitionID(ingesterID)
+					require.NoError(t, err)
+
+					actualIngestersSharding[strconv.Itoa(int(partitionID))] = slices.Clone(ingesterMetrics)
+					slices.Sort(actualIngestersSharding[strconv.Itoa(int(partitionID))])
+				}
+
+				require.NotEqual(t, actualPartitionsSharding, actualIngestersSharding)
+			}
+
+			// Setup distributors and ingesters.
+			limits := prepareDefaultLimits()
+			limits.IngestionPartitionsTenantShardSize = testData.shardSize
+			limits.IngestionTenantShardSize = testData.shardSize
+
+			testConfig := prepConfig{
+				numDistributors:         1,
+				numIngesters:            3,
+				happyIngesters:          3,
+				replicationFactor:       1,
+				ingesterIngestionType:   ingesterIngestionTypeGRPC, // Do not consume from Kafka. Partitions are asserted directly checking Kafka.
+				ingestStorageEnabled:    true,
+				ingestStoragePartitions: 3,
+				limits:                  limits,
+				configure: func(cfg *Config) {
+					cfg.IngestStorageConfig.Migration.DistributorSendToIngestersEnabled = true
+				},
+			}
+
+			distributors, ingesters, regs, kafkaCluster := prepare(t, testConfig)
+			require.Len(t, distributors, 1)
+			require.Len(t, ingesters, 3)
+			require.Len(t, regs, 1)
+
+			if testData.shouldFailWritingToPartitions {
+				kafkaCluster.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
+					kafkaCluster.KeepControl()
+
+					partitionID := req.(*kmsg.ProduceRequest).Topics[0].Partitions[0].Partition
+					res := testkafka.CreateProduceResponseError(req.GetVersion(), kafkaTopic, partitionID, kerr.InvalidTopicException)
+
+					return res, nil, true
+				})
+			}
+
+			if testData.shouldFailWritingToIngesters {
+				for _, ingester := range ingesters {
+					ingester.happy = false
+				}
+			}
+
+			// Send write request.
+			_, err := distributors[0].Push(ctx, createRequest())
+
+			if testData.expectedErr != "" {
+				require.Error(t, err)
+
+				// We expect a gRPC error.
+				errStatus, ok := grpcutil.ErrorToStatus(err)
+				require.True(t, ok)
+				assert.Equal(t, codes.Internal, errStatus.Code())
+				assert.ErrorContains(t, errStatus.Err(), testData.expectedErr)
+
+				// End the test here.
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Ensure series has been correctly sharded to partitions.
+			actualSeriesByPartition := readAllMetricNamesByPartitionFromKafka(t, kafkaCluster.ListenAddrs(), testConfig.ingestStoragePartitions, time.Second)
+			assert.Equal(t, testData.expectedMetricsByPartition, actualSeriesByPartition)
+
+			// Ensure series have been correctly sharded to ingesters.
+			for _, ingester := range ingesters {
+				assert.ElementsMatchf(t, testData.expectedMetricsByIngester[ingester.instanceID()], ingester.metricNames(), "ingester ID: %s", ingester.instanceID())
+			}
+		})
+	}
+}
+
+func TestDistributor_Push_ShouldCleanupWriteRequestAfterWritingBothToIngestersAndPartitions(t *testing.T) {
+	t.Parallel()
+
+	ctx := user.InjectOrgID(context.Background(), "user")
+	now := time.Now()
+
+	// To keep assertions simple, all tests send the same request.
+	createRequest := func() *mimirpb.WriteRequest {
+		return &mimirpb.WriteRequest{
+			Timeseries: []mimirpb.PreallocTimeseries{
+				makeTimeseries([]string{model.MetricNameLabel, "series_one"}, makeSamples(now.UnixMilli(), 1), nil),
+			},
+		}
+	}
+
+	testConfig := prepConfig{
+		numDistributors:         1,
+		numIngesters:            3,
+		happyIngesters:          3,
+		replicationFactor:       3,
+		ingesterIngestionType:   ingesterIngestionTypeGRPC, // Do not consume from Kafka in this test.
+		ingestStorageEnabled:    true,
+		ingestStoragePartitions: 1,
+		limits:                  prepareDefaultLimits(),
+		configure: func(cfg *Config) {
+			cfg.IngestStorageConfig.Migration.DistributorSendToIngestersEnabled = true
+		},
+	}
+
+	distributors, ingesters, regs, kafkaCluster := prepare(t, testConfig)
+	require.Len(t, distributors, 1)
+	require.Len(t, ingesters, 3)
+	require.Len(t, regs, 1)
+
+	// In this test ingesters have been configured with RF=3. This means that the write request will succeed
+	// once written to at least 2 out of 3 ingesters. We configure 1 ingester to block the Push() request, and
+	// then we control when unblocking it.
+	releaseSlowIngesterPush := make(chan struct{})
+	ingesters[0].registerBeforePushHook(func(_ context.Context, _ *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error, bool) {
+		<-releaseSlowIngesterPush
+		return nil, nil, false
+	})
+
+	// Wrap the distributor Push() to inject a custom cleanup function, so that we can track when it gets called.
+	pushCleanupCallsCount := atomic.NewInt64(0)
+	origPushWithMiddlewares := distributors[0].PushWithMiddlewares
+	distributors[0].PushWithMiddlewares = func(ctx context.Context, req *Request) error {
+		req.AddCleanup(func() {
+			pushCleanupCallsCount.Inc()
+		})
+
+		return origPushWithMiddlewares(ctx, req)
+	}
+
+	// Send write request.
+	_, err := distributors[0].Push(ctx, createRequest())
+	require.NoError(t, err)
+
+	// Since there's still 1 ingester in-flight request, we expect the cleanup function not being called yet.
+	require.Equal(t, int64(0), pushCleanupCallsCount.Load())
+	time.Sleep(time.Second)
+	require.Equal(t, int64(0), pushCleanupCallsCount.Load())
+
+	// Unblock the slow ingester.
+	close(releaseSlowIngesterPush)
+
+	// Now we expect the cleanup function being called as soon as the request to the slow ingester completes.
+	test.Poll(t, time.Second, int64(1), func() interface{} {
+		return pushCleanupCallsCount.Load()
+	})
+
+	// Ensure series has been correctly written to partitions.
+	actualSeriesByPartition := readAllMetricNamesByPartitionFromKafka(t, kafkaCluster.ListenAddrs(), testConfig.ingestStoragePartitions, time.Second)
+	assert.Equal(t, map[int32][]string{0: {"series_one"}}, actualSeriesByPartition)
+
+	// Ensure series have been correctly sharded to ingesters.
+	for _, ingester := range ingesters {
+		assert.Equal(t, []string{"series_one"}, ingester.metricNames(), "ingester ID: %s", ingester.instanceID())
 	}
 }
 
@@ -1209,4 +1440,22 @@ func readAllRequestsByPartitionFromKafka(t testing.TB, kafkaAddresses []string, 
 	}
 
 	return requestsByPartition
+}
+
+func readAllMetricNamesByPartitionFromKafka(t testing.TB, kafkaAddresses []string, numPartitions int32, timeout time.Duration) map[int32][]string {
+	requestsByPartition := readAllRequestsByPartitionFromKafka(t, kafkaAddresses, numPartitions, timeout)
+	actualSeriesByPartition := map[int32][]string{}
+
+	for partitionID, requests := range requestsByPartition {
+		for _, req := range requests {
+			for _, series := range req.Timeseries {
+				metricName, _ := extract.UnsafeMetricNameFromLabelAdapters(series.Labels)
+				actualSeriesByPartition[partitionID] = append(actualSeriesByPartition[partitionID], metricName)
+			}
+		}
+
+		slices.Sort(actualSeriesByPartition[partitionID])
+	}
+
+	return actualSeriesByPartition
 }

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -26,14 +26,16 @@ var (
 )
 
 type Config struct {
-	Enabled     bool        `yaml:"enabled"`
-	KafkaConfig KafkaConfig `yaml:"kafka"`
+	Enabled     bool            `yaml:"enabled"`
+	KafkaConfig KafkaConfig     `yaml:"kafka"`
+	Migration   MigrationConfig `yaml:"migration"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.Enabled, "ingest-storage.enabled", false, "True to enable the ingestion via object storage.")
 
 	cfg.KafkaConfig.RegisterFlagsWithPrefix("ingest-storage.kafka", f)
+	cfg.Migration.RegisterFlagsWithPrefix("ingest-storage.migration", f)
 }
 
 // Validate the config.
@@ -100,4 +102,18 @@ func (cfg *KafkaConfig) Validate() error {
 	}
 
 	return nil
+}
+
+// MigrationConfig holds the configuration used to migrate Mimir to ingest storage. This config shouldn't be
+// set for any other reason.
+type MigrationConfig struct {
+	DistributorSendToIngestersEnabled bool `yaml:"distributor_send_to_ingesters_enabled"`
+}
+
+func (cfg *MigrationConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("", f)
+}
+
+func (cfg *MigrationConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.BoolVar(&cfg.DistributorSendToIngestersEnabled, prefix+".distributor-send-to-ingesters-enabled", false, "When both this option and ingest storage is enabled, distributors will both write to Kafka and ingesters. A write request will be considered successful only when written to both backends.")
 }


### PR DESCRIPTION
#### What this PR does

As part of the experimental ingest storage project, we're working on a migration path from a classic Mimir architecture (where distributors directly write to ingesters) to the ingest storage architecture (where distributors write to Kafka and ingesters consume from Kafka). In the migration procedure we designed, we need a way to tee writes both to ingesters and Kafka when the migration is on-going.

In this PR I'm proposing to add such feature to distributors. The code changes are relatively small, since we already support to either write to ingesters or Kafka (partitions). So what I'm doing in this PR is adding an option to do both at the same time (concurrently).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
