### PR TITLE
Do not recycle Exemplars slices with a capacity > 10

### DIFF
--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -33,9 +33,9 @@ var (
 	timeSeriesPool = sync.Pool{
 		New: func() interface{} {
 			return &TimeSeries{
-				Labels:    make([]LabelAdapter, 0, minPreallocatedLabels),
-				Samples:   make([]Sample, 0, minPreallocatedSamplesPerSeries),
-				Exemplars: make([]Exemplar, 0, minPreallocatedExemplarsPerSeries),
+				Labels:     make([]LabelAdapter, 0, minPreallocatedLabels),
+				Samples:    make([]Sample, 0, minPreallocatedSamplesPerSeries),
+				Exemplars:  make([]Exemplar, 0, minPreallocatedExemplarsPerSeries),
 				Histograms: nil,
 			}
 		},

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -18,23 +18,24 @@ import (
 )
 
 const (
-	expectedTimeseries         = 100
-	expectedLabels             = 20
-	expectedSamplesPerSeries   = 10
-	expectedExemplarsPerSeries = 1
+	minPreallocatedTimeseries         = 100
+	minPreallocatedLabels             = 20
+	minPreallocatedSamplesPerSeries   = 10
+	minPreallocatedExemplarsPerSeries = 1
+	maxPreallocatedExemplarsPerSeries = 10
 )
 
 var (
 	preallocTimeseriesSlicePool = zeropool.New(func() []PreallocTimeseries {
-		return make([]PreallocTimeseries, 0, expectedTimeseries)
+		return make([]PreallocTimeseries, 0, minPreallocatedTimeseries)
 	})
 
 	timeSeriesPool = sync.Pool{
 		New: func() interface{} {
 			return &TimeSeries{
-				Labels:     make([]LabelAdapter, 0, expectedLabels),
-				Samples:    make([]Sample, 0, expectedSamplesPerSeries),
-				Exemplars:  make([]Exemplar, 0, expectedExemplarsPerSeries),
+				Labels:    make([]LabelAdapter, 0, minPreallocatedLabels),
+				Samples:   make([]Sample, 0, minPreallocatedSamplesPerSeries),
+				Exemplars: make([]Exemplar, 0, minPreallocatedExemplarsPerSeries),
 				Histograms: nil,
 			}
 		},
@@ -447,6 +448,16 @@ func ReuseTimeseries(ts *TimeSeries) {
 
 // ClearExemplars safely removes exemplars from TimeSeries.
 func ClearExemplars(ts *TimeSeries) {
+	// When cleaning exemplars, retain the slice only if its capacity is not bigger than
+	// the desired max preallocated size. This allow us to ensure we don't put very large
+	// slices back to the pool (e.g. a few requests with an huge number of exemplars may cause
+	// in-use heap memory to significantly increase, because the slices allocated by such poison
+	// requests would be reused by other requests with a normal number of exemplars).
+	if cap(ts.Exemplars) > maxPreallocatedExemplarsPerSeries {
+		ts.Exemplars = nil
+		return
+	}
+
 	// Name and Value may point into a large gRPC buffer, so clear the reference in each exemplar to allow GC
 	for i := range ts.Exemplars {
 		for j := range ts.Exemplars[i].Labels {


### PR DESCRIPTION
#### What this PR does

We're dealing with an issue causing some ingesters memory to skyrocket. We believe the issue is caused by very few requests with an insane number of exemplars per series. When such requests are pooled, the `TimeSeries.Exemplars` slice put back into the pool will have a large capacity. Next requests will reuse the TimeSeries from the pool, keeping the large Exemplars slice allocated and in-use even if other requests don't have an huge number of exemplars. This go on and on, until many (if not all) requests in the pool have an huge Exemplars slice, causing the in-use heap to increase.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
