### PR TITLE
indexheader: keep pre-shutdown snapshot between restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [ENHANCEMENT] Ingester: reduce the amount of locks taken during the Head compaction's garbage-collection process, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326 #8370 #8373
 * [ENHANCEMENT] Query-frontend: be able to block remote read queries via the per tenant runtime override `blocked_queries`. #8372
+* [ENHANCEMENT] Store-gateway: keep index headers that were loaded before the previous shutdown. #8281
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@
 * [ENHANCEMENT] Ingester: reduce the amount of locks taken during the Head compaction's garbage-collection process, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326 #8370 #8373
 * [ENHANCEMENT] Query-frontend: be able to block remote read queries via the per tenant runtime override `blocked_queries`. #8372
-* [ENHANCEMENT] Store-gateway: keep index headers that were loaded before the previous shutdown. #8281
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
@@ -108,6 +107,7 @@
 * [BUGFIX] Ingester: fix sporadic `not found` error causing an internal server error if label names are queried with matchers during head compaction. #8391
 * [BUGFIX] Ingester, store-gateway: fix case insensitive regular expressions not matching correctly some Unicode characters. #8391
 * [BUGFIX] Query-frontend: "query stats" log now includes the actual `status_code` when the request fails due to an error occurring in the query-frontend itself. #8407
+* [BUGFIX] Store-gateway: fixed a case where, on a quick subsequent restart, the previous lazy-loaded index header snapshot was overwritten by a partially loaded one. #8281
 
 ### Mixin
 

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -240,13 +240,15 @@ func NewBucketStore(
 	}
 
 	snapConfig := indexheader.SnapshotterConfig{
-		Enabled: bucketStoreConfig.IndexHeader.EagerLoadingStartupEnabled,
-		Path:    dir,
-		UserID:  userID,
+		Path:   dir,
+		UserID: userID,
 	}
 	s.indexHeadersSnapshotter = indexheader.NewSnapshotter(s.logger, snapConfig)
 
-	lazyLoadedBlocks := s.indexHeadersSnapshotter.RestoreLoadedBlocks()
+	var lazyLoadedBlocks map[ulid.ULID]int64
+	if bucketStoreConfig.IndexHeader.EagerLoadingStartupEnabled {
+		lazyLoadedBlocks = s.indexHeadersSnapshotter.RestoreLoadedBlocks()
+	}
 	s.indexReaderPool = indexheader.NewReaderPool(s.logger, bucketStoreConfig.IndexHeader, s.lazyLoadingGate, metrics.indexHeaderReaderMetrics, lazyLoadedBlocks)
 
 	if err := os.MkdirAll(dir, 0750); err != nil {

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -360,7 +360,7 @@ func (s *BucketStore) syncBlocks(ctx context.Context, initialSync bool) error {
 		level.Info(s.logger).Log("msg", "dropped outdated block", "block", id)
 	}
 
-	// Start snapshotter in the end of the sync, but do that only once per BucketStore's life time.
+	// Start snapshotter in the end of the sync, but do that only once per BucketStore's lifetime.
 	// We do that here so the snapshotter watched after blocks from both initial sync and those discovered later.
 	var err error
 	s.snapshotterStartOnce.Do(func() {

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -361,14 +361,10 @@ func (s *BucketStore) syncBlocks(ctx context.Context, initialSync bool) error {
 	}
 
 	// Start snapshotter in the end of the sync, but do that only once per BucketStore's lifetime.
-	// We do that here so the snapshotter watched after blocks from both initial sync and those discovered later.
-	var err error
+	// We do that here, so the snapshotter watched after blocks from both initial sync and those discovered later.
 	s.snapshotterStartOnce.Do(func() {
-		err = s.snapshotter.Start(ctx, s.indexReaderPool)
+		s.snapshotter.Start(ctx, s.indexReaderPool)
 	})
-	if err != nil {
-		return errors.Wrap(err, "start index headers snapshotter")
-	}
 
 	return nil
 }

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1777,7 +1777,7 @@ func TestBucketStore_Series_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), indexheader.Config{
 			LazyLoadingEnabled:     false,
 			LazyLoadingIdleTimeout: 0,
-		}, gate.NewNoop(), indexheader.NewReaderPoolMetrics(nil), indexheader.LazyLoadedHeadersSnapshotConfig{}),
+		}, gate.NewNoop(), indexheader.NewReaderPoolMetrics(nil), nil),
 		metrics:  NewBucketStoreMetrics(nil),
 		blockSet: &bucketBlockSet{blocks: []*bucketBlock{b1, b2}},
 		blocks: map[ulid.ULID]*bucketBlock{

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1504,9 +1504,12 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 			NewBucketStoreMetrics(reg),
 			testData.options...,
 		)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		t.Run(testName, func(t test.TB) {
+			t.Cleanup(func() {
+				st.RemoveBlocksAndClose()
+			})
 			runTestWithStore(t, st, reg)
 		})
 	}
@@ -1634,6 +1637,10 @@ func TestBucketStore_Series_Concurrency(t *testing.T) {
 					)
 					require.NoError(t, err)
 					require.NoError(t, store.SyncBlocks(ctx))
+
+					t.Cleanup(func() {
+						store.RemoveBlocksAndClose()
+					})
 
 					// Run workers.
 					wg := sync.WaitGroup{}
@@ -2013,7 +2020,7 @@ func TestBucketStore_Series_CanceledRequest(t *testing.T) {
 		WithLogger(logger),
 		WithQueryGate(gate.NewBlocking(0)),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { assert.NoError(t, store.RemoveBlocksAndClose()) }()
 
 	req := &storepb.SeriesRequest{

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -127,7 +127,7 @@ func NewLazyBinaryReader(
 		logger:          logger,
 		filepath:        path,
 		metrics:         metrics,
-		usedAt:          atomic.NewInt64(time.Now().UnixNano()),
+		usedAt:          atomic.NewInt64(0),
 		onClosed:        onClosed,
 		readerFactory:   readerFactory,
 		blockID:         id,

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -195,8 +195,9 @@ func (p *ReaderPool) LoadedBlocks() map[ulid.ULID]int64 {
 
 	blocks := make(map[ulid.ULID]int64, len(p.lazyReaders))
 	for r := range p.lazyReaders {
-		if r.reader != nil {
-			blocks[r.blockID] = r.usedAt.Load() / int64(time.Millisecond)
+		usedAt := r.usedAt.Load()
+		if usedAt != 0 {
+			blocks[r.blockID] = usedAt / int64(time.Millisecond)
 		}
 	}
 

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -6,11 +6,7 @@
 package indexheader
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -21,11 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
-
-	"github.com/grafana/mimir/pkg/util/atomicfs"
 )
-
-const lazyLoadedHeadersListFileName = "lazy-loaded.json"
 
 // ReaderPoolMetrics holds metrics tracked by ReaderPool.
 type ReaderPoolMetrics struct {
@@ -58,52 +50,15 @@ type ReaderPool struct {
 	close chan struct{}
 
 	// Keep track of all readers managed by the pool.
-	lazyReadersMx           sync.Mutex
-	lazyReaders             map[*LazyBinaryReader]struct{}
-	preShutdownLoadedBlocks *lazyLoadedHeadersSnapshot
+	lazyReadersMx sync.Mutex
+	lazyReaders   map[*LazyBinaryReader]struct{}
+	// Snapshot of blocks loaded by the pool before the last shutdown.
+	preShutdownLoadedBlocks map[ulid.ULID]int64
 }
 
-// LazyLoadedHeadersSnapshotConfig stores information needed to track lazy loaded index headers.
-type LazyLoadedHeadersSnapshotConfig struct {
-	// Path stores where lazy loaded blocks will be tracked in a single file per tenant
-	Path   string
-	UserID string
-}
-
-type lazyLoadedHeadersSnapshot struct {
-	// IndexHeaderLastUsedTime is map of index header ulid.ULID to timestamp in millisecond.
-	IndexHeaderLastUsedTime map[ulid.ULID]int64 `json:"index_header_last_used_time"`
-	UserID                  string              `json:"user_id"`
-}
-
-// persist atomically writes this snapshot to persistDir.
-func (l lazyLoadedHeadersSnapshot) persist(persistDir string) error {
-	// Create temporary path for fsync.
-	// We don't use temporary folder because the process might not have access to the temporary folder.
-	tmpPath := filepath.Join(persistDir, "tmp-"+lazyLoadedHeadersListFileName)
-	// the actual path we want to store the file in
-	finalPath := filepath.Join(persistDir, lazyLoadedHeadersListFileName)
-
-	data, err := json.Marshal(l)
-	if err != nil {
-		return err
-	}
-
-	return atomicfs.CreateFileAndMove(tmpPath, finalPath, bytes.NewReader(data))
-}
-
-// NewReaderPool makes a new ReaderPool. If lazy-loading is enabled, NewReaderPool also starts a background task for unloading idle Readers and persisting a list of loaded Readers to disk.
-func NewReaderPool(logger log.Logger, indexHeaderConfig Config, lazyLoadingGate gate.Gate, metrics *ReaderPoolMetrics, lazyLoadedSnapshotConfig LazyLoadedHeadersSnapshotConfig) *ReaderPool {
-	var snapshot *lazyLoadedHeadersSnapshot
-
-	// Eager loading can only be enabled if lazy-loading is enabled.
-	eagerLoadingEnabled := indexHeaderConfig.LazyLoadingEnabled && indexHeaderConfig.EagerLoadingStartupEnabled
-
-	if eagerLoadingEnabled {
-		snapshot = tryRestoreLazyLoadedHeadersSnapshot(logger, lazyLoadedSnapshotConfig)
-	}
-
-	p := newReaderPool(logger, indexHeaderConfig, lazyLoadingGate, metrics, snapshot)
+// NewReaderPool makes a new ReaderPool. If lazy-loading is enabled, NewReaderPool also starts a background task for unloading idle Readers.
+func NewReaderPool(logger log.Logger, indexHeaderConfig Config, lazyLoadingGate gate.Gate, metrics *ReaderPoolMetrics, loadedBlocks map[ulid.ULID]int64) *ReaderPool {
+	p := newReaderPool(logger, indexHeaderConfig, lazyLoadingGate, metrics, loadedBlocks)
 
 	// Start a goroutine to close idle readers (only if required).
 	if p.lazyReaderEnabled && p.lazyReaderIdleTimeout > 0 {
@@ -112,35 +67,12 @@ func NewReaderPool(logger log.Logger, indexHeaderConfig Config, lazyLoadingGate 
 		go func() {
 			tickerIdleReader := time.NewTicker(checkFreq)
 			defer tickerIdleReader.Stop()
-
-			var lazyLoadC <-chan time.Time
-
-			if eagerLoadingEnabled {
-				tickerLazyLoadPersist := time.NewTicker(time.Minute)
-				defer tickerLazyLoadPersist.Stop()
-
-				lazyLoadC = tickerLazyLoadPersist.C
-			}
-
 			for {
 				select {
 				case <-p.close:
 					return
 				case <-tickerIdleReader.C:
 					p.closeIdleReaders()
-				case t := <-lazyLoadC:
-					// minUsedAt is the threshold for how recently used should the block be to stay in the snapshot;
-					// we add an extra couple of minutes to make sure the pool closes the idle readers.
-					dur := p.lazyReaderIdleTimeout + (10 * time.Minute)
-					minUsedAt := t.Truncate(time.Minute).Add(-dur).UnixMilli()
-					snapshot := lazyLoadedHeadersSnapshot{
-						IndexHeaderLastUsedTime: p.LoadedBlocks(minUsedAt),
-						UserID:                  lazyLoadedSnapshotConfig.UserID,
-					}
-
-					if err := snapshot.persist(lazyLoadedSnapshotConfig.Path); err != nil {
-						level.Warn(p.logger).Log("msg", "failed to persist list of lazy-loaded index headers", "err", err)
-					}
 				}
 			}
 
@@ -150,34 +82,8 @@ func NewReaderPool(logger log.Logger, indexHeaderConfig Config, lazyLoadingGate 
 	return p
 }
 
-func tryRestoreLazyLoadedHeadersSnapshot(logger log.Logger, cfg LazyLoadedHeadersSnapshotConfig) *lazyLoadedHeadersSnapshot {
-	fileName := filepath.Join(cfg.Path, lazyLoadedHeadersListFileName)
-	snapshot, err := loadLazyLoadedHeadersSnapshot(fileName)
-	if os.IsNotExist(err) {
-		// We didn't find the snapshot. Could be because we crashed after restoring it last time
-		// or because the previous binary didn't support eager loading.
-		// Either way, we can continue without eagerly loading blocks.
-		// Since the file wasn't found, we also won't try to remove it.
-		return nil
-	}
-	if err != nil {
-		level.Warn(logger).Log(
-			"msg", "loading the list of index-headers from snapshot file failed; not eagerly loading index-headers for tenant",
-			"file", fileName,
-			"err", err,
-		)
-	}
-	// We will remove the file regardless whether err is nil or not nil.
-	// In the case such as snapshot loading causing OOM, we will still
-	// remove the snapshot and lazy load after server is restarted.
-	if err := os.Remove(fileName); err != nil {
-		level.Warn(logger).Log("msg", "removing the lazy-loaded index-header snapshot failed", "file", fileName, "err", err)
-	}
-	return snapshot
-}
-
 // newReaderPool makes a new ReaderPool.
-func newReaderPool(logger log.Logger, indexHeaderConfig Config, lazyLoadingGate gate.Gate, metrics *ReaderPoolMetrics, lazyLoadedHeadersSnapshot *lazyLoadedHeadersSnapshot) *ReaderPool {
+func newReaderPool(logger log.Logger, indexHeaderConfig Config, lazyLoadingGate gate.Gate, metrics *ReaderPoolMetrics, loadedBlocks map[ulid.ULID]int64) *ReaderPool {
 	return &ReaderPool{
 		logger:                  logger,
 		metrics:                 metrics,
@@ -185,22 +91,9 @@ func newReaderPool(logger log.Logger, indexHeaderConfig Config, lazyLoadingGate 
 		lazyReaderIdleTimeout:   indexHeaderConfig.LazyLoadingIdleTimeout,
 		lazyReaders:             make(map[*LazyBinaryReader]struct{}),
 		close:                   make(chan struct{}),
-		preShutdownLoadedBlocks: lazyLoadedHeadersSnapshot,
+		preShutdownLoadedBlocks: loadedBlocks,
 		lazyLoadingGate:         lazyLoadingGate,
 	}
-}
-
-func loadLazyLoadedHeadersSnapshot(fileName string) (*lazyLoadedHeadersSnapshot, error) {
-	snapshotBytes, err := os.ReadFile(fileName)
-	if err != nil {
-		return nil, err
-	}
-	snapshot := &lazyLoadedHeadersSnapshot{}
-	err = json.Unmarshal(snapshotBytes, snapshot)
-	if err != nil {
-		return nil, err
-	}
-	return snapshot, nil
 }
 
 // NewBinaryReader creates and returns a new binary reader. If the pool has been configured
@@ -224,7 +117,7 @@ func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt
 		// we only try to eager load during initialSync
 		if initialSync && p.preShutdownLoadedBlocks != nil {
 			// we only eager load if we have preShutdownLoadedBlocks for the given block id
-			if p.preShutdownLoadedBlocks.IndexHeaderLastUsedTime[id] > 0 {
+			if p.preShutdownLoadedBlocks[id] > 0 {
 				lazyBinaryReader.EagerLoad()
 			}
 		}
@@ -296,30 +189,14 @@ func (p *ReaderPool) onLazyReaderClosed(r *LazyBinaryReader) {
 }
 
 // LoadedBlocks returns a new map of lazy-loaded block IDs and the last time they were used in milliseconds.
-// It skips blocks, which weren't in use after minUsedAt.
-func (p *ReaderPool) LoadedBlocks(minUsedAt int64) map[ulid.ULID]int64 {
+func (p *ReaderPool) LoadedBlocks() map[ulid.ULID]int64 {
 	p.lazyReadersMx.Lock()
 	defer p.lazyReadersMx.Unlock()
 
 	blocks := make(map[ulid.ULID]int64, len(p.lazyReaders))
 	for r := range p.lazyReaders {
 		if r.reader != nil {
-			usedAt := r.usedAt.Load() / int64(time.Millisecond)
-			if usedAt > minUsedAt {
-				blocks[r.blockID] = usedAt
-			}
-		}
-	}
-
-	// Add blocks from the pre-shutdown snapshot if those are still "fresh".
-	if p.lazyReaderEnabled && p.preShutdownLoadedBlocks != nil {
-		for id, usedAt := range p.preShutdownLoadedBlocks.IndexHeaderLastUsedTime {
-			if _, ok := blocks[id]; ok {
-				continue
-			}
-			if usedAt > minUsedAt {
-				blocks[id] = usedAt
-			}
+			blocks[r.blockID] = r.usedAt.Load() / int64(time.Millisecond)
 		}
 	}
 

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -8,8 +8,6 @@ package indexheader
 import (
 	"context"
 	"crypto/rand"
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +31,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 		lazyReaderIdleTimeout                       time.Duration
 		eagerLoadReaderEnabled                      bool
 		initialSync                                 bool
-		createLazyLoadedHeadersSnapshotFn           func(blockId ulid.ULID) lazyLoadedHeadersSnapshot
+		createLoadedBlocksSnapshotFn                func(blockId ulid.ULID) map[ulid.ULID]int64
 		expectedLoadCountMetricBeforeLabelNamesCall int
 		expectedLoadCountMetricAfterLabelNamesCall  int
 	}{
@@ -58,11 +56,8 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 			initialSync:            true,
 			expectedLoadCountMetricBeforeLabelNamesCall: 1, // the index header will be eagerly loaded before the operation
 			expectedLoadCountMetricAfterLabelNamesCall:  1,
-			createLazyLoadedHeadersSnapshotFn: func(blockId ulid.ULID) lazyLoadedHeadersSnapshot {
-				return lazyLoadedHeadersSnapshot{
-					IndexHeaderLastUsedTime: map[ulid.ULID]int64{blockId: time.Now().UnixMilli()},
-					UserID:                  "anonymous",
-				}
+			createLoadedBlocksSnapshotFn: func(blockId ulid.ULID) map[ulid.ULID]int64 {
+				return map[ulid.ULID]int64{blockId: time.Now().UnixMilli()}
 			},
 		},
 		"block is present in pre-shutdown loaded blocks and eager-loading is enabled, loading index header after initial sync": {
@@ -72,11 +67,8 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 			initialSync:            false,
 			expectedLoadCountMetricBeforeLabelNamesCall: 0, // the index header is not eager loaded if not during initial-sync
 			expectedLoadCountMetricAfterLabelNamesCall:  1,
-			createLazyLoadedHeadersSnapshotFn: func(blockId ulid.ULID) lazyLoadedHeadersSnapshot {
-				return lazyLoadedHeadersSnapshot{
-					IndexHeaderLastUsedTime: map[ulid.ULID]int64{blockId: time.Now().UnixMilli()},
-					UserID:                  "anonymous",
-				}
+			createLoadedBlocksSnapshotFn: func(blockId ulid.ULID) map[ulid.ULID]int64 {
+				return map[ulid.ULID]int64{blockId: time.Now().UnixMilli()}
 			},
 		},
 		"block is not present in pre-shutdown loaded blocks snapshot and eager-loading is enabled": {
@@ -86,15 +78,11 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 			initialSync:            true,
 			expectedLoadCountMetricBeforeLabelNamesCall: 0, // although eager loading is enabled, this test will not do eager loading because the block ID is not in the lazy loaded file.
 			expectedLoadCountMetricAfterLabelNamesCall:  1,
-			createLazyLoadedHeadersSnapshotFn: func(_ ulid.ULID) lazyLoadedHeadersSnapshot {
+			createLoadedBlocksSnapshotFn: func(_ ulid.ULID) map[ulid.ULID]int64 {
 				// let's create a random fake blockID to be stored in lazy loaded headers file
 				fakeBlockID := ulid.MustNew(ulid.Now(), rand.Reader)
 				// this snapshot will refer to fake block, hence eager load wouldn't be executed for the real block that we test
-
-				return lazyLoadedHeadersSnapshot{
-					IndexHeaderLastUsedTime: map[ulid.ULID]int64{fakeBlockID: time.Now().UnixMilli()},
-					UserID:                  "anonymous",
-				}
+				return map[ulid.ULID]int64{fakeBlockID: time.Now().UnixMilli()}
 			},
 		},
 		"pre-shutdown loaded blocks snapshot doesn't exist and eager-loading is enabled": {
@@ -112,14 +100,10 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			snapshotConfig := LazyLoadedHeadersSnapshotConfig{
-				Path:   tmpDir,
-				UserID: "anonymous",
-			}
-			if testData.createLazyLoadedHeadersSnapshotFn != nil {
-				lazyLoadedSnapshot := testData.createLazyLoadedHeadersSnapshotFn(blockID)
-				err := lazyLoadedSnapshot.persist(snapshotConfig.Path)
-				require.NoError(t, err)
+			var lazyLoadedBlocks map[ulid.ULID]int64
+			if testData.createLoadedBlocksSnapshotFn != nil {
+				lazyLoadedBlocks = testData.createLoadedBlocksSnapshotFn(blockID)
+				require.NotNil(t, lazyLoadedBlocks)
 			}
 
 			metrics := NewReaderPoolMetrics(nil)
@@ -128,7 +112,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 				LazyLoadingIdleTimeout:     testData.lazyReaderIdleTimeout,
 				EagerLoadingStartupEnabled: testData.eagerLoadReaderEnabled,
 			}
-			pool := NewReaderPool(log.NewNopLogger(), indexHeaderConfig, gate.NewNoop(), metrics, snapshotConfig)
+			pool := NewReaderPool(log.NewNopLogger(), indexHeaderConfig, gate.NewNoop(), metrics, lazyLoadedBlocks)
 			defer pool.Close()
 
 			r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, indexHeaderConfig, testData.initialSync)
@@ -199,154 +183,20 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 
 func TestReaderPool_LoadedBlocks(t *testing.T) {
 	usedAt := time.Now()
-	minUsedAt := usedAt.Add(-time.Minute)
+	id, err := ulid.New(ulid.Now(), rand.Reader)
+	require.NoError(t, err)
 
-	id1 := ulid.MustNew(ulid.Now(), rand.Reader)
-	lb1 := LazyBinaryReader{
-		blockID: id1,
-		usedAt:  atomic.NewInt64(usedAt.Add(-5 * time.Minute).UnixNano()), // idle block
-		// we just set to make reader != nil
-		reader: &StreamBinaryReader{},
-	}
-
-	id2 := ulid.MustNew(ulid.Now(), rand.Reader)
-	lb2 := LazyBinaryReader{
-		blockID: id2,
+	lb := LazyBinaryReader{
+		blockID: id,
 		usedAt:  atomic.NewInt64(usedAt.UnixNano()),
 		// we just set to make reader != nil
 		reader: &StreamBinaryReader{},
 	}
 	rp := ReaderPool{
 		lazyReaderEnabled: true,
-		lazyReaders: map[*LazyBinaryReader]struct{}{
-			&lb1: {},
-			&lb2: {},
-		},
+		lazyReaders:       map[*LazyBinaryReader]struct{}{&lb: {}},
 	}
-	require.Equal(t, map[ulid.ULID]int64{id2: usedAt.UnixMilli()}, rp.LoadedBlocks(minUsedAt.UnixMilli()))
-}
-
-func TestReaderPool_PersistLazyLoadedBlock(t *testing.T) {
-	const idleTimeout = time.Second
-	ctx, tmpDir, bkt, blockID, metrics := prepareReaderPool(t)
-
-	// Note that we are creating a ReaderPool that doesn't run a background cleanup task for idle
-	// Reader instances. We'll manually invoke the cleanup task when we need it as part of this test.
-	pool := newReaderPool(log.NewNopLogger(), Config{
-		LazyLoadingEnabled:         true,
-		LazyLoadingIdleTimeout:     idleTimeout,
-		EagerLoadingStartupEnabled: true,
-	}, gate.NewNoop(), metrics, nil)
-	defer pool.Close()
-
-	r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, Config{}, false)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, r.Close()) }()
-
-	// Ensure it can read data.
-	labelNames, err := r.LabelNames()
-	require.NoError(t, err)
-	require.Equal(t, []string{"a"}, labelNames)
-	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.lazyReader.loadCount))
-	require.Equal(t, float64(0), promtestutil.ToFloat64(metrics.lazyReader.unloadCount))
-
-	minUsedAt := time.Now().Add(-time.Minute)
-
-	snapshot := lazyLoadedHeadersSnapshot{
-		IndexHeaderLastUsedTime: pool.LoadedBlocks(minUsedAt.UnixMilli()),
-		UserID:                  "anonymous",
-	}
-
-	err = snapshot.persist(tmpDir)
-	require.NoError(t, err)
-
-	persistedFile := filepath.Join(tmpDir, lazyLoadedHeadersListFileName)
-	persistedData, err := os.ReadFile(persistedFile)
-	require.NoError(t, err)
-
-	var expected string
-	// we know that there is only one lazyReader, hence just use formatter to set the ULID and timestamp.
-	require.Equal(t, 1, len(pool.lazyReaders), "expecting only one lazyReaders")
-	for r := range pool.lazyReaders {
-		expected = fmt.Sprintf(`{"index_header_last_used_time":{"%s":%d},"user_id":"anonymous"}`, r.blockID, r.usedAt.Load()/int64(time.Millisecond))
-	}
-	require.JSONEq(t, expected, string(persistedData))
-
-	// Wait enough time before checking it.
-	time.Sleep(idleTimeout * 2)
-	pool.closeIdleReaders()
-
-	// LoadedBlocks will update the IndexHeaderLastUsedTime map with the removal of idle blocks.
-	snapshot.IndexHeaderLastUsedTime = pool.LoadedBlocks(minUsedAt.UnixMilli())
-	err = snapshot.persist(tmpDir)
-	require.NoError(t, err)
-
-	persistedData, err = os.ReadFile(persistedFile)
-	require.NoError(t, err)
-
-	require.JSONEq(t, `{"index_header_last_used_time":{},"user_id":"anonymous"}`, string(persistedData), "index_header_last_used_time should be cleared")
-}
-
-func TestReaderPool_PersistLazyLoadedBlock_restoredSnapshot(t *testing.T) {
-	const idleTimeout = time.Second
-	ctx, tmpDir, bkt, blockID, metrics := prepareReaderPool(t)
-
-	testNow := time.Now()
-	minUsedAt := testNow.Add(-time.Hour)
-
-	fakeBlockID := ulid.MustNew(ulid.Now(), rand.Reader)
-	restoredSnapshot := lazyLoadedHeadersSnapshot{
-		IndexHeaderLastUsedTime: map[ulid.ULID]int64{fakeBlockID: testNow.UnixMilli()},
-		UserID:                  "anonymous",
-	}
-
-	// Note that we are creating a ReaderPool that doesn't run a background cleanup task for idle
-	// Reader instances. We'll manually invoke the cleanup task when we need it as part of this test.
-	pool := newReaderPool(log.NewNopLogger(), Config{
-		LazyLoadingEnabled:         true,
-		LazyLoadingIdleTimeout:     idleTimeout,
-		EagerLoadingStartupEnabled: true,
-	}, gate.NewNoop(), metrics, &restoredSnapshot)
-	defer pool.Close()
-
-	r, err := pool.NewBinaryReader(ctx, log.NewNopLogger(), bkt, tmpDir, blockID, 3, Config{}, false)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, r.Close()) }()
-
-	// Ensure it can read data.
-	labelNames, err := r.LabelNames()
-	require.NoError(t, err)
-	require.Equal(t, []string{"a"}, labelNames)
-	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.lazyReader.loadCount))
-	require.Equal(t, float64(0), promtestutil.ToFloat64(metrics.lazyReader.unloadCount))
-
-	snapshot := lazyLoadedHeadersSnapshot{
-		IndexHeaderLastUsedTime: pool.LoadedBlocks(minUsedAt.UnixMilli()),
-		UserID:                  "anonymous",
-	}
-
-	err = snapshot.persist(tmpDir)
-	require.NoError(t, err)
-
-	persistedFile := filepath.Join(tmpDir, lazyLoadedHeadersListFileName)
-	persistedData, err := os.ReadFile(persistedFile)
-	require.NoError(t, err)
-
-	expectedIndex := map[string]any{
-		fakeBlockID.String(): testNow.UnixMilli(),
-	}
-	// we know that there is only one lazyReader, hence simply set the ULID and timestamp.
-	require.Equal(t, 1, len(pool.lazyReaders), "expecting only one lazyReaders")
-	for r := range pool.lazyReaders {
-		expectedIndex[r.blockID.String()] = r.usedAt.Load() / int64(time.Millisecond)
-	}
-	expected := map[string]any{
-		"user_id":                     "anonymous",
-		"index_header_last_used_time": expectedIndex,
-	}
-	expectedData, err := json.Marshal(expected)
-	require.NoError(t, err)
-	require.JSONEq(t, string(expectedData), string(persistedData))
+	require.Equal(t, map[ulid.ULID]int64{id: usedAt.UnixMilli()}, rp.LoadedBlocks())
 }
 
 func prepareReaderPool(t *testing.T) (context.Context, string, *filesystem.Bucket, ulid.ULID, *ReaderPoolMetrics) {

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package indexheader
 
 import (

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -1,0 +1,145 @@
+package indexheader
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid"
+
+	"github.com/grafana/mimir/pkg/util/atomicfs"
+)
+
+const lazyLoadedHeadersListFileName = "lazy-loaded.json"
+
+type SnapshotterConfig struct {
+	Enabled bool
+
+	// Path stores where lazy loaded blocks will be tracked in a single file per tenant
+	Path   string
+	UserID string
+}
+
+// Snapshotter manages the snapshots of lazy loaded blocks.
+type Snapshotter struct {
+	logger log.Logger
+	conf   SnapshotterConfig
+
+	done chan struct{}
+}
+
+func NewSnapshotter(logger log.Logger, conf SnapshotterConfig) *Snapshotter {
+	return &Snapshotter{
+		logger: logger,
+		conf:   conf,
+		done:   make(chan struct{}),
+	}
+}
+
+type blocksLoader interface {
+	LoadedBlocks() map[ulid.ULID]int64
+}
+
+func (s *Snapshotter) Start(ctx context.Context, l blocksLoader) error {
+	if !s.conf.Enabled {
+		return nil
+	}
+
+	err := s.persistLoadedBlocks(l)
+	if err != nil {
+		return fmt.Errorf("persist initial list of lazy-loaded index headers: %w", err)
+	}
+
+	go func() {
+		tick := time.NewTicker(time.Minute)
+		defer tick.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.done:
+				return
+			case <-tick.C:
+				if err := s.persistLoadedBlocks(l); err != nil {
+					level.Warn(s.logger).Log("msg", "failed to persist list of lazy-loaded index headers", "err", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (s *Snapshotter) persistLoadedBlocks(l blocksLoader) error {
+	snapshot := &indexHeadersSnapshot{
+		IndexHeaderLastUsedTime: l.LoadedBlocks(),
+		UserID:                  s.conf.UserID,
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return err
+	}
+
+	// Create temporary path for fsync.
+	// We don't use temporary folder because the process might not have access to the temporary folder.
+	tmpPath := filepath.Join(s.conf.Path, "tmp-"+lazyLoadedHeadersListFileName)
+	// the actual path we want to store the file in
+	finalPath := filepath.Join(s.conf.Path, lazyLoadedHeadersListFileName)
+
+	return atomicfs.CreateFileAndMove(tmpPath, finalPath, bytes.NewReader(data))
+}
+
+func (s *Snapshotter) Stop() {
+	close(s.done)
+}
+
+func (s *Snapshotter) RestoreLoadedBlocks() map[ulid.ULID]int64 {
+	if !s.conf.Enabled {
+		return nil
+	}
+
+	var snapshot indexHeadersSnapshot
+	fileName := filepath.Join(s.conf.Path, lazyLoadedHeadersListFileName)
+	err := loadIndexHeadersSnapshot(fileName, &snapshot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// We didn't find the snapshot. Could be because we crashed after restoring it last time
+			// or because the previous binary didn't support eager loading.
+			return nil
+		}
+		level.Warn(s.logger).Log(
+			"msg", "loading the list of index-headers from snapshot file failed; not eagerly loading index-headers for tenant",
+			"tenant", s.conf.UserID,
+			"file", fileName,
+			"err", err,
+		)
+		// We will remove the file only on error.
+		// Note, in the case such as snapshot loading causing OOM, we will need to
+		// remove the snapshot and lazy load after server is restarted.
+		if err := os.Remove(fileName); err != nil {
+			level.Warn(s.logger).Log("msg", "removing the lazy-loaded index-header snapshot failed", "file", fileName, "err", err)
+		}
+	}
+	return snapshot.IndexHeaderLastUsedTime
+}
+
+type indexHeadersSnapshot struct {
+	// IndexHeaderLastUsedTime is map of index header ulid.ULID to timestamp in millisecond.
+	IndexHeaderLastUsedTime map[ulid.ULID]int64 `json:"index_header_last_used_time"`
+	UserID                  string              `json:"user_id"`
+}
+
+func loadIndexHeadersSnapshot(fileName string, snapshot *indexHeadersSnapshot) error {
+	snapshotBytes, err := os.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(snapshotBytes, snapshot)
+}

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -121,8 +121,10 @@ func (s *Snapshotter) RestoreLoadedBlocks() map[ulid.ULID]int64 {
 			"err", err,
 		)
 		// We will remove the file only on error.
-		// Note, in the case such as snapshot loading causing OOM, we will need to
-		// remove the snapshot and lazy load after server is restarted.
+		// Note, in the case such as snapshot loading causing OOM, an operator will need to
+		// remove the snapshot manually and let it lazy load after server restarts.
+		// The current experience is that this is less of a problem than not eagerly loading
+		// index headers after two consecutive restarts (ref grafana/mimir#8281).
 		if err := os.Remove(fileName); err != nil {
 			level.Warn(s.logger).Log("msg", "removing the lazy-loaded index-header snapshot failed", "file", fileName, "err", err)
 		}

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -19,8 +19,6 @@ import (
 const lazyLoadedHeadersListFileName = "lazy-loaded.json"
 
 type SnapshotterConfig struct {
-	Enabled bool
-
 	// Path stores where lazy loaded blocks will be tracked in a single file per tenant
 	Path   string
 	UserID string
@@ -47,10 +45,6 @@ type blocksLoader interface {
 }
 
 func (s *Snapshotter) Start(ctx context.Context, bl blocksLoader) error {
-	if !s.conf.Enabled {
-		return nil
-	}
-
 	err := s.PersistLoadedBlocks(bl)
 	if err != nil {
 		return fmt.Errorf("persist initial list of lazy-loaded index headers: %w", err)
@@ -101,10 +95,6 @@ func (s *Snapshotter) PersistLoadedBlocks(bl blocksLoader) error {
 }
 
 func (s *Snapshotter) RestoreLoadedBlocks() map[ulid.ULID]int64 {
-	if !s.conf.Enabled {
-		return nil
-	}
-
 	var snapshot indexHeadersSnapshot
 	fileName := filepath.Join(s.conf.Path, lazyLoadedHeadersListFileName)
 	err := loadIndexHeadersSnapshot(fileName, &snapshot)

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -31,14 +31,14 @@ type Snapshotter struct {
 	logger log.Logger
 	conf   SnapshotterConfig
 
-	done chan struct{}
+	stop chan struct{}
 }
 
 func NewSnapshotter(logger log.Logger, conf SnapshotterConfig) *Snapshotter {
 	return &Snapshotter{
 		logger: logger,
 		conf:   conf,
-		done:   make(chan struct{}),
+		stop:   make(chan struct{}),
 	}
 }
 
@@ -60,7 +60,7 @@ func (s *Snapshotter) Start(ctx context.Context, bl blocksLoader) error {
 			select {
 			case <-ctx.Done():
 				return
-			case <-s.done:
+			case <-s.stop:
 				return
 			case <-tick.C:
 				if err := s.PersistLoadedBlocks(bl); err != nil {
@@ -74,7 +74,7 @@ func (s *Snapshotter) Start(ctx context.Context, bl blocksLoader) error {
 }
 
 func (s *Snapshotter) Stop() {
-	close(s.done)
+	close(s.stop)
 }
 
 func (s *Snapshotter) PersistLoadedBlocks(bl blocksLoader) error {

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -102,8 +102,7 @@ func (s *Snapshotter) RestoreLoadedBlocks() map[ulid.ULID]int64 {
 	err := loadIndexHeadersSnapshot(fileName, &snapshot)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// We didn't find the snapshot. Could be because we crashed after restoring it last time
-			// or because the previous binary didn't support eager loading.
+			// We didn't find the snapshot. Could be because the previous binary didn't support eager loading.
 			return nil
 		}
 		level.Warn(s.logger).Log(

--- a/pkg/storegateway/indexheader/snapshotter_test.go
+++ b/pkg/storegateway/indexheader/snapshotter_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package indexheader
 
 import (

--- a/pkg/storegateway/indexheader/snapshotter_test.go
+++ b/pkg/storegateway/indexheader/snapshotter_test.go
@@ -25,9 +25,8 @@ func TestSnapshotter_PersistAndRestoreLoadedBlocks(t *testing.T) {
 	testBlocksLoader := testBlocksLoaderFunc(func() map[ulid.ULID]int64 { return origBlocks })
 
 	config := SnapshotterConfig{
-		Enabled: true,
-		Path:    tmpDir,
-		UserID:  "anonymous",
+		Path:   tmpDir,
+		UserID: "anonymous",
 	}
 
 	// First instance persists the original snapshot.

--- a/pkg/storegateway/indexheader/snapshotter_test.go
+++ b/pkg/storegateway/indexheader/snapshotter_test.go
@@ -1,0 +1,56 @@
+package indexheader
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotter_PersistAndRestoreLoadedBlocks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	usedAt := time.Now()
+	testBlockID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	origBlocks := map[ulid.ULID]int64{
+		testBlockID: usedAt.UnixMilli(),
+	}
+	testBlocksLoader := testBlocksLoaderFunc(func() map[ulid.ULID]int64 { return origBlocks })
+
+	config := SnapshotterConfig{
+		Enabled: true,
+		Path:    tmpDir,
+		UserID:  "anonymous",
+	}
+
+	// First instance persists the original snapshot.
+	s1 := NewSnapshotter(log.NewNopLogger(), config)
+	err := s1.PersistLoadedBlocks(testBlocksLoader)
+	require.NoError(t, err)
+
+	persistedFile := filepath.Join(tmpDir, lazyLoadedHeadersListFileName)
+	data, err := os.ReadFile(persistedFile)
+	require.NoError(t, err)
+
+	expected := fmt.Sprintf(`{"index_header_last_used_time":{"%s":%d},"user_id":"anonymous"}`, testBlockID, usedAt.UnixMilli())
+	require.JSONEq(t, expected, string(data))
+
+	// Another instance restores the snapshot persisted earlier.
+	s2 := NewSnapshotter(log.NewNopLogger(), config)
+
+	restoredBlocks := s2.RestoreLoadedBlocks()
+	require.Equal(t, origBlocks, restoredBlocks)
+}
+
+type testBlocksLoaderFunc func() map[ulid.ULID]int64
+
+func (f testBlocksLoaderFunc) LoadedBlocks() map[ulid.ULID]int64 {
+	return f()
+}

--- a/pkg/util/test/leak.go
+++ b/pkg/util/test/leak.go
@@ -28,6 +28,9 @@ func goLeakOptions() []goleak.Option {
 		// it gets closed when we close the BucketStore. However, we currently don't close BucketStore
 		// on store-gateway termination so it never gets terminated.
 		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.NewReaderPool.func1"),
+		// Similar to the one above, store-gateway BucketStore starts a goroutine in snapshotter
+		// that manages lazy-loaded snapshots. It stops the snapshotter on BucketStore close.
+		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.(*Snapshotter).Start.func1"),
 
 		// The FastRegexMatcher uses a global instance of ristretto.Cache which is never stopped,
 		// so we ignore its gouroutines and then ones from glog which is a ristretto dependency.


### PR DESCRIPTION
#### What this PR does

The PR updates `indexheader` in a way so `ReaderPool` preserved the blocks found in the pre-shutdown snapshot. ~~That it, when `ReaderPool` persists its own set of blocks to `lazy-loaded.json`, it also amends the set with the blocks, it eagerly loaded (or still loading) on startup. The changes make sure we only persist "fresh" blocks, so idle blocks will be evicted from the snapshots, eventually.~~

#### Which issue(s) this PR fixes or relates to

Fixes #8255

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
