### PR TITLE
Alertmanager: Add alerting logger

### DIFF
--- a/pkg/alertmanager/log.go
+++ b/pkg/alertmanager/log.go
@@ -1,0 +1,54 @@
+package alertmanager
+
+import (
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	alertingLogging "github.com/grafana/alerting/logging"
+)
+
+// alertingLogger implements the alertingLogging.Logger interface.
+type alertingLogger struct {
+	kitLogger log.Logger
+}
+
+// newLoggerFactory returns a function that implements the alertingLogging.LoggerFactory interface.
+func newLoggerFactory(logger log.Logger) alertingLogging.LoggerFactory {
+	return func(loggerName string, ctx ...any) alertingLogging.Logger {
+		keyvals := append([]any{"logger", loggerName}, ctx...)
+		return &alertingLogger{kitLogger: log.With(logger, keyvals...)}
+	}
+}
+
+func (l *alertingLogger) New(ctx ...any) alertingLogging.Logger {
+	return &alertingLogger{log.With(l.kitLogger, ctx...)}
+}
+
+func (l *alertingLogger) Log(keyvals ...any) error {
+	return l.kitLogger.Log(keyvals...)
+}
+
+func (l *alertingLogger) Debug(msg string, ctx ...any) {
+	args := buildKeyvals(msg, ctx)
+	level.Debug(l.kitLogger).Log(args...)
+}
+
+func (l *alertingLogger) Info(msg string, ctx ...any) {
+	args := buildKeyvals(msg, ctx)
+	level.Info(l.kitLogger).Log(args...)
+}
+
+func (l *alertingLogger) Warn(msg string, ctx ...any) {
+	args := buildKeyvals(msg, ctx)
+	level.Warn(l.kitLogger).Log(args...)
+}
+
+func (l *alertingLogger) Error(msg string, ctx ...any) {
+	args := buildKeyvals(msg, ctx)
+	level.Error(l.kitLogger).Log(args...)
+}
+
+// buildKeyvals builds the keyvals for the log message.
+// It adds "msg" and the message string as the first two elements.
+func buildKeyvals(msg string, ctx []any) []any {
+	return append([]any{"msg", msg}, ctx...)
+}

--- a/pkg/alertmanager/log_test.go
+++ b/pkg/alertmanager/log_test.go
@@ -1,0 +1,48 @@
+package alertmanager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildKeyvals(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		ctx  []any
+		want []any
+	}{
+		{
+			name: "empty context slice",
+			msg:  "test message",
+			ctx:  []any{},
+			want: []any{"msg", "test message"},
+		},
+		{
+			name: "nil context slice",
+			msg:  "test message",
+			ctx:  nil,
+			want: []any{"msg", "test message"},
+		},
+		{
+			name: "context slice with one element",
+			msg:  "test message",
+			ctx:  []any{"key1"},
+			want: []any{"msg", "test message", "key1"},
+		},
+		{
+			name: "context slice with two elements",
+			msg:  "test message",
+			ctx:  []any{"key1", "value1"},
+			want: []any{"msg", "test message", "key1", "value1"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := buildKeyvals(test.msg, test.ctx)
+			require.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a struct that implements the [logging.Logger interface](https://github.com/grafana/alerting/blob/22ab1ef45ca3b0f8629157dbe5d7e73521718cb5/logging/log.go#L5-L22) described in the alerting package. This package will use the [logging.LoggerFactory](https://github.com/grafana/alerting/blob/22ab1ef45ca3b0f8629157dbe5d7e73521718cb5/logging/log.go#L3) function returned by `newLoggerFactory()` to create loggers for the Grafana notifiers.

Related PR: https://github.com/grafana/mimir/pull/8066

