### PR TITLE
Add experimental kafkatool with 1 command: create-partitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ cmd/mimir-continuous-test/mimir-continuous-test
 cmd/mimir-continuous-test/mimir-continuous-test_linux_amd64
 cmd/mimir-continuous-test/mimir-continuous-test_linux_arm64
 tools/config-inspector/config-inspector
+tools/kafkatool/kafkatool
 .bak
 .uptodate
 .pkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@
 
 ### Tools
 
+* [FEATURE] kafkatool: add new CLI tool to operate Kafka. Support commands: #7983
+  * `create-partitions`
 * [ENHANCEMENT] ulidtime: add option to show random part of ULID, timestamp in milliseconds and header. #7615
 
 ## 2.12.0

--- a/tools/kafkatool/main.go
+++ b/tools/kafkatool/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package main
 
 import (

--- a/tools/kafkatool/main.go
+++ b/tools/kafkatool/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/mimir/tools/kafkatool/pkg/commands"
+)
+
+func main() {
+	var (
+		kafkaAddress  string
+		kafkaClientID string
+		kafkaClient   *kgo.Client
+	)
+
+	app := kingpin.New("kafkatool", "A command-line tool to manage Kafka.")
+	app.Flag("kafka-address", "Kafka broker address.").Required().StringVar(&kafkaAddress)
+	app.Flag("kafka-client-id", "Kafka client ID.").StringVar(&kafkaClientID)
+
+	// Create the Kafka client before any command is executed.
+	app.Action(func(context *kingpin.ParseContext) error {
+		var err error
+		kafkaClient, err = kgo.NewClient(kgo.SeedBrokers(kafkaAddress), kgo.ClientID(kafkaClientID))
+		return err
+	})
+
+	// Ensure to close the Kafka client before exiting.
+	defer func() {
+		if kafkaClient != nil {
+			kafkaClient.Close()
+		}
+	}()
+
+	// Function passed to commands to get Kafka client.
+	getKafkaClient := func() *kgo.Client {
+		return kafkaClient
+	}
+
+	createPartitionsCommand := commands.CreatePartitionsCommand{}
+	createPartitionsCommand.Register(app, getKafkaClient)
+
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+}

--- a/tools/kafkatool/pkg/commands/create_partitions.go
+++ b/tools/kafkatool/pkg/commands/create_partitions.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package commands
 
 import (
@@ -37,7 +39,7 @@ func (c *CreatePartitionsCommand) createPartitions(_ *kingpin.ParseContext) erro
 		return err
 	}
 
-	fmt.Println(fmt.Sprintf("Number of partitions before creating additional partitions: %d", len(details.Partitions)))
+	fmt.Printf("Number of partitions before creating additional partitions: %d\n", len(details.Partitions))
 
 	// Create new partitions.
 	responses, err := adm.CreatePartitions(context.Background(), c.numPartitions, c.topic)
@@ -54,7 +56,7 @@ func (c *CreatePartitionsCommand) createPartitions(_ *kingpin.ParseContext) erro
 		return res.Err
 	}
 
-	fmt.Println(fmt.Sprintf("Created %d additional partitions to topic %s", c.numPartitions, c.topic))
+	fmt.Printf("Created %d additional partitions to topic %s\n", c.numPartitions, c.topic)
 
 	// Get the current number of partitions (just for logging purposes).
 	details, err = getTopicDetails(adm, c.topic)
@@ -62,7 +64,7 @@ func (c *CreatePartitionsCommand) createPartitions(_ *kingpin.ParseContext) erro
 		return err
 	}
 
-	fmt.Println(fmt.Sprintf("Number of partitions after creating additional partitions: %d", len(details.Partitions)))
+	fmt.Printf("Number of partitions after creating additional partitions: %d\n", len(details.Partitions))
 	return nil
 }
 

--- a/tools/kafkatool/pkg/commands/create_partitions.go
+++ b/tools/kafkatool/pkg/commands/create_partitions.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/pkg/errors"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// CreatePartitionsCommand creates Kafka partitions.
+type CreatePartitionsCommand struct {
+	getKafkaClient func() *kgo.Client
+
+	topic         string
+	numPartitions int
+}
+
+// Register is used to register the command to a parent command.
+func (c *CreatePartitionsCommand) Register(app *kingpin.Application, getKafkaClient func() *kgo.Client) {
+	c.getKafkaClient = getKafkaClient
+
+	cmd := app.Command("create-partitions", "Creates Kafka partitions to a topic.").Action(c.createPartitions)
+	cmd.Flag("topic", "Kafka topic to which partitions should be added.").Required().StringVar(&c.topic)
+	cmd.Flag("num-partitions", "Number of additional partitions to add to the topic.").Required().IntVar(&c.numPartitions)
+}
+
+func (c *CreatePartitionsCommand) createPartitions(_ *kingpin.ParseContext) error {
+	client := c.getKafkaClient()
+	adm := kadm.NewClient(client)
+
+	// Get the current number of partitions (just for logging purposes).
+	details, err := getTopicDetails(adm, c.topic)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(fmt.Sprintf("Number of partitions before creating additional partitions: %d", len(details.Partitions)))
+
+	// Create new partitions.
+	responses, err := adm.CreatePartitions(context.Background(), c.numPartitions, c.topic)
+	if err != nil {
+		return err
+	}
+
+	res, err := responses.On(c.topic, nil)
+	if err != nil {
+		return err
+	}
+
+	if res.Err != nil {
+		return res.Err
+	}
+
+	fmt.Println(fmt.Sprintf("Created %d additional partitions to topic %s", c.numPartitions, c.topic))
+
+	// Get the current number of partitions (just for logging purposes).
+	details, err = getTopicDetails(adm, c.topic)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(fmt.Sprintf("Number of partitions after creating additional partitions: %d", len(details.Partitions)))
+	return nil
+}
+
+func getTopicDetails(adm *kadm.Client, topic string) (kadm.TopicDetail, error) {
+	topics, err := adm.ListTopics(context.Background(), topic)
+	if err != nil {
+		return kadm.TopicDetail{}, errors.Wrap(err, "failed to list topics")
+	}
+
+	if topics.Error() != nil {
+		return kadm.TopicDetail{}, errors.Wrap(topics.Error(), "failed to list topics")
+	}
+
+	details, ok := topics[topic]
+	if !ok {
+		return kadm.TopicDetail{}, errors.New("unable to requested find topic")
+	}
+
+	return details, nil
+}


### PR DESCRIPTION
#### What this PR does

As part of our work on the experimental new Kafka-based architecture, I had a need to create more partitions. This looked the right time to introduce a new easy tool that we can use to operate Kafka. Over the time we can add the commands we need.

In this PR I'm adding `create-partitions` command, which I've successfully used to add more partitions:

```
$ /tmp/kafkatool --kafka-address=localhost:9092 create-partitions --topic=ingest --num-partitions=999

Number of partitions before creating additional partitions: 1
Created 999 additional partitions to topic ingest
Number of partitions after creating additional partitions: 1000
```

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
