### PR TITLE
Run kafka in kraft mode for ingest-storage development

### DIFF
--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -9,7 +9,6 @@ std.manifestYamlDoc({
     self.grafana +
     self.grafana_agent +
     self.memcached +
-    self.zookeeper +
     self.kafka +
     {},
 
@@ -117,36 +116,24 @@ std.manifestYamlDoc({
     },
   },
 
-  zookeeper:: {
-    zookeeper: {
-      image: 'confluentinc/cp-zookeeper:latest',
-      environment: [
-        'ZOOKEEPER_CLIENT_PORT=2181',
-        'ZOOKEEPER_TICK_TIME=2000',
-        'ZOOKEEPER_AUTOPURGE_SNAPRETAINCOUNT=5',
-        'ZOOKEEPER_AUTOPURGE_PURGEINTERVAL=1',
-      ],
-      ports: [
-        '22181:22181',
-      ],
-    },
-  },
-
   kafka:: {
     kafka: {
       image: 'confluentinc/cp-kafka:latest',
-      depends_on: ['zookeeper'],
       environment: [
+        'CLUSTER_ID=zH1GDqcNTzGMDCXm5VZQdg',  // Cluster ID is required in KRaft mode; the value is random UUID.
         'KAFKA_BROKER_ID=1',
         'KAFKA_NUM_PARTITIONS=100',  // Default number of partitions for auto-created topics.
-        'KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181',
-        'KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,ORBSTACK://kafka.mimir-read-write-mode.orb.local:9091,PLAINTEXT_HOST://localhost:29092',
-        'KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,ORBSTACK:PLAINTEXT',
+        'KAFKA_PROCESS_ROLES=broker,controller',
+        'KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29092',
+        'KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092',
+        'KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT',
         'KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT',
+        'KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER',
+        'KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093',
         'KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1',
         'KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=10000',
 
-        // Decomment the following config to keep a short retentino of records in Kafka.
+        // Decomment the following config to keep a short retention of records in Kafka.
         // This is useful to test the behaviour when Kafka records are deleted.
         // 'KAFKA_LOG_RETENTION_MINUTES=1',
         // 'KAFKA_LOG_SEGMENT_BYTES=1000000',

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -24,15 +24,17 @@
     "volumes":
       - "./config:/etc/agent-config"
   "kafka":
-    "depends_on":
-      - "zookeeper"
     "environment":
+      - "CLUSTER_ID=zH1GDqcNTzGMDCXm5VZQdg"
       - "KAFKA_BROKER_ID=1"
       - "KAFKA_NUM_PARTITIONS=100"
-      - "KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181"
-      - "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,ORBSTACK://kafka.mimir-read-write-mode.orb.local:9091,PLAINTEXT_HOST://localhost:29092"
-      - "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,ORBSTACK:PLAINTEXT"
+      - "KAFKA_PROCESS_ROLES=broker,controller"
+      - "KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29092"
+      - "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092"
+      - "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
       - "KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      - "KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093"
       - "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1"
       - "KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=10000"
     "healthcheck":
@@ -307,13 +309,4 @@
       - "8080:8080"
     "volumes":
       - "../common/config:/etc/nginx/templates"
-  "zookeeper":
-    "environment":
-      - "ZOOKEEPER_CLIENT_PORT=2181"
-      - "ZOOKEEPER_TICK_TIME=2000"
-      - "ZOOKEEPER_AUTOPURGE_SNAPRETAINCOUNT=5"
-      - "ZOOKEEPER_AUTOPURGE_PURGEINTERVAL=1"
-    "image": "confluentinc/cp-zookeeper:latest"
-    "ports":
-      - "22181:22181"
 "version": "3.4"


### PR DESCRIPTION
#### What this PR does

This one simplifies the dev setup for ingest-storage by switching local Kafka from Zookeeper to KRaft. Zookeeper mode [is deprecated][1] in Confluent, and we aren't running Kafka this way either.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

[1]: https://docs.confluent.io/platform/current/installation/docker/config-reference.html#required-ak-configurations-for-zk-mode