### PR TITLE
util: avoid pooling large buffers in `util.RequestBuffers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [BUGFIX] OTLP: Don't generate target_info unless there are metrics. #8012
 * [BUGFIX] Query-frontend: Experimental query queue splitting: fix issue where offset and range selector duration were not considered when predicting query component. #7742
 * [BUGFIX] Querying: Empty matrix results were incorrectly returning `null` instead of `[]`. #8029
+* [BUGFIX] Distributor: Avoid pooling large buffers objects when unmarshalling incoming requests. #8044
 
 ### Mixin
 

--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -5,7 +5,10 @@ import (
 	"bytes"
 )
 
-const maxInPoolRequestBufferSize = 1024 * 1024 // 1MB
+// The maximum buffer size allowed in the pool.
+// A sane default value of 1MB is chosen, which should be sufficient for most use cases, though it could be
+// revisited if necessary.
+const maxInPoolRequestBufferSize = 1024 * 1024
 
 // Pool is an abstraction of sync.Pool, for testability.
 type Pool interface {

--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -33,6 +33,7 @@ func NewRequestBuffers(p Pool) *RequestBuffers {
 }
 
 // Get obtains a buffer from the pool. It will be returned back to the pool when CleanUp is called.
+// If size exceeds the maximum buffer size allowed in the pool, a new buffer from the heap is returned.
 func (rb *RequestBuffers) Get(size int) *bytes.Buffer {
 	if rb == nil || size > maxInPoolRequestBufferSize {
 		if size < 0 {

--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 )
 
+const maxInPoolRequestBufferSize = 1024 * 1024 // 1MB
+
 // Pool is an abstraction of sync.Pool, for testability.
 type Pool interface {
 	// Get a pooled object.
@@ -53,6 +55,9 @@ func (rb *RequestBuffers) CleanUp() {
 	for i, b := range rb.buffers {
 		// Make sure the backing array doesn't retain a reference
 		rb.buffers[i] = nil
+		if b.Cap() > maxInPoolRequestBufferSize {
+			continue // Avoid pooling large buffers
+		}
 		rb.p.Put(b)
 	}
 	rb.buffers = rb.buffers[:0]

--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -34,7 +34,7 @@ func NewRequestBuffers(p Pool) *RequestBuffers {
 
 // Get obtains a buffer from the pool. It will be returned back to the pool when CleanUp is called.
 func (rb *RequestBuffers) Get(size int) *bytes.Buffer {
-	if rb == nil {
+	if rb == nil || size > maxInPoolRequestBufferSize {
 		if size < 0 {
 			size = 0
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Currently, we are dealing with an issue that appears to point to a memory leak in the distributor. Similar to https://github.com/grafana/mimir/pull/7936, we believe the issue stems from certain requests containing an insane number of exemplars, causing the buffers used for unmarshalling those requests to unexpectedly grow.

This PR sets a maximum buffer size (originally set at 1MB but subject to review later) for objects returned to the pool, aiming to prevent large memory blocks from being retained.

#### Which issue(s) this PR fixes or relates to

Fixes N/A
