### PR TITLE
add metric to track out-of-space errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * Query blocking can no longer be circumvented with an equivalent query in a different format; see [Configure queries to block](https://grafana.com/docs/mimir/latest/configure/configure-blocked-queries/)
 * [CHANGE] Query-frontend: stop using `-validation.create-grace-period` to clamp how far into the future a query can span.
 * [CHANGE] Clamp [`GOMAXPROCS`](https://pkg.go.dev/runtime#GOMAXPROCS) to [`runtime.NumCPU`](https://pkg.go.dev/runtime#NumCPU). #8201
+* [CHANGE] Added new metric `cortex_compactor_disk_out_of_space_errors_total` which counts how many times a compaction failed due to the compactor being out of disk. #8237
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -389,10 +389,10 @@ func newMultitenantCompactor(
 			Name: "cortex_compactor_compaction_interval_seconds",
 			Help: "The configured interval on which compaction is run in seconds. Useful when compared to the last successful run metric to accurately detect multiple failed compaction runs.",
 		}),
-		outOfSpace:  promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+		outOfSpace: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_compactor_out_of_space_errors_total",
 			Help: "Number of times a compaction failed because the compactor was out of space.",
-		}),,
+		}),
 		blocksMarkedForDeletion: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 			Name:        blocksMarkedForDeletionName,
 			Help:        blocksMarkedForDeletionHelp,

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -286,7 +286,7 @@ type MultitenantCompactor struct {
 	compactionRunInterval          prometheus.Gauge
 	blocksMarkedForDeletion        prometheus.Counter
 
-	// outOfSpace is a separate metric for out-of-space errors because this is a common issue which is rarely transient,
+	// outOfSpace is a separate metric for out-of-space errors because this is a common issue which often requires an operator to investigate,
 	// so alerts need to be able to treat it with higher priority than other compaction errors.
 	outOfSpace prometheus.Counter
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -390,8 +390,8 @@ func newMultitenantCompactor(
 			Help: "The configured interval on which compaction is run in seconds. Useful when compared to the last successful run metric to accurately detect multiple failed compaction runs.",
 		}),
 		outOfSpace: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
-			Name: "cortex_compactor_out_of_space_errors_total",
-			Help: "Number of times a compaction failed because the compactor was out of space.",
+			Name: "cortex_compactor_disk_out_of_space_errors_total",
+			Help: "Number of times a compaction failed because the compactor disk was out of space.",
 		}),
 		blocksMarkedForDeletion: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 			Name:        blocksMarkedForDeletionName,


### PR DESCRIPTION
This adds a separate metric to count how many times a compaction failed due to an out of space error.

We need to be able to alert on out of space conditions with higher criticality than we alert on compaction failures because generic compaction failures can happen due to various transient issues such as network lag and we wouldn't want to get alerted on every network lag, an out of space condition is usually not transient and it usually requires an operator to resolve the problem so it makes sense to separate that metric from other compaction failures.