### PR TITLE
Mimir query engine: rename metrics and CLI flag values to match new name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=streaming`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277 #8291
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1913,9 +1913,9 @@
           "kind": "field",
           "name": "promql_engine",
           "required": false,
-          "desc": "PromQL engine to use, either 'standard' or 'streaming'",
+          "desc": "PromQL engine to use, either 'prometheus' or 'mimir'",
           "fieldValue": null,
-          "fieldDefaultValue": "standard",
+          "fieldDefaultValue": "prometheus",
           "fieldFlag": "querier.promql-engine",
           "fieldType": "string",
           "fieldCategory": "experimental"

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1784,7 +1784,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.prefer-streaming-chunks-from-store-gateways
     	[experimental] Request store-gateways stream chunks. Store-gateways will only respond with a stream of chunks if the target store-gateway supports this, and this preference will be ignored by store-gateways that do not support this.
   -querier.promql-engine string
-    	[experimental] PromQL engine to use, either 'standard' or 'streaming' (default "standard")
+    	[experimental] PromQL engine to use, either 'prometheus' or 'mimir' (default "prometheus")
   -querier.promql-experimental-functions-enabled
     	[experimental] Enable experimental PromQL functions. This config option should be set on query-frontend too when query sharding is enabled.
   -querier.query-ingesters-within duration

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -140,7 +140,7 @@ The following features are currently experimental:
   - Maximum response size for active series queries (`-querier.active-series-results-max-size-bytes`)
   - Enable PromQL experimental functions (`-querier.promql-experimental-functions-enabled`)
   - Allow streaming of `/active_series` responses to the frontend (`-querier.response-streaming-enabled`)
-  - Streaming PromQL engine (`-querier.promql-engine=streaming` and `-querier.enable-promql-engine-fallback`)
+  - Mimir query engine (`-querier.promql-engine=mimir` and `-querier.enable-promql-engine-fallback`)
   - Maximum estimated memory consumption per query limit (`-querier.max-estimated-memory-consumption-per-query`)
 - Query-frontend
   - `-query-frontend.querier-forget-delay`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1379,9 +1379,9 @@ store_gateway_client:
 # CLI flag: -querier.minimize-ingester-requests-hedging-delay
 [minimize_ingester_requests_hedging_delay: <duration> | default = 3s]
 
-# (experimental) PromQL engine to use, either 'standard' or 'streaming'
+# (experimental) PromQL engine to use, either 'prometheus' or 'mimir'
 # CLI flag: -querier.promql-engine
-[promql_engine: <string> | default = "standard"]
+[promql_engine: <string> | default = "prometheus"]
 
 # (experimental) If set to true and the streaming engine is in use, fall back to
 # using the Prometheus PromQL engine for any queries not supported by the

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -2009,7 +2009,7 @@ How to **fix** it:
 This error occurs when execution of a query exceeds the limit on the maximum estimated memory consumed by a single query.
 
 This limit is used to protect the system’s stability from potential abuse or mistakes, when running a query fetching a huge amount of data.
-This limit only applies when Mimir's query engine is used (ie. `-querier.promql-engine=streaming`).
+This limit only applies when Mimir's query engine is used (ie. `-querier.promql-engine=mimir`).
 To configure the limit on a global basis, use the `-querier.max-estimated-memory-consumption-per-query` option.
 To configure the limit on a per-tenant basis, set the `max_estimated_memory_consumption_per_query` per-tenant override in the runtime configuration.
 

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -512,13 +512,13 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 	}
 }
 
-func TestStreamingPromQLEngine(t *testing.T) {
+func TestMimirPromQLEngine(t *testing.T) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
 
 	flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), map[string]string{
-		"-querier.promql-engine": "streaming",
+		"-querier.promql-engine": "mimir",
 	})
 
 	consul := e2edb.NewConsul()

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -163,7 +163,7 @@ func TestMimir(t *testing.T) {
 			InstanceInterfaceNames: []string{"en0", "eth0", "lo0", "lo"},
 		}},
 		Querier: querier.Config{
-			PromQLEngine: "standard",
+			PromQLEngine: "prometheus",
 		},
 	}
 	require.NoError(t, cfg.Server.LogLevel.Set("info"))

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -65,9 +65,9 @@ type Config struct {
 }
 
 const (
-	queryStoreAfterFlag   = "querier.query-store-after"
-	standardPromQLEngine  = "standard"
-	streamingPromQLEngine = "streaming"
+	queryStoreAfterFlag    = "querier.query-store-after"
+	prometheusPromQLEngine = "prometheus"
+	mimirPromQLEngine      = "mimir"
 )
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -89,14 +89,14 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Uint64Var(&cfg.StreamingChunksPerIngesterSeriesBufferSize, "querier.streaming-chunks-per-ingester-buffer-size", 256, "Number of series to buffer per ingester when streaming chunks from ingesters.")
 	f.Uint64Var(&cfg.StreamingChunksPerStoreGatewaySeriesBufferSize, "querier.streaming-chunks-per-store-gateway-buffer-size", 256, "Number of series to buffer per store-gateway when streaming chunks from store-gateways.")
 
-	f.StringVar(&cfg.PromQLEngine, "querier.promql-engine", standardPromQLEngine, fmt.Sprintf("PromQL engine to use, either '%v' or '%v'", standardPromQLEngine, streamingPromQLEngine))
+	f.StringVar(&cfg.PromQLEngine, "querier.promql-engine", prometheusPromQLEngine, fmt.Sprintf("PromQL engine to use, either '%v' or '%v'", prometheusPromQLEngine, mimirPromQLEngine))
 	f.BoolVar(&cfg.EnablePromQLEngineFallback, "querier.enable-promql-engine-fallback", true, "If set to true and the streaming engine is in use, fall back to using the Prometheus PromQL engine for any queries not supported by the streaming engine.")
 
 	cfg.EngineConfig.RegisterFlags(f)
 }
 
 func (cfg *Config) Validate() error {
-	if cfg.PromQLEngine != standardPromQLEngine && cfg.PromQLEngine != streamingPromQLEngine {
+	if cfg.PromQLEngine != prometheusPromQLEngine && cfg.PromQLEngine != mimirPromQLEngine {
 		return fmt.Errorf("unknown PromQL engine '%s'", cfg.PromQLEngine)
 	}
 
@@ -161,9 +161,9 @@ func New(cfg Config, limits *validation.Overrides, distributor Distributor, stor
 	var eng promql.QueryEngine
 
 	switch cfg.PromQLEngine {
-	case standardPromQLEngine:
+	case prometheusPromQLEngine:
 		eng = promql.NewEngine(opts)
-	case streamingPromQLEngine:
+	case mimirPromQLEngine:
 		limitsProvider := &tenantQueryLimitsProvider{limits: limits}
 		streamingEngine, err := streamingpromql.NewEngine(opts, limitsProvider, logger)
 		if err != nil {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -605,7 +605,7 @@ func TestQuerier_QueryIngestersWithinConfig(t *testing.T) {
 		MaxSamples:         1e6,
 		Timeout:            1 * time.Minute,
 	})
-	cfg := Config{PromQLEngine: standardPromQLEngine}
+	cfg := Config{PromQLEngine: prometheusPromQLEngine}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			distributor := &errDistributor{}

--- a/pkg/streamingpromql/compat/fallback_engine.go
+++ b/pkg/streamingpromql/compat/fallback_engine.go
@@ -33,12 +33,12 @@ func NewEngineWithFallback(preferred, fallback promql.QueryEngine, reg prometheu
 		fallback:  fallback,
 
 		supportedQueries: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_streaming_promql_engine_supported_queries_total",
-			Help: "Total number of queries that were supported by the streaming engine.",
+			Name: "cortex_mimir_query_engine_supported_queries_total",
+			Help: "Total number of queries that were supported by the Mimir query engine.",
 		}),
 		unsupportedQueries: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_streaming_promql_engine_unsupported_queries_total",
-			Help: "Total number of queries that were not supported by the streaming engine and so fell back to Prometheus' engine.",
+			Name: "cortex_mimir_query_engine_unsupported_queries_total",
+			Help: "Total number of queries that were not supported by the Mimir query engine and so fell back to Prometheus' engine.",
 		}, []string{"reason"}),
 
 		logger: logger,

--- a/pkg/streamingpromql/compat/fallback_engine_test.go
+++ b/pkg/streamingpromql/compat/fallback_engine_test.go
@@ -46,10 +46,10 @@ func TestEngineWithFallback(t *testing.T) {
 				require.False(t, fallbackEngine.wasCalled, "should not call fallback engine if expression is supported by preferred engine")
 
 				require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-					# HELP cortex_streaming_promql_engine_supported_queries_total Total number of queries that were supported by the streaming engine.
-					# TYPE cortex_streaming_promql_engine_supported_queries_total counter
-					cortex_streaming_promql_engine_supported_queries_total 1
-				`), "cortex_streaming_promql_engine_supported_queries_total", "cortex_streaming_promql_engine_unsupported_queries_total"))
+					# HELP cortex_mimir_query_engine_supported_queries_total Total number of queries that were supported by the Mimir query engine.
+					# TYPE cortex_mimir_query_engine_supported_queries_total counter
+					cortex_mimir_query_engine_supported_queries_total 1
+				`), "cortex_mimir_query_engine_supported_queries_total", "cortex_mimir_query_engine_unsupported_queries_total"))
 			})
 
 			t.Run("should fall back for unsupported expressions", func(t *testing.T) {
@@ -63,13 +63,13 @@ func TestEngineWithFallback(t *testing.T) {
 				require.Equal(t, fallbackEngine.query, query, "should return query from fallback engine if expression is not supported by preferred engine")
 
 				require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-					# HELP cortex_streaming_promql_engine_supported_queries_total Total number of queries that were supported by the streaming engine.
-					# TYPE cortex_streaming_promql_engine_supported_queries_total counter
-					cortex_streaming_promql_engine_supported_queries_total 0
-					# HELP cortex_streaming_promql_engine_unsupported_queries_total Total number of queries that were not supported by the streaming engine and so fell back to Prometheus' engine.
-					# TYPE cortex_streaming_promql_engine_unsupported_queries_total counter
-					cortex_streaming_promql_engine_unsupported_queries_total{reason="this expression is not supported"} 1
-				`), "cortex_streaming_promql_engine_supported_queries_total", "cortex_streaming_promql_engine_unsupported_queries_total"))
+					# HELP cortex_mimir_query_engine_supported_queries_total Total number of queries that were supported by the Mimir query engine.
+					# TYPE cortex_mimir_query_engine_supported_queries_total counter
+					cortex_mimir_query_engine_supported_queries_total 0
+					# HELP cortex_mimir_query_engine_unsupported_queries_total Total number of queries that were not supported by the Mimir query engine and so fell back to Prometheus' engine.
+					# TYPE cortex_mimir_query_engine_unsupported_queries_total counter
+					cortex_mimir_query_engine_unsupported_queries_total{reason="this expression is not supported"} 1
+				`), "cortex_mimir_query_engine_supported_queries_total", "cortex_mimir_query_engine_unsupported_queries_total"))
 			})
 
 			t.Run("should not fall back if creating query fails for another reason", func(t *testing.T) {

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -46,7 +46,7 @@ func NewEngine(opts promql.EngineOpts, limitsProvider QueryLimitsProvider, logge
 
 		logger: logger,
 		estimatedPeakMemoryConsumption: promauto.With(opts.Reg).NewHistogram(prometheus.HistogramOpts{
-			Name:                        "cortex_streaming_promql_engine_estimated_query_peak_memory_consumption",
+			Name:                        "cortex_mimir_query_engine_estimated_query_peak_memory_consumption",
 			Help:                        "Estimated peak memory consumption of each query (in bytes)",
 			NativeHistogramBucketFactor: 1.1,
 		}),

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -146,7 +146,7 @@ func TestUpstreamTestCases(t *testing.T) {
 
 func TestOurTestCases(t *testing.T) {
 	opts := NewTestEngineOpts()
-	streamingEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), log.NewNopLogger())
 	require.NoError(t, err)
 
 	prometheusEngine := promql.NewEngine(opts)
@@ -166,8 +166,8 @@ func TestOurTestCases(t *testing.T) {
 
 			testScript := string(b)
 
-			t.Run("streaming engine", func(t *testing.T) {
-				promqltest.RunTest(t, testScript, streamingEngine)
+			t.Run("Mimir's engine", func(t *testing.T) {
+				promqltest.RunTest(t, testScript, mimirEngine)
 			})
 
 			// Run the tests against Prometheus' engine to ensure our test cases are valid.
@@ -184,7 +184,7 @@ func TestOurTestCases(t *testing.T) {
 // So instead, we test these few cases here instead.
 func TestRangeVectorSelectors(t *testing.T) {
 	opts := NewTestEngineOpts()
-	streamingEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), log.NewNopLogger())
 	require.NoError(t, err)
 
 	prometheusEngine := promql.NewEngine(opts)
@@ -283,8 +283,8 @@ func TestRangeVectorSelectors(t *testing.T) {
 				require.Equal(t, expected, res)
 			}
 
-			t.Run("streaming engine", func(t *testing.T) {
-				runTest(t, streamingEngine, testCase.expr, testCase.ts, testCase.expected)
+			t.Run("Mimir's engine", func(t *testing.T) {
+				runTest(t, mimirEngine, testCase.expr, testCase.ts, testCase.expected)
 			})
 
 			// Run the tests against Prometheus' engine to ensure our test cases are valid.

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -564,7 +564,7 @@ func TestMemoryConsumptionLimit(t *testing.T) {
 	}
 
 	assertEstimatedPeakMemoryConsumption := func(t *testing.T, reg *prometheus.Registry, span opentracing.Span, expectedMemoryConsumptionEstimate uint64) {
-		peakMemoryConsumptionHistogram := getHistogram(t, reg, "cortex_streaming_promql_engine_estimated_query_peak_memory_consumption")
+		peakMemoryConsumptionHistogram := getHistogram(t, reg, "cortex_mimir_query_engine_estimated_query_peak_memory_consumption")
 		require.Equal(t, float64(expectedMemoryConsumptionEstimate), peakMemoryConsumptionHistogram.GetSampleSum())
 
 		jaegerSpan, ok := span.(*jaeger.Span)

--- a/tools/benchmark-query-engine/compare.sh
+++ b/tools/benchmark-query-engine/compare.sh
@@ -7,11 +7,11 @@ set -euo pipefail
 RESULTS_FILE="$1" # Should be the path to a file produced by a command like `go run . -count=6 | tee output.txt`
 
 PROMETHEUS_RESULTS_FILE=$(mktemp /tmp/prometheus.XXXX)
-STREAMING_RESULTS_FILE=$(mktemp /tmp/streaming.XXXX)
+MIMIR_RESULTS_FILE=$(mktemp /tmp/mimir.XXXX)
 
-grep --invert-match "streaming-" "$RESULTS_FILE" | sed -E 's#/Prometheus-[0-9]+##g' > "$PROMETHEUS_RESULTS_FILE"
-grep --invert-match "Prometheus-" "$RESULTS_FILE" | sed -E 's#/streaming-[0-9]+##g' > "$STREAMING_RESULTS_FILE"
+grep --invert-match "Mimir-" "$RESULTS_FILE" | sed -E 's#/Prometheus-[0-9]+##g' > "$PROMETHEUS_RESULTS_FILE"
+grep --invert-match "Prometheus-" "$RESULTS_FILE" | sed -E 's#/Mimir-[0-9]+##g' > "$MIMIR_RESULTS_FILE"
 
-benchstat "$PROMETHEUS_RESULTS_FILE" "$STREAMING_RESULTS_FILE" | sed "s#$PROMETHEUS_RESULTS_FILE#     Prometheus     #g" | sed "s#$STREAMING_RESULTS_FILE#     streaming     #g"
+benchstat "$PROMETHEUS_RESULTS_FILE" "$MIMIR_RESULTS_FILE" | sed "s#$PROMETHEUS_RESULTS_FILE#     Prometheus     #g" | sed "s#$MIMIR_RESULTS_FILE#     Mimir     #g"
 
-rm "$PROMETHEUS_RESULTS_FILE" "$STREAMING_RESULTS_FILE"
+rm "$PROMETHEUS_RESULTS_FILE" "$MIMIR_RESULTS_FILE"

--- a/tools/benchmark-query-engine/main.go
+++ b/tools/benchmark-query-engine/main.go
@@ -271,7 +271,7 @@ func (a *app) allTestCaseNames() []string {
 	names := make([]string, 0, 2*len(cases))
 
 	for _, c := range cases {
-		names = append(names, benchmarkName+"/"+c.Name()+"/streaming")
+		names = append(names, benchmarkName+"/"+c.Name()+"/Mimir")
 		names = append(names, benchmarkName+"/"+c.Name()+"/Prometheus")
 	}
 
@@ -317,8 +317,8 @@ func (a *app) runTestCase(name string, printBenchmarkHeader bool) error {
 	buf := &bytes.Buffer{}
 	cmd.Stdout = buf
 	cmd.Stderr = os.Stderr
-	cmd.Env = append(cmd.Env, "STREAMING_PROMQL_ENGINE_BENCHMARK_INGESTER_ADDR="+a.ingesterAddress)
-	cmd.Env = append(cmd.Env, "STREAMING_PROMQL_ENGINE_BENCHMARK_SKIP_COMPARE_RESULTS=true")
+	cmd.Env = append(cmd.Env, "MIMIR_PROMQL_ENGINE_BENCHMARK_INGESTER_ADDR="+a.ingesterAddress)
+	cmd.Env = append(cmd.Env, "MIMIR_PROMQL_ENGINE_BENCHMARK_SKIP_COMPARE_RESULTS=true")
 
 	if err := cmd.Run(); err != nil {
 		slog.Warn("output from failed command", "output", buf.String())


### PR DESCRIPTION
#### What this PR does

We've started referring to the new query engine as the "Mimir query engine" rather than the "streaming query engine", and the existing query engine as "Prometheus' query engine".

This PR updates the metrics emitted by the engine and the values of the `-querier.promql-engine` CLI flag to match this new preferred name.

I haven't renamed the `streamingpromql` package as that will be disruptive to in-progress PRs - we can change this later if it really annoys us.

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/8270

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
