### PR TITLE
Alertmanager: Implement experimental extended /receivers API.

### DIFF
--- a/development/common/config/nginx.conf.template
+++ b/development/common/config/nginx.conf.template
@@ -70,6 +70,9 @@ http {
     location = /api/v1/grafana/state {
       proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
     }
+    location = /api/v1/grafana/receivers {
+      proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
+    }
 
     # Ruler endpoints
     location /prometheus/config/v1/rules {

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	alertingmodels "github.com/grafana/alerting/models"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
@@ -647,11 +648,11 @@ func TestAlertmanagerSharding(t *testing.T) {
 				for _, c := range clients {
 					list, err := c.GetReceiversExperimental(context.Background())
 					assert.NoError(t, err)
-					assert.ElementsMatch(t, list, []e2emimir.Receiver{
+					assert.ElementsMatch(t, list, []alertingmodels.Receiver{
 						{
 							Name:   "dummy",
 							Active: true,
-							Integrations: []e2emimir.Integration{
+							Integrations: []alertingmodels.Integration{
 								{
 									LastNotifyAttemptDuration: "0s",
 									Name:                      "email",

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -642,7 +642,7 @@ func TestAlertmanagerSharding(t *testing.T) {
 				}
 			}
 
-			// Endpoint: GET /experimental/api/v1/receivers
+			// Endpoint: GET /api/v1/grafana/receivers
 			{
 				for _, c := range clients {
 					list, err := c.GetReceiversExperimental(context.Background())

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -32,11 +32,18 @@ import (
 	"github.com/grafana/mimir/pkg/storage/bucket/s3"
 )
 
-const simpleAlertmanagerConfig = `route:
+const simpleAlertmanagerConfig = `
+global:
+  smtp_smarthost: 'localhost:25'
+  smtp_from: 'youraddress@example.org'
+route:
   receiver: dummy
   group_by: [group]
 receivers:
-  - name: dummy`
+  - name: dummy
+    email_configs:
+    - to: 'youraddress@example.org'
+`
 
 // uploadAlertmanagerConfig uploads the provided config to the minio bucket for the specified user.
 // Uses default test minio credentials.
@@ -460,7 +467,9 @@ func TestAlertmanagerSharding(t *testing.T) {
 			require.NoError(t, err)
 			defer s.Close()
 
-			flags := mergeFlags(AlertmanagerFlags(), AlertmanagerS3Flags())
+			flags := mergeFlags(AlertmanagerFlags(),
+				AlertmanagerS3Flags(),
+				AlertmanagerGrafanaCompatibilityFlags())
 
 			// Start dependencies.
 			consul := e2edb.NewConsul()
@@ -630,6 +639,26 @@ func TestAlertmanagerSharding(t *testing.T) {
 					list, err := c.GetReceivers(context.Background())
 					assert.NoError(t, err)
 					assert.ElementsMatch(t, list, []string{"dummy"})
+				}
+			}
+
+			// Endpoint: GET /experimental/api/v1/receivers
+			{
+				for _, c := range clients {
+					list, err := c.GetReceiversExperimental(context.Background())
+					assert.NoError(t, err)
+					assert.ElementsMatch(t, list, []e2emimir.Receiver{
+						{
+							Name:   "dummy",
+							Active: true,
+							Integrations: []e2emimir.Integration{
+								{
+									LastNotifyAttemptDuration: "0s",
+									Name:                      "email",
+								},
+							},
+						},
+					})
 				}
 			}
 
@@ -1013,7 +1042,7 @@ func TestAlertmanagerGrafanaAlertmanagerAPI(t *testing.T) {
 	flags := mergeFlags(AlertmanagerFlags(),
 		AlertmanagerS3Flags(),
 		AlertmanagerShardingFlags(consul.NetworkHTTPEndpoint(), 1),
-		map[string]string{"-alertmanager.grafana-alertmanager-compatibility-enabled": "true"})
+		AlertmanagerGrafanaCompatibilityFlags())
 
 	am := e2emimir.NewAlertmanager(
 		"alertmanager",

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -138,6 +138,12 @@ var (
 		}
 	}
 
+	AlertmanagerGrafanaCompatibilityFlags = func() map[string]string {
+		return map[string]string{
+			"-alertmanager.grafana-alertmanager-compatibility-enabled": "true",
+		}
+	}
+
 	RulerFlags = func() map[string]string {
 		return map[string]string{
 			"-ruler.poll-interval":             "2s",

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -18,9 +18,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-openapi/strfmt"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	alertingmodels "github.com/grafana/alerting/models"
 	"github.com/klauspost/compress/s2"
 	alertConfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/types"
@@ -1453,21 +1453,7 @@ func (c *Client) GetReceivers(ctx context.Context) ([]string, error) {
 	return receivers, nil
 }
 
-type Integration struct {
-	LastNotifyAttempt         strfmt.DateTime `json:"lastNotifyAttempt"`
-	LastNotifyAttemptDuration string          `json:"lastNotifyAttemptDuration"`
-	LastNotifyAttemptError    string          `json:"lastNotifyAttemptError"`
-	Name                      string          `json:"name"`
-	SendResolved              bool            `json:"sendResolved"`
-}
-
-type Receiver struct {
-	Name         string        `json:"name"`
-	Active       bool          `json:"active"`
-	Integrations []Integration `json:"integrations"`
-}
-
-func (c *Client) GetReceiversExperimental(ctx context.Context) ([]Receiver, error) {
+func (c *Client) GetReceiversExperimental(ctx context.Context) ([]alertingmodels.Receiver, error) {
 	u := c.alertmanagerClient.URL("api/v1/grafana/receivers", nil)
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
@@ -1488,7 +1474,7 @@ func (c *Client) GetReceiversExperimental(ctx context.Context) ([]Receiver, erro
 		return nil, fmt.Errorf("getting receivers failed with status %d and error %v", resp.StatusCode, string(body))
 	}
 
-	decoded := []Receiver{}
+	decoded := []alertingmodels.Receiver{}
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		return nil, err
 	}

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -1468,7 +1468,7 @@ type Receiver struct {
 }
 
 func (c *Client) GetReceiversExperimental(ctx context.Context) ([]Receiver, error) {
-	u := c.alertmanagerClient.URL("alertmanager/experimental/api/v1/receivers", nil)
+	u := c.alertmanagerClient.URL("api/v1/grafana/receivers", nil)
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -309,9 +309,7 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 	// This route is an experimental Mimir extension to the receivers, API, so we put
 	// it under an additional prefix to avoid any confusion with upstream Alertmanager.
 	if cfg.GrafanaAlertmanagerCompatibility {
-		am.mux.Handle(
-			path.Join(am.cfg.ExternalURL.Path, "/experimental/api/v1/receivers"),
-			http.HandlerFunc(am.GetReceiversHandler))
+		am.mux.Handle("/api/v1/grafana/receivers", http.HandlerFunc(am.GetReceiversHandler))
 	}
 
 	am.dispatcherMetrics = dispatch.NewDispatcherMetrics(true, am.registry)

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -429,11 +429,7 @@ func (am *Alertmanager) ApplyConfig(userID string, conf *definition.PostableApiA
 	route := dispatch.NewRoute(cfg.Route, nil)
 
 	receivers := make([]*nfstatus.Receiver, 0, len(integrationsMap))
-	activeReceivers := make(map[string]struct{})
-	visitFunc := func(r *dispatch.Route) {
-		activeReceivers[r.RouteOpts.Receiver] = struct{}{}
-	}
-	route.Walk(visitFunc)
+	activeReceivers := alertingNotify.GetActiveReceiversMap(route)
 
 	baseIntegrationsMap := make(map[string][]*notify.Integration)
 	for name, v := range integrationsMap {

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -23,6 +24,7 @@ import (
 	"github.com/grafana/alerting/definition"
 	"github.com/grafana/alerting/images"
 	alertingNotify "github.com/grafana/alerting/notify"
+	"github.com/grafana/alerting/notify/nfstatus"
 	alertingReceivers "github.com/grafana/alerting/receivers"
 	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
@@ -95,6 +97,8 @@ type Config struct {
 	Replicator        Replicator
 	Store             alertstore.AlertStore
 	PersisterConfig   PersisterConfig
+
+	GrafanaAlertmanagerCompatibility bool
 }
 
 // An Alertmanager manages the alerts for one user.
@@ -115,6 +119,8 @@ type Alertmanager struct {
 	wg              sync.WaitGroup
 	mux             *http.ServeMux
 	registry        *prometheus.Registry
+	receiversMtx    sync.Mutex
+	receivers       []*nfstatus.Receiver
 
 	// Pipeline created during last ApplyConfig call. Used for testing only.
 	lastPipeline notify.Stage
@@ -300,10 +306,40 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 		am.mux.Handle(a, http.NotFoundHandler())
 	}
 
+	// This route is an experimental Mimir extension to the receivers, API, so we put
+	// it under an additional prefix to avoid any confusion with upstream Alertmanager.
+	if cfg.GrafanaAlertmanagerCompatibility {
+		am.mux.Handle(
+			path.Join(am.cfg.ExternalURL.Path, "/experimental/api/v1/receivers"),
+			http.HandlerFunc(am.GetReceiversHandler))
+	}
+
 	am.dispatcherMetrics = dispatch.NewDispatcherMetrics(true, am.registry)
 
 	//TODO: From this point onward, the alertmanager _might_ receive requests - we need to make sure we've settled and are ready.
 	return am, nil
+}
+
+func (am *Alertmanager) GetReceiversHandler(w http.ResponseWriter, _ *http.Request) {
+	am.receiversMtx.Lock()
+	receivers := am.receivers
+	am.receiversMtx.Unlock()
+
+	response := alertingNotify.GetReceivers(receivers)
+
+	d, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w,
+			fmt.Sprintf("error marshalling receivers: %s", err.Error()),
+			http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(d); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 func (am *Alertmanager) WaitInitialStateSync(ctx context.Context) error {
@@ -392,8 +428,27 @@ func (am *Alertmanager) ApplyConfig(userID string, conf *definition.PostableApiA
 	}
 	intervener := timeinterval.NewIntervener(timeIntervals)
 
+	route := dispatch.NewRoute(cfg.Route, nil)
+
+	receivers := make([]*nfstatus.Receiver, 0, len(integrationsMap))
+	activeReceivers := make(map[string]struct{})
+	visitFunc := func(r *dispatch.Route) {
+		activeReceivers[r.RouteOpts.Receiver] = struct{}{}
+	}
+	route.Walk(visitFunc)
+
+	baseIntegrationsMap := make(map[string][]*notify.Integration)
+	for name, v := range integrationsMap {
+		_, isActive := activeReceivers[name]
+		receivers = append(receivers, nfstatus.NewReceiver(name, isActive, v))
+		baseIntegrationsMap[name] = nfstatus.GetIntegrations(v)
+	}
+	am.receiversMtx.Lock()
+	am.receivers = receivers
+	am.receiversMtx.Unlock()
+
 	pipeline := am.pipelineBuilder.New(
-		integrationsMap,
+		baseIntegrationsMap,
 		waitFunc,
 		am.inhibitor,
 		silence.NewSilencer(am.silences, am.marker, am.logger),
@@ -404,7 +459,7 @@ func (am *Alertmanager) ApplyConfig(userID string, conf *definition.PostableApiA
 	am.lastPipeline = pipeline
 	am.dispatcher = dispatch.NewDispatcher(
 		am.alerts,
-		dispatch.NewRoute(cfg.Route, nil),
+		route,
 		pipeline,
 		am.marker,
 		timeoutFunc,
@@ -460,10 +515,10 @@ func (am *Alertmanager) getFullState() (*clusterpb.FullState, error) {
 }
 
 // buildIntegrationsMap builds a map of name to the list of integration notifiers off of a list of receiver config.
-func buildIntegrationsMap(nc []*definition.PostableApiReceiver, tmpl *template.Template, firewallDialer *util_net.FirewallDialer, logger log.Logger, notifierWrapper func(string, notify.Notifier) notify.Notifier) (map[string][]*notify.Integration, error) {
-	integrationsMap := make(map[string][]*notify.Integration, len(nc))
+func buildIntegrationsMap(nc []*definition.PostableApiReceiver, tmpl *template.Template, firewallDialer *util_net.FirewallDialer, logger log.Logger, notifierWrapper func(string, notify.Notifier) notify.Notifier) (map[string][]*nfstatus.Integration, error) {
+	integrationsMap := make(map[string][]*nfstatus.Integration, len(nc))
 	for _, rcv := range nc {
-		var integrations []*notify.Integration
+		var integrations []*nfstatus.Integration
 		var err error
 		if rcv.Type() == definition.GrafanaReceiverType {
 			integrations, err = buildGrafanaReceiverIntegrations(rcv, tmpl, logger)
@@ -480,7 +535,7 @@ func buildIntegrationsMap(nc []*definition.PostableApiReceiver, tmpl *template.T
 	return integrationsMap, nil
 }
 
-func buildGrafanaReceiverIntegrations(rcv *definition.PostableApiReceiver, tmpl *template.Template, logger log.Logger) ([]*notify.Integration, error) {
+func buildGrafanaReceiverIntegrations(rcv *definition.PostableApiReceiver, tmpl *template.Template, logger log.Logger) ([]*nfstatus.Integration, error) {
 	loggerFactory := newLoggerFactory(logger)
 	whFn := func(n alertingReceivers.Metadata) (alertingReceivers.WebhookSender, error) {
 		return NewSender(logger), nil
@@ -510,21 +565,16 @@ func buildGrafanaReceiverIntegrations(rcv *definition.PostableApiReceiver, tmpl 
 		return nil, err
 	}
 
-	// TODO: use the nfstatus.Integration wrapper for all integrations.
-	upstreamIntegrations := make([]*notify.Integration, 0, len(integrations))
-	for _, integration := range integrations {
-		upstreamIntegrations = append(upstreamIntegrations, integration.Integration())
-	}
-	return upstreamIntegrations, nil
+	return integrations, nil
 }
 
 // buildReceiverIntegrations builds a list of integration notifiers off of a
 // receiver config.
 // Taken from https://github.com/prometheus/alertmanager/blob/94d875f1227b29abece661db1a68c001122d1da5/cmd/alertmanager/main.go#L112-L159.
-func buildReceiverIntegrations(nc config.Receiver, tmpl *template.Template, firewallDialer *util_net.FirewallDialer, logger log.Logger, wrapper func(string, notify.Notifier) notify.Notifier) ([]*notify.Integration, error) {
+func buildReceiverIntegrations(nc config.Receiver, tmpl *template.Template, firewallDialer *util_net.FirewallDialer, logger log.Logger, wrapper func(string, notify.Notifier) notify.Notifier) ([]*nfstatus.Integration, error) {
 	var (
 		errs         types.MultiError
-		integrations []*notify.Integration
+		integrations []*nfstatus.Integration
 		add          = func(name string, i int, rs notify.ResolvedSender, f func(l log.Logger) (notify.Notifier, error)) {
 			n, err := f(log.With(logger, "integration", name))
 			if err != nil {
@@ -532,7 +582,7 @@ func buildReceiverIntegrations(nc config.Receiver, tmpl *template.Template, fire
 				return
 			}
 			n = wrapper(name, n)
-			integrations = append(integrations, notify.NewIntegration(n, rs, name, i, nc.Name))
+			integrations = append(integrations, nfstatus.NewIntegration(n, rs, name, i, nc.Name))
 		}
 	)
 

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -7,14 +7,19 @@ package alertmanager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/alerting/definition"
+	alertingmodels "github.com/grafana/alerting/models"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/test"
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
@@ -418,4 +423,133 @@ func TestSilenceLimits(t *testing.T) {
 	// due to padding.
 	require.Contains(t, err.Error(), "silence exceeded maximum size")
 	require.Equal(t, "", id3)
+}
+
+func TestExperimentalReceiversAPI(t *testing.T) {
+	var buf concurrency.SyncBuffer
+	logger := log.NewLogfmtLogger(&buf)
+
+	user := "test"
+	reg := prometheus.NewPedanticRegistry()
+	am, err := New(&Config{
+		UserID:            user,
+		Logger:            logger,
+		Limits:            &mockAlertManagerLimits{maxDispatcherAggregationGroups: 10},
+		Features:          featurecontrol.NoopFlags{},
+		TenantDataDir:     t.TempDir(),
+		ExternalURL:       &url.URL{Path: "/am"},
+		ShardingEnabled:   true,
+		Store:             prepareInMemoryAlertStore(),
+		Replicator:        &stubReplicator{},
+		ReplicationFactor: 1,
+		PersisterConfig:   PersisterConfig{Interval: time.Hour},
+	}, reg)
+	require.NoError(t, err)
+	defer am.StopAndWait()
+
+	cfgRaw := `receivers:
+- name: 'recv-1'
+  webhook_configs:
+  - url: http://example.com/
+    send_resolved: true
+
+- name: 'recv-2'
+  webhook_configs:
+  - url: http://example.com/
+    send_resolved: false
+
+route:
+  group_by: ['alertname']
+  group_wait: 10ms
+  group_interval: 10ms
+  receiver: 'recv-1'`
+
+	cfg, err := definition.LoadCompat([]byte(cfgRaw))
+	require.NoError(t, err)
+	require.NoError(t, am.ApplyConfig(user, cfg, cfgRaw))
+
+	doGetReceivers := func() []alertingmodels.Receiver {
+		rr := httptest.NewRecorder()
+		am.GetReceiversHandler(rr, nil)
+		require.Equal(t, http.StatusOK, rr.Code)
+		result := []alertingmodels.Receiver{}
+		err = json.Unmarshal(rr.Body.Bytes(), &result)
+		assert.NoError(t, err)
+		sort.Slice(result, func(i, j int) bool {
+			return result[i].Name < result[j].Name
+		})
+		return result
+	}
+
+	// Check the API returns all receivers but without any notification status.
+
+	result := doGetReceivers()
+	assert.Equal(t, []alertingmodels.Receiver{
+		{
+			Name:   "recv-1",
+			Active: true,
+			Integrations: []alertingmodels.Integration{
+				{
+					Name:                      "webhook",
+					LastNotifyAttemptDuration: "0s",
+					SendResolved:              true,
+				},
+			},
+		},
+		{
+			Name: "recv-2",
+			// Receiver not used in a route.
+			Active: false,
+			Integrations: []alertingmodels.Integration{
+				{
+					Name:                      "webhook",
+					LastNotifyAttemptDuration: "0s",
+					// We configure send_resolved to false.
+					SendResolved: false,
+				},
+			},
+		},
+	}, result)
+
+	// Send an alert which to cause a notification attempt.
+
+	now := time.Now()
+	inputAlerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels: model.LabelSet{
+					"alertname": model.LabelValue("Alert-1"),
+					"a":         "b",
+				},
+				Annotations:  model.LabelSet{"foo": "bar"},
+				StartsAt:     now,
+				EndsAt:       now.Add(5 * time.Minute),
+				GeneratorURL: "http://example.com/prometheus",
+			},
+			UpdatedAt: now,
+			Timeout:   false,
+		},
+	}
+	require.NoError(t, am.alerts.Put(inputAlerts...))
+
+	// Wait for the API to tell us there was a notification attempt.
+
+	result = []alertingmodels.Receiver{}
+	require.Eventually(t, func() bool {
+		result = doGetReceivers()
+		return len(result) == 2 &&
+			len(result[0].Integrations) == 1 &&
+			len(result[1].Integrations) == 1 &&
+			!result[0].Integrations[0].LastNotifyAttempt.IsZero()
+	}, 5*time.Second, 100*time.Millisecond)
+
+	assert.Equal(t, "webhook", result[0].Integrations[0].Name)
+	assert.NotZero(t, result[0].Integrations[0].LastNotifyAttempt)
+	assert.Equal(t, "failed to notify due to rate limits", result[0].Integrations[0].LastNotifyAttemptError)
+
+	// Check the status of the other integration is not changed.
+
+	assert.Equal(t, "webhook", result[1].Integrations[0].Name)
+	assert.Zero(t, result[1].Integrations[0].LastNotifyAttempt)
+	assert.Equal(t, "", result[1].Integrations[0].LastNotifyAttemptError)
 }

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -511,7 +511,7 @@ route:
 		},
 	}, result)
 
-	// Send an alert which to cause a notification attempt.
+	// Send an alert to cause a notification attempt.
 
 	now := time.Now()
 	inputAlerts := []*types.Alert{
@@ -545,7 +545,7 @@ route:
 
 	assert.Equal(t, "webhook", result[0].Integrations[0].Name)
 	assert.NotZero(t, result[0].Integrations[0].LastNotifyAttempt)
-	assert.Equal(t, "failed to notify due to rate limits", result[0].Integrations[0].LastNotifyAttemptError)
+	assert.Equal(t, errRateLimited.Error(), result[0].Integrations[0].LastNotifyAttemptError)
 
 	// Check the status of the other integration is not changed.
 

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -95,6 +95,9 @@ func (d *Distributor) isQuorumReadPath(p string) (bool, merger.Merger) {
 	if strings.HasSuffix(path.Dir(p), "/v2/silence") {
 		return true, merger.V2SilenceID{}
 	}
+	if strings.HasSuffix(p, "/experimental/api/v1/receivers") {
+		return true, merger.ExperimentalReceivers{}
+	}
 	return false, nil
 }
 

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -95,7 +95,7 @@ func (d *Distributor) isQuorumReadPath(p string) (bool, merger.Merger) {
 	if strings.HasSuffix(path.Dir(p), "/v2/silence") {
 		return true, merger.V2SilenceID{}
 	}
-	if strings.HasSuffix(p, "/experimental/api/v1/receivers") {
+	if strings.HasSuffix(p, "/api/v1/grafana/receivers") {
 		return true, merger.ExperimentalReceivers{}
 	}
 	return false, nil

--- a/pkg/alertmanager/distributor_test.go
+++ b/pkg/alertmanager/distributor_test.go
@@ -197,6 +197,16 @@ func TestDistributor_DistributeRequest(t *testing.T) {
 			expectedTotalCalls: 1,
 			route:              "/receivers",
 		}, {
+			name:               "Read /experimental/api/v1/receivers is sent to 3 AMs",
+			numAM:              5,
+			numHappyAM:         5,
+			replicationFactor:  3,
+			isRead:             true,
+			expStatusCode:      http.StatusOK,
+			expectedTotalCalls: 3,
+			route:              "/experimental/api/v1/receivers",
+			responseBody:       []byte(`[]`),
+		}, {
 			name:                "Write /receivers not supported",
 			numAM:               5,
 			numHappyAM:          5,

--- a/pkg/alertmanager/distributor_test.go
+++ b/pkg/alertmanager/distributor_test.go
@@ -197,14 +197,14 @@ func TestDistributor_DistributeRequest(t *testing.T) {
 			expectedTotalCalls: 1,
 			route:              "/receivers",
 		}, {
-			name:               "Read /experimental/api/v1/receivers is sent to 3 AMs",
+			name:               "Read /api/v1/grafana/receivers is sent to 3 AMs",
 			numAM:              5,
 			numHappyAM:         5,
 			replicationFactor:  3,
 			isRead:             true,
 			expStatusCode:      http.StatusOK,
 			expectedTotalCalls: 3,
-			route:              "/experimental/api/v1/receivers",
+			route:              "/api/v1/grafana/receivers",
 			responseBody:       []byte(`[]`),
 		}, {
 			name:                "Write /receivers not supported",

--- a/pkg/alertmanager/merger/experimental_receivers.go
+++ b/pkg/alertmanager/merger/experimental_receivers.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package merger
+
+import (
+	"encoding/json"
+	"sort"
+	"time"
+
+	alertingmodels "github.com/grafana/alerting/models"
+)
+
+// ExperimentalReceivers implements the Merger interface for GET /experimental/api/v1/receivers.
+// It returns the union of receivers and integrations from all responses, merging duplicates.
+// When an integration is duplicated in multiple responses, the integration status is taken
+// from the integration with the most recent notification attempt.
+type ExperimentalReceivers struct{}
+
+func (ExperimentalReceivers) MergeResponses(in [][]byte) ([]byte, error) {
+	responses := make([]alertingmodels.Receiver, 0)
+	for _, body := range in {
+		parsed := make([]alertingmodels.Receiver, 0)
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			return nil, err
+		}
+		responses = append(responses, parsed...)
+	}
+
+	merged, err := mergeReceivers(responses)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(merged)
+}
+
+func mergeReceivers(in []alertingmodels.Receiver) ([]alertingmodels.Receiver, error) {
+	receivers := make(map[string]alertingmodels.Receiver)
+	for _, recv := range in {
+		name := recv.Name
+
+		if current, ok := receivers[name]; ok {
+			merged, err := mergeReceiver(current, recv)
+			if err != nil {
+				return nil, err
+			}
+			receivers[name] = merged
+		} else {
+			receivers[name] = recv
+		}
+	}
+
+	result := make([]alertingmodels.Receiver, 0, len(receivers))
+	for _, recv := range receivers {
+		result = append(result, recv)
+	}
+
+	// Sort receivers by name to give a stable response.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result, nil
+}
+
+func mergeReceiver(lhs alertingmodels.Receiver, rhs alertingmodels.Receiver) (alertingmodels.Receiver, error) {
+	// Receiver is active if it's active anywhere. In theory these should never
+	// be different, but perhaps during reconfiguration, one replica thinks
+	// a receiver is active, and another doesn't.
+	active := lhs.Active || rhs.Active
+
+	integrations, err := mergeIntegrations(append(lhs.Integrations, rhs.Integrations...))
+	if err != nil {
+		return alertingmodels.Receiver{}, err
+	}
+
+	return alertingmodels.Receiver{
+		Name:         lhs.Name,
+		Active:       active,
+		Integrations: integrations,
+	}, nil
+}
+
+func mergeIntegrations(in []alertingmodels.Integration) ([]alertingmodels.Integration, error) {
+	integrations := make(map[string]alertingmodels.Integration)
+
+	for _, integration := range in {
+		if current, ok := integrations[integration.Name]; ok {
+			// If this is a duplicate integration, check if it has a more recent
+			// notification attempt than the current integration.
+			if time.Time(integration.LastNotifyAttempt).After(time.Time(current.LastNotifyAttempt)) {
+				integrations[integration.Name] = integration
+			}
+		} else {
+			integrations[integration.Name] = integration
+		}
+
+	}
+
+	result := make([]alertingmodels.Integration, 0, len(integrations))
+	for _, integration := range integrations {
+		result = append(result, integration)
+	}
+
+	// Sort integrations by name to give a stable response.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result, nil
+}

--- a/pkg/alertmanager/merger/experimental_receivers.go
+++ b/pkg/alertmanager/merger/experimental_receivers.go
@@ -91,9 +91,8 @@ func mergeIntegrations(in []alertingmodels.Integration) ([]alertingmodels.Integr
 			if !time.Time(integration.LastNotifyAttempt).After(time.Time(current.LastNotifyAttempt)) {
 				continue
 			}
-			integrations[integration.Name] = integration
 		}
-
+		integrations[integration.Name] = integration
 	}
 
 	result := make([]alertingmodels.Integration, 0, len(integrations))

--- a/pkg/alertmanager/merger/experimental_receivers.go
+++ b/pkg/alertmanager/merger/experimental_receivers.go
@@ -88,10 +88,9 @@ func mergeIntegrations(in []alertingmodels.Integration) ([]alertingmodels.Integr
 		if current, ok := integrations[integration.Name]; ok {
 			// If this is a duplicate integration, check if it has a more recent
 			// notification attempt than the current integration.
-			if time.Time(integration.LastNotifyAttempt).After(time.Time(current.LastNotifyAttempt)) {
-				integrations[integration.Name] = integration
+			if !time.Time(integration.LastNotifyAttempt).After(time.Time(current.LastNotifyAttempt)) {
+				continue
 			}
-		} else {
 			integrations[integration.Name] = integration
 		}
 

--- a/pkg/alertmanager/merger/experimental_receivers.go
+++ b/pkg/alertmanager/merger/experimental_receivers.go
@@ -10,7 +10,7 @@ import (
 	alertingmodels "github.com/grafana/alerting/models"
 )
 
-// ExperimentalReceivers implements the Merger interface for GET /experimental/api/v1/receivers.
+// ExperimentalReceivers implements the Merger interface for GET /api/v1/grafana/receivers.
 // It returns the union of receivers and integrations from all responses, merging duplicates.
 // When an integration is duplicated in multiple responses, the integration status is taken
 // from the integration with the most recent notification attempt.

--- a/pkg/alertmanager/merger/experimental_receivers_test.go
+++ b/pkg/alertmanager/merger/experimental_receivers_test.go
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package merger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	alertingmodels "github.com/grafana/alerting/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExperimentalReceivers(t *testing.T) {
+
+	// This test is to check the parsing round-trip is working as expected, the merging logic is
+	// tested in TestMergeReceivers and TestMergeIntegrations.
+
+	in := [][]byte{
+		[]byte(`[` +
+			`{"active":true,"integrations":[{"lastNotifyAttempt":"0001-01-01T00:00:00.000Z","lastNotifyAttemptDuration":"0s","name":"email","sendResolved":false}],"name":"dummy"}` +
+			`]`),
+		[]byte(`[` +
+			`{"active":true,"integrations":[{"lastNotifyAttempt":"0001-01-01T00:00:00.000Z","lastNotifyAttemptDuration":"0s","name":"email","sendResolved":false}],"name":"dummy"}` +
+			`]`),
+		[]byte(`[]`),
+	}
+
+	expected := []byte(`[` +
+		`{"active":true,"integrations":[{"lastNotifyAttempt":"0001-01-01T00:00:00.000Z","lastNotifyAttemptDuration":"0s","name":"email","sendResolved":false}],"name":"dummy"}` +
+		`]`)
+
+	out, err := ExperimentalReceivers{}.MergeResponses(in)
+	require.NoError(t, err)
+	require.Equal(t, expected, out)
+}
+
+func TestMergeReceivers(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []alertingmodels.Receiver
+		err  error
+		out  []alertingmodels.Receiver
+	}{
+		{
+			name: "no receivers, should return an empty list",
+			in:   []alertingmodels.Receiver{},
+			out:  []alertingmodels.Receiver{},
+		},
+		{
+			name: "one receiver, should return the receiver",
+			in: []alertingmodels.Receiver{
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+			},
+			out: []alertingmodels.Receiver{
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "two receivers with different names, should return two receivers",
+			in: []alertingmodels.Receiver{
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+				{
+					Name:   "recv-b",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+			},
+			out: []alertingmodels.Receiver{
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+				{
+					Name:   "recv-b",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+			},
+		},
+		// Two replicas might briefly have different configurations, causing this case.
+		{
+			name: "two receivers with same names, with integrations with different names, should return one receiver with two integrations",
+			in: []alertingmodels.Receiver{
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-b",
+						},
+					},
+				},
+			},
+			out: []alertingmodels.Receiver{
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+						{
+							Name: "inte-b",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "two receivers with same names, with integrations with same names, should return one receiver with one integrations",
+			in: []alertingmodels.Receiver{
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+			},
+			out: []alertingmodels.Receiver{
+				{
+					Name:   "recv-a",
+					Active: true,
+					Integrations: []alertingmodels.Integration{
+						{
+							Name: "inte-a",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := mergeReceivers(c.in)
+			require.Equal(t, c.err, err)
+			require.Equal(t, c.out, out)
+		})
+	}
+}
+
+func TestMergeIntegrations(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []alertingmodels.Integration
+		err  error
+		out  []alertingmodels.Integration
+	}{
+		{
+			name: "no integrations, should return an empty list",
+			in:   []alertingmodels.Integration{},
+			out:  []alertingmodels.Integration{},
+		},
+		{
+			name: "one integration, should return the integration",
+			in: []alertingmodels.Integration{
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:00.000Z"),
+					LastNotifyAttemptDuration: "1s",
+					LastNotifyAttemptError:    "",
+				},
+			},
+			out: []alertingmodels.Integration{
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:00.000Z"),
+					LastNotifyAttemptDuration: "1s",
+					LastNotifyAttemptError:    "",
+				},
+			},
+		},
+		{
+			name: "two integrations with different names, should return two integrations in name order",
+			in: []alertingmodels.Integration{
+				{
+					Name:                      "int-b",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:01.000Z"),
+					LastNotifyAttemptDuration: "2s",
+					LastNotifyAttemptError:    "err-b",
+				},
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:00.000Z"),
+					LastNotifyAttemptDuration: "1s",
+					LastNotifyAttemptError:    "err-a",
+				},
+			},
+			out: []alertingmodels.Integration{
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:00.000Z"),
+					LastNotifyAttemptDuration: "1s",
+					LastNotifyAttemptError:    "err-a",
+				},
+				{
+					Name:                      "int-b",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:01.000Z"),
+					LastNotifyAttemptDuration: "2s",
+					LastNotifyAttemptError:    "err-b",
+				},
+			},
+		},
+		{
+			name: "two integrations with same name, should return integration with newest notify attempt",
+			in: []alertingmodels.Integration{
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:01.000Z"),
+					LastNotifyAttemptDuration: "2s",
+					LastNotifyAttemptError:    "err-2",
+				},
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:00.000Z"),
+					LastNotifyAttemptDuration: "1s",
+					LastNotifyAttemptError:    "err-1",
+				},
+			},
+			out: []alertingmodels.Integration{
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:01.000Z"),
+					LastNotifyAttemptDuration: "2s",
+					LastNotifyAttemptError:    "err-2",
+				},
+			},
+		},
+		{
+			name: "two integrations with same name, one without a notify attempt, should return integration with notify attempt",
+			in: []alertingmodels.Integration{
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         strfmt.DateTime(time.Time{}),
+					LastNotifyAttemptDuration: "",
+					LastNotifyAttemptError:    "",
+				},
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:00.000Z"),
+					LastNotifyAttemptDuration: "1s",
+					LastNotifyAttemptError:    "",
+				},
+			},
+			out: []alertingmodels.Integration{
+				{
+					Name:                      "int-a",
+					SendResolved:              true,
+					LastNotifyAttempt:         *v2ParseTime("2020-01-01T12:00:00.000Z"),
+					LastNotifyAttemptDuration: "1s",
+					LastNotifyAttemptError:    "",
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := mergeIntegrations(c.in)
+			require.Equal(t, c.err, err)
+			require.Equal(t, c.out, out)
+		})
+	}
+}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -851,6 +851,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *defi
 		PersisterConfig:                   am.cfg.Persister,
 		Limits:                            am.limits,
 		Features:                          am.features,
+		GrafanaAlertmanagerCompatibility:  am.cfg.GrafanaAlertmanagerCompatibilityEnabled,
 	}, reg)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start Alertmanager for user %v: %v", userID, err)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -224,6 +224,8 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, api
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.SetUserGrafanaState), true, true, http.MethodPost)
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.DeleteUserGrafanaState), true, true, http.MethodDelete)
 
+			// This API is handled by the per-tenant Alertmanager, so it's handed by the distributor.
+			a.RegisterRoute("/api/v1/grafana/receivers", am, true, true, http.MethodGet)
 		}
 	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Grafana Alertmanager has an extended version of the /receivers API that we would like to provide compatibility for. This API is however not in upstream Prometheus Alertmanager, and so the proposal is to add this API strictly under an experimental banner, and not change the existing /receivers API to maintain strict compatability with upstream.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
