### PR TITLE
Add documentation for helm memberlist cluster label migration

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -47,7 +47,7 @@ Rollout the installation to apply the configuration changes by running `helm upg
 
 ### 2. Set cluster label on all Mimir components
 
-Set cluster label to all Mimir components by setting the following configuration below.
+Set cluster label on all Mimir components by setting the following configuration.
 The configuration will set `cluster_label` to the Helm release name and the namespace where the helm release is installed.
 Updating a new cluster label after disabling cluster label verification will prevent Memberlist from forming a partition.
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -9,7 +9,7 @@ weight: 110
 
 # Configure a unique Grafana Mimir's Memberlist cluster label in the mimir-distributed Helm chart installation
 
-This document shows the step to configure cluster label verification in a Grafana Mimir installed by Helm.
+This document shows the steps to configure cluster label verification in a Grafana Mimir installed by Helm.
 Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) cluster is at risk of merging into one without enabling cluster label verification.
 For example, if a Mimir, Tempo or Loki are running in the same Kubernetes cluster, they might communicate with each other without this configuration update.
 Once cluster label verification is enabled, before Mimir components communicate with other components, it will verify whether those other components are having same cluster label.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -13,7 +13,7 @@ This document shows the steps to configure cluster label verification in a Grafa
 Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) clusters are at risk of merging into one without enabling cluster label verification.
 For example, if a Mimir, Tempo or Loki are running in the same Kubernetes cluster, they might communicate with each other without this configuration update.
 Once cluster label verification is enabled, before Mimir components communicate with other components, they will verify whether the other components have the same cluster label.
-The process to update the configuration should take around 30 minutes.
+The process to update the configuration will take three rollouts of the whole cluster.
 
 ## Before you begin
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -9,19 +9,23 @@ weight: 110
 # Configure a unique Grafana Mimir's Memberlist cluster label in helm installation
 
 This document shows the step to configure cluster label verification in a Grafana Mimir installed by Helm.
-The process to update the configuration should take around 30 minutes.
-Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) cluster is at risk of merging into without enabling cluster label verification. 
+Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) cluster is at risk of merging into one without enabling cluster label verification. 
 For example, if a Mimir, Tempo or Loki are running in the same Kubernetes cluster, they might communicate with each other without this configuration update. 
-Once cluster label verification is enabled, before Memberlist communicate with other components, it will verify whether that new components are having same cluster label and only allowing communication for the parties that are having the same cluster label.
+Once cluster label verification is enabled, before Mimir components communicate with other components, it will verify whether those other components are having same cluster label.
+The process to update the configuration should take around 30 minutes.
 
-There are three steps of the configuration update which we will describe in details in following section. 
-But in brief summary the steps are:
+## Before you begin
+
+- You have a Grafana Mimir installed by mimir-distributed helm chart with its Memberlist cluster label still set to default value. 
+- You have `kubectl` and `helm` command line configured to connect to the Kubernetes cluster where your Grafana Mimir is running.
+
+## Configuration update steps
+
+There are three steps of the configuration update:
 
 1. Disable Memberlist cluster label verification
 1. Set cluster label to all Mimir components
 1. Enable Memberlist cluster label verification again
-
-## Configuration update
 
 ### 1. Disable Memberlist cluster label verification
 
@@ -84,4 +88,4 @@ Ensure the host port 8080 and 8081 are available, otherwise use different availa
 Make sure that the container port which is set by default to port 80 is also correct.
 
 Open the port-forwarded URL in browser to see the Memberlist status http://localhost:8080/memberlist, http://localhost:8081/memberlist and also 
-few others Grafana mimir components. The member list page must show same view of all of their members.
+few others Grafana Mimir components. The Memberlist page from different pods must show same view of all of their members.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -87,7 +87,7 @@ Run the following port-forward command on several different Grafana Mimir compon
    kubectl port-forward pod/<mimir-pod-2> --kube-context=<my-k8s-context> --namespace=<my-mimir-namespace> 8081:8080
 ```
 
-Replace <mimir-pod-1> and <mimir-pod-2> with several actual pods from different Mimir components.
+Replace `<mimir-pod-1>` and `<mimir-pod-2>` with several actual pods from different Mimir components.
 Ensure the host port 8080 and 8081 are available, otherwise use different available ports.
 
 Open the port-forwarded URL in browser to see the Memberlist status http://localhost:8080/memberlist, http://localhost:8081/memberlist and also

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -6,7 +6,7 @@ title: "Configure a unique Grafana Mimir's Memberlist cluster label in the mimir
 weight: 110
 ---
 
-# Configure a unique Grafana Mimir's Memberlist cluster label in helm installation
+# Configure a unique Grafana Mimir's Memberlist cluster label in the mimir-distributed Helm chart installation
 
 This document shows the step to configure cluster label verification in a Grafana Mimir installed by Helm.
 Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) cluster is at risk of merging into one without enabling cluster label verification. 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -75,7 +75,7 @@ mimir:
 ```
 
 Apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
-Wait until all Pods are ready before verifying that the configuration is applied correctly.
+Replace `<my-mimir-release>` with the actual Mimir release name. Wait until all Pods are ready before verifying that the configuration is applied correctly.
 
 ## Verifying the configuration changes
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -5,7 +5,9 @@ menuTitle: "Migrating Mimir Helm Installation to Use Memberlist Cluster Label"
 weight: 110
 ---
 
-# Introduction
+# Migrating Mimir Helm Installation to Use Memberlist Cluster Label
+
+## Introduction
 
 Grafana Mimir uses memberlist to decide where the series should go when ingesting series. Memberlist encodes the replica information in data structure called hash ring, this is a consistent hashing in which different ingesters instance is placed around the ring and each ingester will have tokens. The combination of token and ingester position determines which ingester should handle a request. The information of this hash ring is delivered to different components by using gossip protocol.
 
@@ -18,19 +20,18 @@ There are three steps of the migration which we will describe in details in the 
 1. Disable memberlist cluster label verification
 1. Set cluster label to all mimir components
 1. Enable memberlist cluster label verification again
-1. Verifying the migration
 
 The migration should take around 30 minutes. The risk of not doing this migration if you have Mimir and Tempo or Loki in the same cluster is the possibility of those different backend to talk with each other.
 
-# How The Migration Solve The Issue
+## How The Migration Solve The Issue
 
 Non-Mimir component can merge with Mimir memberlist because by default memberlist applies globally. As an example, consider a loki pod is terminated and the IP address reused by a new mimir pod in the same cluster. This might cause other Loki components try to talk and sending data to this new Mimir pod.
 
 Cluster label will prevent such situation by only allowing communication for components that has same cluster label. Once that is enabled, before memberlist try to communicate with other components, it will verify whether that new components are having same cluster label and only allowing memberlist to communicate if the parties are having the same cluster label.
 
-# Migration
+## Migration
 
-## 1. Disable memberlist cluster label verification
+### 1. Disable memberlist cluster label verification
 
 By default memberlist will verify the cluster label. But by default too, all cluster labels are an empty string which means, if different systems that using memberlist and not setting the cluster label, they can talk with each other. The very first step is for us to disable cluster label verification flag. In helm we do this by setting the following structured config. In mimir-distributed helm chart version x.x.x this value will be the default hence you don't have to do this step at all.
 
@@ -43,7 +44,7 @@ mimir
 
 Make sure to rollout the installation to apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
 
-## 2. Set cluster label to all mimir components
+### 2. Set cluster label to all mimir components
 
 Set cluster label to all mimir components by setting the following configuration. Later after applying this configuration changes, and enabling cluster label verification again, all Mimir components will only communicate via memberlist if the other component is having the same cluster label.
 
@@ -57,7 +58,7 @@ mimir
 
 Apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
 
-## 3. Enable memberlist cluster label verification
+### 3. Enable memberlist cluster label verification
 
 Set `memberlist.cluster_label_verification_disabled` to false to enable again memberlist cluster label verification.
 
@@ -71,7 +72,7 @@ mimir
 
 Apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
 
-# 4. Verifying The Migration
+## Verifying The Migration
 
 Once the rollout has been done run the following helm command to verify if we have successfully migrate the Mimir memberlist to check the cluster label.
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -31,7 +31,7 @@ There are three steps of the configuration update:
 ### 1. Disable Memberlist cluster label verification
 
 Cluster label verification flag is enabled by default with cluster label set to an empty string.
-Letting default value of cluster label can make different systems that use Memberlist to communicate with each other if they also have not updated the default cluster label.
+Using the default value of cluster label can make different systems that use Memberlist communicate with each other if they also have not updated the default cluster label.
 Updating a new cluster label directly to a non-empty string value without disabling cluster label verification will cause Memberlist to form partition in the Grafana Mimir cluster.
 The partition makes some Mimir components to have different cluster label values which can make the cluster member can't communicate.
 To disable cluster label verification flag, set the following structured config in mimir-distributed values.yaml configuration.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -9,14 +9,14 @@ weight: 110
 # Configure a unique Grafana Mimir's Memberlist cluster label in the mimir-distributed Helm chart installation
 
 This document shows the step to configure cluster label verification in a Grafana Mimir installed by Helm.
-Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) cluster is at risk of merging into one without enabling cluster label verification. 
-For example, if a Mimir, Tempo or Loki are running in the same Kubernetes cluster, they might communicate with each other without this configuration update. 
+Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) cluster is at risk of merging into one without enabling cluster label verification.
+For example, if a Mimir, Tempo or Loki are running in the same Kubernetes cluster, they might communicate with each other without this configuration update.
 Once cluster label verification is enabled, before Mimir components communicate with other components, it will verify whether those other components are having same cluster label.
 The process to update the configuration should take around 30 minutes.
 
 ## Before you begin
 
-- You have a Grafana Mimir installed by mimir-distributed helm chart with its Memberlist cluster label still set to default value. 
+- You have a Grafana Mimir installed by mimir-distributed helm chart with its Memberlist cluster label still set to default value.
 - You have `kubectl` and `helm` command line configured to connect to the Kubernetes cluster where your Grafana Mimir is running.
 
 ## Configuration update steps
@@ -55,7 +55,7 @@ mimir:
   structuredConfig:
     memberlist:
       cluster_label_verification_disabled: true
-      cluster_label: '{{.Release.Name}}-{{.Release.Namespace}}'
+      cluster_label: "{{.Release.Name}}-{{.Release.Namespace}}"
 ```
 
 Apply the configuration changes again by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
@@ -68,7 +68,7 @@ Remove `mimir.structuredConfig.memberlist.cluster_label_verification_disabled` f
 mimir:
   structuredConfig:
     memberlist:
-      cluster_label: '{{.Release.Name}}-{{.Release.Namespace}}'
+      cluster_label: "{{.Release.Name}}-{{.Release.Namespace}}"
 ```
 
 Apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
@@ -83,9 +83,9 @@ Run the following port-forward command on several different Grafana Mimir compon
    kubectl port-forward pod/<mimir-pod-2> --kube-context=<my-k8s-context> --namespace=<my-mimir-namespace> 8081:80
 ```
 
-Replace mimir-pod with several actual pods from different Mimir components. 
-Ensure the host port 8080 and 8081 are available, otherwise use different available ports. 
+Replace mimir-pod with several actual pods from different Mimir components.
+Ensure the host port 8080 and 8081 are available, otherwise use different available ports.
 Make sure that the container port which is set by default to port 80 is also correct.
 
-Open the port-forwarded URL in browser to see the Memberlist status http://localhost:8080/memberlist, http://localhost:8081/memberlist and also 
+Open the port-forwarded URL in browser to see the Memberlist status http://localhost:8080/memberlist, http://localhost:8081/memberlist and also
 few others Grafana Mimir components. The Memberlist page from different pods must show same view of all of their members.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -86,21 +86,20 @@ Apply the configuration changes by running `helm upgrade <my-mimir-release> mimi
 
 ## Verifying The Migration
 
-Once the rollout has been done run the following helm command to verify if we have successfully migrated the Mimir memberlist to check the cluster label.
+Once the rollout is completed, verify the change by looking at the `/memberlist` in some pods. 
+Run the following port-forward command on several different Grafana Mimir components.
 
 ```bash
-helm --kube-context=[your-k8s-context] --namespace=[your-mimir-namespace] get values [your-mimir-release-name]
+   kubectl port-forward pod/<mimir-pod-1> --kube-context=<my-k8s-context> --namespace=<my-mimir-namespace> 8080:80
+   kubectl port-forward pod/<mimir-pod-2> --kube-context=<my-k8s-context> --namespace=<my-mimir-namespace> 8081:80
 ```
 
-You should see the following config the in the values as what we have set above.
+Replace mimir-pod with several actual pods from different Mimir components. 
+Ensure the host port 8080 and 8081 are available, otherwise use different available ports. 
+Make sure that the container port which is set by default to port 80 is also correct.
 
-```yaml
-mimir:
-  structuredConfig:
-    memberlist:
-      cluster_label_verification_disabled: false
-      cluster_label: '{{.Release.Name}}-{{.Release.Namespace}}'
-```
+Open the port-forwarded URL in browser to see the memberlist status http://localhost:8080/memberlist, http://localhost:8081/memberlist and also 
+few others Grafana mimir components. The member list page must show same view of all of their members.
 
 {{% docs/reference %}}
 [memberlist]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/memberlist-and-the-gossip-protocol"

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -8,31 +8,43 @@ weight: 110
 
 # Configure a unique Grafana Mimir's Memberlist cluster label in helm installation
 
-Grafana Mimir uses [memberlist] to share works and deciding which component replica to send the workload such as when ingesting series. Memberlist encodes the replica information in data structure called [hash ring], this is a consistent hashing scheme in which different ingesters instance tokens are placed around the ring. The token position in the ring determines which ingester should handle a request. The information of this hash ring is delivered to different components by using gossip protocol.
+Grafana Mimir uses [memberlist] to share works and deciding which component replica to send the workload such as when ingesting series. 
+Memberlist encodes the replica information in data structure called [hash ring], this is a consistent hashing scheme in which different ingesters instance tokens are placed around the ring. 
+The token position in the ring determines which ingester should handle a request. 
+The information of this hash ring is delivered to different components by using gossip protocol.
 
-By default, hash ring is global. If we also have Grafana Tempo and Grafana Loki in the same Kubernetes cluster, their components can unintentionally talk and sending data with each other, because Loki and Tempo also uses memberlist. This possibility to happen increases in cluster where the pods may reuse each other's IPs after churning.
+By default, hash ring is global. If we also have Grafana Tempo and Grafana Loki in the same Kubernetes cluster, their components can unintentionally talk and sending data with each other, because Loki and Tempo also uses memberlist. 
+This possibility to happen increases in cluster where the pods may reuse each other's IPs after churning.
 
 In this document we will describe the step on how to migrate a Mimir installation to prevent two separate memberlist gossip hash ring to join into one.
 
-There are three steps of the migration which we will describe in details in the migration section. But in brief summary the steps are:
+There are three steps of the migration which we will describe in details in the migration section. 
+But in brief summary the steps are:
 
 1. Disable memberlist cluster label verification
 1. Set cluster label to all Mimir components
 1. Enable memberlist cluster label verification again
 
-The migration should take around 30 minutes. The risk of not doing this migration if you have Mimir and Tempo or Loki in the same cluster is the possibility of those different backend to talk with each other.
+The migration should take around 30 minutes. 
+The risk of not doing this migration if you have Mimir and Tempo or Loki in the same cluster is the possibility of those different backend to talk with each other.
 
 ## How The Migration Solve The Issue
 
-Non-Mimir component can merge with Mimir memberlist because by default, memberlist is not namespaced and applies globally. As an example, consider a Loki pod is terminated and the IP address reused by a new Mimir pod in the same cluster. This might cause other Loki components try to talk and sending data to this new Mimir pod.
+Non-Mimir component can merge with Mimir memberlist because by default, memberlist is not namespaced and applies globally. 
+As an example, consider a Loki pod is terminated and the IP address reused by a new Mimir pod in the same cluster. 
+This might cause other Loki components try to talk and sending data to this new Mimir pod.
 
-Cluster label will prevent such situation by only allowing communication for components that has same cluster label. Once that is enabled, before memberlist try to communicate with other components, it will verify whether that new components are having same cluster label and only allowing memberlist to communicate if the parties are having the same cluster label.
+Cluster label will prevent such situation by only allowing communication for components that has same cluster label. 
+Once that is enabled, before memberlist try to communicate with other components, it will verify whether that new components are having same cluster label and only allowing memberlist to communicate if the parties are having the same cluster label.
 
 ## Migration
 
 ### 1. Disable memberlist cluster label verification
 
-Cluster label verification flag is enabled by default. However, cluster label default value is an empty string. If different systems that using memberlist and not setting the cluster label, they can talk with each other. To disable cluster label verification flag, set the following structured config.
+Cluster label verification flag is enabled by default. 
+However, cluster label default value is an empty string. 
+If different systems that using memberlist and not setting the cluster label, they can talk with each other. 
+To disable cluster label verification flag, set the following structured config.
 
 ```
 mimir
@@ -45,7 +57,8 @@ Rollout the installation to apply the configuration changes by running `helm upg
 
 ### 2. Set cluster label to all Mimir components
 
-Set cluster label to all Mimir components by setting the following configuration. Once the configuration is applied, all Mimir components will only communicate via memberlist if the other component is having the same cluster label.
+Set cluster label to all Mimir components by setting the following configuration. 
+Once the configuration is applied, all Mimir components will only communicate via memberlist if the other component is having the same cluster label.
 
 ```
 mimir

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -14,14 +14,14 @@ Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/
 For example, if a Mimir, Tempo or Loki are running in the same Kubernetes cluster, they might communicate with each other without this configuration update. 
 Once cluster label verification is enabled, before Memberlist communicate with other components, it will verify whether that new components are having same cluster label and only allowing communication for the parties that are having the same cluster label.
 
-There are three steps of the migration which we will describe in details in the migration section. 
+There are three steps of the configuration update which we will describe in details in following section. 
 But in brief summary the steps are:
 
 1. Disable memberlist cluster label verification
 1. Set cluster label to all Mimir components
 1. Enable memberlist cluster label verification again
 
-## Migration
+## Configuration update
 
 ### 1. Disable memberlist cluster label verification
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -25,7 +25,7 @@ The process to update the configuration should take around 30 minutes.
 There are three steps of the configuration update:
 
 1. Disable Memberlist cluster label verification
-1. Set cluster label to all Mimir components
+1. Set cluster label on all Mimir components
 1. Enable Memberlist cluster label verification again
 
 ### 1. Disable Memberlist cluster label verification
@@ -43,7 +43,8 @@ mimir:
       cluster_label_verification_disabled: true
 ```
 
-Rollout the installation to apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`. Replace `<my-mimir-release>` with the actual Mimir release name.
+Rollout the installation to apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
+Replace `<my-mimir-release>` with the actual Mimir release name. Wait until all Pods are ready before going to the next step.
 
 ### 2. Set cluster label on all Mimir components
 
@@ -60,6 +61,7 @@ mimir:
 ```
 
 Apply the configuration changes again by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
+Wait until all Pods are ready before going to the next step.
 
 ### 3. Enable Memberlist cluster label verification
 
@@ -73,8 +75,9 @@ mimir:
 ```
 
 Apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
+Wait until all Pods are ready before verifying that the configuration is applied correctly.
 
-## Verifying The Migration
+## Verifying the configuration changes
 
 Once the rollout is completed, verify the change by looking at the `/memberlist` endpoint in some of Grafana Mimir pods.
 Run the following port-forward command on several different Grafana Mimir components.
@@ -84,9 +87,8 @@ Run the following port-forward command on several different Grafana Mimir compon
    kubectl port-forward pod/<mimir-pod-2> --kube-context=<my-k8s-context> --namespace=<my-mimir-namespace> 8081:8080
 ```
 
-Replace mimir-pod with several actual pods from different Mimir components.
+Replace <mimir-pod-1> and <mimir-pod-2> with several actual pods from different Mimir components.
 Ensure the host port 8080 and 8081 are available, otherwise use different available ports.
-Make sure that the container port which is set by default to port 80 is also correct.
 
 Open the port-forwarded URL in browser to see the Memberlist status http://localhost:8080/memberlist, http://localhost:8081/memberlist and also
 few others Grafana Mimir components. The Memberlist page from different pods must show same view of all of their members.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -2,6 +2,7 @@
 description:
   Learn how to configure Helm installed Grafana Mimir's cluster label to prevent the Mimir components to join
   different Memberlist cluster.
+menuTitle: "Configure a unique Memberlist cluster label"
 title: "Configure a unique Grafana Mimir's Memberlist cluster label in the mimir-distributed Helm chart installation"
 weight: 110
 ---

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -46,56 +46,56 @@ However, cluster label default value is an empty string.
 If different systems that using memberlist and not setting the cluster label, they can talk with each other. 
 To disable cluster label verification flag, set the following structured config.
 
-```
-mimir
+```yaml
+mimir:
   structuredConfig:
     memberlist:
       cluster_label_verification_disabled: true
 ```
 
-Rollout the installation to apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
+Rollout the installation to apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
 
 ### 2. Set cluster label to all Mimir components
 
 Set cluster label to all Mimir components by setting the following configuration. 
 Once the configuration is applied, all Mimir components will only communicate via memberlist if the other component is having the same cluster label.
 
-```
-mimir
+```yaml
+mimir:
   structuredConfig:
     memberlist:
       cluster_label_verification_disabled: true
       cluster_label: "$helm-release-name"
 ```
 
-Apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
+Apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
 
 ### 3. Enable memberlist cluster label verification
 
 Set `memberlist.cluster_label_verification_disabled` to false, to re-enable memberlist cluster label verification.
 
-```
-mimir
+```yaml
+mimir:
   structuredConfig:
     memberlist:
       cluster_label_verification_disabled: false
       cluster_label: "$helm-release-name"
 ```
 
-Apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
+Apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
 
 ## Verifying The Migration
 
 Once the rollout has been done run the following helm command to verify if we have successfully migrated the Mimir memberlist to check the cluster label.
 
-```
+```bash
 helm --kube-context=[your-k8s-context] --namespace=[your-mimir-namespace] get values [your-mimir-release-name]
 ```
 
 You should see the following config the in the values as what we have set above.
 
-```
-mimir
+```yaml
+mimir:
   structuredConfig:
     memberlist:
       cluster_label_verification_disabled: false

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -61,7 +61,7 @@ mimir:
 ```
 
 Apply the configuration changes again by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
-Wait until all Pods are ready before going to the next step.
+Replace `<my-mimir-release>` with the actual Mimir release name. Wait until all Pods are ready before going to the next step.
 
 ### 3. Enable Memberlist cluster label verification
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -45,7 +45,7 @@ mimir:
 
 Rollout the installation to apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`. Replace `my-mimir-release` with the actual Mimir release name.
 
-### 2. Set cluster label to all Mimir components
+### 2. Set cluster label on all Mimir components
 
 Set cluster label to all Mimir components by setting the following configuration below.
 The configuration will set `cluster_label` to the Helm release name and the namespace where the helm release is installed.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -57,7 +57,8 @@ Rollout the installation to apply the configuration changes by running `helm upg
 
 ### 2. Set cluster label to all Mimir components
 
-Set cluster label to all Mimir components by setting the following configuration. 
+Set cluster label to all Mimir components by setting the following configuration.
+The configuration will set `cluster_label` to the Helm release name and the namespace where the helm release is installed.
 Once the configuration is applied, all Mimir components will only communicate via memberlist if the other component is having the same cluster label.
 
 ```yaml
@@ -65,21 +66,20 @@ mimir:
   structuredConfig:
     memberlist:
       cluster_label_verification_disabled: true
-      cluster_label: "$helm-release-name"
+      cluster_label: '{{.Release.Name}}-{{.Release.Namespace}}'
 ```
 
 Apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
 
 ### 3. Enable memberlist cluster label verification
 
-Set `memberlist.cluster_label_verification_disabled` to false, to re-enable memberlist cluster label verification.
+Remove `mimir.structuredCOnfig.memebrlist.cluster_label_verification_disabled` from the values.yaml file to re-enable Memberlist cluster label verification.
 
 ```yaml
 mimir:
   structuredConfig:
     memberlist:
-      cluster_label_verification_disabled: false
-      cluster_label: "$helm-release-name"
+      cluster_label: '{{.Release.Name}}-{{.Release.Namespace}}'
 ```
 
 Apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
@@ -99,7 +99,7 @@ mimir:
   structuredConfig:
     memberlist:
       cluster_label_verification_disabled: false
-      cluster_label: "$helm-release-name"
+      cluster_label: '{{.Release.Name}}-{{.Release.Namespace}}'
 ```
 
 {{% docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -43,7 +43,7 @@ mimir:
       cluster_label_verification_disabled: true
 ```
 
-Rollout the installation to apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`. Replace `my-mimir-release` with the actual Mimir release name.
+Rollout the installation to apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`. Replace `<my-mimir-release>` with the actual Mimir release name.
 
 ### 2. Set cluster label on all Mimir components
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -12,7 +12,7 @@ weight: 110
 This document shows the steps to configure cluster label verification in a Grafana Mimir installed by Helm.
 Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) clusters are at risk of merging into one without enabling cluster label verification.
 For example, if a Mimir, Tempo or Loki are running in the same Kubernetes cluster, they might communicate with each other without this configuration update.
-Once cluster label verification is enabled, before Mimir components communicate with other components, it will verify whether those other components are having same cluster label.
+Once cluster label verification is enabled, before Mimir components communicate with other components, they will verify whether the other components have the same cluster label.
 The process to update the configuration should take around 30 minutes.
 
 ## Before you begin

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -32,7 +32,7 @@ There are three steps of the configuration update:
 
 Cluster label verification flag is enabled by default with cluster label set to an empty string.
 Using the default value of cluster label can make different systems that use Memberlist communicate with each other if they also have not updated the default cluster label.
-Updating a new cluster label directly to a non-empty string value without disabling cluster label verification will cause Memberlist to form partition in the Grafana Mimir cluster.
+Setting a new cluster label directly to a non-empty string value without first disabling cluster label verification will cause Memberlist to form partition in the Grafana Mimir cluster.
 The partition makes some Mimir components to have different cluster label values which can make the cluster member can't communicate.
 To disable cluster label verification flag, set the following structured config in mimir-distributed values.yaml configuration.
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -33,7 +33,7 @@ There are three steps of the configuration update:
 Cluster label verification flag is enabled by default with cluster label set to an empty string.
 Using the default value of cluster label can make different systems that use Memberlist communicate with each other if they also have not updated the default cluster label.
 Setting a new cluster label directly to a non-empty string value without first disabling cluster label verification will cause Memberlist to form partition in the Grafana Mimir cluster.
-The partition makes some Mimir components to have different cluster label values which can make the cluster member can't communicate.
+The partition makes some Mimir components have different cluster label values which can prevent the component from communicating.
 To disable cluster label verification flag, set the following structured config in mimir-distributed values.yaml configuration.
 
 ```yaml

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -80,8 +80,8 @@ Once the rollout is completed, verify the change by looking at the `/memberlist`
 Run the following port-forward command on several different Grafana Mimir components.
 
 ```bash
-   kubectl port-forward pod/<mimir-pod-1> --kube-context=<my-k8s-context> --namespace=<my-mimir-namespace> 8080:80
-   kubectl port-forward pod/<mimir-pod-2> --kube-context=<my-k8s-context> --namespace=<my-mimir-namespace> 8081:80
+   kubectl port-forward pod/<mimir-pod-1> --kube-context=<my-k8s-context> --namespace=<my-mimir-namespace> 8080:8080
+   kubectl port-forward pod/<mimir-pod-2> --kube-context=<my-k8s-context> --namespace=<my-mimir-namespace> 8081:8080
 ```
 
 Replace mimir-pod with several actual pods from different Mimir components.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -1,13 +1,12 @@
 ---
-description: "Migrating Mimir Helm Installation to Use Memberlist Cluster Label"
-title: "Migrating Mimir Helm Installation to Use Memberlist Cluster Label"
-menuTitle: "Migrating Mimir Helm Installation to Use Memberlist Cluster Label"
+description:
+  Learn how to configure Grafana Mimir's cluster label to prevent the Memberlist gossip ring to join
+  different memberlist cluster.
+title: "Configure a unique Grafana Mimir's Memberlist cluster label in helm installation"
 weight: 110
 ---
 
-# Migrating Mimir Helm Installation to Use Memberlist Cluster Label
-
-## Introduction
+# Configure a unique Grafana Mimir's Memberlist cluster label in helm installation
 
 Grafana Mimir uses [memberlist] to share works and deciding which component replica to send the workload such as when ingesting series. Memberlist encodes the replica information in data structure called [hash ring], this is a consistent hashing scheme in which different ingesters instance tokens are placed around the ring. The token position in the ring determines which ingester should handle a request. The information of this hash ring is delivered to different components by using gossip protocol.
 

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -8,8 +8,8 @@ weight: 110
 
 # Configure a unique Grafana Mimir's Memberlist cluster label in helm installation
 
-Grafana Mimir uses [memberlist] to share works and deciding which component replica to send the workload such as when ingesting series. 
-Memberlist encodes the replica information in data structure called [hash ring], this is a consistent hashing scheme in which different ingesters instance tokens are placed around the ring. 
+Grafana Mimir uses [memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) to share works and deciding which component replica to send the workload such as when ingesting series. 
+Memberlist encodes the replica information in data structure called [hash ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/), this is a consistent hashing scheme in which different ingesters instance tokens are placed around the ring. 
 The token position in the ring determines which ingester should handle a request. 
 The information of this hash ring is delivered to different components by using gossip protocol.
 
@@ -100,8 +100,3 @@ Make sure that the container port which is set by default to port 80 is also cor
 
 Open the port-forwarded URL in browser to see the memberlist status http://localhost:8080/memberlist, http://localhost:8081/memberlist and also 
 few others Grafana mimir components. The member list page must show same view of all of their members.
-
-{{% docs/reference %}}
-[memberlist]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/memberlist-and-the-gossip-protocol"
-[hash ring]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/hash-ring"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -1,22 +1,18 @@
 ---
 description:
-  Learn how to configure Grafana Mimir's cluster label to prevent the Memberlist gossip ring to join
-  different memberlist cluster.
-title: "Configure a unique Grafana Mimir's Memberlist cluster label in helm installation"
+  Learn how to configure Helm installed Grafana Mimir's cluster label to prevent the Mimir components to join
+  different Memberlist cluster.
+title: "Configure a unique Grafana Mimir's Memberlist cluster label in the mimir-distributed Helm chart installation"
 weight: 110
 ---
 
 # Configure a unique Grafana Mimir's Memberlist cluster label in helm installation
 
-Grafana Mimir uses [memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) to share works and deciding which component replica to send the workload such as when ingesting series. 
-Memberlist encodes the replica information in data structure called [hash ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/), this is a consistent hashing scheme in which different ingesters instance tokens are placed around the ring. 
-The token position in the ring determines which ingester should handle a request. 
-The information of this hash ring is delivered to different components by using gossip protocol.
-
-By default, hash ring is global. If we also have Grafana Tempo and Grafana Loki in the same Kubernetes cluster, their components can unintentionally talk and sending data with each other, because Loki and Tempo also uses memberlist. 
-This possibility to happen increases in cluster where the pods may reuse each other's IPs after churning.
-
-In this document we will describe the step on how to migrate a Mimir installation to prevent two separate memberlist gossip hash ring to join into one.
+This document shows the step to configure cluster label verification in a Grafana Mimir installed by Helm.
+The process to update the configuration should take around 30 minutes.
+Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) cluster is at risk of merging into without enabling cluster label verification. 
+For example, if a Mimir, Tempo or Loki are running in the same Kubernetes cluster, they might communicate with each other without this configuration update. 
+Once cluster label verification is enabled, before Memberlist communicate with other components, it will verify whether that new components are having same cluster label and only allowing communication for the parties that are having the same cluster label.
 
 There are three steps of the migration which we will describe in details in the migration section. 
 But in brief summary the steps are:
@@ -25,26 +21,15 @@ But in brief summary the steps are:
 1. Set cluster label to all Mimir components
 1. Enable memberlist cluster label verification again
 
-The migration should take around 30 minutes. 
-The risk of not doing this migration if you have Mimir and Tempo or Loki in the same cluster is the possibility of those different backend to talk with each other.
-
-## How The Migration Solve The Issue
-
-Non-Mimir component can merge with Mimir memberlist because by default, memberlist is not namespaced and applies globally. 
-As an example, consider a Loki pod is terminated and the IP address reused by a new Mimir pod in the same cluster. 
-This might cause other Loki components try to talk and sending data to this new Mimir pod.
-
-Cluster label will prevent such situation by only allowing communication for components that has same cluster label. 
-Once that is enabled, before memberlist try to communicate with other components, it will verify whether that new components are having same cluster label and only allowing memberlist to communicate if the parties are having the same cluster label.
-
 ## Migration
 
 ### 1. Disable memberlist cluster label verification
 
-Cluster label verification flag is enabled by default. 
-However, cluster label default value is an empty string. 
-If different systems that using memberlist and not setting the cluster label, they can talk with each other. 
-To disable cluster label verification flag, set the following structured config.
+Cluster label verification flag is enabled by default with cluster label set to an empty string.
+Letting default value of cluster label can make different systems that use Memberlist and also not setting the cluster label to communicate with each other.
+Updating a new cluster label directly to a non-empty string value without disabling cluster label verification will cause Memberlist to form partition in the Grafana Mimir cluster.
+The partition makes some Mimir components to have different cluster label values which can make the cluster member can't communicate.
+To disable cluster label verification flag, set the following structured config in mimir-distributed values.yaml configuration.
 
 ```yaml
 mimir:
@@ -53,13 +38,13 @@ mimir:
       cluster_label_verification_disabled: true
 ```
 
-Rollout the installation to apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
+Rollout the installation to apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`. Replace `my-mimir-release` with the actual Mimir release name.
 
 ### 2. Set cluster label to all Mimir components
 
-Set cluster label to all Mimir components by setting the following configuration.
+Set cluster label to all Mimir components by setting the following configuration below.
 The configuration will set `cluster_label` to the Helm release name and the namespace where the helm release is installed.
-Once the configuration is applied, all Mimir components will only communicate via memberlist if the other component is having the same cluster label.
+Updating a new cluster label after disabling cluster label verification will prevent Memberlist to form partition.
 
 ```yaml
 mimir:
@@ -69,11 +54,11 @@ mimir:
       cluster_label: '{{.Release.Name}}-{{.Release.Namespace}}'
 ```
 
-Apply the configuration changes by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
+Apply the configuration changes again by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
 
 ### 3. Enable memberlist cluster label verification
 
-Remove `mimir.structuredCOnfig.memebrlist.cluster_label_verification_disabled` from the values.yaml file to re-enable Memberlist cluster label verification.
+Remove `mimir.structuredConfig.memberlist.cluster_label_verification_disabled` from the values.yaml file to re-enable Memberlist cluster label verification.
 
 ```yaml
 mimir:
@@ -86,7 +71,7 @@ Apply the configuration changes by running `helm upgrade <my-mimir-release> mimi
 
 ## Verifying The Migration
 
-Once the rollout is completed, verify the change by looking at the `/memberlist` in some pods. 
+Once the rollout is completed, verify the change by looking at the `/memberlist` endpoint in some of Grafana Mimir pods.
 Run the following port-forward command on several different Grafana Mimir components.
 
 ```bash

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -1,0 +1,90 @@
+---
+description: "Migrating Mimir Helm Installation to Use Memberlist Cluster Label"
+title: "Migrating Mimir Helm Installation to Use Memberlist Cluster Label"
+menuTitle: "Migrating Mimir Helm Installation to Use Memberlist Cluster Label"
+weight: 110
+---
+
+# Introduction
+
+Grafana Mimir uses memberlist to decide where the series should go when ingesting series. Memberlist encodes the replica information in data structure called hash ring, this is a consistent hashing in which different ingesters instance is placed around the ring and each ingester will have tokens. The combination of token and ingester position determines which ingester should handle a request. The information of this hash ring is delivered to different components by using gossip protocol.
+
+By default hash ring is global. If we also have Grafana Tempo and Grafana Loki in the same Kubernetes cluster, their components can unintentionally talk and sending data with each other (which is not compatible), because Loki and Tempo also uses memberlist. (TODO: More generally in any cluster where the pods may reuse each other's IPs after churning).
+
+In this document we will describe the step on how to migrate a Mimir installation to prevent non Mimir installation to talk to its memberlist cluster.
+
+There are three steps of the migration which we will describe in details in the migration section. But in brief summary the steps are:
+
+1. Disable memberlist cluster label verification
+1. Set cluster label to all mimir components
+1. Enable memberlist cluster label verification again
+1. Verifying the migration
+
+The migration should take around 30 minutes. The risk of not doing this migration if you have Mimir and Tempo or Loki in the same cluster is the possibility of those different backend to talk with each other.
+
+# How The Migration Solve The Issue
+
+Non-Mimir component can merge with Mimir memberlist because by default memberlist applies globally. As an example, consider a loki pod is terminated and the IP address reused by a new mimir pod in the same cluster. This might cause other Loki components try to talk and sending data to this new Mimir pod.
+
+Cluster label will prevent such situation by only allowing communication for components that has same cluster label. Once that is enabled, before memberlist try to communicate with other components, it will verify whether that new components are having same cluster label and only allowing memberlist to communicate if the parties are having the same cluster label.
+
+# Migration
+
+## 1. Disable memberlist cluster label verification
+
+By default memberlist will verify the cluster label. But by default too, all cluster labels are an empty string which means, if different systems that using memberlist and not setting the cluster label, they can talk with each other. The very first step is for us to disable cluster label verification flag. In helm we do this by setting the following structured config. In mimir-distributed helm chart version x.x.x this value will be the default hence you don't have to do this step at all.
+
+```
+mimir
+  structuredConfig:
+    memberlist:
+      cluster_label_verification_disabled: true
+```
+
+Make sure to rollout the installation to apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
+
+## 2. Set cluster label to all mimir components
+
+Set cluster label to all mimir components by setting the following configuration. Later after applying this configuration changes, and enabling cluster label verification again, all Mimir components will only communicate via memberlist if the other component is having the same cluster label.
+
+```
+mimir
+  structuredConfig:
+    memberlist:
+      cluster_label_verification_disabled: true
+      cluster_label: "$helm-release-name"
+```
+
+Apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
+
+## 3. Enable memberlist cluster label verification
+
+Set `memberlist.cluster_label_verification_disabled` to false to enable again memberlist cluster label verification.
+
+```
+mimir
+  structuredConfig:
+    memberlist:
+      cluster_label_verification_disabled: false
+      cluster_label: "$helm-release-name"
+```
+
+Apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
+
+# 4. Verifying The Migration
+
+Once the rollout has been done run the following helm command to verify if we have successfully migrate the Mimir memberlist to check the cluster label.
+
+```
+helm --kube-context=k3d-mimir --namespace=x-mimir get values [your-mimir-release-name]
+```
+
+You should see the following values as what we have set above.
+
+```
+mimir
+  structuredConfig:
+    memberlist:
+      cluster_label_verification_disabled: false
+      cluster_label: "$helm-release-name"
+```

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -10,7 +10,7 @@ weight: 110
 # Configure a unique Grafana Mimir's Memberlist cluster label in the mimir-distributed Helm chart installation
 
 This document shows the steps to configure cluster label verification in a Grafana Mimir installed by Helm.
-Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) cluster is at risk of merging into one without enabling cluster label verification.
+Multiple [Memberlist](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/memberlist-and-the-gossip-protocol/) [gossip ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) clusters are at risk of merging into one without enabling cluster label verification.
 For example, if a Mimir, Tempo or Loki are running in the same Kubernetes cluster, they might communicate with each other without this configuration update.
 Once cluster label verification is enabled, before Mimir components communicate with other components, it will verify whether those other components are having same cluster label.
 The process to update the configuration should take around 30 minutes.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -9,7 +9,7 @@ weight: 110
 
 ## Introduction
 
-Grafana Mimir uses [memberlist] to share works and deciding which component replica to send the workload such as when ingesting series. Memberlist encodes the replica information in data structure called [hash ring], this is a consistent hashing in which different ingesters instance tokens are placed around the ring. The token position in the ring determines which ingester should handle a request. The information of this hash ring is delivered to different components by using gossip protocol.
+Grafana Mimir uses [memberlist] to share works and deciding which component replica to send the workload such as when ingesting series. Memberlist encodes the replica information in data structure called [hash ring], this is a consistent hashing scheme in which different ingesters instance tokens are placed around the ring. The token position in the ring determines which ingester should handle a request. The information of this hash ring is delivered to different components by using gossip protocol.
 
 By default, hash ring is global. If we also have Grafana Tempo and Grafana Loki in the same Kubernetes cluster, their components can unintentionally talk and sending data with each other, because Loki and Tempo also uses memberlist. This possibility to happen increases in cluster where the pods may reuse each other's IPs after churning.
 
@@ -18,7 +18,7 @@ In this document we will describe the step on how to migrate a Mimir installatio
 There are three steps of the migration which we will describe in details in the migration section. But in brief summary the steps are:
 
 1. Disable memberlist cluster label verification
-1. Set cluster label to all mimir components
+1. Set cluster label to all Mimir components
 1. Enable memberlist cluster label verification again
 
 The migration should take around 30 minutes. The risk of not doing this migration if you have Mimir and Tempo or Loki in the same cluster is the possibility of those different backend to talk with each other.
@@ -44,7 +44,7 @@ mimir
 
 Rollout the installation to apply the configuration changes by running `helm upgrade mimir-distributed -f values.yaml`.
 
-### 2. Set cluster label to all mimir components
+### 2. Set cluster label to all Mimir components
 
 Set cluster label to all Mimir components by setting the following configuration. Once the configuration is applied, all Mimir components will only communicate via memberlist if the other component is having the same cluster label.
 
@@ -77,10 +77,10 @@ Apply the configuration changes by running `helm upgrade mimir-distributed -f va
 Once the rollout has been done run the following helm command to verify if we have successfully migrated the Mimir memberlist to check the cluster label.
 
 ```
-helm --kube-context=k3d-mimir --namespace=[your-mimir-namespace] get values [your-mimir-release-name]
+helm --kube-context=[your-k8s-context] --namespace=[your-mimir-namespace] get values [your-mimir-release-name]
 ```
 
-You should see the following values as what we have set above.
+You should see the following config the in the values as what we have set above.
 
 ```
 mimir

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -31,7 +31,7 @@ There are three steps of the configuration update:
 ### 1. Disable Memberlist cluster label verification
 
 Cluster label verification flag is enabled by default with cluster label set to an empty string.
-Letting default value of cluster label can make different systems that use Memberlist and also not setting the cluster label to communicate with each other.
+Letting default value of cluster label can make different systems that use Memberlist to communicate with each other if they also have not updated the default cluster label.
 Updating a new cluster label directly to a non-empty string value without disabling cluster label verification will cause Memberlist to form partition in the Grafana Mimir cluster.
 The partition makes some Mimir components to have different cluster label values which can make the cluster member can't communicate.
 To disable cluster label verification flag, set the following structured config in mimir-distributed values.yaml configuration.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -17,13 +17,13 @@ Once cluster label verification is enabled, before Memberlist communicate with o
 There are three steps of the configuration update which we will describe in details in following section. 
 But in brief summary the steps are:
 
-1. Disable memberlist cluster label verification
+1. Disable Memberlist cluster label verification
 1. Set cluster label to all Mimir components
-1. Enable memberlist cluster label verification again
+1. Enable Memberlist cluster label verification again
 
 ## Configuration update
 
-### 1. Disable memberlist cluster label verification
+### 1. Disable Memberlist cluster label verification
 
 Cluster label verification flag is enabled by default with cluster label set to an empty string.
 Letting default value of cluster label can make different systems that use Memberlist and also not setting the cluster label to communicate with each other.
@@ -56,7 +56,7 @@ mimir:
 
 Apply the configuration changes again by running `helm upgrade <my-mimir-release> mimir-distributed -f values.yaml`.
 
-### 3. Enable memberlist cluster label verification
+### 3. Enable Memberlist cluster label verification
 
 Remove `mimir.structuredConfig.memberlist.cluster_label_verification_disabled` from the values.yaml file to re-enable Memberlist cluster label verification.
 
@@ -83,5 +83,5 @@ Replace mimir-pod with several actual pods from different Mimir components.
 Ensure the host port 8080 and 8081 are available, otherwise use different available ports. 
 Make sure that the container port which is set by default to port 80 is also correct.
 
-Open the port-forwarded URL in browser to see the memberlist status http://localhost:8080/memberlist, http://localhost:8081/memberlist and also 
+Open the port-forwarded URL in browser to see the Memberlist status http://localhost:8080/memberlist, http://localhost:8081/memberlist and also 
 few others Grafana mimir components. The member list page must show same view of all of their members.

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md
@@ -49,7 +49,7 @@ Rollout the installation to apply the configuration changes by running `helm upg
 
 Set cluster label to all Mimir components by setting the following configuration below.
 The configuration will set `cluster_label` to the Helm release name and the namespace where the helm release is installed.
-Updating a new cluster label after disabling cluster label verification will prevent Memberlist to form partition.
+Updating a new cluster label after disabling cluster label verification will prevent Memberlist from forming a partition.
 
 ```yaml
 mimir:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Add documentation to migrate mimir helm installation to enable cluster label verification. The rendered doc is [here](https://github.com/grafana/mimir/blob/lamida/helm-enable-cluster-label/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-enable-cluster-label-verification/_index.md).

#### Which issue(s) this PR fixes or relates to

Fixes #2865

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
