### PR TITLE
Export `distributor.NextOrCleanup`

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1272,6 +1272,8 @@ func (d *Distributor) limitsMiddleware(next PushFunc) PushFunc {
 
 // NextOrCleanup returns a new PushFunc and a cleanup function that should be deferred by the caller.
 // The cleanup function will only call Request.CleanUp() if next() wasn't called previously.
+//
+// This function is used outside of this codebase.
 func NextOrCleanup(next PushFunc, pushReq *Request) (_ PushFunc, maybeCleanup func()) {
 	cleanupInDefer := true
 	return func(ctx context.Context, req *Request) error {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -744,7 +744,7 @@ func (d *Distributor) wrapPushWithMiddlewares(next PushFunc) PushFunc {
 
 func (d *Distributor) prePushHaDedupeMiddleware(next PushFunc) PushFunc {
 	return func(ctx context.Context, pushReq *Request) error {
-		next, maybeCleanup := nextOrCleanup(next, pushReq)
+		next, maybeCleanup := NextOrCleanup(next, pushReq)
 		defer maybeCleanup()
 
 		req, err := pushReq.WriteRequest()
@@ -810,7 +810,7 @@ func (d *Distributor) prePushHaDedupeMiddleware(next PushFunc) PushFunc {
 
 func (d *Distributor) prePushRelabelMiddleware(next PushFunc) PushFunc {
 	return func(ctx context.Context, pushReq *Request) error {
-		next, maybeCleanup := nextOrCleanup(next, pushReq)
+		next, maybeCleanup := NextOrCleanup(next, pushReq)
 		defer maybeCleanup()
 
 		userID, err := tenant.TenantID(ctx)
@@ -869,7 +869,7 @@ func (d *Distributor) prePushRelabelMiddleware(next PushFunc) PushFunc {
 // filtering empty values. This is a protection mechanism for ingesters.
 func (d *Distributor) prePushSortAndFilterMiddleware(next PushFunc) PushFunc {
 	return func(ctx context.Context, pushReq *Request) error {
-		next, maybeCleanup := nextOrCleanup(next, pushReq)
+		next, maybeCleanup := NextOrCleanup(next, pushReq)
 		defer maybeCleanup()
 
 		req, err := pushReq.WriteRequest()
@@ -912,7 +912,7 @@ func (d *Distributor) prePushSortAndFilterMiddleware(next PushFunc) PushFunc {
 
 func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 	return func(ctx context.Context, pushReq *Request) error {
-		next, maybeCleanup := nextOrCleanup(next, pushReq)
+		next, maybeCleanup := NextOrCleanup(next, pushReq)
 		defer maybeCleanup()
 
 		req, err := pushReq.WriteRequest()
@@ -1051,7 +1051,7 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 // including data that later gets modified or dropped.
 func (d *Distributor) metricsMiddleware(next PushFunc) PushFunc {
 	return func(ctx context.Context, pushReq *Request) error {
-		next, maybeCleanup := nextOrCleanup(next, pushReq)
+		next, maybeCleanup := NextOrCleanup(next, pushReq)
 		defer maybeCleanup()
 
 		req, err := pushReq.WriteRequest()
@@ -1239,7 +1239,7 @@ func (d *Distributor) limitsMiddleware(next PushFunc) PushFunc {
 			d.cleanupAfterPushFinished(rs)
 		})
 
-		next, maybeCleanup := nextOrCleanup(next, pushReq)
+		next, maybeCleanup := NextOrCleanup(next, pushReq)
 		defer maybeCleanup()
 
 		userID, err := tenant.TenantID(ctx)
@@ -1270,9 +1270,9 @@ func (d *Distributor) limitsMiddleware(next PushFunc) PushFunc {
 	}
 }
 
-// nextOrCleanup returns a new PushFunc and a cleanup function that should be deferred by the caller.
+// NextOrCleanup returns a new PushFunc and a cleanup function that should be deferred by the caller.
 // The cleanup function will only call Request.CleanUp() if next() wasn't called previously.
-func nextOrCleanup(next PushFunc, pushReq *Request) (_ PushFunc, maybeCleanup func()) {
+func NextOrCleanup(next PushFunc, pushReq *Request) (_ PushFunc, maybeCleanup func()) {
 	cleanupInDefer := true
 	return func(ctx context.Context, req *Request) error {
 			cleanupInDefer = false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This exports the `distributor.NextOrCleanup` utility so it can be used in push wrappers injected by clients via [this config](https://github.com/grafana/mimir/blob/4d82008ffcbe5d4c36741b6afc3e5f2ce5aadd33/pkg/distributor/distributor.go#L210).

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
