### PR TITLE
ingest storage: record latency in replaying records

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -336,7 +336,9 @@ func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetche
 	})
 
 	for boff.Ongoing() {
+		consumeStart := time.Now()
 		err := r.consumer.consume(ctx, records)
+		r.metrics.consumeLatency.Observe(time.Since(consumeStart).Seconds())
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
#### What this PR does

I'm scoping work related to improving the replay speed in the new ingest storage. This PR adds some metrics which show where time is spent between processing batches and fetching them from kafka.
