### PR TITLE
Add `component` label to "discard" metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Query blocking can no longer be circumvented with an equivalent query in a different format; see [Configure queries to block](https://grafana.com/docs/mimir/latest/configure/configure-blocked-queries/)
 * [CHANGE] Query-frontend: stop using `-validation.create-grace-period` to clamp how far into the future a query can span.
 * [CHANGE] Clamp [`GOMAXPROCS`](https://pkg.go.dev/runtime#GOMAXPROCS) to [`runtime.NumCPU`](https://pkg.go.dev/runtime#NumCPU). #8201
+* [CHANGE] Add `component` label to `cortex_discarded_requests_total`, `cortex_discarded_samples_total`, `cortex_discarded_exemplars_total` and `cortex_discarded_metadata_total` metrics. This allows to distinguish which component did the discard and compute correct discard rates, by correctly adjusting for replication factor for discards from ingesters.
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -86,6 +86,8 @@ const (
 	// Size of "slab" when using pooled buffers for marshaling write requests. When handling single Push request
 	// buffers for multiple write requests sent to ingesters will be allocated from single "slab", if there is enough space.
 	writeRequestSlabPoolSize = 512 * 1024
+
+	componentName = "distributor"
 )
 
 // Distributor forwards appends and queries to individual ingesters.
@@ -411,11 +413,11 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 			Help: "Unix timestamp of latest received sample per user.",
 		}, []string{"user"}),
 
-		discardedSamplesTooManyHaClusters: validation.DiscardedSamplesCounter(reg, reasonTooManyHAClusters),
-		discardedSamplesRateLimited:       validation.DiscardedSamplesCounter(reg, reasonRateLimited),
-		discardedRequestsRateLimited:      validation.DiscardedRequestsCounter(reg, reasonRateLimited),
-		discardedExemplarsRateLimited:     validation.DiscardedExemplarsCounter(reg, reasonRateLimited),
-		discardedMetadataRateLimited:      validation.DiscardedMetadataCounter(reg, reasonRateLimited),
+		discardedSamplesTooManyHaClusters: validation.DiscardedSamplesCounter(reg, componentName, reasonTooManyHAClusters),
+		discardedSamplesRateLimited:       validation.DiscardedSamplesCounter(reg, componentName, reasonRateLimited),
+		discardedRequestsRateLimited:      validation.DiscardedRequestsCounter(reg, componentName, reasonRateLimited),
+		discardedExemplarsRateLimited:     validation.DiscardedExemplarsCounter(reg, componentName, reasonRateLimited),
+		discardedMetadataRateLimited:      validation.DiscardedMetadataCounter(reg, componentName, reasonRateLimited),
 
 		rejectedRequests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_distributor_instance_rejected_requests_total",

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1619,7 +1619,7 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			expectedMetrics: `
 			# HELP cortex_discarded_exemplars_total The total number of exemplars that were discarded.
 			# TYPE cortex_discarded_exemplars_total counter
-			cortex_discarded_exemplars_total{reason="exemplar_too_old",user="user"} 1
+			cortex_discarded_exemplars_total{component="distributor",reason="exemplar_too_old",user="user"} 1
 		`,
 		},
 		"should drop exemplars with timestamp lower than the accepted minimum, when multiple exemplars are specified for the same series": {
@@ -1650,7 +1650,7 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			expectedMetrics: `
 			# HELP cortex_discarded_exemplars_total The total number of exemplars that were discarded.
 			# TYPE cortex_discarded_exemplars_total counter
-			cortex_discarded_exemplars_total{reason="exemplar_too_old",user="user"} 1
+			cortex_discarded_exemplars_total{component="distributor",reason="exemplar_too_old",user="user"} 1
 		`,
 		},
 		"should drop exemplars with timestamp lower than the accepted minimum, when multiple exemplars are specified in the same series": {
@@ -1681,7 +1681,7 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			expectedMetrics: `
 			# HELP cortex_discarded_exemplars_total The total number of exemplars that were discarded.
 			# TYPE cortex_discarded_exemplars_total counter
-			cortex_discarded_exemplars_total{reason="exemplar_too_old",user="user"} 1
+			cortex_discarded_exemplars_total{component="distributor",reason="exemplar_too_old",user="user"} 1
 		`,
 		},
 		"should drop exemplars with timestamp greater than the accepted maximum, when multiple exemplars are specified in the same series": {
@@ -1712,7 +1712,7 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			expectedMetrics: `
 		        # HELP cortex_discarded_exemplars_total The total number of exemplars that were discarded.
 		        # TYPE cortex_discarded_exemplars_total counter
-		        cortex_discarded_exemplars_total{reason="exemplar_too_far_in_future",user="user"} 1
+		        cortex_discarded_exemplars_total{component="distributor",reason="exemplar_too_far_in_future",user="user"} 1
 		    `,
 		},
 		"should drop exemplars above the allowed exemplars per series limit, when multiple exemplars are specified in the same series": {
@@ -1746,7 +1746,7 @@ func TestDistributor_ExemplarValidation(t *testing.T) {
 			expectedMetrics: `
                 # HELP cortex_discarded_exemplars_total The total number of exemplars that were discarded.
                 # TYPE cortex_discarded_exemplars_total counter
-                cortex_discarded_exemplars_total{reason="too_many_exemplars_per_series_per_request",user="user"} 1
+                cortex_discarded_exemplars_total{component="distributor",reason="too_many_exemplars_per_series_per_request",user="user"} 1
             `,
 		},
 		"should sort exemplars if they are not sorted": {

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -54,7 +54,7 @@ func OTLPHandler(
 	reg prometheus.Registerer,
 	logger log.Logger,
 ) http.Handler {
-	discardedDueToOtelParseError := validation.DiscardedSamplesCounter(reg, otelParseError)
+	discardedDueToOtelParseError := validation.DiscardedSamplesCounter(reg, componentName, otelParseError)
 
 	return handler(maxRecvMsgSize, requestBufferPool, sourceIPs, allowSkipLabelNameValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, logger log.Logger) error {
 		contentType := r.Header.Get("Content-Type")

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -155,16 +155,16 @@ func (m *sampleValidationMetrics) deleteUserMetricsForGroup(userID, group string
 
 func newSampleValidationMetrics(r prometheus.Registerer) *sampleValidationMetrics {
 	return &sampleValidationMetrics{
-		missingMetricName:            validation.DiscardedSamplesCounter(r, reasonMissingMetricName),
-		invalidMetricName:            validation.DiscardedSamplesCounter(r, reasonInvalidMetricName),
-		maxLabelNamesPerSeries:       validation.DiscardedSamplesCounter(r, reasonMaxLabelNamesPerSeries),
-		invalidLabel:                 validation.DiscardedSamplesCounter(r, reasonInvalidLabel),
-		labelNameTooLong:             validation.DiscardedSamplesCounter(r, reasonLabelNameTooLong),
-		labelValueTooLong:            validation.DiscardedSamplesCounter(r, reasonLabelValueTooLong),
-		maxNativeHistogramBuckets:    validation.DiscardedSamplesCounter(r, reasonMaxNativeHistogramBuckets),
-		invalidNativeHistogramSchema: validation.DiscardedSamplesCounter(r, reasonInvalidNativeHistogramSchema),
-		duplicateLabelNames:          validation.DiscardedSamplesCounter(r, reasonDuplicateLabelNames),
-		tooFarInFuture:               validation.DiscardedSamplesCounter(r, reasonTooFarInFuture),
+		missingMetricName:            validation.DiscardedSamplesCounter(r, componentName, reasonMissingMetricName),
+		invalidMetricName:            validation.DiscardedSamplesCounter(r, componentName, reasonInvalidMetricName),
+		maxLabelNamesPerSeries:       validation.DiscardedSamplesCounter(r, componentName, reasonMaxLabelNamesPerSeries),
+		invalidLabel:                 validation.DiscardedSamplesCounter(r, componentName, reasonInvalidLabel),
+		labelNameTooLong:             validation.DiscardedSamplesCounter(r, componentName, reasonLabelNameTooLong),
+		labelValueTooLong:            validation.DiscardedSamplesCounter(r, componentName, reasonLabelValueTooLong),
+		maxNativeHistogramBuckets:    validation.DiscardedSamplesCounter(r, componentName, reasonMaxNativeHistogramBuckets),
+		invalidNativeHistogramSchema: validation.DiscardedSamplesCounter(r, componentName, reasonInvalidNativeHistogramSchema),
+		duplicateLabelNames:          validation.DiscardedSamplesCounter(r, componentName, reasonDuplicateLabelNames),
+		tooFarInFuture:               validation.DiscardedSamplesCounter(r, componentName, reasonTooFarInFuture),
 	}
 }
 
@@ -191,13 +191,13 @@ func (m *exemplarValidationMetrics) deleteUserMetrics(userID string) {
 
 func newExemplarValidationMetrics(r prometheus.Registerer) *exemplarValidationMetrics {
 	return &exemplarValidationMetrics{
-		labelsMissing:    validation.DiscardedExemplarsCounter(r, reasonExemplarLabelsMissing),
-		timestampInvalid: validation.DiscardedExemplarsCounter(r, reasonExemplarTimestampInvalid),
-		labelsTooLong:    validation.DiscardedExemplarsCounter(r, reasonExemplarLabelsTooLong),
-		labelsBlank:      validation.DiscardedExemplarsCounter(r, reasonExemplarLabelsBlank),
-		tooOld:           validation.DiscardedExemplarsCounter(r, reasonExemplarTooOld),
-		tooFarInFuture:   validation.DiscardedExemplarsCounter(r, reasonExemplarTooFarInFuture),
-		tooManyExemplars: validation.DiscardedExemplarsCounter(r, reasonTooManyExemplarsPerSeriesPerRequest),
+		labelsMissing:    validation.DiscardedExemplarsCounter(r, componentName, reasonExemplarLabelsMissing),
+		timestampInvalid: validation.DiscardedExemplarsCounter(r, componentName, reasonExemplarTimestampInvalid),
+		labelsTooLong:    validation.DiscardedExemplarsCounter(r, componentName, reasonExemplarLabelsTooLong),
+		labelsBlank:      validation.DiscardedExemplarsCounter(r, componentName, reasonExemplarLabelsBlank),
+		tooOld:           validation.DiscardedExemplarsCounter(r, componentName, reasonExemplarTooOld),
+		tooFarInFuture:   validation.DiscardedExemplarsCounter(r, componentName, reasonExemplarTooFarInFuture),
+		tooManyExemplars: validation.DiscardedExemplarsCounter(r, componentName, reasonTooManyExemplarsPerSeriesPerRequest),
 	}
 }
 
@@ -402,9 +402,9 @@ func (m *metadataValidationMetrics) deleteUserMetrics(userID string) {
 
 func newMetadataValidationMetrics(r prometheus.Registerer) *metadataValidationMetrics {
 	return &metadataValidationMetrics{
-		missingMetricName: validation.DiscardedMetadataCounter(r, reasonMissingMetricName),
-		metricNameTooLong: validation.DiscardedMetadataCounter(r, reasonMetadataMetricNameTooLong),
-		unitTooLong:       validation.DiscardedMetadataCounter(r, reasonMetadataUnitTooLong),
+		missingMetricName: validation.DiscardedMetadataCounter(r, componentName, reasonMissingMetricName),
+		metricNameTooLong: validation.DiscardedMetadataCounter(r, componentName, reasonMetadataMetricNameTooLong),
+		unitTooLong:       validation.DiscardedMetadataCounter(r, componentName, reasonMetadataUnitTooLong),
 	}
 }
 

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -158,20 +158,20 @@ func TestValidateLabels(t *testing.T) {
 		assert.Equal(t, c.err, err, "wrong error")
 	}
 
-	randomReason := validation.DiscardedSamplesCounter(reg, "random reason")
+	randomReason := validation.DiscardedSamplesCounter(reg, "test_component", "random reason")
 	randomReason.WithLabelValues("different user", "custom label").Inc()
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{group="custom label",reason="label_invalid",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="label_name_too_long",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="label_value_too_long",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="max_label_names_per_series",user="testUser"} 1
-			cortex_discarded_samples_total{group="custom label",reason="metric_name_invalid",user="testUser"} 2
-			cortex_discarded_samples_total{group="custom label",reason="missing_metric_name",user="testUser"} 1
+			cortex_discarded_samples_total{component="distributor",group="custom label",reason="label_invalid",user="testUser"} 1
+			cortex_discarded_samples_total{component="distributor",group="custom label",reason="label_name_too_long",user="testUser"} 1
+			cortex_discarded_samples_total{component="distributor",group="custom label",reason="label_value_too_long",user="testUser"} 1
+			cortex_discarded_samples_total{component="distributor",group="custom label",reason="max_label_names_per_series",user="testUser"} 1
+			cortex_discarded_samples_total{component="distributor",group="custom label",reason="metric_name_invalid",user="testUser"} 2
+			cortex_discarded_samples_total{component="distributor",group="custom label",reason="missing_metric_name",user="testUser"} 1
 
-			cortex_discarded_samples_total{group="custom label",reason="random reason",user="different user"} 1
+			cortex_discarded_samples_total{component="test_component",group="custom label",reason="random reason",user="different user"} 1
 	`), "cortex_discarded_samples_total"))
 
 	s.deleteUserMetrics(userID)
@@ -179,7 +179,7 @@ func TestValidateLabels(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{group="custom label",reason="random reason",user="different user"} 1
+			cortex_discarded_samples_total{component="test_component",group="custom label",reason="random reason",user="different user"} 1
 	`), "cortex_discarded_samples_total"))
 }
 
@@ -236,17 +236,17 @@ func TestValidateExemplars(t *testing.T) {
 		assert.NoError(t, validateExemplar(m, userID, []mimirpb.LabelAdapter{}, ve))
 	}
 
-	validation.DiscardedExemplarsCounter(reg, "random reason").WithLabelValues("different user").Inc()
+	validation.DiscardedExemplarsCounter(reg, "test_component", "random reason").WithLabelValues("different user").Inc()
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_exemplars_total The total number of exemplars that were discarded.
 			# TYPE cortex_discarded_exemplars_total counter
-			cortex_discarded_exemplars_total{reason="exemplar_labels_blank",user="testUser"} 2
-			cortex_discarded_exemplars_total{reason="exemplar_labels_missing",user="testUser"} 1
-			cortex_discarded_exemplars_total{reason="exemplar_labels_too_long",user="testUser"} 1
-			cortex_discarded_exemplars_total{reason="exemplar_timestamp_invalid",user="testUser"} 1
+			cortex_discarded_exemplars_total{component="distributor",reason="exemplar_labels_blank",user="testUser"} 2
+			cortex_discarded_exemplars_total{component="distributor",reason="exemplar_labels_missing",user="testUser"} 1
+			cortex_discarded_exemplars_total{component="distributor",reason="exemplar_labels_too_long",user="testUser"} 1
+			cortex_discarded_exemplars_total{component="distributor",reason="exemplar_timestamp_invalid",user="testUser"} 1
 
-			cortex_discarded_exemplars_total{reason="random reason",user="different user"} 1
+			cortex_discarded_exemplars_total{component="test_component",reason="random reason",user="different user"} 1
 		`), "cortex_discarded_exemplars_total"))
 
 	// Delete test user and verify only different remaining
@@ -254,7 +254,7 @@ func TestValidateExemplars(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_exemplars_total The total number of exemplars that were discarded.
 			# TYPE cortex_discarded_exemplars_total counter
-			cortex_discarded_exemplars_total{reason="random reason",user="different user"} 1
+			cortex_discarded_exemplars_total{component="test_component",reason="random reason",user="different user"} 1
 	`), "cortex_discarded_exemplars_total"))
 }
 
@@ -325,16 +325,16 @@ func TestValidateMetadata(t *testing.T) {
 		})
 	}
 
-	validation.DiscardedMetadataCounter(reg, "random reason").WithLabelValues("different user").Inc()
+	validation.DiscardedMetadataCounter(reg, "test_component", "random reason").WithLabelValues("different user").Inc()
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_metadata_total The total number of metadata that were discarded.
 			# TYPE cortex_discarded_metadata_total counter
-			cortex_discarded_metadata_total{reason="metric_name_too_long",user="testUser"} 1
-			cortex_discarded_metadata_total{reason="missing_metric_name",user="testUser"} 1
-			cortex_discarded_metadata_total{reason="unit_too_long",user="testUser"} 1
+			cortex_discarded_metadata_total{component="distributor",reason="metric_name_too_long",user="testUser"} 1
+			cortex_discarded_metadata_total{component="distributor",reason="missing_metric_name",user="testUser"} 1
+			cortex_discarded_metadata_total{component="distributor",reason="unit_too_long",user="testUser"} 1
 
-			cortex_discarded_metadata_total{reason="random reason",user="different user"} 1
+			cortex_discarded_metadata_total{component="test_component",reason="random reason",user="different user"} 1
 	`), "cortex_discarded_metadata_total"))
 
 	m.deleteUserMetrics(userID)
@@ -342,7 +342,7 @@ func TestValidateMetadata(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_discarded_metadata_total The total number of metadata that were discarded.
 			# TYPE cortex_discarded_metadata_total counter
-			cortex_discarded_metadata_total{reason="random reason",user="different user"} 1
+			cortex_discarded_metadata_total{component="test_component",reason="random reason",user="different user"} 1
 	`), "cortex_discarded_metadata_total"))
 }
 
@@ -541,7 +541,7 @@ func TestMaxNativeHistorgramBuckets(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{group="group-1",reason="max_native_histogram_buckets",user="user-1"} 8
+			cortex_discarded_samples_total{component="distributor",group="group-1",reason="max_native_histogram_buckets",user="user-1"} 8
 	`), "cortex_discarded_samples_total"))
 }
 
@@ -580,7 +580,7 @@ func TestInvalidNativeHistogramSchema(t *testing.T) {
 	require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
 			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 			# TYPE cortex_discarded_samples_total counter
-			cortex_discarded_samples_total{group="group-1",reason="invalid_native_histogram_schema",user="user-1"} 2
+			cortex_discarded_samples_total{component="distributor",group="group-1",reason="invalid_native_histogram_schema",user="user-1"} 2
 	`), "cortex_discarded_samples_total"))
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -1258,7 +1258,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_ingested_samples_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="invalid-native-histogram",user="test"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="invalid-native-histogram",user="test"} 1
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
 				cortex_ingester_ingested_samples_failures_total{user="test"} 1
@@ -1299,7 +1299,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_ingested_samples_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="invalid-native-histogram",user="test"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="invalid-native-histogram",user="test"} 1
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
 				cortex_ingester_ingested_samples_failures_total{user="test"} 1
@@ -1340,7 +1340,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_ingested_samples_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="invalid-native-histogram",user="test"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="invalid-native-histogram",user="test"} 1
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
 				cortex_ingester_ingested_samples_failures_total{user="test"} 1
@@ -1381,7 +1381,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_ingested_samples_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="invalid-native-histogram",user="test"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="invalid-native-histogram",user="test"} 1
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
 				cortex_ingester_ingested_samples_failures_total{user="test"} 1
@@ -1422,7 +1422,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_ingested_samples_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="invalid-native-histogram",user="test"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="invalid-native-histogram",user="test"} 1
 				# HELP cortex_ingester_ingested_samples_failures_total The total number of samples that errored on ingestion per user.
 				# TYPE cortex_ingester_ingested_samples_failures_total counter
 				cortex_ingester_ingested_samples_failures_total{user="test"} 1
@@ -1678,7 +1678,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-order",user="test"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-order",user="test"} 1
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -1736,7 +1736,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="test"} 2
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-bounds",user="test"} 2
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -1795,7 +1795,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="test"} 3
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-bounds",user="test"} 3
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -1914,7 +1914,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="test"} 2
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-bounds",user="test"} 2
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -1976,7 +1976,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="test"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-too-far-in-future",user="test"} 1
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -2031,7 +2031,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="test"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-too-far-in-future",user="test"} 1
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -2167,7 +2167,7 @@ func TestIngester_Push(t *testing.T) {
 				cortex_ingester_memory_series_removed_total{user="test"} 0
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="new-value-for-timestamp",user="test"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="new-value-for-timestamp",user="test"} 1
 				# HELP cortex_ingester_active_series Number of currently active series per user.
 				# TYPE cortex_ingester_active_series gauge
 				cortex_ingester_active_series{user="test"} 1
@@ -2436,7 +2436,7 @@ func TestIngester_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_metadata_total The total number of metadata that were discarded.
 				# TYPE cortex_discarded_metadata_total counter
-				cortex_discarded_metadata_total{reason="per_user_metadata_limit",user="test"} 1
+				cortex_discarded_metadata_total{component="ingester",reason="per_user_metadata_limit",user="test"} 1
 				# HELP cortex_ingester_ingested_metadata_failures_total The total number of metadata that errored on ingestion.
 				# TYPE cortex_ingester_ingested_metadata_failures_total counter
 				cortex_ingester_ingested_metadata_failures_total 1
@@ -2490,7 +2490,7 @@ func TestIngester_Push(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_metadata_total The total number of metadata that were discarded.
 				# TYPE cortex_discarded_metadata_total counter
-				cortex_discarded_metadata_total{reason="per_metric_metadata_limit",user="test"} 1
+				cortex_discarded_metadata_total{component="ingester",reason="per_metric_metadata_limit",user="test"} 1
 				# HELP cortex_ingester_ingested_metadata_failures_total The total number of metadata that errored on ingestion.
 				# TYPE cortex_ingester_ingested_metadata_failures_total counter
 				cortex_ingester_ingested_metadata_failures_total 1
@@ -9983,8 +9983,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-order",user="test"} 4
-				cortex_discarded_samples_total{group="",reason="sample-out-of-order",user="tset"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-order",user="test"} 4
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-order",user="tset"} 1
 			`,
 		},
 		"should soft fail on all samples out of bound in a write request": {
@@ -10016,8 +10016,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="test"} 8
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="tset"} 2
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-bounds",user="test"} 8
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-bounds",user="tset"} 2
 			`,
 		},
 		"should soft fail on all samples with histograms out of bound in a write request": {
@@ -10050,8 +10050,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="test"} 12
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="tset"} 3
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-bounds",user="test"} 12
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-bounds",user="tset"} 3
 			`,
 			nativeHistograms: true,
 		},
@@ -10087,8 +10087,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="test"} 8
-				cortex_discarded_samples_total{group="",reason="sample-out-of-bounds",user="tset"} 2
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-bounds",user="test"} 8
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-out-of-bounds",user="tset"} 2
 			`,
 		},
 		"should soft fail on some samples with timestamp too far in future in a write request": {
@@ -10121,8 +10121,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="test"} 4
-				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="tset"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-too-far-in-future",user="test"} 4
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-too-far-in-future",user="tset"} 1
 			`,
 		},
 		"should soft fail on some histograms with timestamp too far in future in a write request": {
@@ -10149,8 +10149,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="test"} 4
-				cortex_discarded_samples_total{group="",reason="sample-too-far-in-future",user="tset"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-too-far-in-future",user="test"} 4
+				cortex_discarded_samples_total{component="ingester",group="",reason="sample-too-far-in-future",user="tset"} 1
 			`,
 		},
 		"should soft fail on some exemplars with timestamp too far in future in a write request": {
@@ -10203,8 +10203,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 				# TYPE cortex_discarded_samples_total counter
-				cortex_discarded_samples_total{group="",reason="new-value-for-timestamp",user="test"} 4
-				cortex_discarded_samples_total{group="",reason="new-value-for-timestamp",user="tset"} 1
+				cortex_discarded_samples_total{component="ingester",group="",reason="new-value-for-timestamp",user="test"} 4
+				cortex_discarded_samples_total{component="ingester",group="",reason="new-value-for-timestamp",user="tset"} 1
 			`,
 		},
 		"should soft fail on exemplar with unknown series": {
@@ -10437,7 +10437,7 @@ func TestIngester_SampledUserLimitExceeded(t *testing.T) {
 	expectedMetrics := `
 		# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 		# TYPE cortex_discarded_samples_total counter
-		cortex_discarded_samples_total{group="",reason="per_user_series_limit",user="1"} 10
+		cortex_discarded_samples_total{component="ingester",group="",reason="per_user_series_limit",user="1"} 10
 	`
 	err = testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...)
 	assert.NoError(t, err)
@@ -10541,7 +10541,7 @@ func TestIngester_SampledMetricLimitExceeded(t *testing.T) {
 	expectedMetrics := `
 		# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 		# TYPE cortex_discarded_samples_total counter
-		cortex_discarded_samples_total{group="",reason="per_metric_series_limit",user="1"} 10
+		cortex_discarded_samples_total{component="ingester",group="",reason="per_metric_series_limit",user="1"} 10
 	`
 	err = testutil.GatherAndCompare(registry, strings.NewReader(expectedMetrics), metricNames...)
 	assert.NoError(t, err)

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -18,6 +18,8 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
+const componentName = "ingester"
+
 type ingesterMetrics struct {
 	ingestedSamples       *prometheus.CounterVec
 	ingestedExemplars     prometheus.Counter
@@ -368,8 +370,8 @@ func newIngesterMetrics(
 			Help: "Requests rejected for hitting per-instance limits",
 		}, []string{"reason"}),
 
-		discardedMetadataPerUserMetadataLimit:   validation.DiscardedMetadataCounter(r, perUserMetadataLimit),
-		discardedMetadataPerMetricMetadataLimit: validation.DiscardedMetadataCounter(r, perMetricMetadataLimit),
+		discardedMetadataPerUserMetadataLimit:   validation.DiscardedMetadataCounter(r, componentName, perUserMetadataLimit),
+		discardedMetadataPerMetricMetadataLimit: validation.DiscardedMetadataCounter(r, componentName, perMetricMetadataLimit),
 
 		shutdownMarker: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_prepare_shutdown_requested",
@@ -432,14 +434,14 @@ type discardedMetrics struct {
 
 func newDiscardedMetrics(r prometheus.Registerer) *discardedMetrics {
 	return &discardedMetrics{
-		sampleOutOfBounds:      validation.DiscardedSamplesCounter(r, reasonSampleOutOfBounds),
-		sampleOutOfOrder:       validation.DiscardedSamplesCounter(r, reasonSampleOutOfOrder),
-		sampleTooOld:           validation.DiscardedSamplesCounter(r, reasonSampleTooOld),
-		sampleTooFarInFuture:   validation.DiscardedSamplesCounter(r, reasonSampleTooFarInFuture),
-		newValueForTimestamp:   validation.DiscardedSamplesCounter(r, reasonNewValueForTimestamp),
-		perUserSeriesLimit:     validation.DiscardedSamplesCounter(r, reasonPerUserSeriesLimit),
-		perMetricSeriesLimit:   validation.DiscardedSamplesCounter(r, reasonPerMetricSeriesLimit),
-		invalidNativeHistogram: validation.DiscardedSamplesCounter(r, reasonInvalidNativeHistogram),
+		sampleOutOfBounds:      validation.DiscardedSamplesCounter(r, componentName, reasonSampleOutOfBounds),
+		sampleOutOfOrder:       validation.DiscardedSamplesCounter(r, componentName, reasonSampleOutOfOrder),
+		sampleTooOld:           validation.DiscardedSamplesCounter(r, componentName, reasonSampleTooOld),
+		sampleTooFarInFuture:   validation.DiscardedSamplesCounter(r, componentName, reasonSampleTooFarInFuture),
+		newValueForTimestamp:   validation.DiscardedSamplesCounter(r, componentName, reasonNewValueForTimestamp),
+		perUserSeriesLimit:     validation.DiscardedSamplesCounter(r, componentName, reasonPerUserSeriesLimit),
+		perMetricSeriesLimit:   validation.DiscardedSamplesCounter(r, componentName, reasonPerMetricSeriesLimit),
+		invalidNativeHistogram: validation.DiscardedSamplesCounter(r, componentName, reasonInvalidNativeHistogram),
 	}
 }
 

--- a/pkg/util/validation/discarded_metrics.go
+++ b/pkg/util/validation/discarded_metrics.go
@@ -8,49 +8,54 @@ import (
 )
 
 const (
+	componentLabel     = "component"
 	discardReasonLabel = "reason"
 )
 
 // DiscardedRequestsCounter creates per-user counter vector for requests discarded for a given reason.
-func DiscardedRequestsCounter(reg prometheus.Registerer, reason string) *prometheus.CounterVec {
+func DiscardedRequestsCounter(reg prometheus.Registerer, component, reason string) *prometheus.CounterVec {
 	return promauto.With(reg).NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cortex_discarded_requests_total",
 			Help: "The total number of requests that were discarded due to rate limiting.",
 			ConstLabels: map[string]string{
+				componentLabel:     component,
 				discardReasonLabel: reason,
 			},
 		}, []string{"user"})
 }
 
 // DiscardedSamplesCounter creates per-user counter vector for samples discarded for a given reason.
-func DiscardedSamplesCounter(reg prometheus.Registerer, reason string) *prometheus.CounterVec {
+func DiscardedSamplesCounter(reg prometheus.Registerer, component, reason string) *prometheus.CounterVec {
 	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_discarded_samples_total",
 		Help: "The total number of samples that were discarded.",
 		ConstLabels: map[string]string{
+			componentLabel:     component,
 			discardReasonLabel: reason,
 		},
 	}, []string{"user", "group"})
 }
 
 // DiscardedExemplarsCounter creates per-user counter vector for exemplars discarded for a given reason.
-func DiscardedExemplarsCounter(reg prometheus.Registerer, reason string) *prometheus.CounterVec {
+func DiscardedExemplarsCounter(reg prometheus.Registerer, component, reason string) *prometheus.CounterVec {
 	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_discarded_exemplars_total",
 		Help: "The total number of exemplars that were discarded.",
 		ConstLabels: map[string]string{
+			componentLabel:     component,
 			discardReasonLabel: reason,
 		},
 	}, []string{"user"})
 }
 
 // DiscardedMetadataCounter creates per-user counter vector for metadata discarded for a given reason.
-func DiscardedMetadataCounter(reg prometheus.Registerer, reason string) *prometheus.CounterVec {
+func DiscardedMetadataCounter(reg prometheus.Registerer, component, reason string) *prometheus.CounterVec {
 	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_discarded_metadata_total",
 		Help: "The total number of metadata that were discarded.",
 		ConstLabels: map[string]string{
+			componentLabel:     component,
 			discardReasonLabel: reason,
 		},
 	}, []string{"user"})


### PR DESCRIPTION
#### What this PR does

This PR adds `component` label to "discard" metrics
* `cortex_discarded_requests_total`
* `cortex_discarded_samples_total`
* `cortex_discarded_exemplars_total`
* `cortex_discarded_metadata_total`

This allows to distinguish which component did the discard and compute correct discard rates, by correctly adjusting for replication factor for discards from ingesters.

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
