### PR TITLE
mixin: Remove usage of cortex_distributor_replication_factor from MimirIngesterInstanceHasNoTenants

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -163,9 +163,24 @@ spec:
             expr: |
               (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
               and on (cluster, namespace)
-              # Only if there are more time-series than would be expected due to continuous testing load
-              max by(cluster, namespace) (
-                sum by(job, cluster, namespace) (cortex_ingester_memory_series)
+              # Only if there are more timeseries than would be expected due to continuous testing load
+              (
+                ( # Classic storage timeseries
+                  sum by(cluster, namespace) (cortex_ingester_memory_series)
+                  /
+                  max by(cluster, namespace) (cortex_distributor_replication_factor)
+                )
+                or
+                ( # Ingest storage timeseries
+                  sum by(cluster, namespace) (
+                    max by(ingester_id, cluster, namespace) (
+                      label_replace(cortex_ingester_memory_series,
+                        "ingester_id", "$1",
+                        "pod", ".*-([0-9]+)$"
+                      )
+                    )
+                  )
+                )
               ) > 100000
             for: 1h
             labels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -164,10 +164,8 @@ spec:
               (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
               and on (cluster, namespace)
               # Only if there are more time-series than would be expected due to continuous testing load
-              (
-                sum by(cluster, namespace) (cortex_ingester_memory_series)
-                /
-                max by(cluster, namespace) (cortex_distributor_replication_factor)
+              max by(cluster, namespace) (
+                sum by(job, cluster, namespace) (cortex_ingester_memory_series)
               ) > 100000
             for: 1h
             labels:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -151,9 +151,24 @@ groups:
           expr: |
             (min by(cluster, namespace, instance) (cortex_ingester_memory_users) == 0)
             and on (cluster, namespace)
-            # Only if there are more time-series than would be expected due to continuous testing load
-            max by(cluster, namespace) (
-              sum by(job, cluster, namespace) (cortex_ingester_memory_series)
+            # Only if there are more timeseries than would be expected due to continuous testing load
+            (
+              ( # Classic storage timeseries
+                sum by(cluster, namespace) (cortex_ingester_memory_series)
+                /
+                max by(cluster, namespace) (cortex_distributor_replication_factor)
+              )
+              or
+              ( # Ingest storage timeseries
+                sum by(cluster, namespace) (
+                  max by(ingester_id, cluster, namespace) (
+                    label_replace(cortex_ingester_memory_series,
+                      "ingester_id", "$1",
+                      "pod", ".*-([0-9]+)$"
+                    )
+                  )
+                )
+              )
             ) > 100000
           for: 1h
           labels:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -164,7 +164,7 @@ groups:
                   max by(ingester_id, cluster, namespace) (
                     label_replace(cortex_ingester_memory_series,
                       "ingester_id", "$1",
-                      "pod", ".*-([0-9]+)$"
+                      "instance", ".*-([0-9]+)$"
                     )
                   )
                 )

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -152,10 +152,8 @@ groups:
             (min by(cluster, namespace, instance) (cortex_ingester_memory_users) == 0)
             and on (cluster, namespace)
             # Only if there are more time-series than would be expected due to continuous testing load
-            (
-              sum by(cluster, namespace) (cortex_ingester_memory_series)
-              /
-              max by(cluster, namespace) (cortex_distributor_replication_factor)
+            max by(cluster, namespace) (
+              sum by(job, cluster, namespace) (cortex_ingester_memory_series)
             ) > 100000
           for: 1h
           labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -151,9 +151,24 @@ groups:
           expr: |
             (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
             and on (cluster, namespace)
-            # Only if there are more time-series than would be expected due to continuous testing load
-            max by(cluster, namespace) (
-              sum by(job, cluster, namespace) (cortex_ingester_memory_series)
+            # Only if there are more timeseries than would be expected due to continuous testing load
+            (
+              ( # Classic storage timeseries
+                sum by(cluster, namespace) (cortex_ingester_memory_series)
+                /
+                max by(cluster, namespace) (cortex_distributor_replication_factor)
+              )
+              or
+              ( # Ingest storage timeseries
+                sum by(cluster, namespace) (
+                  max by(ingester_id, cluster, namespace) (
+                    label_replace(cortex_ingester_memory_series,
+                      "ingester_id", "$1",
+                      "pod", ".*-([0-9]+)$"
+                    )
+                  )
+                )
+              )
             ) > 100000
           for: 1h
           labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -152,10 +152,8 @@ groups:
             (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
             and on (cluster, namespace)
             # Only if there are more time-series than would be expected due to continuous testing load
-            (
-              sum by(cluster, namespace) (cortex_ingester_memory_series)
-              /
-              max by(cluster, namespace) (cortex_distributor_replication_factor)
+            max by(cluster, namespace) (
+              sum by(job, cluster, namespace) (cortex_ingester_memory_series)
             ) > 100000
           for: 1h
           labels:

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -254,10 +254,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
             (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_memory_users) == 0)
             and on (%(alert_aggregation_labels)s)
             # Only if there are more time-series than would be expected due to continuous testing load
-            (
-              sum by(%(alert_aggregation_labels)s) (cortex_ingester_memory_series)
-              /
-              max by(%(alert_aggregation_labels)s) (cortex_distributor_replication_factor)
+            max by(%(alert_aggregation_labels)s) (
+              sum by(%(per_job_label)s, %(alert_aggregation_labels)s) (cortex_ingester_memory_series)
             ) > 100000
           ||| % $._config,
           labels: {

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -266,7 +266,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                   max by(ingester_id, %(alert_aggregation_labels)s) (
                     label_replace(cortex_ingester_memory_series,
                       "ingester_id", "$1",
-                      "pod", ".*-([0-9]+)$"
+                      "%(per_instance_label)s", ".*-([0-9]+)$"
                     )
                   )
                 )


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does


The metric was only used to remove false positives for Mimir clusters with no tenants. using the zone with most series should still be a decent approximation for this.

cortex_distributor_replication_factor is no longer emitted when using ingest storage (Kafka).


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
