### PR TITLE
mimir: update http-metrics TCP port in continuous-test deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 * [CHANGE] Fine-tuned `terminationGracePeriodSeconds` for the following components: #7364
   * Querier: changed from `30` to `180`
   * Query-scheduler: changed from `30` to `180`
-* [CHANGE] Change TCP port exposed by `mimir-continuous-test` deployment to match with updated defaults of its container image (see changes below).
+* [CHANGE] Change TCP port exposed by `mimir-continuous-test` deployment to match with updated defaults of its container image (see changes below). #7958
 * [ENHANCEMENT] Compactor: add `$._config.cortex_compactor_concurrent_rollout_enabled` option (disabled by default) that makes use of rollout-operator to speed up the rollout of compactors. #7783 #7878
 * [ENHANCEMENT] Shuffle-sharding: add `$._config.shuffle_sharding.ingest_storage_partitions_enabled` and `$._config.shuffle_sharding.ingester_partitions_shard_size` options, that allow configuring partitions shard size in ingest-storage mode. #7804
 * [ENHANCEMENT] Rollout-operator: upgrade to v0.14.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * [CHANGE] Fine-tuned `terminationGracePeriodSeconds` for the following components: #7364
   * Querier: changed from `30` to `180`
   * Query-scheduler: changed from `30` to `180`
+* [CHANGE] Change TCP port exposed by `mimir-continuous-test` deployment to match with updated defaults of its container image (see changes below).
 * [ENHANCEMENT] Compactor: add `$._config.cortex_compactor_concurrent_rollout_enabled` option (disabled by default) that makes use of rollout-operator to speed up the rollout of compactors. #7783 #7878
 * [ENHANCEMENT] Shuffle-sharding: add `$._config.shuffle_sharding.ingest_storage_partitions_enabled` and `$._config.shuffle_sharding.ingester_partitions_shard_size` options, that allow configuring partitions shard size in ingest-storage mode. #7804
 * [ENHANCEMENT] Rollout-operator: upgrade to v0.14.0.
@@ -82,8 +83,8 @@
 
 * [CHANGE] `mimir-continuous-test` has been deprecated and replaced by a Mimir module that can be run as a target from the `mimir` binary using `mimir -target=continuous-test`. #7753
 * [CHANGE] `-server.metrics-port` flag is no longer available for use in the module run of mimir-continuous-test, including the grafana/mimir-continuous-test Docker image which uses the new module. Configuring this port is still possible in the binary, which is deprecated. #7747
-* [BUGFIX] Set `User-Agent` header for all requests sent from the testing client. #7607
 * [CHANGE] Allowed authenticatication to Mimir using both Tenant ID and basic/bearer auth #7619.
+* [BUGFIX] Set `User-Agent` header for all requests sent from the testing client. #7607
 
 ### Query-tee
 

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -455,7 +455,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: continuous-test
         ports:
-        - containerPort: 9900
+        - containerPort: 8080
           name: http-metrics
         resources:
           limits:

--- a/operations/mimir/continuous-test.libsonnet
+++ b/operations/mimir/continuous-test.libsonnet
@@ -26,7 +26,7 @@ local k = import 'ksonnet-util/kausal.libsonnet';
     container.new('continuous-test', $._images.continuous_test) +
     container.withArgsMixin(k.util.mapToFlags($.continuous_test_args)) +
     container.withPorts([
-      k.core.v1.containerPort.new('http-metrics', 9900),
+      k.core.v1.containerPort.new('http-metrics', 8080),
     ]) +
     k.util.resourcesRequests('1', '512Mi') +
     k.util.resourcesLimits(null, '1Gi') +


### PR DESCRIPTION
#### What this PR does

After we switched CT to be a module in `mimir` binary, its default TCP port was changed to `:8080`. This PR updates the jsonnet to support these changes.

What do you think @dimitarvdimitrov @johannaratliff @56quarters?

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/7747

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
