### PR TITLE
Streaming PromQL engine: benchmarking improvements

### DIFF
--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -216,7 +216,6 @@ func TestCases(metricSizes []int) []BenchCase {
 			tmp = append(tmp, c)
 		} else {
 			tmp = append(tmp, BenchCase{Expr: c.Expr, Steps: 0})
-			tmp = append(tmp, BenchCase{Expr: c.Expr, Steps: 1})
 			tmp = append(tmp, BenchCase{Expr: c.Expr, Steps: 100})
 			tmp = append(tmp, BenchCase{Expr: c.Expr, Steps: 1000})
 			// Important: if adding test cases with larger numbers of steps, make sure to adjust NumIntervals as well.

--- a/tools/benchmark-query-engine/main.go
+++ b/tools/benchmark-query-engine/main.go
@@ -46,15 +46,15 @@ type app struct {
 func (a *app) run() error {
 	a.parseArgs()
 
-	if a.listTests {
-		a.printTests()
-		return nil
-	}
-
 	// Do this early, to avoid doing a bunch of pointless work if the regex is invalid or doesn't match any tests.
 	filteredNames, err := a.filteredTestCaseNames()
 	if err != nil {
 		return err
+	}
+
+	if a.listTests {
+		a.printTests(filteredNames)
+		return nil
 	}
 
 	if err := a.findBenchmarkPackageDir(); err != nil {
@@ -196,8 +196,8 @@ func (a *app) startIngesterAndLoadData() error {
 	return nil
 }
 
-func (a *app) printTests() {
-	for _, name := range a.allTestCaseNames() {
+func (a *app) printTests(names []string) {
+	for _, name := range names {
 		println(name)
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR makes two small improvements to the benchmarks for the streaming PromQL engine:

* It removes the "single step range query" benchmark cases. These aren't particularly valuable given we also benchmark instant queries, and running the full benchmark suite already takes quite a while.

* It changes the behaviour of `tools/benchmark-query-engine` to apply the supplied filter when listing test cases (eg. running `benchmark-query-engine -list -bench "blah"` now shows only benchmarks matching `blah`, rather than all benchmarks).

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
