### PR TITLE
Exit continuous-test when smokes finish

### DIFF
--- a/pkg/continuoustest/manager.go
+++ b/pkg/continuoustest/manager.go
@@ -75,12 +75,10 @@ func (m *Manager) Run(ctx context.Context) error {
 					level.Info(m.logger).Log("msg", "Test failed", "test", t.Name(), "err", err)
 					util_log.Flush()
 					os.Exit(1)
-				} else {
-					level.Info(m.logger).Log("msg", "Test passed", "test", t.Name())
-					util_log.Flush()
-					os.Exit(0)
 				}
-				return err
+				level.Info(m.logger).Log("msg", "Test passed", "test", t.Name())
+				util_log.Flush()
+				os.Exit(0)
 			}
 
 			ticker := time.NewTicker(m.cfg.RunInterval)

--- a/pkg/continuoustest/manager.go
+++ b/pkg/continuoustest/manager.go
@@ -5,10 +5,12 @@ package continuoustest
 import (
 	"context"
 	"flag"
+	"os"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	util_log "github.com/grafana/mimir/pkg/util/log"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -71,8 +73,12 @@ func (m *Manager) Run(ctx context.Context) error {
 			if m.cfg.SmokeTest {
 				if err != nil {
 					level.Info(m.logger).Log("msg", "Test failed", "test", t.Name(), "err", err)
+					util_log.Flush()
+					os.Exit(1)
 				} else {
 					level.Info(m.logger).Log("msg", "Test passed", "test", t.Name())
+					util_log.Flush()
+					os.Exit(0)
 				}
 				return err
 			}


### PR DESCRIPTION
#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes [non-termination of smoke-tests on module run
](https://github.com/grafana/mimir/pull/7869#discussion_r1562643103)
#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
