### PR TITLE
chore:mixin update deps to pick up upstream fix

### DIFF
--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "f95501009c9b29bed87fe9d57c1a6e72e210f137",
+      "version": "653836fa707a591b36fe490be350b1540e4f14ce",
       "sum": "+z5VY+bPBNqXcmNAV8xbJcbsRA+pro1R3IM7aIY8OlU="
     },
     {
@@ -18,8 +18,8 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "f95501009c9b29bed87fe9d57c1a6e72e210f137",
-      "sum": "0jg7qc3N8FtMnnQbunYCGSNcjHr9Y1krZW9OSTmWcEQ="
+      "version": "653836fa707a591b36fe490be350b1540e4f14ce",
+      "sum": "wi1o6t5nUZVcsatqMdGLOWIv1HxNnlaE84oRE0Cl0ec="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

On my quest to make the mixin work with scrape interval of `1m` I found one more place with hardcoded range_interval of `1m`. I fixed it in the upstream repo. Now I need to update the mixin dependencies to pick up the fix.

#### What this PR does

Updating the mixin dependencies to pick up this fix  https://github.com/grafana/jsonnet-libs/pull/1190

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
