### PR TITLE
Alertmanager: Make sender use go-kit logger and add no-op e-mail sender

### DIFF
--- a/pkg/alertmanager/sender.go
+++ b/pkg/alertmanager/sender.go
@@ -121,5 +121,5 @@ func (s *Sender) SendWebhook(ctx context.Context, cmd *alertingReceivers.SendWeb
 // SendEmail implements alertingReceivers.EmailSender.
 // TODO: no-op for now, implement.
 func (s *Sender) SendEmail(ctx context.Context, cmd *alertingReceivers.SendEmailSettings) error {
-	return nil
+	return errors.New("e-mail sending not implemented")
 }

--- a/pkg/alertmanager/sender.go
+++ b/pkg/alertmanager/sender.go
@@ -120,6 +120,6 @@ func (s *Sender) SendWebhook(ctx context.Context, cmd *alertingReceivers.SendWeb
 
 // SendEmail implements alertingReceivers.EmailSender.
 // TODO: no-op for now, implement.
-func (s *Sender) SendEmail(ctx context.Context, cmd *alertingReceivers.SendEmailSettings) error {
+func (s *Sender) SendEmail(_ context.Context, _ *alertingReceivers.SendEmailSettings) error {
 	return errors.New("e-mail sending not implemented")
 }

--- a/pkg/alertmanager/sender.go
+++ b/pkg/alertmanager/sender.go
@@ -16,7 +16,8 @@ import (
 	"net/http"
 	"time"
 
-	alertingLogging "github.com/grafana/alerting/logging"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	alertingReceivers "github.com/grafana/alerting/receivers"
 	"github.com/pkg/errors"
 
@@ -29,10 +30,10 @@ var (
 
 type Sender struct {
 	c   *http.Client
-	log alertingLogging.Logger
+	log log.Logger
 }
 
-func NewSender(log alertingLogging.Logger) *Sender {
+func NewSender(log log.Logger) *Sender {
 	netTransport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			Renegotiation: tls.RenegotiateFreelyAsClient,
@@ -59,7 +60,7 @@ func (s *Sender) SendWebhook(ctx context.Context, cmd *alertingReceivers.SendWeb
 		cmd.HTTPMethod = http.MethodPost
 	}
 
-	s.log.Debug("Sending webhook", "url", cmd.URL, "http method", cmd.HTTPMethod)
+	level.Debug(s.log).Log("msg", "Sending webhook", "url", cmd.URL, "http method", cmd.HTTPMethod)
 
 	if cmd.HTTPMethod != http.MethodPost && cmd.HTTPMethod != http.MethodPut {
 		return ErrInvalidMethod
@@ -91,7 +92,7 @@ func (s *Sender) SendWebhook(ctx context.Context, cmd *alertingReceivers.SendWeb
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			s.log.Warn("Failed to close response body", "err", err)
+			level.Warn(s.log).Log("msg", "Failed to close response body", "err", err)
 		}
 	}()
 
@@ -103,16 +104,22 @@ func (s *Sender) SendWebhook(ctx context.Context, cmd *alertingReceivers.SendWeb
 	if cmd.Validation != nil {
 		err := cmd.Validation(body, resp.StatusCode)
 		if err != nil {
-			s.log.Debug("Webhook failed validation", "url", cmd.URL, "statuscode", resp.Status, "body", string(body))
+			level.Debug(s.log).Log("msg", "Webhook failed validation", "url", cmd.URL, "statuscode", resp.Status, "body", string(body))
 			return fmt.Errorf("webhook failed validation: %w", err)
 		}
 	}
 
 	if resp.StatusCode/100 == 2 {
-		s.log.Debug("Webhook succeeded", "url", cmd.URL, "statuscode", resp.Status)
+		level.Debug(s.log).Log("msg", "Webhook succeeded", "url", cmd.URL, "statuscode", resp.Status)
 		return nil
 	}
 
-	s.log.Debug("Webhook failed", "url", cmd.URL, "statuscode", resp.Status, "body", string(body))
+	level.Debug(s.log).Log("msg", "Webhook failed", "url", cmd.URL, "statuscode", resp.Status, "body", string(body))
 	return fmt.Errorf("webhook response status %v", resp.Status)
+}
+
+// SendEmail implements alertingReceivers.EmailSender.
+// TODO: no-op for now, implement.
+func (s *Sender) SendEmail(ctx context.Context, cmd *alertingReceivers.SendEmailSettings) error {
+	return nil
 }


### PR DESCRIPTION
This PR modifies the logging in the `Sender` struct to use go-kit instead of alerting's [Logger](https://github.com/grafana/alerting/blob/e545a06ed7d0986992a361d15f44e20276438106/logging/log.go#L5-L22) interface, making it consistent with the rest of the codebase.
It also adds a no-op `SendEmail()` method, which implements alerting's [EmailSender](https://github.com/grafana/alerting/blob/e545a06ed7d0986992a361d15f44e20276438106/receivers/email.go#L24-L26) interface.

Related PR: https://github.com/grafana/mimir/pull/8066