### PR TITLE
Docs: add runbook 'Ingester is overloaded when consuming from Kafka'

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1393,6 +1393,8 @@ How to **investigate**:
 
 - Check if ingester is fast enough to process all data in Kafka.
 
+See also "[Ingester is overloaded when consuming from Kafka](#ingester-is-overloaded-when-consuming-from-kafka)".
+
 ### MimirRunningIngesterReceiveDelayTooHigh
 
 This alert fires when "receive delay" reported by ingester while it's running reaches alert threshold.
@@ -1408,6 +1410,8 @@ How to **investigate**:
 
 - Check if ingester is fast enough to process all data in Kafka.
 - If ingesters are too slow, consider scaling ingesters horizontally to spread incoming series between more ingesters.
+
+See also "[Ingester is overloaded when consuming from Kafka](#ingester-is-overloaded-when-consuming-from-kafka)".
 
 ### MimirIngesterFailsToProcessRecordsFromKafka
 
@@ -1437,6 +1441,44 @@ How to **investigate**:
 
 - Check wait latency of requests with strong-consistency on `Mimir / Queries` dashboard.
 - Check if ingester needs to process too many records, and whether ingesters need to be scaled up (vertically or horizontally).
+
+### Ingester is overloaded when consuming from Kafka
+
+This runbook covers the case an ingester is overloaded when ingesting metrics data (consuming) from Kafka.
+
+For example, if the amount of active series written to a partition exceeds the ingester capacity, the write-path will keep writing to the partition, but then the ingesters owning that partition will fail ingesting the data. Possible symptoms of this situation:
+
+- The ingester is lagging behind replaying metrics data from Kafka, and [`MimirStartingIngesterKafkaReceiveDelayIncreasing`](#MimirStartingIngesterKafkaReceiveDelayIncreasing) or [`MimirRunningIngesterReceiveDelayTooHigh`](#MimirRunningIngesterReceiveDelayTooHigh) alerts get fired.
+- The ingester logs [`err-mimir-ingester-max-series`](#err-mimir-ingester-max-series) when ingesting metrics data from Kafka.
+- The ingester is OOMKilled.
+
+How it **works**:
+
+- An ingester owns 1 and only 1 partition. A partition can be owned by multiple ingesters, but each ingester always own a single partition.
+- Metrics data is written to a partition by distributors, and the amount of written data is driven by the incoming traffic in the write-path. Distributors don't know whether the per-partition load is "too much" for the ingesters that will consume from that partition.
+- Ingesters are expected to autoscale. When the number of active series in ingesters grow above the scaling threshold, more ingesters will be added to the cluster. When ingesters are scaled out, new partitions are added and incoming metrics data re-balanced between partitions. However, the old data (already written to partitions) will not be moved, and the load will be re-balanced only for metrics data ingested after the scaling.
+
+How to **fix**:
+
+- **Vertical scale ingesters** (no data loss)
+  - Add more CPU/memory/disk to ingesters, depending on the saturated resources.
+  - Increase the ingester max series instance limit (see [`MimirIngesterReachingSeriesLimit`](#MimirIngesterReachingSeriesLimit) runbook).
+- **Skip replaying overloading backlog from partition** (data loss)
+  1. Ensure ingesters have been scaled out, and the new partitions are ACTIVE in the partitions ring. If autoscaler didn't scaled out ingesters yet, manually add more ingester replicas (e.g. increasing HPA min replicas or manually setting the desired number of ingester replicas).
+  1. Find out the timestamp at which new partitions were created and became ACTIVE in the ring (e.g. looking at new ingesters logs).
+  1. Temporarily restart ingesters with the following configuration:
+     ```
+     # Set <value> to the timestamp retrived from previous step. The timestamp should be Unix epoch with milliseconds precision.
+     -ingest-storage.kafka.consume-from-position-at-startup=timestamp
+     -ingest-storage.kafka.consume-from-timestamp-at-startup=<value>
+     ```
+
+     Alternatively, if you can quickly find the timestamp at which new partitions became ACTIVE in the ring, you can temporarily configure ingesters to replay a partition from the end:
+     ```
+     -ingest-storage.kafka.consume-from-position-at-startup=end
+     ```
+  1. Once ingesters are stable, revert the temporarily config applied in the previous step.
+
 
 ## Errors catalog
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1468,7 +1468,7 @@ How to **fix**:
   1. Find out the timestamp at which new partitions were created and became ACTIVE in the ring (e.g. looking at new ingesters logs).
   1. Temporarily restart ingesters with the following configuration:
      ```
-     # Set <value> to the timestamp retrived from previous step. The timestamp should be Unix epoch with milliseconds precision.
+     # Set <value> to the timestamp retrieved from previous step. The timestamp should be Unix epoch with milliseconds precision.
      -ingest-storage.kafka.consume-from-position-at-startup=timestamp
      -ingest-storage.kafka.consume-from-timestamp-at-startup=<value>
      ```

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1448,7 +1448,7 @@ This runbook covers the case an ingester is overloaded when ingesting metrics da
 
 For example, if the amount of active series written to a partition exceeds the ingester capacity, the write-path will keep writing to the partition, but then the ingesters owning that partition will fail ingesting the data. Possible symptoms of this situation:
 
-- The ingester is lagging behind replaying metrics data from Kafka, and [`MimirStartingIngesterKafkaReceiveDelayIncreasing`](#MimirStartingIngesterKafkaReceiveDelayIncreasing) or [`MimirRunningIngesterReceiveDelayTooHigh`](#MimirRunningIngesterReceiveDelayTooHigh) alerts get fired.
+- The ingester is lagging behind replaying metrics data from Kafka, and [`MimirStartingIngesterKafkaReceiveDelayIncreasing`](#MimirStartingIngesterKafkaReceiveDelayIncreasing) or [`MimirRunningIngesterReceiveDelayTooHigh`](#MimirRunningIngesterReceiveDelayTooHigh) alerts are firing.
 - The ingester logs [`err-mimir-ingester-max-series`](#err-mimir-ingester-max-series) when ingesting metrics data from Kafka.
 - The ingester is OOMKilled.
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1464,9 +1464,11 @@ How to **fix**:
   - Add more CPU/memory/disk to ingesters, depending on the saturated resources.
   - Increase the ingester max series instance limit (see [`MimirIngesterReachingSeriesLimit`](#MimirIngesterReachingSeriesLimit) runbook).
 - **Skip replaying overloading backlog from partition** (data loss)
-  1. Ensure ingesters have been scaled out, and the new partitions are ACTIVE in the partitions ring. If autoscaler didn't scaled out ingesters yet, manually add more ingester replicas (e.g. increasing HPA min replicas or manually setting the desired number of ingester replicas).
+
+  1. Ensure ingesters have been scaled out, and the new partitions are ACTIVE in the partitions ring. If autoscaler didn't scaled out ingesters yet, manually add more ingester replicas (e.g. increasing HPA min replicas or manually setting the desired number of ingester replicas if ingester autoscaling is disabled).
   1. Find out the timestamp at which new partitions were created and became ACTIVE in the ring (e.g. looking at new ingesters logs).
   1. Temporarily restart ingesters with the following configuration:
+
      ```
      # Set <value> to the timestamp retrieved from previous step. The timestamp should be Unix epoch with milliseconds precision.
      -ingest-storage.kafka.consume-from-position-at-startup=timestamp
@@ -1474,11 +1476,12 @@ How to **fix**:
      ```
 
      Alternatively, if you can quickly find the timestamp at which new partitions became ACTIVE in the ring, you can temporarily configure ingesters to replay a partition from the end:
+
      ```
      -ingest-storage.kafka.consume-from-position-at-startup=end
      ```
-  1. Once ingesters are stable, revert the temporarily config applied in the previous step.
 
+  1. Once ingesters are stable, revert the temporarily config applied in the previous step.
 
 ## Errors catalog
 


### PR DESCRIPTION
#### What this PR does

In this PR I'm proposing to add a new runbook for the experimental ingest storage. The runbook is not linked to a specific alert, but it's about a failure scenario that could happen because of different causes. It's something we somewhat experienced in one of test clusters, and the proposed solution is based on a couple of options we brainstormed so far.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
