### PR TITLE
Jsonnet: remove cortex_ prefix from ruler-querier HPA scaling metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@
 * [ENHANCEMENT] Shuffle-sharding: add `$._config.shuffle_sharding.ingest_storage_partitions_enabled` and `$._config.shuffle_sharding.ingester_partitions_shard_size` options, that allow configuring partitions shard size in ingest-storage mode. #7804
 * [ENHANCEMENT] Rollout-operator: upgrade to v0.14.0.
 * [ENHANCEMENT] Add `_config.autoscaling_querier_predictive_scaling_enabled` to scale querier based on inflight queries 7 days ago. #7775
-* [ENHANCEMENT] Add support to autoscale ruler-querier replicas based on in-flight queries too (in addition to CPU and memory based scaling). #8060
+* [ENHANCEMENT] Add support to autoscale ruler-querier replicas based on in-flight queries too (in addition to CPU and memory based scaling). #8060 #8188
 * [BUGFIX] Guard against missing samples in KEDA queries. #7691
 
 ### Mimirtool

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2384,11 +2384,11 @@ spec:
     type: prometheus
   - metadata:
       ignoreNullValues: "false"
-      metricName: cortex_ruler_querier_queries_hpa_default
+      metricName: ruler_querier_queries_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "7"
-    name: cortex_ruler_querier_queries_hpa_default
+    name: ruler_querier_queries_hpa_default
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2384,11 +2384,11 @@ spec:
     type: prometheus
   - metadata:
       ignoreNullValues: "false"
-      metricName: cortex_ruler_querier_queries_hpa_default
+      metricName: ruler_querier_queries_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="default",quantile="0.5"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
-    name: cortex_ruler_querier_queries_hpa_default
+    name: ruler_querier_queries_hpa_default
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -478,7 +478,7 @@
           local name = 'ruler-querier-queries',
           local querier_max_concurrent = $.ruler_querier_args['querier.max-concurrent'],
 
-          metric_name: 'cortex_%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
+          metric_name: '%s_hpa_%s' % [std.strReplace(name, '-', '_'), $._config.namespace],
 
           // Each ruler-query-scheduler tracks *at regular intervals* the number of inflight requests
           // (both enqueued and processing queries) as a summary. With the following query we target


### PR DESCRIPTION
#### What this PR does

ruler-querier is autoscaled based on CPU, memory and queries. The scaling metric based on queries has been recently introduced (#8060). When I introduced it, I didn't noticed that CPU and memory scaling metrics have no `cortex_` prefix but the queries one does. In this PR I'm fixing this inconsistency, removing the `cortex_` from the queries one too.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
