### PR TITLE
store-gateway: persiste sparse index headers in object store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [ENHANCEMENT] Distributor: Introduce `-distributor.max-request-pool-buffer-size` to allow configuring the maximum size of the request pool buffers. #8082
 * [ENHANCEMENT] Store-gateway: improve performance when streaming chunks to queriers is enabled (`-querier.prefer-streaming-chunks-from-store-gateways=true`) and the query selects fewer than `-blocks-storage.bucket-store.batch-series-size` series (defaults to 5000 series). #8039
 * [ENHANCEMENT] Ingester: active series are now updated along with owned series. They decrease when series change ownership between ingesters. This helps provide a more accurate total of active series when ingesters are added. This is only enabled when `-ingester.track-ingester-owned-series` or `-ingester.use-ingester-owned-series-for-limits` are enabled. #8084
+* [ENHANCEMENT] Store-gateway: upload sparse index headers to object storage. This prevents latency spikes after adding store-gateway replicas. The store-gateway will now check object storage before creating a sparse index header. If the header is neither on disk, nor in object store, the store-gateway will both persist it to disk and upload it to object storage. #8182
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -84,7 +84,7 @@ type BucketStore struct {
 	userID          string
 	logger          log.Logger
 	metrics         *BucketStoreMetrics
-	bkt             objstore.InstrumentedBucketReader
+	bkt             objstore.InstrumentedBucket
 	fetcher         block.MetadataFetcher
 	dir             string
 	indexCache      indexcache.IndexCache
@@ -199,7 +199,7 @@ func WithLazyLoadingGate(lazyLoadingGate gate.Gate) BucketStoreOption {
 // an object store bucket. It is optimized to work against high latency backends.
 func NewBucketStore(
 	userID string,
-	bkt objstore.InstrumentedBucketReader,
+	bkt objstore.InstrumentedBucket,
 	fetcher block.MetadataFetcher,
 	dir string,
 	bucketStoreConfig tsdb.BucketStoreConfig,

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -36,7 +36,7 @@ var implementations = []struct {
 	{
 		name: "stream binary reader",
 		factory: func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader {
-			br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, dir, id, 32, NewStreamBinaryReaderMetrics(nil), Config{})
+			br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), objstore.NewInMemBucket(), dir, id, 32, NewStreamBinaryReaderMetrics(nil), Config{})
 			require.NoError(t, err)
 			requireCleanup(t, br.Close)
 			return br
@@ -46,7 +46,7 @@ var implementations = []struct {
 		name: "lazy stream binary reader",
 		factory: func(t *testing.T, ctx context.Context, dir string, id ulid.ULID) Reader {
 			readerFactory := func() (Reader, error) {
-				return NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, dir, id, 32, NewStreamBinaryReaderMetrics(nil), Config{})
+				return NewStreamBinaryReader(ctx, log.NewNopLogger(), objstore.NewInMemBucket(), dir, id, 32, NewStreamBinaryReaderMetrics(nil), Config{})
 			}
 
 			br, err := NewLazyBinaryReader(ctx, readerFactory, log.NewNopLogger(), nil, dir, id, NewLazyBinaryReaderMetrics(nil), nil, gate.NewNoop())

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -269,7 +269,7 @@ func initBucketAndBlocksForTest(t *testing.T) (string, *filesystem.Bucket, ulid.
 	return tmpDir, bkt, blockID
 }
 
-func testLazyBinaryReader(t *testing.T, bkt objstore.BucketReader, dir string, id ulid.ULID, test func(t *testing.T, r *LazyBinaryReader, err error)) {
+func testLazyBinaryReader(t *testing.T, bkt objstore.Bucket, dir string, id ulid.ULID, test func(t *testing.T, r *LazyBinaryReader, err error)) {
 	ctx := context.Background()
 	logger := log.NewNopLogger()
 	factory := func() (Reader, error) {

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -202,7 +202,7 @@ func loadLazyLoadedHeadersSnapshot(fileName string) (*lazyLoadedHeadersSnapshot,
 // NewBinaryReader creates and returns a new binary reader. If the pool has been configured
 // with lazy reader enabled, this function will return a lazy reader. The returned lazy reader
 // is tracked by the pool and automatically closed once the idle timeout expires.
-func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, cfg Config, initialSync bool) (Reader, error) {
+func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.Bucket, dir string, id ulid.ULID, postingOffsetsInMemSampling int, cfg Config, initialSync bool) (Reader, error) {
 	var readerFactory func() (Reader, error)
 	var reader Reader
 	var err error

--- a/pkg/storegateway/indexheader/stream_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	streamindex "github.com/grafana/mimir/pkg/storegateway/indexheader/index"
-	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 // TestStreamBinaryReader_ShouldBuildSparseHeadersFromFileSimple tests if StreamBinaryReader constructs
@@ -46,11 +45,10 @@ func TestStreamBinaryReader_ShouldBuildSparseHeadersFromFileSimple(t *testing.T)
 
 	// Read sparse index headers to disk on second build.
 	sparseHeadersPath := filepath.Join(tmpDir, blockID.String(), block.SparseIndexHeaderFilename)
-	sparseData, err := os.ReadFile(sparseHeadersPath)
+	header, err := sparseHeaderLoader{sparseHeadersPath: sparseHeadersPath, logger: log.NewNopLogger()}.sparseHeader()
 	require.NoError(t, err)
 
-	logger := spanlogger.FromContext(context.Background(), log.NewNopLogger())
-	err = r.loadFromSparseIndexHeader(logger, blockID, sparseHeadersPath, sparseData, 3)
+	err = r.loadFromSparseIndexHeader(header, 3)
 	require.NoError(t, err)
 }
 

--- a/pkg/storegateway/indexheader/stream_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader_test.go
@@ -6,18 +6,23 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	promtestutil "github.com/prometheus/prometheus/util/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore/providers/filesystem"
 
+	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	streamindex "github.com/grafana/mimir/pkg/storegateway/indexheader/index"
+	"github.com/grafana/mimir/pkg/storegateway/indexheader/indexheaderpb"
 )
 
 // TestStreamBinaryReader_ShouldBuildSparseHeadersFromFileSimple tests if StreamBinaryReader constructs
@@ -45,11 +50,44 @@ func TestStreamBinaryReader_ShouldBuildSparseHeadersFromFileSimple(t *testing.T)
 
 	// Read sparse index headers to disk on second build.
 	sparseHeadersPath := filepath.Join(tmpDir, blockID.String(), block.SparseIndexHeaderFilename)
-	header, err := sparseHeaderLoader{sparseHeadersPath: sparseHeadersPath, logger: log.NewNopLogger()}.sparseHeader()
+	header, err := bucketAndDiskSparseHeaderLoader{localPath: sparseHeadersPath, logger: log.NewNopLogger()}.SparseHeader()
 	require.NoError(t, err)
 
 	err = r.loadFromSparseIndexHeader(header, 3)
 	require.NoError(t, err)
+}
+
+func TestStreamBinaryReader_SparseHeaderWithPersistanceFailure(t *testing.T) {
+	level.Error(level.Info(log.NewLogfmtLogger(os.Stdout))).Log("msg", "test")
+	ctx := context.Background()
+
+	tmpDir := filepath.Join(t.TempDir(), "test-sparse index headers")
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bkt.Close()) })
+
+	// Create block.
+	blockID, err := block.CreateBlock(ctx, tmpDir, []labels.Labels{
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
+		labels.FromStrings("a", "3"),
+	}, 100, 0, 1000, labels.FromStrings("ext1", "1"))
+	require.NoError(t, err)
+	require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, filepath.Join(tmpDir, blockID.String()), nil))
+
+	// Write sparse index header and index header to disk on first build.
+	_, err = NewStreamBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, NewStreamBinaryReaderMetrics(nil), Config{})
+	require.NoError(t, err)
+
+	// Delete sparse index header file and object.
+	sparseHeadersPath := filepath.Join(blockID.String(), block.SparseIndexHeaderFilename)
+	require.NoError(t, os.Remove(path.Join(tmpDir, sparseHeadersPath)))
+	require.NoError(t, bkt.Delete(ctx, block.SparseIndexHeaderFilename))
+
+	// Change bucket to one which will fail to persist the sparse index header.
+	errBkt := &bucket.ErrorInjectedBucketClient{Bucket: bkt, Injector: func(bucket.Operation, string) error { return fmt.Errorf("test error") }}
+	_, err = NewStreamBinaryReader(ctx, log.NewNopLogger(), errBkt, tmpDir, blockID, 3, NewStreamBinaryReaderMetrics(nil), Config{})
+	require.NoError(t, err, "error while persisting sparse index header should not affect the creation of StreamBinaryReader")
 }
 
 // TestStreamBinaryReader_CheckSparseHeadersCorrectnessExtensive tests if StreamBinaryReader
@@ -83,23 +121,13 @@ func TestStreamBinaryReader_CheckSparseHeadersCorrectnessExtensive(t *testing.T)
 				// Write sparse index headers to disk on first build.
 				_, err = NewStreamBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, NewStreamBinaryReaderMetrics(nil), Config{})
 				require.NoError(t, err)
+
 				// Read sparse index headers to disk on second build.
 				r2, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, NewStreamBinaryReaderMetrics(nil), Config{})
 				require.NoError(t, err)
 
 				// Check correctness of sparse index headers.
 				compareIndexToHeader(t, b, r2)
-
-				// Delete sparse index header from disk.
-				sparseHeadersPath := filepath.Join(tmpDir, blockID.String(), block.SparseIndexHeaderFilename)
-				require.NoError(t, os.Remove(sparseHeadersPath))
-
-				// Read sparse index header from object storage on third build.
-				r3, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, NewStreamBinaryReaderMetrics(nil), Config{})
-				require.NoError(t, err)
-
-				// Check correctness of sparse index headers.
-				compareIndexToHeader(t, b, r3)
 			})
 		}
 	}
@@ -134,4 +162,102 @@ func TestStreamBinaryReader_LabelValuesOffsetsHonorsContextCancel(t *testing.T) 
 	_, err = r.LabelValuesOffsets(ctx, "a", "", func(string) bool { return true })
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestBucketAndDiskSparseHeaderLoader_SparseHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	require.NoError(t, err)
+	loader := bucketAndDiskSparseHeaderLoader{
+		ctx:       context.Background(),
+		bkt:       bkt,
+		localPath: path.Join(tmpDir, block.SparseIndexHeaderFilename),
+		logger:    log.NewNopLogger(),
+	}
+
+	// SparseHeader not found on disk or in object store
+	_, err = loader.SparseHeader()
+	require.Error(t, err)
+
+	// SparseHeader found on disk
+	sparseHeader := &indexheaderpb.Sparse{
+		Symbols: &indexheaderpb.Symbols{
+			Offsets:      []int64{0, 1, 2, 3, 4},
+			SymbolsCount: 6,
+		},
+		PostingsOffsetTable: &indexheaderpb.PostingOffsetTable{
+			Postings: map[string]*indexheaderpb.PostingValueOffsets{
+				"a": {
+					Offsets:       []*indexheaderpb.PostingOffset{{Value: "1", TableOff: 1}},
+					LastValOffset: 5,
+				},
+			},
+		},
+	}
+
+	err = loader.PersistSparseHeader(sparseHeader)
+	require.NoError(t, err)
+
+	loaded, err := loader.SparseHeader()
+	require.NoError(t, err)
+
+	require.Equal(t, sparseHeader, loaded)
+}
+
+func TestBucketAndDiskSparseHeaderLoader_AvailableOnlyOnDisk(t *testing.T) {
+	tmpDir := t.TempDir()
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	require.NoError(t, err)
+	loader := bucketAndDiskSparseHeaderLoader{
+		ctx:       context.Background(),
+		bkt:       bkt,
+		localPath: path.Join(tmpDir, block.SparseIndexHeaderFilename),
+		logger:    log.NewNopLogger(),
+	}
+
+	// Persist a non-zero-valued sparse header
+	sparseHeader := &indexheaderpb.Sparse{
+		Symbols: &indexheaderpb.Symbols{
+			SymbolsCount: 7,
+		},
+	}
+
+	err = loader.PersistSparseHeader(sparseHeader)
+	assert.NoError(t, err)
+
+	// Sparse header is deleted in the bucket, but invoking SparseHeader() returns the header
+	require.NoError(t, bkt.Delete(context.Background(), block.SparseIndexHeaderFilename))
+
+	loaded, err := loader.SparseHeader()
+	assert.NoError(t, err)
+	assert.Equal(t, sparseHeader, loaded)
+}
+
+func TestBucketAndDiskSparseHeaderLoader_AvailableOnlyInBucket(t *testing.T) {
+	tmpDir := t.TempDir()
+	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	require.NoError(t, err)
+	loader := bucketAndDiskSparseHeaderLoader{
+		ctx:       context.Background(),
+		bkt:       bkt,
+		localPath: path.Join(tmpDir, block.SparseIndexHeaderFilename),
+		logger:    log.NewNopLogger(),
+	}
+
+	// Persist a non-zero-valued sparse header
+	sparseHeader := &indexheaderpb.Sparse{
+		Symbols: &indexheaderpb.Symbols{
+			SymbolsCount: 7,
+		},
+	}
+
+	err = loader.PersistSparseHeader(sparseHeader)
+	assert.NoError(t, err)
+
+	// Sparse header is deleted in the bucket, but invoking SparseHeader() returns the header
+	require.NoError(t, os.Remove(loader.localPath))
+
+	loaded, err := loader.SparseHeader()
+	assert.NoError(t, err)
+	assert.Equal(t, sparseHeader, loaded)
 }

--- a/pkg/storegateway/indexheader/stream_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader_test.go
@@ -260,4 +260,10 @@ func TestBucketAndDiskSparseHeaderLoader_AvailableOnlyInBucket(t *testing.T) {
 	loaded, err := loader.SparseHeader()
 	assert.NoError(t, err)
 	assert.Equal(t, sparseHeader, loaded)
+
+	// The header should now be on disk
+	require.NoError(t, bkt.Delete(context.Background(), block.SparseIndexHeaderFilename))
+	loaded, err = loader.SparseHeader()
+	assert.NoError(t, err)
+	assert.Equal(t, sparseHeader, loaded)
 }


### PR DESCRIPTION
#### What this PR does

Fixes https://github.com/grafana/mimir/issues/8166; see the issue for more details about the problem.

There are two main things to consider before reviewing:

**Uploading on `loadedIndexReader()` instead of on `addBlock()`:** The code is slightly less invasive if we load the sparse index only when the block should be lazy loaded instead of when the block is first added to the store-gateway. This keeps some latency on the hot path, but perhaps the benefit of this change will be enough. Happy to hear other opinions.

**Only upload for new blocks:** Sparse headers won't be uploaded when they already exists on disk. This means that sparse headers will be uploaded only
* for blocks created after this change is deployed 
* by store-gateways that need to download the block for the first time (e.g. shard size changed or a new store-gateway is added or a store-gateway starts with a brand new disk). 

The reason for this is to save on object store operations. This also means the effect of this change on solving #8166 will be delayed.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
