### PR TITLE
Return 400 status code if a write request is too large to be ingested via Kafka even after splitting

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -2193,6 +2193,22 @@ How to **fix** it:
 
 - Increase the allowed limit by using the `-distributor.max-recv-msg-size` option.
 
+### err-mimir-distributor-max-write-request-data-item-size
+
+This error can only be returned when the experimental ingest storage is enabled and is caused by a write request containing a timeseries or metadata entry which is larger than the allowed limit.
+
+How it **works**:
+
+- The distributor shards a write request into N partitions, where N is the tenant partitions shard size.
+- For each partition, the write request data is encoded into one or more Kafka records.
+- The maximum size of a Kafka record is hardcoded, so the per-partition write request data is automatically split into multiple Kafka records in order to ingest large write requests.
+- The splitting uses a single timeseries or metadata entry has a the splittable unit, which means that a single timeseries or metadata entry can't be split into multiple Kafka records.
+- If the write request contains a single timeseries or metadata entry whose size is bigger than the Kafka record size limit, then the ingestion of the write request will fail and return a 4xx HTTP status code. The 4xx status code is used to ensure the client will not retry sending a request which will consistently fail.
+
+How to **fix** it:
+
+- Configure the client remote writing to Mimir to send smaller write requests.
+
 ### err-mimir-query-blocked
 
 This error occurs when a query-frontend blocks a read request because the query matches at least one of the rules defined in the limits.

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -2202,8 +2202,8 @@ How it **works**:
 - The distributor shards a write request into N partitions, where N is the tenant partitions shard size.
 - For each partition, the write request data is encoded into one or more Kafka records.
 - The maximum size of a Kafka record is hardcoded, so the per-partition write request data is automatically split into multiple Kafka records in order to ingest large write requests.
-- The splitting uses a single timeseries or metadata entry has a the splittable unit, which means that a single timeseries or metadata entry can't be split into multiple Kafka records.
-- If the write request contains a single timeseries or metadata entry whose size is bigger than the Kafka record size limit, then the ingestion of the write request will fail and return a 4xx HTTP status code. The 4xx status code is used to ensure the client will not retry sending a request which will consistently fail.
+- A single timeseries or metadata is the smallest splittable unit, which means that a single timeseries or metadata entry can't be split into multiple Kafka records.
+- If the write request contains a single timeseries or metadata entry whose size is bigger than the Kafka record size limit, then the ingestion of the write request will fail and the distributor will return a 4xx HTTP status code. The 4xx status code is used to ensure the client will not retry a request which will consistently fail.
 
 How to **fix** it:
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1498,7 +1498,7 @@ func (d *Distributor) sendWriteRequestToBackends(ctx context.Context, tenantID s
 
 	batchOptions := ring.DoBatchOptions{
 		Cleanup:       batchCleanup,
-		IsClientError: isIngesterClientError,
+		IsClientError: isIngestionClientError,
 		Go:            d.doBatchPushWorkers,
 	}
 

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -7,14 +7,17 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"slices"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
+	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/mtime"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/test"
@@ -263,6 +266,65 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 			))
 		})
 	}
+}
+
+func TestDistributor_Push_ShouldReturnErrorMappedTo4xxStatusCodeIfWriteRequestContainsTimeseriesBiggerThanLimit(t *testing.T) {
+	ctx := user.InjectOrgID(context.Background(), "user")
+	now := time.Now()
+
+	hugeLabelValueLength := 100 * 1024 * 1024
+
+	createWriteRequest := func() *mimirpb.WriteRequest {
+		return &mimirpb.WriteRequest{
+			Timeseries: []mimirpb.PreallocTimeseries{
+				makeTimeseries([]string{model.MetricNameLabel, strings.Repeat("x", hugeLabelValueLength)}, makeSamples(now.UnixMilli(), 1), nil),
+			},
+		}
+	}
+
+	limits := prepareDefaultLimits()
+	limits.MaxLabelValueLength = hugeLabelValueLength
+
+	testConfig := prepConfig{
+		numDistributors:         1,
+		ingestStorageEnabled:    true,
+		ingestStoragePartitions: 1,
+		limits:                  limits,
+	}
+
+	distributors, _, regs, _ := prepare(t, testConfig)
+	require.Len(t, distributors, 1)
+	require.Len(t, regs, 1)
+
+	t.Run("Push()", func(t *testing.T) {
+		// Send write request.
+		res, err := distributors[0].Push(ctx, createWriteRequest())
+		require.Error(t, err)
+		require.Nil(t, res)
+
+		// We expect a gRPC error.
+		errStatus, ok := grpcutil.ErrorToStatus(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, errStatus.Code())
+		assert.ErrorContains(t, errStatus.Err(), ingest.ErrWriteRequestDataItemTooLarge.Error())
+
+		// We expect the gRPC error to be detected as client error.
+		assert.True(t, mimirpb.IsClientError(err))
+	})
+
+	t.Run("Handler()", func(t *testing.T) {
+		marshalledReq, err := createWriteRequest().Marshal()
+		require.NoError(t, err)
+
+		maxRecvMsgSize := hugeLabelValueLength * 2
+		resp := httptest.NewRecorder()
+		sourceIPs, _ := middleware.NewSourceIPs("SomeField", "(.*)", false)
+
+		// Send write request through the HTTP handler.
+		h := Handler(maxRecvMsgSize, nil, sourceIPs, false, nil, RetryConfig{}, distributors[0].PushWithMiddlewares, nil, log.NewNopLogger())
+		h.ServeHTTP(resp, createRequest(t, marshalledReq))
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+	})
 }
 
 func TestDistributor_Push_ShouldSupportWriteBothToIngestersAndPartitions(t *testing.T) {

--- a/pkg/distributor/errors_test.go
+++ b/pkg/distributor/errors_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/storage/ingest"
 )
 
 func TestNewReplicasNotMatchError(t *testing.T) {
@@ -167,6 +168,16 @@ func TestNewIngesterPushError(t *testing.T) {
 			checkDistributorError(t, wrappedErr, testData.expectedCause)
 		})
 	}
+}
+
+func TestPartitionPushError(t *testing.T) {
+	origErr := errors.New("the original error")
+	pushErr := newPartitionPushError(origErr, mimirpb.BAD_DATA)
+
+	assert.ErrorIs(t, pushErr, origErr)
+	assert.NotErrorIs(t, pushErr, context.Canceled)
+
+	assert.Equal(t, mimirpb.BAD_DATA, pushErr.Cause())
 }
 
 func TestNewCircuitBreakerOpenError(t *testing.T) {
@@ -489,7 +500,36 @@ func TestWrapIngesterPushError(t *testing.T) {
 	}
 }
 
-func TestIsIngesterClientError(t *testing.T) {
+func TestWrapPartitionPushError(t *testing.T) {
+	tests := map[string]struct {
+		err           error
+		expectedMsg   string
+		expectedCause mimirpb.ErrorCause
+	}{
+		"should wrap ingest.ErrWriteRequestDataItemTooLarge": {
+			err:           wrapPartitionPushError(ingest.ErrWriteRequestDataItemTooLarge, 1),
+			expectedMsg:   "failed pushing to partition 1: " + ingest.ErrWriteRequestDataItemTooLarge.Error(),
+			expectedCause: mimirpb.BAD_DATA,
+		},
+		"should wrap context.Canceled": {
+			err:           wrapPartitionPushError(context.Canceled, 1),
+			expectedMsg:   "failed pushing to partition 1: context canceled",
+			expectedCause: mimirpb.UNKNOWN_CAUSE,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testData.expectedMsg, testData.err.Error())
+
+			partitionPushErr, ok := testData.err.(partitionPushError)
+			require.True(t, ok)
+			assert.Equal(t, testData.expectedCause, partitionPushErr.Cause())
+		})
+	}
+}
+
+func TestIsIngestionClientError(t *testing.T) {
 	testCases := map[string]struct {
 		err             error
 		expectedOutcome bool
@@ -504,6 +544,14 @@ func TestIsIngesterClientError(t *testing.T) {
 		},
 		"an ingesterPushError with other error cause is not a client error": {
 			err:             ingesterPushError{cause: mimirpb.SERVICE_UNAVAILABLE},
+			expectedOutcome: false,
+		},
+		"an partitionPushError with error cause BAD_DATA is a client error": {
+			err:             partitionPushError{cause: mimirpb.BAD_DATA},
+			expectedOutcome: true,
+		},
+		"an partitionPushError with other error cause is not a client error": {
+			err:             partitionPushError{cause: mimirpb.SERVICE_UNAVAILABLE},
 			expectedOutcome: false,
 		},
 		"an gRPC error with status code 4xx built by httpgrpc package is a client error": {
@@ -537,7 +585,7 @@ func TestIsIngesterClientError(t *testing.T) {
 	}
 	for testName, testData := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			require.Equal(t, testData.expectedOutcome, isIngesterClientError(testData.err))
+			require.Equal(t, testData.expectedOutcome, isIngestionClientError(testData.err))
 		})
 	}
 }

--- a/pkg/util/globalerror/user.go
+++ b/pkg/util/globalerror/user.go
@@ -71,7 +71,8 @@ const (
 	StoreConsistencyCheckFailed ID = "store-consistency-check-failed"
 	BucketIndexTooOld           ID = "bucket-index-too-old"
 
-	DistributorMaxWriteMessageSize ID = "distributor-max-write-message-size"
+	DistributorMaxWriteMessageSize         ID = "distributor-max-write-message-size"
+	DistributorMaxWriteRequestDataItemSize ID = "distributor-max-write-request-data-item-size"
 
 	// Map Prometheus TSDB native histogram validation errors to Mimir errors.
 	// E.g. histogram.ErrHistogramCountNotBigEnough -> NativeHistogramCountNotBigEnough


### PR DESCRIPTION
#### What this PR does

This PR is a follow up of https://github.com/grafana/mimir/pull/8077. As mentioned in https://github.com/grafana/mimir/pull/8077:

> The splitting is a best-effort. If a single Timeseries or Metadata entry is bigger than the allowed max size (about 16MB) then the result record will still be rejected by Kafka. I want to treat such case as a client-side error, so that the client will not indefinitely try to push a WriteRequest which will consistently fail. To keep this PR smaller, I will do this change in a follow up PR.

In this PR I'm changing the write path to return 400 HTTP status code if a WriteRequest can't be written to Kafka even after splitting. It's expected to be a rare event, but it could happen on edge cases. When it happens, we don't want the client to infinitely retry sending a request that will fail forever, so we return a 4xx code to let the client move on.

Tested in the local dev environment, manually setting a very low limit for the record size, and the Grafana Agent got 400 status code (the following is Grafana Agent log):

```
ts=2024-05-31T11:13:03.886516516Z level=error msg="non-recoverable error" component=prometheus.remote_write.metrics_local subcomponent=rw remote_name=local url=http://mimir-write-zone-a-1:8080/api/v1/push count=54967 exemplarCount=0 err="server returned HTTP status 400 Bad Request: send data to partitions: failed pushing to partition 2: the write request contains a timeseries or metadata item which is larger that the maximum allowed size of 5000 bytes (err-mimir-distributor-max-write-request-data-item-size)"
```

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
