### PR TITLE
Runbooks: Add OTLP Mimir route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 ### Documentation
 
 * [ENHANCEMENT] Clarify Compactor and its storage volume when configured under Kubernetes. #7675
+* [ENHANCEMENT] Add OTLP route to _Mimir routes by path_ runbooks section. #8074
 
 ### Tools
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -2139,6 +2139,7 @@ This error only occurs when an administrator has explicitly define a blocked lis
 - `/cortex.Ingester/Push`
 - `api_v1_push`
 - `api_v1_push_influx_write`
+- `otlp_v1_metrics`
 
 **Read path**:
 


### PR DESCRIPTION
#### What this PR does
Add OTLP route to runbooks section _Mimir routes by path_.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
