### PR TITLE
Introduce option to delay newly uploaded blocks being queried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [ENHANCEMENT] OTLP: Improve remote write format translation performance by using label set hashes for metric identifiers instead of string based ones. #8012
 * [ENHANCEMENT] Querying: Remove OpEmptyMatch from regex concatenations. #8012
 * [ENHANCEMENT] Store-gateway: add `-blocks-storage.bucket-store.max-concurrent-queue-timeout`. When set, queries at the store-gateway's query gate will not wait longer than that to execute. If a query reaches the wait timeout, then the querier will retry the blocks on a different store-gateway. If all store-gateways are unavailable, then the query will fail with `err-mimir-store-consistency-check-failed`. #7777
+* [ENHANCEMENT] Querier: Add experimental `-blocks-storage.bucket-store.ignore-uploaded-within` flag to allow recently uploaded blocks to be excluded from being queried. #8095
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8360,6 +8360,17 @@
               "fieldCategory": "advanced"
             },
             {
+              "kind": "field",
+              "name": "ignore_uploaded_within",
+              "required": false,
+              "desc": "Blocks with upload time within this duration are ignored by queriers. This only is only useful when using shorter values of -blocks-storage.bucket-store.ignore-blocks-within to ensure both queriers and store-gateways are aware of blocks added to the bucket index.",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "blocks-storage.bucket-store.ignore-uploaded-within",
+              "fieldType": "duration",
+              "fieldCategory": "experimental"
+            },
+            {
               "kind": "block",
               "name": "bucket_index",
               "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -427,6 +427,8 @@ Usage of ./cmd/mimir/mimir:
     	Blocks with minimum time within this duration are ignored, and not loaded by store-gateway. Useful when used together with -querier.query-store-after to prevent loading young blocks, because there are usually many of them (depending on number of ingesters) and they are not yet compacted. Negative values or 0 disable the filter. (default 10h0m0s)
   -blocks-storage.bucket-store.ignore-deletion-marks-delay duration
     	Duration after which the blocks marked for deletion will be filtered out while fetching blocks. The idea of ignore-deletion-marks-delay is to ignore blocks that are marked for deletion with some delay. This ensures store can still serve blocks that are meant to be deleted but do not have a replacement yet. (default 1h0m0s)
+  -blocks-storage.bucket-store.ignore-uploaded-within duration
+    	[experimental] Blocks with upload time within this duration are ignored by queriers. This only is only useful when using shorter values of -blocks-storage.bucket-store.ignore-blocks-within to ensure both queriers and store-gateways are aware of blocks added to the bucket index.
   -blocks-storage.bucket-store.index-cache.backend string
     	The index cache backend type. Supported values: inmemory, memcached, redis. (default "inmemory")
   -blocks-storage.bucket-store.index-cache.inmemory.max-size-bytes uint

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -129,6 +129,7 @@ The following features are currently experimental:
   - Enable PromQL experimental functions (`-querier.promql-experimental-functions-enabled`)
   - Allow streaming of `/active_series` responses to the frontend (`-querier.response-streaming-enabled`)
   - Streaming PromQL engine (`-querier.promql-engine=streaming` and `-querier.enable-promql-engine-fallback`)
+  - Exclude recently uploaded blocks from queries (`-blocks-storage.bucket-store.ignore-uploaded-within`)
 - Query-frontend
   - `-query-frontend.querier-forget-delay`
   - Instant query splitting (`-query-frontend.split-instant-queries-by-interval`)

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3683,6 +3683,13 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.ignore-deletion-marks-delay
   [ignore_deletion_mark_delay: <duration> | default = 1h]
 
+  # (experimental) Blocks with upload time within this duration are ignored by
+  # queriers. This only is only useful when using shorter values of
+  # -blocks-storage.bucket-store.ignore-blocks-within to ensure both queriers
+  # and store-gateways are aware of blocks added to the bucket index.
+  # CLI flag: -blocks-storage.bucket-store.ignore-uploaded-within
+  [ignore_uploaded_within: <duration> | default = 0s]
+
   bucket_index:
     # (advanced) How frequently a bucket index, which previously failed to load,
     # should be tried to load again. This option is used only by querier.

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -224,6 +224,7 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 		},
 		MaxStalePeriod:           storageCfg.BucketStore.BucketIndex.MaxStalePeriod,
 		IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksDelay,
+		IgnoreUploadedWithin:     storageCfg.BucketStore.IgnoreUploadedWithin,
 	}, bucketClient, limits, logger, reg)
 
 	storesRingCfg := gatewayCfg.ShardingRing.ToRingConfig()

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -397,6 +397,7 @@ type BucketStoreConfig struct {
 	ChunksCache               ChunksCacheConfig   `yaml:"chunks_cache"`
 	MetadataCache             MetadataCacheConfig `yaml:"metadata_cache"`
 	IgnoreDeletionMarksDelay  time.Duration       `yaml:"ignore_deletion_mark_delay" category:"advanced"`
+	IgnoreUploadedWithin      time.Duration       `yaml:"ignore_uploaded_within" category:"experimental"`
 	BucketIndex               BucketIndexConfig   `yaml:"bucket_index"`
 	IgnoreBlocksWithin        time.Duration       `yaml:"ignore_blocks_within" category:"advanced"`
 
@@ -455,6 +456,7 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MetaSyncConcurrency, "blocks-storage.bucket-store.meta-sync-concurrency", 20, "Number of Go routines to use when syncing block meta files from object storage per tenant.")
 	f.DurationVar(&cfg.IgnoreDeletionMarksDelay, "blocks-storage.bucket-store.ignore-deletion-marks-delay", time.Hour*1, "Duration after which the blocks marked for deletion will be filtered out while fetching blocks. "+
 		"The idea of ignore-deletion-marks-delay is to ignore blocks that are marked for deletion with some delay. This ensures store can still serve blocks that are meant to be deleted but do not have a replacement yet.")
+	f.DurationVar(&cfg.IgnoreUploadedWithin, "blocks-storage.bucket-store.ignore-uploaded-within", 0, "Blocks with upload time within this duration are ignored by queriers. This only is only useful when using shorter values of -blocks-storage.bucket-store.ignore-blocks-within to ensure both queriers and store-gateways are aware of blocks added to the bucket index.")
 	f.DurationVar(&cfg.IgnoreBlocksWithin, "blocks-storage.bucket-store.ignore-blocks-within", 10*time.Hour, "Blocks with minimum time within this duration are ignored, and not loaded by store-gateway. Useful when used together with -querier.query-store-after to prevent loading young blocks, because there are usually many of them (depending on number of ingesters) and they are not yet compacted. Negative values or 0 disable the filter.")
 	f.IntVar(&cfg.PostingOffsetsInMemSampling, "blocks-storage.bucket-store.posting-offsets-in-mem-sampling", DefaultPostingOffsetInMemorySampling, "Controls what is the ratio of postings offsets that the store will hold in memory.")
 	f.Uint64Var(&cfg.PartitionerMaxGapBytes, "blocks-storage.bucket-store.partitioner-max-gap-bytes", DefaultPartitionerMaxGapSize, "Max size - in bytes - of a gap for which the partitioner aggregates together two bucket GET object requests.")


### PR DESCRIPTION
#### What this PR does

Add an experimental option to ignore blocks added to the bucket index that have been recently uploaded. This can be used to prevent queriers from querying store-gateways for blocks that we only recently added to the bucket index before the store-gateways have a chance to load them. This is only useful when store-gateways are using a non-default and short (~4h) `ignore-blocks-within` setting.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
