### PR TITLE
Add OTel resource attribute promotion feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [FEATURE] Distributor: Added `-api.skip-label-count-validation-header-enabled` option to allow skipping label count validation on the HTTP write path based on `X-Mimir-SkipLabelCountValidation` header being `true` or not. #9576
 * [FEATURE] Ruler: Add experimental support for caching the contents of rule groups. This is disabled by default and can be enabled by setting `-ruler-storage.cache.rule-group-enabled`. #9595
 * [FEATURE] PromQL: Add experimental `info` function. Experimental functions are disabled by default, but can be enabled setting `-querier.promql-experimental-functions-enabled=true` in the query-frontend and querier. #9879
+* [FEATURE] Distributor: Support promotion of OTel resource attributes to labels. #8271
 * [ENHANCEMENT] mimirtool: Adds bearer token support for mimirtool's analyze ruler/prometheus commands. #9587
 * [ENHANCEMENT] Ruler: Support `exclude_alerts` parameter in `<prometheus-http-prefix>/api/v1/rules` endpoint. #9300
 * [ENHANCEMENT] Distributor: add a metric to track tenants who are sending newlines in their label values called `cortex_distributor_label_values_with_newlines_total`. #9400

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4770,7 +4770,7 @@
           "desc": "Optionally specify OTel resource attributes to promote to labels.",
           "fieldValue": null,
           "fieldDefaultValue": "",
-          "fieldFlag": "distributor.promote-otel-resource-attributes",
+          "fieldFlag": "distributor.otel-promote-resource-attributes",
           "fieldType": "string",
           "fieldCategory": "experimental"
         },

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4767,7 +4767,7 @@
           "kind": "field",
           "name": "promote_otel_resource_attributes",
           "required": false,
-          "desc": "Eventual OTel resource attributes to promote to labels.",
+          "desc": "Optionally specify OTel resource attributes to promote to labels.",
           "fieldValue": null,
           "fieldDefaultValue": "",
           "fieldFlag": "distributor.promote-otel-resource-attributes",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4765,6 +4765,17 @@
         },
         {
           "kind": "field",
+          "name": "promote_otel_resource_attributes",
+          "required": false,
+          "desc": "Eventual OTel resource attributes to promote to labels.",
+          "fieldValue": null,
+          "fieldDefaultValue": "",
+          "fieldFlag": "distributor.promote-otel-resource-attributes",
+          "fieldType": "string",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "ingest_storage_read_consistency",
           "required": false,
           "desc": "The default consistency level to enforce for queries when using the ingest storage. Supports values: strong, eventual.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1389,7 +1389,7 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.
   -distributor.otel-metric-suffixes-enabled
     	Whether to enable automatic suffixes to names of metrics ingested through OTLP.
-  -distributor.promote-otel-resource-attributes comma-separated-list-of-strings
+  -distributor.otel-promote-resource-attributes comma-separated-list-of-strings
     	[experimental] Optionally specify OTel resource attributes to promote to labels.
   -distributor.remote-timeout duration
     	Timeout for downstream ingesters. (default 2s)

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1389,6 +1389,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.
   -distributor.otel-metric-suffixes-enabled
     	Whether to enable automatic suffixes to names of metrics ingested through OTLP.
+  -distributor.promote-otel-resource-attributes comma-separated-list-of-strings
+    	[experimental] Eventual OTel resource attributes to promote to labels.
   -distributor.remote-timeout duration
     	Timeout for downstream ingesters. (default 2s)
   -distributor.request-burst-size int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1390,7 +1390,7 @@ Usage of ./cmd/mimir/mimir:
   -distributor.otel-metric-suffixes-enabled
     	Whether to enable automatic suffixes to names of metrics ingested through OTLP.
   -distributor.promote-otel-resource-attributes comma-separated-list-of-strings
-    	[experimental] Eventual OTel resource attributes to promote to labels.
+    	[experimental] Optionally specify OTel resource attributes to promote to labels.
   -distributor.remote-timeout duration
     	Timeout for downstream ingesters. (default 2s)
   -distributor.request-burst-size int

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -86,6 +86,8 @@ The following features are currently experimental:
     - `-distributor.max-request-pool-buffer-size`
   - Enable conversion of OTel start timestamps to Prometheus zero samples to mark series start
     - `-distributor.otel-created-timestamp-zero-ingestion-enabled`
+  - Promote a certain set of OTel resource attributes to labels
+    - `-distributor.promote-otel-resource-attributes`
 - Hash ring
   - Disabling ring heartbeat timeouts
     - `-distributor.ring.heartbeat-timeout=0`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3762,6 +3762,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -distributor.otel-created-timestamp-zero-ingestion-enabled
 [otel_created_timestamp_zero_ingestion_enabled: <boolean> | default = false]
 
+# (experimental) Eventual OTel resource attributes to promote to labels.
+# CLI flag: -distributor.promote-otel-resource-attributes
+[promote_otel_resource_attributes: <string> | default = ""]
+
 # (experimental) The default consistency level to enforce for queries when using
 # the ingest storage. Supports values: strong, eventual.
 # CLI flag: -ingest-storage.read-consistency

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3762,7 +3762,8 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -distributor.otel-created-timestamp-zero-ingestion-enabled
 [otel_created_timestamp_zero_ingestion_enabled: <boolean> | default = false]
 
-# (experimental) Eventual OTel resource attributes to promote to labels.
+# (experimental) Optionally specify OTel resource attributes to promote to
+# labels.
 # CLI flag: -distributor.promote-otel-resource-attributes
 [promote_otel_resource_attributes: <string> | default = ""]
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3764,7 +3764,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 
 # (experimental) Optionally specify OTel resource attributes to promote to
 # labels.
-# CLI flag: -distributor.promote-otel-resource-attributes
+# CLI flag: -distributor.otel-promote-resource-attributes
 [promote_otel_resource_attributes: <string> | default = ""]
 
 # (experimental) The default consistency level to enforce for queries when using

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -264,8 +264,14 @@ const OTLPPushEndpoint = "/otlp/v1/metrics"
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config, reg prometheus.Registerer, limits *validation.Overrides) {
 	distributorpb.RegisterDistributorServer(a.server.GRPC, d)
 
-	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader, a.cfg.SkipLabelCountValidationHeader, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, d.PushMetrics, a.logger), true, false, "POST")
-	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(pushConfig.MaxOTLPRequestSize, d.RequestBufferPool, a.sourceIPs, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, d.PushMetrics, reg, a.logger), true, false, "POST")
+	a.RegisterRoute(PrometheusPushEndpoint, distributor.Handler(
+		pushConfig.MaxRecvMsgSize, d.RequestBufferPool, a.sourceIPs, a.cfg.SkipLabelNameValidationHeader,
+		a.cfg.SkipLabelCountValidationHeader, limits, pushConfig.RetryConfig, d.PushWithMiddlewares, d.PushMetrics, a.logger,
+	), true, false, "POST")
+	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(
+		pushConfig.MaxOTLPRequestSize, d.RequestBufferPool, a.sourceIPs, limits, pushConfig.OTelResourceAttributePromotionConfig,
+		pushConfig.RetryConfig, d.PushWithMiddlewares, d.PushMetrics, reg, a.logger,
+	), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -179,6 +179,12 @@ type Distributor struct {
 	partitionsRing *ring.PartitionInstanceRing
 }
 
+// OTelResourceAttributePromotionConfig contains methods for configuring OTel resource attribute promotion.
+type OTelResourceAttributePromotionConfig interface {
+	// PromoteOTelResourceAttributes returns which OTel resource attributes to promote for tenant ID.
+	PromoteOTelResourceAttributes(id string) []string
+}
+
 // Config contains the configuration required to
 // create a Distributor
 type Config struct {
@@ -227,6 +233,9 @@ type Config struct {
 
 	WriteRequestsBufferPoolingEnabled bool `yaml:"write_requests_buffer_pooling_enabled" category:"experimental"`
 	ReusableIngesterPushWorkers       int  `yaml:"reusable_ingester_push_workers" category:"advanced"`
+
+	// OTelResourceAttributePromotionConfig allows for specializing OTel resource attribute promotion.
+	OTelResourceAttributePromotionConfig OTelResourceAttributePromotionConfig `yaml:"-"`
 }
 
 // PushWrapper wraps around a push. It is similar to middleware.Interface.

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -50,6 +50,7 @@ const (
 type OTLPHandlerLimits interface {
 	OTelMetricSuffixesEnabled(id string) bool
 	OTelCreatedTimestampZeroIngestionEnabled(id string) bool
+	PromoteOTelResourceAttributes(id string) []string
 }
 
 // OTLPHandler is an http.Handler accepting OTLP write requests.
@@ -58,6 +59,7 @@ func OTLPHandler(
 	requestBufferPool util.Pool,
 	sourceIPs *middleware.SourceIPExtractor,
 	limits OTLPHandlerLimits,
+	resourceAttributePromotionConfig OTelResourceAttributePromotionConfig,
 	retryCfg RetryConfig,
 	push PushFunc,
 	pushMetrics *PushMetrics,
@@ -168,12 +170,18 @@ func OTLPHandler(
 		}
 		addSuffixes := limits.OTelMetricSuffixesEnabled(tenantID)
 		enableCTZeroIngestion := limits.OTelCreatedTimestampZeroIngestionEnabled(tenantID)
+		var promoteResourceAttributes []string
+		if resourceAttributePromotionConfig != nil {
+			promoteResourceAttributes = resourceAttributePromotionConfig.PromoteOTelResourceAttributes(tenantID)
+		} else {
+			promoteResourceAttributes = limits.PromoteOTelResourceAttributes(tenantID)
+		}
 
 		pushMetrics.IncOTLPRequest(tenantID)
 		pushMetrics.ObserveUncompressedBodySize(tenantID, float64(uncompressedBodySize))
 
 		var metrics []mimirpb.PreallocTimeseries
-		metrics, err = otelMetricsToTimeseries(ctx, tenantID, addSuffixes, enableCTZeroIngestion, discardedDueToOtelParseError, spanLogger, otlpReq.Metrics())
+		metrics, err = otelMetricsToTimeseries(ctx, tenantID, addSuffixes, enableCTZeroIngestion, promoteResourceAttributes, discardedDueToOtelParseError, logger, otlpReq.Metrics())
 		if err != nil {
 			return err
 		}
@@ -195,6 +203,7 @@ func OTLPHandler(
 			"sample_count", sampleCount,
 			"histogram_count", histogramCount,
 			"exemplar_count", exemplarCount,
+			"promoted_resource_attributes", promoteResourceAttributes,
 		)
 
 		req.Timeseries = metrics
@@ -400,11 +409,12 @@ func otelMetricsToMetadata(addSuffixes bool, md pmetric.Metrics) []*mimirpb.Metr
 	return metadata
 }
 
-func otelMetricsToTimeseries(ctx context.Context, tenantID string, addSuffixes, enableCTZeroIngestion bool, discardedDueToOtelParseError *prometheus.CounterVec, logger log.Logger, md pmetric.Metrics) ([]mimirpb.PreallocTimeseries, error) {
+func otelMetricsToTimeseries(ctx context.Context, tenantID string, addSuffixes, enableCTZeroIngestion bool, promoteResourceAttributes []string, discardedDueToOtelParseError *prometheus.CounterVec, logger log.Logger, md pmetric.Metrics) ([]mimirpb.PreallocTimeseries, error) {
 	converter := otlp.NewMimirConverter()
 	_, errs := converter.FromMetrics(ctx, md, otlp.Settings{
 		AddMetricSuffixes:                   addSuffixes,
 		EnableCreatedTimestampZeroIngestion: enableCTZeroIngestion,
+		PromoteResourceAttributes:           promoteResourceAttributes,
 	}, logger)
 	mimirTS := converter.TimeSeries()
 	if errs != nil {
@@ -443,8 +453,10 @@ func TimeseriesToOTLPRequest(timeseries []prompb.TimeSeries, metadata []mimirpb.
 			attributes.PutStr(l.Name, l.Value)
 		}
 
-		rm := d.ResourceMetrics()
-		sm := rm.AppendEmpty().ScopeMetrics()
+		rms := d.ResourceMetrics()
+		rm := rms.AppendEmpty()
+		rm.Resource().Attributes().PutStr("resource.attr", "value")
+		sm := rm.ScopeMetrics()
 
 		if len(ts.Samples) > 0 {
 			metric := sm.AppendEmpty().Metrics().AppendEmpty()

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -21,13 +21,18 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/pierrec/lz4/v4"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
+	prometheustranslator "github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"golang.org/x/exp/slices"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
@@ -36,6 +41,174 @@ import (
 	"github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
+
+func TestOTelMetricsToTimeSeries(t *testing.T) {
+	const tenantID = "testTenant"
+	discardedDueToOTelParseError := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{
+		Name: "discarded_due_to_otel_parse_error",
+		Help: "Number of metrics discarded due to OTLP parse errors.",
+	}, []string{tenantID, "group"})
+	resourceAttrs := map[string]string{
+		"service.name":        "service name",
+		"service.instance.id": "service ID",
+		"existent-attr":       "resource value",
+		// This one is for testing conflict with metric attribute.
+		"metric-attr": "resource value",
+		// This one is for testing conflict with auto-generated job attribute.
+		"job": "resource value",
+		// This one is for testing conflict with auto-generated instance attribute.
+		"instance": "resource value",
+	}
+	expTargetInfoLabels := []mimirpb.LabelAdapter{
+		{
+			Name:  labels.MetricName,
+			Value: "target_info",
+		},
+	}
+	for k, v := range resourceAttrs {
+		switch k {
+		case "service.name":
+			k = "job"
+		case "service.instance.id":
+			k = "instance"
+		case "job", "instance":
+			// Ignore, as these labels are generated from service.name and service.instance.id
+			continue
+		default:
+			k = prometheustranslator.NormalizeLabel(k)
+		}
+		expTargetInfoLabels = append(expTargetInfoLabels, mimirpb.LabelAdapter{
+			Name:  k,
+			Value: v,
+		})
+	}
+	slices.SortStableFunc(expTargetInfoLabels, func(a, b mimirpb.LabelAdapter) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	md := pmetric.NewMetrics()
+	{
+		rm := md.ResourceMetrics().AppendEmpty()
+		for k, v := range resourceAttrs {
+			rm.Resource().Attributes().PutStr(k, v)
+		}
+		il := rm.ScopeMetrics().AppendEmpty()
+		m := il.Metrics().AppendEmpty()
+		m.SetName("test_metric")
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetIntValue(123)
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		dp.Attributes().PutStr("metric-attr", "metric value")
+	}
+
+	testCases := []struct {
+		name                      string
+		promoteResourceAttributes []string
+		expectedLabels            []mimirpb.LabelAdapter
+	}{
+		{
+			name:                      "Successful conversion without resource attribute promotion",
+			promoteResourceAttributes: nil,
+			expectedLabels: []mimirpb.LabelAdapter{
+				{
+					Name:  "__name__",
+					Value: "test_metric",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
+				},
+				{
+					Name:  "job",
+					Value: "service name",
+				},
+				{
+					Name:  "metric_attr",
+					Value: "metric value",
+				},
+			},
+		},
+		{
+			name:                      "Successful conversion with resource attribute promotion",
+			promoteResourceAttributes: []string{"non-existent-attr", "existent-attr"},
+			expectedLabels: []mimirpb.LabelAdapter{
+				{
+					Name:  "__name__",
+					Value: "test_metric",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
+				},
+				{
+					Name:  "job",
+					Value: "service name",
+				},
+				{
+					Name:  "metric_attr",
+					Value: "metric value",
+				},
+				{
+					Name:  "existent_attr",
+					Value: "resource value",
+				},
+			},
+		},
+		{
+			name:                      "Successful conversion with resource attribute promotion, conflicting resource attributes are ignored",
+			promoteResourceAttributes: []string{"non-existent-attr", "existent-attr", "metric-attr", "job", "instance"},
+			expectedLabels: []mimirpb.LabelAdapter{
+				{
+					Name:  "__name__",
+					Value: "test_metric",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
+				},
+				{
+					Name:  "job",
+					Value: "service name",
+				},
+				{
+					Name:  "existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "metric_attr",
+					Value: "metric value",
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mimirTS, err := otelMetricsToTimeseries(
+				context.Background(), tenantID, true, false, tc.promoteResourceAttributes, discardedDueToOTelParseError, log.NewNopLogger(), md,
+			)
+			require.NoError(t, err)
+			require.Len(t, mimirTS, 2)
+			var ts mimirpb.PreallocTimeseries
+			var targetInfo mimirpb.PreallocTimeseries
+			for i := range mimirTS {
+				for _, lbl := range mimirTS[i].Labels {
+					if lbl.Name != labels.MetricName {
+						continue
+					}
+
+					if lbl.Value == "target_info" {
+						targetInfo = mimirTS[i]
+					} else {
+						ts = mimirTS[i]
+					}
+				}
+			}
+
+			assert.ElementsMatch(t, ts.Labels, tc.expectedLabels)
+			assert.ElementsMatch(t, targetInfo.Labels, expTargetInfoLabels)
+		})
+	}
+}
 
 func BenchmarkOTLPHandler(b *testing.B) {
 	var samples []prompb.Sample
@@ -79,7 +252,7 @@ func BenchmarkOTLPHandler(b *testing.B) {
 		validation.NewMockTenantLimits(map[string]*validation.Limits{}),
 	)
 	require.NoError(b, err)
-	handler := OTLPHandler(100000, nil, nil, limits, RetryConfig{}, pushFunc, nil, nil, log.NewNopLogger())
+	handler := OTLPHandler(100000, nil, nil, limits, nil, RetryConfig{}, pushFunc, nil, nil, log.NewNopLogger())
 
 	b.Run("protobuf", func(b *testing.B) {
 		req := createOTLPProtoRequest(b, exportReq, "")
@@ -205,12 +378,37 @@ func TestHandlerOTLPPush(t *testing.T) {
 			Unit: "metric_unit",
 		},
 	}
-	samplesVerifierFunc := func(t *testing.T, pushReq *Request) error {
+
+	type testCase struct {
+		name                             string
+		series                           []prompb.TimeSeries
+		metadata                         []mimirpb.MetricMetadata
+		compression                      string
+		maxMsgSize                       int
+		verifyFunc                       func(*testing.T, *Request, testCase) error
+		responseCode                     int
+		errMessage                       string
+		expectedLogs                     []string
+		expectedRetryHeader              bool
+		promoteResourceAttributes        []string
+		expectedAttributePromotions      map[string]string
+		resourceAttributePromotionConfig OTelResourceAttributePromotionConfig
+	}
+
+	samplesVerifierFunc := func(t *testing.T, pushReq *Request, tc testCase) error {
+		t.Helper()
+
 		request, err := pushReq.WriteRequest()
 		require.NoError(t, err)
 
 		series := request.Timeseries
 		require.Len(t, series, 1)
+
+		for name, value := range tc.expectedAttributePromotions {
+			require.Truef(t, slices.ContainsFunc(series[0].Labels, func(l mimirpb.LabelAdapter) bool {
+				return l.Name == name && l.Value == value
+			}), "OTel resource attribute should have been promoted to label %s=%s", name, value)
+		}
 
 		samples := series[0].Samples
 		require.Len(t, samples, 1)
@@ -228,21 +426,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 		return nil
 	}
 
-	tests := []struct {
-		name     string
-		series   []prompb.TimeSeries
-		metadata []mimirpb.MetricMetadata
-
-		compression string
-		maxMsgSize  int
-
-		verifyFunc   func(*testing.T, *Request) error
-		responseCode int
-		errMessage   string
-
-		expectedLogs        []string
-		expectedRetryHeader bool
-	}{
+	tests := []testCase{
 		{
 			name:         "Write samples. No compression",
 			maxMsgSize:   100000,
@@ -250,6 +434,29 @@ func TestHandlerOTLPPush(t *testing.T) {
 			series:       sampleSeries,
 			metadata:     sampleMetadata,
 			responseCode: http.StatusOK,
+		},
+		{
+			name:                        "Write samples. No compression. Resource attribute promotion.",
+			maxMsgSize:                  100000,
+			verifyFunc:                  samplesVerifierFunc,
+			series:                      sampleSeries,
+			metadata:                    sampleMetadata,
+			responseCode:                http.StatusOK,
+			promoteResourceAttributes:   []string{"resource.attr"},
+			expectedAttributePromotions: map[string]string{"resource_attr": "value"},
+		},
+		{
+			name:                      "Write samples. No compression. Specialized resource attribute promotion.",
+			maxMsgSize:                100000,
+			verifyFunc:                samplesVerifierFunc,
+			series:                    sampleSeries,
+			metadata:                  sampleMetadata,
+			responseCode:              http.StatusOK,
+			promoteResourceAttributes: nil,
+			resourceAttributePromotionConfig: fakeResourceAttributePromotionConfig{
+				promote: []string{"resource.attr"},
+			},
+			expectedAttributePromotions: map[string]string{"resource_attr": "value"},
 		},
 		{
 			name:         "Write samples. With gzip compression",
@@ -274,13 +481,13 @@ func TestHandlerOTLPPush(t *testing.T) {
 			maxMsgSize: 30,
 			series:     sampleSeries,
 			metadata:   sampleMetadata,
-			verifyFunc: func(_ *testing.T, pushReq *Request) error {
+			verifyFunc: func(_ *testing.T, pushReq *Request, _ testCase) error {
 				_, err := pushReq.WriteRequest()
 				return err
 			},
 			responseCode: http.StatusRequestEntityTooLarge,
-			errMessage:   "the incoming OTLP request has been rejected because its message size of 63 bytes is larger",
-			expectedLogs: []string{`level=error user=test msg="detected an error while ingesting OTLP metrics request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = the incoming OTLP request has been rejected because its message size of 63 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-otlp-request-size). To adjust the related limit, configure -distributor.max-otlp-request-size, or contact your service administrator." insight=true`},
+			errMessage:   "the incoming OTLP request has been rejected because its message size of 89 bytes is larger",
+			expectedLogs: []string{`level=error user=test msg="detected an error while ingesting OTLP metrics request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = the incoming OTLP request has been rejected because its message size of 89 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-otlp-request-size). To adjust the related limit, configure -distributor.max-otlp-request-size, or contact your service administrator." insight=true`},
 		},
 		{
 			name:        "Write samples. Unsupported compression",
@@ -288,7 +495,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			maxMsgSize:  100000,
 			series:      sampleSeries,
 			metadata:    sampleMetadata,
-			verifyFunc: func(_ *testing.T, pushReq *Request) error {
+			verifyFunc: func(_ *testing.T, pushReq *Request, _ testCase) error {
 				_, err := pushReq.WriteRequest()
 				return err
 			},
@@ -302,13 +509,13 @@ func TestHandlerOTLPPush(t *testing.T) {
 			maxMsgSize:  30,
 			series:      sampleSeries,
 			metadata:    sampleMetadata,
-			verifyFunc: func(_ *testing.T, pushReq *Request) error {
+			verifyFunc: func(_ *testing.T, pushReq *Request, _ testCase) error {
 				_, err := pushReq.WriteRequest()
 				return err
 			},
 			responseCode: http.StatusRequestEntityTooLarge,
-			errMessage:   "the incoming OTLP request has been rejected because its message size of 78 bytes is larger",
-			expectedLogs: []string{`level=error user=test msg="detected an error while ingesting OTLP metrics request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = the incoming OTLP request has been rejected because its message size of 78 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-otlp-request-size). To adjust the related limit, configure -distributor.max-otlp-request-size, or contact your service administrator." insight=true`},
+			errMessage:   "the incoming OTLP request has been rejected because its message size of 104 bytes is larger",
+			expectedLogs: []string{`level=error user=test msg="detected an error while ingesting OTLP metrics request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = the incoming OTLP request has been rejected because its message size of 104 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-otlp-request-size). To adjust the related limit, configure -distributor.max-otlp-request-size, or contact your service administrator." insight=true`},
 		},
 		{
 			name:        "Write samples. With lz4 compression, request too big",
@@ -316,20 +523,20 @@ func TestHandlerOTLPPush(t *testing.T) {
 			maxMsgSize:  30,
 			series:      sampleSeries,
 			metadata:    sampleMetadata,
-			verifyFunc: func(_ *testing.T, pushReq *Request) error {
+			verifyFunc: func(_ *testing.T, pushReq *Request, _ testCase) error {
 				_, err := pushReq.WriteRequest()
 				return err
 			},
 			responseCode: http.StatusRequestEntityTooLarge,
-			errMessage:   "the incoming OTLP request has been rejected because its message size of 80 bytes is larger",
-			expectedLogs: []string{`level=error user=test msg="detected an error while ingesting OTLP metrics request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = the incoming OTLP request has been rejected because its message size of 80 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-otlp-request-size). To adjust the related limit, configure -distributor.max-otlp-request-size, or contact your service administrator." insight=true`},
+			errMessage:   "the incoming OTLP request has been rejected because its message size of 106 bytes is larger",
+			expectedLogs: []string{`level=error user=test msg="detected an error while ingesting OTLP metrics request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = the incoming OTLP request has been rejected because its message size of 106 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-otlp-request-size). To adjust the related limit, configure -distributor.max-otlp-request-size, or contact your service administrator." insight=true`},
 		},
 		{
 			name:       "Rate limited request",
 			maxMsgSize: 100000,
 			series:     sampleSeries,
 			metadata:   sampleMetadata,
-			verifyFunc: func(*testing.T, *Request) error {
+			verifyFunc: func(*testing.T, *Request, testCase) error {
 				return httpgrpc.Errorf(http.StatusTooManyRequests, "go slower")
 			},
 			responseCode:        http.StatusTooManyRequests,
@@ -356,7 +563,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 					Unit: "metric_unit",
 				},
 			},
-			verifyFunc: func(t *testing.T, pushReq *Request) error {
+			verifyFunc: func(t *testing.T, pushReq *Request, _ testCase) error {
 				request, err := pushReq.WriteRequest()
 				require.NoError(t, err)
 
@@ -398,7 +605,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 					Unit: "metric_unit",
 				},
 			},
-			verifyFunc: func(t *testing.T, pushReq *Request) error {
+			verifyFunc: func(t *testing.T, pushReq *Request, _ testCase) error {
 				request, err := pushReq.WriteRequest()
 				require.NoError(t, err)
 
@@ -426,20 +633,25 @@ func TestHandlerOTLPPush(t *testing.T) {
 			exportReq := TimeseriesToOTLPRequest(tt.series, tt.metadata)
 			req := createOTLPProtoRequest(t, exportReq, tt.compression)
 
+			testLimits := &validation.Limits{
+				PromoteOTelResourceAttributes: tt.promoteResourceAttributes,
+			}
 			limits, err := validation.NewOverrides(
 				validation.Limits{},
-				validation.NewMockTenantLimits(map[string]*validation.Limits{}),
+				validation.NewMockTenantLimits(map[string]*validation.Limits{
+					"test": testLimits,
+				}),
 			)
 			require.NoError(t, err)
 			pusher := func(_ context.Context, pushReq *Request) error {
 				t.Helper()
 				t.Cleanup(pushReq.CleanUp)
-				return tt.verifyFunc(t, pushReq)
+				return tt.verifyFunc(t, pushReq, tt)
 			}
 
 			logs := &concurrency.SyncBuffer{}
 			retryConfig := RetryConfig{Enabled: true, MinBackoff: 5 * time.Second, MaxBackoff: 5 * time.Second}
-			handler := OTLPHandler(tt.maxMsgSize, nil, nil, limits, retryConfig, pusher, nil, nil, level.NewFilter(log.NewLogfmtLogger(logs), level.AllowInfo()))
+			handler := OTLPHandler(tt.maxMsgSize, nil, nil, limits, tt.resourceAttributePromotionConfig, retryConfig, pusher, nil, nil, level.NewFilter(log.NewLogfmtLogger(logs), level.AllowInfo()))
 
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
@@ -512,7 +724,7 @@ func TestHandler_otlpDroppedMetricsPanic(t *testing.T) {
 
 	req := createOTLPProtoRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), "")
 	resp := httptest.NewRecorder()
-	handler := OTLPHandler(100000, nil, nil, limits, RetryConfig{}, func(_ context.Context, pushReq *Request) error {
+	handler := OTLPHandler(100000, nil, nil, limits, nil, RetryConfig{}, func(_ context.Context, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
 		assert.NoError(t, err)
 		assert.Len(t, request.Timeseries, 3)
@@ -558,7 +770,7 @@ func TestHandler_otlpDroppedMetricsPanic2(t *testing.T) {
 
 	req := createOTLPProtoRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), "")
 	resp := httptest.NewRecorder()
-	handler := OTLPHandler(100000, nil, nil, limits, RetryConfig{}, func(_ context.Context, pushReq *Request) error {
+	handler := OTLPHandler(100000, nil, nil, limits, nil, RetryConfig{}, func(_ context.Context, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
 		t.Cleanup(pushReq.CleanUp)
 		require.NoError(t, err)
@@ -584,7 +796,7 @@ func TestHandler_otlpDroppedMetricsPanic2(t *testing.T) {
 
 	req = createOTLPProtoRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), "")
 	resp = httptest.NewRecorder()
-	handler = OTLPHandler(100000, nil, nil, limits, RetryConfig{}, func(_ context.Context, pushReq *Request) error {
+	handler = OTLPHandler(100000, nil, nil, limits, nil, RetryConfig{}, func(_ context.Context, pushReq *Request) error {
 		request, err := pushReq.WriteRequest()
 		t.Cleanup(pushReq.CleanUp)
 		require.NoError(t, err)
@@ -612,7 +824,7 @@ func TestHandler_otlpWriteRequestTooBigWithCompression(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 
-	handler := OTLPHandler(140, nil, nil, nil, RetryConfig{}, readBodyPushFunc(t), nil, nil, log.NewNopLogger())
+	handler := OTLPHandler(140, nil, nil, nil, nil, RetryConfig{}, readBodyPushFunc(t), nil, nil, log.NewNopLogger())
 	handler.ServeHTTP(resp, req)
 	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.Code)
 	body, err := io.ReadAll(resp.Body)
@@ -837,4 +1049,12 @@ func TestHttpRetryableToOTLPRetryable(t *testing.T) {
 			require.Equal(t, testCase.expectedOtlpHTTPStatusCode, otlpHTTPStatusCode)
 		})
 	}
+}
+
+type fakeResourceAttributePromotionConfig struct {
+	promote []string
+}
+
+func (c fakeResourceAttributePromotionConfig) PromoteOTelResourceAttributes(string) []string {
+	return []string{"resource.attr"}
 }

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -1183,7 +1183,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 
 		return nil
 	}
-	h := OTLPHandler(200, util.NewBufferPool(0), nil, otlpLimitsMock{}, RetryConfig{}, push, newPushMetrics(reg), reg, log.NewNopLogger())
+	h := OTLPHandler(200, util.NewBufferPool(0), nil, otlpLimitsMock{}, nil, RetryConfig{}, push, newPushMetrics(reg), reg, log.NewNopLogger())
 	srv.HTTP.Handle("/otlp", h)
 
 	// start the server
@@ -1347,12 +1347,16 @@ func mustMarshalStatus(t *testing.T, code codes.Code, msg string) []byte {
 
 type otlpLimitsMock struct{}
 
-func (o otlpLimitsMock) OTelMetricSuffixesEnabled(_ string) bool {
+func (o otlpLimitsMock) OTelMetricSuffixesEnabled(string) bool {
 	return false
 }
 
-func (o otlpLimitsMock) OTelCreatedTimestampZeroIngestionEnabled(_ string) bool {
+func (o otlpLimitsMock) OTelCreatedTimestampZeroIngestionEnabled(string) bool {
 	return false
+}
+
+func (o otlpLimitsMock) PromoteOTelResourceAttributes(string) []string {
+	return nil
 }
 
 func promToMimirHistogram(h *prompb.Histogram) mimirpb.Histogram {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -237,8 +237,9 @@ type Limits struct {
 	AlertmanagerMaxAlertsSizeBytes             int           `yaml:"alertmanager_max_alerts_size_bytes" json:"alertmanager_max_alerts_size_bytes"`
 
 	// OpenTelemetry
-	OTelMetricSuffixesEnabled                bool `yaml:"otel_metric_suffixes_enabled" json:"otel_metric_suffixes_enabled" category:"advanced"`
-	OTelCreatedTimestampZeroIngestionEnabled bool `yaml:"otel_created_timestamp_zero_ingestion_enabled" json:"otel_created_timestamp_zero_ingestion_enabled" category:"experimental"`
+	OTelMetricSuffixesEnabled                bool                   `yaml:"otel_metric_suffixes_enabled" json:"otel_metric_suffixes_enabled" category:"advanced"`
+	OTelCreatedTimestampZeroIngestionEnabled bool                   `yaml:"otel_created_timestamp_zero_ingestion_enabled" json:"otel_created_timestamp_zero_ingestion_enabled" category:"experimental"`
+	PromoteOTelResourceAttributes            flagext.StringSliceCSV `yaml:"promote_otel_resource_attributes" json:"promote_otel_resource_attributes" category:"experimental"`
 
 	// Ingest storage.
 	IngestStorageReadConsistency       string `yaml:"ingest_storage_read_consistency" json:"ingest_storage_read_consistency" category:"experimental"`
@@ -275,6 +276,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.ServiceOverloadStatusCodeOnRateLimitEnabled, "distributor.service-overload-status-code-on-rate-limit-enabled", false, "If enabled, rate limit errors will be reported to the client with HTTP status code 529 (Service is overloaded). If disabled, status code 429 (Too Many Requests) is used. Enabling -distributor.retry-after-header.enabled before utilizing this option is strongly recommended as it helps prevent premature request retries by the client.")
 	f.BoolVar(&l.OTelMetricSuffixesEnabled, "distributor.otel-metric-suffixes-enabled", false, "Whether to enable automatic suffixes to names of metrics ingested through OTLP.")
 	f.BoolVar(&l.OTelCreatedTimestampZeroIngestionEnabled, "distributor.otel-created-timestamp-zero-ingestion-enabled", false, "Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.")
+	f.Var(&l.PromoteOTelResourceAttributes, "distributor.promote-otel-resource-attributes", "Eventual OTel resource attributes to promote to labels.")
 
 	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, MaxSeriesPerMetricFlag, 0, "The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.")
@@ -1095,6 +1097,10 @@ func (o *Overrides) OTelMetricSuffixesEnabled(tenantID string) bool {
 
 func (o *Overrides) OTelCreatedTimestampZeroIngestionEnabled(tenantID string) bool {
 	return o.getOverridesForUser(tenantID).OTelCreatedTimestampZeroIngestionEnabled
+}
+
+func (o *Overrides) PromoteOTelResourceAttributes(tenantID string) []string {
+	return o.getOverridesForUser(tenantID).PromoteOTelResourceAttributes
 }
 
 func (o *Overrides) AlignQueriesWithStep(userID string) bool {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -276,7 +276,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.ServiceOverloadStatusCodeOnRateLimitEnabled, "distributor.service-overload-status-code-on-rate-limit-enabled", false, "If enabled, rate limit errors will be reported to the client with HTTP status code 529 (Service is overloaded). If disabled, status code 429 (Too Many Requests) is used. Enabling -distributor.retry-after-header.enabled before utilizing this option is strongly recommended as it helps prevent premature request retries by the client.")
 	f.BoolVar(&l.OTelMetricSuffixesEnabled, "distributor.otel-metric-suffixes-enabled", false, "Whether to enable automatic suffixes to names of metrics ingested through OTLP.")
 	f.BoolVar(&l.OTelCreatedTimestampZeroIngestionEnabled, "distributor.otel-created-timestamp-zero-ingestion-enabled", false, "Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.")
-	f.Var(&l.PromoteOTelResourceAttributes, "distributor.promote-otel-resource-attributes", "Optionally specify OTel resource attributes to promote to labels.")
+	f.Var(&l.PromoteOTelResourceAttributes, "distributor.otel-promote-resource-attributes", "Optionally specify OTel resource attributes to promote to labels.")
 
 	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, MaxSeriesPerMetricFlag, 0, "The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -276,7 +276,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.ServiceOverloadStatusCodeOnRateLimitEnabled, "distributor.service-overload-status-code-on-rate-limit-enabled", false, "If enabled, rate limit errors will be reported to the client with HTTP status code 529 (Service is overloaded). If disabled, status code 429 (Too Many Requests) is used. Enabling -distributor.retry-after-header.enabled before utilizing this option is strongly recommended as it helps prevent premature request retries by the client.")
 	f.BoolVar(&l.OTelMetricSuffixesEnabled, "distributor.otel-metric-suffixes-enabled", false, "Whether to enable automatic suffixes to names of metrics ingested through OTLP.")
 	f.BoolVar(&l.OTelCreatedTimestampZeroIngestionEnabled, "distributor.otel-created-timestamp-zero-ingestion-enabled", false, "Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.")
-	f.Var(&l.PromoteOTelResourceAttributes, "distributor.promote-otel-resource-attributes", "Eventual OTel resource attributes to promote to labels.")
+	f.Var(&l.PromoteOTelResourceAttributes, "distributor.promote-otel-resource-attributes", "Optionally specify OTel resource attributes to promote to labels.")
 
 	f.IntVar(&l.MaxGlobalSeriesPerUser, MaxSeriesPerUserFlag, 150000, "The maximum number of in-memory series per tenant, across the cluster before replication. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerMetric, MaxSeriesPerMetricFlag, 0, "The maximum number of in-memory series per metric name, across the cluster before replication. 0 to disable.")


### PR DESCRIPTION
#### What this PR does
Add support for promoting OTel resource attributes.

The flag `-distributor.promote-otel-resource-attributes` (also a runtime config parameter) controls which set of resource attributes to eventually promote.

Additionally, `OTelResourceAttributePromotionConfig` can be set on the distributor configuration in order to specialize the configuration of which OTel resource attributes to promote. This is intended for our enterprise product.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
