### PR TITLE
Mimir query engine: track active queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8277
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -36,16 +36,18 @@ func NewEngine(opts promql.EngineOpts, limitsProvider QueryLimitsProvider) (prom
 	}
 
 	return &Engine{
-		lookbackDelta:  lookbackDelta,
-		timeout:        opts.Timeout,
-		limitsProvider: limitsProvider,
+		lookbackDelta:      lookbackDelta,
+		timeout:            opts.Timeout,
+		limitsProvider:     limitsProvider,
+		activeQueryTracker: opts.ActiveQueryTracker,
 	}, nil
 }
 
 type Engine struct {
-	lookbackDelta  time.Duration
-	timeout        time.Duration
-	limitsProvider QueryLimitsProvider
+	lookbackDelta      time.Duration
+	timeout            time.Duration
+	limitsProvider     QueryLimitsProvider
+	activeQueryTracker promql.QueryTracker
 }
 
 func (e *Engine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -695,9 +695,10 @@ func TestActiveQueryTracker_WaitingForTrackerIncludesQueryTimeout(t *testing.T) 
 			require.NoError(t, err)
 			defer q.Close()
 
+			res := q.Exec(context.Background())
+
 			require.True(t, tracker.sawTimeout, "query tracker was not called with a context that timed out")
 
-			res := q.Exec(context.Background())
 			require.Error(t, res.Err)
 			require.ErrorIs(t, res.Err, context.DeadlineExceeded)
 			require.EqualError(t, res.Err, "context deadline exceeded: query timed out")

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -714,7 +714,7 @@ func (t *timeoutTestingQueryTracker) GetMaxConcurrent() int {
 	return 0
 }
 
-func (t *timeoutTestingQueryTracker) Insert(ctx context.Context, query string) (int, error) {
+func (t *timeoutTestingQueryTracker) Insert(ctx context.Context, _ string) (int, error) {
 	select {
 	case <-ctx.Done():
 		t.sawTimeout = true
@@ -724,6 +724,6 @@ func (t *timeoutTestingQueryTracker) Insert(ctx context.Context, query string) (
 	}
 }
 
-func (t *timeoutTestingQueryTracker) Delete(insertIndex int) {
+func (t *timeoutTestingQueryTracker) Delete(_ int) {
 	panic("should not be called")
 }

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -272,6 +272,15 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 	// (so that it runs before the cancellation of the context with timeout created above).
 	defer cancel(errQueryFinished)
 
+	if q.engine.activeQueryTracker != nil {
+		queryID, err := q.engine.activeQueryTracker.Insert(ctx, q.qs)
+		if err != nil {
+			return &promql.Result{Err: err}
+		}
+
+		defer q.engine.activeQueryTracker.Delete(queryID)
+	}
+
 	series, err := q.root.SeriesMetadata(ctx)
 	if err != nil {
 		return &promql.Result{Err: err}


### PR DESCRIPTION
#### What this PR does

This PR adds support for tracking active queries to the Mimir query engine.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
