### PR TITLE
Improving globalerror package

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -2175,7 +2175,7 @@ func (d *Distributor) ActiveSeries(ctx context.Context, matchers []*labels.Match
 
 		stream, err := client.ActiveSeries(ctx, req)
 		if err != nil {
-			if errors.Is(globalerror.WrapGrpcContextError(err), context.Canceled) {
+			if errors.Is(globalerror.WrapGRPCErrorWithContextError(err), context.Canceled) {
 				return ignored{}, nil
 			}
 			level.Error(log).Log("msg", "error creating active series response stream", "err", err)
@@ -2185,7 +2185,7 @@ func (d *Distributor) ActiveSeries(ctx context.Context, matchers []*labels.Match
 
 		defer func() {
 			err = util.CloseAndExhaust[*ingester_client.ActiveSeriesResponse](stream)
-			if err != nil && !errors.Is(globalerror.WrapGrpcContextError(err), context.Canceled) {
+			if err != nil && !errors.Is(globalerror.WrapGRPCErrorWithContextError(err), context.Canceled) {
 				level.Warn(d.log).Log("msg", "error closing active series response stream", "err", err)
 			}
 		}()
@@ -2196,7 +2196,7 @@ func (d *Distributor) ActiveSeries(ctx context.Context, matchers []*labels.Match
 				if errors.Is(err, io.EOF) {
 					break
 				}
-				if errors.Is(globalerror.WrapGrpcContextError(err), context.Canceled) {
+				if errors.Is(globalerror.WrapGRPCErrorWithContextError(err), context.Canceled) {
 					return ignored{}, nil
 				}
 				level.Error(log).Log("msg", "error receiving active series response", "err", err)

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -254,22 +254,7 @@ func toGRPCError(pushErr error, serviceOverloadErrorEnabled bool) error {
 			errCode = codes.Unimplemented
 		}
 	}
-	return errorWithStatus(pushErr, errCode, errDetails)
-}
-
-// errorWithStatus is slightly different from globalerror.NewErrorWithGRPCStatus. It returns status.Err() instead of an error with the status message.
-// The actual difference is between "rpc error: code = XYZ desc = message" and just "message".
-// At the time of writing this should be purely a cosmetic difference, but it's hard to verify.
-// Because of this difference, the function is used instead of globalerror.NewErrorWithGRPCStatus.
-func errorWithStatus(pushErr error, errCode codes.Code, errDetails *mimirpb.ErrorDetails) error {
-	stat := status.New(errCode, pushErr.Error())
-	if errDetails != nil {
-		statWithDetails, err := stat.WithDetails(errDetails)
-		if err == nil {
-			return statWithDetails.Err()
-		}
-	}
-	return stat.Err()
+	return globalerror.ToGRPCStatusError(pushErr, errCode, errDetails)
 }
 
 func wrapIngesterPushError(err error, ingesterID string) error {

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -254,7 +254,7 @@ func toGRPCError(pushErr error, serviceOverloadErrorEnabled bool) error {
 			errCode = codes.Unimplemented
 		}
 	}
-	return globalerror.ToGRPCStatusError(pushErr, errCode, errDetails)
+	return globalerror.WrapErrorWithGRPCStatus(pushErr, errCode, errDetails).Err()
 }
 
 func wrapIngesterPushError(err error, ingesterID string) error {

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -378,7 +378,7 @@ func (f *Frontend) QueryResult(ctx context.Context, qrReq *frontendv2pb.QueryRes
 func (f *Frontend) QueryResultStream(stream frontendv2pb.FrontendForQuerier_QueryResultStreamServer) (err error) {
 	defer func(s frontendv2pb.FrontendForQuerier_QueryResultStreamServer) {
 		err := s.SendAndClose(&frontendv2pb.QueryResultResponse{})
-		if err != nil && !errors.Is(globalerror.WrapGrpcContextError(err), context.Canceled) {
+		if err != nil && !errors.Is(globalerror.WrapGRPCErrorWithContextError(err), context.Canceled) {
 			level.Warn(f.log).Log("msg", "failed to close query result body stream", "err", err)
 		}
 	}(stream)

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -47,7 +47,7 @@ func newErrorWithStatus(originalErr error, code codes.Code) globalerror.ErrorWit
 	if errors.As(originalErr, &ingesterErr) {
 		errorDetails = &mimirpb.ErrorDetails{Cause: ingesterErr.errorCause()}
 	}
-	return globalerror.NewErrorWithGRPCStatus(originalErr, code, errorDetails)
+	return globalerror.WrapErrorWithGRPCStatus(originalErr, code, errorDetails)
 }
 
 // newErrorWithHTTPStatus creates a new ErrorWithStatus backed by the given error,
@@ -56,8 +56,8 @@ func newErrorWithHTTPStatus(err error, code int) globalerror.ErrorWithStatus {
 	errWithHTTPStatus := httpgrpc.Errorf(code, err.Error())
 	stat, _ := grpcutil.ErrorToStatus(errWithHTTPStatus)
 	return globalerror.ErrorWithStatus{
-		UnderlyingErr: err,
-		Status:        stat,
+		Causes: []error{err},
+		Status: stat,
 	}
 }
 

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -39,7 +39,7 @@ var (
 // and containing the given gRPC code. If the given error is an ingesterError,
 // the resulting ErrorWithStatus will be enriched by the details backed by
 // ingesterError.errorCause. These details are of type mimirpb.ErrorDetails.
-func newErrorWithStatus(originalErr error, code codes.Code) *globalerror.ErrorWithStatus {
+func newErrorWithStatus(originalErr error, code codes.Code) globalerror.ErrorWithStatus {
 	var (
 		ingesterErr  ingesterError
 		errorDetails *mimirpb.ErrorDetails
@@ -52,12 +52,12 @@ func newErrorWithStatus(originalErr error, code codes.Code) *globalerror.ErrorWi
 
 // newErrorWithHTTPStatus creates a new ErrorWithStatus backed by the given error,
 // and containing the given HTTP status code.
-func newErrorWithHTTPStatus(err error, code int) *globalerror.ErrorWithStatus {
+func newErrorWithHTTPStatus(err error, code int) globalerror.ErrorWithStatus {
 	errWithHTTPStatus := httpgrpc.Errorf(code, err.Error())
 	stat, _ := grpcutil.ErrorToStatus(errWithHTTPStatus)
-	return &globalerror.ErrorWithStatus{
-		Causes: []error{err},
-		Status: stat,
+	return globalerror.ErrorWithStatus{
+		UnderlyingErr: err,
+		Status:        stat,
 	}
 }
 

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -39,7 +39,7 @@ var (
 // and containing the given gRPC code. If the given error is an ingesterError,
 // the resulting ErrorWithStatus will be enriched by the details backed by
 // ingesterError.errorCause. These details are of type mimirpb.ErrorDetails.
-func newErrorWithStatus(originalErr error, code codes.Code) globalerror.ErrorWithStatus {
+func newErrorWithStatus(originalErr error, code codes.Code) *globalerror.ErrorWithStatus {
 	var (
 		ingesterErr  ingesterError
 		errorDetails *mimirpb.ErrorDetails
@@ -52,10 +52,10 @@ func newErrorWithStatus(originalErr error, code codes.Code) globalerror.ErrorWit
 
 // newErrorWithHTTPStatus creates a new ErrorWithStatus backed by the given error,
 // and containing the given HTTP status code.
-func newErrorWithHTTPStatus(err error, code int) globalerror.ErrorWithStatus {
+func newErrorWithHTTPStatus(err error, code int) *globalerror.ErrorWithStatus {
 	errWithHTTPStatus := httpgrpc.Errorf(code, err.Error())
 	stat, _ := grpcutil.ErrorToStatus(errWithHTTPStatus)
-	return globalerror.ErrorWithStatus{
+	return &globalerror.ErrorWithStatus{
 		Causes: []error{err},
 		Status: stat,
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -2568,7 +2568,7 @@ func TestIngester_Push(t *testing.T) {
 						assert.NoError(t, err)
 					} else {
 						handledErr := i.mapPushErrorToErrorWithStatus(err)
-						errWithStatus, ok := handledErr.(globalerror.ErrorWithStatus)
+						errWithStatus, ok := handledErr.(*globalerror.ErrorWithStatus)
 						assert.True(t, ok)
 						assert.True(t, errWithStatus.Equals(testData.expectedErr))
 					}
@@ -7530,7 +7530,8 @@ func TestIngester_PushGrpcMethod_Disabled(t *testing.T) {
 		[]mimirpb.Sample{{TimestampMs: 1_000, Value: 1}},
 	)
 	_, err = i.Push(ctx, req)
-	require.ErrorIs(t, err, errPushGrpcDisabled)
+	aa := errPushGrpcDisabled
+	require.ErrorIs(t, err, aa)
 }
 
 func TestIngester_instanceLimitsMetrics(t *testing.T) {
@@ -9952,7 +9953,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 
 	tests := map[string]struct {
 		reqs             []*mimirpb.WriteRequest
-		expectedErrs     []globalerror.ErrorWithStatus
+		expectedErrs     []*globalerror.ErrorWithStatus
 		expectedMetrics  string
 		expectedSampling bool
 		maxExemplars     int
@@ -9975,7 +9976,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					mimirpb.API,
 				),
 			},
-			expectedErrs: []globalerror.ErrorWithStatus{
+			expectedErrs: []*globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10008,7 +10009,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []globalerror.ErrorWithStatus{
+			expectedErrs: []*globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10042,7 +10043,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []globalerror.ErrorWithStatus{
+			expectedErrs: []*globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10079,7 +10080,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []globalerror.ErrorWithStatus{
+			expectedErrs: []*globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10113,7 +10114,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []globalerror.ErrorWithStatus{
+			expectedErrs: []*globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10141,7 +10142,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []globalerror.ErrorWithStatus{
+			expectedErrs: []*globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10172,7 +10173,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []globalerror.ErrorWithStatus{
+			expectedErrs: []*globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), users[1]), codes.FailedPrecondition),
 			},
@@ -10195,7 +10196,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					mimirpb.API,
 				),
 			},
-			expectedErrs: []globalerror.ErrorWithStatus{
+			expectedErrs: []*globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10229,7 +10230,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []globalerror.ErrorWithStatus{
+			expectedErrs: []*globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), users[1]), codes.FailedPrecondition),
 			},
@@ -10654,7 +10655,7 @@ func TestIngester_lastUpdatedTimeIsNotInTheFuture(t *testing.T) {
 
 func checkErrorWithStatus(t *testing.T, err error, expectedErr error) {
 	require.Error(t, err)
-	errWithStatus, ok := err.(globalerror.ErrorWithStatus)
+	errWithStatus, ok := err.(*globalerror.ErrorWithStatus)
 	require.True(t, ok)
 	require.True(t, errWithStatus.Equals(expectedErr))
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -2568,7 +2568,7 @@ func TestIngester_Push(t *testing.T) {
 						assert.NoError(t, err)
 					} else {
 						handledErr := i.mapPushErrorToErrorWithStatus(err)
-						errWithStatus, ok := handledErr.(*globalerror.ErrorWithStatus)
+						errWithStatus, ok := handledErr.(globalerror.ErrorWithStatus)
 						assert.True(t, ok)
 						assert.True(t, errWithStatus.Equals(testData.expectedErr))
 					}
@@ -7530,8 +7530,7 @@ func TestIngester_PushGrpcMethod_Disabled(t *testing.T) {
 		[]mimirpb.Sample{{TimestampMs: 1_000, Value: 1}},
 	)
 	_, err = i.Push(ctx, req)
-	aa := errPushGrpcDisabled
-	require.ErrorIs(t, err, aa)
+	require.ErrorIs(t, err, errPushGrpcDisabled)
 }
 
 func TestIngester_instanceLimitsMetrics(t *testing.T) {
@@ -9953,7 +9952,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 
 	tests := map[string]struct {
 		reqs             []*mimirpb.WriteRequest
-		expectedErrs     []*globalerror.ErrorWithStatus
+		expectedErrs     []globalerror.ErrorWithStatus
 		expectedMetrics  string
 		expectedSampling bool
 		maxExemplars     int
@@ -9976,7 +9975,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					mimirpb.API,
 				),
 			},
-			expectedErrs: []*globalerror.ErrorWithStatus{
+			expectedErrs: []globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleOutOfOrderError(model.Time(9), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10009,7 +10008,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []*globalerror.ErrorWithStatus{
+			expectedErrs: []globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10043,7 +10042,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []*globalerror.ErrorWithStatus{
+			expectedErrs: []globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86800*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10080,7 +10079,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []*globalerror.ErrorWithStatus{
+			expectedErrs: []globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooOldError(model.Time(1575043969-(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10114,7 +10113,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []*globalerror.ErrorWithStatus{
+			expectedErrs: []globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10142,7 +10141,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []*globalerror.ErrorWithStatus{
+			expectedErrs: []globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10173,7 +10172,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []*globalerror.ErrorWithStatus{
+			expectedErrs: []globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarTimestampTooFarInFutureError(model.Time(now.UnixMilli()+(86400*1000)), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "222"}}), users[1]), codes.FailedPrecondition),
 			},
@@ -10196,7 +10195,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					mimirpb.API,
 				),
 			},
-			expectedErrs: []*globalerror.ErrorWithStatus{
+			expectedErrs: []globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[1]), codes.FailedPrecondition),
 			},
@@ -10230,7 +10229,7 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedErrs: []*globalerror.ErrorWithStatus{
+			expectedErrs: []globalerror.ErrorWithStatus{
 				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), users[0]), codes.FailedPrecondition),
 				newErrorWithStatus(wrapOrAnnotateWithUser(newExemplarMissingSeriesError(model.Time(1000), metricLabelAdapters, []mimirpb.LabelAdapter{{Name: "traceID", Value: "123"}}), users[1]), codes.FailedPrecondition),
 			},
@@ -10312,13 +10311,13 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 						require.Error(t, err)
 						status, ok := grpcutil.ErrorToStatus(err)
 						require.True(t, ok)
-						require.ErrorContains(t, status.Err(), testData.expectedErrs[0].Causes[0].Error())
+						require.ErrorContains(t, status.Err(), testData.expectedErrs[0].UnderlyingErr.Error())
 					}
 					_, err = client.Push(ctxs[1], req)
 					require.Error(t, err)
 					status, ok := grpcutil.ErrorToStatus(err)
 					require.True(t, ok)
-					require.ErrorContains(t, status.Err(), testData.expectedErrs[1].Causes[0].Error())
+					require.ErrorContains(t, status.Err(), testData.expectedErrs[1].UnderlyingErr.Error())
 				}
 			}
 
@@ -10655,7 +10654,7 @@ func TestIngester_lastUpdatedTimeIsNotInTheFuture(t *testing.T) {
 
 func checkErrorWithStatus(t *testing.T, err error, expectedErr error) {
 	require.Error(t, err)
-	errWithStatus, ok := err.(*globalerror.ErrorWithStatus)
+	errWithStatus, ok := err.(globalerror.ErrorWithStatus)
 	require.True(t, ok)
 	require.True(t, errWithStatus.Equals(expectedErr))
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -10311,13 +10311,13 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 						require.Error(t, err)
 						status, ok := grpcutil.ErrorToStatus(err)
 						require.True(t, ok)
-						require.ErrorContains(t, status.Err(), testData.expectedErrs[0].UnderlyingErr.Error())
+						require.ErrorContains(t, status.Err(), testData.expectedErrs[0].Causes[0].Error())
 					}
 					_, err = client.Push(ctxs[1], req)
 					require.Error(t, err)
 					status, ok := grpcutil.ErrorToStatus(err)
 					require.True(t, ok)
-					require.ErrorContains(t, status.Err(), testData.expectedErrs[1].UnderlyingErr.Error())
+					require.ErrorContains(t, status.Err(), testData.expectedErrs[1].Causes[0].Error())
 				}
 			}
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -3289,15 +3289,15 @@ func TestShouldStopQueryFunc(t *testing.T) {
 			expected: false,
 		},
 		"should not stop query on store-gateway instance limit": {
-			err:      globalerror.ToGRPCStatusError(errors.New("instance limit"), codes.Aborted, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}),
+			err:      globalerror.WrapErrorWithGRPCStatus(errors.New("instance limit"), codes.Aborted, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}).Err(),
 			expected: false,
 		},
 		"should not stop query on store-gateway instance limit; shouldn't look at the gRPC code, only Mimir error cause": {
-			err:      globalerror.ToGRPCStatusError(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}),
+			err:      globalerror.WrapErrorWithGRPCStatus(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}).Err(),
 			expected: false,
 		},
 		"should not stop query on any other mimirpb error": {
-			err:      globalerror.ToGRPCStatusError(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.TOO_BUSY}),
+			err:      globalerror.WrapErrorWithGRPCStatus(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.TOO_BUSY}).Err(),
 			expected: false,
 		},
 		"should not stop query on any unknown error detail": {

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -3289,15 +3289,15 @@ func TestShouldStopQueryFunc(t *testing.T) {
 			expected: false,
 		},
 		"should not stop query on store-gateway instance limit": {
-			err:      globalerror.NewErrorWithGRPCStatus(errors.New("instance limit"), codes.Aborted, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}),
+			err:      globalerror.ToGRPCStatusError(errors.New("instance limit"), codes.Aborted, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}),
 			expected: false,
 		},
 		"should not stop query on store-gateway instance limit; shouldn't look at the gRPC code, only Mimir error cause": {
-			err:      globalerror.NewErrorWithGRPCStatus(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}),
+			err:      globalerror.ToGRPCStatusError(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}),
 			expected: false,
 		},
 		"should not stop query on any other mimirpb error": {
-			err:      globalerror.NewErrorWithGRPCStatus(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.TOO_BUSY}),
+			err:      globalerror.ToGRPCStatusError(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.TOO_BUSY}),
 			expected: false,
 		},
 		"should not stop query on any unknown error detail": {

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -709,9 +709,9 @@ func mapSeriesError(err error) error {
 	case errors.As(err, &stGwErr):
 		switch cause := stGwErr.errorCause(); cause {
 		case mimirpb.INSTANCE_LIMIT:
-			return globalerror.ToGRPCStatusError(stGwErr, codes.Unavailable, &mimirpb.ErrorDetails{Cause: cause})
+			return globalerror.WrapErrorWithGRPCStatus(stGwErr, codes.Unavailable, &mimirpb.ErrorDetails{Cause: cause}).Err()
 		default:
-			return globalerror.ToGRPCStatusError(stGwErr, codes.Internal, &mimirpb.ErrorDetails{Cause: cause})
+			return globalerror.WrapErrorWithGRPCStatus(stGwErr, codes.Internal, &mimirpb.ErrorDetails{Cause: cause}).Err()
 		}
 	default:
 		code := codes.Internal

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -709,9 +709,9 @@ func mapSeriesError(err error) error {
 	case errors.As(err, &stGwErr):
 		switch cause := stGwErr.errorCause(); cause {
 		case mimirpb.INSTANCE_LIMIT:
-			return globalerror.NewErrorWithGRPCStatus(stGwErr, codes.Unavailable, &mimirpb.ErrorDetails{Cause: cause})
+			return globalerror.ToGRPCStatusError(stGwErr, codes.Unavailable, &mimirpb.ErrorDetails{Cause: cause})
 		default:
-			return globalerror.NewErrorWithGRPCStatus(stGwErr, codes.Internal, &mimirpb.ErrorDetails{Cause: cause})
+			return globalerror.ToGRPCStatusError(stGwErr, codes.Internal, &mimirpb.ErrorDetails{Cause: cause})
 		}
 	default:
 		code := codes.Internal

--- a/pkg/storegateway/storegatewaypb/custom.go
+++ b/pkg/storegateway/storegatewaypb/custom.go
@@ -27,7 +27,7 @@ func NewCustomStoreGatewayClient(cc *grpc.ClientConn) StoreGatewayClient {
 func (c *customStoreGatewayClient) Series(ctx context.Context, in *storepb.SeriesRequest, opts ...grpc.CallOption) (StoreGateway_SeriesClient, error) {
 	client, err := c.wrapped.Series(ctx, in, opts...)
 	if err != nil {
-		return client, globalerror.WrapGrpcContextError(err)
+		return client, globalerror.WrapGRPCErrorWithContextError(err)
 	}
 
 	return newCustomSeriesClient(client), nil
@@ -36,13 +36,13 @@ func (c *customStoreGatewayClient) Series(ctx context.Context, in *storepb.Serie
 // LabelNames implements StoreGatewayClient.
 func (c *customStoreGatewayClient) LabelNames(ctx context.Context, in *storepb.LabelNamesRequest, opts ...grpc.CallOption) (*storepb.LabelNamesResponse, error) {
 	res, err := c.wrapped.LabelNames(ctx, in, opts...)
-	return res, globalerror.WrapGrpcContextError(err)
+	return res, globalerror.WrapGRPCErrorWithContextError(err)
 }
 
 // LabelValues implements StoreGatewayClient.
 func (c *customStoreGatewayClient) LabelValues(ctx context.Context, in *storepb.LabelValuesRequest, opts ...grpc.CallOption) (*storepb.LabelValuesResponse, error) {
 	res, err := c.wrapped.LabelValues(ctx, in, opts...)
-	return res, globalerror.WrapGrpcContextError(err)
+	return res, globalerror.WrapGRPCErrorWithContextError(err)
 }
 
 // customStoreGatewayClient is a custom StoreGateway_SeriesClient which wraps well known gRPC errors into standard golang errors.
@@ -61,7 +61,7 @@ func newCustomSeriesClient(client StoreGateway_SeriesClient) *customSeriesClient
 
 func (c *customSeriesClient) Recv() (*storepb.SeriesResponse, error) {
 	res, err := c.wrapped.Recv()
-	return res, globalerror.WrapGrpcContextError(err)
+	return res, globalerror.WrapGRPCErrorWithContextError(err)
 }
 
 // customClientStream is a custom grpc.ClientStream which wraps well known gRPC errors into standard golang errors.
@@ -72,7 +72,7 @@ type customClientStream struct {
 // Header implements grpc.ClientStream.
 func (c *customClientStream) Header() (metadata.MD, error) {
 	md, err := c.wrapped.Header()
-	return md, globalerror.WrapGrpcContextError(err)
+	return md, globalerror.WrapGRPCErrorWithContextError(err)
 }
 
 // Trailer implements grpc.ClientStream.
@@ -83,7 +83,7 @@ func (c *customClientStream) Trailer() metadata.MD {
 // CloseSend implements grpc.ClientStream.
 func (c *customClientStream) CloseSend() error {
 	//nolint:forbidigo // Here we're just wrapping CloseSend() so it's OK to call it.
-	return globalerror.WrapGrpcContextError(c.wrapped.CloseSend())
+	return globalerror.WrapGRPCErrorWithContextError(c.wrapped.CloseSend())
 }
 
 // Context implements grpc.ClientStream.
@@ -93,10 +93,10 @@ func (c *customClientStream) Context() context.Context {
 
 // SendMsg implements grpc.ClientStream.
 func (c *customClientStream) SendMsg(m any) error {
-	return globalerror.WrapGrpcContextError(c.wrapped.SendMsg(m))
+	return globalerror.WrapGRPCErrorWithContextError(c.wrapped.SendMsg(m))
 }
 
 // RecvMsg implements grpc.ClientStream.
 func (c *customClientStream) RecvMsg(m any) error {
-	return globalerror.WrapGrpcContextError(c.wrapped.RecvMsg(m))
+	return globalerror.WrapGRPCErrorWithContextError(c.wrapped.RecvMsg(m))
 }

--- a/pkg/util/globalerror/grpc.go
+++ b/pkg/util/globalerror/grpc.go
@@ -25,12 +25,12 @@ func WrapGRPCErrorWithContextError(err error) error {
 		switch stat.Code() {
 		case codes.Canceled:
 			return &ErrorWithStatus{
-				Causes: createCauses(err, context.Canceled),
+				Causes: []error{err, context.Canceled},
 				Status: stat,
 			}
 		case codes.DeadlineExceeded:
 			return &ErrorWithStatus{
-				Causes: createCauses(err, context.DeadlineExceeded),
+				Causes: []error{err, context.DeadlineExceeded},
 				Status: stat,
 			}
 		default:
@@ -46,7 +46,7 @@ func WrapGRPCErrorWithContextError(err error) error {
 func WrapErrorWithGRPCStatus(originalErr error, errCode codes.Code, errDetails *mimirpb.ErrorDetails) *ErrorWithStatus {
 	stat := createGRPCStatus(originalErr, errCode, errDetails)
 	return &ErrorWithStatus{
-		Causes: createCauses(originalErr),
+		Causes: []error{originalErr},
 		Status: stat,
 	}
 }
@@ -141,10 +141,4 @@ func (e *ErrorWithStatus) Equals(err error) bool {
 		return errDetails.GetCause() == otherErrDetails.GetCause()
 	}
 	return false
-}
-
-func createCauses(errs ...error) []error {
-	causes := make([]error, 0, 2)
-	causes = append(causes, errs...)
-	return causes
 }

--- a/pkg/util/globalerror/grpc_test.go
+++ b/pkg/util/globalerror/grpc_test.go
@@ -67,6 +67,16 @@ func TestWrapContextError(t *testing.T) {
 				expectedGrpcCode:   codes.DeadlineExceeded,
 				expectedContextErr: context.DeadlineExceeded,
 			},
+			"ErrorWithStatus with Canceled status": {
+				origErr:            WrapErrorWithGRPCStatus(errors.New("cancel error"), codes.Canceled, nil),
+				expectedGrpcCode:   codes.Canceled,
+				expectedContextErr: context.Canceled,
+			},
+			"ErrorWithStatus with DeadlineExceeded status": {
+				origErr:            WrapErrorWithGRPCStatus(errors.New("timeout error"), codes.DeadlineExceeded, nil),
+				expectedGrpcCode:   codes.DeadlineExceeded,
+				expectedContextErr: context.DeadlineExceeded,
+			},
 		}
 
 		for testName, testData := range tests {

--- a/pkg/util/globalerror/grpc_test.go
+++ b/pkg/util/globalerror/grpc_test.go
@@ -71,10 +71,10 @@ func TestWrapContextError(t *testing.T) {
 
 		for testName, testData := range tests {
 			t.Run(testName, func(t *testing.T) {
-				wrapped := WrapGrpcContextError(testData.origErr)
+				wrapped := WrapGRPCErrorWithContextError(testData.origErr)
 
 				assert.NotEqual(t, testData.origErr, wrapped)
-				assert.Equal(t, testData.origErr, errors.Unwrap(wrapped))
+				assert.ErrorIs(t, wrapped, testData.origErr)
 
 				assert.True(t, errors.Is(wrapped, testData.expectedContextErr))
 				assert.Equal(t, testData.expectedGrpcCode, grpcutil.ErrorToStatusCode(wrapped))
@@ -98,11 +98,11 @@ func TestWrapContextError(t *testing.T) {
 
 	t.Run("should return the input error on a non-gRPC error", func(t *testing.T) {
 		orig := errors.New("mock error")
-		assert.Equal(t, orig, WrapGrpcContextError(orig))
+		assert.Equal(t, orig, WrapGRPCErrorWithContextError(orig))
 
-		assert.Equal(t, context.Canceled, WrapGrpcContextError(context.Canceled))
-		assert.Equal(t, context.DeadlineExceeded, WrapGrpcContextError(context.DeadlineExceeded))
-		assert.Equal(t, io.EOF, WrapGrpcContextError(io.EOF))
+		assert.Equal(t, context.Canceled, WrapGRPCErrorWithContextError(context.Canceled))
+		assert.Equal(t, context.DeadlineExceeded, WrapGRPCErrorWithContextError(context.DeadlineExceeded))
+		assert.Equal(t, io.EOF, WrapGRPCErrorWithContextError(io.EOF))
 	})
 }
 
@@ -144,7 +144,7 @@ func TestErrorWithStatus(t *testing.T) {
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
 			const statusCode = codes.Unimplemented
-			errWithStatus := NewErrorWithGRPCStatus(data.originErr, statusCode, data.details)
+			errWithStatus := WrapErrorWithGRPCStatus(data.originErr, statusCode, data.details)
 			require.Error(t, errWithStatus)
 			require.Errorf(t, errWithStatus, data.expectedErrorMessage)
 


### PR DESCRIPTION
#### What this PR does

This PR refactors the `globalerror` package in such a way that it exports the following functions:
- `ToGRPCStatusError()`, that returns an error corresponding to a gRPC status built out of the given parameters: the gRPC status' code and details are passed as parameters, while its message corresponds to the original error. The resulting error is of type error, and it can be parsed to the corresponding gRPC status by both gogo/status and grpc/status packages.
- `WrapErrorWithGRPCStatus()`, that wraps a given error with a gRPC status, which is built out of the given parameters: the gRPC status' code and details are passed as parameters, while its message corresponds to the original error. The resulting error is of type `globalerror.ErrorWithStatus`. This function replaces the previously available `globalerror.NewErrorWithGRPCStatus()` function.
- `WrapGRPCErrorWithContextError()`, that checks if the given error is a gRPC error corresponding to a standard golang context error, and if it is, wraps the former with the latter. If the given error isn't a gRPC error, or it doesn't correspond to a standard golang context error, the original error is returned. This function replaces the previously available `globalerror.WrapGrpcContextError()` function.

This PR also replaces usages of `globalerror.NewErrorWithGRPCStatus()` in `storegateway` and `querier` packages with the new `globalerror.ToGRPCStatusError()`, because the latter is more appropriate.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
