### PR TITLE
helm docs: clarify the chart can run on read-only filesystems

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
@@ -227,6 +227,11 @@ cluster, refer to
 
 For OpenShift-specific instructions see [Deploy on OpenShift](#deploy-on-openshift).
 
+The `mimir-distributed` Helm chart also deploys most of the containers
+with a read-only root filesystem (`readOnlyRootFilesystem: true`).
+The exceptions are the optional MinIO and Grafana Agent containers.
+The PodSecurityPolicy resource enforces this setting.
+
 ## Monitor the health of your Grafana Mimir cluster
 
 To monitor the health of your Grafana Mimir cluster, which is also known as


### PR DESCRIPTION
The Restricted Kubernetes policy doesn't actually specify its read-only restrictions.


#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
