### PR TITLE
reverts "util: avoid pooling large buffers in util.RequestBuffers"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,6 @@
 * [BUGFIX] OTLP: Don't generate target_info unless there are metrics. #8012
 * [BUGFIX] Query-frontend: Experimental query queue splitting: fix issue where offset and range selector duration were not considered when predicting query component. #7742
 * [BUGFIX] Querying: Empty matrix results were incorrectly returning `null` instead of `[]`. #8029
-* [BUGFIX] Distributor: Avoid pooling large buffers objects when unmarshalling incoming requests. #8044
 * [BUGFIX] All: don't increment `thanos_objstore_bucket_operation_failures_total` metric for cancelled requests. #8072
 * [BUGFIX] Query-frontend: fix empty metric name matcher not being applied under certain conditions. #8076
 * [BUGFIX] Querying: Fix regex matching of multibyte runes with dot operator. #8089

--- a/pkg/util/requestbuffers.go
+++ b/pkg/util/requestbuffers.go
@@ -5,11 +5,6 @@ import (
 	"bytes"
 )
 
-// The maximum buffer size allowed in the pool.
-// A sane default value of 1MB is chosen, which should be sufficient for most use cases, though it could be
-// revisited if necessary.
-const maxInPoolRequestBufferSize = 1024 * 1024
-
 // Pool is an abstraction of sync.Pool, for testability.
 type Pool interface {
 	// Get a pooled object.
@@ -36,9 +31,8 @@ func NewRequestBuffers(p Pool) *RequestBuffers {
 }
 
 // Get obtains a buffer from the pool. It will be returned back to the pool when CleanUp is called.
-// If size exceeds the maximum buffer size allowed in the pool, a new buffer from the heap is returned.
 func (rb *RequestBuffers) Get(size int) *bytes.Buffer {
-	if rb == nil || size > maxInPoolRequestBufferSize {
+	if rb == nil {
 		if size < 0 {
 			size = 0
 		}
@@ -59,9 +53,6 @@ func (rb *RequestBuffers) CleanUp() {
 	for i, b := range rb.buffers {
 		// Make sure the backing array doesn't retain a reference
 		rb.buffers[i] = nil
-		if b.Cap() > maxInPoolRequestBufferSize {
-			continue // Avoid pooling large buffers
-		}
 		rb.p.Put(b)
 	}
 	rb.buffers = rb.buffers[:0]


### PR DESCRIPTION
reverting https://github.com/grafana/mimir/pull/8044 in favor of https://github.com/grafana/mimir/pull/8082
