### PR TITLE
Use zone tracker for store-gateway or ingester autoscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 * [ENHANCEMENT] Add `_config.autoscaling_querier_predictive_scaling_enabled` to scale querier based on inflight queries 7 days ago. #7775
 * [ENHANCEMENT] Add support to autoscale ruler-querier replicas based on in-flight queries too (in addition to CPU and memory based scaling). #8060 #8188
 * [ENHANCEMENT] Distributor: improved distributor HPA scaling metric to only take in account ready pods. This requires the metric `kube_pod_status_ready` to be available in the data source used by KEDA to query scaling metrics (configured via `_config.autoscaling_prometheus_url`). #8250
+* [ENHANCEMENT] Add zone tracker usage whenever `$._config.ingester_zone_a_autoscaling_enabled || $._config.store_gateway_zone_a_autoscaling_enabled`. #8275
 * [BUGFIX] Guard against missing samples in KEDA queries. #7691
 * [BUGFIX] Add configmaps mutability to the `rollout_operator_role`. #8228
 

--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -12,9 +12,19 @@
     $._config.cortex_compactor_concurrent_rollout_enabled ||
     $._config.ingest_storage_ingester_autoscaling_enabled,
 
-  rollout_operator_args:: {
-    'kubernetes.namespace': $._config.namespace,
-  },
+  local zone_tracker =
+    $._config.ingester_zone_a_autoscaling_enabled ||
+    $._config.store_gateway_zone_a_autoscaling_enabled,
+
+  rollout_operator_args::
+    {
+      'kubernetes.namespace': $._config.namespace,
+    } +
+    if !zone_tracker then null
+    else {
+      'use-zone-tracker': true,
+      'zone-tracker.config-map-name': 'rollout-operator-zone-tracker',
+    },
 
   rollout_operator_node_affinity_matchers:: [],
 

--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -20,11 +20,11 @@
     {
       'kubernetes.namespace': $._config.namespace,
     } +
-    if !zone_tracker then null
-    else {
-      'use-zone-tracker': true,
-      'zone-tracker.config-map-name': 'rollout-operator-zone-tracker',
-    },
+    if !zone_tracker then null else
+      {
+        'use-zone-tracker': true,
+        'zone-tracker.config-map-name': 'rollout-operator-zone-tracker',
+      },
 
   rollout_operator_node_affinity_matchers:: [],
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Enables zone tracker from the rollout-operator use whenever ingester or store-gateway autoscaling, which need it, are enabled.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
