### PR TITLE
Distributor: make OTLP endpoint return marshalled proto bytes as response body for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [ENHANCEMENT] Ingester: active series are now updated along with owned series. They decrease when series change ownership between ingesters. This helps provide a more accurate total of active series when ingesters are added. This is only enabled when `-ingester.track-ingester-owned-series` or `-ingester.use-ingester-owned-series-for-limits` are enabled. #8084
 * [ENHANCEMENT] Query-frontend: include route name in query stats log lines. #8191
 * [ENHANCEMENT] OTLP: Speed up conversion from OTel to Mimir format by about 8% and reduce memory consumption by about 30%. Can be disabled via `-distributor.direct-otlp-translation-enabled=false` #7957
-* [ENHANCEMENT] Ingester/Querier: Optimise regexps with long lists of alternates. #8221
+* [ENHANCEMENT] Ingester/Querier: Optimise regexps with long lists of alternates. #8221, #8234
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@
 * [ENHANCEMENT] Ingester: active series are now updated along with owned series. They decrease when series change ownership between ingesters. This helps provide a more accurate total of active series when ingesters are added. This is only enabled when `-ingester.track-ingester-owned-series` or `-ingester.use-ingester-owned-series-for-limits` are enabled. #8084
 * [ENHANCEMENT] Query-frontend: include route name in query stats log lines. #8191
 * [ENHANCEMENT] OTLP: Speed up conversion from OTel to Mimir format by about 8% and reduce memory consumption by about 30%. Can be disabled via `-distributor.direct-otlp-translation-enabled=false` #7957
-* [ENHANCEMENT] Ingester/Querier: Optimise regexps with long lists of alternates. #8221, #8234
+* [ENHANCEMENT] Ingester/Querier: Optimise regexps with long lists of alternates. #8221
+* [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520
 * [BUGFIX] Ingester: Prevent timely compaction of empty blocks. #7624

--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 	golang.org/x/tools v0.20.0 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240415180920-8c6c420018be // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240429193739-8cf5692501f6 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240429193739-8cf5692501f6
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/telebot.v3 v3.2.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -262,7 +262,7 @@ func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distrib
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
 	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, d.PushMetrics, a.logger), true, false, "POST")
-	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.EnableOtelMetadataStorage, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, d.PushMetrics, reg, a.logger, pushConfig.DirectOTLPTranslationEnabled), true, false, "POST")
+	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.EnableOtelMetadataStorage, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, d.PushMetrics, reg, a.logger, pushConfig.DirectOTLPTranslationEnabled), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -46,7 +46,6 @@ func OTLPHandler(
 	maxRecvMsgSize int,
 	requestBufferPool util.Pool,
 	sourceIPs *middleware.SourceIPExtractor,
-	allowSkipLabelNameValidation bool,
 	enableOtelMetadataStorage bool,
 	limits *validation.Overrides,
 	retryCfg RetryConfig,
@@ -58,7 +57,7 @@ func OTLPHandler(
 ) http.Handler {
 	discardedDueToOtelParseError := validation.DiscardedSamplesCounter(reg, otelParseError)
 
-	return handler(maxRecvMsgSize, requestBufferPool, sourceIPs, allowSkipLabelNameValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, logger log.Logger) error {
+	return otlpHandler(maxRecvMsgSize, requestBufferPool, sourceIPs, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, logger log.Logger) error {
 		contentType := r.Header.Get("Content-Type")
 		contentEncoding := r.Header.Get("Content-Encoding")
 		var compression util.CompressionType

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -66,7 +66,7 @@ func BenchmarkOTLPHandler(b *testing.B) {
 		validation.NewMockTenantLimits(map[string]*validation.Limits{}),
 	)
 	require.NoError(b, err)
-	handler := OTLPHandler(100000, nil, nil, false, true, limits, RetryConfig{}, pushFunc, nil, nil, log.NewNopLogger(), true)
+	handler := OTLPHandler(100000, nil, nil, true, limits, RetryConfig{}, pushFunc, nil, nil, log.NewNopLogger(), true)
 
 	b.Run("protobuf", func(b *testing.B) {
 		req := createOTLPProtoRequest(b, exportReq, false)

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -16,11 +16,15 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/httpgrpc/server"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/tenant"
 	"github.com/opentracing/opentracing-go"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util"
@@ -169,7 +173,8 @@ func handler(
 			if resp, ok := httpgrpc.HTTPResponseFromError(err); ok {
 				code, msg = int(resp.Code), string(resp.Body)
 			} else {
-				code, msg = toHTTPStatus(ctx, err, limits), err.Error()
+				_, code = toGRPCHTTPStatus(ctx, err, limits)
+				msg = err.Error()
 			}
 			if code != 202 {
 				level.Error(logger).Log("msg", "push error", "err", err)
@@ -178,6 +183,93 @@ func handler(
 			http.Error(w, msg, code)
 		}
 	})
+}
+
+func otlpHandler(
+	maxRecvMsgSize int,
+	requestBufferPool util.Pool,
+	sourceIPs *middleware.SourceIPExtractor,
+	limits *validation.Overrides,
+	retryCfg RetryConfig,
+	push PushFunc,
+	logger log.Logger,
+	parser parserFunc,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		logger := utillog.WithContext(ctx, logger)
+		if sourceIPs != nil {
+			source := sourceIPs.Get(r)
+			if source != "" {
+				logger = utillog.WithSourceIPs(source, logger)
+			}
+		}
+		supplier := func() (*mimirpb.WriteRequest, func(), error) {
+			rb := util.NewRequestBuffers(requestBufferPool)
+			var req mimirpb.PreallocWriteRequest
+			if err := parser(ctx, r, maxRecvMsgSize, rb, &req, logger); err != nil {
+				// Check for httpgrpc error, default to client error if parsing failed
+				if _, ok := httpgrpc.HTTPResponseFromError(err); !ok {
+					err = httpgrpc.Errorf(http.StatusBadRequest, err.Error())
+				}
+
+				rb.CleanUp()
+				return nil, nil, err
+			}
+
+			cleanup := func() {
+				mimirpb.ReuseSlice(req.Timeseries)
+				rb.CleanUp()
+			}
+			return &req.WriteRequest, cleanup, nil
+		}
+		req := newRequest(supplier)
+		if err := push(ctx, req); err != nil {
+			if errors.Is(err, context.Canceled) {
+				level.Warn(logger).Log("msg", "push request canceled", "err", err)
+				writeErrorToHTTPResponseBody(w, statusClientClosedRequest, codes.Canceled, "push request context canceled", logger)
+				return
+			}
+			var (
+				httpCode int
+				grpcCode codes.Code
+			)
+			if resp, ok := httpgrpc.HTTPResponseFromError(err); ok {
+				// here the error would always be nil, since it is already checked in httpgrpc.HTTPResponseFromError
+				s, _ := grpcutil.ErrorToStatus(err)
+				writeErrorToHTTPResponseBody(w, int(resp.Code), s.Code(), string(resp.Body), logger)
+			} else {
+				grpcCode, httpCode = toGRPCHTTPStatus(ctx, err, limits)
+				writeErrorToHTTPResponseBody(w, httpCode, grpcCode, err.Error(), logger)
+			}
+			if httpCode != 202 {
+				level.Error(logger).Log("msg", "push error", "err", err)
+			}
+			addHeaders(w, err, r, httpCode, retryCfg)
+		}
+	})
+}
+
+// writeErrorToHTTPResponseBody converts the given error into a grpc status and marshals it into a byte slice, in order to be written to the response body.
+// See doc https://opentelemetry.io/docs/specs/otlp/#failures-1
+func writeErrorToHTTPResponseBody(w http.ResponseWriter, httpCode int, grpcCode codes.Code, msg string, logger log.Logger) {
+	// writeResponseFailedError would be returned when writeErrorToHTTPResponseBody fails to write the error to the response body.
+	writeResponseFailedBody, _ := proto.Marshal(grpcstatus.New(codes.Internal, "write error to response failed").Proto())
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(httpCode)
+
+	respBytes, err := proto.Marshal(grpcstatus.New(grpcCode, msg).Proto())
+	if err != nil {
+		level.Warn(logger).Log("msg", "response marshal failed", "err", err)
+		_, _ = w.Write(writeResponseFailedBody)
+		return
+	}
+	_, err = w.Write(respBytes)
+	if err != nil {
+		level.Warn(logger).Log("msg", "write response failed", "err", err)
+		_, _ = w.Write(writeResponseFailedBody)
+	}
 }
 
 func calculateRetryAfter(retryAttemptHeader string, baseSeconds int, maxBackoffExponent int) string {
@@ -198,19 +290,19 @@ func calculateRetryAfter(retryAttemptHeader string, baseSeconds int, maxBackoffE
 	return strconv.FormatInt(delaySeconds, 10)
 }
 
-// toHTTPStatus converts the given error into an appropriate HTTP status corresponding
-// to that error, if the error is one of the errors from this package. Otherwise, an
+// toGRPCHTTPStatus converts the given error into an appropriate GRPC and HTTP status corresponding
+// to that error, if the error is one of the errors from this package. Otherwise, codes.Internal and
 // http.StatusInternalServerError is returned.
-func toHTTPStatus(ctx context.Context, pushErr error, limits *validation.Overrides) int {
+func toGRPCHTTPStatus(ctx context.Context, pushErr error, limits *validation.Overrides) (codes.Code, int) {
 	if errors.Is(pushErr, context.DeadlineExceeded) {
-		return http.StatusInternalServerError
+		return codes.Internal, http.StatusInternalServerError
 	}
 
 	var distributorErr Error
 	if errors.As(pushErr, &distributorErr) {
 		switch distributorErr.Cause() {
 		case mimirpb.BAD_DATA:
-			return http.StatusBadRequest
+			return codes.InvalidArgument, http.StatusBadRequest
 		case mimirpb.INGESTION_RATE_LIMITED, mimirpb.REQUEST_RATE_LIMITED:
 			serviceOverloadErrorEnabled := false
 			userID, err := tenant.TenantID(ctx)
@@ -221,24 +313,24 @@ func toHTTPStatus(ctx context.Context, pushErr error, limits *validation.Overrid
 			// Client may discard the data or slow down and re-send.
 			// Prometheus v2.26 added a remote-write option 'retry_on_http_429'.
 			if serviceOverloadErrorEnabled {
-				return StatusServiceOverloaded
+				return codes.ResourceExhausted, StatusServiceOverloaded
 			}
-			return http.StatusTooManyRequests
+			return codes.ResourceExhausted, http.StatusTooManyRequests
 		case mimirpb.REPLICAS_DID_NOT_MATCH:
-			return http.StatusAccepted
+			return codes.OK, http.StatusAccepted
 		case mimirpb.TOO_MANY_CLUSTERS:
-			return http.StatusBadRequest
+			return codes.InvalidArgument, http.StatusBadRequest
 		case mimirpb.TSDB_UNAVAILABLE:
-			return http.StatusServiceUnavailable
+			return codes.Unavailable, http.StatusServiceUnavailable
 		case mimirpb.CIRCUIT_BREAKER_OPEN:
-			return http.StatusServiceUnavailable
+			return codes.Unavailable, http.StatusServiceUnavailable
 		case mimirpb.METHOD_NOT_ALLOWED:
 			// Return a 501 (and not 405) to explicitly signal a misconfiguration and to possibly track that amongst other 5xx errors.
-			return http.StatusNotImplemented
+			return codes.Unimplemented, http.StatusNotImplemented
 		}
 	}
 
-	return http.StatusInternalServerError
+	return codes.Internal, http.StatusInternalServerError
 }
 
 func addHeaders(w http.ResponseWriter, err error, r *http.Request, responseCode int, retryCfg RetryConfig) {

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -261,13 +261,13 @@ func writeErrorToHTTPResponseBody(w http.ResponseWriter, httpCode int, grpcCode 
 
 	respBytes, err := proto.Marshal(grpcstatus.New(grpcCode, msg).Proto())
 	if err != nil {
-		level.Warn(logger).Log("msg", "response marshal failed", "err", err)
+		level.Error(logger).Log("msg", "otlp response marshal failed", "err", err)
 		_, _ = w.Write(writeResponseFailedBody)
 		return
 	}
 	_, err = w.Write(respBytes)
 	if err != nil {
-		level.Warn(logger).Log("msg", "write response failed", "err", err)
+		level.Error(logger).Log("msg", "write error to otlp response failed", "err", err)
 		_, _ = w.Write(writeResponseFailedBody)
 	}
 }

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -255,7 +255,7 @@ func otlpHandler(
 func writeErrorToHTTPResponseBody(w http.ResponseWriter, httpCode int, grpcCode codes.Code, msg string, logger log.Logger) {
 	// writeResponseFailedError would be returned when writeErrorToHTTPResponseBody fails to write the error to the response body.
 	writeResponseFailedBody, _ := proto.Marshal(grpcstatus.New(codes.Internal, "write error to response failed").Proto())
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(httpCode)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #8185 , as discussed there are 2 possible ways to solve this:
- pass a error handling function to handler, have 2 different implementation for otlp and normal push request
- replicate the handler function for otlp and normal push request.

This PR is using the 2nd solution since it allows us to have more different logics for otlp endpoint in the future.

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
