### PR TITLE
distributor: allow enforcing maximum buffer size for write request pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [ENHANCEMENT] Querying: Remove OpEmptyMatch from regex concatenations. #8012
 * [ENHANCEMENT] Store-gateway: add `-blocks-storage.bucket-store.max-concurrent-queue-timeout`. When set, queries at the store-gateway's query gate will not wait longer than that to execute. If a query reaches the wait timeout, then the querier will retry the blocks on a different store-gateway. If all store-gateways are unavailable, then the query will fail with `err-mimir-store-consistency-check-failed`. #7777
 * [ENHANCEMENT] Ingester: Optimize querying with regexp matchers. #8106
+* [ENHANCEMENT] Distributor: Introduce `-distributor.max-request-pool-buffer-size` to allow configuring the maximum size of the request pool buffers. #8082
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1199,6 +1199,17 @@
         },
         {
           "kind": "field",
+          "name": "max_request_pool_buffer_size",
+          "required": false,
+          "desc": "Max size of the pooled buffers used for marshaling write requests. If 0, no max size is enforced.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "distributor.max-request-pool-buffer-size",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "remote_timeout",
           "required": false,
           "desc": "Timeout for downstream ingesters.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1187,6 +1187,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Maximum number of exemplars per series per request. 0 to disable limit in request. The exceeding exemplars are dropped.
   -distributor.max-recv-msg-size int
     	Max message size in bytes that the distributors will accept for incoming push requests to the remote write API. If exceeded, the request will be rejected. (default 104857600)
+  -distributor.max-request-pool-buffer-size int
+    	[experimental] Max size of the pooled buffers used for marshaling write requests. If 0, no max size is enforced.
   -distributor.metric-relabeling-enabled
     	[experimental] Enable metric relabeling for the tenant. This configuration option can be used to forcefully disable metric relabeling on a per-tenant basis. (default true)
   -distributor.otel-metric-suffixes-enabled

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -71,6 +71,8 @@ The following features are currently experimental:
     - `-distributor.retry-after-header.max-backoff-exponent`
   - Limit exemplars per series per request
     - `-distributor.max-exemplars-per-series-per-request`
+  - Enforce a maximum pool buffer size for write requests
+    - `-distributor.max-request-pool-buffer-size`
 - Hash ring
   - Disabling ring heartbeat timeouts
     - `-distributor.ring.heartbeat-timeout=0`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -842,6 +842,11 @@ ha_tracker:
 # CLI flag: -distributor.max-recv-msg-size
 [max_recv_msg_size: <int> | default = 104857600]
 
+# (experimental) Max size of the pooled buffers used for marshaling write
+# requests. If 0, no max size is enforced.
+# CLI flag: -distributor.max-request-pool-buffer-size
+[max_request_pool_buffer_size: <int> | default = 0]
+
 # (advanced) Timeout for downstream ingesters.
 # CLI flag: -distributor.remote-timeout
 [remote_timeout: <duration> | default = 2s]

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -261,8 +261,8 @@ const OTLPPushEndpoint = "/otlp/v1/metrics"
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config, reg prometheus.Registerer, limits *validation.Overrides) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, a.logger), true, false, "POST")
-	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, pushConfig.RetryConfig, reg, d.PushWithMiddlewares, a.logger), true, false, "POST")
+	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, a.logger), true, false, "POST")
+	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, pushConfig.RetryConfig, reg, d.PushWithMiddlewares, a.logger), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -261,8 +261,8 @@ const OTLPPushEndpoint = "/otlp/v1/metrics"
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config, reg prometheus.Registerer, limits *validation.Overrides) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, reg, a.logger), true, false, "POST")
-	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, pushConfig.RetryConfig, reg, d.PushWithMiddlewares, a.logger), true, false, "POST")
+	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, d.PushMetrics, a.logger), true, false, "POST")
+	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, d.PushMetrics, reg, a.logger), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -261,7 +261,7 @@ const OTLPPushEndpoint = "/otlp/v1/metrics"
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config, reg prometheus.Registerer, limits *validation.Overrides) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, a.logger), true, false, "POST")
+	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, reg, a.logger), true, false, "POST")
 	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, pushConfig.RetryConfig, reg, d.PushWithMiddlewares, a.logger), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -259,17 +259,17 @@ const (
 )
 
 type PushMetrics struct {
-	OTLPRequestCounter   *prometheus.CounterVec
-	UncompressedBodySize *prometheus.HistogramVec
+	otlpRequestCounter   *prometheus.CounterVec
+	uncompressedBodySize *prometheus.HistogramVec
 }
 
 func newPushMetrics(reg prometheus.Registerer) *PushMetrics {
 	return &PushMetrics{
-		OTLPRequestCounter: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		otlpRequestCounter: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_distributor_otlp_requests_total",
 			Help: "The total number of OTLP requests that have come in to the distributor.",
 		}, []string{"user"}),
-		UncompressedBodySize: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		uncompressedBodySize: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "cortex_distributor_uncompressed_request_body_size_bytes",
 			Help:                            "Size of uncompressed request body in bytes.",
 			NativeHistogramBucketFactor:     1.1,
@@ -281,19 +281,19 @@ func newPushMetrics(reg prometheus.Registerer) *PushMetrics {
 
 func (m *PushMetrics) IncOTLPRequest(user string) {
 	if m != nil {
-		m.OTLPRequestCounter.WithLabelValues(user).Inc()
+		m.otlpRequestCounter.WithLabelValues(user).Inc()
 	}
 }
 
 func (m *PushMetrics) ObserveUncompressedBodySize(user string, size float64) {
 	if m != nil {
-		m.UncompressedBodySize.WithLabelValues(user).Observe(size)
+		m.uncompressedBodySize.WithLabelValues(user).Observe(size)
 	}
 }
 
 func (m *PushMetrics) deleteUserMetrics(user string) {
-	m.OTLPRequestCounter.DeleteLabelValues(user)
-	m.UncompressedBodySize.DeleteLabelValues(user)
+	m.otlpRequestCounter.DeleteLabelValues(user)
+	m.uncompressedBodySize.DeleteLabelValues(user)
 }
 
 // New constructs a new Distributor

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -317,7 +317,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 
 	var requestBufferPool util.Pool
 	if cfg.MaxRequestPoolBufferSize > 0 {
-		requestBufferPool = util.NewBucketedBufferPool(1e3, cfg.MaxRequestPoolBufferSize, 2)
+		requestBufferPool = util.NewBucketedBufferPool(1<<10, cfg.MaxRequestPoolBufferSize, 4)
 	} else {
 		requestBufferPool = util.NewBufferPool()
 	}

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -62,9 +62,11 @@ func OTLPHandler(
 	}, []string{"user"})
 
 	otlpUncompressedBodySize := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "cortex_distributor_otlp_uncompressed_request_body_size_bytes",
-		Help:    "Size of uncompressed OTLP request body in bytes.",
-		Buckets: uncompressedBodySizeBuckets,
+		Name:                            "cortex_distributor_otlp_uncompressed_request_body_size_bytes",
+		Help:                            "Size of uncompressed OTLP request body in bytes.",
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+		NativeHistogramMaxBucketNumber:  100,
 	}, []string{"user"})
 
 	return handler(maxRecvMsgSize, requestBufferPool, sourceIPs, allowSkipLabelNameValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, logger log.Logger) error {

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -44,6 +44,7 @@ const (
 // OTLPHandler is an http.Handler accepting OTLP write requests.
 func OTLPHandler(
 	maxRecvMsgSize int,
+	requestBufferPool util.Pool,
 	sourceIPs *middleware.SourceIPExtractor,
 	allowSkipLabelNameValidation bool,
 	enableOtelMetadataStorage bool,
@@ -60,7 +61,7 @@ func OTLPHandler(
 		Help: "The total number of OTLP requests that have come in to the distributor.",
 	}, []string{"user"})
 
-	return handler(maxRecvMsgSize, sourceIPs, allowSkipLabelNameValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, logger log.Logger) error {
+	return handler(maxRecvMsgSize, requestBufferPool, sourceIPs, allowSkipLabelNameValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, logger log.Logger) error {
 		contentType := r.Header.Get("Content-Type")
 		contentEncoding := r.Header.Get("Content-Encoding")
 		var compression util.CompressionType

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	prometheustranslator "github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheus"
@@ -50,24 +49,12 @@ func OTLPHandler(
 	enableOtelMetadataStorage bool,
 	limits *validation.Overrides,
 	retryCfg RetryConfig,
-	reg prometheus.Registerer,
 	push PushFunc,
+	pushMetrics *PushMetrics,
+	reg prometheus.Registerer,
 	logger log.Logger,
 ) http.Handler {
 	discardedDueToOtelParseError := validation.DiscardedSamplesCounter(reg, otelParseError)
-
-	otlpRequestsCounter := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "cortex_distributor_otlp_requests_total",
-		Help: "The total number of OTLP requests that have come in to the distributor.",
-	}, []string{"user"})
-
-	otlpUncompressedBodySize := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-		Name:                            "cortex_distributor_otlp_uncompressed_request_body_size_bytes",
-		Help:                            "Size of uncompressed OTLP request body in bytes.",
-		NativeHistogramBucketFactor:     1.1,
-		NativeHistogramMinResetDuration: 1 * time.Hour,
-		NativeHistogramMaxBucketNumber:  100,
-	}, []string{"user"})
 
 	return handler(maxRecvMsgSize, requestBufferPool, sourceIPs, allowSkipLabelNameValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, logger log.Logger) error {
 		contentType := r.Header.Get("Content-Type")
@@ -164,8 +151,8 @@ func OTLPHandler(
 		}
 		addSuffixes := limits.OTelMetricSuffixesEnabled(tenantID)
 
-		otlpRequestsCounter.WithLabelValues(tenantID).Inc()
-		otlpUncompressedBodySize.WithLabelValues(tenantID).Observe(float64(uncompressedBodySize))
+		pushMetrics.IncOTLPRequest(tenantID)
+		pushMetrics.ObserveUncompressedBodySize(tenantID, float64(uncompressedBodySize))
 
 		metrics, err := otelMetricsToTimeseries(tenantID, addSuffixes, discardedDueToOtelParseError, logger, otlpReq.Metrics())
 		if err != nil {

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/require"
@@ -67,7 +66,7 @@ func BenchmarkOTLPHandler(b *testing.B) {
 		validation.NewMockTenantLimits(map[string]*validation.Limits{}),
 	)
 	require.NoError(b, err)
-	handler := OTLPHandler(100000, nil, nil, false, true, limits, RetryConfig{}, prometheus.NewPedanticRegistry(), pushFunc, log.NewNopLogger())
+	handler := OTLPHandler(100000, nil, nil, false, true, limits, RetryConfig{}, pushFunc, nil, nil, log.NewNopLogger())
 
 	b.Run("protobuf", func(b *testing.B) {
 		req := createOTLPProtoRequest(b, exportReq, false)

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -67,7 +67,7 @@ func BenchmarkOTLPHandler(b *testing.B) {
 		validation.NewMockTenantLimits(map[string]*validation.Limits{}),
 	)
 	require.NoError(b, err)
-	handler := OTLPHandler(100000, nil, false, true, limits, RetryConfig{}, prometheus.NewPedanticRegistry(), pushFunc, log.NewNopLogger())
+	handler := OTLPHandler(100000, nil, nil, false, true, limits, RetryConfig{}, prometheus.NewPedanticRegistry(), pushFunc, log.NewNopLogger())
 
 	b.Run("protobuf", func(b *testing.B) {
 		req := createOTLPProtoRequest(b, exportReq, false)

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -6,7 +6,6 @@
 package distributor
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -14,7 +13,6 @@ import (
 	"math/rand"
 	"net/http"
 	"strconv"
-	"sync"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -38,11 +36,6 @@ type PushFunc func(ctx context.Context, req *Request) error
 type parserFunc func(ctx context.Context, r *http.Request, maxSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, logger log.Logger) error
 
 var (
-	bufferPool = sync.Pool{
-		New: func() any {
-			return bytes.NewBuffer(make([]byte, 0, 256*1024))
-		},
-	}
 	errRetryBaseLessThanOneSecond    = errors.New("retry base duration should not be less than 1 second")
 	errNonPositiveMaxBackoffExponent = errors.New("max backoff exponent should be a positive value")
 )
@@ -78,6 +71,7 @@ func (cfg *RetryConfig) Validate() error {
 // Handler is a http.Handler which accepts WriteRequests.
 func Handler(
 	maxRecvMsgSize int,
+	requestBufferPool util.Pool,
 	sourceIPs *middleware.SourceIPExtractor,
 	allowSkipLabelNameValidation bool,
 	limits *validation.Overrides,
@@ -85,7 +79,7 @@ func Handler(
 	push PushFunc,
 	logger log.Logger,
 ) http.Handler {
-	return handler(maxRecvMsgSize, sourceIPs, allowSkipLabelNameValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, _ log.Logger) error {
+	return handler(maxRecvMsgSize, requestBufferPool, sourceIPs, allowSkipLabelNameValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, _ log.Logger) error {
 		err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRecvMsgSize, buffers, req, util.RawSnappy)
 		if errors.Is(err, util.MsgSizeTooLargeErr{}) {
 			err = distributorMaxWriteMessageSizeErr{actual: int(r.ContentLength), limit: maxRecvMsgSize}
@@ -108,6 +102,7 @@ func (e distributorMaxWriteMessageSizeErr) Error() string {
 
 func handler(
 	maxRecvMsgSize int,
+	requestBufferPool util.Pool,
 	sourceIPs *middleware.SourceIPExtractor,
 	allowSkipLabelNameValidation bool,
 	limits *validation.Overrides,
@@ -126,7 +121,7 @@ func handler(
 			}
 		}
 		supplier := func() (*mimirpb.WriteRequest, func(), error) {
-			rb := util.NewRequestBuffers(&bufferPool)
+			rb := util.NewRequestBuffers(requestBufferPool)
 			var req mimirpb.PreallocWriteRequest
 			if err := parser(ctx, r, maxRecvMsgSize, rb, &req, logger); err != nil {
 				// Check for httpgrpc error, default to client error if parsing failed

--- a/pkg/ingester/client/client_test.go
+++ b/pkg/ingester/client/client_test.go
@@ -50,9 +50,9 @@ func TestMarshall(t *testing.T) {
 			plentySize   = 1024 * 1024
 		)
 		req := mimirpb.WriteRequest{}
-		err := util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), tooSmallSize, nil, &req, util.RawSnappy)
+		_, err := util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), tooSmallSize, nil, &req, util.RawSnappy)
 		require.Error(t, err)
-		err = util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), plentySize, nil, &req, util.RawSnappy)
+		_, err = util.ParseProtoReader(context.Background(), recorder.Body, recorder.Body.Len(), plentySize, nil, &req, util.RawSnappy)
 		require.NoError(t, err)
 		require.Len(t, req.Timeseries, numSeries)
 	}

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -51,7 +51,7 @@ func remoteReadHandler(q storage.SampleAndChunkQueryable, maxBytesInFrame int, l
 		ctx := r.Context()
 		var req client.ReadRequest
 		logger := util_log.WithContext(r.Context(), lg)
-		if err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRemoteReadQuerySize, nil, &req, util.RawSnappy); err != nil {
+		if _, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRemoteReadQuerySize, nil, &req, util.RawSnappy); err != nil {
 			level.Error(logger).Log("msg", "failed to parse proto", "err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -217,7 +217,7 @@ func TestParseProtoReader(t *testing.T) {
 				reader = bytesBuffered{Buffer: &buf}
 			}
 
-			err = ParseProtoReader(context.Background(), reader, 0, tt.maxSize, nil, &fromWire, tt.compression)
+			_, err = ParseProtoReader(context.Background(), reader, 0, tt.maxSize, nil, &fromWire, tt.compression)
 			if tt.expectParseErr {
 				require.Error(t, err)
 				return

--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"sync"
 
-	"github.com/prometheus/prometheus/util/pool"
+	"github.com/grafana/mimir/pkg/util/pool"
 )
 
 // Pool is an abstraction for a pool of byte slices.
@@ -35,19 +35,12 @@ func NewBufferPool() Pool {
 	}
 }
 
-type bucketedBufferPool struct{ p *pool.Pool }
-
-func (p *bucketedBufferPool) Get(sz int) []byte { return p.p.Get(sz).([]byte) }
-func (p *bucketedBufferPool) Put(s []byte)      { p.p.Put(s) } //nolint:staticcheck
-
 // NewBucketedBufferPool returns a new Pool for byte slices with bucketing.
 // The pool will have buckets for sizes from minSize to maxSize increasing by the given factor.
 func NewBucketedBufferPool(minSize, maxSize int, factor float64) Pool {
-	return &bucketedBufferPool{
-		p: pool.New(minSize, maxSize, factor, func(sz int) interface{} {
-			return make([]byte, 0, sz)
-		}),
-	}
+	return pool.NewBucketedPool(minSize, maxSize, factor, func(sz int) []byte {
+		return make([]byte, 0, sz)
+	})
 }
 
 // RequestBuffers provides pooled request buffers.

--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -3,14 +3,51 @@ package util
 
 import (
 	"bytes"
+	"sync"
+
+	"github.com/prometheus/prometheus/util/pool"
 )
 
-// Pool is an abstraction of sync.Pool, for testability.
+// Pool is an abstraction for a pool of objects.
 type Pool interface {
-	// Get a pooled object.
-	Get() any
-	// Put back an object into the pool.
-	Put(any)
+	// Get returns a new byte slices that fits the given size.
+	Get(sz int) []byte
+
+	// Put puts a slice back into the pool.
+	Put(s []byte)
+}
+
+type bufferPool struct {
+	p sync.Pool
+}
+
+func (p *bufferPool) Get(_ int) []byte { return p.p.Get().([]byte) }
+func (p *bufferPool) Put(s []byte)     { p.p.Put(s) } //nolint:staticcheck
+
+// NewBufferPool returns a new Pool for byte slices.
+func NewBufferPool() Pool {
+	return &bufferPool{
+		p: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, 0, 256*1024)
+			},
+		},
+	}
+}
+
+type bucketedBufferPool struct{ p *pool.Pool }
+
+func (p *bucketedBufferPool) Get(sz int) []byte { return p.p.Get(sz).([]byte) }
+func (p *bucketedBufferPool) Put(s []byte)      { p.p.Put(s) } //nolint:staticcheck
+
+// NewBucketedBufferPool returns a new Pool for byte slices with bucketing.
+// The pool will have buckets for sizes from minSize to maxSize increasing by the given factor.
+func NewBucketedBufferPool(minSize, maxSize int, factor float64) Pool {
+	return &bucketedBufferPool{
+		p: pool.New(minSize, maxSize, factor, func(sz int) interface{} {
+			return make([]byte, 0, sz)
+		}),
+	}
 }
 
 // RequestBuffers provides pooled request buffers.
@@ -32,20 +69,22 @@ func NewRequestBuffers(p Pool) *RequestBuffers {
 
 // Get obtains a buffer from the pool. It will be returned back to the pool when CleanUp is called.
 func (rb *RequestBuffers) Get(size int) *bytes.Buffer {
-	if rb == nil {
+	if rb == nil || rb.p == nil {
 		if size < 0 {
 			size = 0
 		}
 		return bytes.NewBuffer(make([]byte, 0, size))
 	}
 
-	b := rb.p.Get().(*bytes.Buffer)
-	b.Reset()
+	b := rb.p.Get(size)
+	buf := bytes.NewBuffer(b)
+	buf.Reset()
 	if size > 0 {
-		b.Grow(size)
+		buf.Grow(size)
 	}
-	rb.buffers = append(rb.buffers, b)
-	return b
+
+	rb.buffers = append(rb.buffers, buf)
+	return buf
 }
 
 // CleanUp releases buffers back to the pool.
@@ -53,7 +92,7 @@ func (rb *RequestBuffers) CleanUp() {
 	for i, b := range rb.buffers {
 		// Make sure the backing array doesn't retain a reference
 		rb.buffers[i] = nil
-		rb.p.Put(b)
+		rb.p.Put(b.Bytes())
 	}
 	rb.buffers = rb.buffers[:0]
 }

--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+
 package util
 
 import (

--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/prometheus/util/pool"
 )
 
-// Pool is an abstraction for a pool of objects.
+// Pool is an abstraction for a pool of byte slices.
 type Pool interface {
 	// Get returns a new byte slices that fits the given size.
 	Get(sz int) []byte

--- a/pkg/util/requestbuffers_test.go
+++ b/pkg/util/requestbuffers_test.go
@@ -2,6 +2,7 @@
 package util
 
 import (
+	"runtime/debug"
 	"testing"
 	"unsafe"
 
@@ -10,6 +11,10 @@ import (
 )
 
 func TestRequestBuffers(t *testing.T) {
+	// Disable GC
+	originalGCPercent := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(originalGCPercent)
+
 	const maxBufferSize = 32 * 1024
 
 	p := NewBucketedBufferPool(1024, maxBufferSize, 2)

--- a/pkg/util/requestbuffers_test.go
+++ b/pkg/util/requestbuffers_test.go
@@ -2,15 +2,19 @@
 package util
 
 import (
-	"bytes"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRequestBuffers(t *testing.T) {
-	rb := NewRequestBuffers(&fakePool{})
+	const maxBufferSize = 32 * 1024
+
+	p := NewBucketedBufferPool(1024, maxBufferSize, 2)
+
+	rb := NewRequestBuffers(p)
 	t.Cleanup(rb.CleanUp)
 
 	b := rb.Get(1024)
@@ -24,10 +28,23 @@ func TestRequestBuffers(t *testing.T) {
 	rb.CleanUp()
 	assert.Nil(t, rb.buffersBacking[0])
 
-	b1 := rb.Get(2048)
-	assert.Same(t, b1, b)
-	assert.Equal(t, 2048, b1.Cap())
+	// Retrieve a new buffer of the same size after cleanup
+	// to test if it reuses the previously returned buffer.
+	b1 := rb.Get(1024)
+	assert.Same(t, unsafe.SliceData(b1.Bytes()), unsafe.SliceData(b.Bytes()))
+	assert.Equal(t, 1024, b1.Cap())
 	assert.Zero(t, b1.Len())
+
+	// Retrieve a buffer larger than maxBufferSize to ensure
+	// it doesn't get reused.
+	b2 := rb.Get(maxBufferSize + 1)
+	assert.Equal(t, maxBufferSize+1, b2.Cap())
+	assert.Zero(t, b2.Len())
+
+	rb.CleanUp()
+
+	b3 := rb.Get(maxBufferSize + 1)
+	assert.NotSame(t, unsafe.SliceData(b2.Bytes()), unsafe.SliceData(b3.Bytes()))
 
 	t.Run("as nil pointer", func(t *testing.T) {
 		var rb *RequestBuffers
@@ -36,22 +53,11 @@ func TestRequestBuffers(t *testing.T) {
 		assert.Equal(t, 1024, b.Cap())
 		assert.Zero(t, b.Len())
 	})
-}
-
-type fakePool struct {
-	buffers []*bytes.Buffer
-}
-
-func (p *fakePool) Get() any {
-	if len(p.buffers) > 0 {
-		b := p.buffers[0]
-		p.buffers = p.buffers[1:]
-		return b
-	}
-
-	return bytes.NewBuffer(nil)
-}
-
-func (p *fakePool) Put(x any) {
-	p.buffers = append(p.buffers, x.(*bytes.Buffer))
+	t.Run("as nil p", func(t *testing.T) {
+		rb := &RequestBuffers{}
+		b := rb.Get(1024)
+		require.NotNil(t, b)
+		assert.Equal(t, 1024, b.Cap())
+		assert.Zero(t, b.Len())
+	})
 }

--- a/tools/trafficdump/parser.go
+++ b/tools/trafficdump/parser.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 
 	"github.com/grafana/regexp"
 	"github.com/prometheus/prometheus/model/labels"
@@ -24,6 +23,10 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util"
 )
+
+const maxBufferPoolSize = 1024 * 1024
+
+var bufferPool = util.NewBucketedBufferPool(1e3, maxBufferPoolSize, 2)
 
 type parser struct {
 	processorConfig processorConfig
@@ -134,7 +137,7 @@ func (rp *parser) processHTTPRequest(req *http.Request, body []byte) *request {
 
 	if rp.decodePush && req.Method == "POST" && strings.Contains(req.URL.Path, "/push") {
 		var matched bool
-		rb := util.NewRequestBuffers(&bufferPool)
+		rb := util.NewRequestBuffers(bufferPool)
 		r.cleanup = rb.CleanUp
 		r.PushRequest, matched = rp.decodePushRequest(req, body, rp.matchers, rb)
 		if !matched {
@@ -152,12 +155,6 @@ func (rp *parser) processHTTPRequest(req *http.Request, body []byte) *request {
 	}
 
 	return &r
-}
-
-var bufferPool = sync.Pool{
-	New: func() any {
-		return bytes.NewBuffer(make([]byte, 0, 256*1024))
-	},
 }
 
 func (rp *parser) decodePushRequest(req *http.Request, body []byte, matchers []*labels.Matcher, buffers *util.RequestBuffers) (*pushRequest, bool) {

--- a/tools/trafficdump/parser.go
+++ b/tools/trafficdump/parser.go
@@ -161,7 +161,7 @@ func (rp *parser) decodePushRequest(req *http.Request, body []byte, matchers []*
 	res := &pushRequest{Version: req.Header.Get("X-Prometheus-Remote-Write-Version")}
 
 	var wr mimirpb.WriteRequest
-	if err := util.ParseProtoReader(context.Background(), bytes.NewReader(body), int(req.ContentLength), 100<<20, buffers, &wr, util.RawSnappy); err != nil {
+	if _, err := util.ParseProtoReader(context.Background(), bytes.NewReader(body), int(req.ContentLength), 100<<20, buffers, &wr, util.RawSnappy); err != nil {
 		res.Error = fmt.Errorf("failed to decode decodePush request: %s", err).Error()
 		return nil, true
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds a new experimental CLI parameter called `-distributor.max-request-pool-buffer-size` that allows enforcing a maximum size in bytes for the pool buffers used for decompressing request bodies in both Prometheus and OTLP handlers. By default, this is set to `0`, which means no maximum will be enforced (same behavior as currently).

Additionally, a new metric named `cortex_distributor_uncompressed_request_body_size_bytes` has been included in order to provide visibility on the average of uncompressed body payload, thus allowing for an informed decision to be made when setting the previously mentioned maximum.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [X] Tests updated.
- [X] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
