### PR TITLE
Always enable partition ring codec

### DIFF
--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -979,9 +979,7 @@ func (t *Mimir) initStoreGateway() (serv services.Service, err error) {
 func (t *Mimir) initMemberlistKV() (services.Service, error) {
 	// Append to the list of codecs instead of overwriting the value to allow third parties to inject their own codecs.
 	t.Cfg.MemberlistKV.Codecs = append(t.Cfg.MemberlistKV.Codecs, ring.GetCodec())
-	if t.Cfg.IngestStorage.Enabled {
-		t.Cfg.MemberlistKV.Codecs = append(t.Cfg.MemberlistKV.Codecs, ring.GetPartitionRingCodec())
-	}
+	t.Cfg.MemberlistKV.Codecs = append(t.Cfg.MemberlistKV.Codecs, ring.GetPartitionRingCodec())
 
 	dnsProviderReg := prometheus.WrapRegistererWithPrefix(
 		"cortex_",


### PR DESCRIPTION
#### What this PR does

I'm working on a migration procedure from Mimir classic architecture to ingest storage. During the migration we'll have some Mimir components with ingest storage enabled, and others with ingest storage disabled. However, all components form a unique memberlist cluster, so we need to make sure that partition ring changes get propagated correctly. To make it happen, we need to make sure that the partition ring memberlist codec is always enabled.

History: when we introduced the partition ring, and it was still under development, we decided to not register the codec by default as a safety countermeasure. We're now testing the ingest storage since a while, so I think it's safe to enable the codec by default.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
