### PR TITLE
Query Scheduler: fix inflight request tracking

### DIFF
--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -51,9 +51,9 @@ blocks_storage:
     sync_interval: 1m
     # ignore_blocks_within and sync_interval must be small enough for the store-gateways
     # to discover & load new blocks shipped from the ingesters before they begin to be queried.
-    # With querier.query_store_after: 10m and sync_interval: 1m, anything larger than 4m causes issues.
+    # With querier.query_store_after: 10m and sync_interval: 1m, anything larger than 2m causes issues.
     # Slightly larger values for ignore_blocks_within work if sync_interval is reduced.
-    ignore_blocks_within: 4m
+    ignore_blocks_within: 2m
 
     index_cache:
       # Cache is configured via CLI flags. See docker-compose.jsonnet
@@ -113,7 +113,7 @@ alertmanager_storage:
 
 compactor:
   data_dir: "/tmp/mimir-compactor"
-  block_ranges: [ 4m, 8m, 16m ]
+  block_ranges: [ 2m, 4m, 8m, 16m ]
   compaction_interval: 1m
   compaction_concurrency: 2
   cleanup_interval: 1m

--- a/pkg/scheduler/queue/query_component_utilization.go
+++ b/pkg/scheduler/queue/query_component_utilization.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/atomic"
 )
 
 type QueryComponent string
@@ -53,9 +52,9 @@ type QueryComponentUtilization struct {
 	// for queries to the less-loaded query component when the query queue becomes backlogged.
 	targetReservedCapacity float64
 
-	ingesterInflightRequests     *atomic.Int64
-	storeGatewayInflightRequests *atomic.Int64
-	querierInflightRequestsTotal *atomic.Int64
+	ingesterInflightRequests     int
+	storeGatewayInflightRequests int
+	querierInflightRequestsTotal int
 
 	querierInflightRequestsGauge *prometheus.GaugeVec
 }
@@ -84,9 +83,9 @@ func NewQueryComponentUtilization(
 	return &QueryComponentUtilization{
 		targetReservedCapacity: targetReservedCapacity,
 
-		ingesterInflightRequests:     atomic.NewInt64(0),
-		storeGatewayInflightRequests: atomic.NewInt64(0),
-		querierInflightRequestsTotal: atomic.NewInt64(0),
+		ingesterInflightRequests:     0,
+		storeGatewayInflightRequests: 0,
+		querierInflightRequestsTotal: 0,
 
 		querierInflightRequestsGauge: querierInflightRequests,
 	}, nil
@@ -113,7 +112,7 @@ func NewQueryComponentUtilization(
 // As the inflight queries complete or fail, the component's utilization will naturally decrease.
 // This method will continue to indicate to skip queries for the component until it is back under the threshold.
 func (qcl *QueryComponentUtilization) ExceedsThresholdForComponentName(
-	name string, connectedWorkers int64, queueLen, waitingWorkers int,
+	name string, connectedWorkers, queueLen, waitingWorkers int,
 ) (bool, QueryComponent) {
 	if waitingWorkers > queueLen {
 		// excess querier-worker capacity; no need to reserve any for now
@@ -125,10 +124,10 @@ func (qcl *QueryComponentUtilization) ExceedsThresholdForComponentName(
 	}
 
 	// allow the functionality to be turned off via setting targetReservedCapacity to 0
-	minReservedConnections := int64(0)
+	minReservedConnections := 0
 	if qcl.targetReservedCapacity > 0 {
 		// reserve at least one connection in case (connected workers) * (reserved capacity) is less than one
-		minReservedConnections = int64(
+		minReservedConnections = int(
 			math.Ceil(
 				math.Max(qcl.targetReservedCapacity*float64(connectedWorkers), 1),
 			),
@@ -137,12 +136,12 @@ func (qcl *QueryComponentUtilization) ExceedsThresholdForComponentName(
 
 	isIngester, isStoreGateway := queryComponentFlags(name)
 	if isIngester {
-		if connectedWorkers-(qcl.ingesterInflightRequests.Load()) <= minReservedConnections {
+		if connectedWorkers-(qcl.ingesterInflightRequests) <= minReservedConnections {
 			return true, Ingester
 		}
 	}
 	if isStoreGateway {
-		if connectedWorkers-(qcl.storeGatewayInflightRequests.Load()) <= minReservedConnections {
+		if connectedWorkers-(qcl.storeGatewayInflightRequests) <= minReservedConnections {
 			return true, StoreGateway
 		}
 	}
@@ -159,16 +158,28 @@ func (qcl *QueryComponentUtilization) DecrementForComponentName(expectedQueryCom
 	qcl.updateForComponentName(expectedQueryComponent, -1)
 }
 
-func (qcl *QueryComponentUtilization) updateForComponentName(expectedQueryComponent string, increment int64) {
+func (qcl *QueryComponentUtilization) updateForComponentName(expectedQueryComponent string, increment int) {
 	isIngester, isStoreGateway := queryComponentFlags(expectedQueryComponent)
 
 	if isIngester {
-		qcl.ingesterInflightRequests.Add(increment)
+		qcl.ingesterInflightRequests += increment
 		qcl.querierInflightRequestsGauge.WithLabelValues(string(Ingester)).Add(float64(increment))
 	}
 	if isStoreGateway {
-		qcl.storeGatewayInflightRequests.Add(increment)
+		qcl.storeGatewayInflightRequests += increment
 		qcl.querierInflightRequestsGauge.WithLabelValues(string(StoreGateway)).Add(float64(increment))
 	}
-	qcl.querierInflightRequestsTotal.Add(increment)
+	qcl.querierInflightRequestsTotal += increment
+}
+
+// test-only util
+func (qcl *QueryComponentUtilization) GetForComponent(component QueryComponent) int {
+	switch component {
+	case Ingester:
+		return qcl.ingesterInflightRequests
+	case StoreGateway:
+		return qcl.storeGatewayInflightRequests
+	default:
+		return 0
+	}
 }

--- a/pkg/scheduler/queue/query_component_utilization.go
+++ b/pkg/scheduler/queue/query_component_utilization.go
@@ -172,7 +172,7 @@ func (qcl *QueryComponentUtilization) updateForComponentName(expectedQueryCompon
 	qcl.querierInflightRequestsTotal += increment
 }
 
-// test-only util
+// GetForComponent is a test-only util
 func (qcl *QueryComponentUtilization) GetForComponent(component QueryComponent) int {
 	switch component {
 	case Ingester:

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -33,8 +33,20 @@ var (
 	ErrQuerierShuttingDown = errors.New("querier has informed the scheduler it is shutting down")
 )
 
+type SchedulerRequestKey struct {
+	frontendAddr string
+	queryID      uint64
+}
+
+func NewSchedulerRequestKey(frontendAddr string, queryID uint64) SchedulerRequestKey {
+	return SchedulerRequestKey{
+		frontendAddr: frontendAddr,
+		queryID:      queryID,
+	}
+}
+
 type SchedulerRequest struct {
-	FrontendAddress           string
+	FrontendAddr              string
 	UserID                    string
 	QueryID                   uint64
 	Request                   *httpgrpc.HTTPRequest
@@ -50,10 +62,17 @@ type SchedulerRequest struct {
 	ParentSpanContext opentracing.SpanContext
 }
 
+func (sr *SchedulerRequest) Key() SchedulerRequestKey {
+	return SchedulerRequestKey{
+		frontendAddr: sr.FrontendAddr,
+		queryID:      sr.QueryID,
+	}
+}
+
 // ExpectedQueryComponentName parses the expected query component from annotations by the frontend.
-func (req *SchedulerRequest) ExpectedQueryComponentName() string {
-	if len(req.AdditionalQueueDimensions) > 0 {
-		return req.AdditionalQueueDimensions[0]
+func (sr *SchedulerRequest) ExpectedQueryComponentName() string {
+	if len(sr.AdditionalQueueDimensions) > 0 {
+		return sr.AdditionalQueueDimensions[0]
 	}
 	return ""
 }

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -33,13 +33,13 @@ var (
 	ErrQuerierShuttingDown = errors.New("querier has informed the scheduler it is shutting down")
 )
 
-type SchedulerRequestKey struct {
+type RequestKey struct {
 	frontendAddr string
 	queryID      uint64
 }
 
-func NewSchedulerRequestKey(frontendAddr string, queryID uint64) SchedulerRequestKey {
-	return SchedulerRequestKey{
+func NewSchedulerRequestKey(frontendAddr string, queryID uint64) RequestKey {
+	return RequestKey{
 		frontendAddr: frontendAddr,
 		queryID:      queryID,
 	}
@@ -62,8 +62,8 @@ type SchedulerRequest struct {
 	ParentSpanContext opentracing.SpanContext
 }
 
-func (sr *SchedulerRequest) Key() SchedulerRequestKey {
-	return SchedulerRequestKey{
+func (sr *SchedulerRequest) Key() RequestKey {
+	return RequestKey{
 		frontendAddr: sr.FrontendAddr,
 		queryID:      sr.QueryID,
 	}
@@ -133,8 +133,13 @@ type RequestQueue struct {
 	stopRequested chan struct{} // Written to by stop() to wake up dispatcherLoop() in response to a stop request.
 	stopCompleted chan struct{} // Closed by dispatcherLoop() after a stop is requested and the dispatcher has stopped.
 
-	querierOperations             chan querierOperation
+	// querierInflightRequests tracks requests from the time the request was successfully sent to a querier
+	// to the time the request was completed by the querier or failed due to cancel, timeout, or disconnect.
+	querierInflightRequests       map[RequestKey]*SchedulerRequest
 	requestsToEnqueue             chan requestToEnqueue
+	requestsSent                  chan *SchedulerRequest
+	requestsCompleted             chan *SchedulerRequest
+	querierOperations             chan querierOperation
 	waitingQuerierConns           chan *waitingQuerierConn
 	waitingQuerierConnsToDispatch *list.List
 
@@ -176,9 +181,9 @@ func NewRequestQueue(
 	queueLength *prometheus.GaugeVec,
 	discardedRequests *prometheus.CounterVec,
 	enqueueDuration prometheus.Histogram,
-	querierInflightRequests *prometheus.GaugeVec,
+	querierInflightRequestsGauge *prometheus.GaugeVec,
 ) (*RequestQueue, error) {
-	queryComponentCapacity, err := NewQueryComponentUtilization(DefaultReservedQueryComponentCapacity, querierInflightRequests)
+	queryComponentCapacity, err := NewQueryComponentUtilization(DefaultReservedQueryComponentCapacity, querierInflightRequestsGauge)
 	if err != nil {
 		return nil, err
 	}
@@ -197,10 +202,14 @@ func NewRequestQueue(
 		enqueueDuration:         enqueueDuration,
 
 		// channels must not be buffered so that we can detect when dispatcherLoop() has finished.
-		stopRequested:                 make(chan struct{}),
-		stopCompleted:                 make(chan struct{}),
-		querierOperations:             make(chan querierOperation),
+		stopRequested: make(chan struct{}),
+		stopCompleted: make(chan struct{}),
+
 		requestsToEnqueue:             make(chan requestToEnqueue),
+		querierInflightRequests:       map[RequestKey]*SchedulerRequest{},
+		requestsSent:                  make(chan *SchedulerRequest),
+		requestsCompleted:             make(chan *SchedulerRequest),
+		querierOperations:             make(chan querierOperation),
 		waitingQuerierConns:           make(chan *waitingQuerierConn),
 		waitingQuerierConnsToDispatch: list.New(),
 
@@ -233,12 +242,16 @@ func (q *RequestQueue) dispatcherLoop() {
 		case querierOp := <-q.querierOperations:
 			// Need to attempt to dispatch queries only if querier operation results in a resharding
 			needToDispatchQueries = q.processQuerierOperation(querierOp)
-		case r := <-q.requestsToEnqueue:
-			err := q.enqueueRequestInternal(r)
-			r.errChan <- err
+		case reqToEnqueue := <-q.requestsToEnqueue:
+			err := q.enqueueRequestInternal(reqToEnqueue)
+			reqToEnqueue.errChan <- err
 			if err == nil {
 				needToDispatchQueries = true
 			}
+		case sentReq := <-q.requestsSent:
+			q.processRequestSent(sentReq)
+		case completedReq := <-q.requestsCompleted:
+			q.processRequestCompleted(completedReq)
 		case waitingConn := <-q.waitingQuerierConns:
 			requestSent := q.trySendNextRequestForQuerier(waitingConn)
 			if !requestSent {
@@ -262,6 +275,8 @@ func (q *RequestQueue) dispatcherLoop() {
 			}
 		}
 
+		// if we have received a signal to stop, we continue to dispatch queries until
+		// the queue is empty or until we have no more connected querier workers.
 		if stopping && (q.queueBroker.isEmpty() || q.connectedQuerierWorkers.Load() == 0) {
 			// tell any waiting querier connections that nothing is coming
 			currentElement := q.waitingQuerierConnsToDispatch.Front()
@@ -273,10 +288,9 @@ func (q *RequestQueue) dispatcherLoop() {
 			}
 
 			if !q.queueBroker.isEmpty() {
-				// This should never happen: unless all queriers have shut down themselves, they should remain connected
-				// until the RequestQueue service enters the stopped state (see Scheduler.QuerierLoop()), and so we won't
-				// stop the RequestQueue until we've drained all enqueued queries.
-				// But if this does happen, we want to know about it.
+				// All queriers have disconnected, but we still have requests in the queue.
+				// Without any consumers we have nothing to do but stop the RequestQueue.
+				// This should never happen, but if this does happen, we want to know about it.
 				level.Warn(q.log).Log("msg", "shutting down dispatcher loop: have no connected querier workers, but request queue is not empty, so these requests will be abandoned")
 			}
 
@@ -289,7 +303,7 @@ func (q *RequestQueue) dispatcherLoop() {
 
 // enqueueRequestInternal processes a request into the RequestQueue's internal queue structure.
 //
-// If request is successfully enqueued, successFn is called before any querier can receive the request.
+// If request is enqueued successFn is called before the request can be dispatched to a querier.
 func (q *RequestQueue) enqueueRequestInternal(r requestToEnqueue) error {
 	tr := tenantRequest{
 		tenantID: r.tenantID,
@@ -302,13 +316,11 @@ func (q *RequestQueue) enqueueRequestInternal(r requestToEnqueue) error {
 		}
 		return err
 	}
-	q.queueLength.WithLabelValues(string(r.tenantID)).Inc()
-
-	// Call the successFn here to ensure we call it before sending this request to a waiting querier.
 	if r.successFn != nil {
 		r.successFn()
 	}
 
+	q.queueLength.WithLabelValues(string(r.tenantID)).Inc()
 	return nil
 }
 
@@ -355,9 +367,7 @@ func (q *RequestQueue) trySendNextRequestForQuerier(waitingConn *waitingQuerierC
 					"overloaded_query_component", queryComponent,
 				)
 			}
-			q.QueryComponentUtilization.IncrementForComponentName(queryComponentName)
 		}
-
 	}
 
 	reqForQuerier := requestForQuerier{
@@ -523,6 +533,41 @@ func (q *RequestQueue) processUnregisterQuerierConnection(querierID QuerierID) (
 
 func (q *RequestQueue) processForgetDisconnectedQueriers() (resharded bool) {
 	return q.queueBroker.forgetDisconnectedQueriers(time.Now())
+}
+
+func (q *RequestQueue) SubmitRequestSent(req *SchedulerRequest) {
+	if req != nil {
+		select {
+		case q.requestsSent <- req:
+		case <-q.stopCompleted:
+		}
+	}
+}
+
+func (q *RequestQueue) processRequestSent(req *SchedulerRequest) {
+	if req != nil {
+		q.querierInflightRequests[req.Key()] = req
+		q.QueryComponentUtilization.IncrementForComponentName(req.ExpectedQueryComponentName())
+	}
+}
+
+func (q *RequestQueue) SubmitRequestCompleted(req *SchedulerRequest) {
+	if req != nil {
+		select {
+		case q.requestsCompleted <- req:
+		case <-q.stopCompleted:
+		}
+	}
+}
+
+func (q *RequestQueue) processRequestCompleted(req *SchedulerRequest) {
+	if req != nil {
+		reqKey := req.Key()
+		if req, ok := q.querierInflightRequests[reqKey]; ok {
+			q.QueryComponentUtilization.DecrementForComponentName(req.ExpectedQueryComponentName())
+		}
+		delete(q.querierInflightRequests, reqKey)
+	}
 }
 
 // waitingQuerierConn is a "request" indicating that the querier is ready to receive the next query request.

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -355,7 +355,7 @@ func (q *RequestQueue) trySendNextRequestForQuerier(waitingConn *waitingQuerierC
 			queryComponentName := schedulerRequest.ExpectedQueryComponentName()
 			exceedsThreshold, queryComponent := q.QueryComponentUtilization.ExceedsThresholdForComponentName(
 				queryComponentName,
-				q.connectedQuerierWorkers.Load(),
+				int(q.connectedQuerierWorkers.Load()),
 				q.queueBroker.tenantQueuesTree.ItemCount(),
 				q.waitingQuerierConnsToDispatch.Len(),
 			)
@@ -472,7 +472,6 @@ func (q *RequestQueue) GetConnectedQuerierWorkersMetric() float64 {
 
 func (q *RequestQueue) forgetDisconnectedQueriers(_ context.Context) error {
 	q.submitQuerierOperation("", forgetDisconnected)
-
 	return nil
 }
 

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -59,9 +59,9 @@ func randAdditionalQueueDimension(allowEmpty bool) []string {
 // used by the queue mechanics, in order get a more meaningful % delta between competing queue implementations.
 func makeSchedulerRequest(tenantID string, additionalQueueDimensions []string) *SchedulerRequest {
 	return &SchedulerRequest{
-		Ctx:             context.Background(),
-		FrontendAddress: "http://query-frontend:8007",
-		UserID:          tenantID,
+		Ctx:          context.Background(),
+		FrontendAddr: "http://query-frontend:8007",
+		UserID:       tenantID,
 		Request: &httpgrpc.HTTPRequest{
 			Method: "GET",
 			Headers: []*httpgrpc.Header{

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -88,10 +88,10 @@ func TestQueuesRespectMaxTenantQueueSizeWithSubQueues(t *testing.T) {
 		3: {"ingester-and-store-gateway"},
 	}
 	req := &SchedulerRequest{
-		Ctx:             context.Background(),
-		FrontendAddress: "http://query-frontend:8007",
-		UserID:          "tenant-1",
-		Request:         &httpgrpc.HTTPRequest{},
+		Ctx:          context.Background(),
+		FrontendAddr: "http://query-frontend:8007",
+		UserID:       "tenant-1",
+		Request:      &httpgrpc.HTTPRequest{},
 	}
 
 	// build queue evenly with either no additional queue dimension or one of 3 additional dimensions

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -63,7 +63,7 @@ type Scheduler struct {
 	inflightRequestsMu sync.Mutex
 	// schedulerInflightRequests tracks requests from the time they are received to be enqueued by the scheduler
 	// to the time they are completed by the querier or failed due to cancel, timeout, or disconnect.
-	schedulerInflightRequests map[requestKey]*queue.SchedulerRequest
+	schedulerInflightRequests map[queue.SchedulerRequestKey]*queue.SchedulerRequest
 
 	// The ring is used to let other components discover query-scheduler replicas.
 	// The ring is optional.
@@ -81,11 +81,6 @@ type Scheduler struct {
 	connectedFrontendClients prometheus.GaugeFunc
 	queueDuration            *prometheus.HistogramVec
 	inflightRequests         prometheus.Summary
-}
-
-type requestKey struct {
-	frontendAddr string
-	queryID      uint64
 }
 
 type connectedFrontend struct {
@@ -128,7 +123,7 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 		log:    log,
 		limits: limits,
 
-		schedulerInflightRequests: map[requestKey]*queue.SchedulerRequest{},
+		schedulerInflightRequests: map[queue.SchedulerRequestKey]*queue.SchedulerRequest{},
 		connectedFrontends:        map[string]*connectedFrontend{},
 		subservicesWatcher:        services.NewFailureWatcher(),
 	}
@@ -280,7 +275,7 @@ func (s *Scheduler) FrontendLoop(frontend schedulerpb.SchedulerForFrontend_Front
 
 			enqueueSpan.Finish()
 		case schedulerpb.CANCEL:
-			s.cancelRequestAndRemoveFromPending(frontendAddress, msg.QueryID, "frontend cancelled query")
+			s.cancelRequestAndRemoveFromPending(queue.NewSchedulerRequestKey(frontendAddress, msg.QueryID), "frontend cancelled query")
 			resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
 
 		default:
@@ -349,7 +344,7 @@ func (s *Scheduler) enqueueRequest(requestContext context.Context, frontendAddr 
 	userID := msg.GetUserID()
 
 	req := &queue.SchedulerRequest{
-		FrontendAddress:           frontendAddr,
+		FrontendAddr:              frontendAddr,
 		UserID:                    msg.UserID,
 		QueryID:                   msg.QueryID,
 		Request:                   msg.HttpRequest,
@@ -374,19 +369,22 @@ func (s *Scheduler) enqueueRequest(requestContext context.Context, frontendAddr 
 	s.activeUsers.UpdateUserTimestamp(userID, now)
 	return s.requestQueue.SubmitRequestToEnqueue(userID, req, maxQueriers, func() {
 		shouldCancel = false
-
-		s.inflightRequestsMu.Lock()
-		s.schedulerInflightRequests[requestKey{frontendAddr: frontendAddr, queryID: msg.QueryID}] = req
-		s.inflightRequestsMu.Unlock()
+		s.addRequestToPending(req)
 	})
 }
 
-// This method doesn't do removal from the queue.
-func (s *Scheduler) cancelRequestAndRemoveFromPending(frontendAddr string, queryID uint64, reason string) {
+func (s *Scheduler) addRequestToPending(req *queue.SchedulerRequest) {
 	s.inflightRequestsMu.Lock()
 	defer s.inflightRequestsMu.Unlock()
 
-	key := requestKey{frontendAddr: frontendAddr, queryID: queryID}
+	s.schedulerInflightRequests[req.Key()] = req
+}
+
+// This method doesn't do removal from the queue.
+func (s *Scheduler) cancelRequestAndRemoveFromPending(key queue.SchedulerRequestKey, reason string) {
+	s.inflightRequestsMu.Lock()
+	defer s.inflightRequestsMu.Unlock()
+
 	req := s.schedulerInflightRequests[key]
 	if req != nil {
 		req.CancelFunc(cancellation.NewErrorf(reason))
@@ -411,7 +409,7 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 
 	// In stopping state scheduler is not accepting new queries, but still dispatching queries in the queues.
 	for s.isRunningOrStopping() {
-		req, idx, err := s.requestQueue.WaitForRequestForQuerier(querier.Context(), lastUserIndex, querierID)
+		queueReq, idx, err := s.requestQueue.WaitForRequestForQuerier(querier.Context(), lastUserIndex, querierID)
 		if err != nil {
 			// Return a more clear error if the queue is stopped because the query-scheduler is not running.
 			if errors.Is(err, queue.ErrStopped) && !s.isRunning() {
@@ -425,12 +423,12 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 		}
 		lastUserIndex = idx
 
-		r := req.(*queue.SchedulerRequest)
+		schedulerReq := queueReq.(*queue.SchedulerRequest)
 
-		queueTime := time.Since(r.EnqueueTime)
-		additionalQueueDimensionLabels := strings.Join(r.AdditionalQueueDimensions, ":")
-		s.queueDuration.WithLabelValues(r.UserID, additionalQueueDimensionLabels).Observe(queueTime.Seconds())
-		r.QueueSpan.Finish()
+		queueTime := time.Since(schedulerReq.EnqueueTime)
+		additionalQueueDimensionLabels := strings.Join(schedulerReq.AdditionalQueueDimensions, ":")
+		s.queueDuration.WithLabelValues(schedulerReq.UserID, additionalQueueDimensionLabels).Observe(queueTime.Seconds())
+		schedulerReq.QueueSpan.Finish()
 
 		/*
 		  We want to dequeue the next unexpired request from the chosen tenant queue.
@@ -444,15 +442,15 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 		  it's possible that its own queue would perpetually contain only expired requests.
 		*/
 
-		if r.Ctx.Err() != nil {
+		if schedulerReq.Ctx.Err() != nil {
 			// Remove from pending requests.
-			s.cancelRequestAndRemoveFromPending(r.FrontendAddress, r.QueryID, "request cancelled")
+			s.cancelRequestAndRemoveFromPending(schedulerReq.Key(), "request cancelled")
 
 			lastUserIndex = lastUserIndex.ReuseLastTenant()
 			continue
 		}
 
-		if err := s.forwardRequestToQuerier(querier, r, queueTime); err != nil {
+		if err := s.forwardRequestToQuerier(querier, schedulerReq, queueTime); err != nil {
 			return err
 		}
 	}
@@ -469,7 +467,7 @@ func (s *Scheduler) NotifyQuerierShutdown(_ context.Context, req *schedulerpb.No
 
 func (s *Scheduler) forwardRequestToQuerier(querier schedulerpb.SchedulerForQuerier_QuerierLoopServer, req *queue.SchedulerRequest, queueTime time.Duration) error {
 	// Make sure to cancel request at the end to clean up resources.
-	defer s.cancelRequestAndRemoveFromPending(req.FrontendAddress, req.QueryID, "request complete")
+	defer s.cancelRequestAndRemoveFromPending(req.Key(), "request complete")
 
 	queryComponentName := req.ExpectedQueryComponentName()
 	defer s.requestQueue.QueryComponentUtilization.DecrementForComponentName(queryComponentName)
@@ -481,7 +479,7 @@ func (s *Scheduler) forwardRequestToQuerier(querier schedulerpb.SchedulerForQuer
 		err := querier.Send(&schedulerpb.SchedulerToQuerier{
 			UserID:          req.UserID,
 			QueryID:         req.QueryID,
-			FrontendAddress: req.FrontendAddress,
+			FrontendAddress: req.FrontendAddr,
 			HttpRequest:     req.Request,
 			StatsEnabled:    req.StatsEnabled,
 			QueueTimeNanos:  queueTime.Nanoseconds(),
@@ -521,13 +519,13 @@ func (s *Scheduler) forwardErrorToFrontend(ctx context.Context, req *queue.Sched
 		middleware.ClientUserHeaderInterceptor},
 		nil)
 	if err != nil {
-		level.Warn(s.log).Log("msg", "failed to create gRPC options for the connection to frontend to report error", "frontend", req.FrontendAddress, "err", err, "requestErr", requestErr)
+		level.Warn(s.log).Log("msg", "failed to create gRPC options for the connection to frontend to report error", "frontend", req.FrontendAddr, "err", err, "requestErr", requestErr)
 		return
 	}
 
-	conn, err := grpc.DialContext(ctx, req.FrontendAddress, opts...)
+	conn, err := grpc.DialContext(ctx, req.FrontendAddr, opts...)
 	if err != nil {
-		level.Warn(s.log).Log("msg", "failed to create gRPC connection to frontend to report error", "frontend", req.FrontendAddress, "err", err, "requestErr", requestErr)
+		level.Warn(s.log).Log("msg", "failed to create gRPC connection to frontend to report error", "frontend", req.FrontendAddr, "err", err, "requestErr", requestErr)
 		return
 	}
 
@@ -547,7 +545,7 @@ func (s *Scheduler) forwardErrorToFrontend(ctx context.Context, req *queue.Sched
 	})
 
 	if err != nil {
-		level.Warn(s.log).Log("msg", "failed to forward error to frontend", "frontend", req.FrontendAddress, "err", err, "requestErr", requestErr)
+		level.Warn(s.log).Log("msg", "failed to forward error to frontend", "frontend", req.FrontendAddr, "err", err, "requestErr", requestErr)
 		return
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -597,6 +597,10 @@ func verifyNoPendingRequestsLeft(t *testing.T, scheduler *Scheduler) {
 }
 
 func verifyQueryComponentUtilizationLeft(t *testing.T, scheduler *Scheduler) {
+	scheduler.StopAsync()
+	test.Poll(t, 2*time.Second, services.Terminated, func() interface{} {
+		return scheduler.State()
+	})
 	require.Zero(t, scheduler.requestQueue.QueryComponentUtilization.GetForComponent(queue.Ingester))
 	require.Zero(t, scheduler.requestQueue.QueryComponentUtilization.GetForComponent(queue.StoreGateway))
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
+	"github.com/grafana/mimir/pkg/scheduler/queue"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/httpgrpcutil"
@@ -111,6 +112,7 @@ func TestSchedulerBasicEnqueue(t *testing.T) {
 	}
 
 	verifyNoPendingRequestsLeft(t, scheduler)
+	verifyQueryComponentUtilizationLeft(t, scheduler)
 }
 
 func TestSchedulerEnqueueWithCancel(t *testing.T) {
@@ -133,6 +135,7 @@ func TestSchedulerEnqueueWithCancel(t *testing.T) {
 
 	verifyQuerierDoesntReceiveRequest(t, querierLoop, 500*time.Millisecond)
 	verifyNoPendingRequestsLeft(t, scheduler)
+	verifyQueryComponentUtilizationLeft(t, scheduler)
 }
 
 func TestSchedulerEnqueueByMultipleFrontendsWithCancel(t *testing.T) {
@@ -174,6 +177,7 @@ func TestSchedulerEnqueueByMultipleFrontendsWithCancel(t *testing.T) {
 	// But nothing else.
 	verifyQuerierDoesntReceiveRequest(t, querierLoop, 500*time.Millisecond)
 	verifyNoPendingRequestsLeft(t, scheduler)
+	verifyQueryComponentUtilizationLeft(t, scheduler)
 }
 
 func TestSchedulerEnqueueWithFrontendDisconnect(t *testing.T) {
@@ -204,6 +208,7 @@ func TestSchedulerEnqueueWithFrontendDisconnect(t *testing.T) {
 
 	verifyQuerierDoesntReceiveRequest(t, querierLoop, 500*time.Millisecond)
 	verifyNoPendingRequestsLeft(t, scheduler)
+	verifyQueryComponentUtilizationLeft(t, scheduler)
 }
 
 func TestCancelRequestInProgress_QuerierFinishesBeforeObservingCancellation(t *testing.T) {
@@ -237,6 +242,7 @@ func TestCancelRequestInProgress_QuerierFinishesBeforeObservingCancellation(t *t
 	require.Error(t, err)
 
 	verifyNoPendingRequestsLeft(t, scheduler)
+	verifyQueryComponentUtilizationLeft(t, scheduler)
 }
 
 func TestCancelRequestInProgress_QuerierObservesCancellation(t *testing.T) {
@@ -269,6 +275,7 @@ func TestCancelRequestInProgress_QuerierObservesCancellation(t *testing.T) {
 	require.Equal(t, codes.Canceled, status.Code(err))
 
 	verifyNoPendingRequestsLeft(t, scheduler)
+	verifyQueryComponentUtilizationLeft(t, scheduler)
 }
 
 func TestTracingContext(t *testing.T) {
@@ -321,6 +328,7 @@ func TestSchedulerShutdown_FrontendLoop(t *testing.T) {
 	msg, err := frontendLoop.Recv()
 	require.NoError(t, err)
 	require.Equal(t, schedulerpb.SHUTTING_DOWN, msg.Status)
+	verifyQueryComponentUtilizationLeft(t, scheduler)
 }
 
 func TestSchedulerShutdown_QuerierLoop(t *testing.T) {
@@ -400,7 +408,7 @@ func TestSchedulerMaxOutstandingRequests(t *testing.T) {
 }
 
 func TestSchedulerForwardsErrorToFrontend(t *testing.T) {
-	_, frontendClient, querierClient := setupScheduler(t, nil)
+	scheduler, frontendClient, querierClient := setupScheduler(t, nil)
 
 	fm := &frontendMock{resp: map[uint64]*httpgrpc.HTTPResponse{}}
 	frontendAddress := ""
@@ -457,6 +465,7 @@ func TestSchedulerForwardsErrorToFrontend(t *testing.T) {
 		require.Equal(t, int32(http.StatusInternalServerError), resp.Code)
 		return true
 	})
+	verifyQueryComponentUtilizationLeft(t, scheduler)
 }
 
 func TestSchedulerQueueMetrics(t *testing.T) {
@@ -585,6 +594,11 @@ func verifyNoPendingRequestsLeft(t *testing.T, scheduler *Scheduler) {
 		defer scheduler.inflightRequestsMu.Unlock()
 		return len(scheduler.schedulerInflightRequests)
 	})
+}
+
+func verifyQueryComponentUtilizationLeft(t *testing.T, scheduler *Scheduler) {
+	require.Zero(t, scheduler.requestQueue.QueryComponentUtilization.GetForComponent(queue.Ingester))
+	require.Zero(t, scheduler.requestQueue.QueryComponentUtilization.GetForComponent(queue.StoreGateway))
 }
 
 type limits struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds two channels to the `RequestQueue` to handle notifications for queries being sent to the querier, then being completed/canceled.

This is to ensure accurate tracking of the query component utilization and the corresponding metric `cortex_query_scheduler_querier_inflight_requests` - the `RequestQueue` will need this information to make dequeuing decisions once the new queue structures are ready.

There are many workable ways to do this, but the main points are we must:
* always increment anything sent to a querier or attempted to be sent to a querier
* always decrement for anything completed, canceled, or that failed to be sent to a querier

We also cannot add anything to the internal `querierInflightRequests` tracking map until we are ready to increment the utilization, because later if we receive a cancel but we never incremented, we will decrement to below zero.

The original issue found was that I did not decrement when the request was canceled, whether that is before or after  it was dequeued & sent to the querier. This would have been a one-line change but I took the opportunity for a complete approach, using channels to eliminate the need for atomics in `QueryComponentUtilization`.


---
some design notes:
1. I can see an argument for just moving `querierInflightRequests` into the `QueryComponentUtilization` struct.
2. We could technically not add things to a map at all, and just increment/decrement based on the request received
    i. further testing would be needed for this to make sure we aren't over-decrementing - the map adds a guard against decrementing something we have not incremented for yet
    ii. tracking in the map seems more general-purpose - how we use this gets a lot more constrained if we can't have a check against whether we already incremented or not
4. We could also have the requestsCompleted just take a key instead of the full request but the pointers are actually smaller than the key and it's more symmetrical this way

We should incorporate this into the RequestQueue tests since we've added more channels to the dispatcher loop but am hesitant to do this before we get Casie's reworked tests in.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
