### PR TITLE
Fix flakey TestIngester_Starting test

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -10661,7 +10661,6 @@ func (i *failingIngester) startWaitAndCheck(ctx context.Context, t *testing.T) {
 		expectedHealthyIngesters = 1
 	} else {
 		require.Error(t, err)
-		require.ErrorIs(t, err, i.failingCause)
 		expectedHealthyIngesters = 0
 	}
 	test.Poll(t, 100*time.Millisecond, expectedHealthyIngesters, func() interface{} {
@@ -10681,9 +10680,7 @@ func (i *failingIngester) starting(parentCtx context.Context) error {
 	}
 	if errors.Is(i.failingCause, context.Canceled) {
 		ctx, cancel := context.WithCancel(parentCtx)
-		go func() {
-			cancel()
-		}()
+		cancel()
 		return i.Ingester.starting(ctx)
 	}
 	return i.Ingester.starting(&mockContext{ctx: parentCtx, err: i.failingCause})


### PR DESCRIPTION
#### What this PR does

This change fixes occasional failures of `TestIngester_Starting` by removing the error type assertion from the test. The reason the error type assertion needs to be removed is that the type of error returned by `Ingester.starting()` varies based on how fast dependent services start up.

For example when starting with a context that has been canceled or has another error set for `ctx.Err()`, dependent services may complete starting but then immediately stop and go into the terminated state or their `run` method may return early. The `services.Manager` responsible for these dependent services handles service state transitions in a separate goroutine. This means that sometimes the `services.Manager` appears to start and stay running successfully,
allowing the expected error to be returned from `Ingester.starting()` _but sometimes_ it returns an error because a dependent service stopped immediately.

#### Which issue(s) this PR fixes or relates to

Part https://github.com/grafana/mimir/issues/7806

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
