### PR TITLE
Fix reporting of HTTP error messages with binary body content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 * [BUGFIX] Ingester: fixed in-memory series count when replaying a corrupted WAL. #8295
 * [BUGFIX] Ingester: fix context cancellation handling when a query is busy looking up series in the TSDB index and `-blocks-storage.tsdb.head-postings-for-matchers-cache*` or `-blocks-storage.tsdb.block-postings-for-matchers-cache*` are in use. #8337
 * [BUGFIX] Querier: fix edge case where bucket indexes are sometimes cached forever instead of with the expected TTL. #8343
+* [BUGFIX] OTLP handler: fix errors returned by OTLP handler when used via httpgrpc tunelling. #8363
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@
 * [BUGFIX] Ingester: fixed in-memory series count when replaying a corrupted WAL. #8295
 * [BUGFIX] Ingester: fix context cancellation handling when a query is busy looking up series in the TSDB index and `-blocks-storage.tsdb.head-postings-for-matchers-cache*` or `-blocks-storage.tsdb.block-postings-for-matchers-cache*` are in use. #8337
 * [BUGFIX] Querier: fix edge case where bucket indexes are sometimes cached forever instead of with the expected TTL. #8343
-* [BUGFIX] OTLP handler: fix errors returned by OTLP handler when used via httpgrpc tunelling. #8363
+* [BUGFIX] OTLP handler: fix errors returned by OTLP handler when used via httpgrpc tunneling. #8363
 
 ### Mixin
 

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,11 @@ require (
 	github.com/go-openapi/swag v0.23.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gogo/status v1.1.1
-	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v0.0.4
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20240611171734-87c7e9e7a4fe
+	github.com/grafana/dskit v0.0.0-20240613131924-7e83c3cb3b11
 	github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/json-iterator/go v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-openapi/swag v0.23.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gogo/status v1.1.1
-	github.com/golang/protobuf v1.5.4
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20240607182251-835aff588914 h1:WXLbSnnomltxdNcE20CI8RD8quZ/L0YpXP0WK+0S1BU=
 github.com/grafana/alerting v0.0.0-20240607182251-835aff588914/go.mod h1:U7Ta3K4T7jVgqGSYuPsfuPKHFiL2GbCZSHa3nHjmCos=
-github.com/grafana/dskit v0.0.0-20240611171734-87c7e9e7a4fe h1:PpBnljz9oYSp05pCcQl27n69cL9fNeFH+wkG/ga6oGs=
-github.com/grafana/dskit v0.0.0-20240611171734-87c7e9e7a4fe/go.mod h1:HvSf3uf8Ps2vPpzHeAFyZTdUcbVr+Rxpq1xcx7J/muc=
+github.com/grafana/dskit v0.0.0-20240613131924-7e83c3cb3b11 h1:PqVLwm8e1zRSN0syRYfgjyZ3BePo+EnMqA8FaHQEDkQ=
+github.com/grafana/dskit v0.0.0-20240613131924-7e83c3cb3b11/go.mod h1:HvSf3uf8Ps2vPpzHeAFyZTdUcbVr+Rxpq1xcx7J/muc=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc h1:BW+LjKJDz0So5LI8UZfW5neWeKpSkWqhmGjQFzcFfLM=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -8,29 +8,38 @@ package distributor
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/gogo/status"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/httpgrpc/server"
 	"github.com/grafana/dskit/middleware"
+	dskit_server "github.com/grafana/dskit/server"
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -871,4 +880,200 @@ func TestRetryConfig_Validate(t *testing.T) {
 			assert.Equal(t, testData.expectedErr, testData.cfg.Validate())
 		})
 	}
+}
+
+func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	cfg := dskit_server.Config{}
+	// Set default values
+	cfg.RegisterFlags(flag.NewFlagSet("test", flag.ContinueOnError))
+
+	// Configure values for test.
+	cfg.HTTPListenAddress = "localhost"
+	cfg.HTTPListenPort = 0 // auto-assign
+	cfg.GRPCListenAddress = "localhost"
+	cfg.GRPCListenPort = 0 // auto-assign
+	cfg.Registerer = reg
+	cfg.Gatherer = reg
+	cfg.ReportHTTP4XXCodesInInstrumentationLabel = true // report 400 as errors.
+	cfg.GRPCMiddleware = []grpc.UnaryServerInterceptor{middleware.ServerUserHeaderInterceptor}
+	cfg.HTTPMiddleware = []middleware.Interface{middleware.AuthenticateUser}
+
+	srv, err := dskit_server.New(cfg)
+	require.NoError(t, err)
+	//srv.HTTP.
+
+	push := func(ctx context.Context, req *Request) error {
+		// Trigger conversion of incoming request to WriteRequest.
+		wr, err := req.WriteRequest()
+		if err != nil {
+			return err
+		}
+
+		if len(wr.Timeseries) > 0 && len(wr.Timeseries[0].Labels) > 0 && wr.Timeseries[0].Labels[0].Name == "__name__" && wr.Timeseries[0].Labels[0].Value == "report_server_error" {
+			return errors.New("some random push error")
+		}
+
+		return nil
+	}
+	h := OTLPHandler(200, util.NewBufferPool(), nil, false, otlpLimitsMock{}, RetryConfig{Enabled: false}, push, newPushMetrics(reg), reg, log.NewNopLogger(), true)
+	srv.HTTP.Handle("/otlp", h)
+
+	// start the server
+	require.NoError(t, err)
+	go func() { _ = srv.Run() }()
+	t.Cleanup(srv.Stop)
+
+	// create client
+	conn, err := grpc.NewClient(srv.GRPCListenAddr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithUnaryInterceptor(middleware.ClientUserHeaderInterceptor))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	type testCase struct {
+		request                  *httpgrpc.HTTPRequest
+		expectedResponse         *httpgrpc.HTTPResponse
+		expectedGrpcErrorMessage string
+	}
+
+	testcases := map[string]testCase{
+		"missing content type returns 415": {
+			request: &httpgrpc.HTTPRequest{
+				Method: "POST",
+				Url:    "/otlp",
+				Body:   []byte("hello"),
+			},
+			expectedResponse: &httpgrpc.HTTPResponse{Code: 415,
+				Headers: []*httpgrpc.Header{
+					{Key: "Content-Type", Values: []string{"application/octet-stream"}},
+					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
+				},
+				Body: mustMarshalStatus(t, 415, "unsupported content type: , supported: [application/json, application/x-protobuf]"),
+			},
+			expectedGrpcErrorMessage: "rpc error: code = Code(415) desc = unsupported content type: , supported: [application/json, application/x-protobuf]",
+		},
+
+		"invalid JSON request returns 400": {
+			request: &httpgrpc.HTTPRequest{
+				Method: "POST",
+				Headers: []*httpgrpc.Header{
+					{Key: "Content-Type", Values: []string{"application/json"}},
+				},
+				Url:  "/otlp",
+				Body: []byte("invalid"),
+			},
+			expectedResponse: &httpgrpc.HTTPResponse{Code: 400,
+				Headers: []*httpgrpc.Header{
+					{Key: "Content-Type", Values: []string{"application/octet-stream"}},
+					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
+				},
+				Body: mustMarshalStatus(t, 400, "ReadObjectCB: expect { or n, but found i, error found in #1 byte of ...|invalid|..., bigger context ...|invalid|..."),
+			},
+			expectedGrpcErrorMessage: "rpc error: code = Code(400) desc = ReadObjectCB: expect { or n, but found i, error found in #1 byte of ...|invalid|..., bigger context ...|invalid|...",
+		},
+
+		"empty JSON is good request, with 200 status code": {
+			request: &httpgrpc.HTTPRequest{
+				Method: "POST",
+				Headers: []*httpgrpc.Header{
+					{Key: "Content-Type", Values: []string{"application/json"}},
+				},
+				Url:  "/otlp",
+				Body: []byte("{}"),
+			},
+			expectedResponse: &httpgrpc.HTTPResponse{Code: 200,
+				Headers: nil, // No headers expected for 200.
+				Body:    nil, // No body expected for 200 code.
+			},
+			expectedGrpcErrorMessage: "", // No error expected
+		},
+
+		"trigger 5xx error by sending special metric": {
+			request: &httpgrpc.HTTPRequest{
+				Method: "POST",
+				Headers: []*httpgrpc.Header{
+					{Key: "Content-Type", Values: []string{"application/json"}},
+				},
+				Url: "/otlp",
+				// This is simple OTLP request, with "report_server_error".
+				Body: []byte(`{"resourceMetrics": [{"scopeMetrics": [{"metrics": [{"name": "report_server_error", "gauge": {"dataPoints": [{"timeUnixNano": "1679912463340000000", "asDouble": 10.66}]}}]}]}]}`),
+			},
+			expectedResponse: &httpgrpc.HTTPResponse{Code: 503,
+				Headers: []*httpgrpc.Header{
+					{Key: "Content-Type", Values: []string{"application/octet-stream"}},
+					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
+				},
+				Body: mustMarshalStatus(t, codes.Internal, "some random push error"),
+			},
+			expectedGrpcErrorMessage: "rpc error: code = Code(503) desc = some random push error",
+		},
+	}
+
+	hc := httpgrpc.NewHTTPClient(conn)
+	httpClient := http.Client{}
+
+	for name, tc := range testcases {
+		t.Run(fmt.Sprintf("grpc: %s", name), func(t *testing.T) {
+			ctx := user.InjectOrgID(context.Background(), "test")
+			resp, err := hc.Handle(ctx, tc.request)
+
+			if err != nil {
+				require.EqualError(t, err, tc.expectedGrpcErrorMessage)
+
+				errresp, ok := httpgrpc.HTTPResponseFromError(err)
+				require.True(t, ok, "errors reported by OTLP handler should always be convertible to HTTP response")
+				resp = errresp
+			} else if tc.expectedGrpcErrorMessage != "" {
+				require.Failf(t, "expected error message %q, but got no error", tc.expectedGrpcErrorMessage)
+			}
+
+			// Before comparing response, we sort headers, to keep comparison stable.
+			sort.Slice(resp.Headers, func(i, j int) bool {
+				return resp.Headers[i].Key < resp.Headers[j].Key
+			})
+			require.Equal(t, tc.expectedResponse, resp)
+		})
+
+		t.Run(fmt.Sprintf("http: %s", name), func(t *testing.T) {
+			req, err := httpgrpc.ToHTTPRequest(context.Background(), tc.request)
+			require.NoError(t, err)
+
+			req.Header.Add("X-Scope-OrgID", "test")
+			req.RequestURI = ""
+			req.URL.Scheme = "http"
+			req.URL.Host = srv.HTTPListenAddr().String()
+
+			resp, err := httpClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			if len(body) == 0 {
+				body = nil // to simplify test
+			}
+
+			// Verify that body is the same as we expect through gRPC.
+			require.Equal(t, tc.expectedResponse.Body, body)
+
+			// Verify that expected headers are in the response.
+			for _, h := range tc.expectedResponse.Headers {
+				assert.Equal(t, h.Values, resp.Header.Values(h.Key))
+			}
+
+			// Verify that header that indicates grpc error for httpgrpc.Server is not in the response.
+			assert.Empty(t, resp.Header.Get(server.ErrorMessageHeaderKey))
+		})
+	}
+}
+
+func mustMarshalStatus(t *testing.T, code codes.Code, msg string) []byte {
+	bytes, err := proto.Marshal(status.New(code, msg).Proto())
+	require.NoError(t, err)
+	return bytes
+}
+
+type otlpLimitsMock struct{}
+
+func (o otlpLimitsMock) OTelMetricSuffixesEnabled(id string) bool {
+	return false
 }

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -901,7 +901,6 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 
 	srv, err := dskit_server.New(cfg)
 	require.NoError(t, err)
-	//srv.HTTP.
 
 	push := func(ctx context.Context, req *Request) error {
 		// Trigger conversion of incoming request to WriteRequest.
@@ -923,6 +922,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() { defer wg.Done(); _ = srv.Run() }()
 	t.Cleanup(func() {
 		srv.Stop()

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/gogo/status"
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/flagext"
@@ -1073,13 +1072,13 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 }
 
 func mustMarshalStatus(t *testing.T, code codes.Code, msg string) []byte {
-	bytes, err := proto.Marshal(status.New(code, msg).Proto())
+	bytes, err := status.New(code, msg).Proto().Marshal()
 	require.NoError(t, err)
 	return bytes
 }
 
 type otlpLimitsMock struct{}
 
-func (o otlpLimitsMock) OTelMetricSuffixesEnabled(id string) bool {
+func (o otlpLimitsMock) OTelMetricSuffixesEnabled(_ string) bool {
 	return false
 }

--- a/vendor/github.com/grafana/dskit/httpgrpc/httpgrpc.go
+++ b/vendor/github.com/grafana/dskit/httpgrpc/httpgrpc.go
@@ -118,6 +118,10 @@ func Errorf(code int, tmpl string, args ...interface{}) error {
 
 // ErrorFromHTTPResponse converts an HTTP response into a grpc error
 func ErrorFromHTTPResponse(resp *HTTPResponse) error {
+	return ErrorFromHTTPResponseWithMessage(resp, string(resp.Body))
+}
+
+func ErrorFromHTTPResponseWithMessage(resp *HTTPResponse, msg string) error {
 	a, err := types.MarshalAny(resp)
 	if err != nil {
 		return err
@@ -125,10 +129,11 @@ func ErrorFromHTTPResponse(resp *HTTPResponse) error {
 
 	return status.ErrorProto(&spb.Status{
 		Code:    resp.Code,
-		Message: string(resp.Body),
+		Message: msg,
 		Details: []*types.Any{a},
 	})
 }
+
 
 // HTTPResponseFromError converts a grpc error into an HTTP response
 func HTTPResponseFromError(err error) (*HTTPResponse, bool) {

--- a/vendor/github.com/grafana/dskit/httpgrpc/httpgrpc.go
+++ b/vendor/github.com/grafana/dskit/httpgrpc/httpgrpc.go
@@ -116,11 +116,13 @@ func Errorf(code int, tmpl string, args ...interface{}) error {
 	})
 }
 
-// ErrorFromHTTPResponse converts an HTTP response into a grpc error
+// ErrorFromHTTPResponse converts an HTTP response into a grpc error, and uses HTTP response body as an error message.
+// Note that if HTTP response body contains non-utf8 string, then returned error cannot be marshalled by protobuf.
 func ErrorFromHTTPResponse(resp *HTTPResponse) error {
 	return ErrorFromHTTPResponseWithMessage(resp, string(resp.Body))
 }
 
+// ErrorFromHTTPResponseWithMessage converts an HTTP response into a grpc error, and uses supplied message for Error message.
 func ErrorFromHTTPResponseWithMessage(resp *HTTPResponse, msg string) error {
 	a, err := types.MarshalAny(resp)
 	if err != nil {
@@ -133,7 +135,6 @@ func ErrorFromHTTPResponseWithMessage(resp *HTTPResponse, msg string) error {
 		Details: []*types.Any{a},
 	})
 }
-
 
 // HTTPResponseFromError converts a grpc error into an HTTP response
 func HTTPResponseFromError(err error) (*HTTPResponse, bool) {

--- a/vendor/github.com/grafana/dskit/httpgrpc/server/server.go
+++ b/vendor/github.com/grafana/dskit/httpgrpc/server/server.go
@@ -26,10 +26,22 @@ import (
 )
 
 var (
-	// DoNotLogErrorHeaderKey is a header key used for marking non-loggable errors. More precisely, if an HTTP response
+	// DoNotLogErrorHeaderKey is a header name used for marking non-loggable errors. More precisely, if an HTTP response
 	// has a status code 5xx, and contains a header with key DoNotLogErrorHeaderKey and any values, the generated error
 	// will be marked as non-loggable.
 	DoNotLogErrorHeaderKey = http.CanonicalHeaderKey("X-DoNotLogError")
+
+	// ErrorMessageHeaderKey is a header name that contains error message that should be used when httpgrpc.Handler
+	// decides to response as an error, using status.ErrorProto. Normally httpgrpc.Handler would use entire response
+	// body as a error message, but Message field of rcp.Status object is a string, and if body contains non-utf8 bytes,
+	// Marshalling of this object will fail.
+	ErrorMessageHeaderKey = http.CanonicalHeaderKey("X-ErrorMessage")
+)
+
+type contextType int
+
+const (
+	handledByHttpgrpcServer contextType = 0
 )
 
 type Option func(*Server)
@@ -59,6 +71,8 @@ func NewServer(handler http.Handler, opts ...Option) *Server {
 
 // Handle implements HTTPServer.
 func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
+	ctx = context.WithValue(ctx, handledByHttpgrpcServer, true)
+
 	req, err := httpgrpc.ToHTTPRequest(ctx, r)
 	if err != nil {
 		return nil, err
@@ -74,13 +88,24 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 		header.Del(DoNotLogErrorHeaderKey) // remove before converting to httpgrpc resp
 	}
 
+	errorMessageFromHeader := ""
+	if msg, ok := header[ErrorMessageHeaderKey]; ok {
+		errorMessageFromHeader = msg[0]
+		header.Del(ErrorMessageHeaderKey) // remove before converting to httpgrpc resp
+	}
+
 	resp := &httpgrpc.HTTPResponse{
 		Code:    int32(recorder.Code),
 		Headers: httpgrpc.FromHeader(header),
 		Body:    recorder.Body.Bytes(),
 	}
 	if s.shouldReturnError(resp) {
-		err := httpgrpc.ErrorFromHTTPResponse(resp)
+		var err error
+		if errorMessageFromHeader != "" {
+			err = httpgrpc.ErrorFromHTTPResponseWithMessage(resp, errorMessageFromHeader)
+		} else {
+			err = httpgrpc.ErrorFromHTTPResponse(resp)
+		}
 		if doNotLogError {
 			err = middleware.DoNotLogError{Err: err}
 		}
@@ -205,4 +230,12 @@ func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+}
+
+func IsHandledByHttpgrpcServer(ctx context.Context) bool {
+	val := ctx.Value(handledByHttpgrpcServer)
+	if v, ok := val.(bool); ok {
+		return v
+	}
+	return false
 }

--- a/vendor/github.com/grafana/dskit/httpgrpc/server/server.go
+++ b/vendor/github.com/grafana/dskit/httpgrpc/server/server.go
@@ -31,18 +31,16 @@ var (
 	// will be marked as non-loggable.
 	DoNotLogErrorHeaderKey = http.CanonicalHeaderKey("X-DoNotLogError")
 
-	// ErrorMessageHeaderKey is a header name that contains error message that should be used when httpgrpc.Handler
-	// decides to response as an error, using status.ErrorProto. Normally httpgrpc.Handler would use entire response
-	// body as a error message, but Message field of rcp.Status object is a string, and if body contains non-utf8 bytes,
-	// Marshalling of this object will fail.
+	// ErrorMessageHeaderKey is a header name for header that contains error message that should be used when Server.Handle
+	// (httpgrpc.HTTP/Handle implementation) decides to return the response as an error, using status.ErrorProto.
+	// Normally Server.Handle would use entire response body as a error message, but Message field of rcp.Status object
+	// is a string, and if body contains non-utf8 bytes, marshalling of this object will fail.
 	ErrorMessageHeaderKey = http.CanonicalHeaderKey("X-ErrorMessage")
 )
 
 type contextType int
 
-const (
-	handledByHttpgrpcServer contextType = 0
-)
+const handledByHttpgrpcServer contextType = 0
 
 type Option func(*Server)
 
@@ -232,6 +230,8 @@ func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// IsHandledByHttpgrpcServer returns true if context is associated with HTTP request that was initiated by
+// Server.Handle, which is an implementation of httpgrpc.HTTP/Handle gRPC method.
 func IsHandledByHttpgrpcServer(ctx context.Context) bool {
 	val := ctx.Value(handledByHttpgrpcServer)
 	if v, ok := val.(bool); ok {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -597,7 +597,7 @@ github.com/grafana/alerting/receivers/webex
 github.com/grafana/alerting/receivers/webhook
 github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
-# github.com/grafana/dskit v0.0.0-20240611171734-87c7e9e7a4fe
+# github.com/grafana/dskit v0.0.0-20240613131924-7e83c3cb3b11
 ## explicit; go 1.20
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

PR https://github.com/grafana/mimir/pull/8227 introduced sending of binary HTTP response bodies to OTLP requests. Unfortunately our `httpgrpc.Server` implementation tries to use such response bodies as error message in `status.Status` objects, and marshalling such object then fails.

This PR fixes that by adding support for specifying different error message to use in `status.Status` object (PR in dskit TBD), and fixing OTLP handler to use this support.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
