### PR TITLE
Inform reader about get started with mimir tutorial directory changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@
 
 ### Documentation
 
+* [CHANGE] Note that the _Play with Grafana Mimir_ tutorial directory path changed after the release of the video. #8319
 * [ENHANCEMENT] Clarify Compactor and its storage volume when configured under Kubernetes. #7675
 * [ENHANCEMENT] Add OTLP route to _Mimir routes by path_ runbooks section. #8074
 
@@ -389,7 +390,6 @@
 
 ### Documentation
 
-* [CHANGE] Note that the _Play with Grafana Mimir_ tutorial directory path changed after the release of the video. #8319
 * [CHANGE] No longer mark OTLP distributor endpoint as experimental. #7348
 * [ENHANCEMENT] Added runbook for `KubePersistentVolumeFillingUp` alert. #7297
 * [ENHANCEMENT] Add Grafana Cloud recommendations to OTLP documentation. #7375

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,7 +389,7 @@
 
 ### Documentation
 
-* [CHANGE] Inform reader about changes made regarding get started with mimir tutorial files.
+* [CHANGE] Note that the _Play with Grafana Mimir_ tutorial directory path changed after the release of the video. #8319
 * [CHANGE] No longer mark OTLP distributor endpoint as experimental. #7348
 * [ENHANCEMENT] Added runbook for `KubePersistentVolumeFillingUp` alert. #7297
 * [ENHANCEMENT] Add Grafana Cloud recommendations to OTLP documentation. #7375

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,6 +389,7 @@
 
 ### Documentation
 
+* [CHANGE] Inform reader about changes made regarding get started with mimir tutorial files.
 * [CHANGE] No longer mark OTLP distributor endpoint as experimental. #7348
 * [ENHANCEMENT] Added runbook for `KubePersistentVolumeFillingUp` alert. #7297
 * [ENHANCEMENT] Add Grafana Cloud recommendations to OTLP documentation. #7375

--- a/docs/sources/mimir/get-started/_index.md
+++ b/docs/sources/mimir/get-started/_index.md
@@ -14,7 +14,6 @@ You can get started with Grafana Mimir _imperatively_ or _declaratively_:
 - **Imperatively**: The written instructions that follow contain commands to help you start a single Mimir process. You would need to perform the commands again to start another Mimir process.
 - **Declaratively**: The following video tutorial uses `docker-compose` to deploy multiple Mimir processes.
   Therefore, if you want to deploy multiple Mimir processes later, the majority of the configuration work will have already been done.
-  
   {{< admonition type="note" >}}
   The tutorial directory path changed to `docs/sources/mimir/get-started/play-with-grafana-mimir` after the release of the video.
   {{< /admonition >}}

--- a/docs/sources/mimir/get-started/_index.md
+++ b/docs/sources/mimir/get-started/_index.md
@@ -12,7 +12,7 @@ weight: 10
 You can get started with Grafana Mimir _imperatively_ or _declaratively_:
 
 - **Imperatively**: The written instructions that follow contain commands to help you start a single Mimir process. You would need to perform the commands again to start another Mimir process.
-- **Declaratively**: The following video tutorial uses `docker-compose` to deploy multiple Mimir processes. Therefore, if you want to deploy multiple Mimir processes later, the majority of the configuration work will have already been done.
+- **Declaratively**: The following video tutorial uses `docker-compose` to deploy multiple Mimir processes. Therefore, if you want to deploy multiple Mimir processes later, the majority of the configuration work will have already been done. However, the tutorial directory path has been changed to `docs/sources/mimir/get-started/play-with-grafana-mimir` after the release of the video below.
 
   {{< vimeo 691947043 >}}
 

--- a/docs/sources/mimir/get-started/_index.md
+++ b/docs/sources/mimir/get-started/_index.md
@@ -12,7 +12,12 @@ weight: 10
 You can get started with Grafana Mimir _imperatively_ or _declaratively_:
 
 - **Imperatively**: The written instructions that follow contain commands to help you start a single Mimir process. You would need to perform the commands again to start another Mimir process.
-- **Declaratively**: The following video tutorial uses `docker-compose` to deploy multiple Mimir processes. Therefore, if you want to deploy multiple Mimir processes later, the majority of the configuration work will have already been done. However, the tutorial directory path has been changed to `docs/sources/mimir/get-started/play-with-grafana-mimir` after the release of the video below.
+- **Declaratively**: The following video tutorial uses `docker-compose` to deploy multiple Mimir processes.
+  Therefore, if you want to deploy multiple Mimir processes later, the majority of the configuration work will have already been done.
+  
+  {{< admonition type="note" >}}
+  The tutorial directory path changed to `docs/sources/mimir/get-started/play-with-grafana-mimir` after the release of the video.
+  {{< /admonition >}}
 
   {{< vimeo 691947043 >}}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The tutorial directory path has been changed to `docs/sources/mimir/get-started/play-with-grafana-mimir` after the release of the tutorial video. I added a small sentence to inform the reader.

#### Which issue(s) this PR fixes or relates to

There is no issue

#### Checklist

- [X] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [X] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
