### PR TITLE
Add myself to CODEOWNERS for dependencies.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,8 +26,8 @@
 CHANGELOG.md
 
 # Dependencies
-go.mod @grafana/mimir-maintainers @grafanabot
-go.sum @grafana/mimir-maintainers @grafanabot
-/vendor/ @grafana/mimir-maintainers @grafanabot
+go.mod @stevesg @grafana/mimir-maintainers @grafanabot
+go.sum @stevesg @grafana/mimir-maintainers @grafanabot
+/vendor/ @stevesg @grafana/mimir-maintainers @grafanabot
 /vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers @grafanabot
 /vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers @grafanabot


### PR DESCRIPTION
Requesting to add myself to CODEOWNERS for go.mod, so.sum and vendor/ so that
Alertmanager maintainers have a representative to approve vendoring updates.
