### PR TITLE
Jsonnet: add support to autoscale ruler-querier replicas based on in-flight queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 * [ENHANCEMENT] Shuffle-sharding: add `$._config.shuffle_sharding.ingest_storage_partitions_enabled` and `$._config.shuffle_sharding.ingester_partitions_shard_size` options, that allow configuring partitions shard size in ingest-storage mode. #7804
 * [ENHANCEMENT] Rollout-operator: upgrade to v0.14.0.
 * [ENHANCEMENT] Add `_config.autoscaling_querier_predictive_scaling_enabled` to scale querier based on inflight queries 7 days ago. #7775
+* [ENHANCEMENT] Add support to autoscale ruler-querier replicas based on in-flight queries too (in addition to CPU and memory based scaling). #8060
 * [BUGFIX] Guard against missing samples in KEDA queries. #7691
 
 ### Mimirtool

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2382,6 +2382,14 @@ spec:
       threshold: "955630223"
     name: ruler_querier_memory_hpa_default
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_ruler_querier_queries_hpa_default
+      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m]))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "7"
+    name: cortex_ruler_querier_queries_hpa_default
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization.jsonnet
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization.jsonnet
@@ -6,6 +6,7 @@
     autoscaling_querier_target_utilization: targetUtilization,
     autoscaling_ruler_querier_cpu_target_utilization: targetUtilization,
     autoscaling_ruler_querier_memory_target_utilization: targetUtilization,
+    autoscaling_ruler_querier_workers_target_utilization: targetUtilization,
     autoscaling_distributor_cpu_target_utilization: targetUtilization,
     autoscaling_distributor_memory_target_utilization: targetUtilization,
     autoscaling_ruler_cpu_target_utilization: targetUtilization,

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2382,6 +2382,14 @@ spec:
       threshold: "1073741824"
     name: ruler_querier_memory_hpa_default
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_ruler_querier_queries_hpa_default
+      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m]))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_ruler_querier_queries_hpa_default
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject


### PR DESCRIPTION
#### What this PR does

In this PR I'm upstreaming a change we did at Grafana Labs to autoscale ruler-querier replicas based on in-flight queries too, in addition to CPU and memory based scaling.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
