### PR TITLE
Remove unneeded compactor in querier e2e test

### DIFF
--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -445,10 +445,6 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 			const shippedBlocks = 2
 			require.NoError(t, cluster.WaitSumMetrics(e2e.GreaterOrEqual(float64(shippedBlocks*seriesReplicationFactor)), "cortex_bucket_store_blocks_loaded"))
 
-			// Start the compactor to have the bucket index created before querying.
-			compactor := e2emimir.NewCompactor("compactor", consul.NetworkHTTPEndpoint(), flags)
-			require.NoError(t, s.StartAndWaitReady(compactor))
-
 			var expectedCacheRequests int
 
 			// Query back the series (1 only in the storage, 1 only in the ingesters, 1 on both).


### PR DESCRIPTION
#### What this PR does

This compactor was added in #6779 but isn't actually needed since we're testing monolithic mode which already includes the compactor component.

Coincidentally, this also seems to fix #7972

#### Which issue(s) this PR fixes or relates to

Fixes #7972

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
