### PR TITLE
blockbuilder: consume partitions up to their lag

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -2,6 +2,7 @@ package blockbuilder
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -325,7 +326,9 @@ func (b *BlockBuilder) consumePartitions(ctx context.Context, cycleEnd time.Time
 		}
 
 		fetches.EachError(func(_ string, part int32, err error) {
-			level.Error(b.logger).Log("msg", "failed to fetch records", "part", part, "err", err)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				level.Error(b.logger).Log("msg", "failed to fetch records", "part", part, "err", err)
+			}
 		})
 
 		if fetches.Empty() && lag <= 0 {

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -2,12 +2,10 @@ package blockbuilder
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"sync"
 	"time"
 
@@ -33,6 +31,9 @@ type BlockBuilder struct {
 	limits      *validation.Overrides
 	kafkaClient *kgo.Client
 
+	// for testing
+	tsdbBuilder func() builder
+
 	assignmentMu sync.Mutex
 	assignment   map[string][]int32
 }
@@ -48,6 +49,10 @@ func NewBlockBuilder(
 		logger:   logger,
 		register: reg,
 		limits:   limits,
+	}
+
+	b.tsdbBuilder = func() builder {
+		return newTSDBBuilder(b.logger, b.limits, b.cfg.BlocksStorageConfig)
 	}
 
 	b.Service = services.NewBasicService(b.starting, b.running, b.stopping)
@@ -84,7 +89,7 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 		kgo.OnPartitionsRevoked(b.handlePartitionsLost),
 		kgo.OnPartitionsLost(b.handlePartitionsLost),
 
-		kgo.FetchMinBytes(1),
+		kgo.FetchMinBytes(128),
 		kgo.FetchMaxBytes(fetchMaxBytes),
 		kgo.FetchMaxWait(5 * time.Second),
 		kgo.FetchMaxPartitionBytes(50_000_000),
@@ -185,30 +190,26 @@ func (b *BlockBuilder) stopping(_ error) error {
 func (b *BlockBuilder) running(ctx context.Context) error {
 	// Do initial consumption on start using current time as the point up to which we are consuming.
 	// To avoid small blocks at startup, we consume until the last hour boundary + buffer.
-	consumptionItvl := time.Hour
-	timeBuffer := 15 * time.Minute
-	mark := time.Now().Truncate(consumptionItvl).Add(timeBuffer)
-	if mark.After(time.Now()) {
-		mark = mark.Add(-consumptionItvl)
+	cycleEnd := time.Now().Truncate(b.cfg.ConsumeInterval).Add(b.cfg.ConsumeIntervalBuffer)
+	if cycleEnd.After(time.Now()) {
+		cycleEnd = cycleEnd.Add(-b.cfg.ConsumeInterval)
 	}
-	err := b.nextConsumeCycle(ctx, mark)
+	err := b.nextConsumeCycle(ctx, cycleEnd)
 	if err != nil {
 		return err
 	}
 
-	// TODO(v): configure consumption interval
-	// TODO(codesome): validate the consumption interval. Must be <=2h and can divide 2h into an integer.
-
-	nextBlockTime := time.Now().Truncate(consumptionItvl).Add(consumptionItvl + timeBuffer)
+	nextBlockTime := time.Now().Truncate(b.cfg.ConsumeInterval).Add(b.cfg.ConsumeInterval)
 	waitTime := time.Until(nextBlockTime)
 
 	for {
 		select {
-		case mark := <-time.After(waitTime):
-			_ = b.nextConsumeCycle(ctx, mark.Add(-time.Second))
+		case cycleEnd := <-time.After(waitTime):
+			_ = b.nextConsumeCycle(ctx, cycleEnd.Add(-time.Second))
+
 			// If we took more than consumptionItvl time to consume the records, this
 			// will immediately start the next consumption.
-			nextBlockTime = nextBlockTime.Add(consumptionItvl)
+			nextBlockTime = nextBlockTime.Add(b.cfg.ConsumeInterval)
 			waitTime = time.Until(nextBlockTime)
 			if waitTime < 0 {
 				// TODO(codesome): track "-waitTime", which is the time we ran over. Or something better that lets us alert
@@ -221,9 +222,9 @@ func (b *BlockBuilder) running(ctx context.Context) error {
 }
 
 // nextConsumeCycle manages consumption of currently assigned partitions.
-// The mark argument indicates the timestamp (relative to Kafka records) up until which to consume from partitions
+// The cycleEnd argument indicates the timestamp (relative to Kafka records) up until which to consume from partitions
 // in this cycle. That is, Kafka records produced after the mark will be consumed in the next cycle.
-func (b *BlockBuilder) nextConsumeCycle(ctx context.Context, mark time.Time) error {
+func (b *BlockBuilder) nextConsumeCycle(ctx context.Context, cycleEnd time.Time) error {
 	b.assignmentMu.Lock()
 	assignment := b.assignment
 	b.assignmentMu.Unlock()
@@ -240,15 +241,16 @@ func (b *BlockBuilder) nextConsumeCycle(ctx context.Context, mark time.Time) err
 		return fmt.Errorf("get consumer group lag: %w", err)
 	}
 
-	lag := lags[b.cfg.Kafka.ConsumerGroup].Lag
-	parts := make([]int32, 0, len(assignmentParts))
+	// parts maps partition to this partition's current lag
+	parts := make(map[int32]int64, len(assignmentParts))
+	groupLag := lags[b.cfg.Kafka.ConsumerGroup].Lag
 	for _, part := range assignmentParts {
-		pl, ok := lag.Lookup(b.cfg.Kafka.Topic, part)
+		pl, ok := groupLag.Lookup(b.cfg.Kafka.Topic, part)
 		if !ok {
 			continue
 		}
 		if pl.Lag > 0 {
-			parts = append(parts, part)
+			parts[part] = pl.Lag
 		} else {
 			level.Info(b.logger).Log(
 				"msg", "nothing to consume in partition",
@@ -261,154 +263,158 @@ func (b *BlockBuilder) nextConsumeCycle(ctx context.Context, mark time.Time) err
 	}
 
 	if len(parts) == 0 {
-		level.Warn(b.logger).Log("msg", "nothing to consume in this cycle", "assignment", fmt.Sprintf("%+v", assignmentParts))
+		level.Warn(b.logger).Log("msg", "nothing to consume in this cycle", "assignment", fmt.Sprintf("%+v", assignment))
 		return nil
 	}
 
-	slices.Sort(parts)
-
-	// TODO(v): rebalancing can happen between the calls to consumePartitions; if that happens, the instace may loose
+	// TODO(v): rebalancing can happen between the calls to consumePartitions; if that happens, the instance may loose
 	// the ownership of some of its partitions
 	// TODO(v): test for this case
-	for _, part := range parts {
-		err := b.consumePartitions(ctx, part, mark)
+	for part, lag := range parts {
+		err := b.consumePartitions(ctx, cycleEnd, part, lag)
 		if err != nil {
 			level.Error(b.logger).Log("msg", "failed to consume partition", "err", err, "part", part)
 		}
+		// Make sure to unblock rebalance of the group after the partition was consumed AND after we (potentially) committed
+		// this partition's offset to the group.
+		// TODO(v): test for this case
+		b.kafkaClient.AllowRebalance()
 	}
 
 	return nil
 }
 
-func (b *BlockBuilder) consumePartitions(ctx context.Context, part int32, mark time.Time) error {
+func (b *BlockBuilder) consumePartitions(ctx context.Context, cycleEnd time.Time, part int32, lag int64) (err error) {
 	// TopicPartition to resume consuming on this iteration.
-	tp := map[string][]int32{b.cfg.Kafka.Topic: {part}}
-
 	// Note: pause/resume is a client-local state. On restart or a crash, the client will be assigned its share of partitions,
 	// during consumer group's rebalancing, and it will continue consuming as usual.
+	tp := map[string][]int32{b.cfg.Kafka.Topic: {part}}
 	b.kafkaClient.ResumeFetchPartitions(tp)
 	defer b.kafkaClient.PauseFetchPartitions(tp)
 
-	// Make sure to unblock rebalance of the group after the very last poll AND after we (potentially) commited
-	// this partition's offset to the group.
-	// TODO(v): test for this case
-	defer b.kafkaClient.AllowRebalance()
-
-	level.Info(b.logger).Log(
-		"msg", "consume partition",
-		"part", part,
-	)
+	level.Info(b.logger).Log("msg", "consume partition", "part", part, "lag", lag, "cycle_end", cycleEnd)
 
 	defer func(t time.Time) {
-		level.Info(b.logger).Log(
-			"msg", "done consuming partition",
-			"part", part,
-			"dur", time.Since(t),
-		)
+		level.Info(b.logger).Log("msg", "done consuming partition", "part", part, "dur", time.Since(t))
 	}(time.Now())
 
-	var lastOffset int64
+	builder := b.tsdbBuilder()
+	defer builder.close()
 
-	// TODO(v): signal to bail out from the consume loop, otherwise a busy partition will starve the consumer
+	blockStartAt, blockEndAt := blockBounds(cycleEnd, b.cfg.ConsumeInterval)
+	if blockEndAt.Before(cycleEnd) {
+		// This should never happen.
+		panic(fmt.Errorf("block bounds [%s, %s] outside of cycle %s", blockStartAt, blockEndAt, cycleEnd))
+	}
+
 	var (
-		consumptionItvl     = time.Hour        // TODO(codesome): get this from config
-		timeBuffer          = 15 * time.Minute // TODO(codesome): get this from config
-		checkpointOffset    = int64(-1)
-		resetBlockBuilderAt time.Time
-		builder             *tsdbBuilder
-		currEnd, lastEnd    int64
-		done                bool
+		done bool
+
+		firstUncommittedRec *kgo.Record
+		checkpointRec       *kgo.Record
 	)
 	for !done {
-		// Limit the time the client waits for new batch of records, otherwise, it will hang when landed to a inactive partition.
-		// TODO(v): configure fetch timeout
-		ctx1, cancel := context.WithTimeout(ctx, 10*time.Second)
+		// Limit time client waits for a new batch. Otherwise, the client will hang if it lands on an inactive partition.
+		ctx1, cancel := context.WithTimeout(ctx, 5*time.Second)
 		fetches := b.kafkaClient.PollFetches(ctx1)
 		cancel()
 
 		if fetches.IsClientClosed() {
+			level.Warn(b.logger).Log("msg", "client closed when fetching records")
 			return nil
 		}
 
 		fetches.EachError(func(_ string, part int32, err error) {
-			if !errors.Is(err, context.DeadlineExceeded) {
-				level.Error(b.logger).Log("msg", "failed to fetch records", "part", part, "err", err)
-			}
+			level.Error(b.logger).Log("msg", "failed to fetch records", "part", part, "err", err)
 		})
 
-		if fetches.Empty() {
-			done = true
+		if fetches.Empty() && lag <= 0 {
+			level.Warn(b.logger).Log("msg", "got empty fetches from broker", "part", part)
+			break
 		}
 
-		fetches.EachPartition(func(ftp kgo.FetchTopicPartition) {
-			level.Info(b.logger).Log("msg", "consumed", "part", ftp.Partition, "hi", ftp.HighWatermark, "lo", ftp.LogStartOffset, "batch_size", len(ftp.Records))
+		recIter := fetches.RecordIter()
+		for !recIter.Done() {
+			rec := recIter.Next()
 
-			for _, rec := range ftp.Records {
+			lag--
+
+			// Stop consuming after we reached the cycleEnd marker.
+			// NOTE: the timestamp of the record is when the record was produced relative to distributor's time.
+			if rec.Timestamp.After(cycleEnd) {
+				if firstUncommittedRec == nil {
+					firstUncommittedRec = rec
+				}
+				done = true
+				break
+			}
+
+			// TODO(v): refactor block bounds check into a state machine:
+			// During catching up, if builder skipped samples, roll back the offset to first uncommited after compacting and starting next block
+			if rec.Timestamp.Before(blockStartAt) || rec.Timestamp.After(blockEndAt) {
 				// When BB is first deployed or if it is lagging behind, then it might consuming data from too much
 				// in the past. In which case if we try to consume all at once, it can overwhelm the system.
-				// So we break this into multiple block building cycles by resetting the block builder at intervals.
-				// TODO(codesome): the logic for this below is broken. Fix it. How can we determine the block ends when we are catching up?
-				if builder != nil && rec.Timestamp.After(resetBlockBuilderAt) {
-					if err := builder.compactAndClose(ctx, b.shipperDir()); err != nil {
-						level.Error(b.logger).Log("msg", "failed to compact and remove dbs", "part", part, "err", err)
-						// TODO(codesome): return err?
-						// TODO(codesome): add metric
+				// So we break this into multiple block building cycles.
+				if rec.Timestamp.After(blockEndAt) {
+					if err := builder.compact(ctx, b.shipperDir()); err != nil {
+						return fmt.Errorf("compact tsdb builder: %w", err)
 					}
-					builder = nil
 				}
-				if builder == nil {
-					builder = newTSDBBuilder(b.logger, b.limits, part, b.cfg.BlocksStorageConfig)
-					resetBlockBuilderAt = rec.Timestamp.Truncate(consumptionItvl).Add(consumptionItvl + timeBuffer)
+				blockStartAt, blockEndAt = blockBounds(rec.Timestamp, b.cfg.ConsumeInterval)
+			}
 
-					// TODO(codesome): verify. this can be wrong.
-					currEnd = rec.Timestamp.Truncate(consumptionItvl).UnixMilli()
-					lastEnd = currEnd - consumptionItvl.Milliseconds()
-				}
+			level.Debug(b.logger).Log("msg", "process record", "offset", rec.Offset, "rec", rec.Timestamp, "bmin", blockStartAt, "bmax", blockEndAt)
 
-				// TODO(v): the allSamplesProcessed logic isn't seem right.
-				// I.e. kafka client consumes the log in one direction, thus skipped records will be skipped until either
-				// 1. we manually set the offset of the kafka client on every cycle (ref. kgo#Client.SetOffsets)
-				// 2. process was restarted, the client fetched last commited offset for the group+partition and started consuming from this (old) offset
-				recordProcessedBefore := false // TODO(codesome): get this from checkpoint
-				allSamplesProcessed, err := builder.process(ctx, rec, lastEnd, currEnd, recordProcessedBefore)
-				if !allSamplesProcessed && checkpointOffset < 0 {
-					checkpointOffset = rec.Offset
-				}
-				if err != nil {
-					level.Error(b.logger).Log("msg", "failed to process record", "part", part, "key", string(rec.Key), "err", err)
-					// TODO(codesome): do we just ignore this? What if it was Mimir's issue and this leading to data loss?
-					// TODO(codesome): add metric
-				}
-
-				lastOffset = rec.Offset
-
-				// Stop consuming after we reached the marker.
-				// NOTE: the timestamp of the record is when the record was produced relative to distributor's time.
-				if rec.Timestamp.After(mark) {
-					done = true
+			recProcessedBefore := false
+			blockMin, blockMax := blockStartAt.UnixMilli(), blockEndAt.UnixMilli()
+			allSamplesProcessed, err := builder.process(ctx, rec, blockMin, blockMax, recProcessedBefore)
+			if err != nil {
+				level.Error(b.logger).Log("msg", "failed to process record", "part", part, "key", string(rec.Key), "err", err)
+				// TODO(codesome): do we just ignore this? What if it was Mimir's issue and this leading to data loss?
+				// TODO(codesome): add metric
+			} else if allSamplesProcessed {
+				// TODO(v): only advance checkpoint when all previously seen records from this cycle were processed
+				checkpointRec = rec
+			} else {
+				if firstUncommittedRec == nil {
+					firstUncommittedRec = rec
 				}
 			}
-		})
-
-		// After the rebalance, if another instance took over the partition, the next poll
-		// will return empty fetches, and the loop will bail out.
-		// TODO(v): test for this case
-		b.kafkaClient.AllowRebalance()
+		}
 	}
 
-	if builder != nil {
-		if err := builder.compactAndClose(ctx, b.shipperDir()); err != nil {
+	if err := builder.compact(ctx, b.shipperDir()); err != nil {
+		// TODO(codesome): add metric
+		return err
+	}
+
+	// TODO(codesome): Make sure all the blocks have been shipped before committing the offset.
+	return b.finalizePartition(ctx, firstUncommittedRec, checkpointRec)
+}
+
+func (b *BlockBuilder) finalizePartition(ctx context.Context, uncommittedRec, checkpointRec *kgo.Record) error {
+	// If there is an uncommitted record, rewind the client to the record's offset to consume it on the next cycle.
+	if uncommittedRec != nil {
+		part := uncommittedRec.Partition
+		b.kafkaClient.SetOffsets(map[string]map[int32]kgo.EpochOffset{
+			b.cfg.Kafka.Topic: {
+				part: {
+					Epoch:  uncommittedRec.LeaderEpoch,
+					Offset: uncommittedRec.Offset - 1,
+				},
+			},
+		})
+	}
+
+	if checkpointRec != nil {
+		// TODO(codesome): persist uncommittedRec with checkpoint's metadata
+		err := b.kafkaClient.CommitRecords(ctx, checkpointRec)
+		if err != nil {
 			// TODO(codesome): add metric
 			return err
 		}
 	}
 
-	if checkpointOffset > 0 {
-		// TODO(codesome): store the lastOffset and currEnd as a metadata in the checkpoint
-		// TODO(codesome): Make sure all the blocks have been shipped before committing the offset.
-		_ = lastOffset // to avoid unused error. TODO: remove this once used
-		return b.commitOffset(ctx, part, checkpointOffset)
-	}
 	return nil
 }
 
@@ -416,33 +422,19 @@ func (b *BlockBuilder) shipperDir() string {
 	return filepath.Join(b.cfg.BlocksStorageConfig.TSDB.Dir, "shipper")
 }
 
-func (b *BlockBuilder) commitOffset(ctx context.Context, part int32, offset int64) (returnErr error) {
-	defer func() {
-		if returnErr != nil {
-			level.Error(b.logger).Log("msg", "failed to commit offset to Kafka", "err", returnErr, "partition", part, "offset", offset)
-			// TODO(codesome): add metric
-		}
-	}()
-
-	toCommit := kadm.Offsets{}
-	toCommit.AddOffset(b.cfg.Kafka.Topic, part, offset, -1)
-
-	committed, err := kadm.NewClient(b.kafkaClient).CommitOffsets(ctx, b.cfg.Kafka.ConsumerGroup, toCommit)
-	if err != nil {
-		return err
-	} else if !committed.Ok() {
-		return committed.Error()
+func blockBounds(t time.Time, length time.Duration) (time.Time, time.Time) {
+	maxt := t.Truncate(length)
+	if maxt.Before(t) {
+		maxt = maxt.Add(length)
 	}
-
-	committedOffset, _ := committed.Lookup(b.cfg.Kafka.Topic, part)
-	level.Debug(b.logger).Log("msg", "offset successfully committed to Kafka", "offset", committedOffset.At)
-	// TODO(codesome): add this metric
-	// r.lastCommittedOffset.Set(float64(committedOffset.At))
-
-	return nil
+	mint := maxt.Add(-length)
+	return mint, maxt
 }
 
 type Config struct {
+	ConsumeInterval       time.Duration `yaml:"consume_interval"`
+	ConsumeIntervalBuffer time.Duration `yaml:"consume_interval_buffer"`
+
 	Kafka               KafkaConfig                    `yaml:"kafka"`
 	BlocksStorageConfig mimir_tsdb.BlocksStorageConfig `yaml:"-"` // TODO(codesome): check how this is passed. Copied over form ingester.
 }
@@ -450,12 +442,20 @@ type Config struct {
 // RegisterFlags registers the MultitenantCompactor flags.
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.Kafka.RegisterFlags(f, logger)
+
+	f.DurationVar(&cfg.ConsumeInterval, "consume-internal", time.Hour, "Interval between block consumption cycles.")
+	f.DurationVar(&cfg.ConsumeIntervalBuffer, "consume-internal-buffer", 5*time.Minute, "Extra buffer between subsequent block consumption cycles to avoid small blocks.")
 }
 
 func (cfg *Config) Validate(logger log.Logger) error {
 	if err := cfg.Kafka.Validate(); err != nil {
 		return err
 	}
+	// TODO(codesome): validate the consumption interval. Must be <=2h and can divide 2h into an integer.
+	if cfg.ConsumeInterval < 0 {
+		return fmt.Errorf("-consume-interval must be non-negative")
+	}
+
 	return nil
 }
 

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -1,1 +1,177 @@
 package blockbuilder
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
+	"github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+func TestBlockBuilder_BuildBlocks(t *testing.T) {
+	const (
+		testTopic     = "test"
+		numPartitions = 2
+
+		userID = "1"
+	)
+
+	testEpoch := time.Now().Truncate(time.Hour).Add(-12 * time.Hour)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	cluster, err := kfake.NewCluster(
+		kfake.NumBrokers(1),
+		kfake.SeedTopics(numPartitions, testTopic),
+	)
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	addrs := cluster.ListenAddrs()
+	require.Len(t, addrs, 1)
+
+	writeClient := newKafkaProduceClient(t, addrs...)
+
+	// Prepopulate 2 groups of samples for T+1h and T+2h.
+	for i := int64(0); i < 10; i++ {
+		ts := testEpoch.Add(time.Duration(i/5) * time.Hour)
+		val := createWriteRequest(t, floatSample(ts.UnixMilli()), nil)
+		rec := &kgo.Record{
+			Timestamp: ts,
+			Key:       []byte(userID),
+			Value:     val,
+			Topic:     testTopic,
+			Partition: int32(i % numPartitions), // samples in this batch are split between N partitions
+		}
+		produceResult := writeClient.ProduceSync(ctx, rec)
+		require.NoError(t, produceResult.FirstErr())
+	}
+
+	cfg := Config{
+		ConsumeInterval:       time.Hour,
+		ConsumeIntervalBuffer: time.Minute,
+		Kafka: KafkaConfig{
+			Address:       addrs[0],
+			Topic:         testTopic,
+			ClientID:      "1",
+			DialTimeout:   10 * time.Second,
+			ConsumerGroup: "testgroup",
+		},
+		BlocksStorageConfig: mimir_tsdb.BlocksStorageConfig{
+			TSDB: mimir_tsdb.TSDBConfig{
+				Dir: t.TempDir(),
+			},
+		},
+	}
+	limits := defaultLimitsTestConfig()
+	limits.OutOfOrderTimeWindow = 2 * model.Duration(time.Hour)
+	limits.NativeHistogramsIngestionEnabled = true
+	overrides, err := validation.NewOverrides(limits, nil)
+
+	bb, err := NewBlockBuilder(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides)
+	require.NoError(t, err)
+
+	compactCalled := make(chan struct{}, 10)
+	testBuilder := testTSDBBuilder{
+		procFunc: func(ctx context.Context, rec *kgo.Record, blockMin, blockMax int64, _ bool) (bool, error) {
+			return true, nil
+		},
+		compactFunc: func(ctx context.Context, shipperDir string) error {
+			compactCalled <- struct{}{}
+			return nil
+		},
+	}
+
+	bb.tsdbBuilder = func() builder {
+		return testBuilder
+	}
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
+	})
+
+	// Assert that N total blocks were compacted (a block per partition per cycle's bounds).
+	for want := 4; want > 0; want-- {
+		select {
+		case <-compactCalled:
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		}
+	}
+
+	// Add samples for T+3h and trigger the cycle.
+	var lastProducedOffest int64
+	for i := 0; i < 10; i++ {
+		ts := testEpoch.Add(3 * time.Hour)
+		val := createWriteRequest(t, floatSample(ts.UnixMilli()), nil)
+		rec := &kgo.Record{
+			Timestamp: ts,
+			Key:       []byte(userID),
+			Value:     val,
+			Topic:     testTopic,
+			Partition: 1, // these samples are only for first partition
+		}
+		produceResult := writeClient.ProduceSync(ctx, rec)
+		require.NoError(t, produceResult.FirstErr())
+
+		lastProducedOffest = produceResult[0].Record.Offset
+	}
+
+	cycleEnd := testEpoch.Add(4 * time.Hour)
+	err = bb.nextConsumeCycle(ctx, cycleEnd)
+	require.NoError(t, err)
+
+	// Assert that one block was compacted (a block per partition per cycle's bounds).
+	select {
+	case <-compactCalled:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	offsets, err := kadm.NewClient(writeClient).ListCommittedOffsets(ctx, testTopic)
+	require.NoError(t, err)
+	offset, ok := offsets.Lookup(testTopic, 1)
+	require.True(t, ok)
+	require.Equal(t, lastProducedOffest+1, offset.Offset) // +1 because lastProducedOffset points at already consumed record
+}
+
+func newKafkaProduceClient(t *testing.T, addrs ...string) *kgo.Client {
+	writeClient, err := kgo.NewClient(
+		kgo.SeedBrokers(addrs...),
+		// We will choose the partition of each record.
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(writeClient.Close)
+	return writeClient
+}
+
+type testTSDBBuilder struct {
+	procFunc    func(ctx context.Context, rec *kgo.Record, blockMin, blockMax int64, recordProcessedBefore bool) (bool, error)
+	compactFunc func(ctx context.Context, shipperDir string) error
+}
+
+func (t testTSDBBuilder) process(ctx context.Context, rec *kgo.Record, blockMin, blockMax int64, recordProcessedBefore bool) (_ bool, err error) {
+	return t.procFunc(ctx, rec, blockMin, blockMax, recordProcessedBefore)
+}
+
+func (t testTSDBBuilder) compact(ctx context.Context, shipperDir string) error {
+	return t.compactFunc(ctx, shipperDir)
+}
+
+func (t testTSDBBuilder) close() error {
+	return nil
+}

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -24,6 +24,41 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
+func createWriteRequest(t *testing.T, samples []mimirpb.Sample, histograms []mimirpb.Histogram) []byte {
+	req := mimirpb.WriteRequest{}
+
+	var seriesValue string
+	if len(histograms) > 0 {
+		seriesValue = "histogram"
+	} else {
+		seriesValue = "float"
+	}
+	req.Timeseries = append(req.Timeseries, mimirpb.PreallocTimeseries{
+		TimeSeries: &mimirpb.TimeSeries{
+			Labels: []mimirpb.LabelAdapter{
+				{Name: "foo", Value: seriesValue},
+			},
+			Samples:    samples,
+			Histograms: histograms,
+		},
+	})
+
+	data, err := req.Marshal()
+	require.NoError(t, err)
+
+	return data
+}
+
+func floatSample(ts int64) []mimirpb.Sample {
+	return []mimirpb.Sample{{TimestampMs: ts, Value: float64(ts)}}
+}
+
+func histogramSample(ts int64) []mimirpb.Histogram {
+	return []mimirpb.Histogram{
+		mimirpb.FromHistogramToHistogramProto(ts, test.GenerateTestHistogram(int(ts))),
+	}
+}
+
 func TestTSDBBuilder(t *testing.T) {
 	limits := defaultLimitsTestConfig()
 	limits.OutOfOrderTimeWindow = 2 * model.Duration(time.Hour)
@@ -38,42 +73,24 @@ func TestTSDBBuilder(t *testing.T) {
 
 	// val is int64 to make calling this function concise.
 	createRequest := func(ts int64, accepted, isHistogram bool) *kgo.Record {
-		var rec kgo.Record
-		rec.Key = []byte(userID)
-
-		req := mimirpb.WriteRequest{}
-
 		var samples []mimirpb.Sample
 		var histograms []mimirpb.Histogram
-		var seriesValue string
 		if isHistogram {
-			seriesValue = "histogram"
-			histograms = []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(ts, test.GenerateTestHistogram(int(ts)))}
+			histograms = histogramSample(ts)
 			if accepted {
 				histograms[0].ResetHint = 0
 				expHistograms = append(expHistograms, histograms[0])
 			}
 		} else {
-			seriesValue = "float"
-			samples = []mimirpb.Sample{{TimestampMs: ts, Value: float64(ts)}}
+			samples = floatSample(ts)
 			if accepted {
 				expSamples = append(expSamples, samples[0])
 			}
 		}
-		req.Timeseries = append(req.Timeseries, mimirpb.PreallocTimeseries{
-			TimeSeries: &mimirpb.TimeSeries{
-				Labels: []mimirpb.LabelAdapter{
-					{Name: "foo", Value: seriesValue},
-				},
-				Samples:    samples,
-				Histograms: histograms,
-			},
-		})
 
-		data, err := req.Marshal()
-		require.NoError(t, err)
-		rec.Value = data
-
+		var rec kgo.Record
+		rec.Key = []byte(userID)
+		rec.Value = createWriteRequest(t, samples, histograms)
 		return &rec
 	}
 	addFloatSample := func(builder *tsdbBuilder, ts int64, lastEnd, currEnd int64, recordProcessedBefore, accepted bool) {
@@ -185,7 +202,7 @@ func TestTSDBBuilder(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			expSamples = expSamples[:0]
 			expHistograms = expHistograms[:0]
-			builder := newTSDBBuilder(log.NewNopLogger(), overrides, 0, mimir_tsdb.BlocksStorageConfig{
+			builder := newTSDBBuilder(log.NewNopLogger(), overrides, mimir_tsdb.BlocksStorageConfig{
 				TSDB: mimir_tsdb.TSDBConfig{
 					Dir: t.TempDir(),
 				},
@@ -243,7 +260,11 @@ func TestTSDBBuilder(t *testing.T) {
 			}
 
 			// Query the TSDB for the expected samples.
-			db, err := builder.getOrCreateTSDB(userID)
+			tenant := tsdbTenant{
+				part: 0,
+				id:   userID,
+			}
+			db, err := builder.getOrCreateTSDB(tenant)
 			require.NoError(t, err)
 
 			// Check the samples in the DB.
@@ -251,9 +272,9 @@ func TestTSDBBuilder(t *testing.T) {
 
 			// This should create the appropriate blocks and close the DB.
 			shipperDir := t.TempDir()
-			err = builder.compactAndClose(context.Background(), shipperDir)
+			err = builder.compact(context.Background(), shipperDir)
 			require.NoError(t, err)
-			require.Nil(t, builder.getTSDB(userID))
+			require.Nil(t, builder.getTSDB(tenant))
 
 			newDB, err := tsdb.Open(shipperDir, log.NewNopLogger(), nil, nil, nil)
 			require.NoError(t, err)
@@ -279,7 +300,7 @@ func TestProcessingEmptyRequest(t *testing.T) {
 
 	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
-	builder := newTSDBBuilder(log.NewNopLogger(), overrides, 0, mimir_tsdb.BlocksStorageConfig{
+	builder := newTSDBBuilder(log.NewNopLogger(), overrides, mimir_tsdb.BlocksStorageConfig{
 		TSDB: mimir_tsdb.TSDBConfig{
 			Dir: t.TempDir(),
 		},


### PR DESCRIPTION
#### What this PR does

@codesome this one fixes a couple of TODOs in the `blockbuilder`

1. Make sure consumer consumes up to the known lag, which fixes the empty fetches.
2. Move consumption interval to config.
3. Fix the logic around how `currEnd` is calculated inside the cycle (still needs checking, but at least it makes it so builder  created the actual blocks).
4. Refactor the internals of TSDB to make unit-testing simpler.