### PR TITLE
Make the 'for' period configurable for for InconsistentRuntimeConfig …

### DIFF
--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -12,6 +12,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
   local groupStatefulSetByRolloutGroup(metricName) =
     'sum without(statefulset) (label_replace(%s, "rollout_group", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?"))' % metricName,
 
+  local customForPeriod = std.extVar('CUSTOM_FOR_PERIOD') || '1h',
+
   local alertGroups = [
     {
       name: 'mimir_alerts',
@@ -88,7 +90,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr: |||
             count(count by(%(alert_aggregation_labels)s, %(per_job_label)s, sha256) (cortex_runtime_config_hash)) without(sha256) > 1
           ||| % $._config,
-          'for': '1h',
+          'for': customForPeriod,
           labels: {
             severity: 'critical',
           },


### PR DESCRIPTION
#### What this PR does
Currently, the `for` period is hardcoded, which may not be suitable for all deployment scenarios. Making this value configurable allows for greater flexibility and can accommodate different deployment strategies.

#### Which issue(s) this PR fixes or relates to

Fixes #8172 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
