### PR TITLE
copyblocks: Configure s3 upload part size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,8 @@
 ### Tools
 
 * [ENHANCEMENT] ulidtime: add option to show random part of ULID, timestamp in milliseconds and header. #7615
+* [ENHANCEMENT] copyblocks: add a flag to configure part-size for multipart uploads in s3 client-side copying. #8292
+* [ENHANCEMENT] copyblocks: enable pprof HTTP endpoints. #8292
 
 ## 2.12.0
 

--- a/pkg/util/objtools/s3.go
+++ b/pkg/util/objtools/s3.go
@@ -169,8 +169,6 @@ func (bkt *s3Bucket) RestoreVersion(ctx context.Context, objectName string, vers
 func (bkt *s3Bucket) Upload(ctx context.Context, objectName string, reader io.Reader, contentLength int64) error {
 	opts := minio.PutObjectOptions{
 		PartSize: bkt.partSize,
-		// Refer to https://github.com/thanos-io/objstore/blob/71ef2d0cf7c4b42a6b25bc019de41bf0acecd30c/providers/s3/s3.go#L513-L516
-		NumThreads: 4,
 	}
 	_, err := bkt.client.PutObject(ctx, bkt.bucketName, objectName, reader, contentLength, opts)
 	return err

--- a/pkg/util/objtools/s3.go
+++ b/pkg/util/objtools/s3.go
@@ -18,6 +18,7 @@ type S3ClientConfig struct {
 	AccessKeyID     string
 	SecretAccessKey string
 	Secure          bool
+	PartSize        uint64
 }
 
 func (c *S3ClientConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
@@ -26,6 +27,7 @@ func (c *S3ClientConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.AccessKeyID, prefix+"access-key-id", "", "The access key ID used in AWS Signature Version 4 authentication.")
 	f.StringVar(&c.SecretAccessKey, prefix+"secret-access-key", "", "The secret access key used in AWS Signature Version 4 authentication.")
 	f.BoolVar(&c.Secure, prefix+"secure", true, "If true (default), use HTTPS when connecting to the bucket. If false, insecure HTTP is used.")
+	f.Uint64Var(&c.PartSize, prefix+"part-size", 0, "If 0, and object's size is known and optimal for multipart upload, the default value is the minimum allowed size 16MiB.")
 }
 
 func (c *S3ClientConfig) Validate(prefix string) error {
@@ -55,12 +57,14 @@ func (c *S3ClientConfig) ToBucket() (Bucket, error) {
 	return &s3Bucket{
 		client:     client,
 		bucketName: c.BucketName,
+		partSize:   c.PartSize,
 	}, nil
 }
 
 type s3Bucket struct {
 	client     *minio.Client
 	bucketName string
+	partSize   uint64
 }
 
 func (bkt *s3Bucket) Get(ctx context.Context, objectName string, options GetOptions) (io.ReadCloser, error) {
@@ -163,7 +167,12 @@ func (bkt *s3Bucket) RestoreVersion(ctx context.Context, objectName string, vers
 }
 
 func (bkt *s3Bucket) Upload(ctx context.Context, objectName string, reader io.Reader, contentLength int64) error {
-	_, err := bkt.client.PutObject(ctx, bkt.bucketName, objectName, reader, contentLength, minio.PutObjectOptions{})
+	opts := minio.PutObjectOptions{
+		PartSize: bkt.partSize,
+		// Refer to https://github.com/thanos-io/objstore/blob/71ef2d0cf7c4b42a6b25bc019de41bf0acecd30c/providers/s3/s3.go#L513-L516
+		NumThreads: 4,
+	}
+	_, err := bkt.client.PutObject(ctx, bkt.bucketName, objectName, reader, contentLength, opts)
 	return err
 }
 

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof" // anonymous import to get the pprof handler registered
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
#### What this PR does

This one updates `copyblocks` package's `s3` client to allow configuring the part-size for multipart uploads.

Also, enable `pprof` endpoints in `copyblocks` tool.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
