### PR TITLE
Fix inconsistent mimir build in development dirs

### DIFF
--- a/development/mimir-ingest-storage/compose-up.sh
+++ b/development/mimir-ingest-storage/compose-up.sh
@@ -20,6 +20,7 @@ cd "$SCRIPT_DIR" && make
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
-CGO_ENABLED=0 GOOS=linux go build -mod=vendor -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" mimir-write-zone-a-1
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -22,6 +22,7 @@ cd "$SCRIPT_DIR" && make
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
-CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" distributor-1
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/development/mimir-monolithic-mode/compose-up.sh
+++ b/development/mimir-monolithic-mode/compose-up.sh
@@ -40,6 +40,9 @@ if [ ${#PROFILES[@]} -eq 0 ]; then
     PROFILES=("${DEFAULT_PROFILES[@]}")
 fi
 
-CGO_ENABLED=0 GOOS=linux go build -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir && \
+# -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
+# GOARCH is not changed.
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build mimir-1 && \
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml "${PROFILES[@]}" up "${ARGS[@]}"


### PR DESCRIPTION
I had a bug but didn't notice because stringlabels build tag was not used in development/mimir-monolithic-mode. Facepalm.

This is just a quick and dirty fix without refactoring the scripts.
