### PR TITLE
Query-frontend: enforce limitsMiddleware for remote read requests

### DIFF
--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -348,8 +348,7 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 					end:   util.TimeToMillis(testData.reqEndTime),
 				},
 				"remote read": &remoteReadQueryRequest{
-					path:      remoteReadPathSuffix,
-					promQuery: "",
+					path: remoteReadPathSuffix,
 					query: &prompb.Query{
 						StartTimestampMs: util.TimeToMillis(testData.reqStartTime),
 						EndTimestampMs:   util.TimeToMillis(testData.reqEndTime),

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -7,6 +7,7 @@ package querymiddleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -16,6 +17,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -132,38 +136,51 @@ func TestLimitsMiddleware_MaxQueryLookback(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			req := &PrometheusRangeQueryRequest{
-				start: util.TimeToMillis(testData.reqStartTime),
-				end:   util.TimeToMillis(testData.reqEndTime),
+			reqs := map[string]MetricsQueryRequest{
+				"range query": &PrometheusRangeQueryRequest{
+					start: util.TimeToMillis(testData.reqStartTime),
+					end:   util.TimeToMillis(testData.reqEndTime),
+				},
+				"remote read": &remoteReadQueryRequest{
+					path: remoteReadPathSuffix,
+					query: &prompb.Query{
+						StartTimestampMs: util.TimeToMillis(testData.reqStartTime),
+						EndTimestampMs:   util.TimeToMillis(testData.reqEndTime),
+					},
+				},
 			}
 
-			limits := mockLimits{maxQueryLookback: testData.maxQueryLookback, compactorBlocksRetentionPeriod: testData.blocksRetentionPeriod}
-			middleware := newLimitsMiddleware(limits, log.NewNopLogger())
+			for reqType, req := range reqs {
+				t.Run(reqType, func(t *testing.T) {
+					limits := mockLimits{maxQueryLookback: testData.maxQueryLookback, compactorBlocksRetentionPeriod: testData.blocksRetentionPeriod}
+					middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
-			innerRes := newEmptyPrometheusResponse()
-			inner := &mockHandler{}
-			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
+					innerRes := newEmptyPrometheusResponse()
+					inner := &mockHandler{}
+					inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
-			ctx := user.InjectOrgID(context.Background(), "test")
-			outer := middleware.Wrap(inner)
-			res, err := outer.Do(ctx, req)
-			require.NoError(t, err)
+					ctx := user.InjectOrgID(context.Background(), "test")
+					outer := middleware.Wrap(inner)
+					res, err := outer.Do(ctx, req)
+					require.NoError(t, err)
 
-			if testData.expectedSkipped {
-				// We expect an empty response, but not the one returned by the inner handler
-				// which we expect has been skipped.
-				assert.NotSame(t, innerRes, res)
-				assert.Len(t, inner.Calls, 0)
-			} else {
-				// We expect the response returned by the inner handler.
-				assert.Same(t, innerRes, res)
+					if testData.expectedSkipped {
+						// We expect an empty response, but not the one returned by the inner handler
+						// which we expect has been skipped.
+						assert.NotSame(t, innerRes, res)
+						assert.Len(t, inner.Calls, 0)
+					} else {
+						// We expect the response returned by the inner handler.
+						assert.Same(t, innerRes, res)
 
-				// Assert on the time range of the request passed to the inner handler (5s delta).
-				delta := float64(5000)
-				require.Len(t, inner.Calls, 1)
+						// Assert on the time range of the request passed to the inner handler (5s delta).
+						delta := float64(5000)
+						require.Len(t, inner.Calls, 1)
 
-				assert.InDelta(t, util.TimeToMillis(testData.expectedStartTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetStart(), delta)
-				assert.InDelta(t, util.TimeToMillis(testData.expectedEndTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetEnd(), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedStartTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetStart(), delta)
+						assert.InDelta(t, util.TimeToMillis(testData.expectedEndTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetEnd(), delta)
+					}
+				})
 			}
 		})
 	}
@@ -206,34 +223,64 @@ func TestLimitsMiddleware_MaxQueryExpressionSizeBytes(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			req := &PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, testData.query),
-				start:     util.TimeToMillis(now.Add(-time.Hour * 2)),
-				end:       util.TimeToMillis(now.Add(-time.Hour)),
-			}
+			startMs := util.TimeToMillis(now.Add(-time.Hour * 2))
+			endMs := util.TimeToMillis(now.Add(-time.Hour))
 
-			limits := multiTenantMockLimits{
-				byTenant: map[string]mockLimits{
-					"test1": {maxQueryExpressionSizeBytes: testData.queryLimits["test1"]},
-					"test2": {maxQueryExpressionSizeBytes: testData.queryLimits["test2"]},
+			reqs := map[string]MetricsQueryRequest{
+				"range query": &PrometheusRangeQueryRequest{
+					queryExpr: parseQuery(t, testData.query),
+					start:     startMs,
+					end:       endMs,
+				},
+				"remote read": &remoteReadQueryRequest{
+					path:      remoteReadPathSuffix,
+					promQuery: testData.query,
+					query: &prompb.Query{
+						StartTimestampMs: startMs,
+						EndTimestampMs:   endMs,
+						Matchers: func() []*prompb.LabelMatcher {
+							v := &findVectorSelectorsVisitor{}
+							require.NoError(t, parser.Walk(v, parseQuery(t, testData.query), nil))
+
+							// This test requires the query has only 1 vector selector.
+							require.Len(t, v.selectors, 1)
+							require.NotEmpty(t, v.selectors[0].LabelMatchers)
+
+							matchers, err := toLabelMatchers(v.selectors[0].LabelMatchers)
+							require.NoError(t, err)
+
+							return matchers
+						}(),
+					},
 				},
 			}
-			middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
-			innerRes := newEmptyPrometheusResponse()
-			inner := &mockHandler{}
-			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
+			for reqType, req := range reqs {
+				t.Run(reqType, func(t *testing.T) {
+					limits := multiTenantMockLimits{
+						byTenant: map[string]mockLimits{
+							"test1": {maxQueryExpressionSizeBytes: testData.queryLimits["test1"]},
+							"test2": {maxQueryExpressionSizeBytes: testData.queryLimits["test2"]},
+						},
+					}
+					middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
-			ctx := user.InjectOrgID(context.Background(), "test1|test2")
-			outer := middleware.Wrap(inner)
-			res, err := outer.Do(ctx, req)
+					innerRes := newEmptyPrometheusResponse()
+					inner := &mockHandler{}
+					inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
-			if testData.expectError {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "err-mimir-max-query-expression-size-bytes")
-			} else {
-				require.NoError(t, err)
-				require.Same(t, innerRes, res)
+					ctx := user.InjectOrgID(context.Background(), "test1|test2")
+					outer := middleware.Wrap(inner)
+					res, err := outer.Do(ctx, req)
+
+					if testData.expectError {
+						require.Error(t, err)
+						require.Contains(t, err.Error(), "err-mimir-max-query-expression-size-bytes")
+					} else {
+						require.NoError(t, err)
+						require.Same(t, innerRes, res)
+					}
+				})
 			}
 		})
 	}
@@ -295,36 +342,50 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			req := &PrometheusRangeQueryRequest{
-				start: util.TimeToMillis(testData.reqStartTime),
-				end:   util.TimeToMillis(testData.reqEndTime),
+			reqs := map[string]MetricsQueryRequest{
+				"range query": &PrometheusRangeQueryRequest{
+					start: util.TimeToMillis(testData.reqStartTime),
+					end:   util.TimeToMillis(testData.reqEndTime),
+				},
+				"remote read": &remoteReadQueryRequest{
+					path:      remoteReadPathSuffix,
+					promQuery: "",
+					query: &prompb.Query{
+						StartTimestampMs: util.TimeToMillis(testData.reqStartTime),
+						EndTimestampMs:   util.TimeToMillis(testData.reqEndTime),
+					},
+				},
 			}
 
-			limits := mockLimits{maxQueryLength: testData.maxQueryLength, maxTotalQueryLength: testData.maxTotalQueryLength}
-			middleware := newLimitsMiddleware(limits, log.NewNopLogger())
+			for reqType, req := range reqs {
+				t.Run(reqType, func(t *testing.T) {
+					limits := mockLimits{maxQueryLength: testData.maxQueryLength, maxTotalQueryLength: testData.maxTotalQueryLength}
+					middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
-			innerRes := newEmptyPrometheusResponse()
-			inner := &mockHandler{}
-			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
+					innerRes := newEmptyPrometheusResponse()
+					inner := &mockHandler{}
+					inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
-			ctx := user.InjectOrgID(context.Background(), "test")
-			outer := middleware.Wrap(inner)
-			res, err := outer.Do(ctx, req)
+					ctx := user.InjectOrgID(context.Background(), "test")
+					outer := middleware.Wrap(inner)
+					res, err := outer.Do(ctx, req)
 
-			if testData.expectedErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), testData.expectedErr)
-				assert.Nil(t, res)
-				assert.Len(t, inner.Calls, 0)
-			} else {
-				// We expect the response returned by the inner handler.
-				require.NoError(t, err)
-				assert.Same(t, innerRes, res)
+					if testData.expectedErr != "" {
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), testData.expectedErr)
+						assert.Nil(t, res)
+						assert.Len(t, inner.Calls, 0)
+					} else {
+						// We expect the response returned by the inner handler.
+						require.NoError(t, err)
+						assert.Same(t, innerRes, res)
 
-				// The time range of the request passed to the inner handler should have not been manipulated.
-				require.Len(t, inner.Calls, 1)
-				assert.Equal(t, util.TimeToMillis(testData.reqStartTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetStart())
-				assert.Equal(t, util.TimeToMillis(testData.reqEndTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetEnd())
+						// The time range of the request passed to the inner handler should have not been manipulated.
+						require.Len(t, inner.Calls, 1)
+						assert.Equal(t, util.TimeToMillis(testData.reqStartTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetStart())
+						assert.Equal(t, util.TimeToMillis(testData.reqEndTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetEnd())
+					}
+				})
 			}
 		})
 	}
@@ -776,4 +837,45 @@ func TestSmallestPositiveNonZeroDuration(t *testing.T) {
 
 	assert.Equal(t, time.Duration(1), smallestPositiveNonZeroDuration(0, 1, -1))
 	assert.Equal(t, time.Duration(1), smallestPositiveNonZeroDuration(0, 2, 1))
+}
+
+type findVectorSelectorsVisitor struct {
+	selectors []*parser.VectorSelector
+}
+
+func (v *findVectorSelectorsVisitor) Visit(node parser.Node, _ []parser.Node) (parser.Visitor, error) {
+	selector, ok := node.(*parser.VectorSelector)
+	if !ok {
+		return v, nil
+	}
+
+	v.selectors = append(v.selectors, selector)
+	return v, nil
+}
+
+// This function has been copied from:
+// https://github.com/prometheus/prometheus/blob/5efc8dd27b6e68d5102b77bc708e52c9821c5101/storage/remote/codec.go#L569
+func toLabelMatchers(matchers []*labels.Matcher) ([]*prompb.LabelMatcher, error) {
+	pbMatchers := make([]*prompb.LabelMatcher, 0, len(matchers))
+	for _, m := range matchers {
+		var mType prompb.LabelMatcher_Type
+		switch m.Type {
+		case labels.MatchEqual:
+			mType = prompb.LabelMatcher_EQ
+		case labels.MatchNotEqual:
+			mType = prompb.LabelMatcher_NEQ
+		case labels.MatchRegexp:
+			mType = prompb.LabelMatcher_RE
+		case labels.MatchNotRegexp:
+			mType = prompb.LabelMatcher_NRE
+		default:
+			return nil, errors.New("invalid matcher type")
+		}
+		pbMatchers = append(pbMatchers, &prompb.LabelMatcher{
+			Type:  mType,
+			Name:  m.Name,
+			Value: m.Value,
+		})
+	}
+	return pbMatchers, nil
 }

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -68,7 +68,7 @@ func (r *remoteReadRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 
 		// Run the query through the middlewares.
 		var updatedQueryReq *remoteReadQueryRequest
-		handler := r.middleware.Wrap(HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+		handler := r.middleware.Wrap(HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
 			var ok bool
 
 			// The middlewares are used only for validation, but some middlewares may manipulate

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -305,10 +305,13 @@ func (r *remoteReadQueryRequest) WithStartEnd(start int64, end int64) (MetricsQu
 	clonedQuery.StartTimestampMs = start
 	clonedQuery.EndTimestampMs = end
 
-	if clonedQuery.Hints != nil && clonedQuery.Hints.StartMs != 0 {
+	// We only clamp the hints time range (and not extend it). If, for any reason, the hints start/end
+	// time range is shorter than the query start/end range, then we manipulate only to clamp it to keep
+	// it within the requested range.
+	if clonedQuery.Hints != nil && clonedQuery.Hints.StartMs < start {
 		clonedQuery.Hints.StartMs = start
 	}
-	if clonedQuery.Hints != nil && clonedQuery.Hints.EndMs != 0 {
+	if clonedQuery.Hints != nil && clonedQuery.Hints.EndMs > end {
 		clonedQuery.Hints.EndMs = end
 	}
 

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -5,12 +5,14 @@ package querymiddleware
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 
+	"github.com/golang/snappy"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -43,47 +45,91 @@ func newRemoteReadRoundTripper(next http.RoundTripper, middlewares ...MetricsQue
 }
 
 func (r *remoteReadRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	remoteReadRequest, err := getRemoteReadRequestWithoutConsumingBody(req)
+	if req.Body == nil {
+		return r.next.RoundTrip(req)
+	}
+
+	// Parse the request body consuming it! From now on we can't call the next http.RoundTrigger without
+	// replacing the Body.
+	remoteReadReq, err := unmarshalRemoteReadRequest(req.Context(), req.Body, int(req.ContentLength))
 	if err != nil {
 		return nil, err
 	}
 
-	if remoteReadRequest == nil {
-		return r.next.RoundTrip(req)
-	}
+	// Run each query through the middlewares.
+	queries := remoteReadReq.GetQueries()
 
-	queries := remoteReadRequest.GetQueries()
 	for i, query := range queries {
-		metricsRequest, err := remoteReadToMetricsQueryRequest(req.URL.Path, query)
+		// Parse the original query.
+		origQueryReq, err := remoteReadToMetricsQueryRequest(req.URL.Path, query)
 		if err != nil {
 			return nil, err
 		}
-		handler := r.middleware.Wrap(HandlerFunc(func(context.Context, MetricsQueryRequest) (Response, error) {
-			// We do not need to do anything here as this middleware is used for
-			// validation only and previous middlewares would have already returned errors.
+
+		// Run the query through the middlewares.
+		var updatedQueryReq *remoteReadQueryRequest
+		handler := r.middleware.Wrap(HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+			var ok bool
+
+			// The middlewares are used only for validation, but some middlewares may manipulate
+			// the request to enforce some limits (e.g. time range limit). For this reason, we
+			// capture the final request in case it was manipulated.
+			if updatedQueryReq, ok = req.(*remoteReadQueryRequest); !ok {
+				// This should never happen.
+				return nil, errors.New("unexpected logic bug: remote read roundtripper received an unexpected data type")
+			}
+
 			return nil, nil
 		}))
-		_, err = handler.Do(req.Context(), metricsRequest)
+
+		_, err = handler.Do(req.Context(), origQueryReq)
 		if err != nil {
-			return nil, apierror.AddDetails(err, fmt.Sprintf("remote read error (%s_%d: %s)", matchersLogKey, i, metricsRequest.GetQuery()))
+			return nil, apierror.AddDetails(err, fmt.Sprintf("remote read error (%s_%d: %s)", matchersLogKey, i, origQueryReq.GetQuery()))
+		}
+
+		// The query may have been manipulated. We always replace it (if it wasn't manipulated, then
+		// we're just overwriting it with the same exact ref).
+		//
+		// NOTE: updatedQueryReq may be nil if a middleware interrupted the middlewares execution without
+		//       returning an error. It could happen in middlewares returning an empty response under some
+		//       conditions. In such case, since we don't have a way to return an empty response for the
+		//       selected query, we simply keep the original one and let it pass-through the downstream.
+		if updatedQueryReq != nil {
+			queries[i] = updatedQueryReq.query
 		}
 	}
+
+	// At this point the queries may have been manipulated by the middlewares. We marshal the remote request again
+	// in order to inject the manipulated queries. We always do it, even if the queries haven't been manipulated by
+	// middlewares, so that we always exercise this code.
+	remoteReadReq.Queries = queries
+
+	// Marshal the (maybe modified) remote read request and replace the request body.
+	encodedData, err := marshalRemoteReadRequest(remoteReadReq)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Body = io.NopCloser(bytes.NewBuffer(encodedData))
+	req.Header.Set("Content-Length", strconv.Itoa(len(encodedData)))
+	req.Header.Set("Content-Encoding", "snappy")
+	req.ContentLength = int64(len(encodedData))
 
 	return r.next.RoundTrip(req)
 }
 
-// ParseRemoteReadRequestWithoutConsumingBody parses a remote read request
+// ParseRemoteReadRequestValuesWithoutConsumingBody parses a remote read request
 // without consuming the body. It does not check the req.Body size, so it is
 // the caller's responsibility to ensure that the body is not too large.
-func ParseRemoteReadRequestWithoutConsumingBody(req *http.Request) (url.Values, error) {
-	remoteReadRequest, err := getRemoteReadRequestWithoutConsumingBody(req)
+func ParseRemoteReadRequestValuesWithoutConsumingBody(req *http.Request) (url.Values, error) {
+	remoteReadRequest, err := parseRemoteReadRequestWithoutConsumingBody(req)
 	if err != nil {
 		return nil, err
 	}
-	return parseRemoteReadRequest(remoteReadRequest)
+	return parseRemoteReadRequestValues(remoteReadRequest)
 }
 
-func getRemoteReadRequestWithoutConsumingBody(req *http.Request) (*prompb.ReadRequest, error) {
+func parseRemoteReadRequestWithoutConsumingBody(req *http.Request) (*prompb.ReadRequest, error) {
 	if req.Body == nil {
 		return nil, nil
 	}
@@ -93,9 +139,15 @@ func getRemoteReadRequestWithoutConsumingBody(req *http.Request) (*prompb.ReadRe
 		return nil, err
 	}
 
+	return unmarshalRemoteReadRequest(req.Context(), io.NopCloser(bytes.NewReader(bodyBytes)), int(req.ContentLength))
+}
+
+// unmarshalRemoteReadRequest reads from the input read and unmarshals the content into a prompb.ReadRequest.
+// This function either returns prompb.ReadRequest or an error, but never nil to both.
+func unmarshalRemoteReadRequest(ctx context.Context, reader io.ReadCloser, contentLength int) (*prompb.ReadRequest, error) {
 	remoteReadRequest := &prompb.ReadRequest{}
 
-	_, err = util.ParseProtoReader(req.Context(), io.NopCloser(bytes.NewReader(bodyBytes)), int(req.ContentLength), querier.MaxRemoteReadQuerySize, nil, remoteReadRequest, util.RawSnappy)
+	_, err := util.ParseProtoReader(ctx, reader, contentLength, querier.MaxRemoteReadQuerySize, nil, remoteReadRequest, util.RawSnappy)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +155,17 @@ func getRemoteReadRequestWithoutConsumingBody(req *http.Request) (*prompb.ReadRe
 	return remoteReadRequest, nil
 }
 
-func parseRemoteReadRequest(remoteReadRequest *prompb.ReadRequest) (url.Values, error) {
+// marshalRemoteReadRequest marshals the input prompb.ReadRequest protobuf and encode it with snappy.
+func marshalRemoteReadRequest(req *prompb.ReadRequest) ([]byte, error) {
+	data, err := req.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	return snappy.Encode(nil, data), nil
+}
+
+func parseRemoteReadRequestValues(remoteReadRequest *prompb.ReadRequest) (url.Values, error) {
 	if remoteReadRequest == nil {
 		return nil, nil
 	}
@@ -229,14 +291,46 @@ func (r *remoteReadQueryRequest) WithQuery(_ string) (MetricsQueryRequest, error
 	panic("not implemented")
 }
 
-func (r *remoteReadQueryRequest) WithHeaders([]*PrometheusHeader) MetricsQueryRequest {
+func (r *remoteReadQueryRequest) WithHeaders(_ []*PrometheusHeader) MetricsQueryRequest {
 	panic("not implemented")
 }
 
-func (r *remoteReadQueryRequest) WithStartEnd(_ int64, _ int64) (MetricsQueryRequest, error) {
-	panic("not implemented")
+// WithStartEnd clones the current remoteReadQueryRequest with a new start and end timestamp.
+func (r *remoteReadQueryRequest) WithStartEnd(start int64, end int64) (MetricsQueryRequest, error) {
+	clonedQuery, err := cloneRemoteReadQuery(r.query)
+	if err != nil {
+		return nil, err
+	}
+
+	clonedQuery.StartTimestampMs = start
+	clonedQuery.EndTimestampMs = end
+
+	if clonedQuery.Hints != nil && clonedQuery.Hints.StartMs != 0 {
+		clonedQuery.Hints.StartMs = start
+	}
+	if clonedQuery.Hints != nil && clonedQuery.Hints.EndMs != 0 {
+		clonedQuery.Hints.EndMs = end
+	}
+
+	return remoteReadToMetricsQueryRequest(r.path, clonedQuery)
 }
 
 func (r *remoteReadQueryRequest) WithTotalQueriesHint(_ int32) MetricsQueryRequest {
 	panic("not implemented")
+}
+
+// cloneRemoteReadQuery returns a deep copy of the input prompb.Query. To keep this function safe,
+// this function does a full marshal and then unmarshal of the prompb.Query.
+func cloneRemoteReadQuery(orig *prompb.Query) (*prompb.Query, error) {
+	data, err := orig.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	cloned := &prompb.Query{}
+	if err := cloned.Unmarshal(data); err != nil {
+		return nil, err
+	}
+
+	return cloned, nil
 }

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -38,22 +39,24 @@ func TestParseRemoteReadRequestWithoutConsumingBody(t *testing.T) {
 			expectedParams: nil,
 		},
 		"valid body": {
-			makeRequest: generateTestRemoteReadRequest,
+			makeRequest: func() *http.Request {
+				return makeTestHTTPRequestFromRemoteRead(makeTestRemoteReadRequest())
+			},
 			expectedParams: url.Values{
 				"start_0":    []string{"0"},
 				"end_0":      []string{"42"},
-				"matchers_0": []string{"{__name__=\"some_metric\",foo=~\".*bar.*\"}"},
+				"matchers_0": []string{`{__name__="some_metric",foo=~".*bar.*"}`},
 				"start_1":    []string{"10"},
 				"end_1":      []string{"20"},
-				"matchers_1": []string{"{__name__=\"up\"}"},
-				"hints_1":    []string{"{\"step_ms\":1000}"},
+				"matchers_1": []string{`{__name__="up"}`},
+				"hints_1":    []string{`{"step_ms":1000,"start_ms":10,"end_ms":20}`},
 			},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			req := tc.makeRequest()
-			params, err := ParseRemoteReadRequestWithoutConsumingBody(req)
+			params, err := ParseRemoteReadRequestValuesWithoutConsumingBody(req)
 			if err != nil {
 				if tc.expectedErrorIs != nil {
 					require.ErrorIs(t, err, tc.expectedErrorIs)
@@ -76,12 +79,11 @@ func TestParseRemoteReadRequestWithoutConsumingBody(t *testing.T) {
 }
 
 type mockRoundTripper struct {
-	called int
+	onRoundTrip func(*http.Request) (*http.Response, error)
 }
 
-func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
-	m.called++
-	return nil, nil
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.onRoundTrip(req)
 }
 
 type skipMiddleware struct {
@@ -120,14 +122,21 @@ func TestRemoteReadRoundTripperCallsDownstreamOnAll(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			roundTripper := &mockRoundTripper{}
-			countMiddleWareCalls := 0
-			middleware := MetricsQueryMiddlewareFunc(func(MetricsQueryHandler) MetricsQueryHandler {
-				countMiddleWareCalls++
+			var actualDownstreamCalls int
+			roundTripper := &mockRoundTripper{
+				onRoundTrip: func(_ *http.Request) (*http.Response, error) {
+					actualDownstreamCalls++
+					return nil, nil
+				},
+			}
+
+			actualMiddleWareCalls := 0
+			middleware := MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+				actualMiddleWareCalls++
 				return tc.handler
 			})
 			rr := newRemoteReadRoundTripper(roundTripper, middleware)
-			_, err := rr.RoundTrip(generateTestRemoteReadRequest())
+			_, err := rr.RoundTrip(makeTestHTTPRequestFromRemoteRead(makeTestRemoteReadRequest()))
 			if tc.expectError != "" {
 				require.Error(t, err)
 				require.Equal(t, tc.expectError, err.Error())
@@ -145,8 +154,8 @@ func TestRemoteReadRoundTripperCallsDownstreamOnAll(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			require.Equal(t, tc.expectDownstreamCalled, roundTripper.called)
-			require.Equal(t, tc.expectMiddlewareCalled, countMiddleWareCalls)
+			require.Equal(t, tc.expectDownstreamCalled, actualDownstreamCalls)
+			require.Equal(t, tc.expectMiddlewareCalled, actualMiddleWareCalls)
 		})
 	}
 }
@@ -157,12 +166,214 @@ type apiResponse struct {
 	Error     string        `json:"error,omitempty"`
 }
 
-func generateTestRemoteReadRequest() *http.Request {
+func TestRemoteReadRoundTripper_ShouldAllowMiddlewaresToManipulateRequest(t *testing.T) {
+	const (
+		expectedStartMs = 1
+		expectedEndMs   = 2
+	)
+
+	origRemoteReadReq := makeTestRemoteReadRequest()
+
+	// Create a middleware that manipulate the query start/end timestamps.
+	middleware := MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+		return HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+			req, err := req.WithStartEnd(expectedStartMs, expectedEndMs)
+			if err != nil {
+				return nil, err
+			}
+
+			return next.Do(ctx, req)
+		})
+	})
+
+	// Mock the downstream to capture the received request.
+	var downstreamReq *http.Request
+	downstream := &mockRoundTripper{
+		onRoundTrip: func(req *http.Request) (*http.Response, error) {
+			downstreamReq = req
+			return nil, nil
+		},
+	}
+
+	rr := newRemoteReadRoundTripper(downstream, middleware)
+	_, err := rr.RoundTrip(makeTestHTTPRequestFromRemoteRead(origRemoteReadReq))
+	require.NoError(t, err)
+	require.NotNil(t, downstreamReq)
+
+	// Ensure the downstream HTTP request has been correctly manipulated.
+	require.Equal(t, strconv.Itoa(int(downstreamReq.ContentLength)), downstreamReq.Header.Get("Content-Length")) // The two should match.
+	require.Equal(t, "snappy", downstreamReq.Header.Get("Content-Encoding"))
+
+	// Parse the HTTP request received by the downstream.
+	downstreamRemoteReadReq, err := unmarshalRemoteReadRequest(downstreamReq.Context(), downstreamReq.Body, int(downstreamReq.ContentLength))
+	require.NoError(t, err)
+	require.Len(t, downstreamRemoteReadReq.Queries, len(origRemoteReadReq.Queries))
+
+	// Ensure the downstream received the manipulated start/end timestamps.
+	for i, query := range downstreamRemoteReadReq.Queries {
+		require.Equal(t, int64(expectedStartMs), query.StartTimestampMs)
+		require.Equal(t, int64(expectedEndMs), query.EndTimestampMs)
+
+		if origRemoteReadReq.Queries[i].Hints != nil {
+			require.NotNil(t, query.Hints)
+			require.Equal(t, int64(expectedStartMs), query.Hints.StartMs)
+			require.Equal(t, int64(expectedEndMs), query.Hints.EndMs)
+		}
+	}
+
+	// Excluding the start/end timestamps, everything else should be equal.
+	// To run this comparison we override the start/end timestamp both in the original and downstream request.
+	for _, req := range []*prompb.ReadRequest{origRemoteReadReq, downstreamRemoteReadReq} {
+		for _, query := range req.Queries {
+			query.StartTimestampMs = 0
+			query.EndTimestampMs = 0
+
+			if query.Hints != nil {
+				query.Hints.StartMs = 0
+				query.Hints.EndMs = 0
+			}
+		}
+	}
+
+	require.Equal(t, origRemoteReadReq, downstreamRemoteReadReq)
+}
+
+func TestRemoteReadRoundTripper_ShouldAllowMiddlewaresToReturnEmptyResponse(t *testing.T) {
+	// Create a middleware that return an empty response.
+	middleware := MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+		return HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+			return newEmptyPrometheusResponse(), nil
+		})
+	})
+
+	// Mock the downstream to capture the received request.
+	var downstreamReq *http.Request
+	downstream := &mockRoundTripper{
+		onRoundTrip: func(req *http.Request) (*http.Response, error) {
+			downstreamReq = req
+			return nil, nil
+		},
+	}
+
+	rr := newRemoteReadRoundTripper(downstream, middleware)
+	origRemoteReadReq := makeTestRemoteReadRequest()
+
+	_, err := rr.RoundTrip(makeTestHTTPRequestFromRemoteRead(origRemoteReadReq))
+	require.NoError(t, err)
+	require.NotNil(t, downstreamReq)
+
+	// Ensure the HTTP request received by the downstream is equal to the original one.
+	downstreamRemoteReadReq, err := unmarshalRemoteReadRequest(downstreamReq.Context(), downstreamReq.Body, int(downstreamReq.ContentLength))
+	require.NoError(t, err)
+	require.Equal(t, origRemoteReadReq, downstreamRemoteReadReq)
+}
+
+func TestRemoteReadQueryRequest_WithStartEnd(t *testing.T) {
+	const (
+		updatedStartMs = 1
+		updatedEndMs   = 2
+	)
+
+	tests := map[string]struct {
+		input    *remoteReadQueryRequest
+		expected *remoteReadQueryRequest
+	}{
+		"without hints": {
+			input: &remoteReadQueryRequest{
+				path:      remoteReadPathSuffix,
+				promQuery: `{pod="pod-1"}`,
+				query: &prompb.Query{
+					StartTimestampMs: 1000,
+					EndTimestampMs:   2000,
+					Matchers:         []*prompb.LabelMatcher{{Type: prompb.LabelMatcher_EQ, Name: "pod", Value: "pod-1"}},
+				},
+			},
+			expected: &remoteReadQueryRequest{
+				path:      remoteReadPathSuffix,
+				promQuery: `{pod="pod-1"}`,
+				query: &prompb.Query{
+					StartTimestampMs: updatedStartMs,
+					EndTimestampMs:   updatedEndMs,
+					Matchers:         []*prompb.LabelMatcher{{Type: prompb.LabelMatcher_EQ, Name: "pod", Value: "pod-1"}},
+				},
+			},
+		},
+		"with hints": {
+			input: &remoteReadQueryRequest{
+				path:      remoteReadPathSuffix,
+				promQuery: `{pod="pod-1"}`,
+				query: &prompb.Query{
+					StartTimestampMs: 1000,
+					EndTimestampMs:   2000,
+					Matchers:         []*prompb.LabelMatcher{{Type: prompb.LabelMatcher_EQ, Name: "pod", Value: "pod-1"}},
+					Hints: &prompb.ReadHints{
+						StepMs:   123,
+						Func:     "series",
+						StartMs:  1000,
+						EndMs:    2000,
+						Grouping: []string{"cluster"},
+						By:       true,
+					},
+				},
+			},
+			expected: &remoteReadQueryRequest{
+				path:      remoteReadPathSuffix,
+				promQuery: `{pod="pod-1"}`,
+				query: &prompb.Query{
+					StartTimestampMs: updatedStartMs,
+					EndTimestampMs:   updatedEndMs,
+					Matchers:         []*prompb.LabelMatcher{{Type: prompb.LabelMatcher_EQ, Name: "pod", Value: "pod-1"}},
+					Hints: &prompb.ReadHints{
+						StepMs:   123,
+						Func:     "series",
+						StartMs:  updatedStartMs,
+						EndMs:    updatedEndMs,
+						Grouping: []string{"cluster"},
+						By:       true,
+					},
+				},
+			},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actual, err := testData.input.WithStartEnd(updatedStartMs, updatedEndMs)
+			require.NoError(t, err)
+			require.NotSame(t, actual, testData.input)
+			require.Equal(t, testData.expected, actual)
+
+			// Ensure it's a deep copy.
+			actualReq, ok := actual.(*remoteReadQueryRequest)
+			require.True(t, ok)
+			require.NotSame(t, actualReq.query, testData.input.query)
+			require.NotSame(t, actualReq.query.Matchers, testData.input.query.Matchers)
+
+			if actualReq.query.Hints != nil {
+				require.NotSame(t, actualReq.query.Hints, testData.input.query.Hints)
+			}
+
+			for i, actualMatcher := range actualReq.query.Matchers {
+				require.NotSame(t, actualMatcher, testData.input.query.Matchers[i])
+			}
+		})
+	}
+}
+
+func makeTestHTTPRequestFromRemoteRead(readReq *prompb.ReadRequest) *http.Request {
 	request := httptest.NewRequest("GET", "/api/v1/read", nil)
 	request.Header.Add("User-Agent", "test-user-agent")
 	request.Header.Add("Content-Type", "application/x-protobuf")
 	request.Header.Add("Content-Encoding", "snappy")
-	remoteReadRequest := &prompb.ReadRequest{
+	data, _ := proto.Marshal(readReq) // Ignore error, if this fails, the test will fail.
+	compressed := snappy.Encode(nil, data)
+	request.Body = io.NopCloser(bytes.NewReader(compressed))
+
+	return request
+}
+
+func makeTestRemoteReadRequest() *prompb.ReadRequest {
+	return &prompb.ReadRequest{
 		Queries: []*prompb.Query{
 			{
 				Matchers: []*prompb.LabelMatcher{
@@ -171,6 +382,7 @@ func generateTestRemoteReadRequest() *http.Request {
 				},
 				StartTimestampMs: 0,
 				EndTimestampMs:   42,
+				Hints:            nil, // Don't add hints to this query so that we exercise code when the request query has no hints.
 			},
 			{
 				Matchers: []*prompb.LabelMatcher{
@@ -179,16 +391,13 @@ func generateTestRemoteReadRequest() *http.Request {
 				StartTimestampMs: 10,
 				EndTimestampMs:   20,
 				Hints: &prompb.ReadHints{
-					StepMs: 1000,
+					StartMs: 10,
+					EndMs:   20,
+					StepMs:  1000,
 				},
 			},
 		},
 	}
-	data, _ := proto.Marshal(remoteReadRequest) // Ignore error, if this fails, the test will fail.
-	compressed := snappy.Encode(nil, data)
-	request.Body = io.NopCloser(bytes.NewReader(compressed))
-
-	return request
 }
 
 // This is not a full test yet, only tests what's needed for the query blocker.

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -168,8 +168,8 @@ type apiResponse struct {
 
 func TestRemoteReadRoundTripper_ShouldAllowMiddlewaresToManipulateRequest(t *testing.T) {
 	const (
-		expectedStartMs = 1
-		expectedEndMs   = 2
+		expectedStartMs = 11
+		expectedEndMs   = 19
 	)
 
 	origRemoteReadReq := makeTestRemoteReadRequest()

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -131,7 +131,7 @@ func TestRemoteReadRoundTripperCallsDownstreamOnAll(t *testing.T) {
 			}
 
 			actualMiddleWareCalls := 0
-			middleware := MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+			middleware := MetricsQueryMiddlewareFunc(func(_ MetricsQueryHandler) MetricsQueryHandler {
 				actualMiddleWareCalls++
 				return tc.handler
 			})
@@ -240,8 +240,8 @@ func TestRemoteReadRoundTripper_ShouldAllowMiddlewaresToManipulateRequest(t *tes
 
 func TestRemoteReadRoundTripper_ShouldAllowMiddlewaresToReturnEmptyResponse(t *testing.T) {
 	// Create a middleware that return an empty response.
-	middleware := MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
-		return HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+	middleware := MetricsQueryMiddlewareFunc(func(_ MetricsQueryHandler) MetricsQueryHandler {
+		return HandlerFunc(func(_ context.Context, _ MetricsQueryRequest) (Response, error) {
 			return newEmptyPrometheusResponse(), nil
 		})
 	})

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -311,7 +311,9 @@ func newQueryMiddlewares(
 	queryBlockerMiddleware := newQueryBlockerMiddleware(limits, log, registerer)
 	queryStatsMiddleware := newQueryStatsMiddleware(registerer, engine)
 
-	remoteReadMiddleware = append(remoteReadMiddleware, queryBlockerMiddleware)
+	remoteReadMiddleware = append(remoteReadMiddleware,
+		newLimitsMiddleware(limits, log),
+		queryBlockerMiddleware)
 
 	queryRangeMiddleware = append(queryRangeMiddleware,
 		// Track query range statistics. Added first before any subsequent middleware modifies the request.

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -189,7 +189,7 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var err error
 
 	if r.Header.Get("Content-Type") == "application/x-protobuf" && querymiddleware.IsRemoteReadQuery(r.URL.Path) {
-		params, err = querymiddleware.ParseRemoteReadRequestWithoutConsumingBody(r)
+		params, err = querymiddleware.ParseRemoteReadRequestValuesWithoutConsumingBody(r)
 	} else {
 		params, err = util.ParseRequestFormWithoutConsumingBody(r)
 	}


### PR DESCRIPTION
#### What this PR does

In this PR I propose to enforce `limitsMiddleware` for remote read requests too.

Before this PR, `-query-frontend.max-query-expression-size-bytes`, `-query-frontend.max-total-query-length` and `-querier.max-query-lookback` were not enforced for remote read requests in the query-frontend. After this PR, they're enforced in the query-frontend. If a remote read request contains only 1 out of N queries failing because of the limit, the whole remote read request will be rejected (as of today it's quite difficult to only fail 1 out of N queries).

The main change in this PR is about introducing support to manipulate the remote read queries before they're passed to downstream (querier). This is needed by the `-querier.max-query-lookback` enforcement done by `limitsMiddleware`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
