### PR TITLE
Expose /multitenant_alertmanager/configs endpoint

### DIFF
--- a/development/common/config/nginx.conf.template
+++ b/development/common/config/nginx.conf.template
@@ -58,6 +58,9 @@ http {
     location = /multitenant_alertmanager/status {
       proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
     }
+    location = /multitenant_alertmanager/configs {
+      proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
+    }
     location = /api/v1/alerts {
       proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
     }
@@ -75,7 +78,7 @@ http {
     location /prometheus/api/v1/rules {
       proxy_pass      http://${RULER_HOST}$request_uri;
     }
-    
+
     location /prometheus/api/v1/alerts {
       proxy_pass      http://${RULER_HOST}$request_uri;
     }

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -52,6 +52,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Smoke-test: Parameterized `backoffLimit` for smoke tests in Helm chart to accommodate slower startup environments like k3d. #8025
 * [ENHANCEMENT] Add a volumeClaimTemplates section to the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` components. #8016
 * [BUGFIX] Helm: Allowed setting static NodePort for nginx gateway via `gateway.service.nodePort`. #6966
+* [BUGFIX] Helm: Expose AM configs in the `gateway` NGINX configuration. #8248
 
 ## 5.3.0
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2983,6 +2983,10 @@ nginx:
             set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
             proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
           }
+          location = /multitenant_alertmanager/configs {
+            set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+            proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+          }
           location = /api/v1/alerts {
             set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
             proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
@@ -3047,6 +3051,7 @@ ingress:
     alertmanager-headless:
       - path: /alertmanager
       - path: /multitenant_alertmanager/status
+      - path: /multitenant_alertmanager/configs
       - path: /api/v1/alerts
     ruler:
       - path: /prometheus/config/v1/rules
@@ -3382,6 +3387,10 @@ gateway:
               proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }
             location = /multitenant_alertmanager/status {
+              set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
+              proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
+            }
+            location = /multitenant_alertmanager/configs {
               set $alertmanager {{ template "mimir.fullname" . }}-alertmanager-headless.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }};
               proxy_pass      http://$alertmanager:{{ include "mimir.serverHttpListenPort" . }}$request_uri;
             }

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
@@ -94,6 +94,10 @@ data:
           set $alertmanager gateway-nginx-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager gateway-nginx-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager gateway-nginx-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager keda-autoscaling-global-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager keda-autoscaling-global-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager keda-autoscaling-global-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager keda-autoscaling-metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager keda-autoscaling-metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager keda-autoscaling-metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager keda-autoscaling-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager keda-autoscaling-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager keda-autoscaling-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager large-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager large-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager large-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager metamonitoring-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager scheduler-name-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager scheduler-name-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager scheduler-name-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager small-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager small-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager small-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingress.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingress.yaml
@@ -28,6 +28,13 @@ spec:
                 name: test-ingress-values-mimir-alertmanager-headless
                 port:
                   number: 8080
+          - path: /multitenant_alertmanager/configs
+            pathType: Prefix
+            backend:
+              service:
+                name: test-ingress-values-mimir-alertmanager-headless
+                port:
+                  number: 8080
           - path: /api/v1/alerts
             pathType: Prefix
             backend:

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager test-ingress-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-ingress-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager test-ingress-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager test-oss-k8s-1.25-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-oss-k8s-1.25-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager test-oss-k8s-1.25-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager test-oss-logical-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-oss-logical-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager test-oss-logical-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager test-oss-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-oss-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager test-oss-multizone-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager test-oss-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-oss-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager test-oss-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager test-requests-and-limits-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-requests-and-limits-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager test-requests-and-limits-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager test-ruler-dedicated-query-path-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-ruler-dedicated-query-path-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager test-ruler-dedicated-query-path-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -89,6 +89,10 @@ data:
           set $alertmanager test-vault-agent-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;
         }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-vault-agent-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
         location = /api/v1/alerts {
           set $alertmanager test-vault-agent-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
           proxy_pass      http://$alertmanager:8080$request_uri;

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -191,6 +191,7 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, api
 
 	a.indexPage.AddLinks(defaultWeight, "Alertmanager", []IndexPageLink{
 		{Desc: "Status", Path: "/multitenant_alertmanager/status"},
+		{Desc: "Status", Path: "/multitenant_alertmanager/configs"},
 		{Desc: "Ring status", Path: "/multitenant_alertmanager/ring"},
 		{Desc: "Alertmanager", Path: "/alertmanager"},
 	})


### PR DESCRIPTION
#### What this PR does

Exposes the `/multitenant_alertmanager/configs` endpoint in the gateway nginx configuration. On `main` this would return a `404` while in this branch a file gets downloaded.

#### Which issue(s) this PR fixes or relates to

Partly #6025

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
