### PR TITLE
Give grafana/alerting ownership mimir-ruler-and-alertmanager-maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,3 +30,4 @@ go.mod @grafana/mimir-maintainers @grafanabot
 go.sum @grafana/mimir-maintainers @grafanabot
 /vendor/ @grafana/mimir-maintainers @grafanabot
 /vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers @grafanabot
+/vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,4 +30,4 @@ go.mod @grafana/mimir-maintainers @grafanabot
 go.sum @grafana/mimir-maintainers @grafanabot
 /vendor/ @grafana/mimir-maintainers @grafanabot
 /vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers @grafanabot
-/vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers
+/vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers @grafanabot


### PR DESCRIPTION
#### What this PR does

#7858 made me realise that we should give `grafana/alerting` ownership to `mimir-ruler-and-alertmanager-maintainers`. It still doesn't solve the problem of updating `grafana/alerting` which brings in other updated vendors, but it's a starting point.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
