### PR TITLE
Mimir query engine: extend binary operation tests to assert on error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277 #8291 #8303
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277 #8291 #8303 #8340
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -126,7 +126,7 @@ load 6m
   right_side{env="test"} 100 200 300
 
 eval_fail range from 0 to 42m step 6m left_side * on (env) right_side
-  # TODO: expected_message multiple matches for labels: many-to-one matching must be explicit (group_left/group_right)
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit \(group_left/group_right\)|found duplicate series for the match group \{env="test"\} on the left side of the operation at timestamp 1970-01-01T00:00:00Z: \{__name__="left_side", env="test", pod="a"\} and \{__name__="left_side", env="test", pod="b"\})
 
 clear
 
@@ -139,7 +139,7 @@ load 6m
   right_side{env="test", pod="d"} _ 10 11
 
 eval_fail range from 0 to 42m step 6m left_side * on (env) right_side
-  # TODO: expected_message found duplicate series for the match group {env="test"} on the right hand-side of the operation: [{__name__="right_side", env="test", pod="b"}, {__name__="right_side", env="test", pod="a"}];many-to-many matching not allowed: matching labels must be unique on one side
+  expected_fail_regexp (found duplicate series for the match group \{env="test"\} on the right hand-side of the operation: \[\{__name__="right_side", env="test", pod="(a|b|c)"\}, \{__name__="right_side", env="test", pod="(a|b|c)"\}\];many-to-many matching not allowed: matching labels must be unique on one side|found duplicate series for the match group \{env="test"\} on the right side of the operation at timestamp 1970-01-01T00:00:00Z: \{__name__="right_side", env="test", pod="a"\} and \{__name__="right_side", env="test", pod="b"\})
 
 clear
 


### PR DESCRIPTION
#### What this PR does

This PR makes use of https://github.com/prometheus/prometheus/pull/14038 to assert that the error messages returned by binary operations are as expected when multiple matching series are found on one side of a one-to-one match.

Note that Prometheus' engine and Mimir's engine return different but equivalent error messages: Mimir's engine includes more detail in all cases.

#### Which issue(s) this PR fixes or relates to

Addresses TODO from https://github.com/grafana/mimir/pull/8096

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
