### PR TITLE
Add temporarily config option -query-frontend.remote-read-limits-enabled

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5988,6 +5988,17 @@
         },
         {
           "kind": "field",
+          "name": "remote_read_limits_enabled",
+          "required": false,
+          "desc": "True to enable limits enforcement for remote read requests.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.remote-read-limits-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "query_result_response_format",
           "required": false,
           "desc": "Format to use when retrieving query results from queriers. Supported values: json, protobuf",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1975,6 +1975,8 @@ Usage of ./cmd/mimir/mimir:
     	The amount of shards to use when doing parallelisation via query sharding by tenant. 0 to disable query sharding for tenant. Query sharding implementation will adjust the number of query shards based on compactor shards. This allows querier to not search the blocks which cannot possibly have the series for given query shard. (default 16)
   -query-frontend.query-stats-enabled
     	False to disable query statistics tracking. When enabled, a message with some statistics is logged for every query. (default true)
+  -query-frontend.remote-read-limits-enabled
+    	[experimental] True to enable limits enforcement for remote read requests.
   -query-frontend.results-cache-ttl duration
     	Time to live duration for cached query results. If query falls into out-of-order time window, -query-frontend.results-cache-ttl-for-out-of-order-time-window is used instead. (default 1w)
   -query-frontend.results-cache-ttl-for-cardinality-query duration

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -158,6 +158,7 @@ The following features are currently experimental:
   - Max number of tenants that may be queried at once (`-tenant-federation.max-tenants`)
   - Sharding of active series queries (`-query-frontend.shard-active-series-queries`)
   - Server-side write timeout for responses to active series requests (`-query-frontend.active-series-write-timeout`)
+  - Remote read request limits (`-query-frontend.remote-read-limits-enabled`)
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
 - Store-gateway

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1613,6 +1613,10 @@ results_cache:
 # CLI flag: -query-frontend.use-active-series-decoder
 [use_active_series_decoder: <boolean> | default = false]
 
+# (experimental) True to enable limits enforcement for remote read requests.
+# CLI flag: -query-frontend.remote-read-limits-enabled
+[remote_read_limits_enabled: <boolean> | default = false]
+
 # Format to use when retrieving query results from queriers. Supported values:
 # json, protobuf
 # CLI flag: -query-frontend.query-result-response-format

--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -11,20 +11,48 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 		e2emimir.SetFlagMapper(map[string]string{"-ingester.ring.readiness-check-ring-health": "false"}),
 		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 		removePartitionRingFlags,
+		removeRemoteReadLimitsFlags,
 	),
 	"grafana/mimir:2.6.0": e2emimir.ChainFlagMappers(
 		e2emimir.RemoveFlagMapper([]string{"-ingester.native-histograms-ingestion-enabled"}),
 		removePartitionRingFlags,
+		removeRemoteReadLimitsFlags,
 	),
-	"grafana/mimir:2.7.1":  removePartitionRingFlags,
-	"grafana/mimir:2.8.0":  removePartitionRingFlags,
-	"grafana/mimir:2.9.1":  removePartitionRingFlags,
-	"grafana/mimir:2.10.0": removePartitionRingFlags,
-	"grafana/mimir:2.11.0": removePartitionRingFlags,
-	"grafana/mimir:2.12.0": removePartitionRingFlags,
+	"grafana/mimir:2.7.1": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+		removeRemoteReadLimitsFlags,
+	),
+	"grafana/mimir:2.8.0": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+		removeRemoteReadLimitsFlags,
+	),
+	"grafana/mimir:2.9.1": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+		removeRemoteReadLimitsFlags,
+	),
+	"grafana/mimir:2.10.0": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+		removeRemoteReadLimitsFlags,
+	),
+	"grafana/mimir:2.11.0": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+		removeRemoteReadLimitsFlags,
+	),
+	"grafana/mimir:2.12.0": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+		removeRemoteReadLimitsFlags,
+	),
 }
+
+// Always remove this flag so that it's not a pain to run GEM integration tests.
+// This temporarily flag will be removed soon from Mimir.
+var defaultPreviousVersionGlobalOverrides = removeRemoteReadLimitsFlags
 
 var removePartitionRingFlags = e2emimir.RemoveFlagMapper([]string{
 	"-ingester.partition-ring.store",
 	"-ingester.partition-ring.consul.hostname",
+})
+
+var removeRemoteReadLimitsFlags = e2emimir.RemoveFlagMapper([]string{
+	"-query-frontend.remote-read-limits-enabled",
 })

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -35,6 +35,7 @@ func previousVersionImages(t *testing.T) map[string]e2emimir.FlagMapper {
 		for key, mapper := range overrides {
 			overrides[key] = e2emimir.ChainFlagMappers(mapper, defaultPreviousVersionGlobalOverrides)
 		}
+		return overrides
 	}
 
 	return DefaultPreviousVersionImages

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -32,7 +32,9 @@ import (
 // see TestParsePreviousImageVersionOverrides for the JSON format to use.
 func previousVersionImages(t *testing.T) map[string]e2emimir.FlagMapper {
 	if overrides := previousImageVersionOverrides(t); len(overrides) > 0 {
-		return overrides
+		for key, mapper := range overrides {
+			overrides[key] = e2emimir.ChainFlagMappers(mapper, defaultPreviousVersionGlobalOverrides)
+		}
 	}
 
 	return DefaultPreviousVersionImages

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -186,6 +186,8 @@ func NewQueryFrontend(name string, flags map[string]string, options ...Option) *
 			"-log.level": "warn",
 			// Quickly detect query-scheduler when running it.
 			"-query-frontend.scheduler-dns-lookup-period": "1s",
+			// Always exercise remote read limits in integration tests.
+			"-query-frontend.remote-read-limits-enabled": "true",
 		},
 		flags,
 		options...,

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -67,6 +67,7 @@ type Config struct {
 	TargetSeriesPerShard           uint64        `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
 	ShardActiveSeriesQueries       bool          `yaml:"shard_active_series_queries" category:"experimental"`
 	UseActiveSeriesDecoder         bool          `yaml:"use_active_series_decoder" category:"experimental"`
+	RemoteReadLimitsEnabled        bool          `yaml:"remote_read_limits_enabled" category:"experimental"`
 
 	// CacheKeyGenerator allows to inject a CacheKeyGenerator to use for generating cache keys.
 	// If nil, the querymiddleware package uses a DefaultCacheKeyGenerator with SplitQueriesByInterval.
@@ -86,6 +87,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatProtobuf, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
 	f.BoolVar(&cfg.ShardActiveSeriesQueries, "query-frontend.shard-active-series-queries", false, "True to enable sharding of active series queries.")
 	f.BoolVar(&cfg.UseActiveSeriesDecoder, "query-frontend.use-active-series-decoder", false, "Set to true to use the zero-allocation response decoder for active series queries.")
+	f.BoolVar(&cfg.RemoteReadLimitsEnabled, "query-frontend.remote-read-limits-enabled", false, "True to enable limits enforcement for remote read requests.")
 	cfg.ResultsCacheConfig.RegisterFlags(f)
 
 	// The query-frontend.align-queries-with-step flag has been moved to the limits.go file
@@ -274,7 +276,7 @@ func newQueryTripperware(
 				return activeNativeHistogramMetrics.RoundTrip(r)
 			case IsLabelsQuery(r.URL.Path):
 				return labels.RoundTrip(r)
-			case IsRemoteReadQuery(r.URL.Path):
+			case IsRemoteReadQuery(r.URL.Path) && cfg.RemoteReadLimitsEnabled:
 				return remoteRead.RoundTrip(r)
 			default:
 				return next.RoundTrip(r)


### PR DESCRIPTION
#### What this PR does

Krajo and I are building remote read limits enforcement in the query-frontend. We're doing it through subsequent PRs, but we don't want to roll it out until it's finished and properly tested. In this PR I'm proposing to introduce a temporarily config option (`-query-frontend.remote-read-limits-enabled`) to enable remote read limits enforcement conditionally (disabled by default). The config option will be removed once the work is completed.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
