### PR TITLE
Remove yaml ser/deser cycle in GCS client creation

### DIFF
--- a/pkg/storage/bucket/gcs/bucket_client.go
+++ b/pkg/storage/bucket/gcs/bucket_client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/gcs"
-	yaml "gopkg.in/yaml.v3"
 )
 
 // NewBucketClient creates a new GCS bucket client
@@ -20,13 +19,5 @@ func NewBucketClient(ctx context.Context, cfg Config, name string, logger log.Lo
 		Bucket:         cfg.BucketName,
 		ServiceAccount: cfg.ServiceAccount.String(),
 	}
-
-	// Thanos currently doesn't support passing the config as is, but expects a YAML,
-	// so we're going to serialize it.
-	serialized, err := yaml.Marshal(bucketConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return gcs.NewBucket(ctx, logger, serialized, name)
+	return gcs.NewBucketWithConfig(ctx, logger, bucketConfig, name)
 }


### PR DESCRIPTION
#### What this PR does

Removes unnecessary yaml ser/deser cycle in GCS client creation. Thanos added a client initializer that makes this unnecessary.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
