### PR TITLE
Make compactor's max_unavailable work with odd number of replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 ### Jsonnet
 
 * [CHANGE] Memcached: Change default read timeout for chunks and index caches to `750ms` from `450ms`. #7778
-* [ENHANCEMENT] Compactor: add `$._config.cortex_compactor_concurrent_rollout_enabled` option (disabled by default) that makes use of rollout-operator to speed up the rollout of compactors. #7783
+* [ENHANCEMENT] Compactor: add `$._config.cortex_compactor_concurrent_rollout_enabled` option (disabled by default) that makes use of rollout-operator to speed up the rollout of compactors. #7783 #7878
 * [ENHANCEMENT] Shuffle-sharding: add `$._config.shuffle_sharding.ingest_storage_partitions_enabled` and `$._config.shuffle_sharding.ingester_partitions_shard_size` options, that allow configuring partitions shard size in ingest-storage mode. #7804
 * [BUGFIX] Guard against missing samples in KEDA queries. #7691
 

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -860,7 +860,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
-    rollout-max-unavailable: "8"
+    rollout-max-unavailable: "7"
   labels:
     name: compactor
     rollout-group: compactor
@@ -868,7 +868,7 @@ metadata:
   namespace: default
 spec:
   podManagementPolicy: Parallel
-  replicas: 16
+  replicas: 15
   selector:
     matchLabels:
       name: compactor

--- a/operations/mimir-tests/test-compactor-concurrent-rollout.jsonnet
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout.jsonnet
@@ -12,5 +12,5 @@ mimir {
   },
 
   compactor_statefulset+:
-    $.apps.v1.statefulSet.mixin.spec.withReplicas(16),
+    $.apps.v1.statefulSet.mixin.spec.withReplicas(15),
 }

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -96,7 +96,7 @@
     // This feature modifies the compactor StatefulSet which cannot be altered, so if it already exists it has to be deleted and re-applied again in order to be enabled.
     cortex_compactor_concurrent_rollout_enabled: false,
     // Maximum number of unavailable replicas during a compactor rollout when using cortex_compactor_concurrent_rollout_enabled feature.
-    cortex_compactor_max_unavailable: std.max($.compactor_statefulset.spec.replicas / 2, 1),
+    cortex_compactor_max_unavailable: std.max(std.floor($.compactor_statefulset.spec.replicas / 2), 1),
 
     // Enable use of bucket index by querier, ruler and store-gateway.
     bucket_index_enabled: true,


### PR DESCRIPTION
#### What this PR does

This PR makes compactor's `max_unavailable` work with odd number of replicas.

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
