### PR TITLE
mimir microservices mode config for faster feedback loop

### DIFF
--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -5,9 +5,7 @@ distributor:
     health_check_ingesters: true
   ring:
     kvstore:
-      store: consul
-      consul:
-        host: consul:8500
+      store: memberlist
 
 ingester_client:
   grpc_client_config:
@@ -22,9 +20,7 @@ ingester:
     final_sleep: 0s
     num_tokens: 512
     kvstore:
-      store: consul
-      consul:
-        host: consul:8500
+      store: memberlist
 
 # These memberlist options will be only used if memberlist is activated via CLI option.
 memberlist:
@@ -37,9 +33,13 @@ blocks_storage:
 
   tsdb:
     dir: /tmp/mimir-tsdb-ingester
+    # Note: this value is intentionally set low to create a faster feedback loop
+    # in development. However, setting this lower than 2m can cause the ruler's
+    # write requests to fail with out of bounds errors
+    block_ranges_period: ["2m"]
+    # retention_period must be larger than block_ranges_period and query_store_after
+    retention_period: 15m
     ship_interval: 1m
-    block_ranges_period: [ 2h ]
-    retention_period: 3h
 
     # Always use the PostingsForMatchers() cache in order to exercise it.
     head_postings_for_matchers_cache_force: true
@@ -49,6 +49,11 @@ blocks_storage:
   bucket_store:
     sync_dir: /tmp/mimir-tsdb-querier
     sync_interval: 1m
+    # ignore_blocks_within and sync_interval must be small enough for the store-gateways
+    # to discover & load new blocks shipped from the ingesters before they begin to be queried.
+    # With querier.query_store_after: 10m and sync_interval: 1m, anything larger than 4m causes issues.
+    # Slightly larger values for may work if sync_interval is reduced.
+    ignore_blocks_within: 4m
 
     index_cache:
       # Cache is configured via CLI flags. See docker-compose.jsonnet
@@ -71,9 +76,7 @@ ruler:
     heartbeat_period:   5s
     heartbeat_timeout:  15s
     kvstore:
-      store: consul
-      consul:
-        host: consul:8500
+      store: memberlist
 
   alertmanager_url: http://alertmanager-1:8031/alertmanager,http://alertmanager-2:8032/alertmanager,http://alertmanager-3:8033/alertmanager
 
@@ -97,9 +100,7 @@ alertmanager:
     heartbeat_period: 5s
     heartbeat_timeout: 15s
     kvstore:
-      store: consul
-      consul:
-        host: consul:8500
+      store: memberlist
 
 alertmanager_storage:
   backend: s3
@@ -111,15 +112,15 @@ alertmanager_storage:
     insecure:          true
 
 compactor:
-  compaction_interval: 30s
-  data_dir:            /tmp/mimir-compactor
-  cleanup_interval:    1m
+  data_dir: "/tmp/cortex-compactor"
+  block_ranges: [ 4m, 8m, 16m ]
+  compaction_interval: 1m
+  compaction_concurrency: 2
+  cleanup_interval: 1m
   tenant_cleanup_delay: 1m
   sharding_ring:
     kvstore:
-      store: consul
-      consul:
-        host: consul:8500
+      store: memberlist
 
 store_gateway:
   sharding_ring:
@@ -128,9 +129,7 @@ store_gateway:
     heartbeat_timeout:  15s
     wait_stability_min_duration: 0
     kvstore:
-      store: consul
-      consul:
-        host: consul:8500
+      store: memberlist
 
 frontend:
   query_stats_enabled: true
@@ -156,6 +155,10 @@ frontend_worker:
   # Uncomment to skip query-scheduler and enqueue queries directly in the query-frontend.
   # frontend_address: "query-frontend:9007"
 
+querier:
+  # query_store_after must be smaller than blocks_storage.tsdb.retention_period
+  query_store_after: 10m
+
 query_scheduler:
   # Change to "dns" to switch to query-scheduler DNS-based service discovery.
   service_discovery_mode: "ring"
@@ -170,6 +173,7 @@ limits:
   ingestion_rate: 50000
   native_histograms_ingestion_enabled: true
   cardinality_analysis_enabled: true
+  query_ingesters_within: 20m
 
 runtime_config:
   file: ./config/runtime.yaml

--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -112,7 +112,7 @@ alertmanager_storage:
     insecure:          true
 
 compactor:
-  data_dir: "/tmp/cortex-compactor"
+  data_dir: "/tmp/mimir-compactor"
   block_ranges: [ 4m, 8m, 16m ]
   compaction_interval: 1m
   compaction_concurrency: 2

--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -37,7 +37,7 @@ blocks_storage:
     # in development. However, setting this lower than 2m can cause the ruler's
     # write requests to fail with out of bounds errors
     block_ranges_period: ["2m"]
-    # retention_period must be larger than block_ranges_period and query_store_after
+    # retention_period must be larger than block_ranges_period and querier.query_store_after
     retention_period: 15m
     ship_interval: 1m
 
@@ -52,7 +52,7 @@ blocks_storage:
     # ignore_blocks_within and sync_interval must be small enough for the store-gateways
     # to discover & load new blocks shipped from the ingesters before they begin to be queried.
     # With querier.query_store_after: 10m and sync_interval: 1m, anything larger than 4m causes issues.
-    # Slightly larger values for may work if sync_interval is reduced.
+    # Slightly larger values for ignore_blocks_within work if sync_interval is reduced.
     ignore_blocks_within: 4m
 
     index_cache:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Largely lifted from GEM.
This config allows several things to be tested much faster in a local dev environment when starting with a blank slate.

Also fixes old consul config that did not work because we don't use consul.

Tested several times in local environment to get working values.

Values are largely set based on ability to easily send queries that are only for ingesters or only for store-gateways, e.g. query_store_after set to 10m so there's buffer where sending queries for the last 5m won't touch the store-gateways.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
