### PR TITLE
BlockBuilder: Add metadata to kafka commit

### DIFF
--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -1,1 +1,22 @@
 package blockbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKafkaCommitMetaMarshalling(t *testing.T) {
+	lastOffset := int64(892734)
+	currEnd := int64(598237948)
+
+	lo, ce, err := unmarshallCommitMeta(marshallCommitMeta(lastOffset, currEnd))
+	require.NoError(t, err)
+	require.Equal(t, lastOffset, lo)
+	require.Equal(t, currEnd, ce)
+
+	// Unsupported version
+	_, _, err = unmarshallCommitMeta("2,2,3")
+	require.Error(t, err)
+	require.Equal(t, "unsupported commit meta version 2", err.Error())
+}


### PR DESCRIPTION
@narqo This PR only adds the metadata to the commit but does not use the metadata from commits yet. I will figure that out in later PRs since it looked like we might need changing few stuff in how we read from kafka and I am hoping we won't have to change a lot.