### PR TITLE
feat(helm): Add volumeClaimTemplates to memcache

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -48,6 +48,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Alerts: exclude `529` and `598` status codes from failure codes in `MimirRequestsError`. #7889
 * [ENHANCEMENT] The new value `metaMonitoring.grafanaAgent.logs.clusterLabel` controls whether to add a `cluster` label and with what content to PodLogs logs. #7764
 * [ENHANCEMENT] The new values `global.extraVolumes` and `global.extraVolumeMounts` adds volumes and volumeMounts to all pods directly managed by mimir-distributed. #7922
+* [ENHANCEMENT] Add a volumeClaimTemplates section to the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` components. #8016
 
 ## 5.3.0
 

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -22,6 +22,12 @@ spec:
   updateStrategy:
     {{- toYaml .statefulStrategy | nindent 4 }}
   serviceName: {{ template "mimir.fullname" $.ctx }}-{{ $.component }}
+  {{- if .volumeClaimTemplates }}
+  volumeClaimTemplates:
+  {{- with .volumeClaimTemplates }}
+      {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 
   template:
     metadata:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2040,6 +2040,9 @@ chunks-cache:
   #   readOnly: true
   extraVolumeMounts: []
 
+  # -- List of additional PVCs to be created for the chunks-cache statefulset
+  volumeClaimTemplates: []
+
   # -- Resource requests and limits for the chunks-cache
   # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
   resources: null
@@ -2131,6 +2134,9 @@ index-cache:
   #   mountPath: /etc/extra-volume
   #   readOnly: true
   extraVolumeMounts: []
+
+  # -- List of additional PVCs to be created for the index-cache statefulset
+  volumeClaimTemplates: []
 
   # -- Resource requests and limits for the index-cache
   # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
@@ -2224,6 +2230,9 @@ metadata-cache:
   #   readOnly: true
   extraVolumeMounts: []
 
+  # -- List of additional PVCs to be created for the metadata-cache statefulset
+  volumeClaimTemplates: []
+
   # -- Resource requests and limits for the metadata-cache
   # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
   resources: null
@@ -2315,6 +2324,9 @@ results-cache:
   #   mountPath: /etc/extra-volume
   #   readOnly: true
   extraVolumeMounts: []
+
+  # -- List of additional PVCs to be created for the results-cache statefulset
+  volumeClaimTemplates: []
 
   # -- Resource requests and limits for the results-cache
   # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).


### PR DESCRIPTION
#### What this PR does

This PR adds a new resource in helm memcache template: `volumeClaimTemplate` to be able to configure the volume claim template for the memcache statefulset.

As reference, the `volumeClaimTemplate` is already used in [loki helm chart](https://github.com/grafana/helm-charts/blob/main/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml#L156) and was used as reference.


Memcache volumes are useful to use SSD disks as an alternative to machine memory as storage, so it helps to reduce memory costs with nearly no degradation in performance.

As reference there is [grafana blog post](https://grafana.com/blog/2023/08/23/how-we-scaled-grafana-cloud-logs-memcached-cluster-to-50tb-and-improved-reliability/) about how it was useful to reduce Memcache cost for Loki. Technical implementation is available at [Memecache wiki page](https://github.com/memcached/memcached/wiki/ConfiguringLokiExtstore) Loki conf.

All these references are about Memcache for Loki but is as useful for Mimir.  

#### Which issue(s) this PR fixes or relates to

Fixes #

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
