### PR TITLE
Prepare UTF-8 for GEM

### DIFF
--- a/pkg/alertmanager/alertmanager_config.go
+++ b/pkg/alertmanager/alertmanager_config.go
@@ -7,8 +7,9 @@
 package alertmanager
 
 import (
+	"fmt"
+
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/alertmanager/matchers/compat"
 	"gopkg.in/yaml.v3"
 
@@ -35,59 +36,57 @@ type matchersInhibitionRule struct {
 }
 
 // validateMatchersInConfigDesc validates that a configuration is forwards compatible with the
-// UTF-8 matchers parser (matchers/parse). It does so via loading the same configuration a second
-// time but instead via the fallback parser which emits logs and metrics about incompatible inputs
-// and disagreement. If no incompatible inputs or disagreement are found, then the Alertmanager
-// can be switched to the UTF-8 strict mode. Otherwise, configurations should be fixed before
-// enabling the mode.
-func validateMatchersInConfigDesc(logger log.Logger, origin string, cfg alertspb.AlertConfigDesc) {
-	// Do not add origin to the logger as it's added in the compat package.
+// UTF-8 matchers parser. It loads the configuration into an intermediate structure that is a
+// subset of the full Alertmanager configuration containing just the fields needed to validate
+// matchers. It then parses all matchers using the UTF-8 parser and returns an error if any of
+// the matchers are incompatible or invalid.
+func validateMatchersInConfigDesc(logger log.Logger, origin string, cfg alertspb.AlertConfigDesc) error {
 	logger = log.With(logger, "user", cfg.User)
-	parseFn := compat.FallbackMatchersParser(logger)
+	parseFn := compat.UTF8MatchersParser(logger)
 	matchersCfg := matchersConfig{}
 	if err := yaml.Unmarshal([]byte(cfg.RawConfig), &matchersCfg); err != nil {
-		level.Warn(logger).Log("msg", "Failed to load configuration in validateMatchersInConfigDesc", "origin", origin, "err", err)
-		return
+		return fmt.Errorf("Failed to load configuration in validateMatchersInConfigDesc: %w", err)
 	}
-	validateRoute(logger, parseFn, origin, matchersCfg.Route, cfg.User)
-	validateInhibitionRules(logger, parseFn, origin, matchersCfg.InhibitRules, cfg.User)
+	if err := validateRoute(parseFn, origin, matchersCfg.Route, cfg.User); err != nil {
+		return err
+	}
+	if err := validateInhibitionRules(parseFn, origin, matchersCfg.InhibitRules, cfg.User); err != nil {
+		return err
+	}
+	return nil
 }
 
-func validateRoute(logger log.Logger, parseFn compat.ParseMatchers, origin string, r *matchersRoute, user string) {
+func validateRoute(parseFn compat.ParseMatchers, origin string, r *matchersRoute, user string) error {
 	if r == nil {
 		// This shouldn't be possible, but if somehow a tenant does have a nil route this prevents
 		// a nil pointer dereference and a subsequent panic.
-		return
+		return nil
 	}
 	for _, m := range r.Matchers {
-		// If parseFn returns an error then the input is invalid in both classic mode and UTF-8
-		// strict mode. The alertmanager_matchers_invalid metric will be incremented in the compat
-		// package, and all occurrences of disagreement and incompatible inputs will be logged.
-		// However, invalid inputs are not logged there, so we log it here just in case we need
-		// this information. Though, in general, we are not concerned about inputs that are invalid
-		// in both modes.
 		if _, err := parseFn(m, origin); err != nil {
-			level.Debug(logger).Log("msg", "Invalid matcher in route", "input", m, "origin", origin, "err", err)
+			return fmt.Errorf("Invalid matcher in route: %s: %w", m, err)
 		}
 	}
 	for _, route := range r.Routes {
-		validateRoute(logger, parseFn, origin, route, user)
+		if err := validateRoute(parseFn, origin, route, user); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func validateInhibitionRules(logger log.Logger, parseFn compat.ParseMatchers, origin string, rules []*matchersInhibitionRule, _ string) {
+func validateInhibitionRules(parseFn compat.ParseMatchers, origin string, rules []*matchersInhibitionRule, _ string) error {
 	for _, r := range rules {
 		for _, m := range r.SourceMatchers {
 			if _, err := parseFn(m, origin); err != nil {
-				// See comments from ValidateRoute.
-				level.Debug(logger).Log("msg", "Invalid matcher in inhibition rule source matchers", "input", m, "origin", origin, "err", err)
+				return fmt.Errorf("Invalid matcher in inhibition rule source matchers: %s: %w", m, err)
 			}
 		}
 		for _, m := range r.TargetMatchers {
 			if _, err := parseFn(m, origin); err != nil {
-				// See comments from ValidateRoute.
-				level.Debug(logger).Log("msg", "Invalid matcher in inhibition rule target matchers", "input", m, "origin", origin, "err", err)
+				return fmt.Errorf("Invalid matcher in inhibition rule target matchers: %s: %w", m, err)
 			}
 		}
 	}
+	return nil
 }

--- a/pkg/alertmanager/alertmanager_config_test.go
+++ b/pkg/alertmanager/alertmanager_config_test.go
@@ -3,8 +3,6 @@
 package alertmanager
 
 import (
-	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -15,9 +13,9 @@ import (
 
 func TestValidateMatchersInConfigDesc(t *testing.T) {
 	tests := []struct {
-		name     string
-		config   alertspb.AlertConfigDesc
-		expected []string
+		name        string
+		config      alertspb.AlertConfigDesc
+		expectedErr string
 	}{{
 		name: "config is accepted",
 		config: alertspb.AlertConfigDesc{
@@ -34,13 +32,8 @@ inhibit_rules:
     - baz=qux
 `,
 		},
-		expected: []string{
-			`level=debug user=1 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="foo=bar" origin=test`,
-			`level=debug user=1 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="bar=baz" origin=test`,
-			`level=debug user=1 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="baz=qux" origin=test`,
-		},
 	}, {
-		name: "config contains invalid input",
+		name: "config contains invalid input in route",
 		config: alertspb.AlertConfigDesc{
 			User: "2",
 			RawConfig: `
@@ -55,14 +48,41 @@ inhibit_rules:
     - baz!qux
 `,
 		},
-		expected: []string{
-			`level=debug user=2 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input=foo!bar origin=test`,
-			`level=debug user=2 msg="Invalid matcher in route" input=foo!bar origin=test err="bad matcher format: foo!bar"`,
-			`level=debug user=2 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input=bar!baz origin=test`,
-			`level=debug user=2 msg="Invalid matcher in inhibition rule source matchers" input=bar!baz origin=test err="bad matcher format: bar!baz"`,
-			`level=debug user=2 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input=baz!qux origin=test`,
-			`level=debug user=2 msg="Invalid matcher in inhibition rule target matchers" input=baz!qux origin=test err="bad matcher format: baz!qux"`,
+		expectedErr: "Invalid matcher in route: foo!bar: 3:4: !: expected one of '=~': expected an operator such as '=', '!=', '=~' or '!~'",
+	}, {
+		name: "config contains invalid input in inhibition rule source matchers",
+		config: alertspb.AlertConfigDesc{
+			User: "2",
+			RawConfig: `
+route:
+  routes:
+   - matchers:
+      - foo=bar
+inhibit_rules:
+  - source_matchers:
+    - bar!baz
+  - target_matchers:
+    - baz!qux
+`,
 		},
+		expectedErr: "Invalid matcher in inhibition rule source matchers: bar!baz: 3:4: !: expected one of '=~': expected an operator such as '=', '!=', '=~' or '!~'",
+	}, {
+		name: "config contains invalid input in inhibition rule target matchers",
+		config: alertspb.AlertConfigDesc{
+			User: "2",
+			RawConfig: `
+route:
+  routes:
+   - matchers:
+      - foo=bar
+inhibit_rules:
+  - source_matchers:
+    - bar=baz
+  - target_matchers:
+    - baz!qux
+`,
+		},
+		expectedErr: "Invalid matcher in inhibition rule target matchers: baz!qux: 3:4: !: expected one of '=~': expected an operator such as '=', '!=', '=~' or '!~'",
 	}, {
 		name: "config is accepted in matchers/parse but not pkg/labels",
 		config: alertspb.AlertConfigDesc{
@@ -78,11 +98,6 @@ inhibit_rules:
   - target_matchers:
     - baz🙂=qux
 `,
-		},
-		expected: []string{
-			`level=debug user=3 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="foo🙂=bar" origin=test`,
-			`level=debug user=3 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="bar🙂=baz" origin=test`,
-			`level=debug user=3 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="baz🙂=qux" origin=test`,
 		},
 	}, {
 		name: "config is accepted in pkg/labels but not matchers/parse",
@@ -100,14 +115,7 @@ inhibit_rules:
     - baz=
 `,
 		},
-		expected: []string{
-			`level=debug user=4 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="foo=" origin=test`,
-			`level=warn user=4 msg="Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the classic matchers parser as a fallback. To make this input compatible with the UTF-8 matchers parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue." input="foo=" origin=test err="end of input: expected label value" suggestion="foo=\"\""`,
-			`level=debug user=4 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="bar=" origin=test`,
-			`level=warn user=4 msg="Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the classic matchers parser as a fallback. To make this input compatible with the UTF-8 matchers parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue." input="bar=" origin=test err="end of input: expected label value" suggestion="bar=\"\""`,
-			`level=debug user=4 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="baz=" origin=test`,
-			`level=warn user=4 msg="Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the classic matchers parser as a fallback. To make this input compatible with the UTF-8 matchers parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue." input="baz=" origin=test err="end of input: expected label value" suggestion="baz=\"\""`,
-		},
+		expectedErr: "Invalid matcher in route: foo=: end of input: expected label value",
 	}, {
 		name: "config contains disagreement",
 		config: alertspb.AlertConfigDesc{
@@ -124,24 +132,15 @@ inhibit_rules:
     - baz="\xf0\x9f\x99\x82"
 `,
 		},
-		expected: []string{
-			`level=debug user=5 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="foo=\"\\xf0\\x9f\\x99\\x82\"" origin=test`,
-			`level=warn user=5 msg="Matchers input has disagreement" input="foo=\"\\xf0\\x9f\\x99\\x82\"" origin=test`,
-			`level=debug user=5 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="bar=\"\\xf0\\x9f\\x99\\x82\"" origin=test`,
-			`level=warn user=5 msg="Matchers input has disagreement" input="bar=\"\\xf0\\x9f\\x99\\x82\"" origin=test`,
-			`level=debug user=5 msg="Parsing with UTF-8 matchers parser, with fallback to classic matchers parser" input="baz=\"\\xf0\\x9f\\x99\\x82\"" origin=test`,
-			`level=warn user=5 msg="Matchers input has disagreement" input="baz=\"\\xf0\\x9f\\x99\\x82\"" origin=test`,
-		},
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			buf := bytes.Buffer{}
-			validateMatchersInConfigDesc(log.NewLogfmtLogger(&buf), "test", test.config)
-			lines := strings.Split(strings.Trim(buf.String(), "\n"), "\n")
-			require.Equal(t, len(test.expected), len(lines))
-			for i := range lines {
-				require.Equal(t, test.expected[i], lines[i])
+			err := validateMatchersInConfigDesc(log.NewNopLogger(), "test", test.config)
+			if test.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, test.expectedErr)
 			}
 		})
 	}

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -186,8 +186,6 @@ func (am *MultitenantAlertmanager) DeleteUserConfig(w http.ResponseWriter, r *ht
 
 // Partially copied from: https://github.com/prometheus/alertmanager/blob/8e861c646bf67599a1704fc843c6a94d519ce312/cli/check_config.go#L65-L96
 func validateUserConfig(logger log.Logger, cfg alertspb.AlertConfigDesc, limits Limits, user string) error {
-	validateMatchersInConfigDesc(logger, "api", cfg)
-
 	// We don't have a valid use case for empty configurations. If a tenant does not have a
 	// configuration set and issue a request to the Alertmanager, we'll a) upload an empty
 	// config and b) immediately start an Alertmanager instance for them if a fallback


### PR DESCRIPTION
#### What this PR does

This pull request improves the logging of tenant configurations that are incompatible with UTF-8 to make it easier to understand for Mimir operators.

It uses the UTF-8 matchers parser instead of the fallback parser so we get errors instead of logs about invalid configurations. While we still log the error at present, this will allow us to set a gauge to 0 or 1 for each tenant.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
