### PR TITLE
Run `skopeo` via docker in integration test jobs

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -347,7 +347,9 @@ jobs:
         run: |
           export IMAGE_TAG=$(make image-tag)
           # skopeo will by default load system-specific version of the image (linux/amd64).
-          skopeo copy oci-archive:/tmp/images/mimirtool.oci "docker-daemon:grafana/mimirtool:$IMAGE_TAG"
+          # note that this doesn't use skopeo version from our build-image, because we don't use build-image when running integration tests.
+          # that's why we use docker run to run latest version.
+          docker run quay.io/skopeo/stable:latest copy oci-archive:/tmp/images/mimirtool.oci "docker-daemon:grafana/mimirtool:$IMAGE_TAG"
       - name: Download Archive with Docker Images
         uses: actions/download-artifact@v4
         with:
@@ -420,6 +422,8 @@ jobs:
         run: |
           export IMAGE_TAG=$(make image-tag)
           # skopeo will by default load system-specific version of the image (linux/amd64).
+          # note that this doesn't use skopeo version from our build-image, because we don't use build-image when running integration tests.
+          # that's why we use docker run to run latest version.
           skopeo copy oci-archive:/tmp/images/mimirtool.oci "docker-daemon:grafana/mimirtool:$IMAGE_TAG"
       - name: Download Archive with Docker Images
         uses: actions/download-artifact@v4


### PR DESCRIPTION
#### What this PR does

We run integration tests on `ubuntu-latest` runner, without using build-image. Current ubuntu-latest is ubuntu-22.04, and it has old skopeo version [1.4.1](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md). Even newer (in beta) ubuntu-24.04 still has skopeo version [1.13.3](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).

Since we need to use skopeo 1.14.2 or later, we try to run it via docker.

