### PR TITLE
mimirtool rules sync: fix sync when query_offset or evaluation_delay change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@
 * [ENHANCEMENT] `mimirtool promql format`: Format PromQL query with Prometheus' string or pretty-print formatter. #7742
 * [BUGFIX] `mimirtool rules prepare`: do not add aggregation label to `on()` clause if already present in `group_left()` or `group_right()`. #7839
 * [BUGFIX] Analyze Grafana: fix parsing queries with variables. #8062
+* [BUGFIX] `mimirtool rules sync`: detect a change when the `query_offset` or the deprecated `evaluation_delay` configuration changes. #8297
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/rules/compare.go
+++ b/pkg/mimirtool/rules/compare.go
@@ -19,11 +19,13 @@ import (
 )
 
 var (
-	errNameDiff          = errors.New("rule groups are named differently")
-	errIntervalDiff      = errors.New("rule groups have different intervals")
-	errDiffRuleLen       = errors.New("rule groups have a different number of rules")
-	errDiffRWConfigs     = errors.New("rule groups have different remote write configs")
-	errDiffSourceTenants = errors.New("rule groups have different source tenants")
+	errNameDiff            = errors.New("rule groups are named differently")
+	errIntervalDiff        = errors.New("rule groups have different intervals")
+	errDiffRuleLen         = errors.New("rule groups have a different number of rules")
+	errDiffRWConfigs       = errors.New("rule groups have different remote write configs")
+	errDiffSourceTenants   = errors.New("rule groups have different source tenants")
+	errDiffEvaluationDelay = errors.New("rule groups have different evaluation delay")
+	errDiffQueryOffset     = errors.New("rule groups have different query offset")
 )
 
 // NamespaceState is used to denote the difference between the staged namespace
@@ -130,6 +132,14 @@ func CompareGroups(groupOne, groupTwo rwrulefmt.RuleGroup) error {
 
 	if len(groupOne.RWConfigs) != len(groupTwo.RWConfigs) {
 		return errDiffRWConfigs
+	}
+
+	if ((groupOne.EvaluationDelay == nil) != (groupTwo.EvaluationDelay == nil)) || (groupOne.EvaluationDelay != nil && groupTwo.EvaluationDelay != nil && *groupOne.EvaluationDelay != *groupTwo.EvaluationDelay) {
+		return errDiffEvaluationDelay
+	}
+
+	if ((groupOne.QueryOffset == nil) != (groupTwo.QueryOffset == nil)) || (groupOne.QueryOffset != nil && groupTwo.QueryOffset != nil && *groupOne.QueryOffset != *groupTwo.QueryOffset) {
+		return errDiffQueryOffset
 	}
 
 	for i := range groupOne.RWConfigs {

--- a/pkg/mimirtool/rules/compare_test.go
+++ b/pkg/mimirtool/rules/compare_test.go
@@ -7,7 +7,9 @@ package rules
 
 import (
 	"testing"
+	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
@@ -151,6 +153,13 @@ func Test_rulesEqual(t *testing.T) {
 }
 
 func TestCompareGroups(t *testing.T) {
+	ruleOne := rulefmt.RuleNode{
+		Record:      yaml.Node{Value: "one"},
+		Expr:        yaml.Node{Value: "up"},
+		Annotations: map[string]string{"a": "b", "c": "d"},
+		Labels:      nil,
+	}
+
 	tests := []struct {
 		name        string
 		groupOne    rwrulefmt.RuleGroup
@@ -161,28 +170,14 @@ func TestCompareGroups(t *testing.T) {
 			name: "identical configs",
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			expectedErr: nil,
@@ -193,28 +188,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-2", "tenant-1"},
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Rules:         []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-2"},
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Rules:         []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			expectedErr: nil,
@@ -223,34 +204,14 @@ func TestCompareGroups(t *testing.T) {
 			name: "different rule length",
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne, ruleOne},
 				},
 			},
 			expectedErr: errDiffRuleLen,
@@ -259,15 +220,8 @@ func TestCompareGroups(t *testing.T) {
 			name: "identical rw configs",
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -275,15 +229,8 @@ func TestCompareGroups(t *testing.T) {
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -295,15 +242,8 @@ func TestCompareGroups(t *testing.T) {
 			name: "different rw config lengths",
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -311,15 +251,8 @@ func TestCompareGroups(t *testing.T) {
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -332,15 +265,8 @@ func TestCompareGroups(t *testing.T) {
 			name: "different rw configs",
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -348,15 +274,8 @@ func TestCompareGroups(t *testing.T) {
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
-					Name: "example_group",
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost2"},
@@ -370,28 +289,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-3"},
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Rules:         []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-2"},
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Rules:         []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			expectedErr: errDiffSourceTenants,
@@ -402,28 +307,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-2"},
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Rules:         []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-1"},
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Rules:         []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			expectedErr: errDiffSourceTenants,
@@ -434,31 +325,121 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1"},
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Rules:         []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-1"},
-					Rules: []rulefmt.RuleNode{
-						{
-							Record:      yaml.Node{Value: "one"},
-							Expr:        yaml.Node{Value: "up"},
-							Annotations: map[string]string{"a": "b", "c": "d"},
-							Labels:      nil,
-						},
-					},
+					Rules:         []rulefmt.RuleNode{ruleOne},
 				},
 			},
 			expectedErr: nil,
+		},
+		{
+			name: "evaluation delay is set only in one of the two rule groups",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:            "example_group",
+					EvaluationDelay: pointerOf[model.Duration](model.Duration(2 * time.Minute)),
+					Rules:           []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			expectedErr: errDiffEvaluationDelay,
+		},
+		{
+			name: "evaluation delay is set in both rule groups but with different value",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:            "example_group",
+					EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
+					Rules:           []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:            "example_group",
+					EvaluationDelay: pointerOf[model.Duration](model.Duration(2 * time.Minute)),
+					Rules:           []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			expectedErr: errDiffEvaluationDelay,
+		},
+		{
+			name: "evaluation delay is set in both rule groups with same value",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:            "example_group",
+					EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
+					Rules:           []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:            "example_group",
+					EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
+					Rules:           []rulefmt.RuleNode{ruleOne},
+				},
+			},
+		},
+		{
+			name: "query offset is set only in one of the two rule groups",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:        "example_group",
+					QueryOffset: pointerOf[model.Duration](model.Duration(2 * time.Minute)),
+					Rules:       []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			expectedErr: errDiffQueryOffset,
+		},
+		{
+			name: "query offset is set in both rule groups but with different value",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:        "example_group",
+					QueryOffset: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
+					Rules:       []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:        "example_group",
+					QueryOffset: pointerOf[model.Duration](model.Duration(2 * time.Minute)),
+					Rules:       []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			expectedErr: errDiffQueryOffset,
+		},
+		{
+			name: "query offset is set in both rule groups with same value",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:        "example_group",
+					QueryOffset: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
+					Rules:       []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:        "example_group",
+					QueryOffset: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
+					Rules:       []rulefmt.RuleNode{ruleOne},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -467,4 +448,8 @@ func TestCompareGroups(t *testing.T) {
 			assert.ErrorIs(t, actualErr, tt.expectedErr)
 		})
 	}
+}
+
+func pointerOf[T any](value T) *T {
+	return &value
 }

--- a/pkg/mimirtool/rules/compare_test.go
+++ b/pkg/mimirtool/rules/compare_test.go
@@ -390,6 +390,22 @@ func TestCompareGroups(t *testing.T) {
 			},
 		},
 		{
+			name: "evaluation delay is set only in one rule group but with zero value (in Mimir ruler we treat it as not being set)",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:            "example_group",
+					EvaluationDelay: pointerOf[model.Duration](model.Duration(0)),
+					Rules:           []rulefmt.RuleNode{ruleOne},
+				},
+			},
+		},
+		{
 			name: "query offset is set only in one of the two rule groups",
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
@@ -437,6 +453,22 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:        "example_group",
 					QueryOffset: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
+					Rules:       []rulefmt.RuleNode{ruleOne},
+				},
+			},
+		},
+		{
+			name: "query offset is set only in one rule group but with zero value (in Mimir ruler we treat it as not being set)",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:  "example_group",
+					Rules: []rulefmt.RuleNode{ruleOne},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name:        "example_group",
+					QueryOffset: pointerOf[model.Duration](model.Duration(0)),
 					Rules:       []rulefmt.RuleNode{ruleOne},
 				},
 			},


### PR DESCRIPTION
#### What this PR does

This PR builds on https://github.com/grafana/mimir/pull/8295. While testing https://github.com/grafana/mimir/pull/8295 I've noticed that the rule group config is not re-synched if you only change `query_offset` or `evaluation_delay`. That's because we don't check these fields in the comparison.

This PR fixes it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
