### PR TITLE
Mixin: Add flexibility to slow queries component label

### DIFF
--- a/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
+++ b/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
@@ -99,4 +99,4 @@ These logs need to have specific labels in order for the dashboard to work.
 | :---------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cluster`   | Yes           | The Kubernetes cluster or datacenter where the Mimir cluster is running. You can configure the cluster label via the `per_cluster_label` field in the mixin configuration. |
 | `namespace` | No            | The Kubernetes namespace where the Mimir cluster is running.                                                                                                               |
-| `name`      | Yes           | Name of the component. For example, `query-frontend`. You can configure the cluster label via the `per_component_loki_label` field in the mixin configuration.           |
+| `name`      | Yes           | Name of the component. For example, `query-frontend`. You can configure the cluster label via the `per_component_loki_label` field in the mixin configuration.             |

--- a/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
+++ b/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
@@ -99,4 +99,4 @@ These logs need to have specific labels in order for the dashboard to work.
 | :---------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cluster`   | Yes           | The Kubernetes cluster or datacenter where the Mimir cluster is running. You can configure the cluster label via the `per_cluster_label` field in the mixin configuration. |
 | `namespace` | No            | The Kubernetes namespace where the Mimir cluster is running.                                                                                                               |
-| `name`      | Yes            | Name of the component. For example, `query-frontend`. You can configure the cluster label via the `per_component_loki_label` field in the mixin configuration. |
+| `name`      | Yes           | Name of the component. For example, `query-frontend`. You can configure the cluster label via the `per_component_loki_label` field in the mixin configuration.           |

--- a/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
+++ b/docs/sources/mimir/manage/monitor-grafana-mimir/requirements.md
@@ -99,4 +99,4 @@ These logs need to have specific labels in order for the dashboard to work.
 | :---------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cluster`   | Yes           | The Kubernetes cluster or datacenter where the Mimir cluster is running. You can configure the cluster label via the `per_cluster_label` field in the mixin configuration. |
 | `namespace` | No            | The Kubernetes namespace where the Mimir cluster is running.                                                                                                               |
-| `name`      | No            | Name of the component. For example, `query-frontend`.                                                                                                                      |
+| `name`      | Yes            | Name of the component. For example, `query-frontend`. You can configure the cluster label via the `per_component_loki_label` field in the mixin configuration. |

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -175,6 +175,7 @@
     per_cluster_label: 'cluster',
     per_namespace_label: 'namespace',
     per_job_label: 'job',
+    per_component_loki_label: 'name',
 
     // Grouping labels, to uniquely identify and group by {jobs, clusters}
     job_labels: [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_job_label],

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -12,8 +12,8 @@ local filename = 'mimir-slow-queries.json';
         $.timeseriesPanel('Response time') +
         $.lokiMetricsQueryPanel(
           [
-            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(response_time) [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
-            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(response_time) [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(response_time) [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
+            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(response_time) [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           ],
           ['p99', 'p50'],
           unit='s',
@@ -23,8 +23,8 @@ local filename = 'mimir-slow-queries.json';
         $.timeseriesPanel('Fetched series') +
         $.lokiMetricsQueryPanel(
           [
-            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_series_count[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
-            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_series_count[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_series_count[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
+            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_series_count[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           ],
           ['p99', 'p50'],
         )
@@ -33,8 +33,8 @@ local filename = 'mimir-slow-queries.json';
         $.timeseriesPanel('Fetched chunks') +
         $.lokiMetricsQueryPanel(
           [
-            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_chunk_bytes[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
-            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_chunk_bytes[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_chunk_bytes[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
+            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_chunk_bytes[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           ],
           ['p99', 'p50'],
           unit='bytes',
@@ -44,8 +44,8 @@ local filename = 'mimir-slow-queries.json';
         $.timeseriesPanel('Response size') +
         $.lokiMetricsQueryPanel(
           [
-            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap response_size_bytes[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
-            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap response_size_bytes[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap response_size_bytes[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
+            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap response_size_bytes[$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           ],
           ['p99', 'p50'],
           unit='bytes',
@@ -55,8 +55,8 @@ local filename = 'mimir-slow-queries.json';
         $.timeseriesPanel('Time span') +
         $.lokiMetricsQueryPanel(
           [
-            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(length) [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
-            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(length) [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(length) [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
+            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(length) [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           ],
           ['p99', 'p50'],
           unit='s',
@@ -66,8 +66,8 @@ local filename = 'mimir-slow-queries.json';
         $.timeseriesPanel('Query wall time') +
         $.lokiMetricsQueryPanel(
           [
-            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
-            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
+            'quantile_over_time(0.5, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by ()' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           ],
           ['p99', 'p50'],
           unit='s',
@@ -87,7 +87,7 @@ local filename = 'mimir-slow-queries.json';
       .addPanel(
         $.timeseriesPanel('P99 response time') +
         $.lokiMetricsQueryPanel(
-          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(response_time) [$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(response_time) [$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           '{{user}}',
           unit='s',
         )
@@ -95,14 +95,14 @@ local filename = 'mimir-slow-queries.json';
       .addPanel(
         $.timeseriesPanel('P99 fetched series') +
         $.lokiMetricsQueryPanel(
-          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_series_count[$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_series_count[$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           '{{user}}',
         )
       )
       .addPanel(
         $.timeseriesPanel('P99 fetched chunks') +
         $.lokiMetricsQueryPanel(
-          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_chunk_bytes[$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_chunk_bytes[$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           '{{user}}',
           unit='bytes',
         )
@@ -110,7 +110,7 @@ local filename = 'mimir-slow-queries.json';
       .addPanel(
         $.timeseriesPanel('P99 response size') +
         $.lokiMetricsQueryPanel(
-          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap response_size_bytes[$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap response_size_bytes[$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           '{{user}}',
           unit='bytes',
         )
@@ -118,7 +118,7 @@ local filename = 'mimir-slow-queries.json';
       .addPanel(
         $.timeseriesPanel('P99 time span') +
         $.lokiMetricsQueryPanel(
-          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(length) [$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(length) [$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           '{{user}}',
           unit='s',
         )
@@ -126,7 +126,7 @@ local filename = 'mimir-slow-queries.json';
       .addPanel(
         $.timeseriesPanel('P99 query wall time') +
         $.lokiMetricsQueryPanel(
-          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+          'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
           '{{user}}',
           unit='s',
         )
@@ -146,7 +146,7 @@ local filename = 'mimir-slow-queries.json';
         .addPanel(
           $.timeseriesPanel('P99 response time') +
           $.lokiMetricsQueryPanel(
-            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(response_time) [$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(response_time) [$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
             '{{user_agent}}',
             unit='s',
           )
@@ -154,14 +154,14 @@ local filename = 'mimir-slow-queries.json';
         .addPanel(
           $.timeseriesPanel('P99 fetched series') +
           $.lokiMetricsQueryPanel(
-            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_series_count[$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_series_count[$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
             '{{user_agent}}',
           )
         )
         .addPanel(
           $.timeseriesPanel('P99 fetched chunks') +
           $.lokiMetricsQueryPanel(
-            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_chunk_bytes[$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap fetched_chunk_bytes[$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
             '{{user_agent}}',
             unit='bytes',
           )
@@ -169,7 +169,7 @@ local filename = 'mimir-slow-queries.json';
         .addPanel(
           $.timeseriesPanel('P99 response size') +
           $.lokiMetricsQueryPanel(
-            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap response_size_bytes[$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap response_size_bytes[$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
             '{{user_agent}}',
             unit='bytes',
           )
@@ -177,7 +177,7 @@ local filename = 'mimir-slow-queries.json';
         .addPanel(
           $.timeseriesPanel('P99 time span') +
           $.lokiMetricsQueryPanel(
-            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(length) [$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap duration_seconds(length) [$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
             '{{user_agent}}',
             unit='s',
           )
@@ -185,7 +185,7 @@ local filename = 'mimir-slow-queries.json';
         .addPanel(
           $.timeseriesPanel('P99 query wall time') +
           $.lokiMetricsQueryPanel(
-            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label],
+            'topk(10, quantile_over_time(0.99, {%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | unwrap query_wall_time_seconds [$__auto]) by (user_agent))' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label],
             '{{user_agent}}',
             unit='s',
           )
@@ -218,7 +218,7 @@ local filename = 'mimir-slow-queries.json';
                 'length_seconds="{{ if .length }} {{ duration .length }} {{ end }}"',
               ],
               // Filter out the remote read endpoint.
-              expr: '{%s=~"$cluster",%s=~"$namespace",name=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | label_format %s' % [$._config.per_cluster_label, $._config.per_namespace_label, std.join(',', extraFields)],
+              expr: '{%s=~"$cluster",%s=~"$namespace",%s=~"query-frontend.*"} |= "query stats" != "/api/v1/read" | logfmt | user=~"${tenant_id}" | user_agent=~"${user_agent}" | response_time > ${min_duration} | label_format %s' % [$._config.per_cluster_label, $._config.per_namespace_label, $._config.per_component_loki_label, std.join(',', extraFields)],
               instant: false,
               legendFormat: '',
               range: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR allows users to change the component label in loki logs as the name label is not always defined (e.g. for promtail users) as explained here https://github.com/grafana/mimir/issues/5558#issuecomment-2062501431

#### Which issue(s) this PR fixes or relates to

Helps fixing https://github.com/grafana/mimir/issues/5558 later

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
