### PR TITLE
Add config option to override consumer group when experimental ingest storage is used

### DIFF
--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -1967,6 +1967,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-a-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2239,6 +2240,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-b-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2505,6 +2507,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-c-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -1979,6 +1979,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-a-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2251,6 +2252,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-b-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2517,6 +2519,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-c-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -1989,6 +1989,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-a-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2261,6 +2262,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-b-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2527,6 +2529,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-c-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -1987,6 +1987,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-a-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2259,6 +2260,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-b-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2525,6 +2527,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-c-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
@@ -1987,6 +1987,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-a-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2259,6 +2260,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-b-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2525,6 +2527,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-c-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -1782,6 +1782,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-a-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -1924,6 +1925,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-b-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2060,6 +2062,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-c-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -1806,6 +1806,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-a-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -1948,6 +1949,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-b-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2084,6 +2086,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-c-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -1806,6 +1806,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-a-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -1948,6 +1949,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-b-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10
@@ -2084,6 +2086,7 @@ spec:
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.consumer-group=ingester-zone-c-<partition>
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -ingester.max-global-metadata-per-metric=10

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -61,6 +62,8 @@ type KafkaConfig struct {
 	DialTimeout  time.Duration `yaml:"dial_timeout"`
 	WriteTimeout time.Duration `yaml:"write_timeout"`
 
+	ConsumerGroup string `yaml:"consumer_group"`
+
 	LastProducedOffsetPollInterval time.Duration `yaml:"last_produced_offset_poll_interval"`
 	LastProducedOffsetRetryTimeout time.Duration `yaml:"last_produced_offset_retry_timeout"`
 
@@ -82,6 +85,8 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.StringVar(&cfg.ClientID, prefix+".client-id", "", "The Kafka client ID.")
 	f.DurationVar(&cfg.DialTimeout, prefix+".dial-timeout", 2*time.Second, "The maximum time allowed to open a connection to a Kafka broker.")
 	f.DurationVar(&cfg.WriteTimeout, prefix+".write-timeout", 10*time.Second, "How long to wait for an incoming write request to be successfully committed to the Kafka backend.")
+
+	f.StringVar(&cfg.ConsumerGroup, prefix+".consumer-group", "", "The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '<partition>' placeholder, it will be replaced with the actual partition ID owned by the ingester. When empty (recommended), Mimir will use the ingester instance ID to guarantee uniqueness.")
 
 	f.DurationVar(&cfg.LastProducedOffsetPollInterval, prefix+".last-produced-offset-poll-interval", time.Second, "How frequently to poll the last produced offset, used to enforce strong read consistency.")
 	f.DurationVar(&cfg.LastProducedOffsetRetryTimeout, prefix+".last-produced-offset-retry-timeout", 10*time.Second, "How long to retry a failed request to get the last produced offset.")
@@ -115,6 +120,15 @@ func (cfg *KafkaConfig) Validate() error {
 	}
 
 	return nil
+}
+
+// GetConsumerGroup returns the consumer group to use for the given instanceID and partitionID.
+func (cfg *KafkaConfig) GetConsumerGroup(instanceID string, partitionID int32) string {
+	if cfg.ConsumerGroup == "" {
+		return instanceID
+	}
+
+	return strings.ReplaceAll(cfg.ConsumerGroup, "<partition>", strconv.Itoa(int(partitionID)))
 }
 
 // MigrationConfig holds the configuration used to migrate Mimir to ingest storage. This config shouldn't be

--- a/pkg/storage/ingest/config_test.go
+++ b/pkg/storage/ingest/config_test.go
@@ -80,3 +80,38 @@ func TestConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_GetConsumerGroup(t *testing.T) {
+	tests := map[string]struct {
+		consumerGroup string
+		instanceID    string
+		partitionID   int32
+		expected      string
+	}{
+		"should return the instance ID if no consumer group is explicitly configured": {
+			consumerGroup: "",
+			instanceID:    "ingester-zone-a-1",
+			partitionID:   1,
+			expected:      "ingester-zone-a-1",
+		},
+		"should return the configured consumer group if set": {
+			consumerGroup: "ingester-a",
+			instanceID:    "ingester-zone-a-1",
+			partitionID:   1,
+			expected:      "ingester-a",
+		},
+		"should support <partition> placeholder in the consumer group": {
+			consumerGroup: "ingester-zone-a-partition-<partition>",
+			instanceID:    "ingester-zone-a-1",
+			partitionID:   1,
+			expected:      "ingester-zone-a-partition-1",
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cfg := KafkaConfig{ConsumerGroup: testData.consumerGroup}
+			assert.Equal(t, testData.expected, cfg.GetConsumerGroup(testData.instanceID, testData.partitionID))
+		})
+	}
+}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -69,17 +69,17 @@ type PartitionReader struct {
 	reg    prometheus.Registerer
 }
 
-func NewPartitionReaderForPusher(kafkaCfg KafkaConfig, partitionID int32, consumerGroup string, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
+func NewPartitionReaderForPusher(kafkaCfg KafkaConfig, partitionID int32, instanceID string, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
 	consumer := newPusherConsumer(pusher, reg, logger)
-	return newPartitionReader(kafkaCfg, partitionID, consumerGroup, consumer, logger, reg)
+	return newPartitionReader(kafkaCfg, partitionID, instanceID, consumer, logger, reg)
 }
 
-func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, consumerGroup string, consumer recordConsumer, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
+func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, instanceID string, consumer recordConsumer, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
 	r := &PartitionReader{
 		kafkaCfg:              kafkaCfg,
 		partitionID:           partitionID,
 		consumer:              consumer,
-		consumerGroup:         consumerGroup,
+		consumerGroup:         kafkaCfg.GetConsumerGroup(instanceID, partitionID),
 		metrics:               newReaderMetrics(partitionID, reg),
 		commitInterval:        time.Second,
 		consumedOffsetWatcher: newPartitionOffsetWatcher(),


### PR DESCRIPTION
#### What this PR does

As part of the migration process from Mimir classic architecture to the experimental ingest storage, it would be very handy being able to customize the consumer group of each `ingester-zone-[abc]-partition` ingester (they're temporarily StatefulSets) so that when they will be migrated back to `ingester-zone-[abc]` the consumer group will be the same. In this PR I'm adding a config option to customize it, allowing to parametrise the `<partition>` ID.

I've updated the migration process codified in jsonnet to show how it will be used. This removes the manual step to copy consumer group offsets from `ingester-zone-[abc]-partition-<partition>` to `ingester-zone-[abc]-<partition>`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
