### PR TITLE
Fix flaky TestOwnedSeriesIngesterRingStrategyRingChanged

### DIFF
--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -1447,7 +1447,9 @@ func TestOwnedSeriesIngesterRingStrategyRingChanged(t *testing.T) {
 
 	t.Run("change of state is not interesting", func(t *testing.T) {
 		updateRingAndWaitForWatcherToReadUpdate(t, wkv, func(desc *ring.Desc) {
-			desc.AddIngester(instanceID2, "localhost:22222", "zone", []uint32{4, 5, 6}, ring.LEAVING, time.Now())
+			ingester2 := desc.Ingesters[instanceID2]
+			ingester2.State = ring.LEAVING
+			desc.Ingesters[instanceID2] = ingester2
 		})
 
 		// Change of state is not interesting.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does


The test case `change of state is not interesting` changes the state of an ingester in the ring. It then expects that the change is classified as "not interesting. "However, it changes the state by adding the ingester again into the ring. This also changes the RegisteredTimestamp of the instance in the ring. Timestamps are unix timestamps in seconds. So if   `change of state is not interesting` runs in a different unix second than `new instance added`, then the test will detect a change in the RegisteredTimestamp, which is an "interesting" change and the test will fail.


This PR fixes `change of state is not interesting` by changing only the state of the ingester.

> NB: The test assumes that its test cases run together. So each subtest requires the previous to have run. Otherwise, they all fail on their own.


#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/7172

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
