### PR TITLE
frontend: active series experimental custom decoder bugfix

### DIFF
--- a/pkg/frontend/querymiddleware/shard_active_series_response_decoder.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_response_decoder.go
@@ -202,6 +202,7 @@ func (d *shardActiveSeriesResponseDecoder) streamData() error {
 		if cb.Len() >= activeSeriesChunkMaxBufferSize {
 			d.streamCh <- cb
 			cb = activeSeriesChunkBufferPool.Get().(*bytes.Buffer)
+			firstItem = true
 		}
 	}
 	d.checkContextCanceled()

--- a/pkg/frontend/querymiddleware/shard_active_series_response_decoder_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_response_decoder_test.go
@@ -14,10 +14,11 @@ import (
 
 func TestShardActiveSeriesResponseDecoder(t *testing.T) {
 	tcs := []struct {
-		name           string
-		input          string
-		expectedOutput string
-		expectedError  string
+		name               string
+		input              string
+		expectedOutput     string
+		expectedError      string
+		chunkBufferMaxSize int
 	}{
 		{
 			name:          "empty response",
@@ -38,6 +39,12 @@ func TestShardActiveSeriesResponseDecoder(t *testing.T) {
 			name:           "multiple labels",
 			input:          `{"data":[{"__name__":"metric","shard":"1"},{"__name__":"metric","shard":"2"}]}`,
 			expectedOutput: `{"__name__":"metric","shard":"1"},{"__name__":"metric","shard":"2"}`,
+		},
+		{
+			name:               "reach max buffer size",
+			input:              `{"data":[{"__name__":"metric","shard":"1"},{"__name__":"metric","shard":"2"},{"__name__":"metric","shard":"3"}]}`,
+			expectedOutput:     `{"__name__":"metric","shard":"1"},{"__name__":"metric","shard":"2"},{"__name__":"metric","shard":"3"}`,
+			chunkBufferMaxSize: 16,
 		},
 		{
 			name:          "unexpected comma",
@@ -80,6 +87,9 @@ func TestShardActiveSeriesResponseDecoder(t *testing.T) {
 
 			r := strings.NewReader(tc.input)
 			d := borrowShardActiveSeriesResponseDecoder(context.Background(), io.NopCloser(r), streamCh)
+			if tc.chunkBufferMaxSize > 0 {
+				d.chunkBufferMaxSize = tc.chunkBufferMaxSize
+			}
 
 			err := d.decode()
 			if err == nil {
@@ -89,7 +99,13 @@ func TestShardActiveSeriesResponseDecoder(t *testing.T) {
 				}()
 
 				// Drain the data channel.
+				firstItem := true
 				for streamBuf := range streamCh {
+					if !firstItem {
+						dataStr.WriteString(",")
+					} else {
+						firstItem = false
+					}
 					dataStr.WriteString(streamBuf.String())
 				}
 			} else {

--- a/pkg/frontend/querymiddleware/shard_active_series_response_decoder_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_response_decoder_test.go
@@ -5,7 +5,6 @@ package querymiddleware
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -91,7 +90,6 @@ func TestShardActiveSeriesResponseDecoder(t *testing.T) {
 
 				// Drain the data channel.
 				for streamBuf := range streamCh {
-					fmt.Println(streamBuf.String())
 					dataStr.WriteString(streamBuf.String())
 				}
 			} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR fixes a bug in the custom decoder of the active series middleware that causes double writing of the comma separator when the streamed buffer exceeds the one-megabyte threshold.

#### Which issue(s) this PR fixes or relates to

Fixes N/A
