### PR TITLE
storage/ingest: Support for consume-from-position-at-startup=timestamp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,9 +71,9 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/prometheus/procfs v0.12.0
 	github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03
-	github.com/twmb/franz-go v1.15.4
+	github.com/twmb/franz-go v1.16.1
 	github.com/twmb/franz-go/pkg/kadm v1.10.0
-	github.com/twmb/franz-go/pkg/kfake v0.0.0-20231206062516-c09dc92d2db1
+	github.com/twmb/franz-go/pkg/kfake v0.0.0-20240412162337-6a58760afaa7
 	github.com/twmb/franz-go/pkg/kmsg v1.7.0
 	github.com/twmb/franz-go/plugin/kprom v1.1.0
 	github.com/xlab/treeprint v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -885,12 +885,12 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.40/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7y
 github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03 h1:VEu81Atmor2RVr5iGzlLc7E8X9jd1ux0ze4Ie5Qw8n0=
 github.com/thanos-io/objstore v0.0.0-20240128223450-bdadaefbfe03/go.mod h1:RMvJQnpB4QQiYGg1gF8mnPJg6IkIPY28Buh8f6b+F0c=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/twmb/franz-go v1.15.4 h1:qBCkHaiutetnrXjAUWA99D9FEcZVMt2AYwkH3vWEQTw=
-github.com/twmb/franz-go v1.15.4/go.mod h1:rC18hqNmfo8TMc1kz7CQmHL74PLNF8KVvhflxiiJZCU=
+github.com/twmb/franz-go v1.16.1 h1:rpWc7fB9jd7TgmCyfxzenBI+QbgS8ZfJOUQE+tzPtbE=
+github.com/twmb/franz-go v1.16.1/go.mod h1:/pER254UPPGp/4WfGqRi+SIRGE50RSQzVubQp6+N4FA=
 github.com/twmb/franz-go/pkg/kadm v1.10.0 h1:3oYKNP+e3HGo4GYadrDeRxOaAIsOXmX6LBVMz9PxpCU=
 github.com/twmb/franz-go/pkg/kadm v1.10.0/go.mod h1:hUMoV4SRho+2ij/S9cL39JaLsr+XINjn0ZkCdBY2DXc=
-github.com/twmb/franz-go/pkg/kfake v0.0.0-20231206062516-c09dc92d2db1 h1:xbSGm02av1df+hkaY+2jGfkuj/XwGaDnUpLo0VvOrY0=
-github.com/twmb/franz-go/pkg/kfake v0.0.0-20231206062516-c09dc92d2db1/go.mod h1:n45fs28DdNx7PRAiYwBTwOORJGUMGqHzmFlr0pcW+BY=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20240412162337-6a58760afaa7 h1:ehifEfv6+joNOFrOZ7vRDcgeAJsOIrav2MrZbGhK2MA=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20240412162337-6a58760afaa7/go.mod h1:DCMFat7WCZfk946rqd9aVAcAmB6/rIcdMTslJSjJZgk=
 github.com/twmb/franz-go/pkg/kmsg v1.7.0 h1:a457IbvezYfA5UkiBvyV3zj0Is3y1i8EJgqjJYoij2E=
 github.com/twmb/franz-go/pkg/kmsg v1.7.0/go.mod h1:se9Mjdt0Nwzc9lnjJ0HyDtLyBnaBDAd7pCje47OhSyw=
 github.com/twmb/franz-go/plugin/kprom v1.1.0 h1:grGeIJbm4llUBF8jkDjTb/b8rKllWSXjMwIqeCCcNYQ=

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -15,6 +15,7 @@ const (
 	consumeFromLastOffset = "last-offset"
 	consumeFromStart      = "start"
 	consumeFromEnd        = "end"
+	consumeFromTimestamp  = "timestamp"
 )
 
 var (
@@ -22,7 +23,7 @@ var (
 	ErrMissingKafkaTopic      = errors.New("the Kafka topic has not been configured")
 	ErrInvalidConsumePosition = errors.New("the configured consume position is invalid")
 
-	consumeFromPositionOptions = []string{consumeFromLastOffset, consumeFromStart, consumeFromEnd}
+	consumeFromPositionOptions = []string{consumeFromLastOffset, consumeFromStart, consumeFromEnd, consumeFromTimestamp}
 )
 
 type Config struct {
@@ -63,8 +64,9 @@ type KafkaConfig struct {
 	LastProducedOffsetPollInterval time.Duration `yaml:"last_produced_offset_poll_interval"`
 	LastProducedOffsetRetryTimeout time.Duration `yaml:"last_produced_offset_retry_timeout"`
 
-	ConsumeFromPositionAtStartup string        `yaml:"consume_from_position_at_startup"`
-	MaxConsumerLagAtStartup      time.Duration `yaml:"max_consumer_lag_at_startup"`
+	ConsumeFromPositionAtStartup  string        `yaml:"consume_from_position_at_startup"`
+	ConsumeFromTimestampAtStartup int64         `yaml:"consume_from_timestamp_at_startup"`
+	MaxConsumerLagAtStartup       time.Duration `yaml:"max_consumer_lag_at_startup"`
 
 	AutoCreateTopicEnabled           bool `yaml:"auto_create_topic_enabled"`
 	AutoCreateTopicDefaultPartitions int  `yaml:"auto_create_topic_default_partitions"`
@@ -85,6 +87,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.DurationVar(&cfg.LastProducedOffsetRetryTimeout, prefix+".last-produced-offset-retry-timeout", 10*time.Second, "How long to retry a failed request to get the last produced offset.")
 
 	f.StringVar(&cfg.ConsumeFromPositionAtStartup, prefix+".consume-from-position-at-startup", consumeFromLastOffset, fmt.Sprintf("From which position to start consuming the partition at startup. Supported options: %s.", strings.Join(consumeFromPositionOptions, ", ")))
+	f.Int64Var(&cfg.ConsumeFromTimestampAtStartup, prefix+".consume-from-timestamp-at-startup", 0, fmt.Sprintf("Milliseconds timestamp after which the consumption of the partition starts at startup. Only applies when consume-from-position-at-startup is %s", consumeFromTimestamp))
 	f.DurationVar(&cfg.MaxConsumerLagAtStartup, prefix+".max-consumer-lag-at-startup", 15*time.Second, "The maximum tolerated lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set 0 to disable waiting for maximum consumer lag being honored at startup.")
 	f.BoolVar(&cfg.AutoCreateTopicEnabled, prefix+".auto-create-topic-enabled", true, "Enable auto-creation of Kafka topic if it doesn't exist.")
 	f.IntVar(&cfg.AutoCreateTopicDefaultPartitions, prefix+".auto-create-topic-default-partitions", 0, "When auto-creation of Kafka topic is enabled and this value is positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that Kafka broker will use for auto-created topics. Note that this is Kafka-cluster wide setting, and applies to any auto-created topic. If setting of num.partitions fails, Mimir will proceed anyway, but auto-created topic may have incorrect number of partitions.")
@@ -99,6 +102,16 @@ func (cfg *KafkaConfig) Validate() error {
 	}
 	if !slices.Contains(consumeFromPositionOptions, cfg.ConsumeFromPositionAtStartup) {
 		return ErrInvalidConsumePosition
+	}
+	if cfg.ConsumeFromPositionAtStartup == consumeFromTimestamp {
+		// We only do a simple soundness check for the value be a millisecond precision timestamp.
+		if cfg.ConsumeFromTimestampAtStartup < 1e12 {
+			return fmt.Errorf("%w: configured timestamp must be a millisecond timestamp", ErrInvalidConsumePosition)
+		}
+	} else {
+		if cfg.ConsumeFromTimestampAtStartup > 0 {
+			return fmt.Errorf("%w: configured consume position must be set to %q", ErrInvalidConsumePosition, consumeFromTimestamp)
+		}
 	}
 
 	return nil

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -161,7 +161,7 @@ func (p *partitionOffsetReader) FetchLastProducedOffset(ctx context.Context) (_ 
 		}
 	}()
 
-	offset, err := p.fetchPartitionOffset(ctx, kafkaEndOffset)
+	offset, err := p.fetchPartitionOffset(ctx, kafkaOffsetEnd)
 	if err != nil {
 		return 0, err
 	}
@@ -188,7 +188,7 @@ func (p *partitionOffsetReader) FetchPartitionStartOffset(ctx context.Context) (
 		}
 	}()
 
-	return p.fetchPartitionOffset(ctx, kafkaStartOffset)
+	return p.fetchPartitionOffset(ctx, kafkaOffsetStart)
 }
 
 func (p *partitionOffsetReader) fetchPartitionOffset(ctx context.Context, position int64) (int64, error) {

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -25,11 +25,11 @@ import (
 )
 
 const (
-	// kafkaStartOffset is a special offset value that means the beginning of the partition.
-	kafkaStartOffset = int64(-2)
+	// kafkaOffsetStart is a special offset value that means the beginning of the partition.
+	kafkaOffsetStart = int64(-2)
 
-	// kafkaEndOffset is a special offset value that means the end of the partition.
-	kafkaEndOffset = int64(-1)
+	// kafkaOffsetEnd is a special offset value that means the end of the partition.
+	kafkaOffsetEnd = int64(-1)
 )
 
 type record struct {
@@ -101,38 +101,9 @@ func (r *PartitionReader) start(ctx context.Context) (returnErr error) {
 		}
 	}()
 
-	var (
-		lastConsumedOffset int64
-		startOffset        int64
-		err                error
-	)
-
-	// Find the offset from which we should start consuming.
-	switch r.kafkaCfg.ConsumeFromPositionAtStartup {
-	case consumeFromStart:
-		lastConsumedOffset = -1
-		startOffset = kafkaStartOffset
-		level.Info(r.logger).Log("msg", "starting consumption from partition start", "start_offset", startOffset, "consumer_group", r.consumerGroup)
-
-	case consumeFromEnd:
-		lastConsumedOffset = -1
-		startOffset = kafkaEndOffset
-		level.Warn(r.logger).Log("msg", "starting consumption from partition end (may cause data loss)", "start_offset", startOffset, "consumer_group", r.consumerGroup)
-
-	default:
-		var exists bool
-		lastConsumedOffset, exists, err = r.fetchLastCommittedOffsetWithRetries(ctx)
-
-		if err != nil {
-			return err
-		} else if exists {
-			startOffset = lastConsumedOffset + 1 // We'll have to start consuming from the next offset (included).
-			level.Info(r.logger).Log("msg", "starting consumption from last consumed offset", "last_consumed_offset", lastConsumedOffset, "start_offset", startOffset, "consumer_group", r.consumerGroup)
-		} else {
-			lastConsumedOffset = -1
-			startOffset = kafkaStartOffset
-			level.Info(r.logger).Log("msg", "starting consumption from partition start because no committed offset has been found", "start_offset", startOffset, "consumer_group", r.consumerGroup)
-		}
+	startOffset, lastConsumedOffset, err := r.getStartOffset(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Initialise the last consumed offset only if we've got an actual offset from the consumer group.
@@ -159,7 +130,7 @@ func (r *PartitionReader) start(ctx context.Context) (returnErr error) {
 
 	// Enforce the max consumer lag (if enabled).
 	if maxLag := r.kafkaCfg.MaxConsumerLagAtStartup; maxLag > 0 {
-		if startOffset != kafkaEndOffset {
+		if startOffset != kafkaOffsetEnd {
 			if err := r.processNextFetchesUntilMaxLagHonored(ctx, maxLag); err != nil {
 				return err
 			}
@@ -437,22 +408,73 @@ func (r *PartitionReader) newKafkaReader(at kgo.Offset) (*kgo.Client, error) {
 	return client, nil
 }
 
-func (r *PartitionReader) fetchLastCommittedOffsetWithRetries(ctx context.Context) (offset int64, exists bool, err error) {
-	var (
-		retry = backoff.New(ctx, backoff.Config{
-			MinBackoff: 100 * time.Millisecond,
-			MaxBackoff: 2 * time.Second,
-			MaxRetries: 10,
-		})
-	)
+func (r *PartitionReader) getStartOffset(ctx context.Context) (startOffset, lastConsumedOffset int64, err error) {
+	switch r.kafkaCfg.ConsumeFromPositionAtStartup {
+	case consumeFromStart:
+		startOffset = kafkaOffsetStart
+		level.Info(r.logger).Log("msg", "starting consumption from partition start", "start_offset", startOffset, "consumer_group", r.consumerGroup)
+		return startOffset, -1, nil
 
-	for retry.Ongoing() {
-		offset, exists, err = r.fetchLastCommittedOffset(ctx)
-		if err == nil {
-			return offset, exists, nil
+	case consumeFromEnd:
+		startOffset = kafkaOffsetEnd
+		level.Warn(r.logger).Log("msg", "starting consumption from partition end (may cause data loss)", "start_offset", startOffset, "consumer_group", r.consumerGroup)
+		return startOffset, -1, nil
+	}
+
+	// We use an ephemeral client to fetch the offset and then create a new client with this offset.
+	// The reason for this is that changing the offset of an existing client requires to have used this client for fetching at least once.
+	// We don't want to do noop fetches just to warm up the client, so we create a new client instead.
+	cl, err := kgo.NewClient(commonKafkaClientOptions(r.kafkaCfg, r.metrics.kprom, r.logger)...)
+	if err != nil {
+		return 0, -1, fmt.Errorf("unable to create bootstrap client: %w", err)
+	}
+	defer cl.Close()
+
+	// lastConsumedOffset is unknown until (and only if) we successfully fetch its value below.
+	lastConsumedOffset = -1
+
+	fetchOffset := func(ctx context.Context) (offset int64, err error) {
+		if r.kafkaCfg.ConsumeFromPositionAtStartup == consumeFromTimestamp {
+			ts := time.UnixMilli(r.kafkaCfg.ConsumeFromTimestampAtStartup)
+			offset, exists, err := r.fetchFirstOffsetAfterTime(ctx, cl, ts)
+			if err != nil {
+				return 0, err
+			}
+			if exists {
+				level.Info(r.logger).Log("msg", "starting consumption from timestamp", "timestamp", ts.UnixMilli(), "start_offset", offset, "consumer_group", r.consumerGroup)
+				return offset, nil
+			}
+		} else {
+			offset, exists, err := r.fetchLastCommittedOffset(ctx, cl)
+			if err != nil {
+				return 0, err
+			}
+			if exists {
+				lastConsumedOffset = offset
+				offset = lastConsumedOffset + 1 // We'll have to start consuming from the next offset (included).
+				level.Info(r.logger).Log("msg", "starting consumption from last consumed offset", "last_consumed_offset", offset, "start_offset", offset, "consumer_group", r.consumerGroup)
+				return offset, nil
+			}
 		}
 
-		level.Warn(r.logger).Log("msg", "failed to fetch last committed offset", "err", err)
+		offset = kafkaOffsetStart
+		level.Info(r.logger).Log("msg", "starting consumption from partition start because no offset has been found", "start_offset", offset, "consumer_group", r.consumerGroup)
+
+		return offset, err
+	}
+
+	retry := backoff.New(ctx, backoff.Config{
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 2 * time.Second,
+		MaxRetries: 10,
+	})
+	for retry.Ongoing() {
+		startOffset, err = fetchOffset(ctx)
+		if err == nil {
+			return startOffset, lastConsumedOffset, nil
+		}
+
+		level.Warn(r.logger).Log("msg", "failed to fetch offset", "err", err)
 		retry.Wait()
 	}
 
@@ -461,28 +483,18 @@ func (r *PartitionReader) fetchLastCommittedOffsetWithRetries(ctx context.Contex
 		err = retry.Err()
 	}
 
-	return 0, false, err
+	return 0, -1, err
 }
 
 // fetchLastCommittedOffset returns the last consumed offset which has been committed by the PartitionReader
 // to the consumer group.
-func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context) (offset int64, exists bool, _ error) {
-	// We use an ephemeral client to fetch the offset and then create a new client with this offset.
-	// The reason for this is that changing the offset of an existing client requires to have used this client for fetching at least once.
-	// We don't want to do noop fetches just to warm up the client, so we create a new client instead.
-	cl, err := kgo.NewClient(commonKafkaClientOptions(r.kafkaCfg, r.metrics.kprom, r.logger)...)
-	if err != nil {
-		return 0, false, errors.Wrap(err, "unable to create admin client")
-	}
-	adm := kadm.NewClient(cl)
-	defer adm.Close()
-
-	offsets, err := adm.FetchOffsets(ctx, r.consumerGroup)
+func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context, cl *kgo.Client) (offset int64, exists bool, _ error) {
+	offsets, err := kadm.NewClient(cl).FetchOffsets(ctx, r.consumerGroup)
 	if errors.Is(err, kerr.GroupIDNotFound) || errors.Is(err, kerr.UnknownTopicOrPartition) {
 		return 0, false, nil
 	}
 	if err != nil {
-		return 0, false, errors.Wrap(err, "unable to fetch group offsets")
+		return 0, false, fmt.Errorf("unable to fetch group offsets: %w", err)
 	}
 
 	offsetRes, exists := offsets.Lookup(r.kafkaCfg.Topic, r.partitionID)
@@ -494,6 +506,27 @@ func (r *PartitionReader) fetchLastCommittedOffset(ctx context.Context) (offset 
 	}
 
 	return offsetRes.At, true, nil
+}
+
+// fetchFirstOffsetAfterMilli returns the first offset after the requested millisecond timestamp.
+func (r *PartitionReader) fetchFirstOffsetAfterTime(ctx context.Context, cl *kgo.Client, ts time.Time) (offset int64, exists bool, _ error) {
+	offsets, err := kadm.NewClient(cl).ListOffsetsAfterMilli(ctx, ts.UnixMilli(), r.kafkaCfg.Topic)
+	if errors.Is(err, kerr.UnknownTopicOrPartition) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("unable to list topic offsets: %w", err)
+	}
+
+	offsetRes, exists := offsets.Lookup(r.kafkaCfg.Topic, r.partitionID)
+	if !exists {
+		return 0, false, nil
+	}
+	if offsetRes.Err != nil {
+		return 0, false, offsetRes.Err
+	}
+
+	return offsetRes.Offset, true, nil
 }
 
 // WaitReadConsistency waits until all data produced up until now has been consumed by the reader.

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -439,7 +439,7 @@ func (r *PartitionReader) getStartOffset(ctx context.Context) (startOffset, last
 			}
 			if exists {
 				lastConsumedOffset = offset - 1 // Offset before the one we'll start the consumption from
-				level.Info(r.logger).Log("msg", "starting consumption from timestamp", "timestamp", ts.UnixMilli(), "start_offset", offset, "consumer_group", r.consumerGroup)
+				level.Info(r.logger).Log("msg", "starting consumption from timestamp", "timestamp", ts.UnixMilli(), "last_consumed_offset", lastConsumedOffset, "start_offset", offset, "consumer_group", r.consumerGroup)
 				return offset, lastConsumedOffset, nil
 			}
 		} else {
@@ -450,7 +450,7 @@ func (r *PartitionReader) getStartOffset(ctx context.Context) (startOffset, last
 			if exists {
 				lastConsumedOffset = offset
 				offset = lastConsumedOffset + 1 // We'll start consuming from the next offset after the last consumed.
-				level.Info(r.logger).Log("msg", "starting consumption from last consumed offset", "last_consumed_offset", offset, "start_offset", offset, "consumer_group", r.consumerGroup)
+				level.Info(r.logger).Log("msg", "starting consumption from last consumed offset", "last_consumed_offset", lastConsumedOffset, "start_offset", offset, "consumer_group", r.consumerGroup)
 				return offset, lastConsumedOffset, nil
 			}
 		}

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/01_fetch.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/01_fetch.go
@@ -18,7 +18,7 @@ import (
 
 func init() { regKey(1, 4, 13) }
 
-func (c *Cluster) handleFetch(creq clientReq, w *watchFetch) (kmsg.Response, error) {
+func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, error) {
 	var (
 		req  = creq.kreq.(*kmsg.FetchRequest)
 		resp = req.ResponseKind().(*kmsg.FetchResponse)
@@ -182,7 +182,7 @@ type watchFetch struct {
 	need     int
 	needp    tps[int]
 	deadline time.Time
-	creq     clientReq
+	creq     *clientReq
 
 	in []*partData
 	cb func()

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/02_list_offsets.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/02_list_offsets.go
@@ -75,10 +75,11 @@ func (c *Cluster) handleListOffsets(b *broker, kreq kmsg.Request) (kmsg.Response
 					sp.Offset = pd.highWatermark
 				}
 			default:
+				// returns the index of the first batch _after_ the requested timestamp
 				idx, _ := sort.Find(len(pd.batches), func(idx int) int {
 					maxEarlier := pd.batches[idx].maxEarlierTimestamp
 					switch {
-					case maxEarlier < rp.Timestamp:
+					case maxEarlier > rp.Timestamp:
 						return -1
 					case maxEarlier == rp.Timestamp:
 						return 0

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/08_offset_commit.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/08_offset_commit.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(8, 0, 8) }
 
-func (c *Cluster) handleOffsetCommit(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleOffsetCommit(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.OffsetCommitRequest)
 	resp := req.ResponseKind().(*kmsg.OffsetCommitResponse)
 

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/09_offset_fetch.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/09_offset_fetch.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(9, 0, 8) }
 
-func (c *Cluster) handleOffsetFetch(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleOffsetFetch(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.OffsetFetchRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/11_join_group.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/11_join_group.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(11, 0, 9) }
 
-func (c *Cluster) handleJoinGroup(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleJoinGroup(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.JoinGroupRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/12_heartbeat.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/12_heartbeat.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(12, 0, 4) }
 
-func (c *Cluster) handleHeartbeat(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleHeartbeat(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.HeartbeatRequest)
 	resp := req.ResponseKind().(*kmsg.HeartbeatResponse)
 

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/13_leave_group.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/13_leave_group.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(13, 0, 5) }
 
-func (c *Cluster) handleLeaveGroup(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleLeaveGroup(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.LeaveGroupRequest)
 	resp := req.ResponseKind().(*kmsg.LeaveGroupResponse)
 

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/14_sync_group.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/14_sync_group.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(14, 0, 5) }
 
-func (c *Cluster) handleSyncGroup(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleSyncGroup(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.SyncGroupRequest)
 	resp := req.ResponseKind().(*kmsg.SyncGroupResponse)
 

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/15_describe_groups.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/15_describe_groups.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(15, 0, 5) }
 
-func (c *Cluster) handleDescribeGroups(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleDescribeGroups(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.DescribeGroupsRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/16_list_groups.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/16_list_groups.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(16, 0, 4) }
 
-func (c *Cluster) handleListGroups(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleListGroups(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.ListGroupsRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/17_sasl_handshake.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/17_sasl_handshake.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(17, 1, 1) }
 
-func (c *Cluster) handleSASLHandshake(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleSASLHandshake(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.SASLHandshakeRequest)
 	resp := req.ResponseKind().(*kmsg.SASLHandshakeResponse)
 

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/36_sasl_authenticate.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/36_sasl_authenticate.go
@@ -9,7 +9,7 @@ import (
 
 func init() { regKey(36, 0, 2) }
 
-func (c *Cluster) handleSASLAuthenticate(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleSASLAuthenticate(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.SASLAuthenticateRequest)
 	resp := req.ResponseKind().(*kmsg.SASLAuthenticateResponse)
 

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/42_delete_groups.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/42_delete_groups.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(42, 0, 2) }
 
-func (c *Cluster) handleDeleteGroups(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleDeleteGroups(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.DeleteGroupsRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/47_offset_delete.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/47_offset_delete.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(47, 0, 0) }
 
-func (c *Cluster) handleOffsetDelete(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleOffsetDelete(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.OffsetDeleteRequest)
 	resp := req.ResponseKind().(*kmsg.OffsetDeleteResponse)
 

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/client_conn.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/client_conn.go
@@ -25,8 +25,8 @@ type (
 		cc   *clientConn
 		kreq kmsg.Request
 		at   time.Time
-		corr int32
 		cid  string
+		corr int32
 		seq  uint32
 	}
 
@@ -38,7 +38,7 @@ type (
 	}
 )
 
-func (creq clientReq) empty() bool { return creq.cc == nil || creq.kreq == nil }
+func (creq *clientReq) empty() bool { return creq == nil || creq.cc == nil || creq.kreq == nil }
 
 func (cc *clientConn) read() {
 	defer cc.conn.Close()
@@ -101,7 +101,7 @@ func (cc *clientConn) read() {
 		}
 
 		select {
-		case cc.c.reqCh <- clientReq{cc, kreq, time.Now(), corr, cid, seq}:
+		case cc.c.reqCh <- &clientReq{cc, kreq, time.Now(), cid, corr, seq}:
 			seq++
 		case <-cc.c.die:
 			return
@@ -141,6 +141,9 @@ func (cc *clientConn) write() {
 			case <-cc.c.die:
 				return
 			}
+		} else {
+			delete(oooresp, seq)
+			seq++
 		}
 		if err := resp.err; err != nil {
 			cc.c.cfg.logger.Logf(LogLevelInfo, "client %s request unable to be handled: %v", who, err)

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/cluster.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/cluster.go
@@ -29,14 +29,19 @@ type (
 		controller *broker
 		bs         []*broker
 
+		coordinatorGen atomic.Uint64
+
 		adminCh      chan func()
-		reqCh        chan clientReq
+		reqCh        chan *clientReq
+		wakeCh       chan *slept
 		watchFetchCh chan *watchFetch
 
-		controlMu          sync.Mutex
-		control            map[int16][]controlFn
-		keepCurrentControl atomic.Bool
-		currentBroker      atomic.Pointer[broker]
+		controlMu      sync.Mutex
+		control        map[int16]map[*controlCtx]struct{}
+		currentBroker  *broker
+		currentControl *controlCtx
+		sleeping       map[*clientConn]*bsleep
+		controlSleep   chan sleepChs
 
 		data   data
 		pids   pids
@@ -56,6 +61,20 @@ type (
 	}
 
 	controlFn func(kmsg.Request) (kmsg.Response, error, bool)
+
+	controlCtx struct {
+		key     int16
+		fn      controlFn
+		keep    bool
+		drop    bool
+		lastReq map[*clientConn]*clientReq // used to not re-run requests that slept, see doc comments below
+	}
+
+	controlResp struct {
+		kresp   kmsg.Response
+		err     error
+		handled bool
+	}
 )
 
 // MustCluster is like NewCluster, but panics on error.
@@ -91,9 +110,13 @@ func NewCluster(opts ...Opt) (*Cluster, error) {
 		cfg: cfg,
 
 		adminCh:      make(chan func()),
-		reqCh:        make(chan clientReq, 20),
+		reqCh:        make(chan *clientReq, 20),
+		wakeCh:       make(chan *slept, 10),
 		watchFetchCh: make(chan *watchFetch, 20),
-		control:      make(map[int16][]controlFn),
+		control:      make(map[int16]map[*controlCtx]struct{}),
+		controlSleep: make(chan sleepChs, 1),
+
+		sleeping: make(map[*clientConn]*bsleep),
 
 		data: data{
 			id2t:      make(map[uuid]string),
@@ -234,28 +257,87 @@ func (b *broker) listen() {
 }
 
 func (c *Cluster) run() {
+outer:
 	for {
-		var creq clientReq
-		var w *watchFetch
+		var (
+			creq    *clientReq
+			w       *watchFetch
+			s       *slept
+			kreq    kmsg.Request
+			kresp   kmsg.Response
+			err     error
+			handled bool
+		)
 
 		select {
+		case <-c.die:
+			return
+
+		case admin := <-c.adminCh:
+			admin()
+			continue
+
 		case creq = <-c.reqCh:
+			if c.cfg.sleepOutOfOrder {
+				break
+			}
+			// If we have any sleeping request on this node,
+			// we enqueue the new live request to the end and
+			// wait for the sleeping request to finish.
+			bs := c.sleeping[creq.cc]
+			if bs.enqueue(&slept{
+				creq:    creq,
+				waiting: true,
+			}) {
+				continue
+			}
+
+		case s = <-c.wakeCh:
+			// On wakeup, we know we are handling a control
+			// function that was slept, or a request that was
+			// waiting for a control function to finish sleeping.
+			creq = s.creq
+			if s.waiting {
+				break
+			}
+
+			// We continue a previously sleeping request, and
+			// handle results similar to tryControl.
+			//
+			// Control flow is weird here, but is described more
+			// fully in the finish/resleep/etc methods.
+			c.continueSleptControl(s)
+		inner:
+			for {
+				select {
+				case admin := <-c.adminCh:
+					admin()
+					continue inner
+				case res := <-s.res:
+					c.finishSleptControl(s)
+					cctx := s.cctx
+					s = nil
+					kresp, err, handled = res.kresp, res.err, res.handled
+					c.maybePopControl(handled, cctx)
+					if handled {
+						goto afterControl
+					}
+					break inner
+				case sleepChs := <-c.controlSleep:
+					c.resleepSleptControl(s, sleepChs)
+					continue outer
+				}
+			}
+
 		case w = <-c.watchFetchCh:
 			if w.cleaned {
 				continue // already cleaned up, this is an extraneous timer fire
 			}
 			w.cleanup(c)
 			creq = w.creq
-		case <-c.die:
-			return
-		case fn := <-c.adminCh:
-			// Run a custom request in the context of the cluster
-			fn()
-			continue
 		}
 
-		kreq := creq.kreq
-		kresp, err, handled := c.tryControl(kreq, creq.cc.b)
+		kresp, err, handled = c.tryControl(creq)
 		if handled {
 			goto afterControl
 		}
@@ -267,6 +349,7 @@ func (c *Cluster) run() {
 			}
 		}
 
+		kreq = creq.kreq
 		switch k := kmsg.Key(kreq.Key()); k {
 		case kmsg.Produce:
 			kresp, err = c.handleProduce(creq.cc.b, kreq)
@@ -331,11 +414,18 @@ func (c *Cluster) run() {
 		case kmsg.AlterUserSCRAMCredentials:
 			kresp, err = c.handleAlterUserSCRAMCredentials(creq.cc.b, kreq)
 		default:
-			err = fmt.Errorf("unahndled key %v", k)
+			err = fmt.Errorf("unhandled key %v", k)
 		}
 
 	afterControl:
-		if kresp == nil && err == nil { // produce request with no acks, or hijacked group request
+		// If s is non-nil, this is either a previously slept control
+		// that finished but was not handled, or a previously slept
+		// waiting request. In either case, we need to signal to the
+		// sleep dequeue loop to continue.
+		if s != nil {
+			s.continueDequeue <- struct{}{}
+		}
+		if kresp == nil && err == nil { // produce request with no acks, or otherwise hijacked request (group, sleep)
 			continue
 		}
 
@@ -358,14 +448,17 @@ func (c *Cluster) run() {
 // Controlling a request drops the control function from the cluster, meaning
 // that a control function can only control *one* request. To keep the control
 // function handling more requests, you can call KeepControl within your
-// control function.
+// control function. Alternatively, if you want to just run some logic in your
+// control function but then have the cluster handle the request as normal,
+// you can call DropControl to drop a control function that was not handled.
 //
-// It is safe to add new control functions within a control function. Control
-// functions are not called concurrently.
+// It is safe to add new control functions within a control function.
+//
+// Control functions are run serially unless you use SleepControl, multiple
+// control functions are "in progress", and you run Cluster.Close. Closing a
+// Cluster awakens all sleeping control functions.
 func (c *Cluster) Control(fn func(kmsg.Request) (kmsg.Response, error, bool)) {
-	c.controlMu.Lock()
-	defer c.controlMu.Unlock()
-	c.control[-1] = append(c.control[-1], fn)
+	c.ControlKey(-1, fn)
 }
 
 // Control is a function to call on a specific request key that the cluster
@@ -380,71 +473,455 @@ func (c *Cluster) Control(fn func(kmsg.Request) (kmsg.Response, error, bool)) {
 // Controlling a request drops the control function from the cluster, meaning
 // that a control function can only control *one* request. To keep the control
 // function handling more requests, you can call KeepControl within your
-// control function.
+// control function. Alternatively, if you want to just run some logic in your
+// control function but then have the cluster handle the request as normal,
+// you can call DropControl to drop a control function that was not handled.
 //
 // It is safe to add new control functions within a control function.
+//
+// Control functions are run serially unless you use SleepControl, multiple
+// control functions are "in progress", and you run Cluster.Close. Closing a
+// Cluster awakens all sleeping control functions.
 func (c *Cluster) ControlKey(key int16, fn func(kmsg.Request) (kmsg.Response, error, bool)) {
 	c.controlMu.Lock()
 	defer c.controlMu.Unlock()
-	c.control[key] = append(c.control[key], fn)
+	m := c.control[key]
+	if m == nil {
+		m = make(map[*controlCtx]struct{})
+		c.control[key] = m
+	}
+	m[&controlCtx{
+		key:     key,
+		fn:      fn,
+		lastReq: make(map[*clientConn]*clientReq),
+	}] = struct{}{}
 }
 
 // KeepControl marks the currently running control function to be kept even if
 // you handle the request and return true. This can be used to continuously
 // control requests without needing to re-add control functions manually.
 func (c *Cluster) KeepControl() {
-	c.keepCurrentControl.Swap(true)
+	c.controlMu.Lock()
+	defer c.controlMu.Unlock()
+	if c.currentControl != nil {
+		c.currentControl.keep = true
+	}
+}
+
+// DropControl allows you to drop the current control function. This takes
+// precedence over KeepControl. The use of this function is you can run custom
+// control logic *once*, drop the control function, and return that the
+// function was not handled -- thus allowing other control functions to run, or
+// allowing the kfake cluster to process the request as normal.
+func (c *Cluster) DropControl() {
+	c.controlMu.Lock()
+	defer c.controlMu.Unlock()
+	if c.currentControl != nil {
+		c.currentControl.drop = true
+	}
+}
+
+// SleepControl sleeps the current control function until wakeup returns. This
+// yields to run any other connection.
+//
+// Note that per protocol, requests on the same connection must be replied to
+// in order. Many clients write multiple requests to the same connection, so
+// if you sleep until a different request runs, you may sleep forever -- you
+// must know the semantics of your client to know whether requests run on
+// different connections (or, ensure you are writing to different brokers).
+//
+// For example, franz-go uses a dedicated connection for:
+//   - produce requests
+//   - fetch requests
+//   - join&sync requests
+//   - requests with a Timeout field
+//   - all other request
+//
+// So, for franz-go, there are up to five separate connections depending
+// on what you are doing.
+//
+// You can run SleepControl multiple times in the same control function. If you
+// sleep a request you are controlling, and another request of the same key
+// comes in, it will run the same control function and may also sleep (i.e.,
+// you must have logic if you want to avoid sleeping on the same request).
+func (c *Cluster) SleepControl(wakeup func()) {
+	c.controlMu.Lock()
+	if c.currentControl == nil {
+		c.controlMu.Unlock()
+		return
+	}
+	c.controlMu.Unlock()
+
+	sleepChs := sleepChs{
+		clientWait: make(chan struct{}, 1),
+		clientCont: make(chan struct{}, 1),
+	}
+	go func() {
+		wakeup()
+		sleepChs.clientWait <- struct{}{}
+	}()
+
+	c.controlSleep <- sleepChs
+	select {
+	case <-sleepChs.clientCont:
+	case <-c.die:
+	}
 }
 
 // CurrentNode is solely valid from within a control function; it returns
 // the broker id that the request was received by.
 // If there's no request currently inflight, this returns -1.
 func (c *Cluster) CurrentNode() int32 {
-	if b := c.currentBroker.Load(); b != nil {
+	c.controlMu.Lock()
+	defer c.controlMu.Unlock()
+	if b := c.currentBroker; b != nil {
 		return b.node
 	}
 	return -1
 }
 
-func (c *Cluster) tryControl(kreq kmsg.Request, b *broker) (kresp kmsg.Response, err error, handled bool) {
-	c.currentBroker.Store(b)
-	defer c.currentBroker.Store(nil)
+func (c *Cluster) tryControl(creq *clientReq) (kresp kmsg.Response, err error, handled bool) {
 	c.controlMu.Lock()
 	defer c.controlMu.Unlock()
 	if len(c.control) == 0 {
 		return nil, nil, false
 	}
-	kresp, err, handled = c.tryControlKey(kreq.Key(), kreq, b)
+	kresp, err, handled = c.tryControlKey(creq.kreq.Key(), creq)
 	if !handled {
-		kresp, err, handled = c.tryControlKey(-1, kreq, b)
+		kresp, err, handled = c.tryControlKey(-1, creq)
 	}
 	return kresp, err, handled
 }
 
-func (c *Cluster) tryControlKey(key int16, kreq kmsg.Request, b *broker) (kresp kmsg.Response, err error, handled bool) {
-	for i, fn := range c.control[key] {
-		kresp, err, handled = c.callControl(key, kreq, fn)
-		if handled {
-			// fn may have called Control, ControlKey, or KeepControl,
-			// all of which will append to c.control; refresh the slice.
-			fns := c.control[key]
-			c.control[key] = append(fns[:i], fns[i+1:]...)
-			return
+func (c *Cluster) tryControlKey(key int16, creq *clientReq) (kmsg.Response, error, bool) {
+	for cctx := range c.control[key] {
+		if cctx.lastReq[creq.cc] == creq {
+			continue
+		}
+		cctx.lastReq[creq.cc] = creq
+		res := c.runControl(cctx, creq)
+		for {
+			select {
+			case admin := <-c.adminCh:
+				admin()
+				continue
+			case res := <-res:
+				c.maybePopControl(res.handled, cctx)
+				return res.kresp, res.err, res.handled
+			case sleepChs := <-c.controlSleep:
+				c.beginSleptControl(&slept{
+					cctx:     cctx,
+					sleepChs: sleepChs,
+					res:      res,
+					creq:     creq,
+				})
+				return nil, nil, true
+			}
 		}
 	}
-	return
+	return nil, nil, false
 }
 
-func (c *Cluster) callControl(key int16, req kmsg.Request, fn controlFn) (kresp kmsg.Response, err error, handled bool) {
-	c.keepCurrentControl.Swap(false)
+func (c *Cluster) runControl(cctx *controlCtx, creq *clientReq) chan controlResp {
+	res := make(chan controlResp, 1)
+	c.currentBroker = creq.cc.b
+	c.currentControl = cctx
+	// We unlock before entering a control function so that the control
+	// function can modify / add more control. We re-lock when exiting the
+	// control function. This does pose some weird control flow issues
+	// w.r.t. sleeping requests. Here, we have to re-lock before sending
+	// down res, otherwise we risk unlocking an unlocked mu in
+	// finishSleepControl.
 	c.controlMu.Unlock()
-	defer func() {
+	go func() {
+		kresp, err, handled := cctx.fn(creq.kreq)
 		c.controlMu.Lock()
-		if handled && c.keepCurrentControl.Swap(false) {
-			c.control[key] = append(c.control[key], fn)
+		c.currentControl = nil
+		c.currentBroker = nil
+		res <- controlResp{kresp, err, handled}
+	}()
+	return res
+}
+
+func (c *Cluster) beginSleptControl(s *slept) {
+	// Control flow gets really weird here. We unlocked when entering the
+	// control function, so we have to re-lock now so that tryControl can
+	// unlock us safely.
+	bs := c.sleeping[s.creq.cc]
+	if bs == nil {
+		bs = &bsleep{
+			c:       c,
+			set:     make(map[*slept]struct{}),
+			setWake: make(chan *slept, 1),
+		}
+		c.sleeping[s.creq.cc] = bs
+	}
+	bs.enqueue(s)
+	c.controlMu.Lock()
+	c.currentControl = nil
+	c.currentBroker = nil
+}
+
+func (c *Cluster) continueSleptControl(s *slept) {
+	// When continuing a slept control, we are in the main run loop and are
+	// not currently under the control mu. We need to re-set the current
+	// broker and current control before resuming.
+	c.controlMu.Lock()
+	c.currentBroker = s.creq.cc.b
+	c.currentControl = s.cctx
+	c.controlMu.Unlock()
+	s.sleepChs.clientCont <- struct{}{}
+}
+
+func (c *Cluster) finishSleptControl(s *slept) {
+	// When finishing a slept control, the control function exited and
+	// grabbed the control mu. We clear the control, unlock, and allow the
+	// slept control to be dequeued.
+	c.currentControl = nil
+	c.currentBroker = nil
+	c.controlMu.Unlock()
+	s.continueDequeue <- struct{}{}
+}
+
+func (c *Cluster) resleepSleptControl(s *slept, sleepChs sleepChs) {
+	// A control function previously slept and is now again sleeping. We
+	// need to clear the control broker / etc, update the sleep channels,
+	// and allow the sleep dequeueing to continue. The control function
+	// will not be deqeueued in the loop because we updated sleepChs with
+	// a non-nil clientWait.
+	c.controlMu.Lock()
+	c.currentBroker = nil
+	c.currentControl = nil
+	c.controlMu.Unlock()
+	s.sleepChs = sleepChs
+	s.continueDequeue <- struct{}{}
+	// For OOO requests, we need to manually trigger a goroutine to
+	// watch for the sleep to end.
+	s.bs.maybeWaitOOOWake(s)
+}
+
+func (c *Cluster) maybePopControl(handled bool, cctx *controlCtx) {
+	if handled && !cctx.keep || cctx.drop {
+		delete(c.control[cctx.key], cctx)
+	}
+}
+
+// bsleep manages sleeping requests on a connection to a broker, or
+// non-sleeping requests that are waiting for sleeping requests to finish.
+type bsleep struct {
+	c       *Cluster
+	mu      sync.Mutex
+	queue   []*slept
+	set     map[*slept]struct{}
+	setWake chan *slept
+}
+
+type slept struct {
+	bs       *bsleep
+	cctx     *controlCtx
+	sleepChs sleepChs
+	res      <-chan controlResp
+	creq     *clientReq
+	waiting  bool
+
+	continueDequeue chan struct{}
+}
+
+type sleepChs struct {
+	clientWait chan struct{}
+	clientCont chan struct{}
+}
+
+// enqueue has a few potential behaviors.
+//
+// (1) If s is waiting, this is a new request enqueueing to the back of an
+// existing queue, where we are waiting for the head request to finish
+// sleeping. Easy case.
+//
+// (2) If s is not waiting, this is a sleeping request. If the queue is empty,
+// this is the first sleeping request on a node. We enqueue and start our wait
+// goroutine. Easy.
+//
+// (3) If s is not waiting, but our queue is non-empty, this must be from a
+// convoluted scenario:
+//
+//	(a) the user has SleepOutOfOrder configured,
+//	(b) or, there was a request in front of us that slept, we were waiting,
+//	    and now we ourselves are sleeping
+//	(c) or, we are sleeping for the second time in a single control
+func (bs *bsleep) enqueue(s *slept) bool {
+	if bs == nil {
+		return false // Do not enqueue, nothing sleeping
+	}
+	s.continueDequeue = make(chan struct{}, 1)
+	s.bs = bs
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if s.waiting {
+		if bs.c.cfg.sleepOutOfOrder {
+			panic("enqueueing a waiting request even though we are sleeping out of order")
+		}
+		if !bs.empty() {
+			bs.keep(s) // Case (1)
+			return true
+		}
+		return false // We do not enqueue, do not wait: nothing sleeping ahead of us
+	}
+	if bs.empty() {
+		bs.keep(s)
+		go bs.wait() // Case (2)
+		return true
+	}
+	var q0 *slept
+	if !bs.c.cfg.sleepOutOfOrder {
+		q0 = bs.queue[0] // Case (3b) or (3c) -- just update values below
+	} else {
+		// Case (3a), out of order sleep: we need to check the entire
+		// queue to see if this request was already sleeping and, if
+		// so, update the values. If it was not already sleeping, we
+		// "keep" the new sleeping item.
+		bs.keep(s)
+		return true
+	}
+	if q0.creq != s.creq {
+		panic("internal error: sleeping request not head request")
+	}
+	// We do not update continueDequeue because it is actively being read,
+	// we just reuse the old value.
+	q0.cctx = s.cctx
+	q0.sleepChs = s.sleepChs
+	q0.res = s.res
+	q0.waiting = s.waiting
+	return true
+}
+
+// keep stores a sleeping request to be managed. For out of order control, the
+// log is a bit more complicated and we need to watch for the control sleep
+// finishing here, and forward the "I'm done sleeping" notification to waitSet.
+func (bs *bsleep) keep(s *slept) {
+	if !bs.c.cfg.sleepOutOfOrder {
+		bs.queue = append(bs.queue, s)
+		return
+	}
+	bs.set[s] = struct{}{}
+	bs.maybeWaitOOOWake(s)
+}
+
+func (bs *bsleep) maybeWaitOOOWake(s *slept) {
+	if !bs.c.cfg.sleepOutOfOrder {
+		return
+	}
+	go func() {
+		select {
+		case <-bs.c.die:
+		case <-s.sleepChs.clientWait:
+			select {
+			case <-bs.c.die:
+			case bs.setWake <- s:
+			}
 		}
 	}()
-	return fn(req)
+}
+
+func (bs *bsleep) empty() bool {
+	return len(bs.queue) == 0 && len(bs.set) == 0
+}
+
+func (bs *bsleep) wait() {
+	if bs.c.cfg.sleepOutOfOrder {
+		bs.waitSet()
+	} else {
+		bs.waitQueue()
+	}
+}
+
+// For out of order control, all control functions run concurrently, serially.
+// Whenever they wake up, they send themselves down setWake. waitSet manages
+// handling the wake up and interacting with the serial manage goroutine to
+// run everything properly.
+func (bs *bsleep) waitSet() {
+	for {
+		bs.mu.Lock()
+		if len(bs.set) == 0 {
+			bs.mu.Unlock()
+			return
+		}
+		bs.mu.Unlock()
+
+		// Wait for a control function to awaken.
+		var q *slept
+		select {
+		case <-bs.c.die:
+			return
+		case q = <-bs.setWake:
+			q.sleepChs.clientWait = nil
+		}
+
+		// Now, schedule ourselves with the run loop.
+		select {
+		case <-bs.c.die:
+			return
+		case bs.c.wakeCh <- q:
+		}
+
+		// Wait for this control function to finish its loop in the run
+		// function. Once it does, if clientWait is non-nil, the
+		// control function went back to sleep. If it is nil, the
+		// control function is done and we remove this from tracking.
+		select {
+		case <-bs.c.die:
+			return
+		case <-q.continueDequeue:
+		}
+		if q.sleepChs.clientWait == nil {
+			bs.mu.Lock()
+			delete(bs.set, q)
+			bs.mu.Unlock()
+		}
+	}
+}
+
+// For in-order control functions, the concept is slightly simpler but the
+// logic flow is the same. We wait for the head control function to wake up,
+// try to run it, and then wait for it to finish. The logic of this function is
+// the same as waitSet, minus the middle part where we wait for something to
+// wake up.
+func (bs *bsleep) waitQueue() {
+	for {
+		bs.mu.Lock()
+		if len(bs.queue) == 0 {
+			bs.mu.Unlock()
+			return
+		}
+		q0 := bs.queue[0]
+		bs.mu.Unlock()
+
+		if q0.sleepChs.clientWait != nil {
+			select {
+			case <-bs.c.die:
+				return
+			case <-q0.sleepChs.clientWait:
+				q0.sleepChs.clientWait = nil
+			}
+		}
+
+		select {
+		case <-bs.c.die:
+			return
+		case bs.c.wakeCh <- q0:
+		}
+
+		select {
+		case <-bs.c.die:
+			return
+		case <-q0.continueDequeue:
+		}
+		if q0.sleepChs.clientWait == nil {
+			bs.mu.Lock()
+			bs.queue = bs.queue[1:]
+			bs.mu.Unlock()
+		}
+	}
 }
 
 // Various administrative requests can be passed into the cluster to simulate
@@ -483,6 +960,28 @@ func (c *Cluster) MoveTopicPartition(topic string, partition int32, nodeID int32
 		pd.leader = br
 	})
 	return err
+}
+
+// CoordinatorFor returns the node ID of the group or transaction coordinator
+// for the given key.
+func (c *Cluster) CoordinatorFor(key string) int32 {
+	var n int32
+	c.admin(func() {
+		l := len(c.bs)
+		if l == 0 {
+			n = -1
+			return
+		}
+		n = c.coordinator(key).node
+	})
+	return n
+}
+
+// RehashCoordinators simulates group and transacational ID coordinators moving
+// around. All group and transactional IDs are rekeyed. This forces clients to
+// reload coordinators.
+func (c *Cluster) RehashCoordinators() {
+	c.coordinatorGen.Add(1)
 }
 
 // AddNode adds a node to the cluster. If nodeID is -1, the next node ID is

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/config.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/config.go
@@ -34,6 +34,8 @@ type cfg struct {
 	enableSASL bool
 	sasls      map[struct{ m, u string }]string // cleared after client initialization
 	tls        *tls.Config
+
+	sleepOutOfOrder bool
 }
 
 // NumBrokers sets the number of brokers to start in the fake cluster.
@@ -112,4 +114,13 @@ func TLS(c *tls.Config) Opt {
 // options, the last specification wins.
 func SeedTopics(partitions int32, ts ...string) Opt {
 	return opt{func(cfg *cfg) { cfg.seedTopics = append(cfg.seedTopics, seedTopics{partitions, ts}) }}
+}
+
+// SleepOutOfOrder allows functions to be handled out of order when control
+// functions are sleeping. The functions are be handled internally out of
+// order, but responses still wait for the sleeping requests to finish. This
+// can be used to set up complicated chains of control where functions only
+// advance when you know another request is actively being handled.
+func SleepOutOfOrder() Opt {
+	return opt{func(cfg *cfg) { cfg.sleepOutOfOrder = true }}
 }

--- a/vendor/github.com/twmb/franz-go/pkg/kfake/sasl.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kfake/sasl.go
@@ -47,7 +47,7 @@ const (
 	saslStageComplete
 )
 
-func (c *Cluster) handleSASL(creq clientReq) (allow bool) {
+func (c *Cluster) handleSASL(creq *clientReq) (allow bool) {
 	switch creq.cc.saslStage {
 	case saslStageBegin:
 		switch creq.kreq.(type) {

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/broker.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/broker.go
@@ -632,7 +632,7 @@ func (b *broker) connect(ctx context.Context) (net.Conn, error) {
 		}
 	})
 	if err != nil {
-		if !errors.Is(err, ErrClientClosed) && !strings.Contains(err.Error(), "operation was canceled") {
+		if !errors.Is(err, ErrClientClosed) && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "operation was canceled") {
 			if errors.Is(err, io.EOF) {
 				b.cl.cfg.logger.Log(LogLevelWarn, "unable to open connection to broker due to an immediate EOF, which often means the client is using TLS when the broker is not expecting it (is TLS misconfigured?)", "addr", b.addr, "broker", logID(b.meta.NodeID), "err", err)
 				return nil, &ErrFirstReadEOF{kind: firstReadTLS, err: err}

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/client.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/client.go
@@ -215,11 +215,11 @@ func (cl *Client) OptValue(opt any) any {
 //			InstanceID("foo"),
 //			ConsumeTopics("foo", "bar"),
 //		)
-//		idValues = cl.OptValues(InstanceID)          // idValues is []any{"foo", true}
-//		tValues  = cl.OptValues(SessionTimeout)      // tValues is []any{45 * time.Second}
-//		topics   = cl.OptValues(ConsumeTopics)       // topics is []any{[]string{"foo", "bar"}
+//		idValues = cl.OptValues(InstanceID)           // idValues is []any{"foo", true}
+//		tValues  = cl.OptValues(SessionTimeout)       // tValues is []any{45 * time.Second}
+//		topics   = cl.OptValues(ConsumeTopics)        // topics is []any{[]string{"foo", "bar"}
 //		bpoll    = cl.OptValues(BlockRebalanceOnPoll) // bpoll is []any{false}
-//		unknown  = cl.OptValues("Unknown")           // unknown is nil
+//		unknown  = cl.OptValues("Unknown")            // unknown is nil
 //	)
 func (cl *Client) OptValues(opt any) []any {
 	name := namefn(opt)
@@ -237,7 +237,7 @@ func (cl *Client) OptValues(opt any) []any {
 	case namefn(SoftwareNameAndVersion):
 		return []any{cfg.softwareName, cfg.softwareVersion}
 	case namefn(WithLogger):
-		if cfg.logger != nil {
+		if _, wrapped := cfg.logger.(*wrappedLogger); wrapped {
 			return []any{cfg.logger.(*wrappedLogger).inner}
 		}
 		return []any{nil}
@@ -524,7 +524,7 @@ func NewClient(opts ...Opt) (*Client, error) {
 // Opts returns the options that were used to create this client. This can be
 // as a base to generate a new client, where you can add override options to
 // the end of the original input list. If you want to know a specific option
-// value, you can use ConfigValue or ConfigValues.
+// value, you can use OptValue or OptValues.
 func (cl *Client) Opts() []Opt {
 	return cl.opts
 }
@@ -2250,8 +2250,12 @@ func (cl *Client) handleShardedReq(ctx context.Context, req kmsg.Request) ([]Res
 				}
 
 				resp, err := broker.waitResp(ctx, myIssue.req)
+				var errIsFromResp bool
 				if err == nil {
 					err = sharder.onResp(myUnderlyingReq, resp) // perform some potential cleanup, and potentially receive an error to retry
+					if ke := (*kerr.Error)(nil); errors.As(err, &ke) {
+						errIsFromResp = true
+					}
 				}
 
 				// If we failed to issue the request, we *maybe* will retry.
@@ -2279,6 +2283,14 @@ func (cl *Client) handleShardedReq(ctx context.Context, req kmsg.Request) ([]Res
 					return
 				}
 
+				// If we pulled an error out of the response body in an attempt
+				// to possibly retry, the request was NOT an error that we want
+				// to bubble as a shard error. The request was successful, we
+				// have a response. Before we add the shard, strip the error.
+				// The end user can parse the response ErrorCode.
+				if errIsFromResp {
+					err = nil
+				}
 				addShard(shard(broker, myUnderlyingReq, resp, err)) // the error was not retryable
 			}()
 		}
@@ -2404,6 +2416,7 @@ func (cl *Client) cachedMappedMetadata(ts ...string) (map[string]mappedMetadataT
 			cached[t] = tcached
 		} else {
 			needed = append(needed, t)
+			delete(cl.mappedMeta, t)
 		}
 	}
 	return cached, needed
@@ -2451,6 +2464,16 @@ func (cl *Client) fetchMappedMetadata(ctx context.Context, topics []string, useC
 		r[*topic.Topic] = t
 		for _, partition := range topic.Partitions {
 			t.ps[partition.Partition] = partition
+		}
+	}
+	if len(meta.Topics) != len(cl.mappedMeta) {
+		for topic, mapped := range cl.mappedMeta {
+			if mapped.when.Equal(when) {
+				continue
+			}
+			if time.Since(mapped.when) > cl.cfg.metadataMinAge {
+				delete(cl.mappedMeta, topic)
+			}
 		}
 	}
 	return r, nil

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/consumer.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/consumer.go
@@ -354,7 +354,7 @@ func NewErrFetch(err error) Fetches {
 		Topics: []FetchTopic{{
 			Topic: "",
 			Partitions: []FetchPartition{{
-				Partition: 0,
+				Partition: -1,
 				Err:       err,
 			}},
 		}},
@@ -384,11 +384,11 @@ func (cl *Client) PollFetches(ctx context.Context) Fetches {
 }
 
 // PollRecords waits for records to be available, returning as soon as any
-// broker returns records in a fetch. If the context is nil, this function
-// will return immediately with any currently buffered records.
+// broker returns records in a fetch. If the context is nil, this function will
+// return immediately with any currently buffered records.
 //
 // If the client is closed, a fake fetch will be injected that has no topic, a
-// partition of 0, and a partition error of ErrClientClosed. If the context is
+// partition of -1, and a partition error of ErrClientClosed. If the context is
 // canceled, a fake fetch will be injected with ctx.Err. These injected errors
 // can be used to break out of a poll loop.
 //

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_direct.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_direct.go
@@ -99,7 +99,7 @@ func (d *directConsumer) findNewAssignments() map[string]map[int32]Offset {
 		// the topic is explicitly specified.
 		if useTopic {
 			partitions := topicPartitions.load()
-			if d.cfg.regex && partitions.isInternal {
+			if d.cfg.regex && partitions.isInternal || len(partitions.partitions) == 0 {
 				continue
 			}
 			toUseTopic := make(map[int32]Offset, len(partitions.partitions))

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/internal/sticky/sticky.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/internal/sticky/sticky.go
@@ -2,7 +2,7 @@
 // complete overhaul to be faster, more understandable, and optimal.
 //
 // For some points on how Java's strategy is flawed, see
-// https://github.com/Shopify/sarama/pull/1416/files/b29086bdaae0da7ce71eae3f854d50685fd6b631#r315005878
+// https://github.com/IBM/sarama/pull/1416/files/b29086bdaae0da7ce71eae3f854d50685fd6b631#r315005878
 package sticky
 
 import (

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/partitioner.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/partitioner.go
@@ -487,7 +487,27 @@ func KafkaHasher(hashFn func([]byte) uint32) PartitionerHasher {
 	}
 }
 
-// SaramaHasher returns a PartitionerHasher using hashFn that mirrors how
+// SaramaHasher is a historical misnamed partitioner. This library's original
+// implementation of the SaramaHasher was incorrect, if you want an exact
+// match for the Sarama partitioner, use the [SaramaCompatHasher].
+//
+// This partitioner remains because as it turns out, other ecosystems provide
+// a similar partitioner and this partitioner is useful for compatibility.
+//
+// In particular, using this function with a crc32.ChecksumIEEE hasher makes
+// this partitioner match librdkafka's consistent partitioner, or the
+// zendesk/ruby-kafka partitioner.
+func SaramaHasher(hashFn func([]byte) uint32) PartitionerHasher {
+	return func(key []byte, n int) int {
+		p := int(hashFn(key)) % n
+		if p < 0 {
+			p = -p
+		}
+		return p
+	}
+}
+
+// SaramaCompatHasher returns a PartitionerHasher using hashFn that mirrors how
 // Sarama partitions after hashing data.
 //
 // Sarama has two differences from Kafka when partitioning:
@@ -506,14 +526,14 @@ func KafkaHasher(hashFn func([]byte) uint32) PartitionerHasher {
 //
 // In short, to *exactly* match the Sarama defaults, use the following:
 //
-//	kgo.StickyKeyPartitioner(kgo.SaramaHasher(fnv.New32a()))
-func SaramaHasher(hashFn func([]byte) uint32) PartitionerHasher {
+//	kgo.StickyKeyPartitioner(kgo.SaramaCompatHasher(fnv.New32a()))
+func SaramaCompatHasher(hashFn func([]byte) uint32) PartitionerHasher {
 	return func(key []byte, n int) int {
-		p := int(hashFn(key)) % n
+		p := int32(hashFn(key)) % int32(n)
 		if p < 0 {
 			p = -p
 		}
-		return p
+		return int(p)
 	}
 }
 

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/sink.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/sink.go
@@ -1144,7 +1144,7 @@ func (recBuf *recBuf) bufferRecord(pr promisedRec, abortOnNewBatch bool) bool {
 	defer recBuf.mu.Unlock()
 
 	// We truncate to milliseconds to avoid some accumulated rounding error
-	// problems (see Shopify/sarama#1455)
+	// problems (see IBM/sarama#1455)
 	if pr.Timestamp.IsZero() {
 		pr.Timestamp = time.Now()
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1028,8 +1028,8 @@ github.com/thanos-io/objstore/providers/gcs
 github.com/thanos-io/objstore/providers/s3
 github.com/thanos-io/objstore/providers/swift
 github.com/thanos-io/objstore/tracing/opentracing
-# github.com/twmb/franz-go v1.15.4
-## explicit; go 1.18
+# github.com/twmb/franz-go v1.16.1
+## explicit; go 1.19
 github.com/twmb/franz-go/pkg/kbin
 github.com/twmb/franz-go/pkg/kerr
 github.com/twmb/franz-go/pkg/kgo
@@ -1039,7 +1039,7 @@ github.com/twmb/franz-go/pkg/sasl
 # github.com/twmb/franz-go/pkg/kadm v1.10.0
 ## explicit; go 1.19
 github.com/twmb/franz-go/pkg/kadm
-# github.com/twmb/franz-go/pkg/kfake v0.0.0-20231206062516-c09dc92d2db1
+# github.com/twmb/franz-go/pkg/kfake v0.0.0-20240412162337-6a58760afaa7
 ## explicit; go 1.20
 github.com/twmb/franz-go/pkg/kfake
 # github.com/twmb/franz-go/pkg/kmsg v1.7.0


### PR DESCRIPTION
#### What this PR does

This one adds a new `ingest-storage.kafka.consume-from-position-at-startup=timestamp` flag. The flag makes the ingest store's partition reader to start consuming from a specific milliseconds timestamp (in oppose to consuming from earliest or latest offsets).

The rationale for the flag is the following:

In case of an incident where the consumer group is lost, at the next ingester startup it will start consuming the partition from start or from end. Both options aren't particularly useful to handle such scenario. Consuming from start could mean replaying a bunch of data already ingested; consuming from end may cause data loss (because the data in between hasn't been consumed).

The new option is a middle ground between two. It allows starting the ingester with a rough point in time, skipping the backlog at the head of the topic.

I've tested it manually against a local Kafka running in docker, and it works as I expected.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
