### PR TITLE
Add panel for ingester autoscaling, when using ingest-storage.

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -25627,7 +25627,7 @@ data:
                 "panels": [
                    {
                       "datasource": "$datasource",
-                      "description": "### Replicas\nThe maximum and current number of ruler-querier replicas.\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                      "description": "### Replicas\nThe maximum and current number of ruler-querier replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -39419,7 +39419,7 @@ data:
                 "panels": [
                    {
                       "datasource": "$datasource",
-                      "description": "### Replicas\nThe maximum and current number of distributor replicas.\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                      "description": "### Replicas\nThe maximum and current number of distributor replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -39679,7 +39679,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Distributor - autoscaling",
+                "title": "Distributor – autoscaling",
                 "titleSize": "h6"
              },
              {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -1251,7 +1251,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of ruler-querier replicas.\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe maximum and current number of ruler-querier replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -1065,7 +1065,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of distributor replicas.\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe maximum and current number of distributor replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1325,7 +1325,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Distributor - autoscaling",
+            "title": "Distributor – autoscaling",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -1251,7 +1251,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of ruler-querier replicas.\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe maximum and current number of ruler-querier replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -1065,7 +1065,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of distributor replicas.\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe maximum and current number of distributor replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1325,7 +1325,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Distributor - autoscaling",
+            "title": "Distributor – autoscaling",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -647,6 +647,10 @@
         enabled: false,
         hpa_name: $._config.autoscaling_hpa_prefix + 'cortex-gw.*',
       },
+      ingester: {
+        enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'ingester-zone-a',
+      },
     },
 
 

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -653,7 +653,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     $.panelDescription(
       title,
       |||
-        The maximum and current number of %s replicas.
+        The maximum and current number of %s replicas.<br /><br />
         Note: The current number of replicas can still show 1 replica even when scaled to 0.
         Because HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.
       ||| % [componentTitle]
@@ -678,7 +678,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
   // The provided componentName should be the name of a component among the ones defined in $._config.autoscaling.
   autoScalingDesiredReplicasByScalingMetricPanel(componentName, scalingMetricName, scalingMetricID)::
-    local title = 'Scaling metric (%s): Desired replicas' % scalingMetricName;
+    local title = if scalingMetricName != '' then 'Scaling metric (%s): Desired replicas' % scalingMetricName else 'Desired replicas';
+    local scalerSelector = if scalingMetricID != '' then ('.*%s.*' % scalingMetricID) else '.+';
 
     $.timeseriesPanel(title) +
     $.queryPanel(
@@ -686,7 +687,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         |||
           sum by (scaler) (
             label_replace(
-              keda_scaler_metrics_value{%(cluster_label)s=~"$cluster", exported_namespace=~"$namespace", scaler=~".*%(scaling_metric_id)s.*"},
+              keda_scaler_metrics_value{%(cluster_label)s=~"$cluster", exported_namespace=~"$namespace", scaler=~"%(scaler_selector)s"},
               "namespace", "$1", "exported_namespace", "(.*)"
             )
             /
@@ -704,7 +705,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           hpa_prefix: $._config.autoscaling_hpa_prefix,
           hpa_name: $._config.autoscaling[componentName].hpa_name,
           namespace: $.namespaceMatcher(),
-          scaling_metric_id: scalingMetricID,
+          scaler_selector: scalerSelector,
         },
       ], [
         '{{ scaler }}',
@@ -737,7 +738,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
   cpuAndMemoryBasedAutoScalingRow(componentTitle)::
     local componentName = std.strReplace(std.asciiLower(componentTitle), '-', '_');
-    super.row('%s - autoscaling' % [componentTitle])
+    super.row('%s – autoscaling' % [componentTitle])
     .addPanel(
       $.autoScalingActualReplicas(componentName)
     )

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -449,7 +449,7 @@ local filename = 'mimir-writes.json';
           'Replicas (ReplicaTemplate)',
           |||
             The maximum and current number of replicas for ReplicaTemplate object.
-            Rollout-operator will keep ingesters replicas updated based on this object.
+            Rollout-operator will keep ingester replicas updated based on this object.
             <br /><br />
             Note: The current number of replicas can still show 1 replica even when scaled to 0.
             Because HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -440,6 +440,41 @@ local filename = 'mimir-writes.json';
       $._config.autoscaling.distributor.enabled,
       $.cpuAndMemoryBasedAutoScalingRow('Distributor'),
     )
+    .addRowIf(
+      $._config.show_ingest_storage_panels && $._config.autoscaling.ingester.enabled,
+      $.row('Ingester (ingest storage) – autoscaling')
+      .addPanel(
+        $.autoScalingActualReplicas('ingester') + { title: 'Replicas (ReplicaTemplate)' } +
+        $.panelDescription(
+          'Replicas (ReplicaTemplate)',
+          |||
+            The maximum and current number of replicas for ReplicaTemplate object.
+            Rollout-operator will keep ingesters replicas updated based on this object.
+            <br /><br />
+            Note: The current number of replicas can still show 1 replica even when scaled to 0.
+            Because HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.
+          |||
+        )
+      )
+      .addPanel(
+        $.timeseriesPanel('Replicas') +
+        $.panelDescription('Replicas', 'Number of ingester replicas.') +
+        $.queryPanel(
+          [
+            'sum by (%s) (up{%s})' % [$._config.per_job_label, $.jobMatcher($._config.job_names.ingester)],
+          ],
+          [
+            '{{ %(per_job_label)s }}' % $._config.per_job_label,
+          ],
+        ),
+      )
+      .addPanel(
+        $.autoScalingDesiredReplicasByScalingMetricPanel('ingester', '', '') + { title: 'Desired replicas (ReplicaTemplate)' }
+      )
+      .addPanel(
+        $.autoScalingFailuresPanel('ingester') + { title: 'Autoscaler failures rate (ReplicaTemplate)' }
+      ),
+    )
     .addRow(
       $.kvStoreRow('Distributor - key-value store for high-availability (HA) deduplication', 'distributor', 'distributor-hatracker')
     )


### PR DESCRIPTION
#### What this PR does

This PR adds panels showing behaviour of ingester-autoscaling, as used with ingest-storage. While autoscaling configuration is not yet open-source (tbd), I'm already adding panels so that we can monitor and test it.

Here is panel in action:

<img width="1954" alt="SCR-20240425-nipz" src="https://github.com/grafana/mimir/assets/895919/ae33ad1b-a835-47bc-9ce1-29741f14d2d5">

#### Which issue(s) this PR fixes or relates to
#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
