### PR TITLE
Upgrade mimir-build-image to go 1.22.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr8032-d6540935d8
+LATEST_BUILD_IMAGE_TAG ?= pr8107-6dc27b0894
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM registry.k8s.io/kustomize/kustomize:v5.4.1 as kustomize
 FROM alpine/helm:3.14.4 as helm
-FROM golang:1.22.2-bookworm
+FROM golang:1.22.3-bookworm
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"


### PR DESCRIPTION
#### What this PR does

Upgrade mimir-build-image to go 1.22.3. Go 1.22.3 includes [security fixes](https://go.dev/doc/devel/release).

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
