### PR TITLE
Include route name in query stats log lines emitted by query-frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [ENHANCEMENT] Distributor: Introduce `-distributor.max-request-pool-buffer-size` to allow configuring the maximum size of the request pool buffers. #8082
 * [ENHANCEMENT] Store-gateway: improve performance when streaming chunks to queriers is enabled (`-querier.prefer-streaming-chunks-from-store-gateways=true`) and the query selects fewer than `-blocks-storage.bucket-store.batch-series-size` series (defaults to 5000 series). #8039
 * [ENHANCEMENT] Ingester: active series are now updated along with owned series. They decrease when series change ownership between ingesters. This helps provide a more accurate total of active series when ingesters are added. This is only enabled when `-ingester.track-ingester-owned-series` or `-ingester.use-ingester-owned-series-for-limits` are enabled. #8084
+* [ENHANCEMENT] Query-frontend: include route name in query stats log lines. #8191
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
+	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/tenant"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -306,6 +307,7 @@ func (f *Handler) reportQueryStats(
 		"component", "query-frontend",
 		"method", r.Method,
 		"path", r.URL.Path,
+		"route_name", middleware.ExtractRouteName(r.Context()),
 		"user_agent", r.UserAgent(),
 		"status_code", queryResponseStatusCode,
 		"response_time", queryResponseTime,

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/httpgrpc"
+	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/test"
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
@@ -61,6 +62,8 @@ func TestWriteError(t *testing.T) {
 }
 
 func TestHandler_ServeHTTP(t *testing.T) {
+	const testRouteName = "the_test_route"
+
 	for _, tt := range []struct {
 		name                    string
 		cfg                     HandlerConfig
@@ -182,6 +185,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 
 			req := tt.request()
 			req = req.WithContext(user.InjectOrgID(req.Context(), "12345"))
+			req = middleware.WithRouteName(req, testRouteName)
 			resp := httptest.NewRecorder()
 
 			handler.ServeHTTP(resp, req)
@@ -215,6 +219,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				require.Equal(t, "12345", msg["user"])
 				require.Equal(t, req.Method, msg["method"])
 				require.Equal(t, req.URL.Path, msg["path"])
+				require.Equal(t, testRouteName, msg["route_name"])
 				require.Equal(t, req.UserAgent(), msg["user_agent"])
 				require.Contains(t, msg, "response_time")
 				require.Equal(t, int64(len(responseData)), msg["response_size_bytes"])


### PR DESCRIPTION
#### What this PR does

This PR builds on https://github.com/grafana/dskit/pull/527 to add the route name to `query stats` log lines emitted by query-frontends.

This is useful when searching or analysing these log lines, particularly for APIs where the URL varies based on the request (eg. the label values API, where the URL is `/prometheus/api/v1/label/{name}/values`).

For example (notice the `route_name` value):

```
ts=2024-05-28T06:56:25.614545465Z caller=handler.go:374 level=info user=anonymous traceID=0c6048d9d2833e7a msg="query stats" component=query-frontend method=GET path=/prometheus/api/v1/query route_name=prometheus_api_v1_query user_agent=Grafana/10.1.5 status_code=200 response_time=4.493ms response_size_bytes=4139 query_wall_time_seconds=0.003131375 fetched_series_count=15 fetched_chunk_bytes=1429 fetched_chunks_count=30 fetched_index_bytes=0 sharded_queries=0 split_queries=0 estimated_series_count=0 queue_time_seconds=3.35e-05 param_query=up param_time=2024-05-28T06:56:25.577Z length=5m0s time_since_min_time=5m0.032958715s time_since_max_time=32.958715ms results_cache_hit_bytes=0 results_cache_miss_bytes=0 status=success
```

The values of `route_name` match those used in metrics and traces emitted by the query-frontend.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
