### PR TITLE
Dashboards: renamed "TCP Connections" panel to "Ingress TCP Connections"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * [ENHANCEMENT] Dashboards: allow switching between using classic of native histograms in dashboards. #7627
   * Overview dashboard, Status panel, `cortex_request_duration_seconds` metric.
 * [ENHANCEMENT] Alerts: exclude `529` and `598` status codes from failure codes in `MimirRequestsError`. #7889
+* [ENHANCEMENT] Dashboards: renamed "TCP Connections" panel to "Ingress TCP Connections" in the networking dashboards. #8092
 * [BUGFIX] Dashboards: Fix regular expression for matching read-path gRPC ingester methods to include querying of exemplars, label-related queries, or active series queries. #7676
 * [BUGFIX] Dashboards: Fix user id abbreviations and column heads for Top Tenants dashboard. #7724
 * [BUGFIX] Dashboards: fix incorrect query used for "queue length" panel on "Ruler" dashboard. #8006

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -7775,6 +7775,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -7833,7 +7834,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -8003,6 +8004,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -8061,7 +8063,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -8231,6 +8233,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -8289,7 +8292,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -13765,6 +13768,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -13823,7 +13827,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -13993,6 +13997,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -14051,7 +14056,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -14221,6 +14226,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -14279,7 +14285,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -14449,6 +14455,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -14507,7 +14514,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -14677,6 +14684,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -14735,7 +14743,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -14905,6 +14913,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -14963,7 +14972,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -22503,6 +22512,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -22561,7 +22571,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -22731,6 +22741,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -22789,7 +22800,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -22959,6 +22970,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -23017,7 +23029,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -23187,6 +23199,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -23245,7 +23258,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -36505,6 +36518,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -36563,7 +36577,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -36733,6 +36747,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -36791,7 +36806,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],
@@ -36961,6 +36976,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                       "fieldConfig": {
                          "custom": {
                             "fillOpacity": 0
@@ -37019,7 +37035,7 @@ data:
                             "legendLink": null
                          }
                       ],
-                      "title": "TCP connections (per pod)",
+                      "title": "Ingress TCP connections (per pod)",
                       "type": "timeseries"
                    }
                 ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-networking.json
@@ -189,6 +189,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -247,7 +248,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -417,6 +418,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -475,7 +477,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -645,6 +647,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -703,7 +706,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-networking.json
@@ -189,6 +189,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -247,7 +248,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -417,6 +418,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -475,7 +477,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -645,6 +647,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -703,7 +706,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -873,6 +876,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -931,7 +935,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -1101,6 +1105,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -1159,7 +1164,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -1329,6 +1334,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -1387,7 +1393,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads-networking.json
@@ -189,6 +189,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -247,7 +248,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -417,6 +418,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -475,7 +477,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -645,6 +647,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -703,7 +706,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -873,6 +876,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -931,7 +935,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-networking.json
@@ -189,6 +189,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -247,7 +248,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -417,6 +418,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -475,7 +477,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -645,6 +647,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -703,7 +706,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview-networking.json
@@ -189,6 +189,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -247,7 +248,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -417,6 +418,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -475,7 +477,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -645,6 +647,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -703,7 +706,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
@@ -189,6 +189,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -247,7 +248,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -417,6 +418,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -475,7 +477,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -645,6 +647,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -703,7 +706,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -873,6 +876,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -931,7 +935,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -1101,6 +1105,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -1159,7 +1164,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -1329,6 +1334,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -1387,7 +1393,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-networking.json
@@ -189,6 +189,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -247,7 +248,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -417,6 +418,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -475,7 +477,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -645,6 +647,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -703,7 +706,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -873,6 +876,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -931,7 +935,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
@@ -189,6 +189,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -247,7 +248,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -417,6 +418,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -475,7 +477,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],
@@ -645,6 +647,7 @@
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Ingress TCP connections (per pod)\nThe number of ingress TCP connections (HTTP and gRPC protocol).\n",
                   "fieldConfig": {
                      "custom": {
                         "fillOpacity": 0
@@ -703,7 +706,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "TCP connections (per pod)",
+                  "title": "Ingress TCP connections (per pod)",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -569,7 +569,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
       },
     )
     .addPanel(
-      $.timeseriesPanel('TCP connections (per pod)') +
+      local title = 'Ingress TCP connections (per pod)';
+
+      $.timeseriesPanel(title) +
+      $.panelDescription(
+        title,
+        'The number of ingress TCP connections (HTTP and gRPC protocol).'
+      ) +
       $.queryPanel([
         'avg(sum by(%(per_instance_label)s) (cortex_tcp_connections{%(namespaceMatcher)s,%(instanceLabel)s=~"%(instanceName)s"}))' % vars,
         'max(sum by(%(per_instance_label)s) (cortex_tcp_connections{%(namespaceMatcher)s,%(instanceLabel)s=~"%(instanceName)s"}))' % vars,


### PR DESCRIPTION
#### What this PR does

The "TCP Connections" panel, displayed in our Networking dashboards, show the number of ingress connections via HTTP or gRPC (we don't support other ingress protocols). However, Mimir does make a bunch of egress connections too, which are not visible through this panel (and it's not something tracked directly by Mimir).

I propose to rename the "TCP Connections" panel to "Ingress TCP Connections" to make it more clear.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
