### PR TITLE
Mimir query engine: complete renaming from #8256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277 #8291 #8303 #8340 #8256
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277 #8291 #8303 #8340 #8256 #8348
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123

--- a/pkg/streamingpromql/functions.go
+++ b/pkg/streamingpromql/functions.go
@@ -13,14 +13,14 @@ import (
 
 type InstantVectorFunctionOperatorFactory func(args []types.Operator, pool *pooling.LimitingPool) (types.InstantVectorOperator, error)
 
-// SingleInputVectorFunctionOperator creates an InstantVectorFunctionOperatorFactory for functions
+// SingleInputVectorFunctionOperatorFactory creates an InstantVectorFunctionOperatorFactory for functions
 // that have exactly 1 argument (v instant-vector).
 //
 // Parameters:
 //   - name: The name of the function.
 //   - metadataFunc: The function for handling metadata
 //   - seriesDataFunc: The function to handle series data
-func SingleInputVectorFunctionOperator(name string, metadataFunc functions.SeriesMetadataFunction, seriesDataFunc functions.InstantVectorFunction) InstantVectorFunctionOperatorFactory {
+func SingleInputVectorFunctionOperatorFactory(name string, metadataFunc functions.SeriesMetadataFunction, seriesDataFunc functions.InstantVectorFunction) InstantVectorFunctionOperatorFactory {
 	return func(args []types.Operator, pool *pooling.LimitingPool) (types.InstantVectorOperator, error) {
 		if len(args) != 1 {
 			// Should be caught by the PromQL parser, but we check here for safety.
@@ -43,17 +43,17 @@ func SingleInputVectorFunctionOperator(name string, metadataFunc functions.Serie
 	}
 }
 
-// TransformationFunctionOperator creates an InstantVectorFunctionOperatorFactory for functions
+// TransformationFunctionOperatorFactory creates an InstantVectorFunctionOperatorFactory for functions
 // that have exactly 1 argument (v instant-vector), and drop the series __name__ label.
 //
 // Parameters:
 //   - name: The name of the function.
 //   - seriesDataFunc: The function to handle series data
-func TransformationFunctionOperator(name string, seriesDataFunc functions.InstantVectorFunction) InstantVectorFunctionOperatorFactory {
-	return SingleInputVectorFunctionOperator(name, functions.DropSeriesName, seriesDataFunc)
+func TransformationFunctionOperatorFactory(name string, seriesDataFunc functions.InstantVectorFunction) InstantVectorFunctionOperatorFactory {
+	return SingleInputVectorFunctionOperatorFactory(name, functions.DropSeriesName, seriesDataFunc)
 }
 
-// LabelManipulationFunctionOperator creates an InstantVectorFunctionOperator for functions
+// LabelManipulationFunctionOperatorFactory creates an InstantVectorFunctionOperator for functions
 // that have exactly 1 argument (v instant-vector), and need to manipulate the labels of
 // each series without manipulating the returned samples.
 // The values of v are passed through.
@@ -65,11 +65,11 @@ func TransformationFunctionOperator(name string, seriesDataFunc functions.Instan
 // Returns:
 //
 //	An InstantVectorFunctionOperator.
-func LabelManipulationFunctionOperator(name string, metadataFunc functions.SeriesMetadataFunction) InstantVectorFunctionOperatorFactory {
-	return SingleInputVectorFunctionOperator(name, metadataFunc, functions.Passthrough)
+func LabelManipulationFunctionOperatorFactory(name string, metadataFunc functions.SeriesMetadataFunction) InstantVectorFunctionOperatorFactory {
+	return SingleInputVectorFunctionOperatorFactory(name, metadataFunc, functions.Passthrough)
 }
 
-func rateFunctionOperator(args []types.Operator, pool *pooling.LimitingPool) (types.InstantVectorOperator, error) {
+func createRateFunctionOperator(args []types.Operator, pool *pooling.LimitingPool) (types.InstantVectorOperator, error) {
 	if len(args) != 1 {
 		// Should be caught by the PromQL parser, but we check here for safety.
 		return nil, fmt.Errorf("expected exactly 1 argument for rate, got %v", len(args))
@@ -89,17 +89,17 @@ func rateFunctionOperator(args []types.Operator, pool *pooling.LimitingPool) (ty
 
 // These functions return an instant-vector.
 var instantVectorFunctionOperatorFactories = map[string]InstantVectorFunctionOperatorFactory{
-	"acos":            TransformationFunctionOperator("acos", functions.Acos),
-	"histogram_count": TransformationFunctionOperator("histogram_count", functions.HistogramCount),
-	"histogram_sum":   TransformationFunctionOperator("histogram_sum", functions.HistogramSum),
-	"rate":            rateFunctionOperator,
+	"acos":            TransformationFunctionOperatorFactory("acos", functions.Acos),
+	"histogram_count": TransformationFunctionOperatorFactory("histogram_count", functions.HistogramCount),
+	"histogram_sum":   TransformationFunctionOperatorFactory("histogram_sum", functions.HistogramSum),
+	"rate":            createRateFunctionOperator,
 }
 
-func RegisterInstantVectorFunctionOperator(functionName string, functionOperator InstantVectorFunctionOperatorFactory) error {
+func RegisterInstantVectorFunctionOperatorFactory(functionName string, factory InstantVectorFunctionOperatorFactory) error {
 	if _, exists := instantVectorFunctionOperatorFactories[functionName]; exists {
 		return fmt.Errorf("function '%s' has already been registered", functionName)
 	}
 
-	instantVectorFunctionOperatorFactories[functionName] = functionOperator
+	instantVectorFunctionOperatorFactories[functionName] = factory
 	return nil
 }

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -10,20 +10,20 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql/functions"
 )
 
-func TestRegisterInstantVectorFunctionOperator(t *testing.T) {
+func TestRegisterInstantVectorFunctionOperatorFactory(t *testing.T) {
 	// Register an already existing function
-	err := RegisterInstantVectorFunctionOperator("acos", LabelManipulationFunctionOperator("acos", functions.DropSeriesName))
+	err := RegisterInstantVectorFunctionOperatorFactory("acos", LabelManipulationFunctionOperatorFactory("acos", functions.DropSeriesName))
 	require.Error(t, err)
 	require.Equal(t, "function 'acos' has already been registered", err.Error())
 
 	// Register a new function
-	newFunc := LabelManipulationFunctionOperator("new_function", functions.DropSeriesName)
-	err = RegisterInstantVectorFunctionOperator("new_function", newFunc)
+	newFunc := LabelManipulationFunctionOperatorFactory("new_function", functions.DropSeriesName)
+	err = RegisterInstantVectorFunctionOperatorFactory("new_function", newFunc)
 	require.NoError(t, err)
 	require.Contains(t, instantVectorFunctionOperatorFactories, "new_function")
 
 	// Register existing function we registered previously
-	err = RegisterInstantVectorFunctionOperator("new_function", newFunc)
+	err = RegisterInstantVectorFunctionOperatorFactory("new_function", newFunc)
 	require.Error(t, err)
 	require.Equal(t, "function 'new_function' has already been registered", err.Error())
 


### PR DESCRIPTION
#### What this PR does

While making use of `RegisterInstantVectorFunctionOperator` in an internal project, I noticed that we didn't completely rename everything to include the word "factory" where appropriate.

This PR clarifies those names.

#### Which issue(s) this PR fixes or relates to

#8256

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
