### PR TITLE
[ENHANCEMENT] Add `mimir-http-prefix` option to introduce a prefix for Mimir URL when use legacy routes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 
 * [CHANGE] Deprecated `--rule-files` flag in favor of CLI arguments. #7756
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
+* [ENHANCEMENT] Add `mimir-http-prefix` option to introduce a prefix for Mimir URL when use legacy routes. #8069
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 * [BUGFIX] Analyze Grafana: fix parsing queries with variables. #8062

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@
 
 * [CHANGE] Deprecated `--rule-files` flag in favor of CLI arguments. #7756
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
-* [ENHANCEMENT] Add `mimir-http-prefix` option to introduce a prefix for Mimir URL when use legacy routes. #8069
+* [ENHANCEMENT] Add `mimir-http-prefix` configuration to set the Mimir URL prefix when using legacy routes. #8069
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 * [BUGFIX] Analyze Grafana: fix parsing queries with variables. #8062

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -46,6 +46,7 @@ type Config struct {
 	ID              string `yaml:"id"`
 	TLS             tls.ClientConfig
 	UseLegacyRoutes bool              `yaml:"use_legacy_routes"`
+	MimirHTTPPrefix string            `yaml:"mimir_http_prefix"`
 	AuthToken       string            `yaml:"auth_token"`
 	ExtraHeaders    map[string]string `yaml:"extra_headers"`
 }
@@ -97,7 +98,10 @@ func New(cfg Config) (*MimirClient, error) {
 
 	path := rulerAPIPath
 	if cfg.UseLegacyRoutes {
-		path = legacyAPIPath
+		var err error
+		if path, err = url.JoinPath(cfg.MimirHTTPPrefix, legacyAPIPath); err != nil {
+			return nil, err
+		}
 	}
 
 	return &MimirClient{

--- a/pkg/mimirtool/client/rules_test.go
+++ b/pkg/mimirtool/client/rules_test.go
@@ -24,22 +24,13 @@ func TestMimirClient_X(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := New(Config{
-		Address: ts.URL,
-		ID:      "my-id",
-		Key:     "my-key",
-		ExtraHeaders: map[string]string{
-			"key1": "value1",
-			"key2": "value2",
-		},
-	})
-	require.NoError(t, err)
-
 	for _, tc := range []struct {
-		test       string
-		namespace  string
-		name       string
-		expURLPath string
+		test            string
+		namespace       string
+		name            string
+		expURLPath      string
+		useLegacyRoutes bool
+		mimirHTTPPrefix string
 	}{
 		{
 			test:       "regular-characters",
@@ -71,9 +62,37 @@ func TestMimirClient_X(t *testing.T) {
 			name:       "last-char-slash/",
 			expURLPath: "/prometheus/config/v1/rules/My%2FNamespace/last-char-slash%2F",
 		},
+		{
+			test:            "use legacy routes with mimir-http-prefix",
+			namespace:       "my-namespace",
+			name:            "my-name",
+			useLegacyRoutes: true,
+			mimirHTTPPrefix: "/foo",
+			expURLPath:      "/foo/api/v1/rules/my-namespace/my-name",
+		},
+		{
+			test:            "use non legacy routes with mimir-http-prefix ignored",
+			namespace:       "my-namespace",
+			name:            "my-name",
+			useLegacyRoutes: false,
+			mimirHTTPPrefix: "/foo",
+			expURLPath:      "/prometheus/config/v1/rules/my-namespace/my-name",
+		},
 	} {
 		t.Run(tc.test, func(t *testing.T) {
 			ctx := context.Background()
+			client, err := New(Config{
+				Address: ts.URL,
+				ID:      "my-id",
+				Key:     "my-key",
+				ExtraHeaders: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+				UseLegacyRoutes: tc.useLegacyRoutes,
+				MimirHTTPPrefix: tc.mimirHTTPPrefix,
+			})
+			require.NoError(t, err)
 			require.NoError(t, client.DeleteRuleGroup(ctx, tc.namespace, tc.name))
 
 			req := <-requestCh

--- a/pkg/mimirtool/commands/env_var.go
+++ b/pkg/mimirtool/commands/env_var.go
@@ -30,6 +30,7 @@ func NewEnvVarsWithPrefix(prefix string) EnvVarNames {
 		useLegacyRoutes       = "USE_LEGACY_ROUTES"
 		authToken             = "AUTH_TOKEN"
 		extraHeaders          = "EXTRA_HEADERS"
+		mimirHTTPPrefix       = "MIMIR_HTTP_PREFIX"
 	)
 
 	if len(prefix) > 0 && prefix[len(prefix)-1] != '_' {
@@ -48,5 +49,6 @@ func NewEnvVarsWithPrefix(prefix string) EnvVarNames {
 		UseLegacyRoutes:       prefix + useLegacyRoutes,
 		AuthToken:             prefix + authToken,
 		ExtraHeaders:          prefix + extraHeaders,
+		MimirHTTPPrefix:       prefix + mimirHTTPPrefix,
 	}
 }

--- a/pkg/mimirtool/commands/env_var.go
+++ b/pkg/mimirtool/commands/env_var.go
@@ -12,6 +12,7 @@ type EnvVarNames struct {
 	TLSInsecureSkipVerify string
 	TenantID              string
 	UseLegacyRoutes       string
+	MimirHTTPPrefix       string
 	AuthToken             string
 	ExtraHeaders          string
 }

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -176,6 +176,11 @@ func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames, re
 			Envar(envVars.UseLegacyRoutes).
 			BoolVar(&r.ClientConfig.UseLegacyRoutes)
 
+		c.Flag("mimir-http-prefix", "Used when use-legacy-routes is set to true. The prefix to use for the url when contacting Grafana Mimir; alternatively, set "+envVars.MimirHTTPPrefix+".").
+			Default("/prometheus").
+			Envar(envVars.MimirHTTPPrefix).
+			StringVar(&r.ClientConfig.MimirHTTPPrefix)
+
 		c.Flag("tls-ca-path", "TLS CA certificate to verify Grafana Mimir API as part of mTLS; alternatively, set "+envVars.TLSCAPath+".").
 			Default("").
 			Envar(envVars.TLSCAPath).


### PR DESCRIPTION
[ENHANCEMENT] Add `mimir-http-prefix` option to introduce a prefix for Mimir URL when use legacy routes.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
clean up some mimirtool bugs, adding mimir-http-prefix for mimir client when use legacy routes 
#### Which issue(s) this PR fixes or relates to

Fixes #8018

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
