### PR TITLE
Streaming PromQL engine: sort series in matrix at end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899 #8058
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [ENHANCEMENT] Distributor: add experimental limit for exemplars per series per request, enabled with `-distributor.max-exemplars-per-series-per-request`, the number of discarded exemplars are tracked with `cortex_discarded_exemplars_total{reason="too_many_exemplars_per_series_per_request"}` #7989 #8010

--- a/pkg/streamingpromql/operator/aggregation.go
+++ b/pkg/streamingpromql/operator/aggregation.go
@@ -29,11 +29,18 @@ type Aggregation struct {
 	remainingGroups             []*group // One entry per group, in the order we want to return them
 }
 
-type group struct {
+type groupWithLabels struct {
 	labels labels.Labels
+	group  *group
+}
 
+type group struct {
 	// The number of input series that belong to this group that we haven't yet seen.
 	remainingSeriesCount uint
+
+	// The index of the last series that contributes to this group.
+	// Used to sort groups in the order that they'll be completed in.
+	lastSeriesIndex int
 
 	// Sum and presence for each step.
 	sums    []float64
@@ -61,12 +68,12 @@ func (a *Aggregation) SeriesMetadata(ctx context.Context) ([]SeriesMetadata, err
 	}
 
 	// Determine the groups we'll return
-	groups := map[uint64]*group{}
+	groups := map[uint64]groupWithLabels{}
 	buf := make([]byte, 0, 1024)
 	lb := labels.NewBuilder(labels.EmptyLabels())
 	a.remainingInnerSeriesToGroup = make([]*group, 0, len(innerSeries))
 
-	for _, series := range innerSeries {
+	for seriesIdx, series := range innerSeries {
 		// Note that this doesn't handle potential hash collisions between groups.
 		// This is something we should likely fix, but at present, Prometheus' PromQL engine doesn't handle collisions either,
 		// so at least both engines will be incorrect in the same way.
@@ -75,15 +82,16 @@ func (a *Aggregation) SeriesMetadata(ctx context.Context) ([]SeriesMetadata, err
 		g, groupExists := groups[groupingKey]
 
 		if !groupExists {
-			g = groupPool.Get()
 			g.labels = a.labelsForGroup(series.Labels, lb)
-			g.remainingSeriesCount = 0
+			g.group = groupPool.Get()
+			g.group.remainingSeriesCount = 0
 
 			groups[groupingKey] = g
 		}
 
-		g.remainingSeriesCount++
-		a.remainingInnerSeriesToGroup = append(a.remainingInnerSeriesToGroup, g)
+		g.group.remainingSeriesCount++
+		g.group.lastSeriesIndex = seriesIdx
+		a.remainingInnerSeriesToGroup = append(a.remainingInnerSeriesToGroup, g.group)
 	}
 
 	// Sort the list of series we'll return, and maintain the order of the corresponding groups at the same time
@@ -92,7 +100,7 @@ func (a *Aggregation) SeriesMetadata(ctx context.Context) ([]SeriesMetadata, err
 
 	for _, g := range groups {
 		seriesMetadata = append(seriesMetadata, SeriesMetadata{Labels: g.labels})
-		a.remainingGroups = append(a.remainingGroups, g)
+		a.remainingGroups = append(a.remainingGroups, g.group)
 	}
 
 	sort.Sort(groupSorter{seriesMetadata, a.remainingGroups})
@@ -197,7 +205,7 @@ func (g groupSorter) Len() int {
 }
 
 func (g groupSorter) Less(i, j int) bool {
-	return labels.Compare(g.metadata[i].Labels, g.metadata[j].Labels) < 0
+	return g.groups[i].lastSeriesIndex < g.groups[j].lastSeriesIndex
 }
 
 func (g groupSorter) Swap(i, j int) {

--- a/pkg/streamingpromql/operator/aggregation_test.go
+++ b/pkg/streamingpromql/operator/aggregation_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package operator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+// Most of the functionality of the aggregation operator is tested through the test scripts in
+// pkg/streamingpromql/testdata.
+//
+// The output sorting behaviour is impossible to test through these scripts, so we instead test it here.
+func TestAggregation_ReturnsGroupsFinishedFirstEarliest(t *testing.T) {
+	testCases := map[string]struct {
+		inputSeries               []labels.Labels
+		grouping                  []string
+		expectedOutputSeriesOrder []labels.Labels
+	}{
+		"empty input": {
+			inputSeries:               []labels.Labels{},
+			grouping:                  []string{},
+			expectedOutputSeriesOrder: []labels.Labels{},
+		},
+		"all series grouped into single group": {
+			inputSeries: []labels.Labels{
+				labels.FromStrings("pod", "1"),
+				labels.FromStrings("pod", "2"),
+			},
+			grouping: []string{},
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.EmptyLabels(),
+			},
+		},
+		"input series already sorted by group": {
+			inputSeries: []labels.Labels{
+				labels.FromStrings("pod", "1", "group", "B"),
+				labels.FromStrings("pod", "2", "group", "B"),
+				labels.FromStrings("pod", "1", "group", "A"),
+				labels.FromStrings("pod", "2", "group", "A"),
+				labels.FromStrings("pod", "1", "group", "C"),
+				labels.FromStrings("pod", "2", "group", "C"),
+			},
+			grouping: []string{"group"},
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("group", "B"),
+				labels.FromStrings("group", "A"),
+				labels.FromStrings("group", "C"),
+			},
+		},
+		"input series not sorted by group": {
+			inputSeries: []labels.Labels{
+				labels.FromStrings("pod", "1", "group", "A"),
+				labels.FromStrings("pod", "1", "group", "B"),
+				labels.FromStrings("pod", "2", "group", "B"),
+				labels.FromStrings("pod", "1", "group", "C"),
+				labels.FromStrings("pod", "2", "group", "A"),
+				labels.FromStrings("pod", "2", "group", "C"),
+			},
+			grouping: []string{"group"},
+			expectedOutputSeriesOrder: []labels.Labels{
+				// Should sort so that the group that is completed first is returned first.
+				labels.FromStrings("group", "B"),
+				labels.FromStrings("group", "A"),
+				labels.FromStrings("group", "C"),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			aggregator := &Aggregation{
+				Inner:    &testOperator{series: testCase.inputSeries},
+				Grouping: testCase.grouping,
+			}
+
+			outputSeries, err := aggregator.SeriesMetadata(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, labelsToSeriesMetadata(testCase.expectedOutputSeriesOrder), outputSeries)
+		})
+	}
+}
+
+func labelsToSeriesMetadata(lbls []labels.Labels) []SeriesMetadata {
+	if len(lbls) == 0 {
+		return nil
+	}
+
+	m := make([]SeriesMetadata, len(lbls))
+
+	for i, l := range lbls {
+		m[i].Labels = l
+	}
+
+	return m
+}
+
+type testOperator struct {
+	series []labels.Labels
+}
+
+func (t *testOperator) SeriesMetadata(_ context.Context) ([]SeriesMetadata, error) {
+	return labelsToSeriesMetadata(t.series), nil
+}
+
+func (t *testOperator) Next(_ context.Context) (InstantVectorSeriesData, error) {
+	panic("Next() not supported")
+}
+
+func (t *testOperator) Close() {
+	panic("Close() not supported")
+}

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -269,6 +270,10 @@ func (q *Query) populateMatrix(ctx context.Context, series []operator.SeriesMeta
 			Histograms: d.Histograms,
 		})
 	}
+
+	slices.SortFunc(m, func(a, b promql.Series) int {
+		return labels.Compare(a.Metric, b.Metric)
+	})
 
 	return m, nil
 }


### PR DESCRIPTION
#### What this PR does

This PR modifies the behaviour of the streaming PromQL engine to not sort series in the aggregation operator, and instead sort the final matrix value. 

Matrix values are expected to be sorted by series labels, so we can't avoid sorting series altogether - but we don't need to sort intermediate results.

Sorting series in the aggregation operator is unnecessary:
* in the specific case of the aggregation operator, it's better to return series in whatever order minimises the number of incomplete groups held in memory, as this reduces peak memory utilisation in the case where the input series are sorted according to the output groups (and in the worst case, peak memory utilisation is no worse than what we have today)
* there may be another operator consuming the result of the aggregation, and so sorting the output may be a waste of time, as the consuming operator might not need its input to be sorted

Some operators (eg. selectors) will always return series in the correct order, but `slices.SortFunc` handles the case where the input is already sorted relatively efficiently, so this extra sorting pass does not add much overhead (<1% latency in our benchmarks). 

The final sorting pass does not require more memory utilisation or allocations.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
