### PR TITLE
Improve TestIngester_StartReadRequest

### DIFF
--- a/pkg/ingester/circuitbreaker.go
+++ b/pkg/ingester/circuitbreaker.go
@@ -250,7 +250,7 @@ func (cb *circuitBreaker) recordResult(errs ...error) error {
 			return err
 		}
 	}
-	cb.metrics.circuitBreakerResults.WithLabelValues(circuitBreakerResultSuccess).Inc()
 	cb.cb.RecordSuccess()
+	cb.metrics.circuitBreakerResults.WithLabelValues(circuitBreakerResultSuccess).Inc()
 	return nil
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -3788,6 +3788,12 @@ func (i *Ingester) ShutdownHandler(w http.ResponseWriter, _ *http.Request) {
 // function is returned.
 func (i *Ingester) startReadRequest() (func(error), error) {
 	start := time.Now()
+
+	// We try to acquire a permit from the circuit breaker.
+	// If it is not possible, it is because the circuit breaker is open, and a circuitBreakerOpenError is returned.
+	// If it is possible, a permit has to be released by recording either a success or a failure with the circuit
+	// breaker, by calling circuitBreaker.finishReadRequest(). This has to be done even if a failure happens withing
+	// startReadRequest.
 	acquiredCircuitBreakerPermit, err := i.circuitBreaker.tryAcquirePermit()
 	if err != nil {
 		return nil, err

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
+	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -229,103 +230,105 @@ func TestIngester_StartPushRequest(t *testing.T) {
 }
 
 func TestIngester_StartReadRequest(t *testing.T) {
-	type failureCause int
-	const (
-		NONE failureCause = iota
-		UNAVAILABLE
-		OVERLOADED
-	)
-
 	type testCase struct {
-		failingCause                         failureCause
-		cbOpen                               bool
-		cbInitialDelay                       time.Duration
-		verifyErr                            func(error)
-		expectedAcquiredCircuitBreakerPermit bool
+		setup                       func(*failingIngester)
+		verifyErr                   func(error)
+		expectedAcquiredPermitCount int
 	}
 
-	utilizationLimiter := &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
+	var (
+		acquiredPermitCount  *atomic.Int64
+		recordedSuccessCount *atomic.Int64
+		recordedFailureCount *atomic.Int64
+		utilizationLimiter   = &fakeUtilizationBasedLimiter{limitingReason: "cpu"}
+	)
 
 	setupIngester := func(tc testCase) *failingIngester {
 		cfg := defaultIngesterTestConfig(t)
 		cfg.CircuitBreakerConfig = CircuitBreakerConfig{
 			Enabled:        true,
-			InitialDelay:   tc.cbInitialDelay,
 			CooldownPeriod: 10 * time.Second,
+			ReadTimeout:    30 * time.Second,
 		}
-		var (
-			failingCause    error
-			expectedState   services.State
-			additionalSetup func(cause *failingIngester)
-		)
-		switch tc.failingCause {
-		case UNAVAILABLE:
-			expectedState = services.Terminated
-			failingCause = newUnavailableError(expectedState)
-		case OVERLOADED:
-			expectedState = services.Running
-			additionalSetup = func(failingIng *failingIngester) {
-				failingIng.utilizationBasedLimiter = utilizationLimiter
-			}
-		case NONE:
-			expectedState = services.Running
-		}
-		failingIng := setupFailingIngester(t, cfg, failingCause)
+		failingIng := newFailingIngester(t, cfg, nil, nil)
 		failingIng.startWaitAndCheck(context.Background(), t)
-		require.Equal(t, expectedState, failingIng.lifecycler.State())
-		if additionalSetup != nil {
-			additionalSetup(failingIng)
-		}
+		require.Equal(t, services.Running, failingIng.lifecycler.State())
 
-		if tc.cbOpen {
-			failingIng.circuitBreaker.cb.Open()
-		} else {
-			failingIng.circuitBreaker.cb.Close()
+		acquiredPermitCount = atomic.NewInt64(0)
+		recordedSuccessCount = atomic.NewInt64(0)
+		recordedFailureCount = atomic.NewInt64(0)
+
+		failingIng.circuitBreaker.cb = mockedCircuitBreaker{
+			acquiredPermitCount: acquiredPermitCount,
+			recordSuccessCount:  recordedSuccessCount,
+			recordFailureCount:  recordedFailureCount,
+			CircuitBreaker:      failingIng.circuitBreaker.cb,
 		}
+		failingIng.circuitBreaker.cb.Close()
 
 		return failingIng
 	}
 
 	testCases := map[string]testCase{
-		"fail if ingester is not available for read": {
-			failingCause: UNAVAILABLE,
+		"fail if ingester is not available for read, and do not acquire a permit": {
+			setup: func(failingIng *failingIngester) {
+				services.StopAndAwaitTerminated(context.Background(), failingIng) //nolint:errcheck
+			},
+			expectedAcquiredPermitCount: 0,
 			verifyErr: func(err error) {
 				require.ErrorAs(t, err, &unavailableError{})
 			},
 		},
-		"fail if ingester is overloaded": {
-			failingCause: OVERLOADED,
+		"fail if ingester is overloaded, and do not acquire a permit": {
+			setup: func(failingIng *failingIngester) {
+				failingIng.utilizationBasedLimiter = utilizationLimiter
+			},
+			expectedAcquiredPermitCount: 0,
 			verifyErr: func(err error) {
 				require.ErrorIs(t, err, errTooBusy)
 			},
 		},
-		"fail if circuit breaker is open": {
-			failingCause: NONE,
-			cbOpen:       true,
+		"fail if circuit breaker is open, and do not acquire a permit": {
+			setup: func(failingIng *failingIngester) {
+				failingIng.circuitBreaker.cb.Open()
+			},
+			expectedAcquiredPermitCount: 0,
 			verifyErr: func(err error) {
 				require.ErrorAs(t, err, &circuitBreakerOpenError{})
 			},
 		},
-		"do not fail if circuit breaker is not active": {
-			failingCause:                         NONE,
-			cbInitialDelay:                       1 * time.Minute,
-			expectedAcquiredCircuitBreakerPermit: false,
+		"do not fail if circuit breaker is not active, and do not acquire a permit": {
+			setup: func(failingIng *failingIngester) {
+				failingIng.circuitBreaker.active.Store(false)
+			},
+			expectedAcquiredPermitCount: 0,
 		},
-		"do not fail if everything is ok": {
-			failingCause:                         NONE,
-			expectedAcquiredCircuitBreakerPermit: true,
+		"do not fail if everything is ok, and acquire a permit": {
+			expectedAcquiredPermitCount: 1,
 		},
 	}
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			failingIng := setupIngester(tc)
+			if tc.setup != nil {
+				tc.setup(failingIng)
+			}
 			defer services.StopAndAwaitTerminated(context.Background(), failingIng) //nolint:errcheck
 
 			finish, err := failingIng.startReadRequest()
+			require.Equal(t, int64(tc.expectedAcquiredPermitCount), acquiredPermitCount.Load())
 
 			if err == nil {
+				require.Nil(t, tc.verifyErr)
 				require.NotNil(t, finish)
-				require.NotNil(t, finish)
+
+				// Calling finish must release a potentially acquired permit
+				// and in that case record a success, and no failures.
+				expectedSuccessCount := acquiredPermitCount.Load()
+				finish(err)
+				require.Equal(t, int64(0), acquiredPermitCount.Load())
+				require.Equal(t, expectedSuccessCount, recordedSuccessCount.Load())
+				require.Equal(t, int64(0), recordedFailureCount.Load())
 			} else {
 				require.NotNil(t, tc.verifyErr)
 				tc.verifyErr(err)


### PR DESCRIPTION
#### What this PR does
In #8285 we added circuit breakers on ingester server side for read path. That PR introduced a unit test `TestIngester_StartReadRequest` that is additionally improved by this PR.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
