### PR TITLE
Mimir query engine: improve performance for case where right side of binary operation has fewer series than the left side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8276
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123

--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -126,6 +126,12 @@ func TestCases(metricSizes []int) []BenchCase {
 		{
 			Expr: `a_2000{l=~"1..."} - b_2000`,
 		},
+		{
+			Expr: `a_2000{l="1234"} - b_2000`,
+		},
+		{
+			Expr: `a_2000 - b_2000{l="1234"}`,
+		},
 		//{
 		//	Expr: "a_X and b_X{l=~'.*[0-4]$'}",
 		//},

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -43,9 +43,9 @@ load 6m
   right_side{env="dev", pod="pod-mno789"}     5    5    5    5
 
 # Matches on both sides: returns results for matching series, ignores non-matching series
-eval range from 0 to 24m step 6m left_side + right_side
-  {env="dev", pod="pod-abc123"} 1010 2020 3030 4040
-  {env="prod", pod="pod-abc123"} 101 202 303 404
+eval range from 0 to 24m step 6m left_side - right_side
+  {env="dev", pod="pod-abc123"} -990 -1980 -2970 -3960
+  {env="prod", pod="pod-abc123"} -99 -198 -297 -396
 
 # No series on either side: returns no results
 eval range from 0 to 24m step 6m left_side_that_doesnt_exist + right_side_that_doesnt_exist
@@ -74,13 +74,13 @@ load 6m
   right_side{env="prod", pod="a"} 10 20 30
   right_side{env="test", pod="b"} 40 50 60
 
-eval range from 0 to 24m step 6m left_side + on(env) right_side
-  {env="prod"} 14 25 36
-  {env="test"} 41 52 63
+eval range from 0 to 24m step 6m left_side - on(env) right_side
+  {env="prod"} -6 -15 -24
+  {env="test"} -39 -48 -57
 
-eval range from 0 to 24m step 6m left_side + ignoring(pod) right_side
-  {env="prod"} 14 25 36
-  {env="test"} 41 52 63
+eval range from 0 to 24m step 6m left_side - ignoring(pod) right_side
+  {env="prod"} -6 -15 -24
+  {env="test"} -39 -48 -57
 
 clear
 
@@ -93,15 +93,15 @@ load 6m
   right_side{env="test", pod="b", group="baz"} 40 50 60
   right_side{env="prod", pod="a", group="foo"} 70 80 90
 
-eval range from 0 to 24m step 6m left_side + on(env, pod) right_side
-  {env="prod", pod="a"} 77 88 99
-  {env="test", pod="a"} 11 22 33
-  {env="test", pod="b"} 44 55 66
+eval range from 0 to 24m step 6m left_side - on(env, pod) right_side
+  {env="prod", pod="a"} -63 -72 -81
+  {env="test", pod="a"} -9 -18 -27
+  {env="test", pod="b"} -36 -45 -54
 
-eval range from 0 to 24m step 6m left_side + ignoring(env, pod) right_side
-  {group="baz"} 47 58 69
-  {group="bar"} 14 25 36
-  {group="foo"} 71 82 93
+eval range from 0 to 24m step 6m left_side - ignoring(env, pod) right_side
+  {group="baz"} -33 -42 -51
+  {group="bar"} -6 -15 -24
+  {group="foo"} -69 -78 -87
 
 clear
 
@@ -112,8 +112,8 @@ load 6m
   right_side{env="test", foo="0"} 2 2 _ _ _ _ 2
   right_side{env="test", foo="1"} _ _ 3 3 _ _ _
 
-eval range from 0 to 42m step 6m left_side * on (env) right_side
-  {env="test"} 2 4 9 12 _ _ _
+eval range from 0 to 42m step 6m left_side - on (env) right_side
+  {env="test"} -1 0 0 1 _ _ _
 
 clear
 

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -142,3 +142,17 @@ eval_fail range from 0 to 42m step 6m left_side * on (env) right_side
   # TODO: expected_message found duplicate series for the match group {env="test"} on the right hand-side of the operation: [{__name__="right_side", env="test", pod="b"}, {__name__="right_side", env="test", pod="a"}];many-to-many matching not allowed: matching labels must be unique on one side
 
 clear
+
+# One-to-one matching with more series on left side than right (and vice-versa)
+# We have an optimsation that favours the smaller side, these tests ensure it behaves correctly.
+load 1m
+  single_series{env="prod"} 100 200 300
+  many_series{env="canary"} 10 20 30
+  many_series{env="prod"} 40 50 60
+  many_series{env="test"} 70 80 90
+
+eval range from 0 to 2m step 1m single_series - many_series
+  {env="prod"} 60 150 240
+
+eval range from 0 to 2m step 1m many_series - single_series
+  {env="prod"} -60 -150 -240


### PR DESCRIPTION
#### What this PR does

This PR improves the performance of binary operations for queries where the right side has fewer series than the left side.

Benchmark results for a query where the left side (`a_2000`) has 2000 series, and the right side has one series:

```
                                                                                    │ original.txt  │             after.txt              │
                                                                                    │    sec/op     │   sec/op     vs base               │
Query/a_2000_-_b_2000{l="1234"},_instant_query/streaming-10                            6.917m ±  4%   6.327m ± 1%   -8.53% (p=0.002 n=6)
Query/a_2000_-_b_2000{l="1234"},_range_query_with_100_steps/streaming-10              10.391m ±  6%   9.670m ± 1%   -6.94% (p=0.002 n=6)
Query/a_2000_-_b_2000{l="1234"},_range_query_with_1000_steps/streaming-10              47.98m ±  4%   46.55m ± 1%   -2.98% (p=0.041 n=6)
```

Latency and peak memory utilisation is unchanged for other benchmarks, and peak memory utilisation is only marginally affected for the benchmark above.

#### Which issue(s) this PR fixes or relates to

Resolves a [TODO](https://github.com/grafana/mimir/pull/8096/files#diff-ccf54e809ccc9d8e8a83091d9fd45f64ba2e3fadb87a02dae00ceb431b62fd4dR159-R160) from https://github.com/grafana/mimir/pull/8096

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
