### PR TITLE
Mimir query engine: support query cancellation and timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899 #8023 #8058 #8096 #8121
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -37,11 +37,13 @@ func NewEngine(opts promql.EngineOpts) (promql.QueryEngine, error) {
 
 	return &Engine{
 		lookbackDelta: lookbackDelta,
+		timeout:       opts.Timeout,
 	}, nil
 }
 
 type Engine struct {
 	lookbackDelta time.Duration
+	timeout       time.Duration
 }
 
 func (e *Engine) NewInstantQuery(_ context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -362,7 +362,7 @@ func (w cancellationQuerier) LabelNames(ctx context.Context, _ ...*labels.Matche
 }
 
 func (w cancellationQuerier) Select(ctx context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
-	return errSeriesSet{w.waitForCancellation(ctx)}
+	return storage.ErrSeriesSet(w.waitForCancellation(ctx))
 }
 
 func (w cancellationQuerier) Close() error {
@@ -378,24 +378,4 @@ func (w cancellationQuerier) waitForCancellation(ctx context.Context) error {
 	case <-time.After(time.Second):
 		return errors.New("expected query context to be cancelled after 1 second, but it was not")
 	}
-}
-
-type errSeriesSet struct {
-	err error
-}
-
-func (e errSeriesSet) Next() bool {
-	return false
-}
-
-func (e errSeriesSet) At() storage.Series {
-	return nil
-}
-
-func (e errSeriesSet) Err() error {
-	return e.err
-}
-
-func (e errSeriesSet) Warnings() annotations.Annotations {
-	return nil
 }

--- a/pkg/streamingpromql/operator/instant_vector_selector.go
+++ b/pkg/streamingpromql/operator/instant_vector_selector.go
@@ -34,13 +34,13 @@ func (v *InstantVectorSelector) SeriesMetadata(ctx context.Context) ([]SeriesMet
 	return v.Selector.SeriesMetadata(ctx)
 }
 
-func (v *InstantVectorSelector) NextSeries(_ context.Context) (InstantVectorSeriesData, error) {
+func (v *InstantVectorSelector) NextSeries(ctx context.Context) (InstantVectorSeriesData, error) {
 	if v.memoizedIterator == nil {
 		v.memoizedIterator = storage.NewMemoizedEmptyIterator(v.Selector.LookbackDelta.Milliseconds())
 	}
 
 	var err error
-	v.chunkIterator, err = v.Selector.Next(v.chunkIterator)
+	v.chunkIterator, err = v.Selector.Next(ctx, v.chunkIterator)
 	if err != nil {
 		return InstantVectorSeriesData{}, err
 	}

--- a/pkg/streamingpromql/operator/range_vector_selector.go
+++ b/pkg/streamingpromql/operator/range_vector_selector.go
@@ -43,9 +43,9 @@ func (m *RangeVectorSelector) Range() time.Duration {
 	return m.Selector.Range
 }
 
-func (m *RangeVectorSelector) NextSeries(_ context.Context) error {
+func (m *RangeVectorSelector) NextSeries(ctx context.Context) error {
 	var err error
-	m.chunkIterator, err = m.Selector.Next(m.chunkIterator)
+	m.chunkIterator, err = m.Selector.Next(ctx, m.chunkIterator)
 	if err != nil {
 		return err
 	}

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -246,6 +246,12 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 	defer q.root.Close()
 
 	ctx, cancel := context.WithCancelCause(ctx)
+
+	if q.engine.timeout != 0 {
+		// We don't need to cancel the timeout context, as we'll always cancel the parent context created above.
+		ctx, _ = context.WithTimeoutCause(ctx, q.engine.timeout, fmt.Errorf("%w: query timed out", context.DeadlineExceeded))
+	}
+
 	q.cancel = cancel
 
 	series, err := q.root.SeriesMetadata(ctx)


### PR DESCRIPTION
#### What this PR does

This PR adds support for cancelling queries (with `Query.Cancel()`) and configuring a timeout for queries (with `EngineOpts.Timeout`) in the Mimir query engine.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
