### PR TITLE
Distributor: export distributor.Error interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20240507172911-12154f083c2c
+	github.com/grafana/dskit v0.0.0-20240509115328-a1bba1277f06
 	github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20240424080142-bb4f4f429d36 h1:v4aQ0cde8SCzNRrD2RczzmFolEkXWriSY9tKakAD0ng=
 github.com/grafana/alerting v0.0.0-20240424080142-bb4f4f429d36/go.mod h1:8nOsn7PWmttOmWiR7bvYIl3VLl+tIq72ZF+1y54w36M=
-github.com/grafana/dskit v0.0.0-20240507172911-12154f083c2c h1:a9QDwklVugrWWvna12T8A9Y9tPqtKz8QR0V1FLRu9AA=
-github.com/grafana/dskit v0.0.0-20240507172911-12154f083c2c/go.mod h1:HvSf3uf8Ps2vPpzHeAFyZTdUcbVr+Rxpq1xcx7J/muc=
+github.com/grafana/dskit v0.0.0-20240509115328-a1bba1277f06 h1:/QUlscuctksoAF335nhWJtNtDO2KB+p7I6C2GmI76lM=
+github.com/grafana/dskit v0.0.0-20240509115328-a1bba1277f06/go.mod h1:HvSf3uf8Ps2vPpzHeAFyZTdUcbVr+Rxpq1xcx7J/muc=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc h1:BW+LjKJDz0So5LI8UZfW5neWeKpSkWqhmGjQFzcFfLM=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/goautoneg v0.0.0-20231010094147-47ce5e72a9ae h1:Yxbw9jKGJVC6qAK5Ubzzb/qZwM6rRMMqaDc/d4Vp3pM=

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -7334,7 +7334,7 @@ func TestHandlePushError(t *testing.T) {
 			pushError:          httpGrpc5xxErr,
 			expectedOtherError: httpGrpc5xxErr,
 		},
-		"a distributorError gives the error returned by toGRPCError()": {
+		"an Error gives the error returned by toGRPCError()": {
 			pushError:         mockDistributorErr(testErrorMsg),
 			expectedGRPCError: status.Convert(toGRPCError(mockDistributorErr(testErrorMsg), false)),
 		},
@@ -7360,8 +7360,8 @@ func TestHandlePushError(t *testing.T) {
 				require.Equal(t, testData.expectedOtherError, err)
 			} else {
 				var expectedDetails *mimirpb.ErrorDetails
-				if distributorErr, ok := testData.pushError.(distributorError); ok {
-					expectedDetails = &mimirpb.ErrorDetails{Cause: distributorErr.errorCause()}
+				if distributorErr, ok := testData.pushError.(Error); ok {
+					expectedDetails = &mimirpb.ErrorDetails{Cause: distributorErr.Cause()}
 				}
 				checkGRPCError(t, testData.expectedGRPCError, expectedDetails, err)
 			}

--- a/pkg/distributor/errors_test.go
+++ b/pkg/distributor/errors_test.go
@@ -484,7 +484,7 @@ func TestWrapIngesterPushError(t *testing.T) {
 			require.True(t, ok)
 
 			require.Equal(t, testData.expectedIngesterPushError.Error(), ingesterPushErr.Error())
-			require.Equal(t, testData.expectedIngesterPushError.errorCause(), ingesterPushErr.errorCause())
+			require.Equal(t, testData.expectedIngesterPushError.Cause(), ingesterPushErr.Cause())
 		})
 	}
 }
@@ -543,9 +543,9 @@ func TestIsIngesterClientError(t *testing.T) {
 }
 
 func checkDistributorError(t *testing.T, err error, expectedCause mimirpb.ErrorCause) {
-	var distributorErr distributorError
+	var distributorErr Error
 	require.ErrorAs(t, err, &distributorErr)
-	require.Equal(t, expectedCause, distributorErr.errorCause())
+	require.Equal(t, expectedCause, distributorErr.Cause())
 }
 
 type mockDistributorErr string
@@ -554,6 +554,6 @@ func (e mockDistributorErr) Error() string {
 	return string(e)
 }
 
-func (e mockDistributorErr) errorCause() mimirpb.ErrorCause {
+func (e mockDistributorErr) Cause() mimirpb.ErrorCause {
 	return mimirpb.UNKNOWN_CAUSE
 }

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -201,9 +201,9 @@ func toHTTPStatus(ctx context.Context, pushErr error, limits *validation.Overrid
 		return http.StatusInternalServerError
 	}
 
-	var distributorErr distributorError
+	var distributorErr Error
 	if errors.As(pushErr, &distributorErr) {
-		switch distributorErr.errorCause() {
+		switch distributorErr.Cause() {
 		case mimirpb.BAD_DATA:
 			return http.StatusBadRequest
 		case mimirpb.INGESTION_RATE_LIMITED, mimirpb.REQUEST_RATE_LIMITED:

--- a/vendor/github.com/grafana/dskit/multierror/multierror.go
+++ b/vendor/github.com/grafana/dskit/multierror/multierror.go
@@ -5,7 +5,6 @@ package multierror
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 )
 
@@ -62,14 +61,6 @@ func (es nonNilMultiError) Error() string {
 	return buf.String()
 }
 
-// Is attempts to match the provided error against errors in the error list.
-//
-// This function allows errors.Is to traverse the values stored in the MultiError.
-func (es nonNilMultiError) Is(target error) bool {
-	for _, err := range es {
-		if errors.Is(err, target) {
-			return true
-		}
-	}
-	return false
+func (es nonNilMultiError) Unwrap() []error {
+	return es
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -567,7 +567,7 @@ github.com/grafana-tools/sdk
 # github.com/grafana/alerting v0.0.0-20240424080142-bb4f4f429d36
 ## explicit; go 1.21
 github.com/grafana/alerting/definition
-# github.com/grafana/dskit v0.0.0-20240507172911-12154f083c2c
+# github.com/grafana/dskit v0.0.0-20240509115328-a1bba1277f06
 ## explicit; go 1.20
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

This PR replaces an already existing private interface `distributor.distributorError` 
```
type distributorError interface {
  errorCause() mimirpb.ErrorCause
}
```
with a new, exported interface `distributor.Error`
```
type Error interface {
  Cause() mimirpb.ErrorCause
}
```

Distributor middlewares are supposed to return errors implementing `distributor.Error` interface. This way distributor will correctly handle them.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
