### PR TITLE
Add insight=true to ingest-storage log messages when data can't be ingested due to client errors

### DIFF
--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -122,7 +122,7 @@ func (c pusherConsumer) pushToStorage(ctx context.Context, tenantID string, req 
 			if reason != "" {
 				err = fmt.Errorf("%w (%s)", err, reason)
 			}
-			level.Warn(spanLog).Log("msg", "detected a client error while ingesting write request (the request may have been partially ingested)", "err", err, "user", tenantID)
+			level.Warn(spanLog).Log("msg", "detected a client error while ingesting write request (the request may have been partially ingested)", "user", tenantID, "insight", "true", "err", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
#### What this PR does

When ingest-storage is processing push requests from Kafka, client errors for push request cause that data cannot be ingested, and no retries are done. We want to report such errors to users, and we do that by using `insight` label.

This PR adds `insight=true` label to log messages about "client errors" to ingest-storage code. 

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
