### PR TITLE
Distributor: move the ordering exemplars from ingester to distributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [ENHANCEMENT] Distributor: add experimental limit for exemplars per series per request, enabled with `-distributor.max-exemplars-per-series-per-request`, the number of discarded exemplars are tracked with `cortex_discarded_exemplars_total{reason="too_many_exemplars_per_series"}` #7989
+* [ENHANCEMENT] Distributor: move ordering exemplars from ingester to distributor. #8014
 * [ENHANCEMENT] Store-gateway: merge series from different blocks concurrently. #7456
 * [ENHANCEMENT] Store-gateway: Add `stage="wait_max_concurrent"` to `cortex_bucket_store_series_request_stage_duration_seconds` which records how long the query had to wait for its turn for `-blocks-storage.bucket-store.max-concurrent`. #7609
 * [ENHANCEMENT] Querier: add `cortex_querier_federation_upstream_query_wait_duration_seconds` to observe time from when a querier picks up a cross-tenant query to when work begins on its single-tenant counterparts. #7209

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [ENHANCEMENT] Distributor: add experimental limit for exemplars per series per request, enabled with `-distributor.max-exemplars-per-series-per-request`, the number of discarded exemplars are tracked with `cortex_discarded_exemplars_total{reason="too_many_exemplars_per_series"}` #7989
-* [ENHANCEMENT] Distributor: move ordering exemplars from ingester to distributor. #8014
 * [ENHANCEMENT] Store-gateway: merge series from different blocks concurrently. #7456
 * [ENHANCEMENT] Store-gateway: Add `stage="wait_max_concurrent"` to `cortex_bucket_store_series_request_stage_duration_seconds` which records how long the query had to wait for its turn for `-blocks-storage.bucket-store.max-concurrent`. #7609
 * [ENHANCEMENT] Querier: add `cortex_querier_federation_upstream_query_wait_duration_seconds` to observe time from when a querier picks up a cross-tenant query to when work begins on its single-tenant counterparts. #7209
@@ -32,7 +31,7 @@
 * [BUGFIX] querier: Don't cache context.Canceled errors for bucket index. #7620
 * [BUGFIX] Store-gateway: account for `"other"` time in LabelValues and LabelNames requests. #7622
 * [BUGFIX] Query-frontend: Don't panic when using the `-query-frontend.downstream-url` flag. #7651
-* [BUGFIX] Ingester: when receiving multiple exemplars for a native histogram via remote write, sort them and only report an error if all are older than the latest exemplar as this could be a partial update. #7640 #7948
+* [BUGFIX] Ingester: when receiving multiple exemplars for a native histogram via remote write, sort them and only report an error if all are older than the latest exemplar as this could be a partial update. #7640 #7948 #8014
 * [BUGFIX] Ingester: don't retain blocks if they finish exactly on the boundary of the retention window. #7656
 * [BUGFIX] Bug-fixes and improvements to experimental native histograms. #7744 #7813
 * [BUGFIX] Querier: return an error when a query uses `label_join` with an invalid destination label name. #7744

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1492,14 +1491,6 @@ func (i *Ingester) pushSamplesToAppender(userID string, timeseries []mimirpb.Pre
 				})
 				stats.failedExemplarsCount += len(ts.Exemplars)
 			} else { // Note that else is explicit, rather than a continue in the above if, in case of additional logic post exemplar processing.
-				if len(ts.Exemplars) > 1 {
-					// We can get multiple exemplars for native histograms.
-					// Sort exemplars by timestamp to ensure they are ingested in order.
-					// OpenTelemetry in particular does not order exemplars.
-					sort.Slice(ts.Exemplars, func(i, j int) bool {
-						return ts.Exemplars[i].TimestampMs < ts.Exemplars[j].TimestampMs
-					})
-				}
 				outOfOrderExemplars := 0
 				for _, ex := range ts.Exemplars {
 					if ex.TimestampMs > maxTimestampMs {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -960,16 +960,15 @@ func TestIngester_Push(t *testing.T) {
 					nil,
 				).AddExemplarsAt(0, // Add exemplars to the first series.
 					[]*mimirpb.Exemplar{
-						// These are intentionally out of order to test the sorting.
-						{
-							Labels:      []mimirpb.LabelAdapter{{Name: "traceID", Value: "456"}},
-							TimestampMs: 2000,
-							Value:       2000,
-						},
 						{
 							Labels:      []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}},
 							TimestampMs: 1000,
 							Value:       1000,
+						},
+						{
+							Labels:      []mimirpb.LabelAdapter{{Name: "traceID", Value: "456"}},
+							TimestampMs: 2000,
+							Value:       2000,
 						},
 					},
 				),

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -8,6 +8,7 @@ package mimirpb
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"sync"
 	"unsafe"
@@ -181,6 +182,13 @@ func (p *PreallocTimeseries) DeleteExemplarByMovingLast(ix int) {
 		p.Exemplars[ix] = p.Exemplars[last]
 	}
 	p.Exemplars = p.Exemplars[:last]
+	p.clearUnmarshalData()
+}
+
+func (p *PreallocTimeseries) SortExemplars() {
+	sort.Slice(p.Exemplars, func(i, j int) bool {
+		return p.Exemplars[i].TimestampMs < p.Exemplars[j].TimestampMs
+	})
 	p.clearUnmarshalData()
 }
 

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -566,3 +566,23 @@ func TestClearExemplars(t *testing.T) {
 		assert.Equal(t, 0, cap(ts.Exemplars))
 	})
 }
+
+func TestSortExemplars(t *testing.T) {
+	t.Run("should sort TimeSeries.Exemplars in order", func(t *testing.T) {
+		p := PreallocTimeseries{
+			TimeSeries: &TimeSeries{
+				Exemplars: []Exemplar{
+					{Labels: []LabelAdapter{{Name: "trace", Value: "1"}, {Name: "service", Value: "A"}}, Value: 1, TimestampMs: 3},
+					{Labels: []LabelAdapter{{Name: "trace", Value: "2"}, {Name: "service", Value: "B"}}, Value: 2, TimestampMs: 2},
+				},
+			},
+			marshalledData: []byte{1, 2, 3},
+		}
+
+		p.SortExemplars()
+		require.Len(t, p.Exemplars, 2)
+		assert.Equal(t, int64(2), p.Exemplars[0].TimestampMs)
+		assert.Equal(t, int64(3), p.Exemplars[1].TimestampMs)
+		assert.Nil(t, p.marshalledData)
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Currently, the exemplars are sorted in ingesters. However, since we're already iterating through exemplars in the distributor, it would be more efficient to perform this ordering earlier in the process. By doing so, we could achieve the ordering just once instead of three separate times.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
