### PR TITLE
Ingester: map circuitBreakerOpenError to codes.Unavailable

### DIFF
--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -560,6 +560,8 @@ func mapPushErrorToErrorWithStatus(err error) error {
 			errCode = codes.Internal
 		case mimirpb.METHOD_NOT_ALLOWED:
 			errCode = codes.Unimplemented
+		case mimirpb.CIRCUIT_BREAKER_OPEN:
+			errCode = codes.Unavailable
 		}
 	}
 	return newErrorWithStatus(wrappedErr, errCode)
@@ -581,6 +583,8 @@ func mapPushErrorToErrorWithHTTPOrGRPCStatus(err error) error {
 			return newErrorWithHTTPStatus(err, http.StatusServiceUnavailable)
 		case mimirpb.METHOD_NOT_ALLOWED:
 			return newErrorWithStatus(err, codes.Unimplemented)
+		case mimirpb.CIRCUIT_BREAKER_OPEN:
+			return newErrorWithStatus(err, codes.Unavailable)
 		}
 	}
 	return err
@@ -600,6 +604,8 @@ func mapReadErrorToErrorWithStatus(err error) error {
 			errCode = codes.Unavailable
 		case mimirpb.METHOD_NOT_ALLOWED:
 			return newErrorWithStatus(err, codes.Unimplemented)
+		case mimirpb.CIRCUIT_BREAKER_OPEN:
+			return newErrorWithStatus(err, codes.Unavailable)
 		}
 	}
 	return newErrorWithStatus(err, errCode)
@@ -619,6 +625,8 @@ func mapReadErrorToErrorWithHTTPOrGRPCStatus(err error) error {
 			return newErrorWithStatus(err, codes.Unavailable)
 		case mimirpb.METHOD_NOT_ALLOWED:
 			return newErrorWithStatus(err, codes.Unimplemented)
+		case mimirpb.CIRCUIT_BREAKER_OPEN:
+			return newErrorWithStatus(err, codes.Unavailable)
 		}
 	}
 	return err

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -555,6 +555,18 @@ func TestMapPushErrorToErrorWithStatus(t *testing.T) {
 			expectedMessage: fmt.Sprintf("wrapped: %s", newPerMetricMetadataLimitReachedError(10, family).Error()),
 			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.BAD_DATA},
 		},
+		"a circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable error with details": {
+			err:             newCircuitBreakerOpenError("foo", 1*time.Second),
+			expectedCode:    codes.Unavailable,
+			expectedMessage: newCircuitBreakerOpenError("foo", 1*time.Second).Error(),
+			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.CIRCUIT_BREAKER_OPEN},
+		},
+		"a wrapped circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable error with details": {
+			err:             fmt.Errorf("wrapped: %w", newCircuitBreakerOpenError("foo", 1*time.Second)),
+			expectedCode:    codes.Unavailable,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newCircuitBreakerOpenError("foo", 1*time.Second).Error()),
+			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.CIRCUIT_BREAKER_OPEN},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -736,6 +748,20 @@ func TestMapPushErrorToErrorWithHTTPOrGRPCStatus(t *testing.T) {
 				codes.Unimplemented,
 			),
 		},
+		"a circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable error": {
+			err: newCircuitBreakerOpenError("foo", 1*time.Second),
+			expectedTranslation: newErrorWithStatus(
+				newCircuitBreakerOpenError("foo", 1*time.Second),
+				codes.Unavailable,
+			),
+		},
+		"a wrapped circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable error": {
+			err: fmt.Errorf("wrapped: %w", newCircuitBreakerOpenError("foo", 1*time.Second)),
+			expectedTranslation: newErrorWithStatus(
+				fmt.Errorf("wrapped: %w", newCircuitBreakerOpenError("foo", 1*time.Second)),
+				codes.Unavailable,
+			),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -793,6 +819,18 @@ func TestMapReadErrorToErrorWithStatus(t *testing.T) {
 			expectedMessage: fmt.Sprintf("wrapped: %s", ingesterTooBusyMsg),
 			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.TOO_BUSY},
 		},
+		"a circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable error with details": {
+			err:             newCircuitBreakerOpenError("foo", 1*time.Second),
+			expectedCode:    codes.Unavailable,
+			expectedMessage: newCircuitBreakerOpenError("foo", 1*time.Second).Error(),
+			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.CIRCUIT_BREAKER_OPEN},
+		},
+		"a wrapped circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable error with details": {
+			err:             fmt.Errorf("wrapped: %w", newCircuitBreakerOpenError("foo", 1*time.Second)),
+			expectedCode:    codes.Unavailable,
+			expectedMessage: fmt.Sprintf("wrapped: %s", newCircuitBreakerOpenError("foo", 1*time.Second)),
+			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.CIRCUIT_BREAKER_OPEN},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -830,9 +868,17 @@ func TestMapReadErrorToErrorWithHTTPOrGRPCStatus(t *testing.T) {
 			err:                 errTooBusy,
 			expectedTranslation: newErrorWithHTTPStatus(errTooBusy, http.StatusServiceUnavailable),
 		},
-		"a wrapped errTooBusy gets translated into an ErrorWithStatus with status code 503": {
+		"a wrapped errTooBusy gets translated into an errorWithHTTPStatus with status code 503": {
 			err:                 fmt.Errorf("wrapped: %w", errTooBusy),
 			expectedTranslation: newErrorWithHTTPStatus(fmt.Errorf("wrapped: %w", errTooBusy), http.StatusServiceUnavailable),
+		},
+		"a circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable error": {
+			err:                 newCircuitBreakerOpenError("foo", 1*time.Second),
+			expectedTranslation: newErrorWithStatus(newCircuitBreakerOpenError("foo", 1*time.Second), codes.Unavailable),
+		},
+		"a wrapped circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable": {
+			err:                 fmt.Errorf("wrapped: %w", newCircuitBreakerOpenError("foo", 1*time.Second)),
+			expectedTranslation: newErrorWithStatus(fmt.Errorf("wrapped: %w", newCircuitBreakerOpenError("foo", 1*time.Second)), codes.Unavailable),
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
#### What this PR does
In #8180 and #8285 we introduced ingester server-side circuit breakers. In #8315 we split circuit breakers related to the push request from those related to the read requests. In both cases, when a circuit breaker is open, ingesters return an instance of `ingester.circuitBreakerOpenError` (with error cause `mimirpb.CIRCUIT_BREAKER_OPEN`), which is then mapped to a gRPC error and returned to other Mimir components via rpc calls.

The PRs mentioned above didn't explicitly handle `ingester.circuitBreakerOpenError` to gRPC error mapping, so depending on the request type and the way ingester is configured, these errors might be mapped to `codes.Internal` or `codes.Unavailable` gRPC errors. Since distributor always translates errors with error cause `mimirpb.CIRCUIT_BREAKER_OPEN` to a `codes.Unavailable` gRPC error, and since `grpcInflightMethodLimiter` converts all the errors returned by `ingester.StartPushRequest()` to a `codes.Unavailable` gRPC error, this PR explicitly map all remaining cases that might give rise to an `ingester.circuitBreakerOpenError` to `codes.Unavailable`, instead of the default mapping to `codes.Internal`.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
