### PR TITLE
Skip unmarshaling of exemplars when exemplars are disabled

### DIFF
--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -7,7 +7,6 @@ package distributor
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -20,7 +19,9 @@ import (
 	"github.com/grafana/dskit/httpgrpc/server"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/tenant"
+	"github.com/grafana/dskit/user"
 	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util"
@@ -145,6 +146,19 @@ func handler(
 		supplier := func() (*mimirpb.WriteRequest, func(), error) {
 			rb := util.NewRequestBuffers(requestBufferPool)
 			var req mimirpb.PreallocWriteRequest
+
+			userID, err := tenant.TenantID(ctx)
+			if err != nil && !errors.Is(err, user.ErrNoOrgID) { // ignore user.ErrNoOrgID
+				return nil, nil, errors.Wrap(err, "failed to get tenant ID")
+			}
+
+			// userID might be empty if none was in the ctx, in this case just use the default setting.
+			if limits.MaxGlobalExemplarsPerUser(userID) == 0 {
+				// The user is not allowed to send exemplars, so there is no need to unmarshal them.
+				// Optimization to avoid the allocations required for unmarshaling exemplars.
+				req.SkipUnmarshalingExemplars = true
+			}
+
 			if err := parser(ctx, r, maxRecvMsgSize, rb, &req, logger); err != nil {
 				// Check for httpgrpc error, default to client error if parsing failed
 				if _, ok := httpgrpc.HTTPResponseFromError(err); !ok {

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -309,7 +309,7 @@ func TestHandler_SkipExemplarUnmarshalingBasedOnLimits(t *testing.T) {
 				Samples: []mimirpb.Sample{
 					{Value: 1, TimestampMs: timestampMs},
 				},
-				Exemplars:  nil,
+				Exemplars:  []mimirpb.Exemplar{},
 				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
 			},
 		}, {
@@ -321,7 +321,7 @@ func TestHandler_SkipExemplarUnmarshalingBasedOnLimits(t *testing.T) {
 				Samples: []mimirpb.Sample{
 					{Value: 1, TimestampMs: timestampMs},
 				},
-				Exemplars:  nil,
+				Exemplars:  []mimirpb.Exemplar{},
 				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
 			},
 			maxGlobalExemplarsPerUser: 1, // exemplars are not disabled
@@ -332,7 +332,7 @@ func TestHandler_SkipExemplarUnmarshalingBasedOnLimits(t *testing.T) {
 				Samples: []mimirpb.Sample{
 					{Value: 1, TimestampMs: timestampMs},
 				},
-				Exemplars:  nil,
+				Exemplars:  []mimirpb.Exemplar{},
 				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
 			},
 		},
@@ -367,6 +367,11 @@ func TestHandler_SkipExemplarUnmarshalingBasedOnLimits(t *testing.T) {
 
 			assert.Len(t, gotReq.Timeseries, 1)
 			gotTimeseries := *(gotReq.Timeseries[0].TimeSeries)
+
+			if gotTimeseries.Exemplars == nil {
+				// To fix equality if the empty slice is nil.
+				gotTimeseries.Exemplars = []mimirpb.Exemplar{}
+			}
 
 			assert.EqualValues(t, tc.expectTimeseries, gotTimeseries)
 		})

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -309,7 +309,7 @@ func TestHandler_SkipExemplarUnmarshalingBasedOnLimits(t *testing.T) {
 				Samples: []mimirpb.Sample{
 					{Value: 1, TimestampMs: timestampMs},
 				},
-				Exemplars:  []mimirpb.Exemplar{},
+				Exemplars:  nil,
 				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
 			},
 		}, {
@@ -321,7 +321,7 @@ func TestHandler_SkipExemplarUnmarshalingBasedOnLimits(t *testing.T) {
 				Samples: []mimirpb.Sample{
 					{Value: 1, TimestampMs: timestampMs},
 				},
-				Exemplars:  []mimirpb.Exemplar{},
+				Exemplars:  nil,
 				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
 			},
 			maxGlobalExemplarsPerUser: 1, // exemplars are not disabled
@@ -332,7 +332,7 @@ func TestHandler_SkipExemplarUnmarshalingBasedOnLimits(t *testing.T) {
 				Samples: []mimirpb.Sample{
 					{Value: 1, TimestampMs: timestampMs},
 				},
-				Exemplars:  []mimirpb.Exemplar{},
+				Exemplars:  nil,
 				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
 			},
 		},

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -49,7 +49,7 @@ import (
 func TestHandler_remoteWrite(t *testing.T) {
 	req := createRequest(t, createPrometheusRemoteWriteProtobuf(t))
 	resp := httptest.NewRecorder()
-	handler := Handler(100000, nil, nil, false, nil, RetryConfig{}, verifyWritePushFunc(t, mimirpb.API), nil, log.NewNopLogger())
+	handler := Handler(100000, nil, nil, false, validation.MockDefaultOverrides(), RetryConfig{}, verifyWritePushFunc(t, mimirpb.API), nil, log.NewNopLogger())
 	handler.ServeHTTP(resp, req)
 	assert.Equal(t, 200, resp.Code)
 }
@@ -117,7 +117,7 @@ func TestHandler_mimirWriteRequest(t *testing.T) {
 	req := createRequest(t, createMimirWriteRequestProtobuf(t, false))
 	resp := httptest.NewRecorder()
 	sourceIPs, _ := middleware.NewSourceIPs("SomeField", "(.*)", false)
-	handler := Handler(100000, nil, sourceIPs, false, nil, RetryConfig{}, verifyWritePushFunc(t, mimirpb.RULE), nil, log.NewNopLogger())
+	handler := Handler(100000, nil, sourceIPs, false, validation.MockDefaultOverrides(), RetryConfig{}, verifyWritePushFunc(t, mimirpb.RULE), nil, log.NewNopLogger())
 	handler.ServeHTTP(resp, req)
 	assert.Equal(t, 200, resp.Code)
 }
@@ -126,7 +126,7 @@ func TestHandler_contextCanceledRequest(t *testing.T) {
 	req := createRequest(t, createMimirWriteRequestProtobuf(t, false))
 	resp := httptest.NewRecorder()
 	sourceIPs, _ := middleware.NewSourceIPs("SomeField", "(.*)", false)
-	handler := Handler(100000, nil, sourceIPs, false, nil, RetryConfig{}, func(_ context.Context, req *Request) error {
+	handler := Handler(100000, nil, sourceIPs, false, validation.MockDefaultOverrides(), RetryConfig{}, func(_ context.Context, req *Request) error {
 		defer req.CleanUp()
 		return fmt.Errorf("the request failed: %w", context.Canceled)
 	}, nil, log.NewNopLogger())
@@ -235,12 +235,140 @@ func TestHandler_EnsureSkipLabelNameValidationBehaviour(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			resp := httptest.NewRecorder()
-			handler := Handler(100000, nil, nil, tc.allowSkipLabelNameValidation, nil, RetryConfig{}, tc.verifyReqHandler, nil, log.NewNopLogger())
+			handler := Handler(100000, nil, nil, tc.allowSkipLabelNameValidation, validation.MockDefaultOverrides(), RetryConfig{}, tc.verifyReqHandler, nil, log.NewNopLogger())
 			if !tc.includeAllowSkiplabelNameValidationHeader {
 				tc.req.Header.Set(SkipLabelNameValidationHeader, "true")
 			}
 			handler.ServeHTTP(resp, tc.req)
 			assert.Equal(t, tc.expectedStatusCode, resp.Code)
+		})
+	}
+}
+
+func TestHandler_SkipExemplarUnmarshalingBasedOnLimits(t *testing.T) {
+	timestampMs := time.Now().UnixMilli()
+
+	tests := []struct {
+		name                      string
+		submitTimeseries          mimirpb.TimeSeries
+		expectTimeseries          mimirpb.TimeSeries
+		maxGlobalExemplarsPerUser int
+	}{
+		{
+			name: "request with exemplars and exemplars are enabled",
+			submitTimeseries: mimirpb.TimeSeries{
+				Labels: []mimirpb.LabelAdapter{
+					{Name: "label1", Value: "value1"},
+				},
+				Samples: []mimirpb.Sample{
+					{Value: 1, TimestampMs: timestampMs},
+				},
+				Exemplars: []mimirpb.Exemplar{
+					{Labels: []mimirpb.LabelAdapter{{Name: "label1", Value: "value1"}}, Value: 1, TimestampMs: timestampMs},
+					{Labels: []mimirpb.LabelAdapter{{Name: "label2", Value: "value2"}}, Value: 2, TimestampMs: timestampMs},
+					{Labels: []mimirpb.LabelAdapter{{Name: "label3", Value: "value3"}}, Value: 3, TimestampMs: timestampMs},
+				},
+				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
+			},
+			maxGlobalExemplarsPerUser: 1, // exemplars are not disabled
+			expectTimeseries: mimirpb.TimeSeries{
+				Labels: []mimirpb.LabelAdapter{
+					{Name: "label1", Value: "value1"},
+				},
+				Samples: []mimirpb.Sample{
+					{Value: 1, TimestampMs: timestampMs},
+				},
+				Exemplars: []mimirpb.Exemplar{
+					{Labels: []mimirpb.LabelAdapter{{Name: "label1", Value: "value1"}}, Value: 1, TimestampMs: timestampMs},
+					{Labels: []mimirpb.LabelAdapter{{Name: "label2", Value: "value2"}}, Value: 2, TimestampMs: timestampMs},
+					{Labels: []mimirpb.LabelAdapter{{Name: "label3", Value: "value3"}}, Value: 3, TimestampMs: timestampMs},
+				},
+				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
+			},
+		}, {
+			name: "request with exemplars and exemplars are disabled",
+			submitTimeseries: mimirpb.TimeSeries{
+				Labels: []mimirpb.LabelAdapter{
+					{Name: "label1", Value: "value1"},
+				},
+				Samples: []mimirpb.Sample{
+					{Value: 1, TimestampMs: timestampMs},
+				},
+				Exemplars: []mimirpb.Exemplar{
+					{Labels: []mimirpb.LabelAdapter{{Name: "label1", Value: "value1"}}, Value: 1, TimestampMs: timestampMs},
+					{Labels: []mimirpb.LabelAdapter{{Name: "label2", Value: "value2"}}, Value: 2, TimestampMs: timestampMs},
+					{Labels: []mimirpb.LabelAdapter{{Name: "label3", Value: "value3"}}, Value: 3, TimestampMs: timestampMs},
+				},
+				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
+			},
+			maxGlobalExemplarsPerUser: 0, // 0 disables exemplars
+			expectTimeseries: mimirpb.TimeSeries{
+				Labels: []mimirpb.LabelAdapter{
+					{Name: "label1", Value: "value1"},
+				},
+				Samples: []mimirpb.Sample{
+					{Value: 1, TimestampMs: timestampMs},
+				},
+				Exemplars:  []mimirpb.Exemplar{},
+				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
+			},
+		}, {
+			name: "request without exemplars and exemplars are enabled",
+			submitTimeseries: mimirpb.TimeSeries{
+				Labels: []mimirpb.LabelAdapter{
+					{Name: "label1", Value: "value1"},
+				},
+				Samples: []mimirpb.Sample{
+					{Value: 1, TimestampMs: timestampMs},
+				},
+				Exemplars:  []mimirpb.Exemplar{},
+				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
+			},
+			maxGlobalExemplarsPerUser: 1, // exemplars are not disabled
+			expectTimeseries: mimirpb.TimeSeries{
+				Labels: []mimirpb.LabelAdapter{
+					{Name: "label1", Value: "value1"},
+				},
+				Samples: []mimirpb.Sample{
+					{Value: 1, TimestampMs: timestampMs},
+				},
+				Exemplars:  []mimirpb.Exemplar{},
+				Histograms: []mimirpb.Histogram{{Sum: 1, Schema: 2, ZeroThreshold: 3, ResetHint: 4, Timestamp: 5}},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reqDecoded := mimirpb.WriteRequest{
+				Timeseries: []mimirpb.PreallocTimeseries{{TimeSeries: &tc.submitTimeseries}},
+				Source:     mimirpb.RULE,
+			}
+			reqEncoded, err := reqDecoded.Marshal()
+			require.NoError(t, err)
+			reqHTTP := createRequest(t, reqEncoded)
+
+			defaults := validation.MockDefaultLimits()
+			defaults.MaxGlobalExemplarsPerUser = tc.maxGlobalExemplarsPerUser
+			limits, err := validation.NewOverrides(*defaults, nil)
+			require.NoError(t, err)
+
+			var gotReqEncoded *Request
+			handler := Handler(100000, nil, nil, true, limits, RetryConfig{}, func(_ context.Context, pushReq *Request) error {
+				gotReqEncoded = pushReq
+				return nil
+			}, nil, log.NewNopLogger())
+
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, reqHTTP)
+			require.Equal(t, http.StatusOK, resp.Code)
+
+			gotReq, err := gotReqEncoded.WriteRequest()
+			require.NoError(t, err)
+
+			assert.Len(t, gotReq.Timeseries, 1)
+			gotTimeseries := *(gotReq.Timeseries[0].TimeSeries)
+
+			assert.EqualValues(t, tc.expectTimeseries, gotTimeseries)
 		})
 	}
 }
@@ -363,7 +491,7 @@ func BenchmarkPushHandler(b *testing.B) {
 		pushReq.CleanUp()
 		return nil
 	}
-	handler := Handler(100000, nil, nil, false, nil, RetryConfig{}, pushFunc, nil, log.NewNopLogger())
+	handler := Handler(100000, nil, nil, false, validation.MockDefaultOverrides(), RetryConfig{}, pushFunc, nil, log.NewNopLogger())
 	b.ResetTimer()
 	for iter := 0; iter < b.N; iter++ {
 		req.Body = bufCloser{Buffer: buf} // reset Body so it can be read each time round the loop
@@ -423,7 +551,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			}
 
 			logs := &concurrency.SyncBuffer{}
-			h := handler(10, nil, nil, false, nil, RetryConfig{}, pushFunc, log.NewLogfmtLogger(logs), parserFunc)
+			h := handler(10, nil, nil, false, validation.MockDefaultOverrides(), RetryConfig{}, pushFunc, log.NewLogfmtLogger(logs), parserFunc)
 
 			recorder := httptest.NewRecorder()
 			ctxWithUser := user.InjectOrgID(context.Background(), "testuser")
@@ -514,7 +642,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			}
 
 			logs := &concurrency.SyncBuffer{}
-			h := handler(10, nil, nil, false, nil, RetryConfig{}, pushFunc, log.NewLogfmtLogger(logs), parserFunc)
+			h := handler(10, nil, nil, false, validation.MockDefaultOverrides(), RetryConfig{}, pushFunc, log.NewLogfmtLogger(logs), parserFunc)
 			recorder := httptest.NewRecorder()
 			ctxWithUser := user.InjectOrgID(context.Background(), "testuser")
 			h.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/push", bufCloser{&bytes.Buffer{}}).WithContext(ctxWithUser))

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -57,12 +57,177 @@ var (
 // PreallocWriteRequest is a WriteRequest which preallocs slices on Unmarshal.
 type PreallocWriteRequest struct {
 	WriteRequest
+
+	// SkipUnmarshalingExemplars is an optimization to not unmarshal exemplars when they are disabled by the config anyway.
+	SkipUnmarshalingExemplars bool
 }
 
 // Unmarshal implements proto.Message.
+// Copied from generated code, the only change is the addition that
+// propagates SkipUnmarshalingExemplars into the .Timeseries slice objects.
 func (p *PreallocWriteRequest) Unmarshal(dAtA []byte) error {
 	p.Timeseries = PreallocTimeseriesSliceFromPool()
-	return p.WriteRequest.Unmarshal(dAtA)
+
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMimir
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: WriteRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: WriteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timeseries", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMimir
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMimir
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			p.Timeseries = append(p.Timeseries, PreallocTimeseries{
+				skipUnmarshalingExemplars: p.SkipUnmarshalingExemplars,
+			})
+			if err := p.Timeseries[len(p.Timeseries)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Source", wireType)
+			}
+			p.Source = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMimir
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				p.Source |= WriteRequest_SourceEnum(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMimir
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMimir
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			p.Metadata = append(p.Metadata, &MetricMetadata{})
+			if err := p.Metadata[len(p.Metadata)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 1000:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SkipLabelNameValidation", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMimir
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			p.SkipLabelNameValidation = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMimir(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 
 func (p *WriteRequest) ClearTimeseriesUnmarshalData() {
@@ -84,6 +249,8 @@ type PreallocTimeseries struct {
 	// Original data used for unmarshalling this PreallocTimeseries. When set, Marshal methods will return it
 	// instead of doing full marshalling again. This assumes that this instance hasn't changed.
 	marshalledData []byte
+
+	skipUnmarshalingExemplars bool
 }
 
 // RemoveLabel removes the label labelName from this timeseries, if it exists.
@@ -200,12 +367,204 @@ func (p *PreallocTimeseries) clearUnmarshalData() {
 var TimeseriesUnmarshalCachingEnabled = true
 
 // Unmarshal implements proto.Message. Input data slice is retained.
+// Copied from generated code, the only change is the conditional skipping of the exemplar unmarshaling.
 func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
 	if TimeseriesUnmarshalCachingEnabled {
 		p.marshalledData = dAtA
 	}
 	p.TimeSeries = TimeseriesFromPool()
-	return p.TimeSeries.Unmarshal(dAtA)
+
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMimir
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TimeSeries: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TimeSeries: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMimir
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMimir
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			p.Labels = append(p.Labels, LabelAdapter{})
+			if err := p.Labels[len(p.Labels)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Samples", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMimir
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMimir
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			p.Samples = append(p.Samples, Sample{})
+			if err := p.Samples[len(p.Samples)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exemplars", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMimir
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMimir
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+
+			if !p.skipUnmarshalingExemplars {
+				p.Exemplars = append(p.Exemplars, Exemplar{})
+				if err := p.Exemplars[len(p.Exemplars)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			}
+
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Histograms", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMimir
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMimir
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			p.Histograms = append(p.Histograms, Histogram{})
+			if err := p.Histograms[len(p.Histograms)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMimir(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthMimir
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 
 func (p *PreallocTimeseries) Size() int {

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -501,7 +501,12 @@ func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 
-			if !p.skipUnmarshalingExemplars {
+			if p.skipUnmarshalingExemplars {
+				if p.Exemplars == nil {
+					// For predictability in tests.
+					p.Exemplars = []Exemplar{}
+				}
+			} else {
 				p.Exemplars = append(p.Exemplars, Exemplar{})
 				if err := p.Exemplars[len(p.Exemplars)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 					return err

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -63,8 +63,8 @@ type PreallocWriteRequest struct {
 }
 
 // Unmarshal implements proto.Message.
-// Copied from generated code, the only change is the addition that
-// propagates SkipUnmarshalingExemplars into the .Timeseries slice objects.
+// Copied from the protobuf generated code, the only change is that in case 1 the value of .SkipUnmarshalingExemplars
+// gets copied into the PreallocTimeseries{} object which gets appended to Timeseries.
 func (p *PreallocWriteRequest) Unmarshal(dAtA []byte) error {
 	p.Timeseries = PreallocTimeseriesSliceFromPool()
 
@@ -367,7 +367,8 @@ func (p *PreallocTimeseries) clearUnmarshalData() {
 var TimeseriesUnmarshalCachingEnabled = true
 
 // Unmarshal implements proto.Message. Input data slice is retained.
-// Copied from generated code, the only change is the conditional skipping of the exemplar unmarshaling.
+// Copied from the protobuf generated code, the only change is that in case 3 the exemplars don't get unmarshaled
+// if p.skipUnmarshalingExemplars is false.
 func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
 	if TimeseriesUnmarshalCachingEnabled {
 		p.marshalledData = dAtA

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -501,12 +501,7 @@ func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 
-			if p.skipUnmarshalingExemplars {
-				if p.Exemplars == nil {
-					// For predictability in tests.
-					p.Exemplars = []Exemplar{}
-				}
-			} else {
+			if !p.skipUnmarshalingExemplars {
 				p.Exemplars = append(p.Exemplars, Exemplar{})
 				if err := p.Exemplars[len(p.Exemplars)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 					return err

--- a/pkg/util/validation/limits_mock.go
+++ b/pkg/util/validation/limits_mock.go
@@ -30,7 +30,7 @@ func (l *mockTenantLimits) AllByUserID() map[string]*Limits {
 
 func MockOverrides(customize func(defaults *Limits, tenantLimits map[string]*Limits)) *Overrides {
 	defaults := MockDefaultLimits()
-	tenantLimits := map[string]*Limits{}
+	tenantLimits := make(map[string]*Limits)
 	customize(defaults, tenantLimits)
 
 	overrides, err := NewOverrides(*defaults, NewMockTenantLimits(tenantLimits))

--- a/pkg/util/validation/limits_mock.go
+++ b/pkg/util/validation/limits_mock.go
@@ -30,7 +30,7 @@ func (l *mockTenantLimits) AllByUserID() map[string]*Limits {
 
 func MockOverrides(customize func(defaults *Limits, tenantLimits map[string]*Limits)) *Overrides {
 	defaults := MockDefaultLimits()
-	tenantLimits := make(map[string]*Limits)
+	tenantLimits := map[string]*Limits{}
 	customize(defaults, tenantLimits)
 
 	overrides, err := NewOverrides(*defaults, NewMockTenantLimits(tenantLimits))


### PR DESCRIPTION
Skipping the unmarshaling of exemplars if a user has exemplars disabled.

In our production environments we have seen users for whom the ingestion of exemplars is disabled, but in their write requests they are still sending very large amounts of exemplars, without this change we're decoding all the exemplars only to then drop them.

The line number looks larger than the PR really is, most of the lines are copy-pasted from protobuf generated files. I did not like having to copy-paste generated code, but I figured it's acceptable because we're already doing the same thing with the `.Unmarshal()` method of the type `LabelAdapter` [here](https://github.com/grafana/mimir/blob/7153e1874384efd56f710412ec0061f9abd6c4e8/pkg/mimirpb/timeseries.go#L620). Also, the only alternative that I have found to copying the generated code was to fork `github.com/golang/protobuf/protoc-gen-go`, which in my opinion is even less preferable than copying the generated code.