### PR TITLE
BlockBuilder: Refactor the consume cycle logic

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -500,13 +500,13 @@ func (b *BlockBuilder) finalizePartition(ctx context.Context, commitRec, lastRec
 
 	ctx = kgo.PreCommitFnContext(ctx, func(req *kmsg.OffsetCommitRequest) error {
 		meta := marshallCommitMeta(commitRec.Timestamp.UnixMilli(), lastRec.Timestamp.UnixMilli(), blockEnd)
-		for _, topic := range req.Topics {
-			if topic.Topic != b.cfg.Kafka.Topic {
+		for ti := range req.Topics {
+			if req.Topics[ti].Topic != b.cfg.Kafka.Topic {
 				continue
 			}
-			for i := range req.Topics[0].Partitions {
-				if req.Topics[0].Partitions[i].Partition == commitRec.Partition {
-					req.Topics[0].Partitions[i].Metadata = &meta
+			for pi := range req.Topics[ti].Partitions {
+				if req.Topics[ti].Partitions[pi].Partition == commitRec.Partition {
+					req.Topics[ti].Partitions[pi].Metadata = &meta
 				}
 			}
 		}

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -60,7 +60,7 @@ func New(
 		return newTSDBBuilder(b.logger, b.limits, b.cfg.BlocksStorageConfig)
 	}
 
-	bucketClient, err := bucket.NewClient(context.Background(), cfg.BlocksStorageConfig.Bucket, "ingester", logger, reg)
+	bucketClient, err := bucket.NewClient(context.Background(), cfg.BlocksStorageConfig.Bucket, "blockbuilder", logger, reg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the bucket client: %w", err)
 	}
@@ -504,9 +504,9 @@ func (b *BlockBuilder) finalizePartition(ctx context.Context, commitRec, lastRec
 			if topic.Topic != b.cfg.Kafka.Topic {
 				continue
 			}
-			for _, part := range req.Topics[0].Partitions {
-				if part.Partition == commitRec.Partition {
-					part.Metadata = &meta
+			for i := range req.Topics[0].Partitions {
+				if req.Topics[0].Partitions[i].Partition == commitRec.Partition {
+					req.Topics[0].Partitions[i].Metadata = &meta
 				}
 			}
 		}

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -175,3 +175,24 @@ func (t testTSDBBuilder) compactAndUpload(ctx context.Context, blockUploaderForU
 func (t testTSDBBuilder) close() error {
 	return nil
 }
+
+func TestKafkaCommitMetaMarshalling(t *testing.T) {
+	v1 := int64(892734)
+	v2 := int64(598237948)
+	v3 := int64(340237948)
+
+	o1, o2, o3, err := unmarshallCommitMeta(marshallCommitMeta(v1, v2, v3))
+	require.NoError(t, err)
+	require.Equal(t, v1, o1)
+	require.Equal(t, v2, o2)
+	require.Equal(t, v3, o3)
+
+	// Unsupported version
+	_, _, _, err = unmarshallCommitMeta("2,2,3,4")
+	require.Error(t, err)
+	require.Equal(t, "unsupported commit meta version 2", err.Error())
+
+	// Error parsing
+	_, _, _, err = unmarshallCommitMeta("1,3,4")
+	require.Error(t, err)
+}


### PR DESCRIPTION
@narqo this moves some logic out of `consumePartition` and into the `nextConsumeCycle`. Main aim of this is to make `consumePartition()` simpler where it just starts consuming from the partition until the given cycle end time. We also pass the block start and end times, and the last seen record as part of arguments.

We now do all the heavy lifting in nextConsumeCycle, where we call `consumePartition()` in parts when it is lagging. We calculate the timestamps appropriately.
