### PR TITLE
Use `grafana/doc-validator:v5.1.0`

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -107,7 +107,7 @@ jobs:
   doc-validator:
     runs-on: ubuntu-latest
     container:
-      image: grafana/doc-validator:d2a46ba
+      image: grafana/doc-validator:v5.1.0
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
It's a version tagged at the same commit as the existing short SHA.

* Update `doc-validator` image to use latest `reviewdog` with workaround for GitHub PR diff limit

