### PR TITLE
Query-tee improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@
 ### Query-tee
 
 * [ENHANCEMENT] Log queries that take longer than `proxy.log-slow-query-response-threshold` when compared to other backends. #7346
-* [ENHANCEMENT] Add two new metrics for measuring the relative duration between backends: #7782 #8013
+* [ENHANCEMENT] Add two new metrics for measuring the relative duration between backends: #7782 #8013 #8330
   * `cortex_querytee_backend_response_relative_duration_seconds`
   * `cortex_querytee_backend_response_relative_duration_proportional`
 

--- a/docs/sources/mimir/manage/tools/query-tee.md
+++ b/docs/sources/mimir/manage/tools/query-tee.md
@@ -165,8 +165,8 @@ cortex_querytee_responses_compared_total{route="<route>",result="<success|fail>"
 
 Additionally, if backend results comparison is configured, two native histograms are available:
 
-- `cortex_querytee_backend_response_relative_duration_seconds`: Time (in seconds) of preferred backend less secondary backend.
-- `cortex_querytee_backend_response_relative_duration_proportional`: Response time of preferred backend, as a proportion of secondary backend response time.
+- `cortex_querytee_backend_response_relative_duration_seconds`: Time (in seconds) of secondary backend less preferred backend.
+- `cortex_querytee_backend_response_relative_duration_proportional`: Response time of secondary backend less preferred backend, as a proportion of preferred backend response time.
 
 ### Ruler remote operational mode test
 

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -224,8 +224,8 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 			)
 		}
 
-		relativeDuration := expectedResponse.elapsedTime - actualResponse.elapsedTime
-		proportionalDuration := expectedResponse.elapsedTime.Seconds() / actualResponse.elapsedTime.Seconds()
+		relativeDuration := actualResponse.elapsedTime - expectedResponse.elapsedTime
+		proportionalDuration := actualResponse.elapsedTime.Seconds() / expectedResponse.elapsedTime.Seconds()
 		p.metrics.relativeDuration.WithLabelValues(p.routeName).Observe(relativeDuration.Seconds())
 		p.metrics.proportionalDuration.WithLabelValues(p.routeName).Observe(proportionalDuration)
 		p.metrics.responsesComparedTotal.WithLabelValues(p.routeName, string(result)).Inc()

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -225,9 +225,9 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 		}
 
 		relativeDuration := actualResponse.elapsedTime - expectedResponse.elapsedTime
-		proportionalDuration := actualResponse.elapsedTime.Seconds() / expectedResponse.elapsedTime.Seconds()
+		proportionalDurationDifference := relativeDuration.Seconds() / expectedResponse.elapsedTime.Seconds()
 		p.metrics.relativeDuration.WithLabelValues(p.routeName).Observe(relativeDuration.Seconds())
-		p.metrics.proportionalDuration.WithLabelValues(p.routeName).Observe(proportionalDuration)
+		p.metrics.proportionalDuration.WithLabelValues(p.routeName).Observe(proportionalDurationDifference)
 		p.metrics.responsesComparedTotal.WithLabelValues(p.routeName, string(result)).Inc()
 	}
 }

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -454,16 +454,17 @@ func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
 		expectedProportionalSampleSum float64
 	}{
 		"secondary backend is faster than preferred": {
-			latencyPairs: []latencyPair{{
-				preferredResponseLatency: 3 * time.Second,
-				secondaryResponseLatency: 1 * time.Second,
-			}, {
-				preferredResponseLatency: 5 * time.Second,
-				secondaryResponseLatency: 2 * time.Second,
-			},
+			latencyPairs: []latencyPair{
+				{
+					preferredResponseLatency: 3 * time.Second,
+					secondaryResponseLatency: 1 * time.Second,
+				}, {
+					preferredResponseLatency: 5 * time.Second,
+					secondaryResponseLatency: 2 * time.Second,
+				},
 			},
 			expectedDurationSampleSum:     -5,
-			expectedProportionalSampleSum: 1.0/3 + 2.0/5,
+			expectedProportionalSampleSum: -2.0/3 + -3.0/5,
 		},
 		"preferred backend is 5 seconds faster than secondary": {
 			latencyPairs: []latencyPair{{
@@ -471,7 +472,7 @@ func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
 				secondaryResponseLatency: 7 * time.Second,
 			}},
 			expectedDurationSampleSum:     5,
-			expectedProportionalSampleSum: 7.0 / 2,
+			expectedProportionalSampleSum: 5.0 / 2,
 		},
 	}
 

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -462,17 +462,16 @@ func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
 				secondaryResponseLatency: 2 * time.Second,
 			},
 			},
-			expectedDurationSampleSum:     5,
-			expectedProportionalSampleSum: (3.0/1 + 5.0/2),
+			expectedDurationSampleSum:     -5,
+			expectedProportionalSampleSum: 1.0/3 + 2.0/5,
 		},
 		"preferred backend is 5 seconds faster than secondary": {
 			latencyPairs: []latencyPair{{
 				preferredResponseLatency: 2 * time.Second,
 				secondaryResponseLatency: 7 * time.Second,
-			},
-			},
-			expectedDurationSampleSum:     -5,
-			expectedProportionalSampleSum: (2.0 / 7),
+			}},
+			expectedDurationSampleSum:     5,
+			expectedProportionalSampleSum: 7.0 / 2,
 		},
 	}
 
@@ -511,12 +510,12 @@ func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
 			gotDuration := filterMetrics(got, []string{"cortex_querytee_backend_response_relative_duration_seconds"})
 			require.Equal(t, 1, len(gotDuration), "Expect only one metric after filtering")
 			require.Equal(t, uint64(len(scenario.latencyPairs)), gotDuration[0].Metric[0].Histogram.GetSampleCount())
-			require.Equal(t, scenario.expectedDurationSampleSum, gotDuration[0].Metric[0].Histogram.GetSampleSum())
+			require.InDelta(t, scenario.expectedDurationSampleSum, gotDuration[0].Metric[0].Histogram.GetSampleSum(), 1e-9)
 
 			gotProportional := filterMetrics(got, []string{"cortex_querytee_backend_response_relative_duration_proportional"})
 			require.Equal(t, 1, len(gotProportional), "Expect only one metric after filtering")
 			require.Equal(t, uint64(len(scenario.latencyPairs)), gotProportional[0].Metric[0].Histogram.GetSampleCount())
-			require.Equal(t, scenario.expectedProportionalSampleSum, gotProportional[0].Metric[0].Histogram.GetSampleSum())
+			require.InDelta(t, scenario.expectedProportionalSampleSum, gotProportional[0].Metric[0].Histogram.GetSampleSum(), 1e-9)
 		})
 	}
 }

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -48,13 +48,13 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 		relativeDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                   queryTeeMetricsNamespace,
 			Name:                        "backend_response_relative_duration_seconds",
-			Help:                        "Time (in seconds) of preferred backend less secondary backend.",
+			Help:                        "Time (in seconds) of secondary backend less preferred backend.",
 			NativeHistogramBucketFactor: 1.1,
 		}, []string{"route"}),
 		proportionalDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                   queryTeeMetricsNamespace,
 			Name:                        "backend_response_relative_duration_proportional",
-			Help:                        "Response time of preferred backend, as a proportion of secondary backend response time.",
+			Help:                        "Response time of secondary backend, as a proportion of preferred backend response time.",
 			NativeHistogramBucketFactor: 1.1,
 		}, []string{"route"}),
 	}

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -49,13 +49,13 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 			Namespace:                   queryTeeMetricsNamespace,
 			Name:                        "backend_response_relative_duration_seconds",
 			Help:                        "Time (in seconds) of preferred backend less secondary backend.",
-			NativeHistogramBucketFactor: 2,
+			NativeHistogramBucketFactor: 1.1,
 		}, []string{"route"}),
 		proportionalDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                   queryTeeMetricsNamespace,
 			Name:                        "backend_response_relative_duration_proportional",
 			Help:                        "Response time of preferred backend, as a proportion of secondary backend response time.",
-			NativeHistogramBucketFactor: 2,
+			NativeHistogramBucketFactor: 1.1,
 		}, []string{"route"}),
 	}
 

--- a/tools/querytee/proxy_metrics.go
+++ b/tools/querytee/proxy_metrics.go
@@ -54,7 +54,7 @@ func NewProxyMetrics(registerer prometheus.Registerer) *ProxyMetrics {
 		proportionalDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                   queryTeeMetricsNamespace,
 			Name:                        "backend_response_relative_duration_proportional",
-			Help:                        "Response time of secondary backend, as a proportion of preferred backend response time.",
+			Help:                        "Response time of secondary backend less preferred backend, as a proportion of preferred backend response time.",
 			NativeHistogramBucketFactor: 1.1,
 		}, []string{"route"}),
 	}


### PR DESCRIPTION
#### What this PR does

This PR makes a number of small improvements to query-tee:

* it reduces the bucket factor of the native histogram metrics introduced in #7782 to give finer granularity
* it flips the meaning of the metrics introduced in #7782 to make them easier to reason about - I find these easier to think about this way around, as "secondary response time was 102% of preferred response time" or "secondary response time was 0.2s slower than preferred"
* it modifies `backend_response_relative_duration_proportional` to report the proportional difference, rather than just the proportional duration, as this gives values closer to 0 and therefore higher resolution

Each of these changes is in its own commit, and I suggest reviewing each commit separately.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
