### PR TITLE
mimirpb: export IsClientErrorCause() function

### DIFF
--- a/pkg/mimirpb/errors.go
+++ b/pkg/mimirpb/errors.go
@@ -6,8 +6,7 @@ import (
 	"github.com/grafana/dskit/grpcutil"
 )
 
-// IsClientError returns true if err is a gRPC or HTTPgRPC error whose cause is a well known
-// client error.
+// IsClientError returns true if err is a gRPC or HTTPgRPC error whose cause is a well-known client error.
 func IsClientError(err error) bool {
 	// This code is needed for backward compatibility.
 	if code := grpcutil.ErrorToStatusCode(err); code/100 == 4 {
@@ -17,10 +16,15 @@ func IsClientError(err error) bool {
 	if status, ok := grpcutil.ErrorToStatus(err); ok {
 		for _, details := range status.Details() {
 			if errDetails, ok := details.(*ErrorDetails); ok {
-				return errDetails.Cause == BAD_DATA
+				return IsClientErrorCause(errDetails.GetCause())
 			}
 		}
 	}
 
 	return false
+}
+
+// IsClientErrorCause returns true if the given ErrorCause corresponds to a well-known client error cause.
+func IsClientErrorCause(errCause ErrorCause) bool {
+	return errCause == BAD_DATA
 }


### PR DESCRIPTION
#### What this PR does
This PR exports `mimirpb.IsClientErrorCause()` function, that distinguishes between `mimirpb.ErrorCause`s corresponding to client and server errors. Currently, `mimirpb.BAD_DATA` is the only `mimirpb.ErrorCause` corresponding to client errors.

This PR makes no semantical change, it just exports the error cause check already used within `mimirpb.IsClientError()`.

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
