### PR TITLE
distributor: fix down scaling of native histograms with unmarshal cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [BUGFIX] Store-gateway: do not track cortex_querier_blocks_consistency_checks_failed_total metric if query has been canceled or interrued due to any error not related to blocks consistency check failed. #7752
 * [BUGFIX] Ingester: ignore instances with no tokens when calculating local limits to prevent discards during ingester scale-up #7881
 * [BUGFIX] Ingester: do not reuse exemplars slice in the write request if there are more than 10 exemplars per series. This should help to reduce the in-use memory in case of few requests with a very large number of exemplars. #7936
+* [BUGFIX] Distributor: fix down scaling of native histograms in the distributor when timeseries unmarshal cache is in use. #7947
 
 ### Mixin
 

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -525,7 +525,7 @@ func TestMaxNativeHistorgramBuckets(t *testing.T) {
 				cfg.maxNativeHistogramBuckets = limit
 				ls := []mimirpb.LabelAdapter{{Name: model.MetricNameLabel, Value: "a"}, {Name: "a", Value: "a"}}
 
-				err := validateSampleHistogram(metrics, model.Now(), cfg, "user-1", "group-1", ls, &h)
+				_, err := validateSampleHistogram(metrics, model.Now(), cfg, "user-1", "group-1", ls, &h)
 
 				if limit == 1 {
 					require.Error(t, err)
@@ -572,7 +572,7 @@ func TestInvalidNativeHistogramSchema(t *testing.T) {
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			hist.Schema = testCase.schema
-			err := validateSampleHistogram(metrics, model.Now(), cfg, "user-1", "group-1", labels, hist)
+			_, err := validateSampleHistogram(metrics, model.Now(), cfg, "user-1", "group-1", labels, hist)
 			require.Equal(t, testCase.expectedError, err)
 		})
 	}

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -155,6 +155,10 @@ func (p *PreallocTimeseries) ClearExemplars() {
 	p.clearUnmarshalData()
 }
 
+func (p *PreallocTimeseries) HistogramsUpdated() {
+	p.clearUnmarshalData()
+}
+
 // DeleteExemplarByMovingLast deletes the exemplar by moving the last one on top and shortening the slice
 func (p *PreallocTimeseries) DeleteExemplarByMovingLast(ix int) {
 	last := len(p.Exemplars) - 1


### PR DESCRIPTION
#### What this PR does

Must use p.clearUnmarshalData() to clear the cached marshall data if histograms are updated.
Sadly this case was not tested in the original PR #6535 .

#### Which issue(s) this PR fixes or relates to

Related to #6535 

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
