### PR TITLE
Refactoring: shift between Labels and LabelAdapters to align better with dedupelabels

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -6270,8 +6270,8 @@ func (i *mockIngester) QueryExemplars(ctx context.Context, req *client.ExemplarQ
 
 	// Sort series by labels because the real ingester returns sorted ones.
 	slices.SortFunc(res.Timeseries, func(a, b mimirpb.TimeSeries) int {
-		aKey := client.LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(a.Labels))
-		bKey := client.LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(b.Labels))
+		aKey := mimirpb.FromLabelAdaptersToKeyString(a.Labels)
+		bKey := mimirpb.FromLabelAdaptersToKeyString(b.Labels)
 		return strings.Compare(aKey, bKey)
 	})
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -181,7 +181,7 @@ func mergeExemplarQueryResponses(results []*ingester_client.ExemplarQueryRespons
 	exemplarResults := make(map[string]mimirpb.TimeSeries)
 	for _, r := range results {
 		for _, ts := range r.Timeseries {
-			lbls := ingester_client.LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(ts.Labels))
+			lbls := mimirpb.FromLabelAdaptersToKeyString(ts.Labels)
 			e, ok := exemplarResults[lbls]
 			if !ok {
 				exemplarResults[lbls] = ts
@@ -374,7 +374,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSets [
 		// Accumulate any chunk series
 		for _, batch := range res.chunkseriesBatches {
 			for _, series := range batch {
-				key := ingester_client.LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(series.Labels))
+				key := mimirpb.FromLabelAdaptersToKeyString(series.Labels)
 				existing := hashToChunkseries[key]
 				existing.Labels = series.Labels
 
@@ -390,7 +390,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSets [
 		// Accumulate any time series
 		for _, batch := range res.timeseriesBatches {
 			for _, series := range batch {
-				key := ingester_client.LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(series.Labels))
+				key := mimirpb.FromLabelAdaptersToKeyString(series.Labels)
 				existing := hashToTimeSeries[key]
 				existing.Labels = series.Labels
 				if existing.Samples == nil {

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -791,7 +791,7 @@ func matrixMerge(resps []*PrometheusResponse) []SampleStream {
 			continue
 		}
 		for _, stream := range resp.Data.Result {
-			metric := mimirpb.FromLabelAdaptersToLabels(stream.Labels).String()
+			metric := mimirpb.FromLabelAdaptersToKeyString(stream.Labels)
 			existing, ok := output[metric]
 			if !ok {
 				existing = &SampleStream{

--- a/pkg/ingester/client/compat.go
+++ b/pkg/ingester/client/compat.go
@@ -223,13 +223,3 @@ func FromLabelMatchers(matchers []*LabelMatcher) ([]*labels.Matcher, error) {
 	}
 	return result, nil
 }
-
-// LabelsToKeyString is used to form a string to be used as
-// the hashKey. Don't print, use l.String() for printing.
-func LabelsToKeyString(l labels.Labels) string {
-	// We are allocating 1024, even though most series are less than 600b long.
-	// But this is not an issue as this function is being inlined when called in a loop
-	// and buffer allocated is a static buffer and not a dynamic buffer on the heap.
-	b := make([]byte, 0, 1024)
-	return string(l.Bytes(b))
-}

--- a/pkg/ingester/client/compat_test.go
+++ b/pkg/ingester/client/compat_test.go
@@ -7,10 +7,8 @@ package client
 
 import (
 	"reflect"
-	"strconv"
 	"testing"
 
-	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
@@ -86,54 +84,4 @@ func TestLabelNamesRequest(t *testing.T) {
 	assert.Equal(t, int64(mint), actualMinT)
 	assert.Equal(t, int64(maxt), actualMaxT)
 	assert.Equal(t, matchers, actualMatchers)
-}
-
-// The main usecase for `LabelsToKeyString` is to generate hashKeys
-// for maps. We are benchmarking that here.
-func BenchmarkSeriesMap(b *testing.B) {
-	benchmarkSeriesMap(100000, b)
-}
-
-func benchmarkSeriesMap(numSeries int, b *testing.B) {
-	series := makeSeries(numSeries)
-	sm := make(map[string]int, numSeries)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for i, s := range series {
-			sm[LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(s))] = i
-		}
-
-		for _, s := range series {
-			_, ok := sm[LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(s))]
-			if !ok {
-				b.Fatal("element missing")
-			}
-		}
-
-		if len(sm) != numSeries {
-			b.Fatal("the number of series expected:", numSeries, "got:", len(sm))
-		}
-	}
-}
-
-func makeSeries(n int) [][]mimirpb.LabelAdapter {
-	series := make([][]mimirpb.LabelAdapter, 0, n)
-	for i := 0; i < n; i++ {
-		series = append(series, []mimirpb.LabelAdapter{
-			{Name: "label0", Value: "value0"},
-			{Name: "label1", Value: "value1"},
-			{Name: "label2", Value: "value2"},
-			{Name: "label3", Value: "value3"},
-			{Name: "label4", Value: "value4"},
-			{Name: "label5", Value: "value5"},
-			{Name: "label6", Value: "value6"},
-			{Name: "label7", Value: "value7"},
-			{Name: "label8", Value: "value8"},
-			{Name: "label9", Value: strconv.Itoa(i)},
-		})
-	}
-
-	return series
 }

--- a/pkg/ingester/client/compat_test.go
+++ b/pkg/ingester/client/compat_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
@@ -101,11 +102,11 @@ func benchmarkSeriesMap(numSeries int, b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		for i, s := range series {
-			sm[LabelsToKeyString(s)] = i
+			sm[LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(s))] = i
 		}
 
 		for _, s := range series {
-			_, ok := sm[LabelsToKeyString(s)]
+			_, ok := sm[LabelsToKeyString(mimirpb.FromLabelAdaptersToLabels(s))]
 			if !ok {
 				b.Fatal("element missing")
 			}
@@ -117,21 +118,21 @@ func benchmarkSeriesMap(numSeries int, b *testing.B) {
 	}
 }
 
-func makeSeries(n int) []labels.Labels {
-	series := make([]labels.Labels, 0, n)
+func makeSeries(n int) [][]mimirpb.LabelAdapter {
+	series := make([][]mimirpb.LabelAdapter, 0, n)
 	for i := 0; i < n; i++ {
-		series = append(series, labels.FromMap(map[string]string{
-			"label0": "value0",
-			"label1": "value1",
-			"label2": "value2",
-			"label3": "value3",
-			"label4": "value4",
-			"label5": "value5",
-			"label6": "value6",
-			"label7": "value7",
-			"label8": "value8",
-			"label9": strconv.Itoa(i),
-		}))
+		series = append(series, []mimirpb.LabelAdapter{
+			{Name: "label0", Value: "value0"},
+			{Name: "label1", Value: "value1"},
+			{Name: "label2", Value: "value2"},
+			{Name: "label3", Value: "value3"},
+			{Name: "label4", Value: "value4"},
+			{Name: "label5", Value: "value5"},
+			{Name: "label6", Value: "value6"},
+			{Name: "label7", Value: "value7"},
+			{Name: "label8", Value: "value8"},
+			{Name: "label9", Value: strconv.Itoa(i)},
+		})
 	}
 
 	return series

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -3603,6 +3603,14 @@ func Test_Ingester_LabelValues(t *testing.T) {
 	})
 }
 
+func l2m(lbls labels.Labels) model.Metric {
+	m := make(model.Metric, 16)
+	lbls.Range(func(l labels.Label) {
+		m[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+	})
+	return m
+}
+
 func Test_Ingester_Query(t *testing.T) {
 	series := []series{
 		{labels.FromStrings(labels.MetricName, "test_1", "status", "200", "route", "get_user"), 1, 100000},
@@ -3631,8 +3639,8 @@ func Test_Ingester_Query(t *testing.T) {
 				{Type: client.EQUAL, Name: model.MetricNameLabel, Value: "test_1"},
 			},
 			expected: model.Matrix{
-				&model.SampleStream{Metric: util.LabelsToMetric(series[0].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 100000}}},
-				&model.SampleStream{Metric: util.LabelsToMetric(series[1].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 110000}}},
+				&model.SampleStream{Metric: l2m(series[0].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 100000}}},
+				&model.SampleStream{Metric: l2m(series[1].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 110000}}},
 			},
 		},
 		"should filter series by != matcher": {
@@ -3642,7 +3650,7 @@ func Test_Ingester_Query(t *testing.T) {
 				{Type: client.NOT_EQUAL, Name: model.MetricNameLabel, Value: "test_1"},
 			},
 			expected: model.Matrix{
-				&model.SampleStream{Metric: util.LabelsToMetric(series[2].lbls), Values: []model.SamplePair{{Value: 2, Timestamp: 200000}}},
+				&model.SampleStream{Metric: l2m(series[2].lbls), Values: []model.SamplePair{{Value: 2, Timestamp: 200000}}},
 			},
 		},
 		"should filter series by =~ matcher": {
@@ -3652,8 +3660,8 @@ func Test_Ingester_Query(t *testing.T) {
 				{Type: client.REGEX_MATCH, Name: model.MetricNameLabel, Value: ".*_1"},
 			},
 			expected: model.Matrix{
-				&model.SampleStream{Metric: util.LabelsToMetric(series[0].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 100000}}},
-				&model.SampleStream{Metric: util.LabelsToMetric(series[1].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 110000}}},
+				&model.SampleStream{Metric: l2m(series[0].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 100000}}},
+				&model.SampleStream{Metric: l2m(series[1].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 110000}}},
 			},
 		},
 		"should filter series by !~ matcher": {
@@ -3663,7 +3671,7 @@ func Test_Ingester_Query(t *testing.T) {
 				{Type: client.REGEX_NO_MATCH, Name: model.MetricNameLabel, Value: ".*_1"},
 			},
 			expected: model.Matrix{
-				&model.SampleStream{Metric: util.LabelsToMetric(series[2].lbls), Values: []model.SamplePair{{Value: 2, Timestamp: 200000}}},
+				&model.SampleStream{Metric: l2m(series[2].lbls), Values: []model.SamplePair{{Value: 2, Timestamp: 200000}}},
 			},
 		},
 		"should filter series by multiple matchers": {
@@ -3674,7 +3682,7 @@ func Test_Ingester_Query(t *testing.T) {
 				{Type: client.REGEX_MATCH, Name: "status", Value: "5.."},
 			},
 			expected: model.Matrix{
-				&model.SampleStream{Metric: util.LabelsToMetric(series[1].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 110000}}},
+				&model.SampleStream{Metric: l2m(series[1].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 110000}}},
 			},
 		},
 		"should filter series by matcher and time range": {
@@ -3684,7 +3692,7 @@ func Test_Ingester_Query(t *testing.T) {
 				{Type: client.EQUAL, Name: model.MetricNameLabel, Value: "test_1"},
 			},
 			expected: model.Matrix{
-				&model.SampleStream{Metric: util.LabelsToMetric(series[0].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 100000}}},
+				&model.SampleStream{Metric: l2m(series[0].lbls), Values: []model.SamplePair{{Value: 1, Timestamp: 100000}}},
 			},
 		},
 	}

--- a/pkg/mimirpb/compat.go
+++ b/pkg/mimirpb/compat.go
@@ -21,8 +21,6 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/util/jsonutil"
-
-	"github.com/grafana/mimir/pkg/util"
 )
 
 // ToWriteRequest converts matched slices of Labels, Samples, Exemplars, and Metadata into a WriteRequest
@@ -101,7 +99,11 @@ func (req *WriteRequest) AddExemplarsAt(i int, exemplars []*Exemplar) *WriteRequ
 // FromLabelAdaptersToMetric converts []LabelAdapter to a model.Metric.
 // Don't do this on any performance sensitive paths.
 func FromLabelAdaptersToMetric(ls []LabelAdapter) model.Metric {
-	return util.LabelsToMetric(FromLabelAdaptersToLabels(ls))
+	m := make(model.Metric, len(ls))
+	for _, la := range ls {
+		m[model.LabelName(la.Name)] = model.LabelValue(la.Value)
+	}
+	return m
 }
 
 // FromLabelAdaptersToKeyString makes a string to be used as a key to a map.

--- a/pkg/mimirpb/compat.go
+++ b/pkg/mimirpb/compat.go
@@ -104,6 +104,19 @@ func FromLabelAdaptersToMetric(ls []LabelAdapter) model.Metric {
 	return util.LabelsToMetric(FromLabelAdaptersToLabels(ls))
 }
 
+// FromLabelAdaptersToKeyString makes a string to be used as a key to a map.
+// It's much simpler than FromLabelAdaptersToString, but not human-readable.
+func FromLabelAdaptersToKeyString(ls []LabelAdapter) string {
+	buf := make([]byte, 0, 1024)
+	for i := range ls {
+		buf = append(buf, '\xff')
+		buf = append(buf, ls[i].Name...)
+		buf = append(buf, '\xff')
+		buf = append(buf, ls[i].Value...)
+	}
+	return string(buf)
+}
+
 // FromLabelAdaptersToString formats label adapters as a metric name with labels, while preserving
 // label order, and keeping duplicates. If there are multiple "__name__" labels, only
 // first one is used as metric name, other ones will be included as regular labels.

--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -743,3 +743,53 @@ func TestCompareLabelAdapters(t *testing.T) {
 func TestRemoteWriteV1HistogramEquivalence(t *testing.T) {
 	test.RequireSameShape(t, prompb.Histogram{}, Histogram{}, false, true)
 }
+
+// The main usecase for `LabelsToKeyString` is to generate hashKeys
+// for maps. We are benchmarking that here.
+func BenchmarkSeriesMap(b *testing.B) {
+	benchmarkSeriesMap(100000, b)
+}
+
+func benchmarkSeriesMap(numSeries int, b *testing.B) {
+	series := makeSeries(numSeries)
+	sm := make(map[string]int, numSeries)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for i, s := range series {
+			sm[FromLabelAdaptersToKeyString(s)] = i
+		}
+
+		for _, s := range series {
+			_, ok := sm[FromLabelAdaptersToKeyString(s)]
+			if !ok {
+				b.Fatal("element missing")
+			}
+		}
+
+		if len(sm) != numSeries {
+			b.Fatal("the number of series expected:", numSeries, "got:", len(sm))
+		}
+	}
+}
+
+func makeSeries(n int) [][]LabelAdapter {
+	series := make([][]LabelAdapter, 0, n)
+	for i := 0; i < n; i++ {
+		series = append(series, []LabelAdapter{
+			{Name: "label0", Value: "value0"},
+			{Name: "label1", Value: "value1"},
+			{Name: "label2", Value: "value2"},
+			{Name: "label3", Value: "value3"},
+			{Name: "label4", Value: "value4"},
+			{Name: "label5", Value: "value5"},
+			{Name: "label6", Value: "value6"},
+			{Name: "label7", Value: "value7"},
+			{Name: "label8", Value: "value8"},
+			{Name: "label9", Value: strconv.Itoa(i)},
+		})
+	}
+
+	return series
+}

--- a/pkg/querier/partitioner.go
+++ b/pkg/querier/partitioner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
-	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/querier/batch"
 	"github.com/grafana/mimir/pkg/storage/chunk"
 	seriesset "github.com/grafana/mimir/pkg/storage/series"
@@ -20,9 +19,10 @@ import (
 // Series in the returned set are sorted alphabetically by labels.
 func partitionChunks(chunks []chunk.Chunk, mint, maxt int64) storage.SeriesSet {
 	chunksBySeries := map[string][]chunk.Chunk{}
+	var buf [1024]byte
 	for _, c := range chunks {
-		key := client.LabelsToKeyString(c.Metric)
-		chunksBySeries[key] = append(chunksBySeries[key], c)
+		key := c.Metric.Bytes(buf[:0])
+		chunksBySeries[string(key)] = append(chunksBySeries[string(key)], c)
 	}
 
 	series := make([]storage.Series, 0, len(chunksBySeries))

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1071,8 +1071,14 @@ func uploadTestBlock(t testing.TB, tmpDir string, bkt objstore.Bucket, dataSetup
 func appendTestSeries(series int) func(testing.TB, func() storage.Appender) {
 	return func(t testing.TB, appenderFactory func() storage.Appender) {
 		app := appenderFactory()
-		addSeries := func(l labels.Labels) {
-			_, err := app.Append(0, l, 0, 0)
+		b := labels.NewScratchBuilder(4)
+		addSeries := func(ss ...string) {
+			b.Reset()
+			for i := 0; i < len(ss); i += 2 {
+				b.Add(ss[i], ss[i+1])
+			}
+			b.Sort()
+			_, err := app.Append(0, b.Labels(), 0, 0)
 			assert.NoError(t, err)
 		}
 
@@ -1080,12 +1086,12 @@ func appendTestSeries(series int) func(testing.TB, func() storage.Appender) {
 		for n := 0; n < 10; n++ {
 			for i := 0; i < series/10; i++ {
 
-				addSeries(labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", strconv.Itoa(n)+labelLongSuffix, "j", "foo", "p", "foo"))
+				addSeries("i", strconv.Itoa(i)+labelLongSuffix, "n", strconv.Itoa(n)+labelLongSuffix, "j", "foo", "p", "foo")
 				// Have some series that won't be matched, to properly test inverted matches.
-				addSeries(labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", strconv.Itoa(n)+labelLongSuffix, "j", "bar", "q", "foo"))
-				addSeries(labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", "0_"+strconv.Itoa(n)+labelLongSuffix, "j", "bar", "r", "foo"))
-				addSeries(labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", "1_"+strconv.Itoa(n)+labelLongSuffix, "j", "bar", "s", "foo"))
-				addSeries(labels.FromStrings("i", strconv.Itoa(i)+labelLongSuffix, "n", "2_"+strconv.Itoa(n)+labelLongSuffix, "j", "foo", "t", "foo"))
+				addSeries("i", strconv.Itoa(i)+labelLongSuffix, "n", strconv.Itoa(n)+labelLongSuffix, "j", "bar", "q", "foo")
+				addSeries("i", strconv.Itoa(i)+labelLongSuffix, "n", "0_"+strconv.Itoa(n)+labelLongSuffix, "j", "bar", "r", "foo")
+				addSeries("i", strconv.Itoa(i)+labelLongSuffix, "n", "1_"+strconv.Itoa(n)+labelLongSuffix, "j", "bar", "s", "foo")
+				addSeries("i", strconv.Itoa(i)+labelLongSuffix, "n", "2_"+strconv.Itoa(n)+labelLongSuffix, "j", "foo", "t", "foo")
 			}
 			assert.NoError(t, app.Commit())
 			app = appenderFactory()

--- a/pkg/storegateway/series_chunks_test.go
+++ b/pkg/storegateway/series_chunks_test.go
@@ -62,6 +62,7 @@ func TestSeriesChunksSet(t *testing.T) {
 		for r := 0; r < numRuns; r++ {
 			set := newSeriesChunksSet(numSeries, true)
 
+			lset := labels.FromStrings(labels.MetricName, "metric")
 			// Ensure the series slice is made of all zero values. Then write something inside before releasing it again.
 			// The slice is expected to be picked from the pool, at least in some runs (there's an assertion on it at
 			// the end of the test).
@@ -69,7 +70,7 @@ func TestSeriesChunksSet(t *testing.T) {
 			for i := 0; i < numSeries; i++ {
 				require.Zero(t, set.series[i])
 
-				set.series[i].lset = labels.FromStrings(labels.MetricName, "metric")
+				set.series[i].lset = lset
 				set.series[i].chks = set.newSeriesAggrChunkSlice(numChunksPerSeries)
 			}
 

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -1120,12 +1120,8 @@ func (s *loadingSeriesChunkRefsSetIterator) loadSeries(ref storage.SeriesRef, lo
 func (s *loadingSeriesChunkRefsSetIterator) singlePassStringify(symbolizedSet symbolizedSeriesChunkRefsSet) (seriesChunkRefsSet, error) {
 	// Some conservative map pre-allocation; the goal is to get an order of magnitude size of the map, so we minimize map growth.
 	symbols := make(map[uint32]string, len(symbolizedSet.series)/2)
-	maxLabelsPerSeries := 0
 
 	for _, series := range symbolizedSet.series {
-		if numLabels := len(series.lset); maxLabelsPerSeries < numLabels {
-			maxLabelsPerSeries = numLabels
-		}
 		for _, symRef := range series.lset {
 			symbols[symRef.value] = ""
 			symbols[symRef.name] = ""

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1087,7 +1087,7 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 }
 
 func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
-	b := labels.NewScratchBuilder(4)
+	b := labels.NewScratchBuilder(1)
 	oneLabel := func(name, value string) labels.Labels {
 		b.Reset()
 		b.Add(name, value)
@@ -2415,7 +2415,7 @@ func readAllSeriesChunkRefs(it iterator[seriesChunkRefs]) []seriesChunkRefs {
 // incremented by +1.
 func createSeriesChunkRefsSet(minSeriesID, maxSeriesID int, releasable bool) seriesChunkRefsSet {
 	set := newSeriesChunkRefsSet(maxSeriesID-minSeriesID+1, releasable)
-	b := labels.NewScratchBuilder(4)
+	b := labels.NewScratchBuilder(1)
 
 	for seriesID := minSeriesID; seriesID <= maxSeriesID; seriesID++ {
 		b.Reset()

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1087,10 +1087,16 @@ func TestLimitingSeriesChunkRefsSetIterator(t *testing.T) {
 }
 
 func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
+	b := labels.NewScratchBuilder(4)
+	oneLabel := func(name, value string) labels.Labels {
+		b.Reset()
+		b.Add(name, value)
+		return b.Labels()
+	}
 	defaultTestBlockFactory := prepareTestBlock(test.NewTB(t), func(t testing.TB, appenderFactory func() storage.Appender) {
 		appender := appenderFactory()
 		for i := 0; i < 100; i++ {
-			_, err := appender.Append(0, labels.FromStrings("l1", fmt.Sprintf("v%d", i)), int64(i*10), 0)
+			_, err := appender.Append(0, oneLabel("l1", fmt.Sprintf("v%d", i)), int64(i*10), 0)
 			assert.NoError(t, err)
 		}
 		assert.NoError(t, appender.Commit())
@@ -1100,7 +1106,7 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 	largerTestBlockFactory := prepareTestBlock(test.NewTB(t), func(t testing.TB, appenderFactory func() storage.Appender) {
 		for i := 0; i < largerTestBlockSeriesCount; i++ {
 			appender := appenderFactory()
-			lbls := labels.FromStrings("l1", fmt.Sprintf("v%d", i))
+			lbls := oneLabel("l1", fmt.Sprintf("v%d", i))
 			var ref storage.SeriesRef
 			const numSamples = 240 // Write enough samples to have two chunks per series
 			for j := 0; j < numSamples; j++ {
@@ -1247,7 +1253,7 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedSets: func() []seriesChunkRefsSet {
 				set := newSeriesChunkRefsSet(largerTestBlockSeriesCount, true)
 				for i := 0; i < largerTestBlockSeriesCount; i++ {
-					set.series = append(set.series, seriesChunkRefs{lset: labels.FromStrings("l1", fmt.Sprintf("v%d", i))})
+					set.series = append(set.series, seriesChunkRefs{lset: oneLabel("l1", fmt.Sprintf("v%d", i))})
 				}
 				// The order of series in the block is by their labels, so we need to sort what we generated.
 				sort.Slice(set.series, func(i, j int) bool {
@@ -1265,7 +1271,7 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			expectedSets: func() []seriesChunkRefsSet {
 				series := make([]seriesChunkRefs, 0, largerTestBlockSeriesCount)
 				for i := 0; i < largerTestBlockSeriesCount; i++ {
-					series = append(series, seriesChunkRefs{lset: labels.FromStrings("l1", fmt.Sprintf("v%d", i))})
+					series = append(series, seriesChunkRefs{lset: oneLabel("l1", fmt.Sprintf("v%d", i))})
 				}
 				// The order of series in the block is by their labels, so we need to sort what we generated.
 				sort.Slice(series, func(i, j int) bool {
@@ -2409,11 +2415,12 @@ func readAllSeriesChunkRefs(it iterator[seriesChunkRefs]) []seriesChunkRefs {
 // incremented by +1.
 func createSeriesChunkRefsSet(minSeriesID, maxSeriesID int, releasable bool) seriesChunkRefsSet {
 	set := newSeriesChunkRefsSet(maxSeriesID-minSeriesID+1, releasable)
+	b := labels.NewScratchBuilder(4)
 
 	for seriesID := minSeriesID; seriesID <= maxSeriesID; seriesID++ {
-		set.series = append(set.series, seriesChunkRefs{
-			lset: labels.FromStrings(labels.MetricName, fmt.Sprintf("metric_%06d", seriesID)),
-		})
+		b.Reset()
+		b.Add(labels.MetricName, fmt.Sprintf("metric_%06d", seriesID))
+		set.series = append(set.series, seriesChunkRefs{lset: b.Labels()})
 	}
 
 	return set

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -8,19 +8,8 @@ package util
 import (
 	"strings"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 )
-
-// LabelsToMetric converts a Labels to Metric
-// Don't do this on any performance sensitive paths.
-func LabelsToMetric(ls labels.Labels) model.Metric {
-	m := make(model.Metric, ls.Len())
-	ls.Range(func(l labels.Label) {
-		m[model.LabelName(l.Name)] = model.LabelValue(l.Value)
-	})
-	return m
-}
 
 // LabelMatchersToString returns a string representing the input label matchers.
 func LabelMatchersToString(matchers []*labels.Matcher) string {


### PR DESCRIPTION
#### What this PR does

This improves efficiency, mostly in tests but a couple of non-tests too.

Split into four commits:
* storegateway tests: re-use Builder when creating labels - this is more efficient, especially with dedupelabels.
* storegateway: retain Builder in loadingSeriesChunkRefsSetIterator - saves memory allocation when moving to next series.
* mimirpb: add FromLabelAdaptersToKeyString - avoid converting to labels and then to string.
* labels: avoid double-converting around FromLabelAdaptersToMetric 

Benchmarks (after changing the benchmark to match usage):
```
             │ before.txt  │             after.txt              │
             │   sec/op    │   sec/op     vs base               │
SeriesMap-28   46.13m ± 2%   22.93m ± 5%  -50.29% (p=0.002 n=6)

             │  before.txt   │              after.txt              │
             │     B/op      │     B/op      vs base               │
SeriesMap-28   115.98Mi ± 0%   27.47Mi ± 0%  -76.31% (p=0.002 n=6)

             │ before.txt  │             after.txt              │
             │  allocs/op  │  allocs/op   vs base               │
SeriesMap-28   600.1k ± 0%   200.0k ± 0%  -66.67% (p=0.002 n=6)
```

#### Checklist

- [x] Tests updated.
- NA Documentation added.
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- NA [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
