### PR TITLE
Jsonnet: fix config drift w/ Grafana Labs

### DIFF
--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1998,11 +1998,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="alertmanager", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="alertmanager", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2076,11 +2076,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2207,11 +2207,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="query-frontend", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="query-frontend", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2285,11 +2285,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="ruler", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2363,11 +2363,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-querier", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="ruler-querier", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2449,11 +2449,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-query-frontend", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="ruler-query-frontend", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2327,7 +2327,7 @@ spec:
   triggers:
   - metadata:
       ignoreNullValues: "false"
-      metricName: ruler_querier_cpu_hpa_default
+      metricName: cortex_ruler_querier_cpu_hpa_default
       query: |
         max_over_time(
           sum(
@@ -2346,11 +2346,11 @@ spec:
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "178"
-    name: ruler_querier_cpu_hpa_default
+    name: cortex_ruler_querier_cpu_hpa_default
     type: prometheus
   - metadata:
       ignoreNullValues: "false"
-      metricName: ruler_querier_memory_hpa_default
+      metricName: cortex_ruler_querier_memory_hpa_default
       query: |
         max_over_time(
           sum(
@@ -2380,7 +2380,7 @@ spec:
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "955630223"
-    name: ruler_querier_memory_hpa_default
+    name: cortex_ruler_querier_memory_hpa_default
     type: prometheus
   - metadata:
       ignoreNullValues: "false"

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2327,7 +2327,7 @@ spec:
   triggers:
   - metadata:
       ignoreNullValues: "false"
-      metricName: ruler_querier_cpu_hpa_default
+      metricName: cortex_ruler_querier_cpu_hpa_default
       query: |
         max_over_time(
           sum(
@@ -2346,11 +2346,11 @@ spec:
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "200"
-    name: ruler_querier_cpu_hpa_default
+    name: cortex_ruler_querier_cpu_hpa_default
     type: prometheus
   - metadata:
       ignoreNullValues: "false"
-      metricName: ruler_querier_memory_hpa_default
+      metricName: cortex_ruler_querier_memory_hpa_default
       query: |
         max_over_time(
           sum(
@@ -2380,7 +2380,7 @@ spec:
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1073741824"
-    name: ruler_querier_memory_hpa_default
+    name: cortex_ruler_querier_memory_hpa_default
     type: prometheus
   - metadata:
       ignoreNullValues: "false"

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1998,11 +1998,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="alertmanager", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="alertmanager", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="alertmanager", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2076,11 +2076,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2207,11 +2207,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="query-frontend", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="query-frontend", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="query-frontend", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2285,11 +2285,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="ruler", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="ruler", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2363,11 +2363,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="ruler-querier", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-querier", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="ruler-querier", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and
@@ -2449,11 +2449,11 @@ spec:
         )
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"}[15m]))
+          sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="ruler-query-frontend", namespace="default", resource="memory"}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-query-frontend", namespace="default"}[15m]) > 0)
+          max by (pod)(changes(kube_pod_container_status_restarts_total{container="ruler-query-frontend", namespace="default"}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
+          max by (pod)(kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
           or vector(0)
         )
         and

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -315,11 +315,11 @@
     )
     +
     sum(
-      sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="%(container)s", namespace="%(namespace)s", resource="memory"}[15m]))
+      sum by (pod)(max_over_time(kube_pod_container_resource_requests{container="%(container)s", namespace="%(namespace)s", resource="memory"}[15m]))
       and
-      max by (pod) (changes(kube_pod_container_status_restarts_total{container="%(container)s", namespace="%(namespace)s"}[15m]) > 0)
+      max by (pod)(changes(kube_pod_container_status_restarts_total{container="%(container)s", namespace="%(namespace)s"}[15m]) > 0)
       and
-      max by (pod) (kube_pod_container_status_last_terminated_reason{container="%(container)s", namespace="%(namespace)s", reason="OOMKilled"})
+      max by (pod)(kube_pod_container_status_last_terminated_reason{container="%(container)s", namespace="%(namespace)s", reason="OOMKilled"})
       or vector(0)
     )
     and

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -473,6 +473,7 @@
       max_replicas=$._config.autoscaling_ruler_querier_max_replicas,
       cpu_target_utilization=$._config.autoscaling_ruler_querier_cpu_target_utilization,
       memory_target_utilization=$._config.autoscaling_ruler_querier_memory_target_utilization,
+      with_cortex_prefix=true,
       extra_triggers=if $._config.autoscaling_ruler_querier_workers_target_utilization <= 0 then [] else [
         {
           local name = 'ruler-querier-queries',


### PR DESCRIPTION
#### What this PR does

At Grafana Labs we have gradually rolled out the improved HPA queries, which we upstreamed to OSS jsonnet some time ago. Unfortunately there's a functional no-op drift between the two which causes a diff due to a missing space in the Grafana Labs. Rolling out the change at Grafana Labs would require few more weeks, so given they're functionally equivalent I would like to change the OSS one instead.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
