### PR TITLE
Remote read first class: workflow structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 * [ENHANCEMENT] Distributor: add `insight=true` to remote-write and OTLP write handlers when the HTTP response status code is 4xx. #8294
 * [ENHANCEMENT] Ingester: reduce locked time while matching postings for a label, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Ingester: reduce the amount of locks taken during the Head compaction's garbage-collection process, improving the write latency and compaction speed. #8327
-* [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326
+* [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326 #8370
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -10,9 +10,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
-
 	"github.com/grafana/dskit/httpgrpc"
+	"github.com/pkg/errors"
 )
 
 type Type string

--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -7,9 +7,10 @@ package error
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/pkg/errors"
 
 	"github.com/grafana/dskit/httpgrpc"
 )
@@ -116,6 +117,17 @@ func Newf(typ Type, tmpl string, args ...interface{}) error {
 func IsAPIError(err error) bool {
 	apiErr := &apiError{}
 	return errors.As(err, &apiErr)
+}
+
+// AddDetails adds details to an existing apiError, but keeps the type and handling.
+// If the error is not an apiError, it will wrap the error with the details.
+func AddDetails(err error, details string) error {
+	apiErr := &apiError{}
+	if !errors.As(err, &apiErr) {
+		return errors.Wrap(err, details)
+	}
+	apiErr.Message = fmt.Sprintf("%s: %s", details, apiErr.Message)
+	return apiErr
 }
 
 // IsNonRetryableAPIError returns true if err is an apiError which should be failed and not retried.

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -4,6 +4,7 @@ package querymiddleware
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,21 +12,81 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage/remote"
 
+	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/util"
 )
+
+// To keep logs and error messages in sync, we define the following keys:
+const (
+	endLogKey      = "end"
+	hintsLogKey    = "hints"
+	matchersLogKey = "matchers"
+	startLogKey    = "start"
+)
+
+type remoteReadRoundTripper struct {
+	next http.RoundTripper
+
+	middleware MetricsQueryMiddleware
+}
+
+func newRemoteReadRoundTripper(next http.RoundTripper, middlewares ...MetricsQueryMiddleware) http.RoundTripper {
+	return &remoteReadRoundTripper{
+		next:       next,
+		middleware: MergeMetricsQueryMiddlewares(middlewares...),
+	}
+}
+
+func (r *remoteReadRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	remoteReadRequest, err := getRemoteReadRequestWithoutConsumingBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if remoteReadRequest == nil {
+		return r.next.RoundTrip(req)
+	}
+
+	queries := remoteReadRequest.GetQueries()
+	for i, query := range queries {
+		metricsRequest, err := toMetricsRequest(req.URL.Path, query)
+		if err != nil {
+			return nil, err
+		}
+		handler := r.middleware.Wrap(HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+			// We do not need to do anything here as this middleware is used for
+			// validation only and previous middlewares would have already returned errors.
+			return nil, nil
+		}))
+		_, error := handler.Do(req.Context(), metricsRequest)
+		if error != nil {
+			return nil, apierror.AddDetails(error, fmt.Sprintf("remote read error (%s_%d: %s)", matchersLogKey, i, metricsRequest.GetQuery()))
+		}
+	}
+
+	return r.next.RoundTrip(req)
+}
 
 // ParseRemoteReadRequestWithoutConsumingBody parses a remote read request
 // without consuming the body. It does not check the req.Body size, so it is
 // the caller's responsibility to ensure that the body is not too large.
 func ParseRemoteReadRequestWithoutConsumingBody(req *http.Request) (url.Values, error) {
-	params := make(url.Values)
+	remoteReadRequest, err := getRemoteReadRequestWithoutConsumingBody(req)
+	if err != nil {
+		return nil, err
+	}
+	return parseRemoteReadRequest(remoteReadRequest)
+}
 
+func getRemoteReadRequestWithoutConsumingBody(req *http.Request) (*prompb.ReadRequest, error) {
 	if req.Body == nil {
-		return params, nil
+		return nil, nil
 	}
 
 	bodyBytes, err := util.ReadRequestBodyWithoutConsuming(req)
@@ -33,38 +94,153 @@ func ParseRemoteReadRequestWithoutConsumingBody(req *http.Request) (url.Values, 
 		return nil, err
 	}
 
-	remoteReadRequest := prompb.ReadRequest{}
+	remoteReadRequest := &prompb.ReadRequest{}
 
-	_, err = util.ParseProtoReader(req.Context(), io.NopCloser(bytes.NewReader(bodyBytes)), int(req.ContentLength), querier.MaxRemoteReadQuerySize, nil, &remoteReadRequest, util.RawSnappy)
+	_, err = util.ParseProtoReader(req.Context(), io.NopCloser(bytes.NewReader(bodyBytes)), int(req.ContentLength), querier.MaxRemoteReadQuerySize, nil, remoteReadRequest, util.RawSnappy)
 	if err != nil {
 		return nil, err
 	}
 
+	return remoteReadRequest, nil
+}
+
+func parseRemoteReadRequest(remoteReadRequest *prompb.ReadRequest) (url.Values, error) {
+	if remoteReadRequest == nil {
+		return nil, nil
+	}
+
+	params := make(url.Values)
 	add := func(i int, name, value string) { params.Add(name+"_"+strconv.Itoa(i), value) }
 
 	queries := remoteReadRequest.GetQueries()
 
 	for i, query := range queries {
-		add(i, "start", fmt.Sprintf("%d", query.GetStartTimestampMs()))
-		add(i, "end", fmt.Sprintf("%d", query.GetEndTimestampMs()))
+		add(i, startLogKey, fmt.Sprintf("%d", query.GetStartTimestampMs()))
+		add(i, endLogKey, fmt.Sprintf("%d", query.GetEndTimestampMs()))
 
-		matchersStrings := make([]string, 0, len(query.Matchers))
-		matchers, err := remote.FromLabelMatchers(query.Matchers)
+		matcher, err := remoteReadMatchersToString(query)
 		if err != nil {
 			return nil, err
 		}
-		for _, m := range matchers {
-			matchersStrings = append(matchersStrings, m.String())
-		}
-		params.Add("matchers_"+strconv.Itoa(i), strings.Join(matchersStrings, ","))
+		add(i, matchersLogKey, matcher)
+
 		if query.Hints != nil {
 			if hints, err := json.Marshal(query.Hints); err == nil {
-				add(i, "hints", string(hints))
+				add(i, hintsLogKey, string(hints))
 			} else {
-				add(i, "hints", fmt.Sprintf("error marshalling hints: %v", err))
+				add(i, hintsLogKey, fmt.Sprintf("error marshalling hints: %v", err))
 			}
 		}
 	}
 
-	return params, err
+	return params, nil
+}
+
+func remoteReadMatchersToString(q *prompb.Query) (string, error) {
+	matchers, err := remote.FromLabelMatchers(q.GetMatchers())
+	if err != nil {
+		return "", err
+	}
+	builder := strings.Builder{}
+	builder.WriteRune('{')
+	for i, m := range matchers {
+		if i > 0 {
+			builder.WriteRune(',')
+		}
+		builder.WriteString(m.String())
+	}
+	builder.WriteRune('}')
+	return builder.String(), nil
+}
+
+func toMetricsRequest(path string, query *prompb.Query) (MetricsQueryRequest, error) {
+	metricsQuery := &remoteReadQuery{
+		path:  path,
+		query: query,
+	}
+	var err error
+	metricsQuery.promQuery, err = remoteReadMatchersToString(query)
+	if err != nil {
+		return nil, err
+	}
+	return metricsQuery, nil
+}
+
+type remoteReadQuery struct {
+	path      string
+	query     *prompb.Query
+	promQuery string
+}
+
+var _ = MetricsQueryRequest(&remoteReadQuery{})
+
+func (r *remoteReadQuery) AddSpanTags(sp opentracing.Span) {
+	// No-op.
+}
+
+func (r *remoteReadQuery) GetStart() int64 {
+	return r.query.GetStartTimestampMs()
+}
+
+func (r *remoteReadQuery) GetEnd() int64 {
+	return r.query.GetEndTimestampMs()
+}
+
+func (r *remoteReadQuery) GetHints() *Hints {
+	return nil
+}
+
+func (r *remoteReadQuery) GetStep() int64 {
+	if r.query.Hints != nil {
+		return r.query.Hints.GetStepMs()
+	}
+	return 0
+}
+
+func (r *remoteReadQuery) GetID() int64 {
+	return 0
+}
+
+func (r *remoteReadQuery) GetMaxT() int64 {
+	return r.GetEnd()
+}
+
+func (r *remoteReadQuery) GetMinT() int64 {
+	return r.GetStart()
+}
+
+func (r *remoteReadQuery) GetOptions() Options {
+	return Options{}
+}
+
+func (r *remoteReadQuery) GetPath() string {
+	return r.path
+}
+
+func (r *remoteReadQuery) GetQuery() string {
+	return r.promQuery
+}
+
+func (r *remoteReadQuery) WithID(_ int64) MetricsQueryRequest {
+	panic("not implemented")
+}
+
+func (r *remoteReadQuery) WithEstimatedSeriesCountHint(_ uint64) MetricsQueryRequest {
+	panic("not implemented")
+}
+
+func (r *remoteReadQuery) WithExpr(_ parser.Expr) MetricsQueryRequest {
+	panic("not implemented")
+}
+
+func (r *remoteReadQuery) WithQuery(_ string) (MetricsQueryRequest, error) {
+	panic("not implemented")
+}
+
+func (r *remoteReadQuery) WithStartEnd(_ int64, _ int64) MetricsQueryRequest {
+	panic("not implemented")
+}
+
+func (r *remoteReadQuery) WithTotalQueriesHint(_ int32) MetricsQueryRequest {
+	panic("not implemented")
 }

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -162,7 +162,7 @@ type remoteReadQueryRequest struct {
 	promQuery string
 }
 
-func (r *remoteReadQueryRequest) AddSpanTags(sp opentracing.Span) {
+func (r *remoteReadQueryRequest) AddSpanTags(_ opentracing.Span) {
 	// No-op.
 }
 

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -78,7 +78,7 @@ type mockRoundTripper struct {
 	called int
 }
 
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 	m.called++
 	return nil, nil
 }
@@ -86,14 +86,14 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 type skipMiddleware struct {
 }
 
-func (s *skipMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+func (s *skipMiddleware) Do(_ context.Context, _ MetricsQueryRequest) (Response, error) {
 	return nil, nil
 }
 
 type errorMiddleware struct {
 }
 
-func (s *errorMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+func (s *errorMiddleware) Do(_ context.Context, _ MetricsQueryRequest) (Response, error) {
 	return nil, fmt.Errorf("TestErrorMiddleware")
 }
 

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -4,8 +4,11 @@ package querymiddleware
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -17,62 +20,36 @@ import (
 
 func TestParseRemoteReadRequestWithoutConsumingBody(t *testing.T) {
 	testCases := map[string]struct {
-		reqBody               func() io.ReadCloser
+		makeRequest           func() *http.Request
 		contentLength         int
 		expectedErrorContains string
 		expectedErrorIs       error
 		expectedParams        url.Values
 	}{
 		"no body": {
-			reqBody: func() io.ReadCloser {
-				return nil
+			makeRequest: func() *http.Request {
+				req := httptest.NewRequest("GET", "/api/v1/read", nil)
+				req.Body = nil
+				return req
 			},
-			expectedParams: make(url.Values),
+			expectedParams: nil,
 		},
 		"valid body": {
-			reqBody: func() io.ReadCloser {
-				remoteReadRequest := &prompb.ReadRequest{
-					Queries: []*prompb.Query{
-						{
-							Matchers: []*prompb.LabelMatcher{
-								{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"},
-								{Name: "foo", Type: prompb.LabelMatcher_RE, Value: ".*bar.*"},
-							},
-							StartTimestampMs: 0,
-							EndTimestampMs:   42,
-						},
-						{
-							Matchers: []*prompb.LabelMatcher{
-								{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "up"},
-							},
-							StartTimestampMs: 10,
-							EndTimestampMs:   20,
-							Hints: &prompb.ReadHints{
-								StepMs: 1000,
-							},
-						},
-					},
-				}
-				data, _ := proto.Marshal(remoteReadRequest) // Ignore error, if this fails, the test will fail.
-				compressed := snappy.Encode(nil, data)
-				return io.NopCloser(bytes.NewReader(compressed))
-			},
+			makeRequest: generateTestRemoteReadRequest,
 			expectedParams: url.Values{
 				"start_0":    []string{"0"},
 				"end_0":      []string{"42"},
-				"matchers_0": []string{"__name__=\"some_metric\",foo=~\".*bar.*\""},
+				"matchers_0": []string{"{__name__=\"some_metric\",foo=~\".*bar.*\"}"},
 				"start_1":    []string{"10"},
 				"end_1":      []string{"20"},
-				"matchers_1": []string{"__name__=\"up\""},
+				"matchers_1": []string{"{__name__=\"up\"}"},
 				"hints_1":    []string{"{\"step_ms\":1000}"},
 			},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			req := &http.Request{
-				Body: tc.reqBody(),
-			}
+			req := tc.makeRequest()
 			params, err := ParseRemoteReadRequestWithoutConsumingBody(req)
 			if err != nil {
 				if tc.expectedErrorIs != nil {
@@ -93,4 +70,103 @@ func TestParseRemoteReadRequestWithoutConsumingBody(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockRoundTripper struct {
+	called int
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.called++
+	return nil, nil
+}
+
+type skipMiddleware struct {
+}
+
+func (s *skipMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+	return nil, nil
+}
+
+type errorMiddleware struct {
+}
+
+func (s *errorMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+	return nil, fmt.Errorf("TestErrorMiddleware")
+}
+
+func TestRemoteReadRoundTripperCallsDownstreamOnAll(t *testing.T) {
+	testCases := map[string]struct {
+		handler                MetricsQueryHandler
+		expectDownstreamCalled int
+		expectMiddlewareCalled int
+		expectError            string
+	}{
+		"skipping middleware": {
+			handler:                &skipMiddleware{},
+			expectDownstreamCalled: 1,
+			expectMiddlewareCalled: 2,
+		},
+		"error middleware": {
+			handler:                &errorMiddleware{},
+			expectDownstreamCalled: 0,
+			expectMiddlewareCalled: 1,
+			expectError:            "remote read error (matchers_0: {__name__=\"some_metric\",foo=~\".*bar.*\"}): TestErrorMiddleware",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			roundTripper := &mockRoundTripper{}
+			countMiddleWareCalls := 0
+			middleware := MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+				countMiddleWareCalls++
+				return tc.handler
+			})
+			rr := newRemoteReadRoundTripper(roundTripper, middleware)
+			_, err := rr.RoundTrip(generateTestRemoteReadRequest())
+			if tc.expectError != "" {
+				require.Error(t, err)
+				require.Equal(t, tc.expectError, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectDownstreamCalled, roundTripper.called)
+			require.Equal(t, tc.expectMiddlewareCalled, countMiddleWareCalls)
+		})
+	}
+}
+
+func generateTestRemoteReadRequest() *http.Request {
+	request := httptest.NewRequest("GET", "/api/v1/read", nil)
+	request.Header.Add("User-Agent", "test-user-agent")
+	request.Header.Add("Content-Type", "application/x-protobuf")
+	request.Header.Add("Content-Encoding", "snappy")
+	remoteReadRequest := &prompb.ReadRequest{
+		Queries: []*prompb.Query{
+			{
+				Matchers: []*prompb.LabelMatcher{
+					{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"},
+					{Name: "foo", Type: prompb.LabelMatcher_RE, Value: ".*bar.*"},
+				},
+				StartTimestampMs: 0,
+				EndTimestampMs:   42,
+			},
+			{
+				Matchers: []*prompb.LabelMatcher{
+					{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "up"},
+				},
+				StartTimestampMs: 10,
+				EndTimestampMs:   20,
+				Hints: &prompb.ReadHints{
+					StepMs: 1000,
+				},
+			},
+		},
+	}
+	data, _ := proto.Marshal(remoteReadRequest) // Ignore error, if this fails, the test will fail.
+	compressed := snappy.Encode(nil, data)
+	request.Body = io.NopCloser(bytes.NewReader(compressed))
+
+	return request
 }

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var _ = MetricsQueryRequest(&remoteReadQueryRequest{})
+
 func TestParseRemoteReadRequestWithoutConsumingBody(t *testing.T) {
 	testCases := map[string]struct {
 		makeRequest           func() *http.Request

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -222,6 +222,10 @@ func newQueryTripperware(
 	queryBlockerMiddleware := newQueryBlockerMiddleware(limits, log, registerer)
 	queryStatsMiddleware := newQueryStatsMiddleware(registerer, engine)
 
+	remoteReadMiddleware := []MetricsQueryMiddleware{
+		// Empty for now.
+	}
+
 	queryRangeMiddleware := []MetricsQueryMiddleware{
 		// Track query range statistics. Added first before any subsequent middleware modifies the request.
 		queryStatsMiddleware,
@@ -323,6 +327,7 @@ func newQueryTripperware(
 	return func(next http.RoundTripper) http.RoundTripper {
 		queryrange := newLimitedParallelismRoundTripper(next, codec, limits, queryRangeMiddleware...)
 		instant := newLimitedParallelismRoundTripper(next, codec, limits, queryInstantMiddleware...)
+		remoteRead := newRemoteReadRoundTripper(next, remoteReadMiddleware...)
 
 		// Wrap next for cardinality, labels queries and all other queries.
 		// That attempts to parse "start" and "end" from the HTTP request and set them in the request's QueryDetails.
@@ -358,6 +363,8 @@ func newQueryTripperware(
 				return activeNativeHistogramMetrics.RoundTrip(r)
 			case IsLabelsQuery(r.URL.Path):
 				return labels.RoundTrip(r)
+			case IsRemoteReadQuery(r.URL.Path):
+				return remoteRead.RoundTrip(r)
 			default:
 				return next.RoundTrip(r)
 			}

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -194,13 +194,13 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				r.Body = io.NopCloser(bytes.NewReader(compressed))
 				return r
 			},
-			expectedActivity: "user:12345 UA:test-user-agent req:GET /api/v1/read end_0=42&end_1=20&hints_1=%7B%22step_ms%22%3A1000%7D&matchers_0=__name__%3D%22some_metric%22%2Cfoo%3D~%22.%2Abar.%2A%22&matchers_1=__name__%3D%22up%22&start_0=0&start_1=10",
+			expectedActivity: "user:12345 UA:test-user-agent req:GET /api/v1/read end_0=42&end_1=20&hints_1=%7B%22step_ms%22%3A1000%7D&matchers_0=%7B__name__%3D%22some_metric%22%2Cfoo%3D~%22.%2Abar.%2A%22%7D&matchers_1=%7B__name__%3D%22up%22%7D&start_0=0&start_1=10",
 			expectedMetrics:  5,
 			expectedParams: url.Values{
-				"matchers_0": []string{"__name__=\"some_metric\",foo=~\".*bar.*\""},
+				"matchers_0": []string{"{__name__=\"some_metric\",foo=~\".*bar.*\"}"},
 				"start_0":    []string{"0"},
 				"end_0":      []string{"42"},
-				"matchers_1": []string{"__name__=\"up\""},
+				"matchers_1": []string{"{__name__=\"up\"}"},
 				"start_1":    []string{"10"},
 				"end_1":      []string{"20"},
 				"hints_1":    []string{"{\"step_ms\":1000}"},


### PR DESCRIPTION
#### What this PR does

Make place for a remote read roundtripper that would wrap limits and blocking checks.

Update the format of how we log the remote read query matchers in query stats and activity tracker. This will enable having the same string in the logs and also the query blocker.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir-squad/issues/2148 (internal, make remote read first class)

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
