### PR TITLE
mimirtool: Add runtime-config verify sub-command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899 #8023 #8058
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
+* [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123
 * [ENHANCEMENT] Reduced memory allocations in functions used to propagate contextual information between gRPC calls. #7529
 * [ENHANCEMENT] Distributor: add experimental limit for exemplars per series per request, enabled with `-distributor.max-exemplars-per-series-per-request`, the number of discarded exemplars are tracked with `cortex_discarded_exemplars_total{reason="too_many_exemplars_per_series_per_request"}` #7989 #8010
 * [ENHANCEMENT] Store-gateway: merge series from different blocks concurrently. #7456

--- a/cmd/mimirtool/main.go
+++ b/cmd/mimirtool/main.go
@@ -31,6 +31,7 @@ var (
 	remoteReadCommand     commands.RemoteReadCommand
 	ruleCommand           commands.RuleCommand
 	backfillCommand       commands.BackfillCommand
+	runtimeConfigCommand  commands.RuntimeConfigCommand
 )
 
 func main() {
@@ -50,6 +51,7 @@ func main() {
 	pushGateway.Register(app, envVars)
 	remoteReadCommand.Register(app, envVars)
 	ruleCommand.Register(app, envVars, prometheus.DefaultRegisterer)
+	runtimeConfigCommand.Register(app, envVars)
 
 	app.Command("version", "Get the version of the mimirtool CLI").Action(func(*kingpin.ParseContext) error {
 		fmt.Fprintln(os.Stdout, mimirversion.Print("Mimirtool"))

--- a/cmd/mimirtool/main.go
+++ b/cmd/mimirtool/main.go
@@ -51,7 +51,7 @@ func main() {
 	pushGateway.Register(app, envVars)
 	remoteReadCommand.Register(app, envVars)
 	ruleCommand.Register(app, envVars, prometheus.DefaultRegisterer)
-	runtimeConfigCommand.Register(app, envVars)
+	runtimeConfigCommand.Register(app)
 
 	app.Command("version", "Get the version of the mimirtool CLI").Action(func(*kingpin.ParseContext) error {
 		fmt.Fprintln(os.Stdout, mimirversion.Print("Mimirtool"))

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -144,7 +144,7 @@ type Config struct {
 	TimeseriesUnmarshalCachingOptimizationEnabled bool `yaml:"timeseries_unmarshal_caching_optimization_enabled" category:"experimental"`
 }
 
-// RegisterFlags registers flag.
+// RegisterFlags registers flags.
 func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.ApplicationName = "Grafana Mimir"
 	c.Server.MetricsNamespace = "cortex"

--- a/pkg/mimir/runtime_config.go
+++ b/pkg/mimir/runtime_config.go
@@ -240,7 +240,7 @@ func NewRuntimeManager(cfg *Config, name string, reg prometheus.Registerer, logg
 		cfg.LimitsConfig.AlignQueriesWithStep = cfg.Frontend.QueryMiddleware.DeprecatedAlignQueriesWithStep
 	}
 
-	// make sure to set default limits before we start loading configuration into memory
+	// Make sure to set default limits before we start loading configuration into memory.
 	validation.SetDefaultLimitsForYAMLUnmarshalling(cfg.LimitsConfig)
 	ingester.SetDefaultInstanceLimitsForYAMLUnmarshalling(cfg.Ingester.DefaultLimits)
 	distributor.SetDefaultInstanceLimitsForYAMLUnmarshalling(cfg.Distributor.DefaultLimits)

--- a/pkg/mimir/runtime_config.go
+++ b/pkg/mimir/runtime_config.go
@@ -10,11 +10,14 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/runtimeconfig"
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/distributor"
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
 	"github.com/grafana/mimir/pkg/ingester"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -221,4 +224,25 @@ func runtimeConfigHandler(runtimeCfgManager *runtimeconfig.Manager, defaultLimit
 		}
 		util.WriteYAMLResponse(w, output)
 	}
+}
+
+// NewRuntimeManager returns a runtimeconfig.Manager, a services.Service that must be explicitly started to perform any work.
+// cfg is initialized as necessary, before being passed to runtimeconfig.New.
+func NewRuntimeManager(cfg *Config, name string, reg prometheus.Registerer, logger log.Logger) (*runtimeconfig.Manager, error) {
+	loader := runtimeConfigLoader{validate: cfg.ValidateLimits}
+	cfg.RuntimeConfig.Loader = loader.load
+
+	// DeprecatedAlignQueriesWithStep is moving from a global config that can in the frontend yaml to a limit config
+	// We need to preserve the option in the frontend yaml for two releases
+	// If the frontend config is configured by the user, the default limit is overwritten
+	// TODO: Remove in Mimir 2.14
+	if cfg.Frontend.QueryMiddleware.DeprecatedAlignQueriesWithStep != querymiddleware.DefaultDeprecatedAlignQueriesWithStep {
+		cfg.LimitsConfig.AlignQueriesWithStep = cfg.Frontend.QueryMiddleware.DeprecatedAlignQueriesWithStep
+	}
+
+	// make sure to set default limits before we start loading configuration into memory
+	validation.SetDefaultLimitsForYAMLUnmarshalling(cfg.LimitsConfig)
+	ingester.SetDefaultInstanceLimitsForYAMLUnmarshalling(cfg.Ingester.DefaultLimits)
+	distributor.SetDefaultInstanceLimitsForYAMLUnmarshalling(cfg.Distributor.DefaultLimits)
+	return runtimeconfig.New(cfg.RuntimeConfig, name, reg, logger)
 }

--- a/pkg/mimirtool/commands/config.go
+++ b/pkg/mimirtool/commands/config.go
@@ -35,7 +35,7 @@ type ConfigCommand struct {
 	gem bool
 }
 
-// Register rule related commands and flags with the kingpin application
+// Register config related commands and flags with the kingpin application.
 func (c *ConfigCommand) Register(app *kingpin.Application, _ EnvVarNames) {
 	configCmd := app.Command("config", "Work with Grafana Mimir configuration.")
 

--- a/pkg/mimirtool/commands/runtimeconfig.go
+++ b/pkg/mimirtool/commands/runtimeconfig.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package commands
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/runtimeconfig"
+
+	"github.com/grafana/mimir/pkg/mimir"
+)
+
+// RuntimeConfigCommand works with Mimir's runtime config.
+type RuntimeConfigCommand struct {
+	configFile string
+}
+
+// Register runtime config related commands and flags with the kingpin application.
+func (c *RuntimeConfigCommand) Register(app *kingpin.Application, _ EnvVarNames) {
+	cmd := app.Command("runtime-config", "Work with Grafana Mimir runtime configuration.")
+	validateCmd := cmd.Command("validate", "Validate a runtime configuration file").Action(c.validateConfig)
+
+	validateCmd.Flag("config-file", "The runtime configuration file to validate.").StringVar(&c.configFile)
+}
+
+func (c *RuntimeConfigCommand) validateConfig(*kingpin.ParseContext) error {
+	if c.configFile == "" {
+		return fmt.Errorf("--config-file cannot be empty")
+	}
+
+	mimirCfg := mimir.Config{
+		RuntimeConfig: runtimeconfig.Config{
+			LoadPath: flagext.StringSliceCSV{c.configFile},
+		},
+	}
+	mimirCfg.RegisterFlags(flag.NewFlagSet("", flag.PanicOnError), log.NewNopLogger())
+	if err := mimirCfg.Validate(log.NewNopLogger()); err != nil {
+		return err
+	}
+
+	serv, err := mimir.NewRuntimeManager(&mimirCfg, "mimirtool-runtime-config", nil, log.NewNopLogger())
+	if err != nil {
+		return fmt.Errorf("create runtime config service: %w", err)
+	}
+	ctx := context.Background()
+	if err := serv.StartAsync(ctx); err != nil {
+		return fmt.Errorf("start runtime config service: %w", err)
+	}
+	if err := serv.AwaitRunning(ctx); err != nil {
+		return fmt.Errorf("wait on runtime config service: %w", err)
+	}
+	serv.StopAsync()
+	if err := serv.AwaitTerminated(ctx); err != nil {
+		return fmt.Errorf("wait on runtime config service termination: %w", err)
+	}
+	return nil
+}

--- a/pkg/mimirtool/commands/runtimeconfig.go
+++ b/pkg/mimirtool/commands/runtimeconfig.go
@@ -21,10 +21,10 @@ type RuntimeConfigCommand struct {
 }
 
 // Register runtime config related commands and flags with the kingpin application.
-func (c *RuntimeConfigCommand) Register(app *kingpin.Application, _ EnvVarNames) {
+func (c *RuntimeConfigCommand) Register(app *kingpin.Application) {
 	cmd := app.Command("runtime-config", "Work with Grafana Mimir runtime configuration.")
-	validateCmd := cmd.Command("validate", "Validate a runtime configuration file").Action(c.validate)
 
+	validateCmd := cmd.Command("validate", "Validate a runtime configuration file").Action(c.validate)
 	validateCmd.Flag("config-file", "The runtime configuration file to validate.").StringVar(&c.configFile)
 }
 

--- a/pkg/mimirtool/commands/runtimeconfig.go
+++ b/pkg/mimirtool/commands/runtimeconfig.go
@@ -23,12 +23,12 @@ type RuntimeConfigCommand struct {
 // Register runtime config related commands and flags with the kingpin application.
 func (c *RuntimeConfigCommand) Register(app *kingpin.Application, _ EnvVarNames) {
 	cmd := app.Command("runtime-config", "Work with Grafana Mimir runtime configuration.")
-	validateCmd := cmd.Command("validate", "Validate a runtime configuration file").Action(c.validateConfig)
+	validateCmd := cmd.Command("validate", "Validate a runtime configuration file").Action(c.validate)
 
 	validateCmd.Flag("config-file", "The runtime configuration file to validate.").StringVar(&c.configFile)
 }
 
-func (c *RuntimeConfigCommand) validateConfig(*kingpin.ParseContext) error {
+func (c *RuntimeConfigCommand) validate(*kingpin.ParseContext) error {
 	if c.configFile == "" {
 		return fmt.Errorf("--config-file cannot be empty")
 	}

--- a/pkg/mimirtool/commands/runtimeconfig_test.go
+++ b/pkg/mimirtool/commands/runtimeconfig_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package commands
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test runtime-config validate sub-command.
+func TestRuntimeConfigValidate(t *testing.T) {
+	t.Run("missing runtime config", func(t *testing.T) {
+		c := RuntimeConfigCommand{}
+		require.EqualError(t, c.validate(nil), "--config-file cannot be empty")
+	})
+
+	t.Run("valid runtime config", func(t *testing.T) {
+		c := RuntimeConfigCommand{
+			configFile: filepath.Join("testdata", "runtimeconfig", "valid.yaml"),
+		}
+		require.NoError(t, c.validate(nil))
+	})
+
+	t.Run("invalid runtime config", func(t *testing.T) {
+		c := RuntimeConfigCommand{
+			configFile: filepath.Join("testdata", "runtimeconfig", "invalid.yaml"),
+		}
+		require.ErrorContains(t, c.validate(nil), "failed to load runtime config")
+	})
+}

--- a/pkg/mimirtool/commands/runtimeconfig_test.go
+++ b/pkg/mimirtool/commands/runtimeconfig_test.go
@@ -27,6 +27,8 @@ func TestRuntimeConfigValidate(t *testing.T) {
 		c := RuntimeConfigCommand{
 			configFile: filepath.Join("testdata", "runtimeconfig", "invalid.yaml"),
 		}
-		require.ErrorContains(t, c.validate(nil), "failed to load runtime config")
+		err := c.validate(nil)
+		require.ErrorContains(t, err, "failed to load runtime config")
+		require.ErrorContains(t, err, "field unknown_field not found in type")
 	})
 }

--- a/pkg/mimirtool/commands/testdata/runtimeconfig/invalid.yaml
+++ b/pkg/mimirtool/commands/testdata/runtimeconfig/invalid.yaml
@@ -1,0 +1,29 @@
+distributor_limits:
+    max_inflight_push_requests: 2000
+    max_inflight_push_requests_bytes: 1.431655765e+09
+ingester_limits:
+    max_inflight_push_requests: 30000
+    max_inflight_push_requests_bytes: 5.36870912e+08
+    max_ingestion_rate: 300000
+    max_series: 3e+06
+    max_tenants: 500
+overrides:
+    "007":
+        active_series_custom_trackers:
+            section: '{section="00"}'
+        unknown_field: test,
+        compactor_split_and_merge_shards: 2
+        compactor_split_groups: 2
+        compactor_tenant_shard_size: 2
+        ingestion_burst_size: 2.25e+07
+        ingestion_rate: 2.25e+06
+        ingestion_tenant_shard_size: 336
+        max_global_metadata_per_metric: 10
+        max_global_metadata_per_user: 2.56e+06
+        max_global_series_per_user: 1.2e+07
+        max_queriers_per_tenant: 120
+        query_sharding_total_shards: 8
+        ruler_max_rule_groups_per_tenant: 300
+        ruler_max_rules_per_rule_group: 50
+        ruler_tenant_shard_size: 8
+        store_gateway_tenant_shard_size: 24

--- a/pkg/mimirtool/commands/testdata/runtimeconfig/invalid.yaml
+++ b/pkg/mimirtool/commands/testdata/runtimeconfig/invalid.yaml
@@ -1,29 +1,4 @@
-distributor_limits:
-    max_inflight_push_requests: 2000
-    max_inflight_push_requests_bytes: 1.431655765e+09
-ingester_limits:
-    max_inflight_push_requests: 30000
-    max_inflight_push_requests_bytes: 5.36870912e+08
-    max_ingestion_rate: 300000
-    max_series: 3e+06
-    max_tenants: 500
 overrides:
     "007":
-        active_series_custom_trackers:
-            section: '{section="00"}'
         unknown_field: test,
         compactor_split_and_merge_shards: 2
-        compactor_split_groups: 2
-        compactor_tenant_shard_size: 2
-        ingestion_burst_size: 2.25e+07
-        ingestion_rate: 2.25e+06
-        ingestion_tenant_shard_size: 336
-        max_global_metadata_per_metric: 10
-        max_global_metadata_per_user: 2.56e+06
-        max_global_series_per_user: 1.2e+07
-        max_queriers_per_tenant: 120
-        query_sharding_total_shards: 8
-        ruler_max_rule_groups_per_tenant: 300
-        ruler_max_rules_per_rule_group: 50
-        ruler_tenant_shard_size: 8
-        store_gateway_tenant_shard_size: 24

--- a/pkg/mimirtool/commands/testdata/runtimeconfig/valid.yaml
+++ b/pkg/mimirtool/commands/testdata/runtimeconfig/valid.yaml
@@ -1,0 +1,28 @@
+distributor_limits:
+    max_inflight_push_requests: 2000
+    max_inflight_push_requests_bytes: 1.431655765e+09
+ingester_limits:
+    max_inflight_push_requests: 30000
+    max_inflight_push_requests_bytes: 5.36870912e+08
+    max_ingestion_rate: 300000
+    max_series: 3e+06
+    max_tenants: 500
+overrides:
+    "007":
+        active_series_custom_trackers:
+            section: '{section="00"}'
+        compactor_split_and_merge_shards: 2
+        compactor_split_groups: 2
+        compactor_tenant_shard_size: 2
+        ingestion_burst_size: 2.25e+07
+        ingestion_rate: 2.25e+06
+        ingestion_tenant_shard_size: 336
+        max_global_metadata_per_metric: 10
+        max_global_metadata_per_user: 2.56e+06
+        max_global_series_per_user: 1.2e+07
+        max_queriers_per_tenant: 120
+        query_sharding_total_shards: 8
+        ruler_max_rule_groups_per_tenant: 300
+        ruler_max_rules_per_rule_group: 50
+        ruler_tenant_shard_size: 8
+        store_gateway_tenant_shard_size: 24


### PR DESCRIPTION
#### What this PR does

Add a `runtime-config verify` sub-command to `mimirtool`.

To facilitate said sub-command, and also Grafana Enterprise Metrics, refactor logic for creating a `github.com/grafana/dskit/runtimeconfig.Manager` into a new function `NewRuntimeManager`. This manager is used for validating runtime config.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
