### PR TITLE
Don't allocate an unnecessary slice when accumulating chunks

### DIFF
--- a/pkg/ingester/client/mimir_util.go
+++ b/pkg/ingester/client/mimir_util.go
@@ -61,7 +61,14 @@ func sendWithContextErrChecking(ctx context.Context, send func() error) error {
 
 // AccumulateChunks builds a slice of chunks, eliminating duplicates.
 // This is O(N^2) but most of the time N is small.
+// AccumulateChunks may return or modify either of the passed in slices.
 func AccumulateChunks(a, b []Chunk) []Chunk {
+	// If a is empty, we can just return b.
+	// The loop below effectively does the same thing for the opposite scenario (if b is empty, we'll just return a unmodified).
+	if len(a) == 0 {
+		return b
+	}
+
 	ret := a
 	for j := range b {
 		if !containsChunk(a, b[j]) {


### PR DESCRIPTION
#### What this PR does

This PR improves the performance of accumulating chunks from ingesters in queriers.

`AccumulateChunks` is called with a slice of chunks from each ingester to build up a final slice containing all unique chunks from all queried ingesters.

The call pattern typically looks like this:

1. `chunks := []Chunk{}`
2. `chunks = AccumulateChunks(chunks, ingester1Chunks)`
3. `chunks = AccumulateChunks(chunks, ingester2Chunks)` 

Without the change in this PR, we'll unnecessarily spend a bunch of time copying `ingester1Chunks` into the empty `chunks` in step 2. Instead, we can just return `ingester1Chunks` as-is, and avoid a bunch of allocations and time spent moving bytes around.

I haven't bothered with a changelog entry as the overall impact is small (this was significant enough to show up in some benchmarks in #8096, but isn't significant in the real world).

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
