### PR TITLE
Streaming PromQL engine: use clear builtin rather than our own implementations

### DIFF
--- a/pkg/streamingpromql/operator/pool.go
+++ b/pkg/streamingpromql/operator/pool.go
@@ -76,7 +76,8 @@ func PutSeriesMetadataSlice(s []SeriesMetadata) {
 func GetFloatSlice(size int) []float64 {
 	s := floatSlicePool.Get(size)
 	if s != nil {
-		return zeroFloatSlice(s, size)
+		clear(s[:size])
+		return s
 	}
 
 	return make([]float64, 0, size)
@@ -90,7 +91,8 @@ func GetBoolSlice(size int) []bool {
 	s := boolSlicePool.Get(size)
 
 	if s != nil {
-		return zeroBoolSlice(s, size)
+		clear(s[:size])
+		return s
 	}
 
 	return make([]bool, 0, size)
@@ -98,24 +100,4 @@ func GetBoolSlice(size int) []bool {
 
 func PutBoolSlice(s []bool) {
 	boolSlicePool.Put(s)
-}
-
-func zeroFloatSlice(s []float64, size int) []float64 {
-	s = s[:size]
-
-	for i := range s {
-		s[i] = 0
-	}
-
-	return s[:0]
-}
-
-func zeroBoolSlice(s []bool, size int) []bool {
-	s = s[:size]
-
-	for i := range s {
-		s[i] = false
-	}
-
-	return s[:0]
 }


### PR DESCRIPTION
#### What this PR does

This PR removes some unnecessary methods that clear the contents of slices and replaces them with the `clear` builtin, which does the same thing.

Given this is a very small change with no user impact I haven't bothered to add a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
