### PR TITLE
Query scheduler: Fix a panic in stats marshaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * [BUGFIX] Query-frontend: fix empty metric name matcher not being applied under certain conditions. #8076
 * [BUGFIX] Querying: Fix regex matching of multibyte runes with dot operator. #8089
 * [BUGFIX] Querying: matrix results returned from instant queries were not sorted by series. #8113
+* [BUGFIX] Query scheduler: Fix a crash in result marshaling. #8140
 
 ### Mixin
 

--- a/pkg/querier/stats/stats.go
+++ b/pkg/querier/stats/stats.go
@@ -210,17 +210,9 @@ func (s *Stats) Copy() *Stats {
 	if s == nil {
 		return nil
 	}
-	return &Stats{
-		WallTime:             s.LoadWallTime(),
-		FetchedSeriesCount:   s.LoadFetchedSeries(),
-		FetchedChunkBytes:    s.LoadFetchedChunkBytes(),
-		FetchedChunksCount:   s.LoadFetchedChunks(),
-		ShardedQueries:       s.LoadShardedQueries(),
-		SplitQueries:         s.LoadSplitQueries(),
-		FetchedIndexBytes:    s.LoadFetchedIndexBytes(),
-		EstimatedSeriesCount: s.LoadEstimatedSeriesCount(),
-		QueueTime:            s.LoadQueueTime(),
-	}
+	c := &Stats{}
+	c.Merge(s)
+	return c
 }
 
 func ShouldTrackHTTPGRPCResponse(r *httpgrpc.HTTPResponse) bool {

--- a/pkg/querier/stats/stats.go
+++ b/pkg/querier/stats/stats.go
@@ -204,6 +204,25 @@ func (s *Stats) Merge(other *Stats) {
 	s.AddQueueTime(other.LoadQueueTime())
 }
 
+// Copy returns a copy of the stats. Use this rather than regular struct assignment
+// to make sure atomic modifications are observed.
+func (s *Stats) Copy() *Stats {
+	if s == nil {
+		return nil
+	}
+	return &Stats{
+		WallTime:             s.LoadWallTime(),
+		FetchedSeriesCount:   s.LoadFetchedSeries(),
+		FetchedChunkBytes:    s.LoadFetchedChunkBytes(),
+		FetchedChunksCount:   s.LoadFetchedChunks(),
+		ShardedQueries:       s.LoadShardedQueries(),
+		SplitQueries:         s.LoadSplitQueries(),
+		FetchedIndexBytes:    s.LoadFetchedIndexBytes(),
+		EstimatedSeriesCount: s.LoadEstimatedSeriesCount(),
+		QueueTime:            s.LoadQueueTime(),
+	}
+}
+
 func ShouldTrackHTTPGRPCResponse(r *httpgrpc.HTTPResponse) bool {
 	// Do no track statistics for requests failed because of a server error.
 	return r.Code < 500

--- a/pkg/querier/stats/stats_test.go
+++ b/pkg/querier/stats/stats_test.go
@@ -178,3 +178,21 @@ func TestStats_Merge(t *testing.T) {
 		assert.Equal(t, time.Duration(0), stats1.LoadQueueTime())
 	})
 }
+
+func TestStats_Copy(t *testing.T) {
+	s := &Stats{
+		WallTime:             1,
+		FetchedSeriesCount:   2,
+		FetchedChunkBytes:    3,
+		FetchedChunksCount:   4,
+		ShardedQueries:       5,
+		SplitQueries:         6,
+		FetchedIndexBytes:    7,
+		EstimatedSeriesCount: 8,
+		QueueTime:            9,
+	}
+	s2 := s.Copy()
+	assert.EqualValues(t, s, s2)
+
+	assert.Nil(t, (*Stats)(nil).Copy())
+}

--- a/pkg/querier/stats/stats_test.go
+++ b/pkg/querier/stats/stats_test.go
@@ -180,7 +180,7 @@ func TestStats_Merge(t *testing.T) {
 }
 
 func TestStats_Copy(t *testing.T) {
-	s := &Stats{
+	s1 := &Stats{
 		WallTime:             1,
 		FetchedSeriesCount:   2,
 		FetchedChunkBytes:    3,
@@ -191,8 +191,9 @@ func TestStats_Copy(t *testing.T) {
 		EstimatedSeriesCount: 8,
 		QueueTime:            9,
 	}
-	s2 := s.Copy()
-	assert.EqualValues(t, s, s2)
+	s2 := s1.Copy()
+	assert.NotSame(t, s1, s2)
+	assert.EqualValues(t, s1, s2)
 
 	assert.Nil(t, (*Stats)(nil).Copy())
 }

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -305,6 +305,10 @@ func (sp *schedulerProcessor) runRequest(ctx context.Context, logger log.Logger,
 	response.Headers, hasStreamHeader = removeStreamingHeader(response.Headers)
 	shouldStream := hasStreamHeader && sp.streamingEnabled && len(response.Body) > responseStreamingBodyChunkSizeBytes
 
+	// Protect against not-yet-exited querier handler goroutines that could
+	// still be incrementing stats when sent for marshaling below.
+	stats = stats.Copy()
+
 	for bof.Ongoing() {
 		c, err = sp.frontendPool.GetClientFor(frontendAddress)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Fixes a panic in Querier services caused by request-processing goroutines that are still running for a short time after their contexts are canceled and are continuing to modify query stats while querier's scheduler attempts to marshal them.

Like so:

1. scheduler processor [invokes](https://github.com/grafana/mimir/blob/97ac27a2a04169bc528fabc6bf3d2431fa97c208/pkg/querier/worker/scheduler_processor.go#L272) the querier handler.
2. the querier handler (way down the call tree) forks off goroutines to do things. Those goroutines increment query stats. (like [here](https://github.com/grafana/mimir/blob/b896aeddd0d74c9d46d90b12ccd8e9f80a4076a9/pkg/querier/blocks_store_queryable.go#L881-L883))
3. the handler context is canceled for whatever reason. (connection to frontend dies, timeout, ...)
4. scheduler processor [invokes](https://github.com/grafana/mimir/blob/97ac27a2a04169bc528fabc6bf3d2431fa97c208/pkg/querier/worker/scheduler_processor.go#L318) QueryResult containing the error, response, and the same stats object those goroutines ^^ are still incrementing because they don't yet know the context has died. So the varint repr of the stats being marshaled are changing/growing during marshaling of the QueryResultRequest and the panic happens.


#### Which issue(s) this PR fixes or relates to

Fixes #7895 

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
