### PR TITLE
Fix flaky TestBucketStore_Series_TimeoutGate

### DIFF
--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2104,7 +2104,12 @@ func TestBucketStore_Series_TimeoutGate(t *testing.T) {
 		conn, err := srv.dialConn()
 		assert.NoError(t, err)
 		t.Cleanup(func() { _ = conn.Close() })
-		_, err = srv.requestSeries(ctx, conn, req)
+		sgClient, err := srv.requestSeries(ctx, conn, req)
+		assert.NoError(t, err)
+		// Receive one message so we can be sure that the server has started processing the request.
+		// Otherwise we cannot be sure that the gate was actually called, making the test flaky.
+		// Depends on the server returning two messages at least: result and stats. We don't read the second one.
+		_, err = sgClient.Recv()
 		assert.NoError(t, err)
 		close(firstRequestStarted)
 		<-ctx.Done()


### PR DESCRIPTION
The test is supposed to start a request on the server, but the GRPC send call does not wait for the server to get the request, only for successful send on the network. See:
https://github.com/grpc/grpc-go/blob/59954c80165855ecd478a79e75bcc7d64f629ded/stream.go#L122

Repro:
go test -count 1000 -timeout 300s \
  -run ^TestBucketStore_Series_TimeoutGate$ \
  github.com/grafana/mimir/pkg/storegateway \
 -tags=acceptance,requires_docker,stringlabels

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
