### PR TITLE
update-gateway-nginx-container-name

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -76,7 +76,7 @@ spec:
             - name: active-queries
               mountPath: /active-query-tracker
         {{- else }}
-        - name: nginx
+        - name: gateway
           image: {{ .nginx.image.registry }}/{{ .nginx.image.repository }}:{{ .nginx.image.tag }}
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           args:


### PR DESCRIPTION
This PR changes the gateway nginx container name to `gateway` so the mixin dashboard work again as they are currently broken when the non enterprise feature is enabled.

For example, this part of the mixin https://github.com/grafana/mimir/blob/1e903e4620504a265d49ccee621f09e17b3a18f8/operations/mimir-mixin/dashboards/overview-resources.libsonnet#L15 actually renders such queries:

```promql
min(container_spec_cpu_quota{cluster_id=~".*", namespace=~"mimir",container=~"(gateway|cortex-gw|cortex-gw-internal)"} / container_spec_cpu_period{cluster_id=~".*", namespace=~"mimir",container=~"(gateway|cortex-gw|cortex-gw-internal)"})
```

This is obviously never going to work because the container name before this fix will be nginx so the panels are empty

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

@dimitarvdimitrov as you're quite active on the helm chart, what do you think?
