### PR TITLE
usage stats: report active series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [CHANGE] Query-frontend: stop using `-validation.create-grace-period` to clamp how far into the future a query can span.
 * [CHANGE] Clamp [`GOMAXPROCS`](https://pkg.go.dev/runtime#GOMAXPROCS) to [`runtime.NumCPU`](https://pkg.go.dev/runtime#NumCPU). #8201
 * [CHANGE] Added new metric `cortex_compactor_disk_out_of_space_errors_total` which counts how many times a compaction failed due to the compactor being out of disk. #8237
+* [CHANGE] Anonymous usage statistics tracking: report active series in addition to in-memory series. #8279
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684

--- a/docs/sources/mimir/configure/about-anonymous-usage-statistics-reporting.md
+++ b/docs/sources/mimir/configure/about-anonymous-usage-statistics-reporting.md
@@ -43,6 +43,7 @@ When the usage statistics reporting is enabled, Grafana Mimir collects the follo
 - Information about the Mimir **cluster scale**:
   - Ingester:
     - The number of in-memory series.
+    - The number of active series.
     - The number of tenants that have in-memory series.
     - The number of tenants that have out-of-order ingestion enabled.
     - The number of samples and exemplars ingested.

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -110,6 +110,7 @@ const (
 	replicationFactorStatsName             = "ingester_replication_factor"
 	ringStoreStatsName                     = "ingester_ring_store"
 	memorySeriesStatsName                  = "ingester_inmemory_series"
+	activeSeriesStatsName                  = "ingester_active_series"
 	memoryTenantsStatsName                 = "ingester_inmemory_tenants"
 	appendedSamplesStatsName               = "ingester_appended_samples"
 	appendedExemplarsStatsName             = "ingester_appended_exemplars"
@@ -138,6 +139,7 @@ var (
 	// updated in Ingester.updateUsageStats.
 	memorySeriesStats                  = usagestats.GetAndResetInt(memorySeriesStatsName)
 	memoryTenantsStats                 = usagestats.GetAndResetInt(memoryTenantsStatsName)
+	activeSeriesStats                  = usagestats.GetAndResetInt(activeSeriesStatsName)
 	tenantsWithOutOfOrderEnabledStat   = usagestats.GetAndResetInt(tenantsWithOutOfOrderEnabledStatName)
 	minOutOfOrderTimeWindowSecondsStat = usagestats.GetAndResetInt(minOutOfOrderTimeWindowSecondsStatName)
 	maxOutOfOrderTimeWindowSecondsStat = usagestats.GetAndResetInt(maxOutOfOrderTimeWindowSecondsStatName)
@@ -839,6 +841,7 @@ func (i *Ingester) updateActiveSeries(now time.Time) {
 func (i *Ingester) updateUsageStats() {
 	memoryUsersCount := int64(0)
 	memorySeriesCount := int64(0)
+	activeSeriesCount := int64(0)
 	tenantsWithOutOfOrderEnabledCount := int64(0)
 	minOutOfOrderTimeWindow := time.Duration(0)
 	maxOutOfOrderTimeWindow := time.Duration(0)
@@ -858,6 +861,9 @@ func (i *Ingester) updateUsageStats() {
 		memoryUsersCount++
 		memorySeriesCount += int64(numSeries)
 
+		activeSeries, _, _ := userDB.activeSeries.Active()
+		activeSeriesCount += int64(activeSeries)
+
 		oooWindow := i.limits.OutOfOrderTimeWindow(userID)
 		if oooWindow > 0 {
 			tenantsWithOutOfOrderEnabledCount++
@@ -873,6 +879,7 @@ func (i *Ingester) updateUsageStats() {
 
 	// Track anonymous usage stats.
 	memorySeriesStats.Set(memorySeriesCount)
+	activeSeriesStats.Set(activeSeriesCount)
 	memoryTenantsStats.Set(memoryUsersCount)
 	tenantsWithOutOfOrderEnabledStat.Set(tenantsWithOutOfOrderEnabledCount)
 	minOutOfOrderTimeWindowSecondsStat.Set(int64(minOutOfOrderTimeWindow.Seconds()))

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -2794,6 +2794,9 @@ func TestIngester_Push(t *testing.T) {
 
 			i.updateUsageStats()
 
+			if !testData.disableActiveSeries {
+				assert.Equal(t, int64(len(testData.expectedIngested)), usagestats.GetInt(activeSeriesStatsName).Value())
+			}
 			assert.Equal(t, int64(len(testData.expectedIngested)), usagestats.GetInt(memorySeriesStatsName).Value())
 			assert.Equal(t, int64(expectedTenantsCount), usagestats.GetInt(memoryTenantsStatsName).Value())
 			assert.Equal(t, int64(expectedSamplesCount)+appendedSamplesStatsBefore, usagestats.GetCounter(appendedSamplesStatsName).Total())


### PR DESCRIPTION
#### What this PR does

Usage stats already include in-memory series. This PR also adds active series to reports. Active series give information closer to the users' needs, whereas in-memory series are more related to how the system handles load. Active series in combination with in-memory series also help estimate churn.


<img width="469" alt="Screenshot 2024-06-05 at 11 48 48" src="https://github.com/grafana/mimir/assets/21020035/980775a4-5668-4605-88d1-564bdb24fd69">



#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
