### PR TITLE
feat: change alertmanagerAPIPath to v2

### DIFF
--- a/pkg/mimirtool/client/alerts.go
+++ b/pkg/mimirtool/client/alerts.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const alertmanagerAPIPath = "/api/v1/alerts"
+const alertmanagerAPIPath = "/api/v2/alerts"
 
 type configCompat struct {
 	TemplateFiles      map[string]string `yaml:"template_files"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This change responds to the recent Alertmanager upgrade, where the deprecation of the `api/v1` path was announced in version `0.27.0` [Alertmanager-PR2970](https://github.com/prometheus/alertmanager/pull/2970). From version `0.28.0`, Alertmanager plans to drop this path, hence I am making this small change for Mimirtool, which currently uses the deprecated path. 

> [CHANGE] Alertmanager: Deprecates the v1 API. All v1 API endpoints now respond with a JSON deprecation notice and a status code of 410. All endpoints have a v2 equivalent. The list of endpoints is: #7103

The new Mimir version `2.12.0` also announced a change to the Alertmanager V1 API in the changelog, so it seems appropriate to have this change ready for the next release.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
