### PR TITLE
mimirtool: use strings replacer in dashboards queries analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
+* [BUGFIX] Analyze Grafana: fix parsing queries with variables. #8062
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/analyze/grafana_test.go
+++ b/pkg/mimirtool/analyze/grafana_test.go
@@ -147,7 +147,7 @@ func TestMetricsFromTemplating(t *testing.T) {
 		require.Empty(t, metrics)
 	})
 
-	t.Run(`label_values query with no metric selector multiline `, func(t *testing.T) {
+	t.Run(`label_values query with no metric selector multiline`, func(t *testing.T) {
 		metrics := make(map[string]struct{})
 		in := minisdk.Templating{
 			List: []minisdk.TemplateVar{
@@ -165,5 +165,43 @@ func TestMetricsFromTemplating(t *testing.T) {
 		errs := metricsFromTemplating(in, metrics)
 		require.Empty(t, errs)
 		require.Empty(t, metrics)
+	})
+
+	t.Run(`query contains a subquery with the $__interval variable`, func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query:      `increase(varnish_main_threads_failed{job=~"$job",instance=~"$instance"}[$__interval:])`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Len(t, metrics, 1)
+		require.Equal(t, map[string]struct{}{"varnish_main_threads_failed": {}}, metrics)
+	})
+
+	t.Run(`query uses offset with $__interval variable`, func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query:      `increase(tomcat_session_processingtime_total{job=~"$job", instance=~"$instance", host=~"$host", context=~"$context"}[$__interval:] offset -$__interval)`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Len(t, metrics, 1)
+		require.Equal(t, map[string]struct{}{"tomcat_session_processingtime_total": {}}, metrics)
 	})
 }

--- a/pkg/mimirtool/analyze/grafana_test.go
+++ b/pkg/mimirtool/analyze/grafana_test.go
@@ -204,4 +204,23 @@ func TestMetricsFromTemplating(t *testing.T) {
 		require.Len(t, metrics, 1)
 		require.Equal(t, map[string]struct{}{"tomcat_session_processingtime_total": {}}, metrics)
 	})
+
+	t.Run(`query contains range with other variables`, func(t *testing.T) {
+		metrics := make(map[string]struct{})
+		in := minisdk.Templating{
+			List: []minisdk.TemplateVar{
+				{
+					Name:       "variable",
+					Type:       "query",
+					Datasource: nil,
+					Query:      `myapp_metric_foo[$__from:$__to]`,
+				},
+			},
+		}
+
+		errs := metricsFromTemplating(in, metrics)
+		require.Empty(t, errs)
+		require.Len(t, metrics, 1)
+		require.Equal(t, map[string]struct{}{"myapp_metric_foo": {}}, metrics)
+	})
 }


### PR DESCRIPTION
#### What this PR does
When parsing queries from grafana dashboards, use a replacer with a list of variables rather than a regex matcher.

The regex matcher works ok with ranges and subqueries, but is not working when the variables are used in other parts of the query (e.g. with `offset`).

This PR switches back to using a list of variables to be replaced, partially reverting the changes from #6657, but uses a `strings.Replacer` for better readability.

#### Which issue(s) this PR fixes or relates to
n.a.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
