### PR TITLE
Ingest writer test nits

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1580,3 +1580,9 @@ type consumerFunc func(ctx context.Context, records []record) error
 func (c consumerFunc) consume(ctx context.Context, records []record) error {
 	return c(ctx, records)
 }
+
+func createTestContextWithTimeout(t *testing.T, timeout time.Duration) context.Context {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	t.Cleanup(cancel)
+	return ctx
+}


### PR DESCRIPTION
Code running in a goroutine (runAsync) shouldn't call require. (because that calls t.Fatal(), but you can't do that from a goroutine).

Also moved a function that was only used in a different test file.
