### PR TITLE
Reduce the number of Kafka clients used by producers

### DIFF
--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -136,6 +136,11 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 				ingestStorageEnabled:    true,
 				ingestStoragePartitions: 3,
 				limits:                  limits,
+				configure: func(cfg *Config) {
+					// Run a number of clients equal to the number of partitions, so that each partition
+					// has its own client, as requested by some test cases.
+					cfg.IngestStorageConfig.KafkaConfig.WriteClients = 3
+				},
 			}
 
 			distributors, _, regs, kafkaCluster := prepare(t, testConfig)

--- a/pkg/storage/ingest/config_test.go
+++ b/pkg/storage/ingest/config_test.go
@@ -68,6 +68,15 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			expectedErr: ErrInvalidConsumePosition,
 		},
+		"should fail if ingest storage is enabled and the configured number of Kafka write clients is 0": {
+			setup: func(cfg *Config) {
+				cfg.Enabled = true
+				cfg.KafkaConfig.Address = "localhost"
+				cfg.KafkaConfig.Topic = "test"
+				cfg.KafkaConfig.WriteClients = 0
+			},
+			expectedErr: ErrInvalidWriteClients,
+		},
 	}
 
 	for testName, testData := range tests {

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -89,6 +89,10 @@ func (w *Writer) stopping(_ error) error {
 	defer w.writersMx.Unlock()
 
 	for idx, client := range w.writers {
+		if client == nil {
+			continue
+		}
+
 		client.Close()
 		w.writers[idx] = nil
 	}

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -85,8 +85,12 @@ func (w *Writer) starting(_ context.Context) error {
 }
 
 func (w *Writer) stopping(_ error) error {
-	for _, client := range w.writers {
+	w.writersMx.Lock()
+	defer w.writersMx.Unlock()
+
+	for idx, client := range w.writers {
 		client.Close()
+		w.writers[idx] = nil
 	}
 
 	return nil

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -103,6 +103,8 @@ func TestWriter_WriteSync(t *testing.T) {
 		t.Parallel()
 
 		for _, writeClients := range []int{1, 2, 10} {
+			writeClients := writeClients
+
 			t.Run(fmt.Sprintf("Write clients = %d", writeClients), func(t *testing.T) {
 				t.Parallel()
 

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 func TestWriter_WriteSync(t *testing.T) {
 	const (
 		topicName     = "test"
-		numPartitions = 1
+		numPartitions = 2
 		partitionID   = 0
 		tenantID      = "user-1"
 	)
@@ -97,6 +97,48 @@ func TestWriter_WriteSync(t *testing.T) {
 			# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
 			cortex_ingest_storage_writer_sent_bytes_total %d
 		`, len(fetches.Records()[0].Value))), "cortex_ingest_storage_writer_sent_bytes_total"))
+	})
+
+	t.Run("should write to the requested partition", func(t *testing.T) {
+		t.Parallel()
+
+		seriesPerPartition := map[int32][]mimirpb.PreallocTimeseries{
+			0: series1,
+			1: series2,
+		}
+
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+		writer, _ := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
+
+		// Write to partitions.
+		for partitionID, series := range seriesPerPartition {
+			err := writer.WriteSync(ctx, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series, Metadata: nil, Source: mimirpb.API})
+			require.NoError(t, err)
+		}
+
+		// Read back from Kafka.
+		for partitionID, expectedSeries := range seriesPerPartition {
+			consumer, err := kgo.NewClient(kgo.SeedBrokers(clusterAddr), kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{topicName: {partitionID: kgo.NewOffset().AtStart()}}))
+			require.NoError(t, err)
+			t.Cleanup(consumer.Close)
+
+			fetchCtx, cancel := context.WithTimeout(ctx, time.Second)
+			t.Cleanup(cancel)
+
+			fetches := consumer.PollFetches(fetchCtx)
+			require.NoError(t, fetches.Err())
+			require.Len(t, fetches.Records(), 1)
+			assert.Equal(t, []byte(tenantID), fetches.Records()[0].Key)
+
+			received := mimirpb.WriteRequest{}
+			require.NoError(t, received.Unmarshal(fetches.Records()[0].Value))
+			require.Len(t, received.Timeseries, len(expectedSeries))
+
+			for idx, expected := range expectedSeries {
+				assert.Equal(t, expected.Labels, received.Timeseries[idx].Labels)
+				assert.Equal(t, expected.Samples, received.Timeseries[idx].Samples)
+			}
+		}
 	})
 
 	t.Run("should interrupt the WriteSync() on context cancelled but other concurrent requests should not fail", func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Currently we run 1 Kafka client per partition. This means that if we have 100 partitions, 100 distributors and a metadata refresh interval of 10s, distributors will issue `100 * 100 / 10 = 1000 req/s` to update cluster metadata. The cluster metadata is an expensive operation, and can put extra pressure to Kafka. The current approach doesn't scale.

In this PR I propose to run 1 Kafka client per producer by default, but allow to increase it via a new config option. When > 1 clients are configured, the `Writer` will simply shard partitions between clients.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
