### PR TITLE
alert if compactor runs out of disk space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [CHANGE] Distributor: Incoming OTLP requests were previously size-limited by using limit from `-distributor.max-recv-msg-size` option. We have added option `-distributor.max-otlp-request-size` for limiting OTLP requests, with default value of 100 MiB. #8574
 * [CHANGE] Query-frontend: Remove deprecated `frontend.align_queries_with_step` YAML configuration. The configuration option has been moved to per-tenant and default `limits` since Mimir 2.12. #8733 #8735
 * [CHANGE] Store-gateway: Change default of `-blocks-storage.bucket-store.max-concurrent` to 200. #8768
+* [CHANGE] Added new metric `cortex_compactor_disk_out_of_space_errors_total` which counts how many times a compaction failed due to the compactor being out of disk, alert if there is a single increase. #8237 #8278
 * [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #8422 #8430 #8454 #8455 #8360 #8490 #8508 #8577 #8671
 * [FEATURE] Experimental Kafka-based ingest storage. #6888 #6894 #6929 #6940 #6951 #6974 #6982 #7029 #7030 #7091 #7142 #7147 #7148 #7153 #7160 #7193 #7349 #7376 #7388 #7391 #7393 #7394 #7402 #7404 #7423 #7424 #7437 #7486 #7503 #7508 #7540 #7621 #7682 #7685 #7694 #7695 #7696 #7697 #7701 #7733 #7734 #7741 #7752 #7838 #7851 #7871 #7877 #7880 #7882 #7887 #7891 #7925 #7955 #7967 #8031 #8063 #8077 #8088 #8135 #8176 #8184 #8194 #8216 #8217 #8222 #8233 #8503 #8542 #8579 #8657 #8686 #8688 #8703 #8706 #8708 #8738 #8750
   * What it is:

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -639,7 +639,7 @@ How to **investigate**:
       - If you encounter any Compactor resource issues, add CPU/Memory as needed temporarily, then scale back later.
       - You can also optionally scale replicas and shards further to split the work up into even smaller pieces until the situation has recovered.
 
-### CompactorHasRunOutOfDiskSpace
+### MimirCompactorHasRunOutOfDiskSpace
 
 This alert fires when the compactor has run out of disk space at least once.
 When this happens the compaction will fail and after some time the compactor will retry the failed compaction, but it is very likely that on each retry it will just hit the same disk space limit again and it won't be able to recover on its own.

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -641,7 +641,7 @@ How to **investigate**:
 
 ### CompactorHasRunOutOfDiskSpace
 
-This alert fires when the compactor has run out of disk space at least once. 
+This alert fires when the compactor has run out of disk space at least once.
 When this happens the compaction will fail and after some time the compactor will retry the failed compaction, but it is very likely that on each retry it will just hit the same disk space limit again and it won't be able to recover on its own.
 
 How to **investigate**:

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -643,7 +643,7 @@ How to **investigate**:
 
 This alert fires when the compactor has run out of disk space at least once.
 When this happens the compaction will fail and after some time the compactor will retry the failed compaction.
-It's very likely that on each retry of the job,  the compactor will just hit the same disk space limit again and it won't be able to recover on its own.
+It's very likely that on each retry of the job, the compactor will just hit the same disk space limit again and it won't be able to recover on its own.
 Alternatively, if compactor concurrency is higher than 1, it could have been just an unlucky combination of jobs that caused compactor to run out of disk space.
 
 How to **investigate**:

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -643,7 +643,7 @@ How to **investigate**:
 
 This alert fires when the compactor has run out of disk space at least once.
 When this happens the compaction will fail and after some time the compactor will retry the failed compaction.
-Unless the compactor concurrency is >=1 it is very likely that on each retry it will just hit the same disk space limit again and it won't be able to recover on its own.
+It is very likely that on each retry of the job, compactor will just hit the same disk space limit again and it won't be able to recover on its own. If compactor concurrency is higher than 1, then it could have been just an unlucky combination of jobs that caused compactor to run out of disk space.
 
 How to **investigate**:
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -649,7 +649,7 @@ Alternatively, if compactor concurrency is higher than 1, it could have been jus
 How to **investigate**:
 
 - Look at the disk space usage in the compactor's data volumes.
-- Look for an error with the string "no space left on device" to confirm that the compactor ran out of disk space.
+- Look for an error with the string `no space left on device` to confirm that the compactor ran out of disk space.
 
 How to **fix** it:
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -642,7 +642,7 @@ How to **investigate**:
 ### MimirCompactorHasRunOutOfDiskSpace
 
 This alert fires when the compactor has run out of disk space at least once.
-When this happens the compaction will fail and after some time the compactor will retry the failed compaction. 
+When this happens the compaction will fail and after some time the compactor will retry the failed compaction.
 Unless the compactor concurrency is >=1 it is very likely that on each retry it will just hit the same disk space limit again and it won't be able to recover on its own.
 
 How to **investigate**:

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -654,7 +654,7 @@ How to **investigate**:
 How to **fix** it:
 
 - The only long-term solution is to give the compactor more disk space, as it requires more space to fit the largest single job into its disk.
-- If the number of blocks that the compactor is failing to compact is not very significant and you want it to skip them in order to focus on more recent blocks instead, you can consider marking the affected blocks for no compaction:
+- If the number of blocks that the compactor is failing to compact is not very significant and you want to skip compacting them and focus on more recent blocks instead, consider marking the affected blocks for no compaction:
   ```
   ./tools/markblocks/markblocks -backend gcs -gcs.bucket-name <bucket> -mark no-compact -tenant <tenant-id> -details "focus on newer blocks"
   ```

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -643,7 +643,8 @@ How to **investigate**:
 
 This alert fires when the compactor has run out of disk space at least once.
 When this happens the compaction will fail and after some time the compactor will retry the failed compaction.
-It is very likely that on each retry of the job, compactor will just hit the same disk space limit again and it won't be able to recover on its own. If compactor concurrency is higher than 1, then it could have been just an unlucky combination of jobs that caused compactor to run out of disk space.
+It's very likely that on each retry of the job,  the compactor will just hit the same disk space limit again and it won't be able to recover on its own.
+Alternatively, if compactor concurrency is higher than 1, it could have been just an unlucky combination of jobs that caused compactor to run out of disk space.
 
 How to **investigate**:
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -642,7 +642,8 @@ How to **investigate**:
 ### MimirCompactorHasRunOutOfDiskSpace
 
 This alert fires when the compactor has run out of disk space at least once.
-When this happens the compaction will fail and after some time the compactor will retry the failed compaction, but it is very likely that on each retry it will just hit the same disk space limit again and it won't be able to recover on its own.
+When this happens the compaction will fail and after some time the compactor will retry the failed compaction. 
+Unless the compactor concurrency is >=1 it is very likely that on each retry it will just hit the same disk space limit again and it won't be able to recover on its own.
 
 How to **investigate**:
 
@@ -651,12 +652,9 @@ How to **investigate**:
 
 How to **fix** it:
 
-- The only long-term solution is to give the compactor more disk space, this can be achieved by doing one or multiple of:
-  - Horizontally scale the compactors
-  - Grow each compactor's disk
+- The only long-term solution is to give the compactor more disk space, as it requires more space to fit the largest single job into its disk.
 - If the number of blocks that the compactor is failing to compact is not very significant and you want it to skip them in order to focus on more recent blocks instead, you can consider marking the affected blocks for no compaction:
   ```
-  # in this example the object storage backend is GCS
   ./tools/markblocks/markblocks -backend gcs -gcs.bucket-name <bucket> -mark no-compact -tenant <tenant-id> -details "focus on newer blocks"
   ```
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -841,6 +841,15 @@ spec:
             labels:
               reason: consecutive-failures
               severity: critical
+          - alert: MimirCompactorHasRunOutOfDiskSpace
+            annotations:
+              message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
+            expr: |
+              increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
+            labels:
+              reason: non-transient
+              severity: critical
           - alert: MimirCompactorHasNotUploadedBlocks
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -846,7 +846,7 @@ spec:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
             expr: |
-              increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
+              increase(cortex_compactor_disk_out_of_space_errors_total{}[15m]) >= 1
             labels:
               reason: non-transient
               severity: critical

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -846,7 +846,7 @@ spec:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
             expr: |
-              increase(cortex_compactor_disk_out_of_space_errors_total{}[15m]) >= 1
+              increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
             labels:
               reason: non-transient
               severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -815,6 +815,15 @@ groups:
           labels:
             reason: consecutive-failures
             severity: critical
+        - alert: MimirCompactorHasRunOutOfDiskSpace
+          annotations:
+            message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
+          expr: |
+            increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
+          labels:
+            reason: non-transient
+            severity: critical
         - alert: MimirCompactorHasNotUploadedBlocks
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -829,6 +829,15 @@ groups:
           labels:
             reason: consecutive-failures
             severity: critical
+        - alert: MimirCompactorHasRunOutOfDiskSpace
+          annotations:
+            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
+          expr: |
+            increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
+          labels:
+            reason: non-transient
+            severity: critical
         - alert: MimirCompactorHasNotUploadedBlocks
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -74,7 +74,7 @@
           // This is a non-transient condition which requires an operator to look at it even if it happens only once.
           alert: $.alertName('CompactorHasRunOutOfDiskSpace'),
           expr: |||
-            increase(cortex_compactor_disk_out_of_space_errors_total{reason!="shutdown"}[24h]) >= 1
+            increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
           |||,
           labels: {
             severity: 'critical',

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -70,6 +70,21 @@
           },
         },
         {
+          // Alert if compactor ran out of disk space in the last 24h.
+          // This is a non-transient condition which requires an operator to look at it even if it happens only once.
+          alert: $.alertName('CompactorHasRunOutOfDiskSpace'),
+          expr: |||
+            increase(cortex_compactor_disk_out_of_space_errors_total{reason!="shutdown"}[24h]) >= 1
+          |||,
+          labels: {
+            severity: 'critical',
+            reason: 'non-transient',
+          },
+          annotations: {
+            message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has hit the disk space limit.' % $._config,
+          },
+        },
+        {
           // Alert if the compactor has not uploaded anything in the last 24h.
           alert: $.alertName('CompactorHasNotUploadedBlocks'),
           'for': '15m',

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -81,7 +81,7 @@
             reason: 'non-transient',
           },
           annotations: {
-            message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has hit the disk space limit.' % $._config,
+            message: '%(product)s Compactor %(alert_instance_variable)s in %(alert_aggregation_variables)s has run out of disk space.' % $._config,
           },
         },
         {


### PR DESCRIPTION
Alerting if there is any increase in the new metric `cortex_compactor_disk_out_of_space_errors_total` which has been added by https://github.com/grafana/mimir/pull/8237/ .

A Compactor running out of disk space is a non-transient condition which will likely keep failing until an operator resolves it, so it makes sense to alert on a single increase already.