### PR TITLE
refactor: query-scheduler control flow cleanup

### DIFF
--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -211,14 +211,14 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 	f.requestQueue.SubmitRegisterQuerierConnection(querierID)
 	defer f.requestQueue.SubmitUnregisterQuerierConnection(querierID)
 
-	lastUserIndex := queue.FirstTenant()
+	lastTenantIndex := queue.FirstTenant()
 
 	for {
-		reqWrapper, idx, err := f.requestQueue.GetNextRequestForQuerier(server.Context(), lastUserIndex, querierID)
+		reqWrapper, idx, err := f.requestQueue.GetNextRequestForQuerier(server.Context(), lastTenantIndex, querierID)
 		if err != nil {
 			return err
 		}
-		lastUserIndex = idx
+		lastTenantIndex = idx
 
 		req := reqWrapper.(*request)
 
@@ -238,7 +238,7 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 		  it's possible that it's own queue would perpetually contain only expired requests.
 		*/
 		if req.originalCtx.Err() != nil {
-			lastUserIndex = lastUserIndex.ReuseLastTenant()
+			lastTenantIndex = lastTenantIndex.ReuseLastTenant()
 			continue
 		}
 

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -211,7 +211,7 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 	f.requestQueue.SubmitRegisterQuerierConnection(querierID)
 	defer f.requestQueue.SubmitUnregisterQuerierConnection(querierID)
 
-	lastUserIndex := queue.FirstUser()
+	lastUserIndex := queue.FirstTenant()
 
 	for {
 		reqWrapper, idx, err := f.requestQueue.GetNextRequestForQuerier(server.Context(), lastUserIndex, querierID)
@@ -238,7 +238,7 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 		  it's possible that it's own queue would perpetually contain only expired requests.
 		*/
 		if req.originalCtx.Err() != nil {
-			lastUserIndex = lastUserIndex.ReuseLastUser()
+			lastUserIndex = lastUserIndex.ReuseLastTenant()
 			continue
 		}
 

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -208,8 +208,8 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 		return err
 	}
 
-	f.requestQueue.RegisterQuerierConnection(querierID)
-	defer f.requestQueue.UnregisterQuerierConnection(querierID)
+	f.requestQueue.SubmitRegisterQuerierConnection(querierID)
+	defer f.requestQueue.SubmitUnregisterQuerierConnection(querierID)
 
 	lastUserIndex := queue.FirstUser()
 
@@ -294,7 +294,7 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 
 func (f *Frontend) NotifyClientShutdown(_ context.Context, req *frontendv1pb.NotifyClientShutdownRequest) (*frontendv1pb.NotifyClientShutdownResponse, error) {
 	level.Info(f.log).Log("msg", "received shutdown notification from querier", "querier", req.GetClientID())
-	f.requestQueue.NotifyQuerierShutdown(req.GetClientID())
+	f.requestQueue.SubmitNotifyQuerierShutdown(req.GetClientID())
 
 	return &frontendv1pb.NotifyClientShutdownResponse{}, nil
 }

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -143,7 +143,7 @@ func TestFrontendCheckReady(t *testing.T) {
 			}()
 
 			for i := 0; i < tt.connectedClients; i++ {
-				f.requestQueue.RegisterQuerierConnection("test")
+				f.requestQueue.SubmitRegisterQuerierConnection("test")
 			}
 			err = f.CheckReady(context.Background())
 			errMsg := ""

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -268,14 +268,14 @@ func (q *RequestQueue) enqueueRequestToBroker(r requestToEnqueue) error {
 
 // trySendNextRequestForQuerier finds and forwards a request to a waiting GetNextRequestForQuerier call.
 //
-// Returns true if a nextRequestForQuerier was written to the nextRequestForQuerierCall's result channel.
+// Returns true if a nextRequestForQuerier was written to the nextRequestForQuerierCall's result channel,
+// indicating that the nextRequestForQuerierCall can be removed from the list of waiting calls.
 // The nextRequestForQuerier result can contain either:
 // a) a query request which was successfully dequeued for the querier, or
 // b) an ErrShuttingDown indicating the querier has been placed in a graceful shutdown state.
 // Returns false if no message was sent to the querier, meaning neither of the above cases occurred.
 //
-// Sending the request to the call's result channel will block until the result is read or the call is canceled.
-// The call can be discarded once it has received a result, otherwise it can remain in the list of waiting calls.
+// Sending the request to the call's result channel blocks until the result is read or the call is canceled.
 func (q *RequestQueue) trySendNextRequestForQuerier(call *nextRequestForQuerierCall) (sent bool) {
 	req, tenant, idx, err := q.queueBroker.dequeueRequestForQuerier(call.lastTenantIndex.last, call.querierID)
 	if err != nil {

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -565,7 +565,7 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 
 	// send to querier will fail but method returns true,
 	// indicating not to re-submit a request for nextRequestForQuerierCall for the querier
-	require.True(t, queue.tryDispatchRequestToQuerier(queueBroker, call))
+	require.True(t, queue.trySendNextRequestForQuerier(queueBroker, call))
 	// assert request was re-enqueued for tenant after failed send
 	require.False(t, queueBroker.tenantQueuesTree.getNode(QueuePath{"tenant-1"}).IsEmpty())
 }

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -559,7 +559,7 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 		ctx:           ctx,
 		querierID:     QuerierID(querierID),
 		lastUserIndex: FirstUser(),
-		processed:     make(chan nextRequestForQuerier),
+		resultChan:    make(chan nextRequestForQuerier),
 	}
 	cancel() // ensure querier context done before send is attempted
 

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -466,9 +466,11 @@ func (tqa *tenantQuerierAssignments) shuffleTenantQueriers(tenantID TenantID, sc
 
 	if tenant.maxQueriers == 0 || len(tqa.querierIDsSorted) <= tenant.maxQueriers {
 		// shuffle shard is either disabled or calculation is unnecessary;
-		// a nil querier set for the tenant indicates tenant can use all queriers
+		prevQuerierIDSet := tqa.tenantQuerierIDs[tenantID]
+		// assigning querier set to nil for the tenant indicates tenant can use all queriers
 		tqa.tenantQuerierIDs[tenantID] = nil
-		return false
+		// tenant may have already been assigned all queriers; only indicate reshard if this changed
+		return prevQuerierIDSet != nil
 	}
 
 	querierIDSet := make(map[QuerierID]struct{}, tenant.maxQueriers)

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -437,7 +437,8 @@ func (tqa *tenantQuerierAssignments) forgetDisconnectedQueriers(now time.Time) (
 	threshold := now.Add(-tqa.querierForgetDelay)
 	for querierID := range tqa.queriersByID {
 		if querier := tqa.queriersByID[querierID]; querier.connections == 0 && querier.disconnectedAt.Before(threshold) {
-			resharded = tqa.removeQuerier(querierID)
+			// operation must be on left to avoid short-circuiting and skipping the operation
+			resharded = tqa.removeQuerier(querierID) || resharded
 		}
 	}
 
@@ -453,7 +454,8 @@ func (tqa *tenantQuerierAssignments) recomputeTenantQueriers() (resharded bool) 
 			// allocate the scratchpad the first time this case is hit and it will be reused after
 			scratchpad = make(querierIDSlice, 0, len(tqa.querierIDsSorted))
 		}
-		resharded = tqa.shuffleTenantQueriers(tenantID, scratchpad)
+		// operation must be on left to avoid short-circuiting and skipping the operation
+		resharded = tqa.shuffleTenantQueriers(tenantID, scratchpad) || resharded
 	}
 	return resharded
 }

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -216,7 +216,7 @@ func (qb *queueBroker) notifyQuerierShutdown(querierID QuerierID) {
 	qb.tenantQuerierAssignments.notifyQuerierShutdown(querierID)
 }
 
-func (qb *queueBroker) forgetDisconnectedQueriers(now time.Time) int {
+func (qb *queueBroker) forgetDisconnectedQueriers(now time.Time) []QuerierID {
 	return qb.tenantQuerierAssignments.forgetDisconnectedQueriers(now)
 }
 
@@ -422,20 +422,20 @@ func (tqa *tenantQuerierAssignments) notifyQuerierShutdown(querierID QuerierID) 
 
 // forgetDisconnectedQueriers removes all disconnected queriers that have gone since at least
 // the forget delay. Returns the number of forgotten queriers.
-func (tqa *tenantQuerierAssignments) forgetDisconnectedQueriers(now time.Time) int {
+func (tqa *tenantQuerierAssignments) forgetDisconnectedQueriers(now time.Time) []QuerierID {
 	// Nothing to do if the forget delay is disabled.
 	if tqa.querierForgetDelay == 0 {
-		return 0
+		return nil
 	}
 
 	// Remove all queriers with no connections that have gone since at least the forget delay.
 	threshold := now.Add(-tqa.querierForgetDelay)
-	forgotten := 0
+	var forgotten []QuerierID
 
 	for querierID := range tqa.queriersByID {
 		if querier := tqa.queriersByID[querierID]; querier.connections == 0 && querier.disconnectedAt.Before(threshold) {
 			tqa.removeQuerier(querierID)
-			forgotten++
+			forgotten = append(forgotten, querierID)
 		}
 	}
 

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -296,7 +296,7 @@ func TestQueuesConsistency(t *testing.T) {
 
 func TestQueues_ForgetDelay(t *testing.T) {
 	const (
-		forgetDelay          = 5 * time.Second
+		forgetDelay          = 1 * time.Minute
 		maxQueriersPerTenant = 1
 		numTenants           = 100
 	)
@@ -326,7 +326,6 @@ func TestQueues_ForgetDelay(t *testing.T) {
 	qb.removeQuerierConnection("querier-1", now.Add(20*time.Second))
 	qb.removeQuerierConnection("querier-1", now.Add(21*time.Second))
 	qb.notifyQuerierShutdown("querier-1")
-	time.Sleep(forgetDelay)
 
 	// We expect querier-1 has been removed.
 	assert.NotContains(t, qb.tenantQuerierAssignments.queriersByID, "querier-1")

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -298,7 +298,7 @@ func TestQueues_ForgetDelay(t *testing.T) {
 	const (
 		forgetDelay          = 1 * time.Minute
 		maxQueriersPerTenant = 1
-		numTenants           = 100
+		numTenants           = 10
 	)
 
 	now := time.Now()

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -296,7 +296,7 @@ func TestQueuesConsistency(t *testing.T) {
 
 func TestQueues_ForgetDelay(t *testing.T) {
 	const (
-		forgetDelay          = time.Minute
+		forgetDelay          = 5 * time.Second
 		maxQueriersPerTenant = 1
 		numTenants           = 100
 	)
@@ -326,6 +326,7 @@ func TestQueues_ForgetDelay(t *testing.T) {
 	qb.removeQuerierConnection("querier-1", now.Add(20*time.Second))
 	qb.removeQuerierConnection("querier-1", now.Add(21*time.Second))
 	qb.notifyQuerierShutdown("querier-1")
+	time.Sleep(forgetDelay)
 
 	// We expect querier-1 has been removed.
 	assert.NotContains(t, qb.tenantQuerierAssignments.queriersByID, "querier-1")

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -383,8 +383,8 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 
 	querierID := resp.GetQuerierID()
 
-	s.requestQueue.RegisterQuerierConnection(querierID)
-	defer s.requestQueue.UnregisterQuerierConnection(querierID)
+	s.requestQueue.SubmitRegisterQuerierConnection(querierID)
+	defer s.requestQueue.SubmitUnregisterQuerierConnection(querierID)
 
 	lastUserIndex := queue.FirstUser()
 
@@ -396,7 +396,10 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 			if errors.Is(err, queue.ErrStopped) && !s.isRunning() {
 				return schedulerpb.ErrSchedulerIsNotRunning
 			}
-
+			// the main other error we receive here is if the querier itself is shutting down;
+			// this information was submitted via another endpoint and processed internally
+			// by the RequestQueue's tracking of querier connections. The error bubbles up here
+			// as a way to exit this loop and allow the querier to shut down gracefully.
 			return err
 		}
 		lastUserIndex = idx
@@ -438,7 +441,7 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 
 func (s *Scheduler) NotifyQuerierShutdown(_ context.Context, req *schedulerpb.NotifyQuerierShutdownRequest) (*schedulerpb.NotifyQuerierShutdownResponse, error) {
 	level.Info(s.log).Log("msg", "received shutdown notification from querier", "querier", req.GetQuerierID())
-	s.requestQueue.NotifyQuerierShutdown(req.GetQuerierID())
+	s.requestQueue.SubmitNotifyQuerierShutdown(req.GetQuerierID())
 
 	return &schedulerpb.NotifyQuerierShutdownResponse{}, nil
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -386,7 +386,7 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 	s.requestQueue.SubmitRegisterQuerierConnection(querierID)
 	defer s.requestQueue.SubmitUnregisterQuerierConnection(querierID)
 
-	lastUserIndex := queue.FirstUser()
+	lastUserIndex := queue.FirstTenant()
 
 	// In stopping state scheduler is not accepting new queries, but still dispatching queries in the queues.
 	for s.isRunningOrStopping() {
@@ -427,7 +427,7 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 			// Remove from pending requests.
 			s.cancelRequestAndRemoveFromPending(r.FrontendAddress, r.QueryID, "request cancelled")
 
-			lastUserIndex = lastUserIndex.ReuseLastUser()
+			lastUserIndex = lastUserIndex.ReuseLastTenant()
 			continue
 		}
 


### PR DESCRIPTION
#### What this PR does

This is part of an effort to
a) make this code more understandable and easier to work on and
b) prepare for the upcoming changes to the queuing structure and algorithm.

These changes are mostly about naming and docstrings to accurately describe what is happening;
several comments were outdated or just wrongly interpreting what is happening.

The main functional change is where I encapsulated the handling of all querier connection/disconnection/shutdown signals in the `dispatcherLoop` when we read `<-q.querierOperations` into a single `processQuerierOperation`.
Previously we assumed that we must attempt to dispatch queries after a querier operation because it _may_ have triggered a reshard - now I actually report whether a reshard happened so we can skip attempting to dispatch if we do not need to.
(Shoutout to the excellent tests that existed there already to help catch some corner cases.)

Two other minor changes:
1. Changed the RequestQueue's `stop` implementation to satisfy the `Service` interface to close the channel instead of sending an empty struct - a change that had been suggested by a comment sitting there for awhile.
2. Deleted the the `haveUsed` flag on the `nextRequestForQuerierCall` struct as well as the check and panic for it - see PR comment on the code, but essentially closing the channel does the same thing

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
