### PR TITLE
Fetch Grafana Alertmanager configuration (sync loop)

### DIFF
--- a/pkg/alertmanager/alertspb/compat.go
+++ b/pkg/alertmanager/alertspb/compat.go
@@ -11,6 +11,12 @@ var (
 	ErrNotFound = errors.New("alertmanager storage object not found")
 )
 
+// AlertConfigDescs is a wrapper for a Mimir and a Grafana Alertmanager configurations.
+type AlertConfigDescs struct {
+	Mimir   AlertConfigDesc
+	Grafana GrafanaAlertConfigDesc
+}
+
 // ToProto transforms a yaml Alertmanager config and map of template files to an AlertConfigDesc.
 func ToProto(cfg string, templates map[string]string, user string) AlertConfigDesc {
 	tmpls := []*TemplateDesc{}

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -83,20 +83,31 @@ func (s *BucketAlertStore) ListAllUsers(ctx context.Context) ([]string, error) {
 }
 
 // GetAlertConfigs implements alertstore.AlertStore.
-func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
+func (s *BucketAlertStore) GetAlertConfigs(ctx context.Context, userIDs []string, fetchGrafanaConfig bool) (map[string]alertspb.AlertConfigDescs, error) {
 	var (
 		cfgsMx = sync.Mutex{}
-		cfgs   = make(map[string]alertspb.AlertConfigDesc, len(userIDs))
+		cfgs   = make(map[string]alertspb.AlertConfigDescs, len(userIDs))
 	)
 
 	err := concurrency.ForEachJob(ctx, len(userIDs), fetchConcurrency, func(ctx context.Context, idx int) error {
 		userID := userIDs[idx]
+		var cfg alertspb.AlertConfigDescs
 
-		cfg, err := s.getAlertConfig(ctx, userID)
+		mimirCfg, err := s.getAlertConfig(ctx, userID)
 		if s.alertsBucket.IsObjNotFoundErr(err) {
 			return nil
 		} else if err != nil {
 			return errors.Wrapf(err, "failed to fetch alertmanager config for user %s", userID)
+		}
+		cfg.Mimir = mimirCfg
+
+		if fetchGrafanaConfig {
+			grafanaCfg, err := s.getGrafanaAlertConfig(ctx, userID)
+			// Users not having a Grafana alerting configuration is expected.
+			if err != nil && !s.alertsBucket.IsObjNotFoundErr(err) {
+				return errors.Wrapf(err, "failed to fetch grafana alertmanager config for user %s", userID)
+			}
+			cfg.Grafana = grafanaCfg
 		}
 
 		cfgsMx.Lock()
@@ -141,8 +152,7 @@ func (s *BucketAlertStore) DeleteAlertConfig(ctx context.Context, userID string)
 }
 
 func (s *BucketAlertStore) GetGrafanaAlertConfig(ctx context.Context, userID string) (alertspb.GrafanaAlertConfigDesc, error) {
-	config := alertspb.GrafanaAlertConfigDesc{}
-	err := s.get(ctx, s.getGrafanaAlertmanagerUserBucket(userID), grafanaConfigName, &config)
+	config, err := s.getGrafanaAlertConfig(ctx, userID)
 	if s.grafanaAMBucket.IsObjNotFoundErr(err) {
 		return config, alertspb.ErrNotFound
 	}
@@ -254,6 +264,12 @@ func (s *BucketAlertStore) DeleteFullGrafanaState(ctx context.Context, userID st
 func (s *BucketAlertStore) getAlertConfig(ctx context.Context, userID string) (alertspb.AlertConfigDesc, error) {
 	config := alertspb.AlertConfigDesc{}
 	err := s.get(ctx, s.getUserBucket(userID), userID, &config)
+	return config, err
+}
+
+func (s *BucketAlertStore) getGrafanaAlertConfig(ctx context.Context, userID string) (alertspb.GrafanaAlertConfigDesc, error) {
+	config := alertspb.GrafanaAlertConfigDesc{}
+	err := s.get(ctx, s.getGrafanaAlertmanagerUserBucket(userID), grafanaConfigName, &config)
 	return config, err
 }
 

--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -56,19 +56,23 @@ type BucketAlertStore struct {
 	amBucket        objstore.Bucket
 	grafanaAMBucket objstore.Bucket
 
-	cfgProvider bucket.TenantConfigProvider
-	logger      log.Logger
-
-	fetchGrafanaCfg bool // Retrieve Grafana AM configs alongside Mimir AM configs.
+	cfgProvider     bucket.TenantConfigProvider
+	fetchGrafanaCfg bool
+	logger          log.Logger
 }
 
-func NewBucketAlertStore(bkt objstore.Bucket, cfgProvider bucket.TenantConfigProvider, fetchGrafanaCfg bool, logger log.Logger) *BucketAlertStore {
+type BucketAlertStoreConfig struct {
+	// Retrieve Grafana AM configs alongside Mimir AM configs.
+	FetchGrafanaConfig bool
+}
+
+func NewBucketAlertStore(cfg BucketAlertStoreConfig, bkt objstore.Bucket, cfgProvider bucket.TenantConfigProvider, logger log.Logger) *BucketAlertStore {
 	return &BucketAlertStore{
 		alertsBucket:    bucket.NewPrefixedBucketClient(bkt, AlertsPrefix),
 		amBucket:        bucket.NewPrefixedBucketClient(bkt, AlertmanagerPrefix),
 		grafanaAMBucket: bucket.NewPrefixedBucketClient(bkt, GrafanaAlertmanagerPrefix),
 		cfgProvider:     cfgProvider,
-		fetchGrafanaCfg: fetchGrafanaCfg,
+		fetchGrafanaCfg: cfg.FetchGrafanaConfig,
 		logger:          logger,
 	}
 }

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -76,16 +76,16 @@ func (f *Store) ListAllUsers(_ context.Context) ([]string, error) {
 }
 
 // GetAlertConfigs implements alertstore.AlertStore.
-func (f *Store) GetAlertConfigs(_ context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error) {
+func (f *Store) GetAlertConfigs(_ context.Context, userIDs []string, _ bool) (map[string]alertspb.AlertConfigDescs, error) {
 	configs, err := f.reloadConfigs()
 	if err != nil {
 		return nil, err
 	}
 
-	filtered := make(map[string]alertspb.AlertConfigDesc, len(userIDs))
+	filtered := make(map[string]alertspb.AlertConfigDescs, len(userIDs))
 	for _, userID := range userIDs {
 		if cfg, ok := configs[userID]; ok {
-			filtered[userID] = cfg
+			filtered[userID] = alertspb.AlertConfigDescs{Mimir: cfg}
 		}
 	}
 

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -76,7 +76,7 @@ func (f *Store) ListAllUsers(_ context.Context) ([]string, error) {
 }
 
 // GetAlertConfigs implements alertstore.AlertStore.
-func (f *Store) GetAlertConfigs(_ context.Context, userIDs []string, _ bool) (map[string]alertspb.AlertConfigDescs, error) {
+func (f *Store) GetAlertConfigs(_ context.Context, userIDs []string) (map[string]alertspb.AlertConfigDescs, error) {
 	configs, err := f.reloadConfigs()
 	if err != nil {
 		return nil, err

--- a/pkg/alertmanager/alertstore/local/store_test.go
+++ b/pkg/alertmanager/alertstore/local/store_test.go
@@ -78,7 +78,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 
 	// The storage is empty.
 	{
-		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
+		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, false)
 		require.NoError(t, err)
 		assert.Empty(t, configs)
 	}
@@ -88,22 +88,22 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 		user1Cfg := prepareAlertmanagerConfig("user-1")
 		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
 
-		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
+		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, false)
 		require.NoError(t, err)
 		assert.Contains(t, configs, "user-1")
 		assert.NotContains(t, configs, "user-2")
-		assert.Equal(t, user1Cfg, configs["user-1"].RawConfig)
+		assert.Equal(t, user1Cfg, configs["user-1"].Mimir.RawConfig)
 
 		// Add another user config.
 		user2Cfg := prepareAlertmanagerConfig("user-2")
 		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
 
-		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
+		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, false)
 		require.NoError(t, err)
 		assert.Contains(t, configs, "user-1")
 		assert.Contains(t, configs, "user-2")
-		assert.Equal(t, user1Cfg, configs["user-1"].RawConfig)
-		assert.Equal(t, user2Cfg, configs["user-2"].RawConfig)
+		assert.Equal(t, user1Cfg, configs["user-1"].Mimir.RawConfig)
+		assert.Equal(t, user2Cfg, configs["user-2"].Mimir.RawConfig)
 	}
 }
 

--- a/pkg/alertmanager/alertstore/local/store_test.go
+++ b/pkg/alertmanager/alertstore/local/store_test.go
@@ -78,7 +78,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 
 	// The storage is empty.
 	{
-		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, false)
+		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
 		require.NoError(t, err)
 		assert.Empty(t, configs)
 	}
@@ -88,7 +88,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 		user1Cfg := prepareAlertmanagerConfig("user-1")
 		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-1.yaml"), []byte(user1Cfg), os.ModePerm))
 
-		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, false)
+		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
 		require.NoError(t, err)
 		assert.Contains(t, configs, "user-1")
 		assert.NotContains(t, configs, "user-2")
@@ -98,7 +98,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 		user2Cfg := prepareAlertmanagerConfig("user-2")
 		require.NoError(t, os.WriteFile(filepath.Join(storeDir, "user-2.yaml"), []byte(user2Cfg), os.ModePerm))
 
-		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, false)
+		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
 		require.NoError(t, err)
 		assert.Contains(t, configs, "user-1")
 		assert.Contains(t, configs, "user-2")

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -73,7 +73,7 @@ type AlertStore interface {
 }
 
 // NewAlertStore returns a alertmanager store backend client based on the provided cfg.
-func NewAlertStore(ctx context.Context, cfg Config, cfgProvider bucket.TenantConfigProvider, fetchGrafanaConfiguration bool, logger log.Logger, reg prometheus.Registerer) (AlertStore, error) {
+func NewAlertStore(ctx context.Context, cfg Config, cfgProvider bucket.TenantConfigProvider, fetchGrafanaCfg bool, logger log.Logger, reg prometheus.Registerer) (AlertStore, error) {
 	if cfg.Backend == local.Name {
 		level.Warn(logger).Log("msg", "-alertmanager-storage.backend=local is not suitable for persisting alertmanager state between replicas (silences, notifications); you should switch to an external object store for production use")
 		return local.NewStore(cfg.Local)
@@ -88,5 +88,8 @@ func NewAlertStore(ctx context.Context, cfg Config, cfgProvider bucket.TenantCon
 		return nil, err
 	}
 
-	return bucketclient.NewBucketAlertStore(bucketClient, cfgProvider, fetchGrafanaConfiguration, logger), nil
+	bCfg := bucketclient.BucketAlertStoreConfig{
+		FetchGrafanaConfig: fetchGrafanaCfg,
+	}
+	return bucketclient.NewBucketAlertStore(bCfg, bucketClient, cfgProvider, logger), nil
 }

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -26,7 +26,7 @@ type AlertStore interface {
 	// GetAlertConfigs loads and returns the alertmanager configuration for given users.
 	// If any of the provided users has no configuration, then this function does not return an
 	// error but the returned configs will not include the missing users.
-	GetAlertConfigs(ctx context.Context, userIDs []string, fetchGrafanaConfig bool) (map[string]alertspb.AlertConfigDescs, error)
+	GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDescs, error)
 
 	// GetAlertConfig loads and returns the alertmanager configuration for the given user.
 	GetAlertConfig(ctx context.Context, user string) (alertspb.AlertConfigDesc, error)
@@ -73,7 +73,7 @@ type AlertStore interface {
 }
 
 // NewAlertStore returns a alertmanager store backend client based on the provided cfg.
-func NewAlertStore(ctx context.Context, cfg Config, cfgProvider bucket.TenantConfigProvider, logger log.Logger, reg prometheus.Registerer) (AlertStore, error) {
+func NewAlertStore(ctx context.Context, cfg Config, cfgProvider bucket.TenantConfigProvider, fetchGrafanaConfiguration bool, logger log.Logger, reg prometheus.Registerer) (AlertStore, error) {
 	if cfg.Backend == local.Name {
 		level.Warn(logger).Log("msg", "-alertmanager-storage.backend=local is not suitable for persisting alertmanager state between replicas (silences, notifications); you should switch to an external object store for production use")
 		return local.NewStore(cfg.Local)
@@ -88,5 +88,5 @@ func NewAlertStore(ctx context.Context, cfg Config, cfgProvider bucket.TenantCon
 		return nil, err
 	}
 
-	return bucketclient.NewBucketAlertStore(bucketClient, cfgProvider, logger), nil
+	return bucketclient.NewBucketAlertStore(bucketClient, cfgProvider, fetchGrafanaConfiguration, logger), nil
 }

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -73,7 +73,7 @@ type AlertStore interface {
 }
 
 // NewAlertStore returns a alertmanager store backend client based on the provided cfg.
-func NewAlertStore(ctx context.Context, cfg Config, cfgProvider bucket.TenantConfigProvider, fetchGrafanaCfg bool, logger log.Logger, reg prometheus.Registerer) (AlertStore, error) {
+func NewAlertStore(ctx context.Context, cfg Config, cfgProvider bucket.TenantConfigProvider, bucketConfig bucketclient.BucketAlertStoreConfig, logger log.Logger, reg prometheus.Registerer) (AlertStore, error) {
 	if cfg.Backend == local.Name {
 		level.Warn(logger).Log("msg", "-alertmanager-storage.backend=local is not suitable for persisting alertmanager state between replicas (silences, notifications); you should switch to an external object store for production use")
 		return local.NewStore(cfg.Local)
@@ -88,8 +88,5 @@ func NewAlertStore(ctx context.Context, cfg Config, cfgProvider bucket.TenantCon
 		return nil, err
 	}
 
-	bCfg := bucketclient.BucketAlertStoreConfig{
-		FetchGrafanaConfig: fetchGrafanaCfg,
-	}
-	return bucketclient.NewBucketAlertStore(bCfg, bucketClient, cfgProvider, logger), nil
+	return bucketclient.NewBucketAlertStore(bucketConfig, bucketClient, cfgProvider, logger), nil
 }

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -26,7 +26,7 @@ type AlertStore interface {
 	// GetAlertConfigs loads and returns the alertmanager configuration for given users.
 	// If any of the provided users has no configuration, then this function does not return an
 	// error but the returned configs will not include the missing users.
-	GetAlertConfigs(ctx context.Context, userIDs []string) (map[string]alertspb.AlertConfigDesc, error)
+	GetAlertConfigs(ctx context.Context, userIDs []string, fetchGrafanaConfig bool) (map[string]alertspb.AlertConfigDescs, error)
 
 	// GetAlertConfig loads and returns the alertmanager configuration for the given user.
 	GetAlertConfig(ctx context.Context, user string) (alertspb.AlertConfigDesc, error)

--- a/pkg/alertmanager/alertstore/store_test.go
+++ b/pkg/alertmanager/alertstore/store_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestAlertStore_ListAllUsers(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, bucket, nil, log.NewNopLogger())
 
 	ctx := context.Background()
 	user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
@@ -48,7 +48,8 @@ func TestAlertStore_ListAllUsers(t *testing.T) {
 
 func TestAlertStore_SetAndGetAlertConfig(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, true, log.NewNopLogger())
+	cfg := bucketclient.BucketAlertStoreConfig{FetchGrafanaConfig: true}
+	store := bucketclient.NewBucketAlertStore(cfg, bucket, nil, log.NewNopLogger())
 
 	ctx := context.Background()
 	user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
@@ -87,7 +88,8 @@ func TestAlertStore_SetAndGetAlertConfig(t *testing.T) {
 
 func TestStore_GetAlertConfigs(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, true, log.NewNopLogger())
+	cfg := bucketclient.BucketAlertStoreConfig{FetchGrafanaConfig: true}
+	store := bucketclient.NewBucketAlertStore(cfg, bucket, nil, log.NewNopLogger())
 
 	ctx := context.Background()
 	user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
@@ -129,7 +131,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 
 func TestAlertStore_DeleteAlertConfig(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, bucket, nil, log.NewNopLogger())
 
 	ctx := context.Background()
 	user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
@@ -190,7 +192,7 @@ func makeTestGrafanaAlertConfig(t *testing.T, user, cfg, hash string, createdAtT
 
 func TestBucketAlertStore_GetSetDeleteFullState(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, bucket, nil, log.NewNopLogger())
 
 	ctx := context.Background()
 	state1 := makeTestFullState("one")
@@ -260,7 +262,7 @@ func TestBucketAlertStore_GetSetDeleteFullState(t *testing.T) {
 
 func TestBucketAlertStore_GetSetDeleteGrafanaState(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, bucket, nil, log.NewNopLogger())
 
 	ctx := context.Background()
 	state1 := makeTestFullState("one")
@@ -318,7 +320,7 @@ func TestBucketAlertStore_GetSetDeleteGrafanaState(t *testing.T) {
 
 func TestBucketAlertStore_GetSetDeleteGrafanaAlertConfig(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, bucket, nil, log.NewNopLogger())
 
 	ctx := context.Background()
 	now := time.Now().UnixMilli()

--- a/pkg/alertmanager/alertstore/store_test.go
+++ b/pkg/alertmanager/alertstore/store_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestAlertStore_ListAllUsers(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
 
 	ctx := context.Background()
 	user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
@@ -48,7 +48,7 @@ func TestAlertStore_ListAllUsers(t *testing.T) {
 
 func TestAlertStore_SetAndGetAlertConfig(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucket, nil, true, log.NewNopLogger())
 
 	ctx := context.Background()
 	user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
@@ -87,7 +87,7 @@ func TestAlertStore_SetAndGetAlertConfig(t *testing.T) {
 
 func TestStore_GetAlertConfigs(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucket, nil, true, log.NewNopLogger())
 
 	ctx := context.Background()
 	user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
@@ -96,7 +96,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 
 	// The storage is empty.
 	{
-		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, false)
+		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
 		require.NoError(t, err)
 		assert.Empty(t, configs)
 	}
@@ -105,7 +105,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 	{
 		require.NoError(t, store.SetAlertConfig(ctx, user1Cfg))
 
-		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, false)
+		configs, err := store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
 		require.NoError(t, err)
 		assert.Contains(t, configs, "user-1")
 		assert.NotContains(t, configs, "user-2")
@@ -115,18 +115,8 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 		require.NoError(t, store.SetAlertConfig(ctx, user2Cfg))
 		require.NoError(t, store.SetGrafanaAlertConfig(ctx, user2GrafanaCfg))
 
-		// Should return only the Mimir Alertmanager configuration.
-		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, false)
-		require.NoError(t, err)
-		assert.Contains(t, configs, "user-1")
-		assert.Contains(t, configs, "user-2")
-		assert.Equal(t, user1Cfg, configs["user-1"].Mimir)
-		assert.Equal(t, alertspb.GrafanaAlertConfigDesc{}, configs["user-1"].Grafana)
-		assert.Equal(t, user2Cfg, configs["user-2"].Mimir)
-		assert.Equal(t, alertspb.GrafanaAlertConfigDesc{}, configs["user-2"].Grafana)
-
 		// Should return both Mimir and Grafana Alertmanager configurations.
-		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"}, true)
+		configs, err = store.GetAlertConfigs(ctx, []string{"user-1", "user-2"})
 		require.NoError(t, err)
 		assert.Contains(t, configs, "user-1")
 		assert.Contains(t, configs, "user-2")
@@ -139,7 +129,7 @@ func TestStore_GetAlertConfigs(t *testing.T) {
 
 func TestAlertStore_DeleteAlertConfig(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
 
 	ctx := context.Background()
 	user1Cfg := alertspb.AlertConfigDesc{User: "user-1", RawConfig: "content-1"}
@@ -200,7 +190,7 @@ func makeTestGrafanaAlertConfig(t *testing.T, user, cfg, hash string, createdAtT
 
 func TestBucketAlertStore_GetSetDeleteFullState(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
 
 	ctx := context.Background()
 	state1 := makeTestFullState("one")
@@ -270,7 +260,7 @@ func TestBucketAlertStore_GetSetDeleteFullState(t *testing.T) {
 
 func TestBucketAlertStore_GetSetDeleteGrafanaState(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
 
 	ctx := context.Background()
 	state1 := makeTestFullState("one")
@@ -328,7 +318,7 @@ func TestBucketAlertStore_GetSetDeleteGrafanaState(t *testing.T) {
 
 func TestBucketAlertStore_GetSetDeleteGrafanaAlertConfig(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucket, nil, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucket, nil, false, log.NewNopLogger())
 
 	ctx := context.Background()
 	now := time.Now().UnixMilli()

--- a/pkg/alertmanager/api_grafana_test.go
+++ b/pkg/alertmanager/api_grafana_test.go
@@ -52,7 +52,7 @@ const (
 
 func TestMultitenantAlertmanager_DeleteUserGrafanaConfig(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
 	now := time.Now().UnixMilli()
 
 	am := &MultitenantAlertmanager{
@@ -111,7 +111,7 @@ func TestMultitenantAlertmanager_DeleteUserGrafanaConfig(t *testing.T) {
 
 func TestMultitenantAlertmanager_DeleteUserGrafanaState(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertstore,
@@ -172,7 +172,7 @@ func TestMultitenantAlertmanager_DeleteUserGrafanaState(t *testing.T) {
 
 func TestMultitenantAlertmanager_GetUserGrafanaConfig(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
 	now := time.Now().UnixMilli()
 
 	am := &MultitenantAlertmanager{
@@ -225,7 +225,7 @@ func TestMultitenantAlertmanager_GetUserGrafanaConfig(t *testing.T) {
 
 func TestMultitenantAlertmanager_GetUserGrafanaState(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertstore,
@@ -277,7 +277,7 @@ func TestMultitenantAlertmanager_GetUserGrafanaState(t *testing.T) {
 
 func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertstore,
@@ -346,7 +346,7 @@ func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 
 func TestMultitenantAlertmanager_SetUserGrafanaState(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertstore,

--- a/pkg/alertmanager/api_grafana_test.go
+++ b/pkg/alertmanager/api_grafana_test.go
@@ -52,7 +52,7 @@ const (
 
 func TestMultitenantAlertmanager_DeleteUserGrafanaConfig(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
 	now := time.Now().UnixMilli()
 
 	am := &MultitenantAlertmanager{
@@ -111,7 +111,7 @@ func TestMultitenantAlertmanager_DeleteUserGrafanaConfig(t *testing.T) {
 
 func TestMultitenantAlertmanager_DeleteUserGrafanaState(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertstore,
@@ -172,7 +172,7 @@ func TestMultitenantAlertmanager_DeleteUserGrafanaState(t *testing.T) {
 
 func TestMultitenantAlertmanager_GetUserGrafanaConfig(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
 	now := time.Now().UnixMilli()
 
 	am := &MultitenantAlertmanager{
@@ -225,7 +225,7 @@ func TestMultitenantAlertmanager_GetUserGrafanaConfig(t *testing.T) {
 
 func TestMultitenantAlertmanager_GetUserGrafanaState(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertstore,
@@ -277,7 +277,7 @@ func TestMultitenantAlertmanager_GetUserGrafanaState(t *testing.T) {
 
 func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertstore,
@@ -346,7 +346,7 @@ func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 
 func TestMultitenantAlertmanager_SetUserGrafanaState(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(storage, nil, log.NewNopLogger())
+	alertstore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertstore,

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -913,7 +913,7 @@ alertmanager_config: |
 
 func TestMultitenantAlertmanager_DeleteUserConfig(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertStore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
+	alertStore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertStore,
@@ -997,7 +997,7 @@ receivers:
 	}
 
 	storage := objstore.NewInMemBucket()
-	alertStore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
+	alertStore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
 
 	for u, cfg := range testCases {
 		err := alertStore.SetAlertConfig(context.Background(), alertspb.AlertConfigDesc{

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -913,7 +913,7 @@ alertmanager_config: |
 
 func TestMultitenantAlertmanager_DeleteUserConfig(t *testing.T) {
 	storage := objstore.NewInMemBucket()
-	alertStore := bucketclient.NewBucketAlertStore(storage, nil, log.NewNopLogger())
+	alertStore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
 
 	am := &MultitenantAlertmanager{
 		store:  alertStore,
@@ -997,7 +997,7 @@ receivers:
 	}
 
 	storage := objstore.NewInMemBucket()
-	alertStore := bucketclient.NewBucketAlertStore(storage, nil, log.NewNopLogger())
+	alertStore := bucketclient.NewBucketAlertStore(storage, nil, false, log.NewNopLogger())
 
 	for u, cfg := range testCases {
 		err := alertStore.SetAlertConfig(context.Background(), alertspb.AlertConfigDesc{

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -610,7 +610,7 @@ func (am *MultitenantAlertmanager) loadAlertmanagerConfigs(ctx context.Context) 
 	numUsersOwned := len(ownedUserIDs)
 
 	// Load the configs for the owned users.
-	configs, err := am.store.GetAlertConfigs(ctx, ownedUserIDs, am.cfg.GrafanaAlertmanagerCompatibilityEnabled)
+	configs, err := am.store.GetAlertConfigs(ctx, ownedUserIDs)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to load alertmanager configurations for owned users")
 	}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -592,7 +592,7 @@ func (am *MultitenantAlertmanager) stopping(_ error) error {
 // loadAlertmanagerConfigs Loads (and filters) the alertmanagers configuration from object storage, taking into consideration the sharding strategy. Returns:
 // - The list of discovered users (all users with a configuration in storage)
 // - The configurations of users owned by this instance.
-func (am *MultitenantAlertmanager) loadAlertmanagerConfigs(ctx context.Context) ([]string, map[string]alertspb.AlertConfigDesc, error) {
+func (am *MultitenantAlertmanager) loadAlertmanagerConfigs(ctx context.Context) ([]string, map[string]alertspb.AlertConfigDescs, error) {
 	// Find all users with an alertmanager config.
 	allUserIDs, err := am.store.ListAllUsers(ctx)
 	if err != nil {
@@ -610,7 +610,7 @@ func (am *MultitenantAlertmanager) loadAlertmanagerConfigs(ctx context.Context) 
 	numUsersOwned := len(ownedUserIDs)
 
 	// Load the configs for the owned users.
-	configs, err := am.store.GetAlertConfigs(ctx, ownedUserIDs)
+	configs, err := am.store.GetAlertConfigs(ctx, ownedUserIDs, am.cfg.GrafanaAlertmanagerCompatibilityEnabled)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to load alertmanager configurations for owned users")
 	}
@@ -631,10 +631,10 @@ func (am *MultitenantAlertmanager) isUserOwned(userID string) bool {
 	return alertmanagers.Includes(am.ringLifecycler.GetInstanceAddr())
 }
 
-func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alertspb.AlertConfigDesc) {
+func (am *MultitenantAlertmanager) syncConfigs(cfgs map[string]alertspb.AlertConfigDescs) {
 	level.Debug(am.logger).Log("msg", "adding configurations", "num_configs", len(cfgs))
 	for user, cfg := range cfgs {
-		err := am.setConfig(cfg)
+		err := am.setConfig(cfg.Mimir)
 		if err != nil {
 			am.multitenantMetrics.lastReloadSuccessful.WithLabelValues(user).Set(float64(0))
 			level.Warn(am.logger).Log("msg", "error applying config", "err", err)

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1326,7 +1326,7 @@ func TestMultitenantAlertmanager_InitialSync(t *testing.T) {
 
 			// Use an alert store with a mocked backend.
 			bkt := &bucket.ClientMock{}
-			alertStore := bucketclient.NewBucketAlertStore(bkt, nil, false, log.NewNopLogger())
+			alertStore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, bkt, nil, log.NewNopLogger())
 
 			// Setup the initial instance state in the ring.
 			if tt.existing {
@@ -1683,7 +1683,7 @@ func TestMultitenantAlertmanager_InitialSyncFailure(t *testing.T) {
 	bkt := &bucket.ClientMock{}
 	bkt.MockIter("alerts/", nil, errors.New("failed to list alerts"))
 	bkt.MockIter("alertmanager/", nil, nil)
-	store := bucketclient.NewBucketAlertStore(bkt, nil, false, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, bkt, nil, log.NewNopLogger())
 
 	am, err := createMultitenantAlertmanager(amConfig, nil, store, ringStore, nil, featurecontrol.NoopFlags{}, log.NewNopLogger(), nil)
 	require.NoError(t, err)
@@ -2145,7 +2145,7 @@ func TestAlertmanager_StateReplication_InitialSyncFromPeers(t *testing.T) {
 
 // prepareInMemoryAlertStore builds and returns an in-memory alert store.
 func prepareInMemoryAlertStore() alertstore.AlertStore {
-	return bucketclient.NewBucketAlertStore(objstore.NewInMemBucket(), nil, false, log.NewNopLogger())
+	return bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, objstore.NewInMemBucket(), nil, log.NewNopLogger())
 }
 
 func TestSafeTemplateFilepath(t *testing.T) {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -1326,7 +1326,7 @@ func TestMultitenantAlertmanager_InitialSync(t *testing.T) {
 
 			// Use an alert store with a mocked backend.
 			bkt := &bucket.ClientMock{}
-			alertStore := bucketclient.NewBucketAlertStore(bkt, nil, log.NewNopLogger())
+			alertStore := bucketclient.NewBucketAlertStore(bkt, nil, false, log.NewNopLogger())
 
 			// Setup the initial instance state in the ring.
 			if tt.existing {
@@ -1683,7 +1683,7 @@ func TestMultitenantAlertmanager_InitialSyncFailure(t *testing.T) {
 	bkt := &bucket.ClientMock{}
 	bkt.MockIter("alerts/", nil, errors.New("failed to list alerts"))
 	bkt.MockIter("alertmanager/", nil, nil)
-	store := bucketclient.NewBucketAlertStore(bkt, nil, log.NewNopLogger())
+	store := bucketclient.NewBucketAlertStore(bkt, nil, false, log.NewNopLogger())
 
 	am, err := createMultitenantAlertmanager(amConfig, nil, store, ringStore, nil, featurecontrol.NoopFlags{}, log.NewNopLogger(), nil)
 	require.NoError(t, err)
@@ -2145,7 +2145,7 @@ func TestAlertmanager_StateReplication_InitialSyncFromPeers(t *testing.T) {
 
 // prepareInMemoryAlertStore builds and returns an in-memory alert store.
 func prepareInMemoryAlertStore() alertstore.AlertStore {
-	return bucketclient.NewBucketAlertStore(objstore.NewInMemBucket(), nil, log.NewNopLogger())
+	return bucketclient.NewBucketAlertStore(objstore.NewInMemBucket(), nil, false, log.NewNopLogger())
 }
 
 func TestSafeTemplateFilepath(t *testing.T) {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -947,7 +947,7 @@ func (t *Mimir) initAlertManager() (serv services.Service, err error) {
 	t.Cfg.Alertmanager.ShardingRing.Common.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.Cfg.Alertmanager.CheckExternalURL(t.Cfg.API.AlertmanagerHTTPPrefix, util_log.Logger)
 
-	store, err := alertstore.NewAlertStore(context.Background(), t.Cfg.AlertmanagerStorage, t.Overrides, util_log.Logger, t.Registerer)
+	store, err := alertstore.NewAlertStore(context.Background(), t.Cfg.AlertmanagerStorage, t.Overrides, t.Cfg.Alertmanager.GrafanaAlertmanagerCompatibilityEnabled, util_log.Logger, t.Registerer)
 	if err != nil {
 		return
 	}

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/alertmanager"
 	"github.com/grafana/mimir/pkg/alertmanager/alertstore"
+	"github.com/grafana/mimir/pkg/alertmanager/alertstore/bucketclient"
 	"github.com/grafana/mimir/pkg/api"
 	"github.com/grafana/mimir/pkg/compactor"
 	"github.com/grafana/mimir/pkg/continuoustest"
@@ -947,7 +948,10 @@ func (t *Mimir) initAlertManager() (serv services.Service, err error) {
 	t.Cfg.Alertmanager.ShardingRing.Common.ListenPort = t.Cfg.Server.GRPCListenPort
 	t.Cfg.Alertmanager.CheckExternalURL(t.Cfg.API.AlertmanagerHTTPPrefix, util_log.Logger)
 
-	store, err := alertstore.NewAlertStore(context.Background(), t.Cfg.AlertmanagerStorage, t.Overrides, t.Cfg.Alertmanager.GrafanaAlertmanagerCompatibilityEnabled, util_log.Logger, t.Registerer)
+	bCfg := bucketclient.BucketAlertStoreConfig{
+		FetchGrafanaConfig: t.Cfg.Alertmanager.GrafanaAlertmanagerCompatibilityEnabled,
+	}
+	store, err := alertstore.NewAlertStore(context.Background(), t.Cfg.AlertmanagerStorage, t.Overrides, bCfg, util_log.Logger, t.Registerer)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This PR enables Mimir to fetch the Grafana Alertmanager configuration on each config sync loop iteration if the compatibility routes are enabled.

This Grafana AM configuration will be merged with the existing Mimir AM config and the result will be applied to the Alertmanager on a per-tenant basis.