### PR TITLE
[mimir-distributed-release-5.2] Replace docs/reference shortcode with ref URIs

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -23,4 +23,3 @@ The mimir-distributed Helm chart for [Grafana Mimir] and [Grafana Enterprise Met
 > **Note:** By default, the mimir-distributed Helm chart documentation applies to both Grafana Mimir and GEM. If it only applies to GEM, it is explicitly stated.
 
 {{< section menuTitle="true" >}}
-

--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -10,6 +10,10 @@ keywords:
 cascade:
   MIMIR_DOCS_VERSION: "v2.11.x"
   gem_docs_version: "v2.11.x"
+refs:
+  grafana-mimir:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/
 ---
 
 # Grafana mimir-distributed Helm chart documentation
@@ -20,6 +24,3 @@ The mimir-distributed Helm chart for [Grafana Mimir] and [Grafana Enterprise Met
 
 {{< section menuTitle="true" >}}
 
-{{% docs/reference %}}
-[Grafana Mimir]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
@@ -2,6 +2,10 @@
 title: "Configure Grafana Mimir to allow Vault Agent to inject certificates and keys into Pods"
 menuTitle: "Vault Agent"
 description: "Learn how to configure Grafana Mimir to receive client and server certificates and keys via Hashicorp Vault Agent"
+refs:
+  securing-grafana-mimir-communications-with-tls:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/secure/securing-communications-with-tls/
 ---
 
 # Configure Grafana Mimir to allow Vault Agent to inject certificates and keys into Pods
@@ -67,6 +71,3 @@ For more information about Vault and Vault Agent, see [Injecting Vault Secrets I
 
 To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS].
 
-{{% docs/reference %}}
-[Securing Grafana Mimir communications with TLS]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/manage/secure/securing-communications-with-tls"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
@@ -70,4 +70,3 @@ spec:
 For more information about Vault and Vault Agent, see [Injecting Vault Secrets Into Kubernetes Pods via a Sidecar](https://www.hashicorp.com/blog/injecting-vault-secrets-into-kubernetes-pods-via-a-sidecar).
 
 To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS].
-

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
@@ -46,4 +46,3 @@ To configure bucket limits for native histograms, refer to [Configure native his
 To configure Grafana Agent or Prometheus to write native histograms to Grafana Mimir, refer to [Send native histograms to Mimir].
 
 To visualize native histograms in Mimir, refer to [Visualize native histograms].
-

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
@@ -2,6 +2,22 @@
 title: "Configure native histograms"
 menuTitle: "Native histograms"
 description: "Learn how to configure Grafana Mimir to ingest and query native histograms."
+refs:
+  visualize-native-histograms:
+    - pattern: /
+      destination: https://grafana.com/docs/mimir/<MIMIR_DOCS_VERSION>/visualize/native-histograms/
+  remote-write-api:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/http-api/#remote-write
+  send-native-histograms-to-mimir:
+    - pattern: /
+      destination: https://grafana.com/docs/mimir/<MIMIR_DOCS_VERSION>/send/native-histograms/
+  configure-native-histograms:
+    - pattern: /
+      destination: https://grafana.com/docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-native-histograms-ingestion/
+  grafana-mimir-query-sharding:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/query-sharding/
 ---
 
 # Configure native histograms
@@ -31,10 +47,3 @@ To configure Grafana Agent or Prometheus to write native histograms to Grafana M
 
 To visualize native histograms in Mimir, refer to [Visualize native histograms].
 
-{{% docs/reference %}}
-[remote write API]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/http-api#remote-write"
-[Grafana Mimir query sharding]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/query-sharding"
-[Configure native histograms]: "/ -> https://grafana.com/docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-native-histograms-ingestion"
-[Send native histograms to Mimir]: "/ -> https://grafana.com/docs/mimir/<MIMIR_DOCS_VERSION>/send/native-histograms/"
-[Visualize native histograms]: "/ -> https://grafana.com/docs/mimir/<MIMIR_DOCS_VERSION>/visualize/native-histograms/"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
@@ -51,4 +51,3 @@ mimir:
         redis:
           endpoint: <redis-url>:6379
 ```
-

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
@@ -2,6 +2,10 @@
 title: "Configure Redis cache"
 menuTitle: "Redis cache"
 description: "Learn how to configure Grafana Mimir to use external Redis as cache"
+refs:
+  the-configuration-parameters-reference:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/configuration-parameters/#redis
 ---
 
 # Configure Redis cache
@@ -48,6 +52,3 @@ mimir:
           endpoint: <redis-url>:6379
 ```
 
-{{% docs/reference %}}
-[the configuration parameters reference]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/configuration-parameters#redis"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
@@ -3,6 +3,25 @@ title: "Migrate from Cortex to Grafana Mimir"
 menuTitle: "Migrate from Cortex"
 description: "Learn how to migrate your deployment of Cortex to Grafana Mimir to simplify the deployment and continued operation of a horizontally scalable, multi-tenant time series database with long-term storage."
 weight: 10
+refs:
+  monitoring-mixin-dashboards:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/dashboards/
+  mimirtool-config-convert:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool/#convert
+  mimirtool_rules:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool/#rules
+  migrate-from-cortex:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR DOCS VERSION>/set-up/migrate/migrate-from-cortex/
+  convert:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool/#convert
+  additional-resources-metrics:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/requirements/#additional-resources-metrics
 ---
 
 # Migrate from Cortex to Grafana Mimir
@@ -255,11 +274,3 @@ You can migrate to the Grafana Mimir Helm chart (`grafana/mimir-distributed` v3.
 
 To verify that the cluster is operating correctly, use the [monitoring mixin dashboards].
 
-{{% docs/reference %}}
-[Migrate from Cortex]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/set-up/migrate/migrate-from-cortex"
-[mimirtool_rules]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool#rules"
-[`mimirtool config convert`]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool#convert"
-[convert]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/tools/mimirtool#convert"
-[Additional resources metrics]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/requirements#additional-resources-metrics"
-[monitoring mixin dashboards]: "/ -> /docs/mimir/<MIMIR DOCS VERSION>/manage/monitor-grafana-mimir/dashboards"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-cortex.md
@@ -273,4 +273,3 @@ You can migrate to the Grafana Mimir Helm chart (`grafana/mimir-distributed` v3.
    ```
 
 To verify that the cluster is operating correctly, use the [monitoring mixin dashboards].
-

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
@@ -3,6 +3,22 @@ title: "Migrate from single zone to zone-aware replication in Mimir Helm chart v
 menuTitle: "Migrate from single zone to zone-aware replication in Mimir Helm chart version 4.0"
 description: "Learn how to migrate from having a single availability zone to full zone-aware replication using the Grafana Mimir Helm chart"
 weight: 10
+refs:
+  store-gateway:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/store-gateway/
+  alertmanager:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/alertmanager/
+  zone-aware-replication:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-zone-aware-replication/
+  ingester:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/ingester/
+  shuffle-sharding:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-shuffle-sharding/
 ---
 
 # Migrate from single zone to zone-aware replication in Mimir Helm chart version 4.0
@@ -789,10 +805,3 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
 
-{{% docs/reference %}}
-[zone-aware replication]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-zone-aware-replication"
-[alertmanager]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/alertmanager"
-[store-gateway]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/store-gateway"
-[ingester]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/ingester"
-[shuffle sharding]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-shuffle-sharding"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
@@ -804,4 +804,3 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 1. Undo the doubling of series limits done in the first step.
 
 1. Upgrade the installation with the `helm` command using your regular command line flags.
-

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
@@ -6,6 +6,28 @@ aliases:
 menuTitle: "Run Mimir in production"
 description: "Learn how to run Grafana Mimir in production using the mimir-distributed Helm chart."
 weight: 40
+refs:
+  replication-across-availability-zones:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-zone-aware-replication/
+  planning-grafana-mimir-capacity:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/run-production-environment/planning-capacity/
+  ingesters-failure-and-data-loss:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/ingester/#ingesters-failure-and-data-loss
+  store-gateway:-blocks-sharding-and-replication:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/store-gateway/#blocks-sharding-and-replication
+  installing-grafana-mimir-dashboards-and-alerts:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts/
+  collecting-metrics-and-logs-from-grafana-mimir:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs/
+  configure-grafana-mimir-object-storage-backend:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-object-storage-backend/
 ---
 
 # Run Grafana Mimir in production using the Helm chart
@@ -342,12 +364,3 @@ rollout_operator:
 >   --set 'mimir-distributed.rollout_operator.podSecurityContext.runAsGroup=null'
 > ```
 
-{{% docs/reference %}}
-[Planning Grafana Mimir capacity]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/manage/run-production-environment/planning-capacity"
-[Ingesters failure and data loss]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/ingester#ingesters-failure-and-data-loss"
-[Collecting metrics and logs from Grafana Mimir]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs"
-[Store-gateway: Blocks sharding and replication]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/store-gateway#blocks-sharding-and-replication"
-[replication across availability zones]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-zone-aware-replication"
-[Configure Grafana Mimir object storage backend]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-object-storage-backend"
-[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
@@ -363,4 +363,3 @@ rollout_operator:
 >   --set 'mimir-distributed.rollout_operator.podSecurityContext.runAsUser=null' \
 >   --set 'mimir-distributed.rollout_operator.podSecurityContext.runAsGroup=null'
 > ```
-

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
@@ -538,4 +538,3 @@ The example is generated with the following steps:
    ```
 
    Lines starting with "`-`" were removed and lines starting with "`+`" were added. The change to the annotation `checksum/config` means the pods will be restarted when this change is applied.
-

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
@@ -6,6 +6,10 @@ weight: 80
 aliases:
   - docs/mimir/latest/operators-guide/run-production-environment-with-helm/configuration-with-helm
   - docs/mimir/latest/operators-guide/running-production-environment-with-helm/configuration-with-helm
+refs:
+  configuration-parameters:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/configuration-parameters/
 ---
 
 # Manage the configuration of Grafana Mimir with Helm
@@ -535,6 +539,3 @@ The example is generated with the following steps:
 
    Lines starting with "`-`" were removed and lines starting with "`+`" were added. The change to the annotation `checksum/config` means the pods will be restarted when this change is applied.
 
-{{% docs/reference %}}
-[configuration parameters]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/configuration-parameters"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
@@ -170,4 +170,3 @@ select Format = Table. In the result you can see the several time series with di
 
 The most important thing is you will not find `__replica__` label (or any label that you set in `ha_replica_label`
 config) anymore. This means you have configured the deduplication successfully.
-

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
@@ -9,6 +9,13 @@ title:
   Configuring Grafana Mimir-Distributed Helm Chart for high-availability deduplication
   with Consul
 weight: 70
+refs:
+  distributor:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/distributor/
+  configure-high-availability:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-high-availability-deduplication/
 ---
 
 # Configuring Grafana Mimir-Distributed Helm Chart for high-availability deduplication with Consul
@@ -164,7 +171,3 @@ select Format = Table. In the result you can see the several time series with di
 The most important thing is you will not find `__replica__` label (or any label that you set in `ha_replica_label`
 config) anymore. This means you have configured the deduplication successfully.
 
-{{% docs/reference %}}
-[Configure high availability]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-high-availability-deduplication"
-[distributor]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/distributor"
-{{% /docs/reference %}}

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -145,4 +145,3 @@ metaMonitoring:
           passwordSecretName: gem-tokens
           passwordSecretKey: metamonitoring
 ```
-

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -5,6 +5,13 @@ description: Learn how to collect metrics and logs from Grafana Mimir or GEM its
 menuTitle: Monitor system health
 title: Monitor the health of your system
 weight: 60
+refs:
+  collect-metrics-and-logs-without-the-helm-chart:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-without-the-helm-chart
+  installing-grafana-mimir-dashboards-and-alerts:
+    - pattern: /
+      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts/
 ---
 
 # Monitor the health of your system
@@ -139,7 +146,3 @@ metaMonitoring:
           passwordSecretKey: metamonitoring
 ```
 
-{{% docs/reference %}}
-[Installing Grafana Mimir dashboards and alerts]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts"
-[Collect metrics and logs without the Helm chart]: "/ -> /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs#collect-metrics-and-logs-without-the-helm-chart"
-{{% /docs/reference %}}


### PR DESCRIPTION
You can use \`ref\` URIs in admonitions (or any shortcodes) because they are inline and not subject to the issues noted in the [\`admonition\` shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/#code-shortcode:~:text=to%20core%20understanding.-,WARNING,For%20more%20information%2C%20refer%20to%20Markdown%20Reference%20Links%20in%20Shortcodes.,-Examples).

The \`ref\` URIs perform the same pattern matching as \`docs/reference\` but don't require the use of reference-style links and the destinations are ordinary (full) URLs that can include version substitution. Unlike \`docs/reference\`, the implementation doesn't use \`relref\` so you don't have to be careful with omitting trailing slashes and the links will follow redirects.

Documentation: https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects

To check the links, refer to the deploy preview in https://github.com/grafana/website/pull/19630.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
