### PR TITLE
feat: add save to directory option for mimirtool rules get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
 * [ENHANCEMENT] Add `mimir-http-prefix` configuration to set the Mimir URL prefix when using legacy routes. #8069
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
-* [ENHANCEMENT] Add option `--output-dir` to `mimirtool rules get` to allow persisting rule to a file for edit and re-upload. #7247
+* [ENHANCEMENT] Add option `--output-dir` to `mimirtool rules get` and `mimirtool rules print` to allow persisting rule groups(s) to a file for edit and re-upload. #7247
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 * [BUGFIX] Analyze Grafana: fix parsing queries with variables. #8062
 * [BUGFIX] `mimirtool rules sync`: detect a change when the `query_offset` or the deprecated `evaluation_delay` configuration changes. #8297

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -384,6 +384,7 @@
 * [ENHANCEMENT] Add `--extra-headers` option to `mimirtool rules` command to add extra headers to requests for auth. #7141
 * [ENHANCEMENT] Analyze Prometheus: set tenant header. #6737
 * [ENHANCEMENT] Add argument `--output-dir` to `mimirtool alertmanager get` where the config and templates will be written to and can be loaded via `mimirtool alertmanager load` #6760
+* [ENHANCEMENT] Add flag `--output-dir` and `--save-file` to `mimirtool rules get` to allow persisting rule to a file for edit and re-upload. #7247
 * [BUGFIX] Analyze rule-file: .metricsUsed field wasn't populated. #6953
 
 ### Mimir Continuous Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
 * [ENHANCEMENT] Add `mimir-http-prefix` configuration to set the Mimir URL prefix when using legacy routes. #8069
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
+* [ENHANCEMENT] Add flag `--output-dir` and `--save-file` to `mimirtool rules get` to allow persisting rule to a file for edit and re-upload. #7247
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 * [BUGFIX] Analyze Grafana: fix parsing queries with variables. #8062
 * [BUGFIX] `mimirtool rules sync`: detect a change when the `query_offset` or the deprecated `evaluation_delay` configuration changes. #8297
@@ -384,7 +385,6 @@
 * [ENHANCEMENT] Add `--extra-headers` option to `mimirtool rules` command to add extra headers to requests for auth. #7141
 * [ENHANCEMENT] Analyze Prometheus: set tenant header. #6737
 * [ENHANCEMENT] Add argument `--output-dir` to `mimirtool alertmanager get` where the config and templates will be written to and can be loaded via `mimirtool alertmanager load` #6760
-* [ENHANCEMENT] Add flag `--output-dir` and `--save-file` to `mimirtool rules get` to allow persisting rule to a file for edit and re-upload. #7247
 * [BUGFIX] Analyze rule-file: .metricsUsed field wasn't populated. #6953
 
 ### Mimir Continuous Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
 * [ENHANCEMENT] Add `mimir-http-prefix` configuration to set the Mimir URL prefix when using legacy routes. #8069
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
-* [ENHANCEMENT] Add option `--output-dir` to `mimirtool rules get` and `mimirtool rules print` to allow persisting rule groups(s) to a file for edit and re-upload. #7247
+* [ENHANCEMENT] Add option `--output-dir` to `mimirtool rules get` and `mimirtool rules print` to allow persisting rule groups to a file for edit and re-upload. #7247
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 * [BUGFIX] Analyze Grafana: fix parsing queries with variables. #8062
 * [BUGFIX] `mimirtool rules sync`: detect a change when the `query_offset` or the deprecated `evaluation_delay` configuration changes. #8297

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
 * [ENHANCEMENT] Add `mimir-http-prefix` configuration to set the Mimir URL prefix when using legacy routes. #8069
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
-* [ENHANCEMENT] Add flag `--output-dir` and `--save-file` to `mimirtool rules get` to allow persisting rule to a file for edit and re-upload. #7247
+* [ENHANCEMENT] Add flag `--output-dir` to `mimirtool rules get` to allow persisting rule to a file for edit and re-upload. #7247
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 * [BUGFIX] Analyze Grafana: fix parsing queries with variables. #8062
 * [BUGFIX] `mimirtool rules sync`: detect a change when the `query_offset` or the deprecated `evaluation_delay` configuration changes. #8297

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
 * [ENHANCEMENT] Add `mimir-http-prefix` configuration to set the Mimir URL prefix when using legacy routes. #8069
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
-* [ENHANCEMENT] Add flag `--output-dir` to `mimirtool rules get` to allow persisting rule to a file for edit and re-upload. #7247
+* [ENHANCEMENT] Add option `--output-dir` to `mimirtool rules get` to allow persisting rule to a file for edit and re-upload. #7247
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 * [BUGFIX] Analyze Grafana: fix parsing queries with variables. #8062
 * [BUGFIX] `mimirtool rules sync`: detect a change when the `query_offset` or the deprecated `evaluation_delay` configuration changes. #8297

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -284,6 +284,14 @@ The following command retrieves a single rule group and prints it to the termina
 mimirtool rules get <namespace> <rule_group_name>
 ```
 
+To save the rule group for editing and re-upload to mimir, simply add the flag `--save-file` and
+to desired output location which is defaulted to the current directory. The output file has the
+format required by `mimirtool rules load`.
+
+```bash
+mimirtool rules get <namespace> <rule_group_name> --save-file --output-dir="rules"
+```
+
 #### Delete rule group
 
 The following command deletes a rule group.

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -276,14 +276,14 @@ The following command retrieves all rule groups in the Grafana Mimir instance an
 mimirtool rules print
 ```
 
-To save all the rules for editing and re-upload to Mimir, use the `--output-dir` flag.
+To save all the rules for editing and re-upload to Mimir, use the `--output-dir` option.
 The default output directory is the current directory.
 The output file has the format required by `mimirtool rules load` or `mimirtool rules sync`.
 
 For example, to save the file in the `rules` subdirectory:
 
 ```bash
-mimirtool rules print --output-dir="rules"
+mimirtool rules print --output-dir=rules
 ```
 
 #### Get rule group
@@ -294,14 +294,14 @@ The following command retrieves a single rule group and prints it to the termina
 mimirtool rules get <namespace> <rule_group_name>
 ```
 
-To save the rule group for editing and re-upload to Mimir, use the `--output-dir` flag.
+To save the rule group for editing and re-upload to Mimir, use the `--output-dir` option.
 The default output directory is the current directory.
 The output file has the format required by `mimirtool rules load` or `mimirtool rules sync`.
 
 For example, to save the file in the `rules` subdirectory:
 
 ```bash
-mimirtool rules get <namespace> <rule_group_name> --output-dir="rules"
+mimirtool rules get <namespace> <rule_group_name> --output-dir=rules
 ```
 
 #### Delete rule group

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -284,9 +284,11 @@ The following command retrieves a single rule group and prints it to the termina
 mimirtool rules get <namespace> <rule_group_name>
 ```
 
-To save the rule group for editing and re-upload to mimir, simply add the flag `--save-file` and
-to desired output location which is defaulted to the current directory. The output file has the
-format required by `mimirtool rules load`.
+To save the rule group for editing and re-upload to mimir , use the `--output-dir` flag.
+The default output directory is the current directory.
+The output file has the format required by `mimirtool rules load`.
+
+For example, to save the file in the `rules` subdirectory:
 
 ```bash
 mimirtool rules get <namespace> <rule_group_name> --output-dir="rules"

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -276,6 +276,16 @@ The following command retrieves all rule groups in the Grafana Mimir instance an
 mimirtool rules print
 ```
 
+To save all the rules for editing and re-upload to Mimir, use the `--output-dir` flag.
+The default output directory is the current directory.
+The output file has the format required by `mimirtool rules load` or `mimirtool rules sync`.
+
+For example, to save the file in the `rules` subdirectory:
+
+```bash
+mimirtool rules print --output-dir="rules"
+```
+
 #### Get rule group
 
 The following command retrieves a single rule group and prints it to the terminal.
@@ -284,9 +294,9 @@ The following command retrieves a single rule group and prints it to the termina
 mimirtool rules get <namespace> <rule_group_name>
 ```
 
-To save the rule group for editing and re-upload to mimir , use the `--output-dir` flag.
+To save the rule group for editing and re-upload to Mimir, use the `--output-dir` flag.
 The default output directory is the current directory.
-The output file has the format required by `mimirtool rules load`.
+The output file has the format required by `mimirtool rules load` or `mimirtool rules sync`.
 
 For example, to save the file in the `rules` subdirectory:
 

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -289,7 +289,7 @@ to desired output location which is defaulted to the current directory. The outp
 format required by `mimirtool rules load`.
 
 ```bash
-mimirtool rules get <namespace> <rule_group_name> --save-file --output-dir="rules"
+mimirtool rules get <namespace> <rule_group_name> --output-dir="rules"
 ```
 
 #### Delete rule group

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -35,7 +35,7 @@ const (
 	// maxSyncConcurrency is the upper bound limit on the concurrency value that can be set.
 	maxSyncConcurrency = 32
 
-	// disallowedNamespaceChars is a regex pattern that matches characters that are not allowed in namespaces.
+	// disallowedNamespaceChars is a regex pattern that matches characters that are not allowed in namespaces. They are characters not allow in Linux and Windows file names.
 	disallowedNamespaceChars = `[<>:"/\\|?*\x00-\x1F]`
 )
 

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -72,8 +72,6 @@ type RuleCommand struct {
 	// Get Rule Groups Configs
 	Namespace string
 	RuleGroup string
-	// Used for both Get and Print
-	SaveFile  bool
 	OutputDir string
 
 	// Load Rules Config
@@ -212,8 +210,7 @@ func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames, re
 	getRuleGroupCmd.Arg("namespace", "Namespace of the rulegroup to retrieve.").Required().StringVar(&r.Namespace)
 	getRuleGroupCmd.Arg("group", "Name of the rulegroup to retrieve.").Required().StringVar(&r.RuleGroup)
 	getRuleGroupCmd.Flag("disable-color", "disable colored output").BoolVar(&r.DisableColor)
-	getRuleGroupCmd.Flag("save-file", "save file to directory").Default("false").BoolVar(&r.SaveFile)
-	getRuleGroupCmd.Flag("output-dir", "The directory where the rules will be written to.").Default(".").ExistingDirVar(&r.OutputDir)
+	getRuleGroupCmd.Flag("output-dir", "The directory where the rules will be written to.").ExistingDirVar(&r.OutputDir)
 
 	// Delete RuleGroup Command
 	deleteRuleGroupCmd.Arg("namespace", "Namespace of the rulegroup to delete.").Required().StringVar(&r.Namespace)
@@ -448,7 +445,7 @@ func (r *RuleCommand) getRuleGroup(_ *kingpin.ParseContext) error {
 		log.Fatalf("Unable to read rules from Grafana Mimir, %v", err)
 	}
 
-	if r.SaveFile {
+	if r.OutputDir != "" {
 		log.Debugf("Writing to file %s.yaml", r.Namespace)
 		err := saveNamespaceRuleGroup(r.Namespace, []rwrulefmt.RuleGroup{*group}, r.OutputDir)
 		if err != nil {

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -34,14 +34,13 @@ const (
 
 	// maxSyncConcurrency is the upper bound limit on the concurrency value that can be set.
 	maxSyncConcurrency = 32
-
-	// disallowedNamespaceChars is a regex pattern that matches characters that are not allowed in namespaces. They are characters not allow in Linux and Windows file names.
-	disallowedNamespaceChars = `[<>:"/\\|?*\x00-\x1F]`
 )
 
 var (
 	backends = []string{rules.MimirBackend}      // list of supported backend types
 	formats  = []string{"json", "yaml", "table"} // list of supported formats for the list command
+	// disallowedNamespaceChars is a regex pattern that matches characters that are not allowed in namespaces. They are characters not allow in Linux and Windows file names.
+	disallowedNamespaceChars = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1F]`)
 )
 
 // ruleCommandClient defines the interface that should be implemented by the API client used by
@@ -440,9 +439,9 @@ func saveNamespaceRuleGroup(ns string, ruleGroup []rwrulefmt.RuleGroup, dir stri
 		return err
 	}
 
-	if regexp.MustCompile(disallowedNamespaceChars).Match([]byte(ns)) {
+	if disallowedNamespaceChars.Match([]byte(ns)) {
 		oldNs := ns
-		ns = strings.TrimSpace(regexp.MustCompile(disallowedNamespaceChars).ReplaceAllString(ns, "_"))
+		ns = strings.TrimSpace(disallowedNamespaceChars.ReplaceAllString(ns, "_"))
 		log.Warnf("We found disallowed characters in the namespace name '%s', replacing them with underscores '%s'", oldNs, ns)
 	}
 

--- a/pkg/mimirtool/commands/rules_test.go
+++ b/pkg/mimirtool/commands/rules_test.go
@@ -212,6 +212,71 @@ func TestRuleCommand_checkRules(t *testing.T) {
 	}
 }
 
+func TestRuleSaveToFile_NamespaceRuleGroup(t *testing.T) {
+	t.Run("Fail save because marshal need node Kind defined", func(t *testing.T) {
+		namespace := "ns1"
+		rule1 := []rwrulefmt.RuleGroup{{
+			RuleGroup: rulefmt.RuleGroup{
+				Name: "group-1",
+				Rules: []rulefmt.RuleNode{
+					{
+						Record: yaml.Node{Value: "up"},
+						Expr:   yaml.Node{Value: "up==1"},
+					},
+				},
+			},
+		}}
+		tempDir := t.TempDir()
+		err := saveNamespaceRuleGroup(namespace, rule1, tempDir)
+		assert.ErrorContains(t, err, "yaml: cannot encode node with unknown kind")
+	})
+	t.Run("Successful save", func(t *testing.T) {
+		namespace := "ns1"
+		rule1 := []rwrulefmt.RuleGroup{{
+			RuleGroup: rulefmt.RuleGroup{
+				Name: "group-1",
+				Rules: []rulefmt.RuleNode{
+					{
+						Record: yaml.Node{Value: "up", Kind: yaml.ScalarNode},
+						Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+					},
+				},
+			},
+		}}
+		tempDir := t.TempDir()
+		err := saveNamespaceRuleGroup(namespace, rule1, tempDir)
+		assert.NoError(t, err)
+	})
+	t.Run("Successful save and load", func(t *testing.T) {
+		expected := `namespace: ns1
+groups:
+    - name: group-1
+      rules:
+        - alert: up
+          expr: up==1
+`
+		namespace := "ns1"
+		rule1 := []rwrulefmt.RuleGroup{{
+			RuleGroup: rulefmt.RuleGroup{
+				Name: "group-1",
+				Rules: []rulefmt.RuleNode{
+					{
+						Alert: yaml.Node{Value: "up", Kind: yaml.ScalarNode},
+						Expr:  yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+					},
+				},
+			},
+		}}
+		tempDir := t.TempDir()
+		err := saveNamespaceRuleGroup(namespace, rule1, tempDir)
+		assert.NoError(t, err)
+		savedFile := filepath.Join(tempDir, fmt.Sprintf("%s.yaml", namespace))
+		content, err := os.ReadFile(savedFile)
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(content))
+	})
+}
+
 type ruleCommandClientMock struct {
 	mock.Mock
 }

--- a/pkg/mimirtool/commands/rules_test.go
+++ b/pkg/mimirtool/commands/rules_test.go
@@ -247,6 +247,27 @@ func TestRuleSaveToFile_NamespaceRuleGroup(t *testing.T) {
 		err := saveNamespaceRuleGroup(namespace, rule1, tempDir)
 		assert.NoError(t, err)
 	})
+	t.Run("Successful save with a modified namespace", func(t *testing.T) {
+		namespace := "a/b/c"
+		rule1 := []rwrulefmt.RuleGroup{{
+			RuleGroup: rulefmt.RuleGroup{
+				Name: "group-1",
+				Rules: []rulefmt.RuleNode{
+					{
+						Record: yaml.Node{Value: "up", Kind: yaml.ScalarNode},
+						Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+					},
+				},
+			},
+		}}
+
+		tempDir := t.TempDir()
+		err := saveNamespaceRuleGroup(namespace, rule1, tempDir)
+		assert.NoError(t, err)
+
+		assert.NoFileExists(t, filepath.Join(tempDir, "a/b/c.yaml"))
+		assert.FileExists(t, filepath.Join(tempDir, "a_b_c.yaml"))
+	})
 	t.Run("Successful save and load", func(t *testing.T) {
 		expected := `namespace: ns1
 groups:


### PR DESCRIPTION
#### What this PR does

Adds the ability to save a rule to a file via `mimirtool rules get`. The command in the current state only prints the rule out to console and the format is not a valid rule file for `mimirtool rules load`. Adds two new flag `--save-file` and `--output-dir`, which may seem to be a bit of over engineering but the hope is that we build on from here and have a "save all rules" ability which allows an easy one-liner backup in the future.

#### Which issue(s) this PR fixes or relates to

Fixes #7054 

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


**NOTE**

This is a copy of #7247 - I had to do some git trickery make it work and the pull request ended up being butchered. I'll try and port over all the context.