### PR TITLE
Ingester circuit breakers: remove unnecessary configuration

### DIFF
--- a/pkg/ingester/circuitbreaker.go
+++ b/pkg/ingester/circuitbreaker.go
@@ -121,7 +121,6 @@ func newCircuitBreaker(cfg CircuitBreakerConfig, logger log.Logger, registerer p
 	}
 
 	cbBuilder := circuitbreaker.Builder[any]().
-		WithFailureThreshold(cfg.FailureThresholdPercentage).
 		WithDelay(cfg.CooldownPeriod).
 		OnClose(func(event circuitbreaker.StateChangedEvent) {
 			circuitBreakerTransitionsCounterFn(cb.metrics, circuitbreaker.ClosedState).Inc()
@@ -250,7 +249,7 @@ func (cb *circuitBreaker) recordResult(errs ...error) error {
 			return err
 		}
 	}
-	cb.metrics.circuitBreakerResults.WithLabelValues(circuitBreakerResultSuccess).Inc()
 	cb.cb.RecordSuccess()
+	cb.metrics.circuitBreakerResults.WithLabelValues(circuitBreakerResultSuccess).Inc()
 	return nil
 }

--- a/pkg/ingester/circuitbreaker_test.go
+++ b/pkg/ingester/circuitbreaker_test.go
@@ -172,7 +172,11 @@ func TestCircuitBreaker_TryAcquirePermit(t *testing.T) {
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			registry := prometheus.NewRegistry()
-			cfg := CircuitBreakerConfig{Enabled: true, CooldownPeriod: 10 * time.Second}
+			cfg := CircuitBreakerConfig{
+				Enabled:         true,
+				CooldownPeriod:  10 * time.Second,
+				testModeEnabled: true,
+			}
 			cb := newCircuitBreaker(cfg, log.NewNopLogger(), registry)
 			testCase.circuitBreakerSetup(cb)
 			status, err := cb.tryAcquirePermit()


### PR DESCRIPTION
#### What this PR does
This PR removes a redundant configuration introduced in #8180. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
