### PR TITLE
Helm: use mimir continuous test as module

### DIFF
--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -98,9 +98,7 @@ new_chart_version=$(calculate_next_chart_version $current_chart_version $latest_
 validate_version_update $new_chart_version $current_chart_version $latest_gem_tag $latest_mimir_tag
 
 update_yaml_node $values_file .image.tag $latest_mimir_tag
-update_yaml_node $values_file .smoke_test.image.tag $latest_mimir_tag
 update_yaml_node $values_file .enterprise.image.tag $latest_gem_tag
-update_yaml_node $values_file .continuous_test.image.tag $latest_mimir_tag
 update_yaml_node $chart_file .appVersion $(extract_r_version $latest_mimir_tag)
 update_yaml_node $chart_file .version $new_chart_version
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -41,6 +41,7 @@ Entries should include a reference to the Pull Request that introduced the chang
   * Index-cache: changed from `60` to `30`
   * Metadata-cache: changed from `60` to `30`
   * Results-cache: changed from `60` to `30`
+* [CHANGE] Smoke-test: remove the `continuous_test.image` section and reuse the main Mimir image from the top `image` section using the new `-target=continuous-test` CLI flag.
 * [ENHANCEMENT] Dashboards: allow switching between using classic of native histograms in dashboards. #7627
   * Overview dashboard, Status panel, `cortex_request_duration_seconds` metric.
 * [ENHANCEMENT] Rollout-operator: upgrade to v0.14.0. #7886

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -41,7 +41,7 @@ Entries should include a reference to the Pull Request that introduced the chang
   * Index-cache: changed from `60` to `30`
   * Metadata-cache: changed from `60` to `30`
   * Results-cache: changed from `60` to `30`
-* [CHANGE] Smoke-test: remove the `smoke_test.image` and `continuous_test.image` sections and reuse the main Mimir image from the top `image` section using the new `-target=continuous-test` CLI flag.
+* [CHANGE] Smoke-test: remove the `smoke_test.image` and `continuous_test.image` sections and reuse the main Mimir image from the top `image` section using the new `-target=continuous-test` CLI flag. #7923
 * [ENHANCEMENT] Dashboards: allow switching between using classic of native histograms in dashboards. #7627
   * Overview dashboard, Status panel, `cortex_request_duration_seconds` metric.
 * [ENHANCEMENT] Rollout-operator: upgrade to v0.14.0. #7886

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -41,7 +41,7 @@ Entries should include a reference to the Pull Request that introduced the chang
   * Index-cache: changed from `60` to `30`
   * Metadata-cache: changed from `60` to `30`
   * Results-cache: changed from `60` to `30`
-* [CHANGE] Smoke-test: remove the `continuous_test.image` section and reuse the main Mimir image from the top `image` section using the new `-target=continuous-test` CLI flag.
+* [CHANGE] Smoke-test: remove the `smoke_test.image` and `continuous_test.image` sections and reuse the main Mimir image from the top `image` section using the new `-target=continuous-test` CLI flag.
 * [ENHANCEMENT] Dashboards: allow switching between using classic of native histograms in dashboards. #7627
   * Overview dashboard, Status panel, `cortex_request_duration_seconds` metric.
 * [ENHANCEMENT] Rollout-operator: upgrade to v0.14.0. #7886

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -71,9 +71,6 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
        > **Note:** Unlike the Mimir image tags, GEM image tags start with `v`. For example, `v2.6.0` instead of `2.6.0`.
 
-     - `smoke_test.image.tag` (Smoke test; usually the same as Mimir)
-     - `continuous_test.image.tag` (Continuous test; usually the same as Mimir)
-
    - Set the `version` field, in the [Chart.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/Chart.yaml) file, to the desired release candidate version.
 
      For example, `4.5.0-rc.0`.

--- a/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
@@ -41,10 +41,12 @@ spec:
       {{- end }}
       containers:
         - name: continuous-test
-          image: {{ .Values.continuous_test.image.repository }}:{{ .Values.continuous_test.image.tag }}
-          imagePullPolicy: {{ .Values.continuous_test.image.pullPolicy }}
+          image: "{{ include "mimir.imageReference" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "-server.metrics-port={{ include "mimir.serverHttpListenPort" . }}"
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
+            - "-server.http-listen-port={{ include "mimir.serverHttpListenPort" . }}"
             - "-tests.write-read-series-test.num-series={{ .Values.continuous_test.numSeries }}"
             - "-tests.write-read-series-test.max-query-age={{ .Values.continuous_test.maxQueryAge }}"
             - "-tests.write-endpoint={{ template "mimir.gatewayUrl" . }}"
@@ -64,6 +66,8 @@ spec:
             - "-{{ $key }}={{ $value }}"
             {{- end }}
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
             {{- if .Values.continuous_test.extraVolumeMounts }}
               {{ toYaml .Values.continuous_test.extraVolumeMounts | nindent 12}}
             {{- end }}
@@ -112,6 +116,8 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.continuous_test.terminationGracePeriodSeconds }}
       volumes:
+        - name: active-queries
+          emptyDir: {}
         {{- if .Values.continuous_test.extraVolumes }}
         {{ toYaml .Values.continuous_test.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -37,20 +37,24 @@ spec:
         {{- toYaml .Values.smoke_test.initContainers | nindent 8 }}
       containers:
         - name: smoke-test
-          image: "{{ .Values.smoke_test.image.repository }}:{{ .Values.smoke_test.image.tag }}"
-          imagePullPolicy: {{ .Values.smoke_test.image.pullPolicy }}
+          image: "{{ include "mimir.imageReference" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint={{ template "mimir.gatewayUrl" . }}"
             - "-tests.read-endpoint={{ template "mimir.gatewayUrl" . }}/prometheus"
             - "-tests.tenant-id={{ .Values.smoke_test.tenantId }}"
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port={{ include "mimir.serverHttpListenPort" . }}"
+            - "-server.http-listen-port={{ include "mimir.serverHttpListenPort" . }}"
             {{- range $key, $value := .Values.smoke_test.extraArgs }}
             - "-{{ $key }}={{ $value }}"
             {{- end }}
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
             {{- if .Values.smoke_test.extraVolumeMounts }}
               {{ toYaml .Values.smoke_test.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -70,6 +74,8 @@ spec:
             {{- end }}
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}
         {{- if .Values.smoke_test.extraVolumes }}
         {{ toYaml .Values.smoke_test.extraVolumes | nindent 8 }}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3874,10 +3874,8 @@ gr-metricname-cache:
 # that writing and reading metrics works. Currently not supported for
 # installations using GEM token-based authentication.
 smoke_test:
-  image:
-    repository: grafana/mimir-continuous-test
-    tag: 2.12.0
-    pullPolicy: IfNotPresent
+  # The image section has been removed as continuous test is now a module of the regular Mimir image.
+  # See settings for the image at the top image section.
   tenantId: ""
   extraArgs: {}
   env: []

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3894,11 +3894,8 @@ continuous_test:
   enabled: false
   # -- Number of replicas to start of continuous test
   replicas: 1
-  image:
-    repository: grafana/mimir-continuous-test
-    tag: 2.12.0
-    pullPolicy: IfNotPresent
-    # Note: optional pullSecrets are set in toplevel 'image' section, not here
+  # The image section has been removed as continuous test is now a module of the regular Mimir image.
+  # See settings for the image at the top image section.
 
   # -- Authentication settings of continuous test
   auth:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://gateway-nginx-values-mimir-gateway.citestns.svc:80"
             - "-tests.read-endpoint=http://gateway-nginx-values-mimir-gateway.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://keda-autoscaling-global-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://keda-autoscaling-global-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://keda-autoscaling-metamonitoring-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://keda-autoscaling-metamonitoring-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://keda-autoscaling-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://keda-autoscaling-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://large-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://large-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://metamonitoring-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://metamonitoring-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://scheduler-name-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://scheduler-name-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://small-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://small-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://test-ingress-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://test-ingress-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://test-oss-k8s-1.25-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://test-oss-k8s-1.25-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://test-oss-logical-multizone-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://test-oss-logical-multizone-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://test-oss-multizone-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://test-oss-multizone-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,17 +39,23 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://test-oss-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://test-oss-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
             - secretRef:
                 name: mimir-minio-secret
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://test-requests-and-limits-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://test-requests-and-limits-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -39,15 +39,21 @@ spec:
         - name: smoke-test
           imagePullPolicy: IfNotPresent
           args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath=/active-query-tracker/activity.log"
             - "-tests.smoke-test"
             - "-tests.write-endpoint=http://test-vault-agent-values-mimir-nginx.citestns.svc:80"
             - "-tests.read-endpoint=http://test-vault-agent-values-mimir-nginx.citestns.svc:80/prometheus"
             - "-tests.tenant-id="
             - "-tests.write-read-series-test.num-series=1000"
             - "-tests.write-read-series-test.max-query-age=48h"
-            - "-server.metrics-port=8080"
+            - "-server.http-listen-port=8080"
           volumeMounts:
+            - name: active-queries
+              mountPath: /active-query-tracker
           env:
           envFrom:
       restartPolicy: OnFailure
       volumes:
+        - name: active-queries
+          emptyDir: {}


### PR DESCRIPTION
#### What this PR does

Use continuous test as a target of the mimir image instead of standalone image.
Simplifies the release process.

#### Which issue(s) this PR fixes or relates to

Related to: #7747 

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
