### PR TITLE
Mimir query engine: report queries rejected due to hitting the memory consumption limit in the `cortex_querier_queries_rejected_total` metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277 #8291
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277 #8291 #8303
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -165,7 +165,7 @@ func New(cfg Config, limits *validation.Overrides, distributor Distributor, stor
 		eng = promql.NewEngine(opts)
 	case mimirPromQLEngine:
 		limitsProvider := &tenantQueryLimitsProvider{limits: limits}
-		streamingEngine, err := streamingpromql.NewEngine(opts, limitsProvider, logger)
+		streamingEngine, err := streamingpromql.NewEngine(opts, limitsProvider, queryMetrics, logger)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/querier/stats/query_metrics.go
+++ b/pkg/querier/stats/query_metrics.go
@@ -11,14 +11,15 @@ import (
 )
 
 const (
-	RejectReasonMaxSeries          = "max-fetched-series-per-query"
-	RejectReasonMaxChunkBytes      = "max-fetched-chunk-bytes-per-query"
-	RejectReasonMaxChunks          = "max-fetched-chunks-per-query"
-	RejectReasonMaxEstimatedChunks = "max-estimated-fetched-chunks-per-query"
+	RejectReasonMaxSeries                          = "max-fetched-series-per-query"
+	RejectReasonMaxChunkBytes                      = "max-fetched-chunk-bytes-per-query"
+	RejectReasonMaxChunks                          = "max-fetched-chunks-per-query"
+	RejectReasonMaxEstimatedChunks                 = "max-estimated-fetched-chunks-per-query"
+	RejectReasonMaxEstimatedQueryMemoryConsumption = "max-estimated-memory-consumption-per-query"
 )
 
 var (
-	rejectReasons = []string{RejectReasonMaxSeries, RejectReasonMaxChunkBytes, RejectReasonMaxChunks, RejectReasonMaxEstimatedChunks}
+	rejectReasons = []string{RejectReasonMaxSeries, RejectReasonMaxChunkBytes, RejectReasonMaxChunks, RejectReasonMaxEstimatedChunks, RejectReasonMaxEstimatedQueryMemoryConsumption}
 )
 
 // QueryMetrics collects metrics on the number of chunks used while serving queries.

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -44,7 +44,7 @@ func BenchmarkQuery(b *testing.B) {
 
 	opts := streamingpromql.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts)
-	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), log.NewNopLogger())
+	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), log.NewNopLogger())
 	require.NoError(b, err)
 
 	// Important: the names below must remain in sync with the names used in tools/benchmark-query-engine.
@@ -96,7 +96,7 @@ func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
 
 	opts := streamingpromql.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts)
-	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), log.NewNopLogger())
+	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), log.NewNopLogger())
 	require.NoError(t, err)
 
 	ctx := user.InjectOrgID(context.Background(), UserID)
@@ -123,7 +123,7 @@ func TestBenchmarkSetup(t *testing.T) {
 	q := createBenchmarkQueryable(t, []int{1})
 
 	opts := streamingpromql.NewTestEngineOpts()
-	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), log.NewNopLogger())
+	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), log.NewNopLogger())
 	require.NoError(t, err)
 
 	ctx := user.InjectOrgID(context.Background(), UserID)

--- a/pkg/streamingpromql/operators/binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binary_operation_test.go
@@ -254,7 +254,7 @@ func TestBinaryOperation_SeriesMerging(t *testing.T) {
 					On:             true,
 					MatchingLabels: []string{"env"},
 				},
-				Pool: pooling.NewLimitingPool(0),
+				Pool: pooling.NewLimitingPool(0, nil),
 			}
 
 			result, err := o.mergeOneSide(testCase.input, testCase.sourceSeriesIndices, testCase.sourceSeriesMetadata, "right")
@@ -526,7 +526,7 @@ func TestBinaryOperationSeriesBuffer(t *testing.T) {
 	}
 
 	seriesUsed := []bool{true, false, true, true, true}
-	buffer := newBinaryOperationSeriesBuffer(inner, seriesUsed, pooling.NewLimitingPool(0))
+	buffer := newBinaryOperationSeriesBuffer(inner, seriesUsed, pooling.NewLimitingPool(0, nil))
 	ctx := context.Background()
 
 	// Read first series.

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -67,7 +67,7 @@ func newQuery(ctx context.Context, queryable storage.Queryable, opts promql.Quer
 		opts:      opts,
 		engine:    engine,
 		qs:        qs,
-		pool:      pooling.NewLimitingPool(maxInMemorySamples),
+		pool:      pooling.NewLimitingPool(maxInMemorySamples, engine.queriesRejectedDueToPeakMemoryConsumption),
 		statement: &parser.EvalStmt{
 			Expr:          expr,
 			Start:         start,

--- a/pkg/util/limiter/query_limiter_test.go
+++ b/pkg/util/limiter/query_limiter_test.go
@@ -201,6 +201,7 @@ func assertRejectedQueriesMetricValue(t *testing.T, c prometheus.Collector, expe
 		cortex_querier_queries_rejected_total{reason="max-fetched-chunk-bytes-per-query"} %v
 		cortex_querier_queries_rejected_total{reason="max-fetched-chunks-per-query"} %v
 		cortex_querier_queries_rejected_total{reason="max-estimated-fetched-chunks-per-query"} %v
+		cortex_querier_queries_rejected_total{reason="max-estimated-memory-consumption-per-query"} 0
 		`,
 		expectedMaxSeries,
 		expectedMaxChunkBytes,


### PR DESCRIPTION
#### What this PR does

This PR builds on https://github.com/grafana/mimir/pull/8230, and adds incrementing the `cortex_querier_queries_rejected_total{reason="max-estimated-memory-consumption-per-query"}` metric when a query is rejected for exceeding the per-query memory consumption limit.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
