### PR TITLE
Do not recycle Exemplars slices with a capacity > 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [BUGFIX] Do not wrap error message with `sampled 1/<frequency>` if it's not actually sampled. #7784
 * [BUGFIX] Store-gateway: do not track cortex_querier_blocks_consistency_checks_failed_total metric if query has been canceled or interrued due to any error not related to blocks consistency check failed. #7752
 * [BUGFIX] Ingester: ignore instances with no tokens when calculating local limits to prevent discards during ingester scale-up #7881
+* [BUGFIX] Ingester: do not reuse exemplars slice in the write request if there are more than 10 exemplars per series. This should help to reduce the in-use memory in case of few requests with a very large number of exemplars. #7936
 
 ### Mixin
 


### PR DESCRIPTION
#### What this PR does

We're dealing with an issue causing some ingesters memory to skyrocket. We believe the issue is caused by very few requests with an insane number of exemplars per series. When such requests are pooled, the `TimeSeries.Exemplars` slice put back into the pool will have a large capacity. Next requests will reuse the TimeSeries from the pool, keeping the large Exemplars slice allocated and in-use even if other requests don't have an huge number of exemplars. This go on and on, until many (if not all) requests in the pool have an huge Exemplars slice, causing the in-use heap to increase.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
