### PR TITLE
ingest-storage: propagate traces from api_v1_push requests through Kafka

### DIFF
--- a/pkg/mimir/tracing_test.go
+++ b/pkg/mimir/tracing_test.go
@@ -20,28 +20,48 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func TestJaegerToOpenTelemetryTraceID(t *testing.T) {
-	expected, _ := generateOpenTelemetryIDs()
+func TestJaegerToOTelTraceID(t *testing.T) {
+	expected, _ := generateOTelIDs()
 
 	jaegerTraceID, err := jaeger.TraceIDFromString(expected.String())
 	require.NoError(t, err)
 
-	actual := jaegerToOpenTelemetryTraceID(jaegerTraceID)
+	actual := jaegerToOTelTraceID(jaegerTraceID)
 	assert.Equal(t, expected, actual)
 }
 
-func TestJaegerToOpenTelemetrySpanID(t *testing.T) {
-	_, expected := generateOpenTelemetryIDs()
+func TestJaegerToOTelSpanID(t *testing.T) {
+	_, expected := generateOTelIDs()
 
 	jaegerSpanID, err := jaeger.SpanIDFromString(expected.String())
 	require.NoError(t, err)
 
-	actual := jaegerToOpenTelemetrySpanID(jaegerSpanID)
+	actual := jaegerToOTelSpanID(jaegerSpanID)
 	assert.Equal(t, expected, actual)
 }
 
-// generateOpenTelemetryIDs generated trace and span IDs. The implementation has been copied from open telemetry.
-func generateOpenTelemetryIDs() (trace.TraceID, trace.SpanID) {
+func TestJaegerFromOTelTraceID(t *testing.T) {
+	traceID, _ := generateOTelIDs()
+
+	expected, err := jaeger.TraceIDFromString(traceID.String())
+	require.NoError(t, err)
+
+	actual := jaegerFromOTelTraceID(traceID)
+	assert.Equal(t, expected, actual)
+}
+
+func TestJaegerFromOTelSpanID(t *testing.T) {
+	_, spanID := generateOTelIDs()
+
+	expected, err := jaeger.SpanIDFromString(spanID.String())
+	require.NoError(t, err)
+
+	actual := jaegerFromOTelSpanID(spanID)
+	assert.Equal(t, expected, actual)
+}
+
+// generateOTelIDs generated trace and span IDs. The implementation has been copied from open telemetry.
+func generateOTelIDs() (trace.TraceID, trace.SpanID) {
 	var rngSeed int64
 	_ = binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
 	randSource := rand.New(rand.NewSource(rngSeed))

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -11,11 +11,11 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/user"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 type Pusher interface {
@@ -34,6 +34,7 @@ type pusherConsumer struct {
 
 type parsedRecord struct {
 	*mimirpb.WriteRequest
+	ctx      context.Context
 	tenantID string
 	err      error
 }
@@ -65,20 +66,21 @@ func newPusherConsumer(p Pusher, reg prometheus.Registerer, l log.Logger) *pushe
 }
 
 func (c pusherConsumer) consume(ctx context.Context, records []record) error {
-	recC := make(chan parsedRecord)
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(cancellation.NewErrorf("done consuming records"))
 
+	recC := make(chan parsedRecord)
+
 	// Speed up consumption by unmarhsalling the next request while the previous one is being pushed.
 	go c.unmarshalRequests(ctx, records, recC)
-	err := c.pushRequests(ctx, recC)
+	err := c.pushRequests(recC)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (c pusherConsumer) pushRequests(ctx context.Context, reqC <-chan parsedRecord) error {
+func (c pusherConsumer) pushRequests(reqC <-chan parsedRecord) error {
 	recordIdx := -1
 	for wr := range reqC {
 		recordIdx++
@@ -86,30 +88,45 @@ func (c pusherConsumer) pushRequests(ctx context.Context, reqC <-chan parsedReco
 			level.Error(c.l).Log("msg", "failed to parse write request; skipping", "err", wr.err)
 			continue
 		}
-		processingStart := time.Now()
 
-		ctx := user.InjectOrgID(ctx, wr.tenantID)
-		err := c.p.PushToStorage(ctx, wr.WriteRequest)
-
-		c.processingTimeSeconds.Observe(time.Since(processingStart).Seconds())
-		c.totalRequests.Inc()
-
+		ctx := user.InjectOrgID(wr.ctx, wr.tenantID)
+		err := c.pushToStorage(ctx, wr.WriteRequest)
 		if err != nil {
-			if !mimirpb.IsClientError(err) {
-				c.serverErrRequests.Inc()
-				return fmt.Errorf("consuming record at index %d for tenant %s: %w", recordIdx, wr.tenantID, err)
-			}
-			c.clientErrRequests.Inc()
+			return fmt.Errorf("consuming record at index %d for tenant %s: %w", recordIdx, wr.tenantID, err)
+		}
+	}
+	return nil
+}
 
-			// The error could be sampled or marked to be skipped in logs, so we check whether it should be
-			// logged before doing it.
-			if keep, reason := shouldLog(ctx, err); keep {
-				if reason != "" {
-					err = fmt.Errorf("%w (%s)", err, reason)
-				}
+func (c pusherConsumer) pushToStorage(ctx context.Context, req *mimirpb.WriteRequest) error {
+	spanLog, spanCtx := spanlogger.NewWithLogger(ctx, c.l, "pusherConsumer.pushToStorage")
+	defer spanLog.Finish()
 
-				level.Warn(c.l).Log("msg", "detected a client error while ingesting write request (the request may have been partially ingested)", "err", err, "user", wr.tenantID)
+	processingStart := time.Now()
+
+	err := c.p.PushToStorage(spanCtx, req)
+
+	c.processingTimeSeconds.Observe(time.Since(processingStart).Seconds())
+	c.totalRequests.Inc()
+
+	if err != nil {
+		// Only return non-client errors; these will stop the processing of the current Kafka fetches and retry (possibly).
+		if !mimirpb.IsClientError(err) {
+			c.serverErrRequests.Inc()
+			return spanLog.Error(err)
+		}
+
+		c.clientErrRequests.Inc()
+
+		// The error could be sampled or marked to be skipped in logs, so we check whether it should be
+		// logged before doing it.
+		if keep, reason := shouldLog(ctx, err); keep {
+			if reason != "" {
+				err = fmt.Errorf("%w (%s)", err, reason)
 			}
+
+			tenantID, _ := user.ExtractOrgID(spanCtx)
+			level.Warn(spanLog).Log("msg", "detected a client error while ingesting write request (the request may have been partially ingested)", "err", err, "user", tenantID)
 		}
 	}
 	return nil
@@ -119,16 +136,23 @@ func (c pusherConsumer) unmarshalRequests(ctx context.Context, records []record,
 	defer close(recC)
 	done := ctx.Done()
 
-	for _, record := range records {
+	for _, rec := range records {
+		// rec.ctx contains the tracing baggage for this record, which we propagate down the call tree.
+		// But this context's cancellation is disjointed from the top-most ctx. The context.AfterFunc below,
+		// is what fuses the two lifetimes together.
+		recCtx, cancel := context.WithCancelCause(rec.ctx)
+		context.AfterFunc(ctx, func() {
+			cancel(context.Cause(ctx))
+		})
 		pRecord := parsedRecord{
-			tenantID:     record.tenantID,
+			ctx:          recCtx,
+			tenantID:     rec.tenantID,
 			WriteRequest: &mimirpb.WriteRequest{},
 		}
 		// We don't free the WriteRequest slices because they are being freed by the Pusher.
-		err := pRecord.WriteRequest.Unmarshal(record.content)
+		err := pRecord.WriteRequest.Unmarshal(rec.content)
 		if err != nil {
-			err = errors.Wrap(err, "parsing ingest consumer write request")
-			pRecord.err = err
+			pRecord.err = fmt.Errorf("parsing ingest consumer write request: %w", err)
 		}
 		select {
 		case <-done:

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/gogo/status"
+	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/tenant"
@@ -46,6 +47,8 @@ func TestPusherConsumer(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	ctx := context.Background()
+
 	type response struct {
 		err error
 	}
@@ -60,7 +63,7 @@ func TestPusherConsumer(t *testing.T) {
 	}{
 		"single record": {
 			records: []record{
-				{content: wrBytes[0], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[0], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -69,9 +72,9 @@ func TestPusherConsumer(t *testing.T) {
 		},
 		"multiple records": {
 			records: []record{
-				{content: wrBytes[0], tenantID: tenantID},
-				{content: wrBytes[1], tenantID: tenantID},
-				{content: wrBytes[2], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[0], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[1], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[2], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -82,9 +85,9 @@ func TestPusherConsumer(t *testing.T) {
 		},
 		"unparsable record": {
 			records: []record{
-				{content: wrBytes[0], tenantID: tenantID},
-				{content: []byte{0}, tenantID: tenantID},
-				{content: wrBytes[1], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[0], tenantID: tenantID},
+				{ctx: ctx, content: []byte{0}, tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[1], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -95,9 +98,9 @@ func TestPusherConsumer(t *testing.T) {
 		},
 		"failed processing of record": {
 			records: []record{
-				{content: wrBytes[0], tenantID: tenantID},
-				{content: wrBytes[1], tenantID: tenantID},
-				{content: wrBytes[2], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[0], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[1], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[2], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -108,8 +111,8 @@ func TestPusherConsumer(t *testing.T) {
 		},
 		"failed processing of last record": {
 			records: []record{
-				{content: wrBytes[0], tenantID: tenantID},
-				{content: wrBytes[1], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[0], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[1], tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -120,9 +123,9 @@ func TestPusherConsumer(t *testing.T) {
 		},
 		"failed processing & failed unmarshalling": {
 			records: []record{
-				{content: wrBytes[0], tenantID: tenantID},
-				{content: wrBytes[1], tenantID: tenantID},
-				{content: []byte{0}, tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[0], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[1], tenantID: tenantID},
+				{ctx: ctx, content: []byte{0}, tenantID: tenantID},
 			},
 			responses: []response{
 				okResponse,
@@ -134,9 +137,9 @@ func TestPusherConsumer(t *testing.T) {
 		"no records": {},
 		"ingester client error": {
 			records: []record{
-				{content: wrBytes[0], tenantID: tenantID},
-				{content: wrBytes[1], tenantID: tenantID},
-				{content: wrBytes[2], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[0], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[1], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[2], tenantID: tenantID},
 			},
 			responses: []response{
 				{err: ingesterError(mimirpb.BAD_DATA, codes.InvalidArgument, "ingester test error")},
@@ -148,11 +151,11 @@ func TestPusherConsumer(t *testing.T) {
 		},
 		"ingester server error": {
 			records: []record{
-				{content: wrBytes[0], tenantID: tenantID},
-				{content: wrBytes[1], tenantID: tenantID},
-				{content: wrBytes[2], tenantID: tenantID},
-				{content: wrBytes[3], tenantID: tenantID},
-				{content: wrBytes[4], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[0], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[1], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[2], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[3], tenantID: tenantID},
+				{ctx: ctx, content: wrBytes[4], tenantID: tenantID},
 			},
 			responses: []response{
 				{err: ingesterError(mimirpb.BAD_DATA, codes.InvalidArgument, "ingester test error")},
@@ -199,9 +202,13 @@ func TestPusherConsumer_consume_ShouldLogErrorsHonoringOptionalLogging(t *testin
 	req := &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1")}}
 	reqBytes, err := req.Marshal()
 	require.NoError(t, err)
-	reqRecord := record{tenantID: "user-1", content: reqBytes}
 
-	// Utility function used to setup the test.
+	reqRecord := record{
+		ctx:      context.Background(),
+		tenantID: "user-1",
+		content:  reqBytes,
+	}
+
 	setupTest := func(pusherErr error) (*pusherConsumer, *concurrency.SyncBuffer, *prometheus.Registry) {
 		pusher := pusherFunc(func(context.Context, *mimirpb.WriteRequest) error {
 			return pusherErr
@@ -273,6 +280,43 @@ func TestPusherConsumer_consume_ShouldLogErrorsHonoringOptionalLogging(t *testin
 		`), "cortex_ingest_storage_reader_records_failed_total"))
 	})
 
+}
+
+func TestPusherConsumer_consume_ShouldHonorContextCancellation(t *testing.T) {
+	// Create a request that will be used in this test; the content doesn't matter,
+	// since we only test errors.
+	req := &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1")}}
+	reqBytes, err := req.Marshal()
+	require.NoError(t, err)
+
+	reqRecord := record{
+		ctx:      context.Background(), // The record's context isn't important for the test.
+		tenantID: "user-1",
+		content:  reqBytes,
+	}
+
+	// didPush signals that the testing record was pushed to the pusher.
+	didPush := make(chan struct{}, 1)
+	pusher := pusherFunc(func(ctx context.Context, _ *mimirpb.WriteRequest) error {
+		close(didPush)
+		<-ctx.Done()
+		return context.Cause(ctx)
+	})
+	consumer := newPusherConsumer(pusher, prometheus.NewPedanticRegistry(), log.NewNopLogger())
+
+	wantCancelErr := cancellation.NewErrorf("stop")
+
+	// For this test, cancelling the top-most context must cancel an in-flight call to push,
+	// to prevent pusher from hanging forever.
+	canceledCtx, cancel := context.WithCancelCause(context.Background())
+	go func() {
+		<-didPush
+		cancel(wantCancelErr)
+	}()
+
+	// Should return no error on client errors.
+	err = consumer.consume(canceledCtx, []record{reqRecord})
+	require.ErrorIs(t, err, wantCancelErr)
 }
 
 // ingesterError mimics how the ingester construct errors

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -35,6 +35,7 @@ const (
 )
 
 type record struct {
+	ctx      context.Context
 	tenantID string
 	content  []byte
 }
@@ -317,12 +318,15 @@ func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetche
 		minOffset = math.MaxInt
 		maxOffset = 0
 	)
-	fetches.EachRecord(func(r *kgo.Record) {
-		minOffset = min(minOffset, int(r.Offset))
-		maxOffset = max(maxOffset, int(r.Offset))
+	fetches.EachRecord(func(rec *kgo.Record) {
+		minOffset = min(minOffset, int(rec.Offset))
+		maxOffset = max(maxOffset, int(rec.Offset))
 		records = append(records, record{
-			content:  r.Value,
-			tenantID: string(r.Key),
+			// This context caries the tracing data for this individual record;
+			// kotel populates this data when it fetches the messages.
+			ctx:      rec.Context,
+			tenantID: string(rec.Key),
+			content:  rec.Value,
 		})
 	})
 
@@ -346,7 +350,6 @@ func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetche
 		)
 		boff.Wait()
 	}
-
 }
 
 func (r *PartitionReader) notifyLastConsumedOffset(fetches kgo.Fetches) {


### PR DESCRIPTION
#### What this PR does

This PR improves the distributed tracing in ingest-storage, by propagating the tracing spans on the write path, from `distributor` to `ingester`.

That is, before the changes the `api_v1_push` trace ended in the `distributor`, after the records were published to Kafka, and the response was sent to the caller:

<img width="1490" alt="Screenshot 2024-05-06 at 14 23 43" src="https://github.com/grafana/mimir/assets/88045/e59c59f0-dfb6-4a70-a777-cf65849f93fb">

After the changes, the trace is picked on the `ingester` side, when it consumes the record from Kafka, and propagates the message to its pusher:

<img width="1498" alt="Screenshot 2024-05-06 at 12 19 01" src="https://github.com/grafana/mimir/assets/88045/737647dd-489a-4a40-95a4-0c19fba08710">

Note on the screenshot above, the trace illustrates how

1. the `mimir-distributor` produced 2 records to 2 different Kafka topics
2. at `T+47ms` `mimir-distributor` replied to the caller, ending its section of the trace
3. meanwhile, `mimir-ingester` (replicas in zone-a and zone-b) received the records from the topics, and pushed them via the pusher.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
