### PR TITLE
Distributor: improve error handling in otlp and push handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 * [CHANGE] Added new metric `cortex_compactor_disk_out_of_space_errors_total` which counts how many times a compaction failed due to the compactor being out of disk. #8237
 * [CHANGE] Anonymous usage statistics tracking: report active series in addition to in-memory series. #8279
 * [CHANGE] Ruler: `evaluation_delay` field in the rule group configuration has been deprecated. Please use `query_offset` instead (it has the same exact meaning and behaviour). #8295
-* [CHANGE] Distributor: `distributor.Push()` errors with error cause `mimirpb.BAD_DATA` are now mapped to gRPC status code `codes.InvalidArgument` instead of `codes.FailedPrecondition`.
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
@@ -429,10 +428,6 @@
 * [CHANGE] Ingester: changed the default value for the experimental configuration parameter `-blocks-storage.tsdb.early-head-compaction-min-estimated-series-reduction-percentage` from 10 to 15. #6186
 * [CHANGE] Ingester: `/ingester/push` HTTP endpoint has been removed. This endpoint was added for testing and troubleshooting, but was never documented or used for anything. #6299
 * [CHANGE] Experimental setting `-log.rate-limit-logs-per-second-burst` renamed to `-log.rate-limit-logs-burst-size`. #6230
-* [CHANGE] Distributor: instead of errors with HTTP status codes, `Push()` now returns errors with gRPC codes: #6377
-  * `http.StatusAccepted` (202) code is replaced with `codes.AlreadyExists`.
-  * `http.BadRequest` (400) code is replaced with `codes.FailedPrecondition`.
-  * `http.StatusTooManyRequests` (429) and the non-standard `529` (The service is overloaded) codes are replaced with `codes.ResourceExhausted`.
 * [CHANGE] Ingester: by setting the newly introduced experimental CLI flag `-ingester.return-only-grpc-errors` to true, ingester will return only gRPC errors. This feature changes the following status codes: #6443 #6680 #6723
   * `http.StatusBadRequest` (400) is replaced with `codes.FailedPrecondition` on the write path.
   * `http.StatusServiceUnavailable` (503) is replaced with `codes.Internal` on the write path, and with `codes.ResourceExhausted` on the read path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,11 +53,11 @@
 * [ENHANCEMENT] OTLP: Speed up conversion from OTel to Mimir format by about 8% and reduce memory consumption by about 30%. Can be disabled via `-distributor.direct-otlp-translation-enabled=false` #7957
 * [ENHANCEMENT] Ingester/Querier: Optimise regexps with long lists of alternates. #8221, #8234
 * [ENHANCEMENT] Ingester: Include more detail in tracing of queries. #8242
-* [EHNAHCEMENT] Distributor: add `insight=true` to remote-write and OTLP write handlers when the HTTP response status code is 4xx. #8294
+* [ENHANCEMENT] Distributor: add `insight=true` to remote-write and OTLP write handlers when the HTTP response status code is 4xx. #8294
 * [ENHANCEMENT] Ingester: reduce locked time while matching postings for a label, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Ingester: reduce the amount of locks taken during the Head compaction's garbage-collection process, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326
-* [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324
+* [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567
 * [BUGFIX] Querier, store-gateway: Protect against panics raised during snappy encoding. #7520

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [CHANGE] Added new metric `cortex_compactor_disk_out_of_space_errors_total` which counts how many times a compaction failed due to the compactor being out of disk. #8237
 * [CHANGE] Anonymous usage statistics tracking: report active series in addition to in-memory series. #8279
 * [CHANGE] Ruler: `evaluation_delay` field in the rule group configuration has been deprecated. Please use `query_offset` instead (it has the same exact meaning and behaviour). #8295
+* [CHANGE] Distributor: `distributor.Push()` errors with error cause `mimirpb.BAD_DATA` are now mapped to gRPC status code `codes.InvalidArgument` instead of `codes.FailedPrecondition`.
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1414,7 +1414,7 @@ func (d *Distributor) handlePushError(ctx context.Context, pushErr error) error 
 	if err == nil {
 		serviceOverloadErrorEnabled = d.limits.ServiceOverloadStatusCodeOnRateLimitEnabled(userID)
 	}
-	return toGRPCError(pushErr, serviceOverloadErrorEnabled)
+	return toErrorWithGRPCStatus(pushErr, serviceOverloadErrorEnabled)
 }
 
 // push takes a write request and distributes it to ingesters using the ring.

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -305,7 +305,7 @@ func TestDistributor_Push_ShouldReturnErrorMappedTo4xxStatusCodeIfWriteRequestCo
 		// We expect a gRPC error.
 		errStatus, ok := grpcutil.ErrorToStatus(err)
 		require.True(t, ok)
-		assert.Equal(t, codes.FailedPrecondition, errStatus.Code())
+		assert.Equal(t, codes.InvalidArgument, errStatus.Code())
 		assert.ErrorContains(t, errStatus.Err(), ingest.ErrWriteRequestDataItemTooLarge.Error())
 
 		// We expect the gRPC error to be detected as client error.

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -285,6 +285,9 @@ func TestDistributor_Push_ShouldReturnErrorMappedTo4xxStatusCodeIfWriteRequestCo
 	limits := prepareDefaultLimits()
 	limits.MaxLabelValueLength = hugeLabelValueLength
 
+	overrides, err := validation.NewOverrides(*limits, nil)
+	require.NoError(t, err)
+
 	testConfig := prepConfig{
 		numDistributors:         1,
 		ingestStorageEnabled:    true,
@@ -321,7 +324,7 @@ func TestDistributor_Push_ShouldReturnErrorMappedTo4xxStatusCodeIfWriteRequestCo
 		sourceIPs, _ := middleware.NewSourceIPs("SomeField", "(.*)", false)
 
 		// Send write request through the HTTP handler.
-		h := Handler(maxRecvMsgSize, nil, sourceIPs, false, nil, RetryConfig{}, distributors[0].PushWithMiddlewares, nil, log.NewNopLogger())
+		h := Handler(maxRecvMsgSize, nil, sourceIPs, false, overrides, RetryConfig{}, distributors[0].PushWithMiddlewares, nil, log.NewNopLogger())
 		h.ServeHTTP(resp, createRequest(t, marshalledReq))
 		assert.Equal(t, http.StatusBadRequest, resp.Code)
 	})

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -7552,9 +7552,9 @@ func TestHandlePushError(t *testing.T) {
 			pushError:          httpGrpc5xxErr,
 			expectedOtherError: httpGrpc5xxErr,
 		},
-		"an Error gives the error returned by toGRPCError()": {
+		"an Error gives the error returned by toErrorWithGRPCStatus()": {
 			pushError:         mockDistributorErr(testErrorMsg),
-			expectedGRPCError: status.Convert(toGRPCError(mockDistributorErr(testErrorMsg), false)),
+			expectedGRPCError: status.Convert(toErrorWithGRPCStatus(mockDistributorErr(testErrorMsg), false)),
 		},
 		"a random error without status gives an Internal gRPC error": {
 			pushError:         errWithUserID,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1005,7 +1005,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 			testReplica:     "instance1234567890123456789012345678901234567890",
 			cluster:         "cluster0",
 			samples:         5,
-			expectedError:   status.New(codes.FailedPrecondition, fmt.Sprintf(labelValueTooLongMsgFormat, "__replica__", "instance1234567890123456789012345678901234567890", mimirpb.FromLabelAdaptersToString(labelSetGenWithReplicaAndCluster("instance1234567890123456789012345678901234567890", "cluster0")(0)))),
+			expectedError:   status.New(codes.InvalidArgument, fmt.Sprintf(labelValueTooLongMsgFormat, "__replica__", "instance1234567890123456789012345678901234567890", mimirpb.FromLabelAdaptersToString(labelSetGenWithReplicaAndCluster("instance1234567890123456789012345678901234567890", "cluster0")(0)))),
 			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.BAD_DATA},
 		},
 	} {
@@ -1528,14 +1528,14 @@ func TestDistributor_Push_HistogramValidation(t *testing.T) {
 		},
 		"too new histogram": {
 			req:         makeWriteRequestHistogram([]string{model.MetricNameLabel, "test"}, math.MaxInt64, generateTestHistogram(0)),
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(sampleTimestampTooNewMsgFormat, math.MaxInt64, "test")),
+			expectedErr: status.New(codes.InvalidArgument, fmt.Sprintf(sampleTimestampTooNewMsgFormat, math.MaxInt64, "test")),
 		},
 		"valid float histogram": {
 			req: makeWriteRequestFloatHistogram([]string{model.MetricNameLabel, "test"}, 1000, generateTestFloatHistogram(0)),
 		},
 		"too new float histogram": {
 			req:         makeWriteRequestFloatHistogram([]string{model.MetricNameLabel, "test"}, math.MaxInt64, generateTestFloatHistogram(0)),
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(sampleTimestampTooNewMsgFormat, math.MaxInt64, "test")),
+			expectedErr: status.New(codes.InvalidArgument, fmt.Sprintf(sampleTimestampTooNewMsgFormat, math.MaxInt64, "test")),
 		},
 		"buckets at limit": {
 			req:         makeWriteRequestFloatHistogram([]string{model.MetricNameLabel, "test"}, 1000, testHistogram),
@@ -1546,7 +1546,7 @@ func TestDistributor_Push_HistogramValidation(t *testing.T) {
 			bucketLimit: 7,
 			errMsg:      "received a native histogram sample with too many buckets, timestamp",
 			errID:       globalerror.MaxNativeHistogramBuckets,
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(maxNativeHistogramBucketsMsgFormat, 1000, "test", 8, 7)),
+			expectedErr: status.New(codes.InvalidArgument, fmt.Sprintf(maxNativeHistogramBucketsMsgFormat, 1000, "test", 8, 7)),
 		},
 	}
 
@@ -6797,7 +6797,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(future),
 				Value:       4,
 			}},
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(sampleTimestampTooNewMsgFormat, future, "testmetric")),
+			expectedErr: status.New(codes.InvalidArgument, fmt.Sprintf(sampleTimestampTooNewMsgFormat, future, "testmetric")),
 		},
 
 		"validation does not fail for samples from the past without past_grace_period setting": {
@@ -6809,7 +6809,7 @@ func TestDistributorValidation(t *testing.T) {
 			labels:      [][]mimirpb.LabelAdapter{{{Name: labels.MetricName, Value: "testmetric"}, {Name: "foo", Value: "bar"}}},
 			samples:     []mimirpb.Sample{{TimestampMs: int64(past), Value: 4}},
 			limits:      func(limits *validation.Limits) { limits.PastGracePeriod = model.Duration(now.Sub(past) / 2) },
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(sampleTimestampTooOldMsgFormat, past, "testmetric")),
+			expectedErr: status.New(codes.InvalidArgument, fmt.Sprintf(sampleTimestampTooOldMsgFormat, past, "testmetric")),
 		},
 
 		"exceeds maximum labels per series": {
@@ -6818,7 +6818,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(now),
 				Value:       2,
 			}},
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(tooManyLabelsMsgFormat, 3, 2, `testmetric{foo="bar", foo2="bar2"}`, "")),
+			expectedErr: status.New(codes.InvalidArgument, fmt.Sprintf(tooManyLabelsMsgFormat, 3, 2, `testmetric{foo="bar", foo2="bar2"}`, "")),
 		},
 		"exceeds maximum labels per series with a metric that exceeds 200 characters when formatted": {
 			labels: [][]mimirpb.LabelAdapter{{
@@ -6832,7 +6832,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(now),
 				Value:       2,
 			}},
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(tooManyLabelsMsgFormat, 5, 2, `testmetric{foo-with-a-long-long-label="bar-with-a-long-long-value", foo2-with-a-long-long-label="bar2-with-a-long-long-value", foo3-with-a-long-long-label="bar3-with-a-long-long-value", foo4-with-a-lo`, "…")),
+			expectedErr: status.New(codes.InvalidArgument, fmt.Sprintf(tooManyLabelsMsgFormat, 5, 2, `testmetric{foo-with-a-long-long-label="bar-with-a-long-long-value", foo2-with-a-long-long-label="bar2-with-a-long-long-value", foo3-with-a-long-long-label="bar3-with-a-long-long-value", foo4-with-a-lo`, "…")),
 		},
 		"exceeds maximum labels per series with a metric that exceeds 200 bytes when formatted": {
 			labels: [][]mimirpb.LabelAdapter{{
@@ -6844,7 +6844,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(now),
 				Value:       2,
 			}},
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(tooManyLabelsMsgFormat, 3, 2, `testmetric{families="👩\u200d👦👨\u200d👧👨\u200d👩\u200d👧👩\u200d👧👩\u200d👩\u200d👦\u200d👦👨\u200d👩\u200d👧\u200d👦👨\u200d👧\u200d👦👨\u200d👩\u200d👦👪👨\u200d👦👨\u200d👦\u200d👦👨\u200d👨\u200d👧👨\u200d👧\u200d👧", foo="b"}`, "")),
+			expectedErr: status.New(codes.InvalidArgument, fmt.Sprintf(tooManyLabelsMsgFormat, 3, 2, `testmetric{families="👩\u200d👦👨\u200d👧👨\u200d👩\u200d👧👩\u200d👧👩\u200d👩\u200d👦\u200d👦👨\u200d👩\u200d👧\u200d👦👨\u200d👧\u200d👦👨\u200d👩\u200d👦👪👨\u200d👦👨\u200d👦\u200d👦👨\u200d👨\u200d👧👨\u200d👧\u200d👧", foo="b"}`, "")),
 		},
 		"multiple validation failures should return the first failure": {
 			labels: [][]mimirpb.LabelAdapter{
@@ -6855,7 +6855,7 @@ func TestDistributorValidation(t *testing.T) {
 				{TimestampMs: int64(now), Value: 2},
 				{TimestampMs: int64(past), Value: 2},
 			},
-			expectedErr: status.New(codes.FailedPrecondition, fmt.Sprintf(tooManyLabelsMsgFormat, 3, 2, `testmetric{foo="bar", foo2="bar2"}`, "")),
+			expectedErr: status.New(codes.InvalidArgument, fmt.Sprintf(tooManyLabelsMsgFormat, 3, 2, `testmetric{foo="bar", foo2="bar2"}`, "")),
 		},
 		"metadata validation failure": {
 			metadata: []*mimirpb.MetricMetadata{{MetricFamilyName: "", Help: "a test metric.", Unit: "", Type: mimirpb.COUNTER}},
@@ -6864,7 +6864,7 @@ func TestDistributorValidation(t *testing.T) {
 				TimestampMs: int64(now),
 				Value:       1,
 			}},
-			expectedErr: status.New(codes.FailedPrecondition, metadataMetricNameMissingMsgFormat),
+			expectedErr: status.New(codes.InvalidArgument, metadataMetricNameMissingMsgFormat),
 		},
 		// Validation passes for empty exemplar labels, since we just want to skip the exemplars and not fail the time series as a whole.
 		"empty exemplar labels": {

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -274,9 +274,8 @@ func toGRPCStatusCode(errCause mimirpb.ErrorCause, serviceOverloadErrorEnabled b
 	case mimirpb.INGESTION_RATE_LIMITED, mimirpb.REQUEST_RATE_LIMITED:
 		if serviceOverloadErrorEnabled {
 			return codes.Unavailable
-		} else {
-			return codes.ResourceExhausted
 		}
+		return codes.ResourceExhausted
 	case mimirpb.REPLICAS_DID_NOT_MATCH:
 		return codes.AlreadyExists
 	case mimirpb.TOO_MANY_CLUSTERS:

--- a/pkg/distributor/errors_test.go
+++ b/pkg/distributor/errors_test.go
@@ -611,15 +611,15 @@ func TestErrorCauseToGRPCStatusCode(t *testing.T) {
 		expectedGRPCStatusCode      codes.Code
 	}
 	testCases := map[string]testStruct{
-		"an REPLICAS_DID_NOT_MATCH error cause gets translated into an AlreadyExist": {
+		"a REPLICAS_DID_NOT_MATCH error cause gets translated into an AlreadyExists": {
 			errorCause:             mimirpb.REPLICAS_DID_NOT_MATCH,
 			expectedGRPCStatusCode: codes.AlreadyExists,
 		},
-		"an TOO_MANY_CLUSTERS error cause gets translated into a FailedPrecondition": {
+		"a TOO_MANY_CLUSTERS error cause gets translated into a FailedPrecondition": {
 			errorCause:             mimirpb.TOO_MANY_CLUSTERS,
 			expectedGRPCStatusCode: codes.FailedPrecondition,
 		},
-		"an BAD_DATA error cause gets translated into a InvalidArgument": {
+		"a BAD_DATA error cause gets translated into a InvalidArgument": {
 			errorCause:             mimirpb.BAD_DATA,
 			expectedGRPCStatusCode: codes.InvalidArgument,
 		},
@@ -633,12 +633,12 @@ func TestErrorCauseToGRPCStatusCode(t *testing.T) {
 			serviceOverloadErrorEnabled: true,
 			expectedGRPCStatusCode:      codes.Unavailable,
 		},
-		"an REQUEST_RATE_LIMITED error cause without serviceOverloadErrorEnabled gets translated into a ResourceExhausted": {
+		"a REQUEST_RATE_LIMITED error cause without serviceOverloadErrorEnabled gets translated into a ResourceExhausted": {
 			errorCause:                  mimirpb.REQUEST_RATE_LIMITED,
 			serviceOverloadErrorEnabled: false,
 			expectedGRPCStatusCode:      codes.ResourceExhausted,
 		},
-		"an REQUEST_RATE_LIMITED error cause with serviceOverloadErrorEnabled gets translated into an Unavailable": {
+		"a REQUEST_RATE_LIMITED error cause with serviceOverloadErrorEnabled gets translated into an Unavailable": {
 			errorCause:                  mimirpb.REQUEST_RATE_LIMITED,
 			serviceOverloadErrorEnabled: true,
 			expectedGRPCStatusCode:      codes.Unavailable,
@@ -651,23 +651,23 @@ func TestErrorCauseToGRPCStatusCode(t *testing.T) {
 			errorCause:             mimirpb.INSTANCE_LIMIT,
 			expectedGRPCStatusCode: codes.Internal,
 		},
-		"an SERVICE_UNAVAILABLE error cause gets translated into an Internal": {
+		"a SERVICE_UNAVAILABLE error cause gets translated into an Internal": {
 			errorCause:             mimirpb.SERVICE_UNAVAILABLE,
 			expectedGRPCStatusCode: codes.Internal,
 		},
-		"an TOO_BUSY error cause gets translated into an Internal": {
+		"a TOO_BUSY error cause gets translated into an Internal": {
 			errorCause:             mimirpb.TOO_BUSY,
 			expectedGRPCStatusCode: codes.Internal,
 		},
-		"an CIRCUIT_BREAKER_OPEN error cause gets translated into an Unavailable": {
+		"a CIRCUIT_BREAKER_OPEN error cause gets translated into an Unavailable": {
 			errorCause:             mimirpb.CIRCUIT_BREAKER_OPEN,
 			expectedGRPCStatusCode: codes.Unavailable,
 		},
-		"an METHOD_NOT_ALLOWED error cause gets translated into an Unimplemented": {
+		"a METHOD_NOT_ALLOWED error cause gets translated into an Unimplemented": {
 			errorCause:             mimirpb.METHOD_NOT_ALLOWED,
 			expectedGRPCStatusCode: codes.Unimplemented,
 		},
-		"an TSDB_UNAVAILABLE error cause gets translated into an Internal": {
+		"a TSDB_UNAVAILABLE error cause gets translated into an Internal": {
 			errorCause:             mimirpb.TSDB_UNAVAILABLE,
 			expectedGRPCStatusCode: codes.Internal,
 		},
@@ -687,15 +687,15 @@ func TestErrorCauseToHTTPStatusCode(t *testing.T) {
 		expectedHTTPStatus          int
 	}
 	testCases := map[string]testStruct{
-		"an REPLICAS_DID_NOT_MATCH error cause gets translated into a HTTP 202": {
+		"a REPLICAS_DID_NOT_MATCH error cause gets translated into a HTTP 202": {
 			errorCause:         mimirpb.REPLICAS_DID_NOT_MATCH,
 			expectedHTTPStatus: http.StatusAccepted,
 		},
-		"an TOO_MANY_CLUSTERS error cause gets translated into a HTTP 400": {
+		"a TOO_MANY_CLUSTERS error cause gets translated into a HTTP 400": {
 			errorCause:         mimirpb.TOO_MANY_CLUSTERS,
 			expectedHTTPStatus: http.StatusBadRequest,
 		},
-		"an BAD_DATA error cause gets translated into a HTTP 400": {
+		"a BAD_DATA error cause gets translated into a HTTP 400": {
 			errorCause:         mimirpb.BAD_DATA,
 			expectedHTTPStatus: http.StatusBadRequest,
 		},
@@ -709,12 +709,12 @@ func TestErrorCauseToHTTPStatusCode(t *testing.T) {
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
 		},
-		"an REQUEST_RATE_LIMITED error cause without serviceOverloadErrorEnabled gets translated into a HTTP 429": {
+		"a REQUEST_RATE_LIMITED error cause without serviceOverloadErrorEnabled gets translated into a HTTP 429": {
 			errorCause:                  mimirpb.REQUEST_RATE_LIMITED,
 			serviceOverloadErrorEnabled: false,
 			expectedHTTPStatus:          http.StatusTooManyRequests,
 		},
-		"an REQUEST_RATE_LIMITED error cause with serviceOverloadErrorEnabled gets translated into a HTTP 529": {
+		"a REQUEST_RATE_LIMITED error cause with serviceOverloadErrorEnabled gets translated into a HTTP 529": {
 			errorCause:                  mimirpb.REQUEST_RATE_LIMITED,
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
@@ -727,23 +727,23 @@ func TestErrorCauseToHTTPStatusCode(t *testing.T) {
 			errorCause:         mimirpb.INSTANCE_LIMIT,
 			expectedHTTPStatus: http.StatusInternalServerError,
 		},
-		"an SERVICE_UNAVAILABLE error cause gets translated into a HTTP 500": {
+		"a SERVICE_UNAVAILABLE error cause gets translated into a HTTP 500": {
 			errorCause:         mimirpb.SERVICE_UNAVAILABLE,
 			expectedHTTPStatus: http.StatusInternalServerError,
 		},
-		"an TOO_BUSY error cause gets translated into a HTTP 500": {
+		"a TOO_BUSY error cause gets translated into a HTTP 500": {
 			errorCause:         mimirpb.TOO_BUSY,
 			expectedHTTPStatus: http.StatusInternalServerError,
 		},
-		"an CIRCUIT_BREAKER_OPEN error cause gets translated into a HTTP 500": {
-			errorCause:         mimirpb.CIRCUIT_BREAKER_OPEN,
-			expectedHTTPStatus: http.StatusServiceUnavailable,
-		},
-		"an METHOD_NOT_ALLOWED error cause gets translated into a HTTP 501": {
+		"a METHOD_NOT_ALLOWED error cause gets translated into a HTTP 501": {
 			errorCause:         mimirpb.METHOD_NOT_ALLOWED,
 			expectedHTTPStatus: http.StatusNotImplemented,
 		},
-		"an TSDB_UNAVAILABLE error cause gets translated into a HTTP 503": {
+		"a CIRCUIT_BREAKER_OPEN error cause gets translated into a HTTP 503": {
+			errorCause:         mimirpb.CIRCUIT_BREAKER_OPEN,
+			expectedHTTPStatus: http.StatusServiceUnavailable,
+		},
+		"a TSDB_UNAVAILABLE error cause gets translated into a HTTP 503": {
 			errorCause:         mimirpb.TSDB_UNAVAILABLE,
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 		},

--- a/pkg/distributor/errors_test.go
+++ b/pkg/distributor/errors_test.go
@@ -253,39 +253,39 @@ func TestToErrorWithGRPCStatus(t *testing.T) {
 			expectedErrorMsg:     tooManyClustersErr.Error(),
 			expectedErrorDetails: &mimirpb.ErrorDetails{Cause: mimirpb.TOO_MANY_CLUSTERS},
 		},
-		"a validationError gets translated into gets translated into an InvalidArgument error with BAD_DATA cause": {
+		"a validationError gets translated into an InvalidArgument error with BAD_DATA cause": {
 			err:                  newValidationError(originalErr),
 			expectedGRPCCode:     codes.InvalidArgument,
 			expectedErrorMsg:     originalMsg,
 			expectedErrorDetails: &mimirpb.ErrorDetails{Cause: mimirpb.BAD_DATA},
 		},
-		"a DoNotLogError of a validationError gets translated into gets translated into an InvalidArgument error with BAD_DATA cause": {
+		"a DoNotLogError of a validationError gets translated into an InvalidArgument error with BAD_DATA cause": {
 			err:                  middleware.DoNotLogError{Err: newValidationError(originalErr)},
 			expectedGRPCCode:     codes.InvalidArgument,
 			expectedErrorMsg:     originalMsg,
 			expectedErrorDetails: &mimirpb.ErrorDetails{Cause: mimirpb.BAD_DATA},
 		},
-		"an ingestionRateLimitedError with serviceOverloadErrorEnabled gets translated into gets translated into an Unavailable error with INGESTION_RATE_LIMITED cause": {
+		"an ingestionRateLimitedError with serviceOverloadErrorEnabled gets translated into an Unavailable error with INGESTION_RATE_LIMITED cause": {
 			err:                         ingestionRateLimitedErr,
 			serviceOverloadErrorEnabled: true,
 			expectedGRPCCode:            codes.Unavailable,
 			expectedErrorMsg:            ingestionRateLimitedErr.Error(),
 			expectedErrorDetails:        &mimirpb.ErrorDetails{Cause: mimirpb.INGESTION_RATE_LIMITED},
 		},
-		"a DoNotLogError of an ingestionRateLimitedError with serviceOverloadErrorEnabled gets translated into gets translated into an Unavailable error with INGESTION_RATE_LIMITED cause": {
+		"a DoNotLogError of an ingestionRateLimitedError with serviceOverloadErrorEnabled gets translated into an Unavailable error with INGESTION_RATE_LIMITED cause": {
 			err:                         middleware.DoNotLogError{Err: ingestionRateLimitedErr},
 			serviceOverloadErrorEnabled: true,
 			expectedGRPCCode:            codes.Unavailable,
 			expectedErrorMsg:            ingestionRateLimitedErr.Error(),
 			expectedErrorDetails:        &mimirpb.ErrorDetails{Cause: mimirpb.INGESTION_RATE_LIMITED},
 		},
-		"an ingestionRateLimitedError without serviceOverloadErrorEnabled gets translated into gets translated into a ResourceExhausted error with INGESTION_RATE_LIMITED cause": {
+		"an ingestionRateLimitedError without serviceOverloadErrorEnabled gets translated into a ResourceExhausted error with INGESTION_RATE_LIMITED cause": {
 			err:                  ingestionRateLimitedErr,
 			expectedGRPCCode:     codes.ResourceExhausted,
 			expectedErrorMsg:     ingestionRateLimitedErr.Error(),
 			expectedErrorDetails: &mimirpb.ErrorDetails{Cause: mimirpb.INGESTION_RATE_LIMITED},
 		},
-		"a DoNotLogError of an ingestionRateLimitedError without serviceOverloadErrorEnabled gets translated into gets translated into a ResourceExhausted error with INGESTION_RATE_LIMITED cause": {
+		"a DoNotLogError of an ingestionRateLimitedError without serviceOverloadErrorEnabled gets translated into a ResourceExhausted error with INGESTION_RATE_LIMITED cause": {
 			err:                  middleware.DoNotLogError{Err: ingestionRateLimitedErr},
 			expectedGRPCCode:     codes.ResourceExhausted,
 			expectedErrorMsg:     ingestionRateLimitedErr.Error(),
@@ -600,6 +600,158 @@ func TestIsIngestionClientError(t *testing.T) {
 	for testName, testData := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			require.Equal(t, testData.expectedOutcome, isIngestionClientError(testData.err))
+		})
+	}
+}
+
+func TestErrorCauseToGRPCStatusCode(t *testing.T) {
+	type testStruct struct {
+		errorCause                  mimirpb.ErrorCause
+		serviceOverloadErrorEnabled bool
+		expectedGRPCStatusCode      codes.Code
+	}
+	testCases := map[string]testStruct{
+		"an REPLICAS_DID_NOT_MATCH error cause gets translated into an AlreadyExist": {
+			errorCause:             mimirpb.REPLICAS_DID_NOT_MATCH,
+			expectedGRPCStatusCode: codes.AlreadyExists,
+		},
+		"an TOO_MANY_CLUSTERS error cause gets translated into a FailedPrecondition": {
+			errorCause:             mimirpb.TOO_MANY_CLUSTERS,
+			expectedGRPCStatusCode: codes.FailedPrecondition,
+		},
+		"an BAD_DATA error cause gets translated into a InvalidArgument": {
+			errorCause:             mimirpb.BAD_DATA,
+			expectedGRPCStatusCode: codes.InvalidArgument,
+		},
+		"an INGESTION_RATE_LIMITED error cause without serviceOverloadErrorEnabled gets translated into a ResourceExhausted": {
+			errorCause:                  mimirpb.INGESTION_RATE_LIMITED,
+			serviceOverloadErrorEnabled: false,
+			expectedGRPCStatusCode:      codes.ResourceExhausted,
+		},
+		"an INGESTION_RATE_LIMITED error cause with serviceOverloadErrorEnabled gets translated into an Unavailable": {
+			errorCause:                  mimirpb.INGESTION_RATE_LIMITED,
+			serviceOverloadErrorEnabled: true,
+			expectedGRPCStatusCode:      codes.Unavailable,
+		},
+		"an REQUEST_RATE_LIMITED error cause without serviceOverloadErrorEnabled gets translated into a ResourceExhausted": {
+			errorCause:                  mimirpb.REQUEST_RATE_LIMITED,
+			serviceOverloadErrorEnabled: false,
+			expectedGRPCStatusCode:      codes.ResourceExhausted,
+		},
+		"an REQUEST_RATE_LIMITED error cause with serviceOverloadErrorEnabled gets translated into an Unavailable": {
+			errorCause:                  mimirpb.REQUEST_RATE_LIMITED,
+			serviceOverloadErrorEnabled: true,
+			expectedGRPCStatusCode:      codes.Unavailable,
+		},
+		"an UNKNOWN error cause gets translated into an Internal": {
+			errorCause:             mimirpb.UNKNOWN_CAUSE,
+			expectedGRPCStatusCode: codes.Internal,
+		},
+		"an INSTANCE_LIMIT error cause gets translated into an Internal": {
+			errorCause:             mimirpb.INSTANCE_LIMIT,
+			expectedGRPCStatusCode: codes.Internal,
+		},
+		"an SERVICE_UNAVAILABLE error cause gets translated into an Internal": {
+			errorCause:             mimirpb.SERVICE_UNAVAILABLE,
+			expectedGRPCStatusCode: codes.Internal,
+		},
+		"an TOO_BUSY error cause gets translated into an Internal": {
+			errorCause:             mimirpb.TOO_BUSY,
+			expectedGRPCStatusCode: codes.Internal,
+		},
+		"an CIRCUIT_BREAKER_OPEN error cause gets translated into an Unavailable": {
+			errorCause:             mimirpb.CIRCUIT_BREAKER_OPEN,
+			expectedGRPCStatusCode: codes.Unavailable,
+		},
+		"an METHOD_NOT_ALLOWED error cause gets translated into an Unimplemented": {
+			errorCause:             mimirpb.METHOD_NOT_ALLOWED,
+			expectedGRPCStatusCode: codes.Unimplemented,
+		},
+		"an TSDB_UNAVAILABLE error cause gets translated into an Internal": {
+			errorCause:             mimirpb.TSDB_UNAVAILABLE,
+			expectedGRPCStatusCode: codes.Internal,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			status := errorCauseToGRPCStatusCode(tc.errorCause, tc.serviceOverloadErrorEnabled)
+			assert.Equal(t, tc.expectedGRPCStatusCode, status)
+		})
+	}
+}
+
+func TestErrorCauseToHTTPStatusCode(t *testing.T) {
+	type testStruct struct {
+		errorCause                  mimirpb.ErrorCause
+		serviceOverloadErrorEnabled bool
+		expectedHTTPStatus          int
+	}
+	testCases := map[string]testStruct{
+		"an REPLICAS_DID_NOT_MATCH error cause gets translated into a HTTP 202": {
+			errorCause:         mimirpb.REPLICAS_DID_NOT_MATCH,
+			expectedHTTPStatus: http.StatusAccepted,
+		},
+		"an TOO_MANY_CLUSTERS error cause gets translated into a HTTP 400": {
+			errorCause:         mimirpb.TOO_MANY_CLUSTERS,
+			expectedHTTPStatus: http.StatusBadRequest,
+		},
+		"an BAD_DATA error cause gets translated into a HTTP 400": {
+			errorCause:         mimirpb.BAD_DATA,
+			expectedHTTPStatus: http.StatusBadRequest,
+		},
+		"an INGESTION_RATE_LIMITED error cause without serviceOverloadErrorEnabled gets translated into a HTTP 429": {
+			errorCause:                  mimirpb.INGESTION_RATE_LIMITED,
+			serviceOverloadErrorEnabled: false,
+			expectedHTTPStatus:          http.StatusTooManyRequests,
+		},
+		"an INGESTION_RATE_LIMITED error cause with serviceOverloadErrorEnabled gets translated into a HTTP 529": {
+			errorCause:                  mimirpb.INGESTION_RATE_LIMITED,
+			serviceOverloadErrorEnabled: true,
+			expectedHTTPStatus:          StatusServiceOverloaded,
+		},
+		"an REQUEST_RATE_LIMITED error cause without serviceOverloadErrorEnabled gets translated into a HTTP 429": {
+			errorCause:                  mimirpb.REQUEST_RATE_LIMITED,
+			serviceOverloadErrorEnabled: false,
+			expectedHTTPStatus:          http.StatusTooManyRequests,
+		},
+		"an REQUEST_RATE_LIMITED error cause with serviceOverloadErrorEnabled gets translated into a HTTP 529": {
+			errorCause:                  mimirpb.REQUEST_RATE_LIMITED,
+			serviceOverloadErrorEnabled: true,
+			expectedHTTPStatus:          StatusServiceOverloaded,
+		},
+		"an UNKNOWN error cause gets translated into a HTTP 500": {
+			errorCause:         mimirpb.UNKNOWN_CAUSE,
+			expectedHTTPStatus: http.StatusInternalServerError,
+		},
+		"an INSTANCE_LIMIT error cause gets translated into a HTTP 500": {
+			errorCause:         mimirpb.INSTANCE_LIMIT,
+			expectedHTTPStatus: http.StatusInternalServerError,
+		},
+		"an SERVICE_UNAVAILABLE error cause gets translated into a HTTP 500": {
+			errorCause:         mimirpb.SERVICE_UNAVAILABLE,
+			expectedHTTPStatus: http.StatusInternalServerError,
+		},
+		"an TOO_BUSY error cause gets translated into a HTTP 500": {
+			errorCause:         mimirpb.TOO_BUSY,
+			expectedHTTPStatus: http.StatusInternalServerError,
+		},
+		"an CIRCUIT_BREAKER_OPEN error cause gets translated into a HTTP 500": {
+			errorCause:         mimirpb.CIRCUIT_BREAKER_OPEN,
+			expectedHTTPStatus: http.StatusServiceUnavailable,
+		},
+		"an METHOD_NOT_ALLOWED error cause gets translated into a HTTP 501": {
+			errorCause:         mimirpb.METHOD_NOT_ALLOWED,
+			expectedHTTPStatus: http.StatusNotImplemented,
+		},
+		"an TSDB_UNAVAILABLE error cause gets translated into a HTTP 503": {
+			errorCause:         mimirpb.TSDB_UNAVAILABLE,
+			expectedHTTPStatus: http.StatusServiceUnavailable,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			status := errorCauseToHTTPStatusCode(tc.errorCause, tc.serviceOverloadErrorEnabled)
+			assert.Equal(t, tc.expectedHTTPStatus, status)
 		})
 	}
 }

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -256,7 +256,7 @@ func otlpHandler(
 				// TODO: This code is needed for backwards compatibility,
 				// and can be removed once -ingester.return-only-grpc-errors
 				// is removed.
-				httpCode = httpRetryableToOtlpRetryable(int(st.Code()))
+				httpCode = httpRetryableToOTLPRetryable(int(st.Code()))
 				grpcCode = st.Code()
 				errorMsg = st.Message()
 			} else {
@@ -286,17 +286,17 @@ func toOtlpGRPCHTTPStatus(pushErr error) (codes.Code, int) {
 
 	grpcStatusCode := errorCauseToGRPCStatusCode(distributorErr.Cause(), false)
 	httpStatusCode := errorCauseToHTTPStatusCode(distributorErr.Cause(), false)
-	otlpHTTPStatusCode := httpRetryableToOtlpRetryable(httpStatusCode)
+	otlpHTTPStatusCode := httpRetryableToOTLPRetryable(httpStatusCode)
 	return grpcStatusCode, otlpHTTPStatusCode
 }
 
-// httpRetryableToOtlpRetryable maps non-retryable 5xx HTTP status codes according
+// httpRetryableToOTLPRetryable maps non-retryable 5xx HTTP status codes according
 // to the OTLP specifications (https://opentelemetry.io/docs/specs/otlp/#failures-1)
 // to http.StatusServiceUnavailable. In case of a non-retryable HTTP status code,
-// httpRetryableToOtlpRetryable returns the HTTP status code itself.
+// httpRetryableToOTLPRetryable returns the HTTP status code itself.
 // Unlike Prometheus, which retries 429 and all 5xx HTTP status codes,
 // the OTLP client only retries on HTTP status codes 429, 502, 503, and 504.
-func httpRetryableToOtlpRetryable(httpStatusCode int) int {
+func httpRetryableToOTLPRetryable(httpStatusCode int) int {
 	if httpStatusCode/100 == 5 {
 		mask := httpStatusCode % 100
 		// We map all 5xx except 502, 503 and 504 into 503.

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -655,12 +655,12 @@ func TestHandler_toOtlpGRPCHTTPStatus(t *testing.T) {
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedGRPCStatus: codes.InvalidArgument,
 		},
-		"an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.StatusNotImplemented and HTTP 503 statuses": {
+		"an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.Unimplemented and HTTP 503 statuses": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Unimplemented, originalMsg, mimirpb.METHOD_NOT_ALLOWED), ingesterID),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Unimplemented,
 		},
-		"a DoNotLogError of an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.StatusNotImplemented and HTTP 503 statuses": {
+		"a DoNotLogError of an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.Unimplemented and HTTP 503 statuses": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Unimplemented, originalMsg, mimirpb.METHOD_NOT_ALLOWED), ingesterID)},
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Unimplemented,
@@ -730,7 +730,7 @@ func TestHandler_toOtlpGRPCHTTPStatus(t *testing.T) {
 	}
 }
 
-func TestHttpRetryableToOtlpRetryable(t *testing.T) {
+func TestHttpRetryableToOTLPRetryable(t *testing.T) {
 	testCases := map[string]struct {
 		httpStatusCode             int
 		expectedOtlpHTTPStatusCode int
@@ -774,7 +774,7 @@ func TestHttpRetryableToOtlpRetryable(t *testing.T) {
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			otlpHTTPStatusCode := httpRetryableToOtlpRetryable(testCase.httpStatusCode)
+			otlpHTTPStatusCode := httpRetryableToOTLPRetryable(testCase.httpStatusCode)
 			require.Equal(t, testCase.expectedOtlpHTTPStatusCode, otlpHTTPStatusCode)
 		})
 	}

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -655,14 +655,14 @@ func TestHandler_toOtlpGRPCHTTPStatus(t *testing.T) {
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedGRPCStatus: codes.InvalidArgument,
 		},
-		"an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.StatusNotImplemented and HTTP 501 statuses": {
+		"an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.StatusNotImplemented and HTTP 503 statuses": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Unimplemented, originalMsg, mimirpb.METHOD_NOT_ALLOWED), ingesterID),
-			expectedHTTPStatus: http.StatusNotImplemented,
+			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Unimplemented,
 		},
-		"a DoNotLogError of an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.StatusNotImplemented and HTTP 501 statuses": {
+		"a DoNotLogError of an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.StatusNotImplemented and HTTP 503 statuses": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Unimplemented, originalMsg, mimirpb.METHOD_NOT_ALLOWED), ingesterID)},
-			expectedHTTPStatus: http.StatusNotImplemented,
+			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Unimplemented,
 		},
 		"an ingesterPushError with TSDB_UNAVAILABLE cause gets translated into gRPC codes.Internal and HTTP 503 statuses": {

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -729,3 +729,53 @@ func TestHandler_toOtlpGRPCHTTPStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestHttpRetryableToOtlpRetryable(t *testing.T) {
+	testCases := map[string]struct {
+		httpStatusCode             int
+		expectedOtlpHTTPStatusCode int
+	}{
+		"HTTP status codes 2xx gets translated into themselves": {
+			httpStatusCode:             http.StatusAccepted,
+			expectedOtlpHTTPStatusCode: http.StatusAccepted,
+		},
+		"HTTP status code 400 gets translated into itself": {
+			httpStatusCode:             http.StatusBadRequest,
+			expectedOtlpHTTPStatusCode: http.StatusBadRequest,
+		},
+		"HTTP status code 429 gets translated into itself": {
+			httpStatusCode:             http.StatusTooManyRequests,
+			expectedOtlpHTTPStatusCode: http.StatusTooManyRequests,
+		},
+		"HTTP status code 500 gets translated into 503": {
+			httpStatusCode:             http.StatusInternalServerError,
+			expectedOtlpHTTPStatusCode: http.StatusServiceUnavailable,
+		},
+		"HTTP status code 501 gets translated into 503": {
+			httpStatusCode:             http.StatusNotImplemented,
+			expectedOtlpHTTPStatusCode: http.StatusServiceUnavailable,
+		},
+		"HTTP status code 502 gets translated into itself": {
+			httpStatusCode:             http.StatusBadGateway,
+			expectedOtlpHTTPStatusCode: http.StatusBadGateway,
+		},
+		"HTTP status code 503 gets translated into itself": {
+			httpStatusCode:             http.StatusServiceUnavailable,
+			expectedOtlpHTTPStatusCode: http.StatusServiceUnavailable,
+		},
+		"HTTP status code 504 gets translated into itself": {
+			httpStatusCode:             http.StatusGatewayTimeout,
+			expectedOtlpHTTPStatusCode: http.StatusGatewayTimeout,
+		},
+		"HTTP status code 507 gets translated into 503": {
+			httpStatusCode:             http.StatusInsufficientStorage,
+			expectedOtlpHTTPStatusCode: http.StatusServiceUnavailable,
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			otlpHTTPStatusCode := httpRetryableToOtlpRetryable(testCase.httpStatusCode)
+			require.Equal(t, testCase.expectedOtlpHTTPStatusCode, otlpHTTPStatusCode)
+		})
+	}
+}

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/failsafe-go/failsafe-go/circuitbreaker"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
@@ -589,173 +588,144 @@ func TestHandler_toOtlpGRPCHTTPStatus(t *testing.T) {
 		err                error
 		expectedHTTPStatus int
 		expectedGRPCStatus codes.Code
-		expectedErrorMsg   string
 	}
 	testCases := map[string]testStruct{
-		"a generic error gets translated into a HTTP 503": {
+		"a generic error gets translated into gRPC code.Internal and HTTP 503 statuses": {
 			err:                originalErr,
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   originalMsg,
 		},
-		"a DoNotLog of a generic error gets translated into a HTTP 503": {
+		"a DoNotLog of a generic error gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                middleware.DoNotLogError{Err: originalErr},
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   originalMsg,
 		},
-		"a context.DeadlineExceeded gets translated into a HTTP 503": {
+		"a context.DeadlineExceeded gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                context.DeadlineExceeded,
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   context.DeadlineExceeded.Error(),
 		},
-		"a replicasDidNotMatchError gets translated into an HTTP 202": {
+		"a replicasDidNotMatchError gets translated into gRPC codes.AlreadyExists and HTTP 202 statuses": {
 			err:                replicasNotMatchErr,
 			expectedHTTPStatus: http.StatusAccepted,
-			expectedGRPCStatus: codes.OK,
-			expectedErrorMsg:   replicasNotMatchErr.Error(),
+			expectedGRPCStatus: codes.AlreadyExists,
 		},
-		"a DoNotLogError of a replicasDidNotMatchError gets translated into an HTTP 202": {
+		"a DoNotLogError of a replicasDidNotMatchError gets translated into gRPC codes.AlreadyExists and HTTP 202 statuses": {
 			err:                middleware.DoNotLogError{Err: replicasNotMatchErr},
 			expectedHTTPStatus: http.StatusAccepted,
-			expectedGRPCStatus: codes.OK,
-			expectedErrorMsg:   replicasNotMatchErr.Error(),
+			expectedGRPCStatus: codes.AlreadyExists,
 		},
-		"a tooManyClustersError gets translated into an HTTP 400": {
+		"a tooManyClustersError gets translated into gRPC codes.FailedPrecondition and HTTP 400 statuses": {
 			err:                tooManyClustersErr,
 			expectedHTTPStatus: http.StatusBadRequest,
-			expectedGRPCStatus: codes.InvalidArgument,
-			expectedErrorMsg:   tooManyClustersErr.Error(),
+			expectedGRPCStatus: codes.FailedPrecondition,
 		},
-		"a DoNotLogError of a tooManyClustersError gets translated into an HTTP 400": {
+		"a DoNotLogError of a tooManyClustersError gets translated into gRPC codes.FailedPrecondition and HTTP 400 statuses": {
 			err:                middleware.DoNotLogError{Err: tooManyClustersErr},
 			expectedHTTPStatus: http.StatusBadRequest,
-			expectedGRPCStatus: codes.InvalidArgument,
-			expectedErrorMsg:   tooManyClustersErr.Error(),
+			expectedGRPCStatus: codes.FailedPrecondition,
 		},
-		"a validationError gets translated into an HTTP 400": {
+		"a validationError gets translated into gRPC codes.InvalidArgument and HTTP 400 statuses": {
 			err:                newValidationError(originalErr),
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedGRPCStatus: codes.InvalidArgument,
-			expectedErrorMsg:   originalMsg,
 		},
-		"a DoNotLogError of a validationError gets translated into an HTTP 400": {
+		"a DoNotLogError of a validationError gets translated into gRPC codes.InvalidArgument and HTTP 400 statuses": {
 			err:                middleware.DoNotLogError{Err: newValidationError(originalErr)},
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedGRPCStatus: codes.InvalidArgument,
-			expectedErrorMsg:   originalMsg,
 		},
-		"an ingestionRateLimitedError gets translated into an HTTP 429": {
+		"an ingestionRateLimitedError gets translated into gRPC codes.ResourceExhausted and HTTP 429 statuses": {
 			err:                ingestionRateLimitedErr,
 			expectedHTTPStatus: http.StatusTooManyRequests,
 			expectedGRPCStatus: codes.ResourceExhausted,
-			expectedErrorMsg:   ingestionRateLimitedErr.Error(),
 		},
-		"a DoNotLogError of an ingestionRateLimitedError gets translated into an HTTP 429": {
+		"a DoNotLogError of an ingestionRateLimitedError gets translated into gRPC codes.ResourceExhausted and HTTP 429 statuses": {
 			err:                middleware.DoNotLogError{Err: ingestionRateLimitedErr},
 			expectedHTTPStatus: http.StatusTooManyRequests,
 			expectedGRPCStatus: codes.ResourceExhausted,
-			expectedErrorMsg:   ingestionRateLimitedErr.Error(),
 		},
-		"an ingesterPushError with BAD_DATA cause gets translated into an HTTP 400": {
+		"an ingesterPushError with BAD_DATA cause gets translated into gRPC codes.InvalidArgument and HTTP 400 statuses": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.BAD_DATA), ingesterID),
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedGRPCStatus: codes.InvalidArgument,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"a DoNotLogError of an ingesterPushError with BAD_DATA cause gets translated into an HTTP 400": {
+		"a DoNotLogError of an ingesterPushError with BAD_DATA cause gets translated into gRPC codes.InvalidArgument and HTTP 400 statuses": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.FailedPrecondition, originalMsg, mimirpb.BAD_DATA), ingesterID)},
 			expectedHTTPStatus: http.StatusBadRequest,
 			expectedGRPCStatus: codes.InvalidArgument,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into an HTTP 501": {
+		"an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.StatusNotImplemented and HTTP 501 statuses": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Unimplemented, originalMsg, mimirpb.METHOD_NOT_ALLOWED), ingesterID),
 			expectedHTTPStatus: http.StatusNotImplemented,
 			expectedGRPCStatus: codes.Unimplemented,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"a DoNotLogError of an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into an HTTP 501": {
+		"a DoNotLogError of an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into gRPC codes.StatusNotImplemented and HTTP 501 statuses": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Unimplemented, originalMsg, mimirpb.METHOD_NOT_ALLOWED), ingesterID)},
 			expectedHTTPStatus: http.StatusNotImplemented,
 			expectedGRPCStatus: codes.Unimplemented,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"an ingesterPushError with TSDB_UNAVAILABLE cause gets translated into an HTTP 503": {
+		"an ingesterPushError with TSDB_UNAVAILABLE cause gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.TSDB_UNAVAILABLE), ingesterID),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
-			expectedGRPCStatus: codes.Unavailable,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
+			expectedGRPCStatus: codes.Internal,
 		},
-		"a DoNotLogError of an ingesterPushError with TSDB_UNAVAILABLE cause gets translated into an HTTP 503": {
+		"a DoNotLogError of an ingesterPushError with TSDB_UNAVAILABLE cause gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.TSDB_UNAVAILABLE), ingesterID)},
 			expectedHTTPStatus: http.StatusServiceUnavailable,
-			expectedGRPCStatus: codes.Unavailable,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
+			expectedGRPCStatus: codes.Internal,
 		},
-		"an ingesterPushError with SERVICE_UNAVAILABLE cause gets translated into an HTTP 503": {
+		"an ingesterPushError with SERVICE_UNAVAILABLE cause gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, originalMsg, mimirpb.SERVICE_UNAVAILABLE), ingesterID),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"a DoNotLogError of an ingesterPushError with SERVICE_UNAVAILABLE cause gets translated into an HTTP 503": {
+		"a DoNotLogError of an ingesterPushError with SERVICE_UNAVAILABLE cause gets translated gRPC codes.Internal and HTTP 503 statuses": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, originalMsg, mimirpb.SERVICE_UNAVAILABLE), ingesterID)},
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"an ingesterPushError with INSTANCE_LIMIT cause gets translated into an HTTP 503": {
+		"an ingesterPushError with INSTANCE_LIMIT cause gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, originalMsg, mimirpb.INSTANCE_LIMIT), ingesterID),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"a DoNotLogError of an ingesterPushError with INSTANCE_LIMIT cause gets translated into an HTTP 503": {
+		"a DoNotLogError of an ingesterPushError with INSTANCE_LIMIT cause gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, originalMsg, mimirpb.INSTANCE_LIMIT), ingesterID)},
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"an ingesterPushError with UNKNOWN_CAUSE cause gets translated into an HTTP 503": {
+		"an ingesterPushError with UNKNOWN_CAUSE cause gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.UNKNOWN_CAUSE), ingesterID),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"a DoNotLogError of an ingesterPushError with UNKNOWN_CAUSE cause gets translated into an HTTP 503": {
+		"a DoNotLogError of an ingesterPushError with UNKNOWN_CAUSE cause gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.UNKNOWN_CAUSE), ingesterID)},
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
-		"an ingesterPushError obtained from a DeadlineExceeded coming from the ingester gets translated into an HTTP 503": {
+		"an ingesterPushError obtained from a DeadlineExceeded coming from the ingester gets translated into gRPC codes.Internal and HTTP 503 statuses": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, context.DeadlineExceeded.Error(), mimirpb.UNKNOWN_CAUSE), ingesterID),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Internal,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, context.DeadlineExceeded),
 		},
-		"a circuitBreakerOpenError gets translated into an HTTP 503": {
+		"a circuitBreakerOpenError gets translated into gRPC codes.Unavailable and HTTP 503 statuses": {
 			err:                newCircuitBreakerOpenError(client.ErrCircuitBreakerOpen{}),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Unavailable,
-			expectedErrorMsg:   circuitbreaker.ErrOpen.Error(),
 		},
-		"a wrapped circuitBreakerOpenError gets translated into an HTTP 503": {
+		"a wrapped circuitBreakerOpenError gets translated into gRPC codes.Unavailable and HTTP 503 statuses": {
 			err:                errors.Wrap(newCircuitBreakerOpenError(client.ErrCircuitBreakerOpen{}), fmt.Sprintf("%s %s", failedPushingToIngesterMessage, ingesterID)),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 			expectedGRPCStatus: codes.Unavailable,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, circuitbreaker.ErrOpen),
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			gStatus, status := toOtlpGRPCHTTPStatus(tc.err)
-			msg := tc.err.Error()
 			assert.Equal(t, tc.expectedHTTPStatus, status)
 			assert.Equal(t, tc.expectedGRPCStatus, gStatus)
-			assert.Equal(t, tc.expectedErrorMsg, msg)
 		})
 	}
 }

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -207,8 +207,6 @@ func calculateRetryAfter(retryAttemptHeader string, baseSeconds int, maxBackoffE
 // toHTTPStatus converts the given error into an appropriate HTTP status corresponding
 // to that error, if the error is one of the errors from this package. Otherwise, an
 // http.StatusInternalServerError is returned.
-// to that error, if the error is one of the errors from this package. Otherwise, codes.Internal and
-// http.StatusInternalServerError is returned.
 func toHTTPStatus(ctx context.Context, pushErr error, limits *validation.Overrides) int {
 	if errors.Is(pushErr, context.DeadlineExceeded) {
 		return http.StatusInternalServerError

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -211,6 +211,10 @@ func calculateRetryAfter(retryAttemptHeader string, baseSeconds int, maxBackoffE
 // to that error, if the error is one of the errors from this package. Otherwise, an
 // http.StatusInternalServerError is returned.
 func toHTTPStatus(ctx context.Context, pushErr error, limits *validation.Overrides) int {
+	if errors.Is(pushErr, context.DeadlineExceeded) {
+		return http.StatusInternalServerError
+	}
+
 	var distributorErr Error
 	if errors.As(pushErr, &distributorErr) {
 		serviceOverloadErrorEnabled := false

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -167,6 +167,9 @@ func handler(
 				msg  string
 			)
 			if resp, ok := httpgrpc.HTTPResponseFromError(err); ok {
+				// TODO: This code is needed for backwards compatibility,
+				// and can be removed once -ingester.return-only-grpc-errors
+				// is removed.
 				code, msg = int(resp.Code), string(resp.Body)
 			} else {
 				code = toHTTPStatus(ctx, err, limits)
@@ -208,40 +211,14 @@ func calculateRetryAfter(retryAttemptHeader string, baseSeconds int, maxBackoffE
 // to that error, if the error is one of the errors from this package. Otherwise, an
 // http.StatusInternalServerError is returned.
 func toHTTPStatus(ctx context.Context, pushErr error, limits *validation.Overrides) int {
-	if errors.Is(pushErr, context.DeadlineExceeded) {
-		return http.StatusInternalServerError
-	}
-
 	var distributorErr Error
 	if errors.As(pushErr, &distributorErr) {
-		switch distributorErr.Cause() {
-		case mimirpb.BAD_DATA:
-			return http.StatusBadRequest
-		case mimirpb.INGESTION_RATE_LIMITED, mimirpb.REQUEST_RATE_LIMITED:
-			serviceOverloadErrorEnabled := false
-			userID, err := tenant.TenantID(ctx)
-			if err == nil {
-				serviceOverloadErrorEnabled = limits.ServiceOverloadStatusCodeOnRateLimitEnabled(userID)
-			}
-			// Return a 429 or a 529 here depending on configuration to tell the client it is going too fast.
-			// Client may discard the data or slow down and re-send.
-			// Prometheus v2.26 added a remote-write option 'retry_on_http_429'.
-			if serviceOverloadErrorEnabled {
-				return StatusServiceOverloaded
-			}
-			return http.StatusTooManyRequests
-		case mimirpb.REPLICAS_DID_NOT_MATCH:
-			return http.StatusAccepted
-		case mimirpb.TOO_MANY_CLUSTERS:
-			return http.StatusBadRequest
-		case mimirpb.TSDB_UNAVAILABLE:
-			return http.StatusServiceUnavailable
-		case mimirpb.CIRCUIT_BREAKER_OPEN:
-			return http.StatusServiceUnavailable
-		case mimirpb.METHOD_NOT_ALLOWED:
-			// Return a 501 (and not 405) to explicitly signal a misconfiguration and to possibly track that amongst other 5xx errors.
-			return http.StatusNotImplemented
+		serviceOverloadErrorEnabled := false
+		userID, err := tenant.TenantID(ctx)
+		if err == nil {
+			serviceOverloadErrorEnabled = limits.ServiceOverloadStatusCodeOnRateLimitEnabled(userID)
 		}
+		return errorCauseToHTTPStatusCode(distributorErr.Cause(), serviceOverloadErrorEnabled)
 	}
 
 	return http.StatusInternalServerError

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/failsafe-go/failsafe-go/circuitbreaker"
 	"github.com/go-kit/log"
 	"github.com/golang/snappy"
 	"github.com/grafana/dskit/concurrency"
@@ -670,168 +669,136 @@ func TestHandler_toHTTPStatus(t *testing.T) {
 		err                         error
 		serviceOverloadErrorEnabled bool
 		expectedHTTPStatus          int
-		expectedErrorMsg            string
 	}
 	testCases := map[string]testStruct{
 		"a generic error gets translated into a HTTP 500": {
 			err:                originalErr,
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   originalMsg,
 		},
 		"a DoNotLog of a generic error gets translated into a HTTP 500": {
 			err:                middleware.DoNotLogError{Err: originalErr},
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   originalMsg,
 		},
 		"a context.DeadlineExceeded gets translated into a HTTP 500": {
 			err:                context.DeadlineExceeded,
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   context.DeadlineExceeded.Error(),
 		},
 		"a replicasDidNotMatchError gets translated into an HTTP 202": {
 			err:                replicasNotMatchErr,
 			expectedHTTPStatus: http.StatusAccepted,
-			expectedErrorMsg:   replicasNotMatchErr.Error(),
 		},
 		"a DoNotLogError of a replicasDidNotMatchError gets translated into an HTTP 202": {
 			err:                middleware.DoNotLogError{Err: replicasNotMatchErr},
 			expectedHTTPStatus: http.StatusAccepted,
-			expectedErrorMsg:   replicasNotMatchErr.Error(),
 		},
 		"a tooManyClustersError gets translated into an HTTP 400": {
 			err:                tooManyClustersErr,
 			expectedHTTPStatus: http.StatusBadRequest,
-			expectedErrorMsg:   tooManyClustersErr.Error(),
 		},
 		"a DoNotLogError of a tooManyClustersError gets translated into an HTTP 400": {
 			err:                middleware.DoNotLogError{Err: tooManyClustersErr},
 			expectedHTTPStatus: http.StatusBadRequest,
-			expectedErrorMsg:   tooManyClustersErr.Error(),
 		},
 		"a validationError gets translated into an HTTP 400": {
 			err:                newValidationError(originalErr),
 			expectedHTTPStatus: http.StatusBadRequest,
-			expectedErrorMsg:   originalMsg,
 		},
 		"a DoNotLogError of a validationError gets translated into an HTTP 400": {
 			err:                middleware.DoNotLogError{Err: newValidationError(originalErr)},
 			expectedHTTPStatus: http.StatusBadRequest,
-			expectedErrorMsg:   originalMsg,
 		},
 		"an ingestionRateLimitedError gets translated into an HTTP 429": {
 			err:                ingestionRateLimitedErr,
 			expectedHTTPStatus: http.StatusTooManyRequests,
-			expectedErrorMsg:   ingestionRateLimitedErr.Error(),
 		},
 		"an ingestionRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529": {
 			err:                         ingestionRateLimitedErr,
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
-			expectedErrorMsg:            ingestionRateLimitedErr.Error(),
 		},
 		"a DoNotLogError of an ingestionRateLimitedError gets translated into an HTTP 429": {
 			err:                middleware.DoNotLogError{Err: ingestionRateLimitedErr},
 			expectedHTTPStatus: http.StatusTooManyRequests,
-			expectedErrorMsg:   ingestionRateLimitedErr.Error(),
 		},
 		"a requestRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529": {
 			err:                         requestRateLimitedErr,
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
-			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
 		"a DoNotLogError of a requestRateLimitedError with serviceOverloadErrorEnabled gets translated into an HTTP 529": {
 			err:                         middleware.DoNotLogError{Err: requestRateLimitedErr},
 			serviceOverloadErrorEnabled: true,
 			expectedHTTPStatus:          StatusServiceOverloaded,
-			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
 		"a requestRateLimitedError without serviceOverloadErrorEnabled gets translated into an HTTP 429": {
 			err:                         requestRateLimitedErr,
 			serviceOverloadErrorEnabled: false,
 			expectedHTTPStatus:          http.StatusTooManyRequests,
-			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
 		"a DoNotLogError of a requestRateLimitedError without serviceOverloadErrorEnabled gets translated into an HTTP 429": {
 			err:                         middleware.DoNotLogError{Err: requestRateLimitedErr},
 			serviceOverloadErrorEnabled: false,
 			expectedHTTPStatus:          http.StatusTooManyRequests,
-			expectedErrorMsg:            requestRateLimitedErr.Error(),
 		},
 		"an ingesterPushError with BAD_DATA cause gets translated into an HTTP 400": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.BAD_DATA), ingesterID),
 			expectedHTTPStatus: http.StatusBadRequest,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"a DoNotLogError of an ingesterPushError with BAD_DATA cause gets translated into an HTTP 400": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.FailedPrecondition, originalMsg, mimirpb.BAD_DATA), ingesterID)},
 			expectedHTTPStatus: http.StatusBadRequest,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into an HTTP 501": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Unimplemented, originalMsg, mimirpb.METHOD_NOT_ALLOWED), ingesterID),
 			expectedHTTPStatus: http.StatusNotImplemented,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"a DoNotLogError of an ingesterPushError with METHOD_NOT_ALLOWED cause gets translated into an HTTP 501": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Unimplemented, originalMsg, mimirpb.METHOD_NOT_ALLOWED), ingesterID)},
 			expectedHTTPStatus: http.StatusNotImplemented,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"an ingesterPushError with TSDB_UNAVAILABLE cause gets translated into an HTTP 503": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.TSDB_UNAVAILABLE), ingesterID),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"a DoNotLogError of an ingesterPushError with TSDB_UNAVAILABLE cause gets translated into an HTTP 503": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.TSDB_UNAVAILABLE), ingesterID)},
 			expectedHTTPStatus: http.StatusServiceUnavailable,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"an ingesterPushError with SERVICE_UNAVAILABLE cause gets translated into an HTTP 500": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, originalMsg, mimirpb.SERVICE_UNAVAILABLE), ingesterID),
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"a DoNotLogError of an ingesterPushError with SERVICE_UNAVAILABLE cause gets translated into an HTTP 500": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, originalMsg, mimirpb.SERVICE_UNAVAILABLE), ingesterID)},
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"an ingesterPushError with INSTANCE_LIMIT cause gets translated into an HTTP 500": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, originalMsg, mimirpb.INSTANCE_LIMIT), ingesterID),
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"a DoNotLogError of an ingesterPushError with INSTANCE_LIMIT cause gets translated into an HTTP 500": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, originalMsg, mimirpb.INSTANCE_LIMIT), ingesterID)},
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"an ingesterPushError with UNKNOWN_CAUSE cause gets translated into an HTTP 500": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.UNKNOWN_CAUSE), ingesterID),
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"a DoNotLogError of an ingesterPushError with UNKNOWN_CAUSE cause gets translated into an HTTP 500": {
 			err:                middleware.DoNotLogError{Err: newIngesterPushError(createStatusWithDetails(t, codes.Internal, originalMsg, mimirpb.UNKNOWN_CAUSE), ingesterID)},
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, originalMsg),
 		},
 		"an ingesterPushError obtained from a DeadlineExceeded coming from the ingester gets translated into an HTTP 500": {
 			err:                newIngesterPushError(createStatusWithDetails(t, codes.Internal, context.DeadlineExceeded.Error(), mimirpb.UNKNOWN_CAUSE), ingesterID),
 			expectedHTTPStatus: http.StatusInternalServerError,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, context.DeadlineExceeded),
 		},
 		"a circuitBreakerOpenError gets translated into an HTTP 503": {
 			err:                newCircuitBreakerOpenError(client.ErrCircuitBreakerOpen{}),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
-			expectedErrorMsg:   circuitbreaker.ErrOpen.Error(),
 		},
 		"a wrapped circuitBreakerOpenError gets translated into an HTTP 503": {
 			err:                errors.Wrap(newCircuitBreakerOpenError(client.ErrCircuitBreakerOpen{}), fmt.Sprintf("%s %s", failedPushingToIngesterMessage, ingesterID)),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
-			expectedErrorMsg:   fmt.Sprintf("%s %s: %s", failedPushingToIngesterMessage, ingesterID, circuitbreaker.ErrOpen),
 		},
 	}
 	for name, tc := range testCases {
@@ -850,9 +817,7 @@ func TestHandler_toHTTPStatus(t *testing.T) {
 			require.NoError(t, err)
 
 			status := toHTTPStatus(ctx, tc.err, limits)
-			msg := tc.err.Error()
 			assert.Equal(t, tc.expectedHTTPStatus, status)
-			assert.Equal(t, tc.expectedErrorMsg, msg)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does
Errors produced by distributors are of type `distributor.Error`. Depending on a use case, they are mapped to the corresponding gRPC and/or HTTP errors:
- `distributor.Push()` converts them to errors with a gRPC status (by using gogo's `status` package) and, therefore, gRPC status codes.
- `distributor.handler()` converts them to HTTP errors with HTTP status codes. 
- `distributor.otlpHandler()` converts them to an HTTP response, encoding a gRPC status, gRPC status code and HTTP status code.

In case of `distributor.Push()`, there is a method that does mapping between `distributor.Error` implementations and gRPC status codes ([here](https://github.com/grafana/mimir/blob/32c668c2722f4db97c20eeb97dc985b39cabd3b6/pkg/distributor/errors.go#L257-L287)). Similarly, there is another method that does mapping between `distributor.Error` implementations and OTLP-related gRPC codes ([here](https://github.com/grafana/mimir/blob/391767983658e7566e19f01f7c4dfca04ca968bb/pkg/distributor/otel.go#L281-L304)). Although in most of the cases these 2 methods map the same `distributor.Error` errors to the same gRPC code, there are some differences. The following table shows the differences and a proposed conflict solution, in order to do a conversion to a gRPC status code in one place only:

| error cause                      | `Push()`             | `otlpHandler()`   | proposed solution    | motivation                                                                                                                                                                                                                         |
|----------------------------------|----------------------|-------------------|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `BAD_DATA`               | `FailedPrecondition` | `InvalidArgument` | `InvalidArgument`    | `BAD_DATA` represents the <br>errors caused by processing<br>bad input data, which fits well here.                                                                                                                          |
| `REPLICAS_DID_NOT_MATCH` | `AlreadyExists`      | `OK`              | `AlreadyExists`      | `AlreadyExists` corresponds better <br>to `mimirpb.REPLICAS_DID_NOT_MATCH`                                                                                                                                                         |
| `TOO_MANY_CLUSTERS`      | `FailedPrecondition` | `InvalidArgument` | `FailedPrecondition` | `FailedPrecondition` is used when a <br>system is not in a state required <br>for the operation's execution which <br>applies to this situation. The error <br>is caused by a system state, not by <br>an input data.              |
| `TSDB_UNAVAILABLE`       | `Unavailable`        | `Internal`        | `Internal`           | `TSDB_UNAVAILABLE` are errors coming <br>from ingesters when they cannot get <br>data from TSDB. From the distributor <br>perspective it is an internal error, <br>because the distributor should not <br>know the ingester logic. |
|                                  |                      |                   |                      |                                                                                                                                                                                                                                    |

Last but not least, I am would like to replace [the following code](https://github.com/grafana/mimir/blob/391767983658e7566e19f01f7c4dfca04ca968bb/pkg/distributor/otel.go#L250-L264) from `distributor.otlpHandler()`:
```
var (
	httpCode int
	grpcCode codes.Code
	errorMsg string
)
if resp, ok := httpgrpc.HTTPResponseFromError(err); ok {
	s, _ := grpcutil.ErrorToStatus(err)
	httpCode = int(resp.Code)
	grpcCode = s.Code() // this will be the same as httpCode.
	errorMsg = string(resp.Body)
} else {
	grpcCode, httpCode = toOtlpGRPCHTTPStatus(err)
	errorMsg = err.Error()
}
```
with
```
var (
	httpCode int
	grpcCode codes.Code
	errorMsg string
)
if st, ok := grpcutil.ErrorToStatus(err); ok {
	httpCode = int(st.Code())
	grpcCode = s.Code()
	errorMsg = st.Message()
} else {
	grpcCode, httpCode = toOtlpGRPCHTTPStatus(err)
	errorMsg = err.Error()
}
```
This way we will avoid a double conversion from an error to a gRPC status that is currently done first in `httpgrpc.HTTPResponseFromError()` and then in `grpcutil.ErrorToStatus()`.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
