### PR TITLE
Revert configmaps permissions and use-zone-tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,6 @@
 * [ENHANCEMENT] Add `_config.autoscaling_querier_predictive_scaling_enabled` to scale querier based on inflight queries 7 days ago. #7775
 * [ENHANCEMENT] Add support to autoscale ruler-querier replicas based on in-flight queries too (in addition to CPU and memory based scaling). #8060 #8188
 * [ENHANCEMENT] Distributor: improved distributor HPA scaling metric to only take in account ready pods. This requires the metric `kube_pod_status_ready` to be available in the data source used by KEDA to query scaling metrics (configured via `_config.autoscaling_prometheus_url`). #8250
-* [ENHANCEMENT] Add zone tracker usage whenever `rollout_operator_enabled`. #8275
 * [BUGFIX] Guard against missing samples in KEDA queries. #7691
 
 ### Mimirtool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,6 @@
 * [ENHANCEMENT] Distributor: improved distributor HPA scaling metric to only take in account ready pods. This requires the metric `kube_pod_status_ready` to be available in the data source used by KEDA to query scaling metrics (configured via `_config.autoscaling_prometheus_url`). #8250
 * [ENHANCEMENT] Add zone tracker usage whenever `rollout_operator_enabled`. #8275
 * [BUGFIX] Guard against missing samples in KEDA queries. #7691
-* [BUGFIX] Add configmaps mutability to the `rollout_operator_role`. #8228
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -230,14 +230,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1016,8 +1016,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -836,8 +836,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -204,14 +204,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1387,8 +1387,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -480,14 +480,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1417,8 +1417,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -1138,8 +1138,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -1209,8 +1209,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -321,14 +321,6 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
-- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -1217,8 +1217,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -321,14 +321,6 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
-- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -1217,8 +1217,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -1215,8 +1215,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -1220,8 +1220,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -1219,8 +1219,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
@@ -1219,8 +1219,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -1150,8 +1150,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -1158,8 +1158,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -1158,8 +1158,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -269,14 +269,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -1158,8 +1158,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -321,14 +321,6 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
-- apiGroups:
   - rollout-operator.grafana.com
   resources:
   - replicatemplates/scale

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -1217,8 +1217,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -230,14 +230,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1016,8 +1016,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1084,8 +1084,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -256,14 +256,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -230,14 +230,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1016,8 +1016,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -619,8 +619,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -152,14 +152,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -482,8 +482,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -100,14 +100,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -620,8 +620,6 @@ spec:
       containers:
       - args:
         - -kubernetes.namespace=default
-        - -use-zone-tracker=true
-        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         image: grafana/rollout-operator:v0.14.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -152,14 +152,6 @@ rules:
   - statefulsets/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -14,8 +14,6 @@
 
   rollout_operator_args:: {
     'kubernetes.namespace': $._config.namespace,
-    'use-zone-tracker': true,
-    'zone-tracker.config-map-name': 'rollout-operator-zone-tracker',
   },
 
   rollout_operator_node_affinity_matchers:: [],

--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -56,9 +56,6 @@
       policyRule.withApiGroups('apps') +
       policyRule.withResources(['statefulsets/status']) +
       policyRule.withVerbs(['update']),
-      policyRule.withApiGroups('') +
-      policyRule.withResources(['configmaps']) +
-      policyRule.withVerbs(['get', 'update', 'create']),
     ]),
 
   rollout_operator_rolebinding: if !rollout_operator_enabled then null else


### PR DESCRIPTION
These features will be re-added once it's rolled out everywhere in our cloud. For now, it's easier to defer addition here until internal rollouts are finished.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
