### PR TITLE
distributor: In-memory series approximation to take into account that number of zones may be large than RF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [BUGFIX] Ingester: ignore instances with no tokens when calculating local limits to prevent discards during ingester scale-up #7881
 * [BUGFIX] Ingester: do not reuse exemplars slice in the write request if there are more than 10 exemplars per series. This should help to reduce the in-use memory in case of few requests with a very large number of exemplars. #7936
 * [BUGFIX] Distributor: fix down scaling of native histograms in the distributor when timeseries unmarshal cache is in use. #7947
+* [BUGFIX] Distributor: fix cardinality API to return more accurate number of in-memory series when number of zones is larger than replication factor. #7984
 
 ### Mixin
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3729,6 +3729,34 @@ func TestDistributor_UserStats(t *testing.T) {
 			shardSize:      1, // Tenant's shard made of: ingester-zone-a-0, ingester-zone-b-0 and ingester-zone-c-0.
 			expectedSeries: 5,
 		},
+		"multi zone, 5 ingesters, every series successfully replicated to 3 ingesters across 5 zones": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 1, happyIngesters: 1},
+				"zone-b": {numIngesters: 1, happyIngesters: 1},
+				"zone-c": {numIngesters: 1, happyIngesters: 1},
+				"zone-d": {numIngesters: 1, happyIngesters: 1},
+				"zone-e": {numIngesters: 1, happyIngesters: 1},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_2", "series_3", "series_4"),
+				},
+				"zone-c": {
+					makeWriteRequest(0, 1, 0, false, false, "series_3", "series_4", "series_5"),
+				},
+				"zone-d": {
+					makeWriteRequest(0, 1, 0, false, false, "series_4", "series_5", "series_1"),
+				},
+				"zone-e": {
+					makeWriteRequest(0, 1, 0, false, false, "series_5", "series_1", "series_2"),
+				},
+			},
+			// We pushed 5 series but every series has been successfully replicated only to 3 ingesters (in different zones).
+			expectedSeries: 4,
+		},
 	}
 
 	for testName, testData := range tests {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3754,8 +3754,8 @@ func TestDistributor_UserStats(t *testing.T) {
 					makeWriteRequest(0, 1, 0, false, false, "series_5", "series_1", "series_2"),
 				},
 			},
-			// We pushed 5 series but every series has been successfully replicated only to 3 ingesters (in different zones).
-			expectedSeries: 4,
+			// We pushed 5 series and every series has been replicated to 3 ingesters (in different zones).
+			expectedSeries: 5,
 		},
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR updates the distributor's internals, that do the approximation of the number of in-memory series, for the `/api/v1/cardinality/label_values` API endpoint. Now, if the number of zones where ingesters run is larger than the replication factor (RF), the approximation falls back to the single zone logic. This seems more accurate, than returning the value of the largest zone.

#### Which issue(s) this PR fixes or relates to

Fixes #7738

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
