### PR TITLE
Fix metadata ingestion test flake

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -2549,9 +2549,10 @@ func TestIngester_Push(t *testing.T) {
 
 			ctx := user.InjectOrgID(context.Background(), userID)
 
-			// Wait until the ingester is healthy
-			test.Poll(t, 100*time.Millisecond, 1, func() interface{} {
-				return i.lifecycler.HealthyInstancesCount()
+			// Wait until the ingester is healthy and owns tokens. Note that the timeout here is set
+			// such that it is longer than the MinReadyDuration configuration for the ingester ring.
+			test.Poll(t, time.Second, nil, func() interface{} {
+				return i.lifecycler.CheckReady(context.Background())
 			})
 
 			// Push timeseries

--- a/pkg/ingester/lifecycle_test.go
+++ b/pkg/ingester/lifecycle_test.go
@@ -45,6 +45,7 @@ func defaultIngesterTestConfig(t testing.TB) Config {
 	cfg.IngesterRing.InstanceAddr = "localhost"
 	cfg.IngesterRing.InstanceID = "localhost"
 	cfg.IngesterRing.FinalSleep = 0
+	cfg.IngesterRing.MinReadyDuration = 100 * time.Millisecond
 	cfg.ActiveSeriesMetrics.Enabled = true
 
 	return cfg


### PR DESCRIPTION
#### What this PR does

This change fixes a metadata ingestion test flake caused by metadata being ingested when it should have been rejected. The conversion of global to local limits only counts the number of ingesters with tokens when determining how to divide the global limit. When there are no ingesters with tokens due to race conditions, 0 is used for the global limit which causes 0 to be used for the local limit which is interpreted as "unlimited".

#### Which issue(s) this PR fixes or relates to

Fixes #7979

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
