### PR TITLE
operations: Upgrade rollout-operator to v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
   * Query-scheduler: changed from `30` to `180`
 * [ENHANCEMENT] Compactor: add `$._config.cortex_compactor_concurrent_rollout_enabled` option (disabled by default) that makes use of rollout-operator to speed up the rollout of compactors. #7783 #7878
 * [ENHANCEMENT] Shuffle-sharding: add `$._config.shuffle_sharding.ingest_storage_partitions_enabled` and `$._config.shuffle_sharding.ingester_partitions_shard_size` options, that allow configuring partitions shard size in ingest-storage mode. #7804
+* [ENHANCEMENT] Rollout-operator: upgrade to v0.14.0.
 * [BUGFIX] Guard against missing samples in KEDA queries. #7691
 
 ### Mimirtool

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -43,6 +43,7 @@ Entries should include a reference to the Pull Request that introduced the chang
   * Results-cache: changed from `60` to `30`
 * [ENHANCEMENT] Dashboards: allow switching between using classic of native histograms in dashboards. #7627
   * Overview dashboard, Status panel, `cortex_request_duration_seconds` metric.
+* [ENHANCEMENT] Rollout-operator: upgrade to v0.14.0. #7886
 
 ## 5.3.0
 

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.3.20
 - name: rollout-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.14.0
-digest: sha256:8696047fdb4e5365086caa05d26796d45a49716d0dda159b9d50789191660524
-generated: "2024-04-08T01:38:16.315284364Z"
+  version: 0.15.0
+digest: sha256:db4d95855a4d9e5e77e84d25b70d09f87170dccaae6860e7268372f2068664eb
+generated: "2024-04-12T09:50:39.876851322+02:00"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
   - name: rollout-operator
     alias: rollout_operator
     repository: https://grafana.github.io/helm-charts
-    version: 0.14.0
+    version: 0.15.0
     condition: rollout_operator.enabled

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -26,7 +26,7 @@ Kubernetes: `^1.20.0-0`
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.0.14 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.3.20 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.14.0 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.15.0 |
 
 # Contributing and releasing
 

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: enterprise-https-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: enterprise-https-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: enterprise-https-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: enterprise-https-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: gateway-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: gateway-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: gateway-nginx-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: gateway-nginx-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: keda-autoscaling-global-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: keda-autoscaling-global-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: keda-autoscaling-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: keda-autoscaling-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: large-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: large-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: openshift-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -40,7 +40,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: openshift-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: scheduler-name-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: scheduler-name-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: small-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: small-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-enterprise-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-ingress-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-ingress-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-multizone-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-requests-and-limits-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-requests-and-limits-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: test-vault-agent-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.13.0"
+          image: "grafana/rollout-operator:v0.14.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: test-vault-agent-values-rollout-operator
   labels:
-    helm.sh/chart: rollout-operator-0.14.0
+    helm.sh/chart: rollout-operator-0.15.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.13.0"
+    app.kubernetes.io/version: "v0.14.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1016,7 +1016,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -836,7 +836,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1387,7 +1387,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1417,7 +1417,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1016,7 +1016,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1084,7 +1084,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1016,7 +1016,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -619,7 +619,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -482,7 +482,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -620,7 +620,7 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        image: grafana/rollout-operator:v0.13.0
+        image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -28,6 +28,6 @@
     mimir_backend: self.mimir,
 
     // See: https://github.com/grafana/rollout-operator
-    rollout_operator: 'grafana/rollout-operator:v0.13.0',
+    rollout_operator: 'grafana/rollout-operator:v0.14.0',
   },
 }


### PR DESCRIPTION
#### What this PR does

Upgrade rollout-operator to v0.14.0, which we've been running in production for a while. The corresponding Helm chart is [v0.15.0](https://github.com/grafana/helm-charts/pull/3076).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
