### PR TITLE
Add insight=true to push handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 * [ENHANCEMENT] Query-frontend: include route name in query stats log lines. #8191
 * [ENHANCEMENT] OTLP: Speed up conversion from OTel to Mimir format by about 8% and reduce memory consumption by about 30%. Can be disabled via `-distributor.direct-otlp-translation-enabled=false` #7957
 * [ENHANCEMENT] Ingester/Querier: Optimise regexps with long lists of alternates. #8221, #8234
-* [EHNAHCEMENT] Distributor: add `insight=true` to remote-write and OTLP write handlers. #8294
+* [EHNAHCEMENT] Distributor: add `insight=true` to remote-write and OTLP write handlers when the HTTP response status code is 4xx. #8294
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [ENHANCEMENT] Query-frontend: include route name in query stats log lines. #8191
 * [ENHANCEMENT] OTLP: Speed up conversion from OTel to Mimir format by about 8% and reduce memory consumption by about 30%. Can be disabled via `-distributor.direct-otlp-translation-enabled=false` #7957
 * [ENHANCEMENT] Ingester/Querier: Optimise regexps with long lists of alternates. #8221, #8234
+* [EHNAHCEMENT] Distributor: add `insight=true` to remote-write and OTLP write handlers. #8294
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -177,6 +177,7 @@ func handler(
 				msg = err.Error()
 			}
 			if code != 202 {
+				// This error message is consistent with error message in OTLP handler, and ingester's ingest-storage pushToStorage method.
 				msgs := []interface{}{"msg", "detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)", "httpCode", code, "err", err}
 				if code/100 == 4 {
 					msgs = append(msgs, "insight", true)
@@ -250,6 +251,7 @@ func otlpHandler(
 				errorMsg = err.Error()
 			}
 			if httpCode != 202 {
+				// This error message is consistent with error message in Prometheus remote-write handler, and ingester's ingest-storage pushToStorage method.
 				msgs := []interface{}{"msg", "detected an error while ingesting OTLP metrics request (the request may have been partially ingested)", "httpCode", httpCode, "err", err}
 				if httpCode/100 == 4 {
 					msgs = append(msgs, "insight", true)

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -177,7 +177,7 @@ func handler(
 				msg = err.Error()
 			}
 			if code != 202 {
-				msgs := []interface{}{"msg", "failed to ingest data from Prometheus remote-write request", "httpCode", code, "err", err}
+				msgs := []interface{}{"msg", "detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)", "httpCode", code, "err", err}
 				if code/100 == 4 {
 					msgs = append(msgs, "insight", true)
 				}
@@ -250,7 +250,7 @@ func otlpHandler(
 				errorMsg = err.Error()
 			}
 			if httpCode != 202 {
-				msgs := []interface{}{"msg", "failed to ingest data from OTLP metrics request", "httpCode", httpCode, "err", err}
+				msgs := []interface{}{"msg", "detected an error while ingesting OTLP metrics request (the request may have been partially ingested)", "httpCode", httpCode, "err", err}
 				if httpCode/100 == 4 {
 					msgs = append(msgs, "insight", true)
 				}

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -177,7 +177,7 @@ func handler(
 				msg = err.Error()
 			}
 			if code != 202 {
-				msgs := []interface{}{"msg", "failed to ingest data from incoming request", "httpCode", code, "err", err}
+				msgs := []interface{}{"msg", "failed to ingest data from Prometheus remote-write request", "httpCode", code, "err", err}
 				if code/100 == 4 {
 					msgs = append(msgs, "insight", true)
 				}
@@ -250,7 +250,7 @@ func otlpHandler(
 				errorMsg = err.Error()
 			}
 			if httpCode != 202 {
-				msgs := []interface{}{"msg", "failed to ingest data from incoming request", "httpCode", httpCode, "err", err}
+				msgs := []interface{}{"msg", "failed to ingest data from OTLP metrics request", "httpCode", httpCode, "err", err}
 				if httpCode/100 == 4 {
 					msgs = append(msgs, "insight", true)
 				}

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -177,7 +177,7 @@ func handler(
 				msg = err.Error()
 			}
 			if code != 202 {
-				msgs := []interface{}{"msg", "push error", "httpCode", code, "err", err}
+				msgs := []interface{}{"msg", "failed to ingest data from incoming request", "httpCode", code, "err", err}
 				if code/100 == 4 {
 					msgs = append(msgs, "insight", true)
 				}
@@ -250,7 +250,7 @@ func otlpHandler(
 				errorMsg = err.Error()
 			}
 			if httpCode != 202 {
-				msgs := []interface{}{"msg", "push error", "httpCode", httpCode, "err", err}
+				msgs := []interface{}{"msg", "failed to ingest data from incoming request", "httpCode", httpCode, "err", err}
 				if httpCode/100 == 4 {
 					msgs = append(msgs, "insight", true)
 				}

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -233,7 +233,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			},
 			responseCode: http.StatusRequestEntityTooLarge,
 			errMessage:   "the incoming push request has been rejected because its message size of 63 bytes is larger",
-			expectedLogs: []string{`level=error user=test msg="failed to ingest data from incoming request" httpCode=413 err="rpc error: code = Code(413) desc = the incoming push request has been rejected because its message size of 63 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-write-message-size). To adjust the related limit, configure -distributor.max-recv-msg-size, or contact your service administrator." insight=true`},
+			expectedLogs: []string{`level=error user=test msg="failed to ingest data from OTLP metrics request" httpCode=413 err="rpc error: code = Code(413) desc = the incoming push request has been rejected because its message size of 63 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-write-message-size). To adjust the related limit, configure -distributor.max-recv-msg-size, or contact your service administrator." insight=true`},
 		},
 		{
 			name:       "Write samples. Unsupported compression",
@@ -247,7 +247,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			},
 			responseCode: http.StatusUnsupportedMediaType,
 			errMessage:   "Only \"gzip\" or no compression supported",
-			expectedLogs: []string{`level=error user=test msg="failed to ingest data from incoming request" httpCode=415 err="rpc error: code = Code(415) desc = unsupported compression: snappy. Only \"gzip\" or no compression supported" insight=true`},
+			expectedLogs: []string{`level=error user=test msg="failed to ingest data from OTLP metrics request" httpCode=415 err="rpc error: code = Code(415) desc = unsupported compression: snappy. Only \"gzip\" or no compression supported" insight=true`},
 		},
 		{
 			name:       "Rate limited request",
@@ -259,7 +259,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			},
 			responseCode:        http.StatusTooManyRequests,
 			errMessage:          "go slower",
-			expectedLogs:        []string{`level=error user=test msg="failed to ingest data from incoming request" httpCode=429 err="rpc error: code = Code(429) desc = go slower" insight=true`},
+			expectedLogs:        []string{`level=error user=test msg="failed to ingest data from OTLP metrics request" httpCode=429 err="rpc error: code = Code(429) desc = go slower" insight=true`},
 			expectedRetryHeader: true,
 		},
 		{
@@ -799,14 +799,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			err:                  fmt.Errorf(errMsg),
 			expectedHTTPStatus:   http.StatusBadRequest,
 			expectedErrorMessage: errMsg,
-			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=400 err="rpc error: code = Code(400) desc = this is an error" insight=true`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from Prometheus remote-write request" httpCode=400 err="rpc error: code = Code(400) desc = this is an error" insight=true`},
 		},
 		{
 			name:                 "a gRPC error with a status during request parsing gets translated into HTTP error without DoNotLogError header",
 			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
-			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from Prometheus remote-write request" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
 		},
 	}
 	for _, tc := range parserTestCases {
@@ -855,7 +855,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			err:                  fmt.Errorf(errMsg),
 			expectedHTTPStatus:   http.StatusInternalServerError,
 			expectedErrorMessage: errMsg,
-			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=500 err="this is an error"`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from Prometheus remote-write request" httpCode=500 err="this is an error"`},
 		},
 		{
 			name:                        "a DoNotLogError of a generic error during push gets a HTTP 500 with DoNotLogError header",
@@ -863,14 +863,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			expectedHTTPStatus:          http.StatusInternalServerError,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,
-			expectedLogs:                []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=500 err="this is an error"`},
+			expectedLogs:                []string{`level=error user=testuser msg="failed to ingest data from Prometheus remote-write request" httpCode=500 err="this is an error"`},
 		},
 		{
 			name:                 "a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
 			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
-			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from Prometheus remote-write request" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
 		},
 		{
 			name:                        "a DoNotLogError of a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
@@ -878,7 +878,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			expectedHTTPStatus:          http.StatusRequestEntityTooLarge,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,
-			expectedLogs:                []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
+			expectedLogs:                []string{`level=error user=testuser msg="failed to ingest data from Prometheus remote-write request" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
 		},
 		{
 			name:                 "a context.Canceled error during push gets translated into a HTTP 499",
@@ -892,7 +892,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			err:                  httpgrpc.Errorf(http.StatusBadRequest, "limits reached"),
 			expectedHTTPStatus:   http.StatusBadRequest,
 			expectedErrorMessage: "limits reached",
-			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=400 err="rpc error: code = Code(400) desc = limits reached" insight=true`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from Prometheus remote-write request" httpCode=400 err="rpc error: code = Code(400) desc = limits reached" insight=true`},
 		},
 	}
 

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -233,7 +233,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			},
 			responseCode: http.StatusRequestEntityTooLarge,
 			errMessage:   "the incoming push request has been rejected because its message size of 63 bytes is larger",
-			expectedLogs: []string{`level=error user=test msg="push error" httpCode=413 err="rpc error: code = Code(413) desc = the incoming push request has been rejected because its message size of 63 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-write-message-size). To adjust the related limit, configure -distributor.max-recv-msg-size, or contact your service administrator." insight=true`},
+			expectedLogs: []string{`level=error user=test msg="failed to ingest data from incoming request" httpCode=413 err="rpc error: code = Code(413) desc = the incoming push request has been rejected because its message size of 63 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-write-message-size). To adjust the related limit, configure -distributor.max-recv-msg-size, or contact your service administrator." insight=true`},
 		},
 		{
 			name:       "Write samples. Unsupported compression",
@@ -247,7 +247,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			},
 			responseCode: http.StatusUnsupportedMediaType,
 			errMessage:   "Only \"gzip\" or no compression supported",
-			expectedLogs: []string{`level=error user=test msg="push error" httpCode=415 err="rpc error: code = Code(415) desc = unsupported compression: snappy. Only \"gzip\" or no compression supported" insight=true`},
+			expectedLogs: []string{`level=error user=test msg="failed to ingest data from incoming request" httpCode=415 err="rpc error: code = Code(415) desc = unsupported compression: snappy. Only \"gzip\" or no compression supported" insight=true`},
 		},
 		{
 			name:       "Rate limited request",
@@ -259,7 +259,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			},
 			responseCode:        http.StatusTooManyRequests,
 			errMessage:          "go slower",
-			expectedLogs:        []string{"level=error user=test msg=\"push error\" httpCode=429 err=\"rpc error: code = Code(429) desc = go slower\" insight=true"},
+			expectedLogs:        []string{`level=error user=test msg="failed to ingest data from incoming request" httpCode=429 err="rpc error: code = Code(429) desc = go slower" insight=true`},
 			expectedRetryHeader: true,
 		},
 		{
@@ -799,14 +799,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			err:                  fmt.Errorf(errMsg),
 			expectedHTTPStatus:   http.StatusBadRequest,
 			expectedErrorMessage: errMsg,
-			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=400 err="rpc error: code = Code(400) desc = this is an error" insight=true`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=400 err="rpc error: code = Code(400) desc = this is an error" insight=true`},
 		},
 		{
 			name:                 "a gRPC error with a status during request parsing gets translated into HTTP error without DoNotLogError header",
 			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
-			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=413 err="rpc error: code = Code(413) desc = this is an error"`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
 		},
 	}
 	for _, tc := range parserTestCases {
@@ -855,7 +855,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			err:                  fmt.Errorf(errMsg),
 			expectedHTTPStatus:   http.StatusInternalServerError,
 			expectedErrorMessage: errMsg,
-			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=500 err="this is an error"`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=500 err="this is an error"`},
 		},
 		{
 			name:                        "a DoNotLogError of a generic error during push gets a HTTP 500 with DoNotLogError header",
@@ -863,14 +863,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			expectedHTTPStatus:          http.StatusInternalServerError,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,
-			expectedLogs:                []string{`level=error user=testuser msg="push error" httpCode=500 err="this is an error"`},
+			expectedLogs:                []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=500 err="this is an error"`},
 		},
 		{
 			name:                 "a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
 			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
-			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=413 err="rpc error: code = Code(413) desc = this is an error"`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
 		},
 		{
 			name:                        "a DoNotLogError of a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
@@ -878,7 +878,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			expectedHTTPStatus:          http.StatusRequestEntityTooLarge,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,
-			expectedLogs:                []string{`level=error user=testuser msg="push error" httpCode=413 err="rpc error: code = Code(413) desc = this is an error"`},
+			expectedLogs:                []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
 		},
 		{
 			name:                 "a context.Canceled error during push gets translated into a HTTP 499",
@@ -892,7 +892,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			err:                  httpgrpc.Errorf(http.StatusBadRequest, "limits reached"),
 			expectedHTTPStatus:   http.StatusBadRequest,
 			expectedErrorMessage: "limits reached",
-			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=400 err="rpc error: code = Code(400) desc = limits reached" insight=true`},
+			expectedLogs:         []string{`level=error user=testuser msg="failed to ingest data from incoming request" httpCode=400 err="rpc error: code = Code(400) desc = limits reached" insight=true`},
 		},
 	}
 

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -14,12 +14,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/failsafe-go/failsafe-go/circuitbreaker"
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/golang/snappy"
+	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/httpgrpc/server"
@@ -186,6 +189,9 @@ func TestHandlerOTLPPush(t *testing.T) {
 		responseCode              int
 		errMessage                string
 		enableOtelMetadataStorage bool
+
+		expectedLogs        []string
+		expectedRetryHeader bool
 	}{
 		{
 			name:                      "Write samples. No compression",
@@ -227,6 +233,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			},
 			responseCode: http.StatusRequestEntityTooLarge,
 			errMessage:   "the incoming push request has been rejected because its message size of 63 bytes is larger",
+			expectedLogs: []string{`level=error user=test msg="push error" httpCode=413 err="rpc error: code = Code(413) desc = the incoming push request has been rejected because its message size of 63 bytes is larger than the allowed limit of 30 bytes (err-mimir-distributor-max-write-message-size). To adjust the related limit, configure -distributor.max-recv-msg-size, or contact your service administrator." insight=true`},
 		},
 		{
 			name:       "Write samples. Unsupported compression",
@@ -240,6 +247,20 @@ func TestHandlerOTLPPush(t *testing.T) {
 			},
 			responseCode: http.StatusUnsupportedMediaType,
 			errMessage:   "Only \"gzip\" or no compression supported",
+			expectedLogs: []string{`level=error user=test msg="push error" httpCode=415 err="rpc error: code = Code(415) desc = unsupported compression: snappy. Only \"gzip\" or no compression supported" insight=true`},
+		},
+		{
+			name:       "Rate limited request",
+			maxMsgSize: 100000,
+			series:     sampleSeries,
+			metadata:   sampleMetadata,
+			verifyFunc: func(_ *testing.T, pushReq *Request) error {
+				return httpgrpc.Errorf(http.StatusTooManyRequests, "go slower")
+			},
+			responseCode:        http.StatusTooManyRequests,
+			errMessage:          "go slower",
+			expectedLogs:        []string{"level=error user=test msg=\"push error\" httpCode=429 err=\"rpc error: code = Code(429) desc = go slower\" insight=true"},
+			expectedRetryHeader: true,
 		},
 		{
 			name:       "Write histograms",
@@ -302,7 +323,10 @@ func TestHandlerOTLPPush(t *testing.T) {
 				t.Cleanup(pushReq.CleanUp)
 				return tt.verifyFunc(t, pushReq)
 			}
-			handler := OTLPHandler(tt.maxMsgSize, nil, nil, tt.enableOtelMetadataStorage, limits, RetryConfig{}, pusher, nil, nil, log.NewNopLogger(), true)
+
+			logs := &concurrency.SyncBuffer{}
+			retryConfig := RetryConfig{Enabled: true, BaseSeconds: 5, MaxBackoffExponent: 5}
+			handler := OTLPHandler(tt.maxMsgSize, nil, nil, tt.enableOtelMetadataStorage, limits, retryConfig, pusher, nil, nil, level.NewFilter(log.NewLogfmtLogger(logs), level.AllowInfo()), true)
 
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
@@ -316,6 +340,15 @@ func TestHandlerOTLPPush(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Contains(t, respStatus.GetMessage(), tt.errMessage)
 			}
+
+			var logLines []string
+			if logsStr := logs.String(); logsStr != "" {
+				logLines = strings.Split(strings.TrimSpace(logsStr), "\n")
+			}
+			assert.Equal(t, tt.expectedLogs, logLines)
+
+			retryAfter := resp.Header().Get("Retry-After")
+			assert.Equal(t, tt.expectedRetryHeader, retryAfter != "")
 		})
 	}
 }
@@ -759,18 +792,21 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 		err                  error
 		expectedHTTPStatus   int
 		expectedErrorMessage string
+		expectedLogs         []string
 	}{
 		{
 			name:                 "a generic error during request parsing gets an HTTP 400",
 			err:                  fmt.Errorf(errMsg),
 			expectedHTTPStatus:   http.StatusBadRequest,
 			expectedErrorMessage: errMsg,
+			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=400 err="rpc error: code = Code(400) desc = this is an error" insight=true`},
 		},
 		{
 			name:                 "a gRPC error with a status during request parsing gets translated into HTTP error without DoNotLogError header",
 			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
+			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=413 err="rpc error: code = Code(413) desc = this is an error"`},
 		},
 	}
 	for _, tc := range parserTestCases {
@@ -783,13 +819,21 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 				return err
 			}
 
-			h := handler(10, nil, nil, false, nil, RetryConfig{}, pushFunc, log.NewNopLogger(), parserFunc)
+			logs := &concurrency.SyncBuffer{}
+			h := handler(10, nil, nil, false, nil, RetryConfig{}, pushFunc, log.NewLogfmtLogger(logs), parserFunc)
 
 			recorder := httptest.NewRecorder()
-			h.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/push", bufCloser{&bytes.Buffer{}}))
+			ctxWithUser := user.InjectOrgID(context.Background(), "testuser")
+			h.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/push", bufCloser{&bytes.Buffer{}}).WithContext(ctxWithUser))
 
 			assert.Equal(t, tc.expectedHTTPStatus, recorder.Code)
 			assert.Equal(t, fmt.Sprintf("%s\n", tc.expectedErrorMessage), recorder.Body.String())
+
+			var logLines []string
+			if logsStr := logs.String(); logsStr != "" {
+				logLines = strings.Split(strings.TrimSpace(logsStr), "\n")
+			}
+			assert.Equal(t, tc.expectedLogs, logLines)
 		})
 	}
 
@@ -799,6 +843,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 		expectedHTTPStatus          int
 		expectedErrorMessage        string
 		expectedDoNotLogErrorHeader bool
+		expectedLogs                []string
 	}{
 		{
 			name:               "no error during push gets translated into a HTTP 200",
@@ -810,6 +855,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			err:                  fmt.Errorf(errMsg),
 			expectedHTTPStatus:   http.StatusInternalServerError,
 			expectedErrorMessage: errMsg,
+			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=500 err="this is an error"`},
 		},
 		{
 			name:                        "a DoNotLogError of a generic error during push gets a HTTP 500 with DoNotLogError header",
@@ -817,12 +863,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			expectedHTTPStatus:          http.StatusInternalServerError,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,
+			expectedLogs:                []string{`level=error user=testuser msg="push error" httpCode=500 err="this is an error"`},
 		},
 		{
 			name:                 "a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
 			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
+			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=413 err="rpc error: code = Code(413) desc = this is an error"`},
 		},
 		{
 			name:                        "a DoNotLogError of a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
@@ -830,12 +878,21 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			expectedHTTPStatus:          http.StatusRequestEntityTooLarge,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,
+			expectedLogs:                []string{`level=error user=testuser msg="push error" httpCode=413 err="rpc error: code = Code(413) desc = this is an error"`},
 		},
 		{
 			name:                 "a context.Canceled error during push gets translated into a HTTP 499",
 			err:                  context.Canceled,
 			expectedHTTPStatus:   statusClientClosedRequest,
 			expectedErrorMessage: context.Canceled.Error(),
+			expectedLogs:         []string{`level=warn user=testuser msg="push request canceled" err="context canceled"`},
+		},
+		{
+			name:                 "StatusBadRequest is logged with insight=true",
+			err:                  httpgrpc.Errorf(http.StatusBadRequest, "limits reached"),
+			expectedHTTPStatus:   http.StatusBadRequest,
+			expectedErrorMessage: "limits reached",
+			expectedLogs:         []string{`level=error user=testuser msg="push error" httpCode=400 err="rpc error: code = Code(400) desc = limits reached" insight=true`},
 		},
 	}
 
@@ -852,9 +909,12 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 				}
 				return tc.err
 			}
-			h := handler(10, nil, nil, false, nil, RetryConfig{}, pushFunc, log.NewNopLogger(), parserFunc)
+
+			logs := &concurrency.SyncBuffer{}
+			h := handler(10, nil, nil, false, nil, RetryConfig{}, pushFunc, log.NewLogfmtLogger(logs), parserFunc)
 			recorder := httptest.NewRecorder()
-			h.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/push", bufCloser{&bytes.Buffer{}}))
+			ctxWithUser := user.InjectOrgID(context.Background(), "testuser")
+			h.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/push", bufCloser{&bytes.Buffer{}}).WithContext(ctxWithUser))
 
 			assert.Equal(t, tc.expectedHTTPStatus, recorder.Code)
 			if tc.err != nil {
@@ -866,6 +926,12 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 			} else {
 				require.Equal(t, "", header)
 			}
+
+			var logLines []string
+			if logsStr := logs.String(); logsStr != "" {
+				logLines = strings.Split(strings.TrimSpace(logsStr), "\n")
+			}
+			assert.Equal(t, tc.expectedLogs, logLines)
 		})
 	}
 }

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -128,6 +128,7 @@ func (c pusherConsumer) pushToStorage(ctx context.Context, tenantID string, req 
 			if reason != "" {
 				err = fmt.Errorf("%w (%s)", err, reason)
 			}
+			// This error message is consistent with error message in Prometheus remote-write and OTLP handlers in distributors.
 			level.Warn(spanLog).Log("msg", "detected a client error while ingesting write request (the request may have been partially ingested)", "user", tenantID, "insight", true, "err", err)
 		}
 	}


### PR DESCRIPTION
#### What this PR does

This PR adds `insight=true` label to push handlers when we're logging push error with 4xx status code.

This applies to both Prometheus and OTLP handlers. This PR also fixes some issues with updated OTLP handler found in https://github.com/grafana/mimir/pull/8227

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
