### PR TITLE
store-gateway: fix flaky TestBucketStore_Series_TimeoutGate

### DIFF
--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -2104,8 +2104,11 @@ func TestBucketStore_Series_TimeoutGate(t *testing.T) {
 		conn, err := srv.dialConn()
 		assert.NoError(t, err)
 		defer conn.Close()
-		_, err = srv.requestSeries(ctx, conn, req)
+		stream, err := srv.requestSeries(ctx, conn, req)
 		assert.NoError(t, err)
+
+		// Do a single read to be sure that the request is being processed in the server.
+		_, _ = stream.Recv()
 		close(firstRequestStarted)
 		<-ctx.Done()
 	}()


### PR DESCRIPTION
@charleskorn mentioned that this test is consistently failing. The problem was that the first call in the goroutine wasn't blocking when the client doesn't read the response. Even though responses are streaming there are buffers in gRPC, so the store-gateway can send the response without having to wait for the client to receive it.

After increasing the size of the response, so that the buffers aren't enough, the test didn't terminate. The reason was that we were trying to gracefully shut down the server before cancelling the client request first. This was because of the order of t.Cleanup's and defers. I changed the usages from t.Cleanup to defers to be more consistent with the rest of the file and also reordered the init steps so that they work with both defers and t.Cleanup's.
