### PR TITLE
Update Tanka in the mimir-build-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr7831-88527a12da
+LATEST_BUILD_IMAGE_TAG ?= pr8030-cf783bf13c
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -30,7 +30,7 @@ RUN GOARCH=$(go env GOARCH) && \
 	chmod +x shfmt && \
 	mv shfmt /usr/bin
 
-ENV TANKA_VERSION=0.19.0
+ENV TANKA_VERSION=0.26.0
 RUN GOARCH=$(go env GOARCH) && \
     curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk


### PR DESCRIPTION
#### What this PR does

We're running jsonnet tests in CI with a very old version of Tanka. The old version of Tanka gets shipped with an old version of jsonnet, which doesn't support new jsonnet functions. In this PR I'm upgrading Tanka to unblock https://github.com/grafana/mimir/pull/8028 (requires `std.parseYaml`).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
