### PR TITLE
Remote read is first class: query stats and activity tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [EHNAHCEMENT] Distributor: add `insight=true` to remote-write and OTLP write handlers when the HTTP response status code is 4xx. #8294
 * [ENHANCEMENT] Ingester: reduce locked time while matching postings for a label, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Ingester: reduce the amount of locks taken during the Head compaction's garbage-collection process, improving the write latency and compaction speed. #8327
+* [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -40,11 +40,13 @@ func ParseRemoteReadRequestWithoutConsumingBody(req *http.Request) (url.Values, 
 		return nil, err
 	}
 
+	add := func(i int, name, value string) { params.Add(name+"_"+strconv.Itoa(i), value) }
+
 	queries := remoteReadRequest.GetQueries()
 
 	for i, query := range queries {
-		params.Add("start_"+strconv.Itoa(i), fmt.Sprintf("%d", query.GetStartTimestampMs()))
-		params.Add("end_"+strconv.Itoa(i), fmt.Sprintf("%d", query.GetEndTimestampMs()))
+		add(i, "start", fmt.Sprintf("%d", query.GetStartTimestampMs()))
+		add(i, "end", fmt.Sprintf("%d", query.GetEndTimestampMs()))
 
 		matchersStrings := make([]string, 0, len(query.Matchers))
 		matchers, err := remote.FromLabelMatchers(query.Matchers)
@@ -57,9 +59,9 @@ func ParseRemoteReadRequestWithoutConsumingBody(req *http.Request) (url.Values, 
 		params.Add("matchers_"+strconv.Itoa(i), strings.Join(matchersStrings, ","))
 		if query.Hints != nil {
 			if hints, err := json.Marshal(query.Hints); err == nil {
-				params.Add("hints_"+strconv.Itoa(i), string(hints))
+				add(i, "hints", string(hints))
 			} else {
-				params.Add("hints_"+strconv.Itoa(i), fmt.Sprintf("error marshalling hints: %v", err))
+				add(i, "hints", fmt.Sprintf("error marshalling hints: %v", err))
 			}
 		}
 	}

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/storage/remote"
+
+	"github.com/grafana/mimir/pkg/querier"
+	"github.com/grafana/mimir/pkg/util"
+)
+
+// ParseRemoteReadRequestWithoutConsumingBody parses a remote read request
+// without consuming the body. It does not check the req.Body size, so it is
+// the caller's responsibility to ensure that the body is not too large.
+func ParseRemoteReadRequestWithoutConsumingBody(req *http.Request) (url.Values, error) {
+	params := make(url.Values)
+
+	if req.Body == nil {
+		return params, nil
+	}
+
+	bodyBytes, err := util.ReadRequestBodyWithoutConsuming(req)
+	if err != nil {
+		return nil, err
+	}
+
+	remoteReadRequest := prompb.ReadRequest{}
+
+	_, err = util.ParseProtoReader(req.Context(), io.NopCloser(bytes.NewReader(bodyBytes)), int(req.ContentLength), querier.MaxRemoteReadQuerySize, nil, &remoteReadRequest, util.RawSnappy)
+	if err != nil {
+		return nil, err
+	}
+
+	queries := remoteReadRequest.GetQueries()
+
+	for i, query := range queries {
+		params.Add("start_"+strconv.Itoa(i), fmt.Sprintf("%d", query.GetStartTimestampMs()))
+		params.Add("end_"+strconv.Itoa(i), fmt.Sprintf("%d", query.GetEndTimestampMs()))
+
+		matchersStrings := make([]string, 0, len(query.Matchers))
+		matchers, err := remote.FromLabelMatchers(query.Matchers)
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range matchers {
+			matchersStrings = append(matchersStrings, m.String())
+		}
+		params.Add("matchers_"+strconv.Itoa(i), strings.Join(matchersStrings, ","))
+		if query.Hints != nil {
+			if hints, err := json.Marshal(query.Hints); err == nil {
+				params.Add("hints_"+strconv.Itoa(i), string(hints))
+			} else {
+				params.Add("hints_"+strconv.Itoa(i), fmt.Sprintf("error marshalling hints: %v", err))
+			}
+		}
+	}
+
+	return params, err
+}

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRemoteReadRequestWithoutConsumingBody(t *testing.T) {
+	testCases := map[string]struct {
+		reqBody               func() io.ReadCloser
+		contentLength         int
+		expectedErrorContains string
+		expectedErrorIs       error
+		expectedParams        url.Values
+	}{
+		"no body": {
+			reqBody: func() io.ReadCloser {
+				return nil
+			},
+			expectedParams: make(url.Values),
+		},
+		"valid body": {
+			reqBody: func() io.ReadCloser {
+				remoteReadRequest := &prompb.ReadRequest{
+					Queries: []*prompb.Query{
+						{
+							Matchers: []*prompb.LabelMatcher{
+								{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"},
+								{Name: "foo", Type: prompb.LabelMatcher_RE, Value: ".*bar.*"},
+							},
+							StartTimestampMs: 0,
+							EndTimestampMs:   42,
+						},
+						{
+							Matchers: []*prompb.LabelMatcher{
+								{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "up"},
+							},
+							StartTimestampMs: 10,
+							EndTimestampMs:   20,
+							Hints: &prompb.ReadHints{
+								StepMs: 1000,
+							},
+						},
+					},
+				}
+				data, _ := proto.Marshal(remoteReadRequest) // Ignore error, if this fails, the test will fail.
+				compressed := snappy.Encode(nil, data)
+				return io.NopCloser(bytes.NewReader(compressed))
+			},
+			expectedParams: url.Values{
+				"start_0":    []string{"0"},
+				"end_0":      []string{"42"},
+				"matchers_0": []string{"__name__=\"some_metric\",foo=~\".*bar.*\""},
+				"start_1":    []string{"10"},
+				"end_1":      []string{"20"},
+				"matchers_1": []string{"__name__=\"up\""},
+				"hints_1":    []string{"{\"step_ms\":1000}"},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			req := &http.Request{
+				Body: tc.reqBody(),
+			}
+			params, err := ParseRemoteReadRequestWithoutConsumingBody(req)
+			if err != nil {
+				if tc.expectedErrorIs != nil {
+					require.ErrorIs(t, err, tc.expectedErrorIs)
+					require.Contains(t, err.Error(), tc.expectedErrorContains)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+			require.Equal(t, tc.expectedParams, params)
+
+			// Check that we can still read the Body after parsing.
+			if req.Body != nil {
+				bodyBytes, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				require.NoError(t, req.Body.Close())
+				require.NotEmpty(t, bodyBytes)
+			}
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -36,6 +36,7 @@ const (
 	cardinalityActiveSeriesPathSuffix                 = "/api/v1/cardinality/active_series"
 	cardinalityActiveNativeHistogramMetricsPathSuffix = "/api/v1/cardinality/active_native_histogram_metrics"
 	labelNamesPathSuffix                              = "/api/v1/labels"
+	remoteReadPathSuffix                              = "/api/v1/read"
 
 	// DefaultDeprecatedAlignQueriesWithStep is the default value for the deprecated querier frontend config DeprecatedAlignQueriesWithStep
 	// which has been moved to a per-tenant limit; TODO remove in Mimir 2.14
@@ -459,4 +460,8 @@ func IsActiveSeriesQuery(path string) bool {
 
 func IsActiveNativeHistogramMetricsQuery(path string) bool {
 	return strings.HasSuffix(path, cardinalityActiveNativeHistogramMetricsPathSuffix)
+}
+
+func IsRemoteReadQuery(path string) bool {
+	return strings.HasSuffix(path, remoteReadPathSuffix)
 }

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -185,7 +185,15 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Limit the read body size.
 	r.Body = http.MaxBytesReader(w, r.Body, f.cfg.MaxBodySize)
 
-	params, err := util.ParseRequestFormWithoutConsumingBody(r)
+	var params url.Values
+	var err error
+
+	if r.Header.Get("Content-Type") == "application/x-protobuf" && querymiddleware.IsRemoteReadQuery(r.URL.Path) {
+		params, err = querymiddleware.ParseRemoteReadRequestWithoutConsumingBody(r)
+	} else {
+		params, err = util.ParseRequestFormWithoutConsumingBody(r)
+	}
+
 	if err != nil {
 		writeError(w, apierror.New(apierror.TypeBadData, err.Error()))
 		return

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -6,6 +6,7 @@
 package transport
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -20,6 +21,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
@@ -28,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -155,6 +159,53 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			expectedActivity:        "user:12345 UA:test-user-agent req:GET /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 		},
+		{
+			name: "handler with stats enabled, serving remote read query with snappy compression",
+			cfg:  HandlerConfig{QueryStatsEnabled: true, MaxBodySize: 1024},
+			request: func() *http.Request {
+				r := httptest.NewRequest("GET", "/api/v1/read", nil)
+				r.Header.Add("User-Agent", "test-user-agent")
+				r.Header.Add("Content-Type", "application/x-protobuf")
+				remoteReadRequest := &prompb.ReadRequest{
+					Queries: []*prompb.Query{
+						{
+							Matchers: []*prompb.LabelMatcher{
+								{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"},
+								{Name: "foo", Type: prompb.LabelMatcher_RE, Value: ".*bar.*"},
+							},
+							StartTimestampMs: 0,
+							EndTimestampMs:   42,
+						},
+						{
+							Matchers: []*prompb.LabelMatcher{
+								{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "up"},
+							},
+							StartTimestampMs: 10,
+							EndTimestampMs:   20,
+							Hints: &prompb.ReadHints{
+								StepMs: 1000,
+							},
+						},
+					},
+				}
+				data, _ := proto.Marshal(remoteReadRequest) // Ignore error, if this fails, the test will fail.
+				r.Header.Add("Content-Encoding", "snappy")
+				compressed := snappy.Encode(nil, data)
+				r.Body = io.NopCloser(bytes.NewReader(compressed))
+				return r
+			},
+			expectedActivity: "user:12345 UA:test-user-agent req:GET /api/v1/read end_0=42&end_1=20&hints_1=%7B%22step_ms%22%3A1000%7D&matchers_0=__name__%3D%22some_metric%22%2Cfoo%3D~%22.%2Abar.%2A%22&matchers_1=__name__%3D%22up%22&start_0=0&start_1=10",
+			expectedMetrics:  5,
+			expectedParams: url.Values{
+				"matchers_0": []string{"__name__=\"some_metric\",foo=~\".*bar.*\""},
+				"start_0":    []string{"0"},
+				"end_0":      []string{"42"},
+				"matchers_1": []string{"__name__=\"up\""},
+				"start_1":    []string{"10"},
+				"end_1":      []string{"20"},
+				"hints_1":    []string{"{\"step_ms\":1000}"},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			activityFile := filepath.Join(t.TempDir(), "activity-tracker")
@@ -165,8 +216,10 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				assert.Len(t, activities, 1)
 				assert.Equal(t, tt.expectedActivity, activities[0].Activity)
 
-				assert.NoError(t, req.ParseForm())
-				assert.Equal(t, tt.expectedParams, req.Form)
+				if req.Header.Get("Content-Type") != "application/x-protobuf" {
+					assert.NoError(t, req.ParseForm())
+					assert.Equal(t, tt.expectedParams, req.Form)
+				}
 
 				return &http.Response{
 					StatusCode: http.StatusOK,
@@ -190,7 +243,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 
 			handler.ServeHTTP(resp, req)
 			responseData, _ := io.ReadAll(resp.Body)
-			require.Equal(t, resp.Code, http.StatusOK)
+			require.Equal(t, http.StatusOK, resp.Code)
 
 			count, err := promtest.GatherAndCount(
 				reg,
@@ -232,6 +285,18 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				require.EqualValues(t, 0, msg["split_queries"])
 				require.EqualValues(t, 0, msg["estimated_series_count"])
 				require.EqualValues(t, 0, msg["queue_time_seconds"])
+
+				// Check that the HTTP or Protobuf request parameters are logged.
+				paramsLogged := 0
+				for key := range msg {
+					if strings.HasPrefix(key, "param_") {
+						paramsLogged++
+					}
+				}
+				require.Equal(t, len(tt.expectedParams), paramsLogged)
+				for key, value := range tt.expectedParams {
+					require.Equal(t, value[0], msg["param_"+key])
+				}
 
 				if tt.expectedReadConsistency != "" {
 					require.Equal(t, tt.expectedReadConsistency, msg["read_consistency"])

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// Queries are a set of matchers with time ranges - should not get into megabytes
-	maxRemoteReadQuerySize = 1024 * 1024
+	MaxRemoteReadQuerySize = 1024 * 1024
 
 	// Maximum number of bytes in frame when using streaming remote read.
 	// Google's recommendation is to keep protobuf message not larger than 1MB.
@@ -51,7 +51,7 @@ func remoteReadHandler(q storage.SampleAndChunkQueryable, maxBytesInFrame int, l
 		ctx := r.Context()
 		var req client.ReadRequest
 		logger := util_log.WithContext(r.Context(), lg)
-		if _, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRemoteReadQuerySize, nil, &req, util.RawSnappy); err != nil {
+		if _, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), MaxRemoteReadQuerySize, nil, &req, util.RawSnappy); err != nil {
 			level.Error(logger).Log("msg", "failed to parse proto", "err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -343,6 +343,7 @@ func SerializeProtoResponse(w http.ResponseWriter, resp proto.Message, compressi
 
 // ParseRequestFormWithoutConsumingBody parsed and returns the request parameters (query string and/or request body)
 // from the input http.Request. If the request has a Body, the request's Body is replaces so that it can be consumed again.
+// It does not check the req.Body size, so it is the caller's responsibility to ensure that the body is not too large.
 func ParseRequestFormWithoutConsumingBody(r *http.Request) (url.Values, error) {
 	if r.Body == nil {
 		if err := r.ParseForm(); err != nil {
@@ -352,16 +353,10 @@ func ParseRequestFormWithoutConsumingBody(r *http.Request) (url.Values, error) {
 		return r.Form, nil
 	}
 
-	// Close the original body reader. It's going to be replaced later in this function.
-	origBody := r.Body
-	defer func() { _ = origBody.Close() }()
-
-	// Store the body contents, so we can read it multiple times.
-	bodyBytes, err := io.ReadAll(r.Body)
+	bodyBytes, err := ReadRequestBodyWithoutConsuming(r)
 	if err != nil {
 		return nil, err
 	}
-	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	// Parse the request data.
 	if err := r.ParseForm(); err != nil {
@@ -376,6 +371,30 @@ func ParseRequestFormWithoutConsumingBody(r *http.Request) (url.Values, error) {
 	r.Form, r.PostForm = nil, nil
 
 	return params, nil
+}
+
+// ReadRequestBodyWithoutConsuming makes a copy of the request body bytes
+// without consuming the body, so it can be read again later.
+// If the request has no body, it returns nil without error.
+// It does not check the req.Body size, so it is the caller's responsibility
+// to ensure that the body is not too large.
+func ReadRequestBodyWithoutConsuming(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+
+	// Close the original body reader. It's going to be replaced later in this function.
+	origBody := r.Body
+	defer func() { _ = origBody.Close() }()
+
+	// Store the body contents, so we can read it multiple times.
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	return bodyBytes, nil
 }
 
 func copyValues(src url.Values) url.Values {


### PR DESCRIPTION
#### What this PR does

Add logging of the start, end time and matchers for remote read requests in query stats and activity tracker.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2064

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
