### PR TITLE
Helm: Change Ruler to not use alertmanager headless service.

### DIFF
--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -347,7 +347,7 @@ mimir:
       max_outstanding_requests_per_tenant: 800
 
     ruler:
-      alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.{{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/alertmanager
+      alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.{{ template "mimir.fullname" . }}-alertmanager.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}/alertmanager
       enable_api: true
       rule_path: /data
 


### PR DESCRIPTION
The jsonnet deployment configures the Ruler to use the cluster IP alertmanager
service, whereas the Helm deployment uses the headless service. This change
updates the Helm chart to match the jsonnet.

The reason we do not need to use a headless service for Mimir Alertmanager is
because it has a distributor built in, so it's only necessary to send alerts
to a single Alertmanager replica, and they will be then distributed to the
correct three replicas for the tenant.
