### PR TITLE
BlockBuilder: Uploads of blocks once they are compacted

### DIFF
--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -1044,7 +1044,7 @@ func (t *Mimir) initUsageStats() (services.Service, error) {
 
 func (t *Mimir) initBlockBuilder() (_ services.Service, err error) {
 	t.Cfg.BlockBuilder.BlocksStorageConfig = t.Cfg.BlocksStorage
-	t.BlockBuilder, err = blockbuilder.NewBlockBuilder(t.Cfg.BlockBuilder, util_log.Logger, t.Registerer, t.Overrides)
+	t.BlockBuilder, err = blockbuilder.New(t.Cfg.BlockBuilder, util_log.Logger, t.Registerer, t.Overrides)
 	if err != nil {
 		return
 	}

--- a/pkg/storage/tsdb/block/meta.go
+++ b/pkg/storage/tsdb/block/meta.go
@@ -30,6 +30,7 @@ const (
 	CompactorRepairSource SourceType = "compactor.repair"
 	BucketRepairSource    SourceType = "bucket.repair"
 	TestSource            SourceType = "test"
+	BlockBuilderSource    SourceType = "blockbuilder"
 )
 
 const (


### PR DESCRIPTION
@narqo 

We follow a simple approach: upload the blocks as soon as they are created. Since we need the blocks to be uploaded before we do a kafka commit, there is no point of using the shipper code.