### PR TITLE
otlp: Fix generating of OTLP code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -793,4 +793,4 @@ generate-otlp:
 
 .PHONY: check-generated-otlp-code
 check-generated-otlp-code: generate-otlp
-	@./tools/find-diff-or-untracked.sh $(OTLP_GOS) || (echo "Please rebuild OTLP code by running 'generate-otlp'" && false)
+	@./tools/find-diff-or-untracked.sh $(OTLP_GOS) || (echo "Please rebuild OTLP code by running 'make generate-otlp'" && false)

--- a/pkg/distributor/otlp/generate.sh
+++ b/pkg/distributor/otlp/generate.sh
@@ -4,7 +4,8 @@
 set -euo pipefail
 
 # Use GNU sed on MacOS falling back to `sed` everywhere else
-SED=$(which gsed || which sed)
+SED=sed
+type gsed >/dev/null 2>&1 && SED=gsed
 
 FILES=$(find ../../../vendor/github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite -name '*.go' ! -name timeseries.go ! -name "*_test.go")
 


### PR DESCRIPTION
#### What this PR does
Fix generating of OTLP code:
* Change `make check-generated-otlp-code` to instruct the user to run `make generate-otlp` and not just `generate-otlp`
* Fix pkg/distributor/otlp/generate.sh so it doesn't emit a warning on Linux

Currently pkg/distributor/otlp/generate.sh emits the following warning on Linux:

```console
which: no gsed in (/usr/lib/go/bin:/home/arve/.gem/ruby/3.0.0/bin:/home/arve/.volta/bin:/home/arve/go/bin:/home/arve/.local/bin:/opt/go/1.17.8/bin:/home/arve/.cargo/bin:/home/arve/.gem/ruby/3.0.0/bin:/home/arve/.volta/bin:/home/arve/go/bin:/home/arve/.local/bin:/opt/go/1.17.8/bin:/home/arve/.cargo/bin:/home/arve/.cargo/bin:/opt/google-cloud-cli/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/lib/rustup/bin)
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
