### PR TITLE
jsonnet: align ingest_storage_partitions_enabled with ingest_storage_enabled

### DIFF
--- a/operations/mimir/shuffle-sharding.libsonnet
+++ b/operations/mimir/shuffle-sharding.libsonnet
@@ -9,7 +9,7 @@
       store_gateway_enabled: false,
 
       // Enables shuffle sharding for partitions, for (experimental) ingest storage.
-      ingest_storage_partitions_enabled: false,
+      ingest_storage_partitions_enabled: $._config.ingest_storage_enabled,
 
       // Default shard sizes. We want the shard size to be divisible by the number of zones.
       // We typically run 3 zones


### PR DESCRIPTION
#### What this PR does

Following #8028 this PR updates the default value of `ingest_storage_partitions_enabled` to mirror `$._config.ingest_storage_enabled`. Such configuration is what we're currently testing internally, as part of the migration of the workloads to the ingest storages.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
