### PR TITLE
BUGFIX: fix yaml format for mimir-nginx affinity in helm chart

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -104,7 +104,7 @@ spec:
         {{- end }}
       {{- with .Values.nginx.affinity }}
       affinity:
-        {{- tpl . $ | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- include "mimir.lib.topologySpreadConstraints" (dict "ctx" . "component" "nginx") | nindent 6 }}
       {{- with .Values.nginx.nodeSelector }}


### PR DESCRIPTION
#### What this PR does
BUGFIX: fix yaml format for mimir-nginx affinity in helm chart