### PR TITLE
mimirtool remote-read remote-write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 ### Mimirtool
 
 * [CHANGE] Deprecated `--rule-files` flag in favor of CLI arguments. #7756
+* [FEATURE] Added `mimirtool remote-read remote-write` that writes the remote-read samples to a remote-write endpont. #8159
 * [BUGFIX] Fix panic in `loadgen` subcommand. #7629
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -120,10 +120,10 @@ func (c *RemoteReadCommand) Register(app *kingpin.Application, envVars EnvVarNam
 	remoteWriteCmd.Flag("write.key", "Basic auth password to use when contacting Grafana Mimir.").
 		Default("").
 		StringVar(&c.write.apiKey)
-	remoteWriteCmd.Flag("write-timeout", "Timeout for write requests.").
+	remoteWriteCmd.Flag("write.timeout", "Timeout for write requests.").
 		Default("30s").
 		DurationVar(&c.write.timeout)
-	remoteWriteCmd.Flag("batch-size", "Number of timeseries to send in a single request.").
+	remoteWriteCmd.Flag("write.batch-size", "Number of timeseries to send in a single request.").
 		Default("1000").
 		IntVar(&c.write.batchSize)
 }


### PR DESCRIPTION
#### What this PR does

This adds a new sub-command to `mimirtool remote-read`, called `remote-write`, that writes the remote read samples to a remote-write endpoint. This is basically an inefficient backfill/copy operation.

It's not intended to be run on large data sets.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
