### PR TITLE
Extend max rules per rule group limit to be supported per namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [ENHANCEMENT] Expose TLS configuration for the S3 backend client. #2652
 * [ENHANCEMENT] Rules: Support expansion of native histogram values when using rule templates #7974
 * [ENHANCEMENT] Rules: Add metric `cortex_prometheus_rule_group_last_restore_duration_seconds` which measures how long it takes to restore rule groups using the `ALERTS_FOR_STATE` series #7974
+* [ENHANCEMENT] Rules: Added per namespace max rules per rule group limit. The maximum number of rules per rule groups for all namespaces continues to be configured by `-ruler.max-rules-per-rule-group`, but now, this can be superseded by the new `-ruler.max-rules-per-rule-group-by-namespace` option on a per namespace basis. This new limit can be overridden using the overrides mechanism to be applied per-tenant. #8378
 * [ENHANCEMENT] OTLP: Improve remote write format translation performance by using label set hashes for metric identifiers instead of string based ones. #8012
 * [ENHANCEMENT] Querying: Remove OpEmptyMatch from regex concatenations. #8012
 * [ENHANCEMENT] Store-gateway: add `-blocks-storage.bucket-store.max-concurrent-queue-timeout`. When set, queries at the store-gateway's query gate will not wait longer than that to execute. If a query reaches the wait timeout, then the querier will retry the blocks on a different store-gateway. If all store-gateways are unavailable, then the query will fail with `err-mimir-store-consistency-check-failed`. #7777 #8149

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4074,7 +4074,7 @@
           "kind": "field",
           "name": "ruler_max_rules_per_rule_group_by_namespace",
           "required": false,
-          "desc": "Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int64). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group.",
+          "desc": "Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group.",
           "fieldValue": null,
           "fieldDefaultValue": {},
           "fieldFlag": "ruler.max-rules-per-rule-group-by-namespace",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4072,6 +4072,17 @@
         },
         {
           "kind": "field",
+          "name": "ruler_max_rules_per_rule_group_by_namespace",
+          "required": false,
+          "desc": "Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int64). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group.",
+          "fieldValue": null,
+          "fieldDefaultValue": {},
+          "fieldFlag": "ruler.max-rules-per-rule-group-by-namespace",
+          "fieldType": "map of string to int64",
+          "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
           "name": "store_gateway_tenant_shard_size",
           "required": false,
           "desc": "The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4078,7 +4078,7 @@
           "fieldValue": null,
           "fieldDefaultValue": {},
           "fieldFlag": "ruler.max-rules-per-rule-group-by-namespace",
-          "fieldType": "map of string to int64",
+          "fieldType": "map of string to int",
           "fieldCategory": "advanced"
         },
         {

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4079,7 +4079,7 @@
           "fieldDefaultValue": {},
           "fieldFlag": "ruler.max-rules-per-rule-group-by-namespace",
           "fieldType": "map of string to int",
-          "fieldCategory": "advanced"
+          "fieldCategory": "experimental"
         },
         {
           "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2517,6 +2517,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of rule groups per-tenant. 0 to disable. (default 70)
   -ruler.max-rules-per-rule-group int
     	Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
+  -ruler.max-rules-per-rule-group-by-namespace value
+    	Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int64). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group. (default {})
   -ruler.notification-queue-capacity int
     	Capacity of the queue for notifications to be sent to the Alertmanager. (default 10000)
   -ruler.notification-timeout duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2518,7 +2518,7 @@ Usage of ./cmd/mimir/mimir:
   -ruler.max-rules-per-rule-group int
     	Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
   -ruler.max-rules-per-rule-group-by-namespace value
-    	Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int64). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group. (default {})
+    	Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group. (default {})
   -ruler.notification-queue-capacity int
     	Capacity of the queue for notifications to be sent to the Alertmanager. (default 10000)
   -ruler.notification-timeout duration

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -646,7 +646,7 @@ Usage of ./cmd/mimir/mimir:
   -ruler.max-rules-per-rule-group int
     	Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
   -ruler.max-rules-per-rule-group-by-namespace value
-    	Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int64). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group. (default {})
+    	Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group. (default {})
   -ruler.query-frontend.address string
     	GRPC listen address of the query-frontend(s). Must be a DNS address (prefixed with dns:///) to enable client side load balancing.
   -ruler.query-frontend.query-result-response-format string

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -645,6 +645,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of rule groups per-tenant. 0 to disable. (default 70)
   -ruler.max-rules-per-rule-group int
     	Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
+  -ruler.max-rules-per-rule-group-by-namespace value
+    	Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int64). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group. (default {})
   -ruler.query-frontend.address string
     	GRPC listen address of the query-frontend(s). Must be a DNS address (prefixed with dns:///) to enable client side load balancing.
   -ruler.query-frontend.query-result-response-format string

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -60,6 +60,8 @@ The following features are currently experimental:
     - `-ruler.recording-rules-evaluation-enabled`
     - `-ruler.alerting-rules-evaluation-enabled`
   - Aligning of evaluation timestamp on interval (`align_evaluation_time_on_interval`)
+  -  Allow defining a limit on the maximum number of rules allowed in a rule group by namespace. If set, this supersedes the `-ruler.max-rules-per-rule-group` limit.
+    - `-ruler.max-rules-per-rule-group-by-namespace`
 - Distributor
   - Metrics relabeling
     - `-distributor.metric-relabeling-enabled`

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -60,8 +60,8 @@ The following features are currently experimental:
     - `-ruler.recording-rules-evaluation-enabled`
     - `-ruler.alerting-rules-evaluation-enabled`
   - Aligning of evaluation timestamp on interval (`align_evaluation_time_on_interval`)
-  -  Allow defining a limit on the maximum number of rules allowed in a rule group by namespace. If set, this supersedes the `-ruler.max-rules-per-rule-group` limit.
-    - `-ruler.max-rules-per-rule-group-by-namespace`
+  - Allow defining a limit on the maximum number of rules allowed in a rule group by namespace. If set, this supersedes the `-ruler.max-rules-per-rule-group` limit.
+  - `-ruler.max-rules-per-rule-group-by-namespace`
 - Distributor
   - Metrics relabeling
     - `-distributor.metric-relabeling-enabled`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3437,7 +3437,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 # -ruler.max-rules-per-rule-group, but only applies for the specific namespace.
 # If specified, it supersedes -ruler.max-rules-per-rule-group.
 # CLI flag: -ruler.max-rules-per-rule-group-by-namespace
-[ruler_max_rules_per_rule_group_by_namespace: <map of string to int64> | default = {}]
+[ruler_max_rules_per_rule_group_by_namespace: <map of string to int> | default = {}]
 
 # The tenant's shard size, used when store-gateway sharding is enabled. Value of
 # 0 disables shuffle sharding for the tenant, that is all tenant blocks are

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3430,7 +3430,14 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -ruler.sync-rules-on-changes-enabled
 [ruler_sync_rules_on_changes_enabled: <boolean> | default = true]
 
-ruler_max_rules_per_rule_group_by_namespace:
+# (advanced) Maximum number of rules per rule group by namespace. Value is a
+# map, where each key is the namespace and value is the number of rules allowed
+# in the namespace (int64). On the command line, this map is given in a JSON
+# format. The number of rules specified has the same meaning as
+# -ruler.max-rules-per-rule-group, but only applies for the specific namespace.
+# If specified, it supersedes -ruler.max-rules-per-rule-group.
+# CLI flag: -ruler.max-rules-per-rule-group-by-namespace
+[ruler_max_rules_per_rule_group_by_namespace: <map of string to int64> | default = {}]
 
 # The tenant's shard size, used when store-gateway sharding is enabled. Value of
 # 0 disables shuffle sharding for the tenant, that is all tenant blocks are
@@ -3515,7 +3522,14 @@ ruler_max_rules_per_rule_group_by_namespace:
 # CLI flag: -alertmanager.notification-rate-limit
 [alertmanager_notification_rate_limit: <float> | default = 0]
 
-alertmanager_notification_rate_limit_per_integration:
+# Per-integration notification rate limits. Value is a map, where each key is
+# integration name and value is a rate-limit (float). On command line, this map
+# is given in JSON format. Rate limit has the same meaning as
+# -alertmanager.notification-rate-limit, but only applies for specific
+# integration. Allowed integration names: webhook, email, pagerduty, opsgenie,
+# wechat, slack, victorops, pushover, sns, webex, telegram, discord, msteams.
+# CLI flag: -alertmanager.notification-rate-limit-per-integration
+[alertmanager_notification_rate_limit_per_integration: <map of string to float64> | default = {}]
 
 # Maximum size of configuration file for Alertmanager that tenant can upload via
 # Alertmanager API. 0 = no limit.

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3432,7 +3432,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 
 # (advanced) Maximum number of rules per rule group by namespace. Value is a
 # map, where each key is the namespace and value is the number of rules allowed
-# in the namespace (int64). On the command line, this map is given in a JSON
+# in the namespace (int). On the command line, this map is given in a JSON
 # format. The number of rules specified has the same meaning as
 # -ruler.max-rules-per-rule-group, but only applies for the specific namespace.
 # If specified, it supersedes -ruler.max-rules-per-rule-group.

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3430,7 +3430,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -ruler.sync-rules-on-changes-enabled
 [ruler_sync_rules_on_changes_enabled: <boolean> | default = true]
 
-# (advanced) Maximum number of rules per rule group by namespace. Value is a
+# (experimental) Maximum number of rules per rule group by namespace. Value is a
 # map, where each key is the namespace and value is the number of rules allowed
 # in the namespace (int). On the command line, this map is given in a JSON
 # format. The number of rules specified has the same meaning as

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3430,6 +3430,8 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -ruler.sync-rules-on-changes-enabled
 [ruler_sync_rules_on_changes_enabled: <boolean> | default = true]
 
+ruler_max_rules_per_rule_group_by_namespace:
+
 # The tenant's shard size, used when store-gateway sharding is enabled. Value of
 # 0 disables shuffle sharding for the tenant, that is all tenant blocks are
 # sharded across all store-gateway replicas.
@@ -3513,14 +3515,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -alertmanager.notification-rate-limit
 [alertmanager_notification_rate_limit: <float> | default = 0]
 
-# Per-integration notification rate limits. Value is a map, where each key is
-# integration name and value is a rate-limit (float). On command line, this map
-# is given in JSON format. Rate limit has the same meaning as
-# -alertmanager.notification-rate-limit, but only applies for specific
-# integration. Allowed integration names: webhook, email, pagerduty, opsgenie,
-# wechat, slack, victorops, pushover, sns, webex, telegram, discord, msteams.
-# CLI flag: -alertmanager.notification-rate-limit-per-integration
-[alertmanager_notification_rate_limit_per_integration: <map of string to float64> | default = {}]
+alertmanager_notification_rate_limit_per_integration:
 
 # Maximum size of configuration file for Alertmanager that tenant can upload via
 # Alertmanager API. 0 = no limit.

--- a/pkg/ingester/activeseries/custom_trackers_config.go
+++ b/pkg/ingester/activeseries/custom_trackers_config.go
@@ -5,6 +5,7 @@ package activeseries
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 
 	amlabels "github.com/prometheus/alertmanager/pkg/labels"
@@ -41,6 +42,31 @@ func (c CustomTrackersConfig) Empty() bool {
 // String is also needed to implement flag.Value.
 func (c CustomTrackersConfig) String() string {
 	return c.string
+}
+
+// Equal compares two CustomTrackersConfig. This is needed to allow cmp.Equal to compare two CustomTrackersConfig.
+func (c CustomTrackersConfig) Equal(other CustomTrackersConfig) bool {
+	if c.string != other.string {
+		return false
+	}
+
+	if len(c.source) != len(other.source) {
+		return false
+	}
+
+	if len(c.config) != len(other.config) {
+		return false
+	}
+
+	if !reflect.DeepEqual(c.source, other.source) {
+		return false
+	}
+
+	if !reflect.DeepEqual(c.config, other.config) {
+		return false
+	}
+
+	return true
 }
 
 func customTrackersConfigString(cfg map[string]string) string {

--- a/pkg/ingester/activeseries/custom_trackers_config_test.go
+++ b/pkg/ingester/activeseries/custom_trackers_config_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -252,4 +253,98 @@ func TestTrackersConfigs_SerializeDeserialize(t *testing.T) {
 		require.NoError(t, err, "Failed to deserialize serialized object")
 		assert.Equal(t, obj, reSerialized)
 	})
+}
+
+func TestCustomTrackersConfig_Equal(t *testing.T) {
+	tc := []struct {
+		name     string
+		cfg1     CustomTrackersConfig
+		cfg2     CustomTrackersConfig
+		expected bool
+	}{
+
+		{
+			name:     "Equal configurations",
+			cfg1:     mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`),
+			cfg2:     mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`),
+			expected: true,
+		},
+		{
+			name: "Different descriptions",
+			cfg1: func() CustomTrackersConfig {
+				c := mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`)
+				c.string = "cfg1"
+				return c
+			}(),
+			cfg2: func() CustomTrackersConfig {
+				c := mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`)
+				c.string = "cfg2"
+				return c
+			}(),
+			expected: false,
+		},
+		{
+			name: "Different source maps",
+			cfg1: func() CustomTrackersConfig {
+				c := mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`)
+				c.source = map[string]string{"a": "source1"}
+				return c
+			}(),
+			cfg2: func() CustomTrackersConfig {
+				c := mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`)
+				c.source = map[string]string{"b": "source2"}
+				return c
+			}(),
+			expected: false,
+		},
+		{
+			name: "Different config maps",
+			cfg1: func() CustomTrackersConfig {
+				c := mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`)
+				c.config = map[string]labelsMatchers{"a": nil}
+				return c
+			}(),
+			cfg2: func() CustomTrackersConfig {
+				c := mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`)
+				c.config = map[string]labelsMatchers{"b": nil}
+				return c
+			}(),
+			expected: false,
+		},
+		{
+			name: "Different keys in source maps",
+			cfg1: CustomTrackersConfig{
+				source: map[string]string{"a": "source1"},
+				config: map[string]labelsMatchers{"b": nil},
+				string: "cfg1",
+			},
+			cfg2: CustomTrackersConfig{
+				source: map[string]string{"c": "source1"},
+				config: map[string]labelsMatchers{"b": nil},
+				string: "cfg1",
+			},
+			expected: false,
+		},
+		{
+			name: "Different keys in config maps",
+			cfg1: CustomTrackersConfig{
+				source: map[string]string{"a": "source1"},
+				config: map[string]labelsMatchers{"b": nil},
+				string: "cfg1",
+			},
+			cfg2: CustomTrackersConfig{
+				source: map[string]string{"a": "source1"},
+				config: map[string]labelsMatchers{"c": nil},
+				string: "cfg1",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.cfg1.Equal(tt.cfg2))
+			assert.Equal(t, tt.expected, cmp.Equal(tt.cfg1, tt.cfg2))
+		})
+	}
 }

--- a/pkg/ingester/activeseries/custom_trackers_config_test.go
+++ b/pkg/ingester/activeseries/custom_trackers_config_test.go
@@ -256,21 +256,18 @@ func TestTrackersConfigs_SerializeDeserialize(t *testing.T) {
 }
 
 func TestCustomTrackersConfig_Equal(t *testing.T) {
-	tc := []struct {
-		name     string
+	tc := map[string]struct {
 		cfg1     CustomTrackersConfig
 		cfg2     CustomTrackersConfig
 		expected bool
 	}{
 
-		{
-			name:     "Equal configurations",
+		"Equal configurations": {
 			cfg1:     mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`),
 			cfg2:     mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`),
 			expected: true,
 		},
-		{
-			name: "Different descriptions",
+		"Different descriptions": {
 			cfg1: func() CustomTrackersConfig {
 				c := mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`)
 				c.string = "cfg1"
@@ -283,8 +280,7 @@ func TestCustomTrackersConfig_Equal(t *testing.T) {
 			}(),
 			expected: false,
 		},
-		{
-			name: "Different source maps",
+		"Different source maps": {
 			cfg1: func() CustomTrackersConfig {
 				c := mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`)
 				c.source = map[string]string{"a": "source1"}
@@ -297,8 +293,7 @@ func TestCustomTrackersConfig_Equal(t *testing.T) {
 			}(),
 			expected: false,
 		},
-		{
-			name: "Different config maps",
+		"Different config maps": {
 			cfg1: func() CustomTrackersConfig {
 				c := mustNewCustomTrackersConfigFromString(t, `foo:{foo="bar"};baz:{baz="bar"}`)
 				c.config = map[string]labelsMatchers{"a": nil}
@@ -311,8 +306,7 @@ func TestCustomTrackersConfig_Equal(t *testing.T) {
 			}(),
 			expected: false,
 		},
-		{
-			name: "Different keys in source maps",
+		"Different keys in source maps": {
 			cfg1: CustomTrackersConfig{
 				source: map[string]string{"a": "source1"},
 				config: map[string]labelsMatchers{"b": nil},
@@ -325,8 +319,7 @@ func TestCustomTrackersConfig_Equal(t *testing.T) {
 			},
 			expected: false,
 		},
-		{
-			name: "Different keys in config maps",
+		"Different keys in config maps": {
 			cfg1: CustomTrackersConfig{
 				source: map[string]string{"a": "source1"},
 				config: map[string]labelsMatchers{"b": nil},
@@ -341,8 +334,8 @@ func TestCustomTrackersConfig_Equal(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tc {
+		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.cfg1.Equal(tt.cfg2))
 			assert.Equal(t, tt.expected, cmp.Equal(tt.cfg1, tt.cfg2))
 		})

--- a/pkg/mimir/runtime_config_test.go
+++ b/pkg/mimir/runtime_config_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,9 +55,9 @@ overrides:
 
 	loadedLimits := runtimeCfg.(*runtimeConfigValues).TenantLimits
 	require.Equal(t, 3, len(loadedLimits))
-	require.Equal(t, expected, *loadedLimits["1234"])
-	require.Equal(t, expected, *loadedLimits["1235"])
-	require.Equal(t, expected, *loadedLimits["1236"])
+	require.True(t, cmp.Equal(expected, *loadedLimits["1234"], cmp.AllowUnexported(validation.Limits{})))
+	require.True(t, cmp.Equal(expected, *loadedLimits["1235"], cmp.AllowUnexported(validation.Limits{})))
+	require.True(t, cmp.Equal(expected, *loadedLimits["1236"], cmp.AllowUnexported(validation.Limits{})))
 }
 
 func TestRuntimeConfigLoader_ShouldLoadEmptyFile(t *testing.T) {

--- a/pkg/mimirtool/config/inspect.go
+++ b/pkg/mimirtool/config/inspect.go
@@ -29,7 +29,7 @@ var (
 type InspectedEntryFactory func() *InspectedEntry
 
 // InspectedEntry is the structure that holds a configuration block or a single configuration parameters.
-// Blocks contain other other InspectedEntries.
+// Blocks contain other InspectedEntries.
 
 type EntryKind string
 

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -524,7 +524,7 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if err := a.ruler.AssertMaxRulesPerRuleGroup(userID, len(rg.Rules)); err != nil {
+	if err := a.ruler.AssertMaxRulesPerRuleGroup(userID, namespace, len(rg.Rules)); err != nil {
 		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -146,7 +146,7 @@ type RulesLimits interface {
 	EvaluationDelay(userID string) time.Duration
 	RulerTenantShardSize(userID string) int
 	RulerMaxRuleGroupsPerTenant(userID string) int
-	RulerMaxRulesPerRuleGroup(userID string) int
+	RulerMaxRulesPerRuleGroup(userID, namespace string) int
 	RulerRecordingRulesEvaluationEnabled(userID string) bool
 	RulerAlertingRulesEvaluationEnabled(userID string) bool
 	RulerSyncRulesOnChangesEnabled(userID string) bool

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -1179,9 +1179,10 @@ func (r *Ruler) AssertMaxRuleGroups(userID string, rg int) error {
 }
 
 // AssertMaxRulesPerRuleGroup limit has not been reached compared to the current
-// number of rules in a rule group in input and returns an error if so.
-func (r *Ruler) AssertMaxRulesPerRuleGroup(userID string, rules int) error {
-	limit := r.limits.RulerMaxRulesPerRuleGroup(userID)
+// number of rules in a rule group and namespace combination in input, returns an error if so.
+// If the limit is set to 0 (or less), then there is no limit.
+func (r *Ruler) AssertMaxRulesPerRuleGroup(userID, namespace string, rules int) error {
+	limit := r.limits.RulerMaxRulesPerRuleGroup(userID, namespace)
 
 	if limit <= 0 {
 		return nil

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -383,9 +383,10 @@ func (l *Limits) unmarshal(decode func(any) error) error {
 	// We want to set l to the defaults and then overwrite it with the input.
 	if defaultLimits != nil {
 		*l = *defaultLimits
+
 		// Make copy of default limits, otherwise unmarshalling would modify map in default limits.
-		l.copyNotificationIntegrationLimits(defaultLimits.NotificationRateLimitPerIntegration)
-		l.copyMaxRulesPerRuleGroupByNamespaceLimits(defaultLimits.RulerMaxRulesPerRuleGroupByNamespace)
+		l.NotificationRateLimitPerIntegration = defaultLimits.NotificationRateLimitPerIntegration.Clone()
+		l.RulerMaxRulesPerRuleGroupByNamespace = defaultLimits.RulerMaxRulesPerRuleGroupByNamespace.Clone()
 	}
 
 	// Decode into a reflection-crafted struct that has fields for the extensions.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -178,14 +178,14 @@ type Limits struct {
 	ActiveSeriesResultsMaxSizeBytes               int  `yaml:"active_series_results_max_size_bytes" json:"active_series_results_max_size_bytes" category:"experimental"`
 
 	// Ruler defaults and limits.
-	RulerEvaluationDelay                 model.Duration   `yaml:"ruler_evaluation_delay_duration" json:"ruler_evaluation_delay_duration"`
-	RulerTenantShardSize                 int              `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
-	RulerMaxRulesPerRuleGroup            int              `yaml:"ruler_max_rules_per_rule_group" json:"ruler_max_rules_per_rule_group"`
-	RulerMaxRuleGroupsPerTenant          int              `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
-	RulerRecordingRulesEvaluationEnabled bool             `yaml:"ruler_recording_rules_evaluation_enabled" json:"ruler_recording_rules_evaluation_enabled" category:"experimental"`
-	RulerAlertingRulesEvaluationEnabled  bool             `yaml:"ruler_alerting_rules_evaluation_enabled" json:"ruler_alerting_rules_evaluation_enabled" category:"experimental"`
-	RulerSyncRulesOnChangesEnabled       bool             `yaml:"ruler_sync_rules_on_changes_enabled" json:"ruler_sync_rules_on_changes_enabled" category:"advanced"`
-	RulerMaxRulesPerRuleGroupByNamespace LimitsMap[int64] `yaml:"ruler_max_rules_per_rule_group_by_namespace" json:"ruler_max_rules_per_rule_group_by_namespace" category:"advanced"`
+	RulerEvaluationDelay                 model.Duration `yaml:"ruler_evaluation_delay_duration" json:"ruler_evaluation_delay_duration"`
+	RulerTenantShardSize                 int            `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
+	RulerMaxRulesPerRuleGroup            int            `yaml:"ruler_max_rules_per_rule_group" json:"ruler_max_rules_per_rule_group"`
+	RulerMaxRuleGroupsPerTenant          int            `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
+	RulerRecordingRulesEvaluationEnabled bool           `yaml:"ruler_recording_rules_evaluation_enabled" json:"ruler_recording_rules_evaluation_enabled" category:"experimental"`
+	RulerAlertingRulesEvaluationEnabled  bool           `yaml:"ruler_alerting_rules_evaluation_enabled" json:"ruler_alerting_rules_evaluation_enabled" category:"experimental"`
+	RulerSyncRulesOnChangesEnabled       bool           `yaml:"ruler_sync_rules_on_changes_enabled" json:"ruler_sync_rules_on_changes_enabled" category:"advanced"`
+	RulerMaxRulesPerRuleGroupByNamespace LimitsMap[int] `yaml:"ruler_max_rules_per_rule_group_by_namespace" json:"ruler_max_rules_per_rule_group_by_namespace" category:"advanced"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size" json:"store_gateway_tenant_shard_size"`
@@ -307,7 +307,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.RulerAlertingRulesEvaluationEnabled, "ruler.alerting-rules-evaluation-enabled", true, "Controls whether alerting rules evaluation is enabled. This configuration option can be used to forcefully disable alerting rules evaluation on a per-tenant basis.")
 	f.BoolVar(&l.RulerSyncRulesOnChangesEnabled, "ruler.sync-rules-on-changes-enabled", true, "True to enable a re-sync of the configured rule groups as soon as they're changed via ruler's config API. This re-sync is in addition of the periodic syncing. When enabled, it may take up to few tens of seconds before a configuration change triggers the re-sync.")
 	if l.RulerMaxRulesPerRuleGroupByNamespace.data == nil {
-		l.RulerMaxRulesPerRuleGroupByNamespace = NewLimitsMap[int64](nil)
+		l.RulerMaxRulesPerRuleGroupByNamespace = NewLimitsMap[int](nil)
 	}
 	f.Var(&l.RulerMaxRulesPerRuleGroupByNamespace, "ruler.max-rules-per-rule-group-by-namespace", "Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int64). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group.")
 
@@ -840,7 +840,7 @@ func (o *Overrides) RulerMaxRulesPerRuleGroup(userID, namespace string) int {
 	u := o.getOverridesForUser(userID)
 
 	if namespaceLimit, ok := u.RulerMaxRulesPerRuleGroupByNamespace.data[namespace]; ok {
-		return int(namespaceLimit)
+		return namespaceLimit
 	}
 
 	return u.RulerMaxRulesPerRuleGroup

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -309,7 +309,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	if l.RulerMaxRulesPerRuleGroupByNamespace.data == nil {
 		l.RulerMaxRulesPerRuleGroupByNamespace = NewLimitsMap[int](nil)
 	}
-	f.Var(&l.RulerMaxRulesPerRuleGroupByNamespace, "ruler.max-rules-per-rule-group-by-namespace", "Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int64). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group.")
+	f.Var(&l.RulerMaxRulesPerRuleGroupByNamespace, "ruler.max-rules-per-rule-group-by-namespace", "Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group.")
 
 	f.Var(&l.CompactorBlocksRetentionPeriod, "compactor.blocks-retention-period", "Delete blocks containing samples older than the specified retention period. Also used by query-frontend to avoid querying beyond the retention period. 0 to disable.")
 	f.IntVar(&l.CompactorSplitAndMergeShards, "compactor.split-and-merge-shards", 0, "The number of shards to use when splitting blocks. 0 to disable splitting.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -307,7 +307,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.RulerAlertingRulesEvaluationEnabled, "ruler.alerting-rules-evaluation-enabled", true, "Controls whether alerting rules evaluation is enabled. This configuration option can be used to forcefully disable alerting rules evaluation on a per-tenant basis.")
 	f.BoolVar(&l.RulerSyncRulesOnChangesEnabled, "ruler.sync-rules-on-changes-enabled", true, "True to enable a re-sync of the configured rule groups as soon as they're changed via ruler's config API. This re-sync is in addition of the periodic syncing. When enabled, it may take up to few tens of seconds before a configuration change triggers the re-sync.")
 	// Needs to be initialised to a value so that the documentation can pick up the default value of `{}` because this is set as JSON from the command-line.
-	if l.RulerMaxRulesPerRuleGroupByNamespace.IsInitialized() {
+	if !l.RulerMaxRulesPerRuleGroupByNamespace.IsInitialized() {
 		l.RulerMaxRulesPerRuleGroupByNamespace = NewLimitsMap[int](nil)
 	}
 	f.Var(&l.RulerMaxRulesPerRuleGroupByNamespace, "ruler.max-rules-per-rule-group-by-namespace", "Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group.")
@@ -345,7 +345,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&l.NotificationRateLimit, "alertmanager.notification-rate-limit", 0, "Per-tenant rate limit for sending notifications from Alertmanager in notifications/sec. 0 = rate limit disabled. Negative value = no notifications are allowed.")
 
 	// Needs to be initialised to a value so that the documentation can pick up the default value of `{}` because this is set as JSON from the command-line.
-	if l.NotificationRateLimitPerIntegration.IsInitialized() {
+	if !l.NotificationRateLimitPerIntegration.IsInitialized() {
 		l.NotificationRateLimitPerIntegration = NotificationRateLimitMap()
 	}
 	f.Var(&l.NotificationRateLimitPerIntegration, "alertmanager.notification-rate-limit-per-integration", "Per-integration notification rate limits. Value is a map, where each key is integration name and value is a rate-limit (float). On command line, this map is given in JSON format. Rate limit has the same meaning as -alertmanager.notification-rate-limit, but only applies for specific integration. Allowed integration names: "+strings.Join(allowedIntegrationNames, ", ")+".")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -435,21 +435,6 @@ func (l *Limits) validate() error {
 	return nil
 }
 
-func (l *Limits) copyNotificationIntegrationLimits(defaults LimitsMap[float64]) {
-	l.NotificationRateLimitPerIntegration = NotificationRateLimitMap()
-	for k, v := range defaults.data {
-		l.NotificationRateLimitPerIntegration.data[k] = v
-	}
-}
-
-func (l *Limits) copyMaxRulesPerRuleGroupByNamespaceLimits(defaults LimitsMap[int64]) {
-	l.RulerMaxRulesPerRuleGroupByNamespace = NewLimitsMap[int64](nil)
-	for k, v := range defaults.data {
-		l.RulerMaxRulesPerRuleGroupByNamespace.data[k] = v
-	}
-
-}
-
 // When we load YAML from disk, we want the various per-customer limits
 // to default to any values specified on the command line, not default
 // command line values.  This global contains those values.  I (Tom) cannot

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -185,7 +185,7 @@ type Limits struct {
 	RulerRecordingRulesEvaluationEnabled bool           `yaml:"ruler_recording_rules_evaluation_enabled" json:"ruler_recording_rules_evaluation_enabled" category:"experimental"`
 	RulerAlertingRulesEvaluationEnabled  bool           `yaml:"ruler_alerting_rules_evaluation_enabled" json:"ruler_alerting_rules_evaluation_enabled" category:"experimental"`
 	RulerSyncRulesOnChangesEnabled       bool           `yaml:"ruler_sync_rules_on_changes_enabled" json:"ruler_sync_rules_on_changes_enabled" category:"advanced"`
-	RulerMaxRulesPerRuleGroupByNamespace LimitsMap[int] `yaml:"ruler_max_rules_per_rule_group_by_namespace" json:"ruler_max_rules_per_rule_group_by_namespace" category:"advanced"`
+	RulerMaxRulesPerRuleGroupByNamespace LimitsMap[int] `yaml:"ruler_max_rules_per_rule_group_by_namespace" json:"ruler_max_rules_per_rule_group_by_namespace" category:"experimental"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size" json:"store_gateway_tenant_shard_size"`

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -185,7 +185,7 @@ type Limits struct {
 	RulerRecordingRulesEvaluationEnabled bool             `yaml:"ruler_recording_rules_evaluation_enabled" json:"ruler_recording_rules_evaluation_enabled" category:"experimental"`
 	RulerAlertingRulesEvaluationEnabled  bool             `yaml:"ruler_alerting_rules_evaluation_enabled" json:"ruler_alerting_rules_evaluation_enabled" category:"experimental"`
 	RulerSyncRulesOnChangesEnabled       bool             `yaml:"ruler_sync_rules_on_changes_enabled" json:"ruler_sync_rules_on_changes_enabled" category:"advanced"`
-	RulerMaxRulesPerRuleGroupByNamespace LimitsMap[int64] `yaml:"ruler_max_rules_per_rule_group_by_namespace" json:"ruler_max_rules_per_rule_group_by_namespace" category:"experimental"`
+	RulerMaxRulesPerRuleGroupByNamespace LimitsMap[int64] `yaml:"ruler_max_rules_per_rule_group_by_namespace" json:"ruler_max_rules_per_rule_group_by_namespace" category:"advanced"`
 
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size" json:"store_gateway_tenant_shard_size"`

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -306,7 +306,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.RulerRecordingRulesEvaluationEnabled, "ruler.recording-rules-evaluation-enabled", true, "Controls whether recording rules evaluation is enabled. This configuration option can be used to forcefully disable recording rules evaluation on a per-tenant basis.")
 	f.BoolVar(&l.RulerAlertingRulesEvaluationEnabled, "ruler.alerting-rules-evaluation-enabled", true, "Controls whether alerting rules evaluation is enabled. This configuration option can be used to forcefully disable alerting rules evaluation on a per-tenant basis.")
 	f.BoolVar(&l.RulerSyncRulesOnChangesEnabled, "ruler.sync-rules-on-changes-enabled", true, "True to enable a re-sync of the configured rule groups as soon as they're changed via ruler's config API. This re-sync is in addition of the periodic syncing. When enabled, it may take up to few tens of seconds before a configuration change triggers the re-sync.")
-	if l.RulerMaxRulesPerRuleGroupByNamespace.data == nil {
+	// Needs to be initialised to a value so that the documentation can pick up the default value of `{}` because this is set as JSON from the command-line.
+	if l.RulerMaxRulesPerRuleGroupByNamespace.IsInitialized() {
 		l.RulerMaxRulesPerRuleGroupByNamespace = NewLimitsMap[int](nil)
 	}
 	f.Var(&l.RulerMaxRulesPerRuleGroupByNamespace, "ruler.max-rules-per-rule-group-by-namespace", "Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group.")
@@ -343,7 +344,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.Float64Var(&l.NotificationRateLimit, "alertmanager.notification-rate-limit", 0, "Per-tenant rate limit for sending notifications from Alertmanager in notifications/sec. 0 = rate limit disabled. Negative value = no notifications are allowed.")
 
-	if l.NotificationRateLimitPerIntegration.data == nil {
+	// Needs to be initialised to a value so that the documentation can pick up the default value of `{}` because this is set as JSON from the command-line.
+	if l.NotificationRateLimitPerIntegration.IsInitialized() {
 		l.NotificationRateLimitPerIntegration = NotificationRateLimitMap()
 	}
 	f.Var(&l.NotificationRateLimitPerIntegration, "alertmanager.notification-rate-limit-per-integration", "Per-integration notification rate limits. Value is a map, where each key is integration name and value is a rate-limit (float). On command line, this map is given in JSON format. Rate limit has the same meaning as -alertmanager.notification-rate-limit, but only applies for specific integration. Allowed integration names: "+strings.Join(allowedIntegrationNames, ", ")+".")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -880,15 +880,6 @@ func (o *Overrides) RulerSyncRulesOnChangesEnabled(userID string) bool {
 	return o.getOverridesForUser(userID).RulerSyncRulesOnChangesEnabled
 }
 
-func (o *Overrides) getRulerMaxRulesPerRuleGroupByNamespaceLimitForUser(user, namespace string) int64 {
-	u := o.getOverridesForUser(user)
-	if n, ok := u.RulerMaxRulesPerRuleGroupByNamespace.data[namespace]; ok {
-		return n
-	}
-
-	return int64(u.RulerMaxRulesPerRuleGroup) // TODO: should I go for int at the end of the day?
-}
-
 // StoreGatewayTenantShardSize returns the store-gateway shard size for a given user.
 func (o *Overrides) StoreGatewayTenantShardSize(userID string) int {
 	return o.getOverridesForUser(userID).StoreGatewayTenantShardSize

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -435,7 +435,7 @@ func (l *Limits) validate() error {
 }
 
 func (l *Limits) copyNotificationIntegrationLimits(defaults LimitsMap[float64]) {
-	l.NotificationRateLimitPerIntegration = NotificationRateLimitMap() // TODO: We need to itnialise the map with the old length.
+	l.NotificationRateLimitPerIntegration = NotificationRateLimitMap()
 	for k, v := range defaults.data {
 		l.NotificationRateLimitPerIntegration.data[k] = v
 	}
@@ -854,7 +854,7 @@ func (o *Overrides) RulerMaxRulesPerRuleGroup(userID, namespace string) int {
 	u := o.getOverridesForUser(userID)
 
 	if namespaceLimit, ok := u.RulerMaxRulesPerRuleGroupByNamespace.data[namespace]; ok {
-		return int(namespaceLimit) // TODO: perhaps this should just be int.
+		return int(namespaceLimit)
 	}
 
 	return u.RulerMaxRulesPerRuleGroup

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -59,15 +59,19 @@ func (m LimitsMap[T]) UnmarshalYAML(value *yaml.Node) error {
 }
 
 func (m LimitsMap[T]) updateMap(newMap map[string]T) error {
-	for k, v := range newMap {
-		if m.validator != nil {
+	// Validate first, as we don't want to allow partial updates.
+	if m.validator != nil {
+		for k, v := range newMap {
 			if err := m.validator(k, v); err != nil {
 				return err
 			}
 		}
+	}
 
+	for k, v := range newMap {
 		m.data[k] = v
 	}
+
 	return nil
 }
 

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package validation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LimitsMap is a generic map that can hold either float64 or int64 as values.
+type LimitsMap[T float64 | int64] struct {
+	data      map[string]T
+	validator func(k string, v T) error
+}
+
+func NewLimitsMap[T float64 | int64](validator func(k string, v T) error) LimitsMap[T] {
+	return LimitsMap[T]{
+		data:      make(map[string]T),
+		validator: validator,
+	}
+}
+
+// String implements flag.Value
+func (m LimitsMap[T]) String() string {
+	out, err := json.Marshal(m.data)
+	if err != nil {
+		return fmt.Sprintf("failed to marshal: %v", err)
+	}
+	return string(out)
+}
+
+// Set implements flag.Value
+func (m LimitsMap[T]) Set(s string) error {
+	newMap := make(map[string]T)
+	if err := json.Unmarshal([]byte(s), &newMap); err != nil {
+		return err
+	}
+	return m.updateMap(newMap)
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (m LimitsMap[T]) UnmarshalYAML(value *yaml.Node) error {
+	newMap := make(map[string]T)
+	if err := value.DecodeWithOptions(newMap, yaml.DecodeOptions{KnownFields: true}); err != nil {
+		return err
+	}
+	return m.updateMap(newMap)
+}
+
+func (m LimitsMap[T]) updateMap(newMap map[string]T) error {
+	for k, v := range newMap {
+		if m.validator != nil {
+			if err := m.validator(k, v); err != nil {
+				return err
+			}
+		}
+
+		m.data[k] = v
+	}
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (m LimitsMap[T]) MarshalYAML() (interface{}, error) {
+	return m.data, nil
+}

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -40,6 +40,15 @@ func (m LimitsMap[T]) Set(s string) error {
 	return m.updateMap(newMap)
 }
 
+// Clone returns a copy of the LimitsMap.
+func (m LimitsMap[T]) Clone() LimitsMap[T] {
+	newMap := make(map[string]T, len(m.data))
+	for k, v := range m.data {
+		newMap[k] = v
+	}
+	return LimitsMap[T]{data: newMap, validator: m.validator}
+}
+
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (m LimitsMap[T]) UnmarshalYAML(value *yaml.Node) error {
 	newMap := make(map[string]T)

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -9,13 +9,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// LimitsMap is a generic map that can hold either float64 or int64 as values.
-type LimitsMap[T float64 | int64] struct {
+// LimitsMap is a generic map that can hold either float64 or int as values.
+type LimitsMap[T float64 | int] struct {
 	data      map[string]T
 	validator func(k string, v T) error
 }
 
-func NewLimitsMap[T float64 | int64](validator func(k string, v T) error) LimitsMap[T] {
+func NewLimitsMap[T float64 | int](validator func(k string, v T) error) LimitsMap[T] {
 	return LimitsMap[T]{
 		data:      make(map[string]T),
 		validator: validator,

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -66,3 +66,18 @@ func (m LimitsMap[T]) updateMap(newMap map[string]T) error {
 func (m LimitsMap[T]) MarshalYAML() (interface{}, error) {
 	return m.data, nil
 }
+
+// Equal compares two LimitsMap. This is needed to allow cmp.Equal to compare two LimitsMap.
+func (m LimitsMap[T]) Equal(other LimitsMap[T]) bool {
+	if len(m.data) != len(other.data) {
+		return false
+	}
+
+	for k, v := range m.data {
+		if other.data[k] != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -22,6 +22,11 @@ func NewLimitsMap[T float64 | int](validator func(k string, v T) error) LimitsMa
 	}
 }
 
+// IsInitialized returns true if the map is initialized.
+func (m LimitsMap[T]) IsInitialized() bool {
+	return m.data != nil
+}
+
 // String implements flag.Value
 func (m LimitsMap[T]) String() string {
 	out, err := json.Marshal(m.data)

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -25,31 +25,28 @@ func TestNewLimitsMap(t *testing.T) {
 }
 
 func TestLimitsMap_SetAndString(t *testing.T) {
-	tc := []struct {
-		name     string
+	tc := map[string]struct {
 		input    string
 		expected map[string]float64
 		error    string
 	}{
-		{
-			name:     "set without error",
+
+		"set without error": {
 			input:    `{"key1":10,"key2":20}`,
 			expected: map[string]float64{"key1": 10, "key2": 20},
 		},
-		{
-			name:  "set with parsing error",
+		"set with parsing error": {
 			input: `{"key1": 10, "key2": 20`,
 			error: "unexpected end of JSON input",
 		},
-		{
-			name:  "set with validation error",
+		"set with validation error": {
 			input: `{"key1": -10, "key2": 20}`,
 			error: "value cannot be negative",
 		},
 	}
 
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tc {
+		t.Run(name, func(t *testing.T) {
 			lm := NewLimitsMap(fakeValidator)
 			err := lm.Set(tt.input)
 			if tt.error != "" {
@@ -124,40 +121,35 @@ func TestLimitsMap_MarshalYAML(t *testing.T) {
 }
 
 func TestLimitsMap_Equal(t *testing.T) {
-	tc := []struct {
-		name     string
+	tc := map[string]struct {
 		map1     LimitsMap[float64]
 		map2     LimitsMap[float64]
 		expected bool
 	}{
-		{
-			name:     "Equal maps with same key-value pairs",
+		"Equal maps with same key-value pairs": {
 			map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
 			map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
 			expected: true,
 		},
-		{
-			name:     "Different maps with different lengths",
+		"Different maps with different lengths": {
 			map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
 			map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
 			expected: false,
 		},
-		{
-			name:     "Different maps with same keys but different values",
+		"Different maps with same keys but different values": {
 			map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
 			map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.2}},
 			expected: false,
 		},
-		{
-			name:     "Equal empty maps",
+		"Equal empty maps": {
 			map1:     LimitsMap[float64]{data: map[string]float64{}},
 			map2:     LimitsMap[float64]{data: map[string]float64{}},
 			expected: true,
 		},
 	}
 
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tc {
+		t.Run(name, func(t *testing.T) {
 			require.Equal(t, tt.expected, tt.map1.Equal(LimitsMap[float64]{data: tt.map2.data}))
 			require.Equal(t, tt.expected, cmp.Equal(tt.map1, tt.map2))
 		})

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -177,3 +177,18 @@ func TestLimitsMap_Clone(t *testing.T) {
 	_, exists := original.data["limit3"]
 	require.False(t, exists, "expected original LimitsMap to be unaffected by changes to cloned")
 }
+
+func TestLimitsMap_updateMap(t *testing.T) {
+	initialData := map[string]float64{"a": 1.0, "b": 2.0}
+	updateData := map[string]float64{"a": 3.0, "b": -3.0, "c": 5.0}
+
+	limitsMap := LimitsMap[float64]{data: initialData, validator: fakeValidator}
+
+	err := limitsMap.updateMap(updateData)
+	require.Error(t, err)
+
+	// Verify that no partial updates were applied.
+	// Because maps in Go are accessed in random order, there's a chance that the validation will fail on the first invalid element of the map thus not asserting partial updates.
+	expectedData := map[string]float64{"a": 1.0, "b": 2.0}
+	require.Equal(t, expectedData, limitsMap.data)
+}

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -4,11 +4,8 @@ package validation
 
 import (
 	"errors"
-	"fmt"
-	"reflect"
 	"testing"
 
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -27,10 +24,6 @@ func TestNewLimitsMap(t *testing.T) {
 }
 
 func TestLimitsMap_SetAndString(t *testing.T) {
-	fmt.Println(reflect.TypeOf(LimitsMap[float64]{}).String())
-	fmt.Println(reflect.TypeOf(model.Duration(0)).String())
-	// validation.LimitsMap[float64]
-	// model.Duration
 	tc := []struct {
 		name     string
 		input    string

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -155,3 +155,25 @@ func TestLimitsMap_Equal(t *testing.T) {
 		})
 	}
 }
+
+func TestLimitsMap_Clone(t *testing.T) {
+	// Create an initial LimitsMap with some data.
+	original := NewLimitsMap[float64](fakeValidator)
+	original.data["limit1"] = 1.0
+	original.data["limit2"] = 2.0
+
+	// Clone the original LimitsMap.
+	cloned := original.Clone()
+
+	// Check that the cloned LimitsMap is equal to the original.
+	require.True(t, original.Equal(cloned), "expected cloned LimitsMap to be different from original")
+
+	// Modify the original LimitsMap and ensure the cloned map is not affected.
+	original.data["limit1"] = 10.0
+	require.False(t, cloned.data["limit1"] == 10.0, "expected cloned LimitsMap to be unaffected by changes to original")
+
+	// Modify the cloned LimitsMap and ensure the original map is not affected.
+	cloned.data["limit3"] = 3.0
+	_, exists := original.data["limit3"]
+	require.False(t, exists, "expected original LimitsMap to be unaffected by changes to cloned")
+}

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package validation
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+var fakeValidator = func(k string, v float64) error {
+	if v < 0 {
+		return errors.New("value cannot be negative")
+	}
+	return nil
+}
+
+func TestNewLimitsMap(t *testing.T) {
+	lm := NewLimitsMap(fakeValidator)
+	lm.data["key1"] = 10
+	require.Len(t, lm.data, 1)
+}
+
+func TestLimitsMap_SetAndString(t *testing.T) {
+	tc := []struct {
+		name     string
+		input    string
+		expected map[string]float64
+		error    string
+	}{
+		{
+			name:     "set without error",
+			input:    `{"key1":10,"key2":20}`,
+			expected: map[string]float64{"key1": 10, "key2": 20},
+		},
+		{
+			name:  "set with parsing error",
+			input: `{"key1": 10, "key2": 20`,
+			error: "unexpected end of JSON input",
+		},
+		{
+			name:  "set with validation error",
+			input: `{"key1": -10, "key2": 20}`,
+			error: "value cannot be negative",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			lm := NewLimitsMap(fakeValidator)
+			err := lm.Set(tt.input)
+			if tt.error != "" {
+				require.Error(t, err)
+				require.Equal(t, tt.error, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, lm.data)
+				require.Equal(t, tt.input, lm.String())
+			}
+		})
+	}
+}
+
+func TestLimitsMap_UnmarshalYAML(t *testing.T) {
+	tc := []struct {
+		name     string
+		input    string
+		expected map[string]float64
+		error    string
+	}{
+		{
+			name: "unmarshal without error",
+			input: `
+key1: 10
+key2: 20
+`,
+			expected: map[string]float64{"key1": 10, "key2": 20},
+		},
+		{
+			name: "unmarshal with validation error",
+			input: `
+key1: -10
+key2: 20
+`,
+			error: "value cannot be negative",
+		},
+		{
+			name: "unmarshal with parsing error",
+			input: `
+key1: 10
+key2: 20
+			key3: 30
+`,
+			error: "yaml: line 3: found a tab character that violates indentation",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			lm := NewLimitsMap(fakeValidator)
+			err := yaml.Unmarshal([]byte(tt.input), &lm)
+			if tt.error != "" {
+				require.Error(t, err)
+				require.Equal(t, tt.error, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, lm.data)
+			}
+		})
+	}
+}
+
+func TestLimitsMap_MarshalYAML(t *testing.T) {
+	lm := NewLimitsMap(fakeValidator)
+	lm.data["key1"] = 10
+	lm.data["key2"] = 20
+
+	out, err := yaml.Marshal(&lm)
+	require.NoError(t, err)
+	require.Equal(t, "key1: 10\nkey2: 20\n", string(out))
+}

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -120,4 +121,45 @@ func TestLimitsMap_MarshalYAML(t *testing.T) {
 	out, err := yaml.Marshal(&lm)
 	require.NoError(t, err)
 	require.Equal(t, "key1: 10\nkey2: 20\n", string(out))
+}
+
+func TestLimitsMap_Equal(t *testing.T) {
+	tc := []struct {
+		name     string
+		map1     LimitsMap[float64]
+		map2     LimitsMap[float64]
+		expected bool
+	}{
+		{
+			name:     "Equal maps with same key-value pairs",
+			map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+			map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+			expected: true,
+		},
+		{
+			name:     "Different maps with different lengths",
+			map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
+			map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+			expected: false,
+		},
+		{
+			name:     "Different maps with same keys but different values",
+			map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
+			map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.2}},
+			expected: false,
+		},
+		{
+			name:     "Equal empty maps",
+			map1:     LimitsMap[float64]{data: map[string]float64{}},
+			map2:     LimitsMap[float64]{data: map[string]float64{}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.map1.Equal(LimitsMap[float64]{data: tt.map2.data}))
+			require.Equal(t, tt.expected, cmp.Equal(tt.map1, tt.map2))
+		})
+	}
 }

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var fakeValidator = func(k string, v float64) error {
+var fakeValidator = func(_ string, v float64) error {
 	if v < 0 {
 		return errors.New("value cannot be negative")
 	}

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -24,6 +24,29 @@ func TestNewLimitsMap(t *testing.T) {
 	require.Len(t, lm.data, 1)
 }
 
+func TestLimitsMap_IsNil(t *testing.T) {
+	tc := map[string]struct {
+		input    LimitsMap[float64]
+		expected bool
+	}{
+
+		"when the map is initialised": {
+			input:    LimitsMap[float64]{data: map[string]float64{"key1": 10}},
+			expected: true,
+		},
+		"when the map is not initialised": {
+			input:    LimitsMap[float64]{data: nil},
+			expected: false,
+		},
+	}
+
+	for name, tt := range tc {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.input.IsInitialized(), tt.expected)
+		})
+	}
+}
+
 func TestLimitsMap_SetAndString(t *testing.T) {
 	tc := map[string]struct {
 		input    string

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -4,8 +4,11 @@ package validation
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -24,6 +27,10 @@ func TestNewLimitsMap(t *testing.T) {
 }
 
 func TestLimitsMap_SetAndString(t *testing.T) {
+	fmt.Println(reflect.TypeOf(LimitsMap[float64]{}).String())
+	fmt.Println(reflect.TypeOf(model.Duration(0)).String())
+	// validation.LimitsMap[float64]
+	// model.Duration
 	tc := []struct {
 		name     string
 		input    string

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -719,7 +719,7 @@ differentuser:
 		"different user override, othernamespace": {
 			inputNamespace: "othernamespace",
 			overrides:      differentUserOverride,
-			expectedLimit:  10,
+			expectedLimit:  5,
 		},
 	}
 

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
@@ -127,7 +128,7 @@ max_partial_query_length: 1s
 	err = json.Unmarshal([]byte(inputJSON), &limitsJSON)
 	require.NoError(t, err, "expected to be able to unmarshal from JSON")
 
-	assert.Equal(t, limitsYAML, limitsJSON)
+	assert.True(t, cmp.Equal(limitsYAML, limitsJSON, cmp.AllowUnexported(Limits{})), "expected YAML and JSON to match")
 }
 
 func TestLimitsAlwaysUsesPromDuration(t *testing.T) {

--- a/pkg/util/validation/notifications_limit_flag.go
+++ b/pkg/util/validation/notifications_limit_flag.go
@@ -6,57 +6,23 @@
 package validation
 
 import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
-
 	"github.com/grafana/mimir/pkg/util"
+	"github.com/pkg/errors"
 )
 
-var allowedIntegrationNames = []string{
-	"webhook", "email", "pagerduty", "opsgenie", "wechat", "slack", "victorops", "pushover", "sns", "webex", "telegram", "discord", "msteams",
-}
-
-type NotificationRateLimitMap map[string]float64
-
-// String implements flag.Value
-func (m NotificationRateLimitMap) String() string {
-	out, err := json.Marshal(map[string]float64(m))
-	if err != nil {
-		return fmt.Sprintf("failed to marshal: %v", err)
-	}
-	return string(out)
-}
-
-// Set implements flag.Value
-func (m NotificationRateLimitMap) Set(s string) error {
-	newMap := map[string]float64{}
-	return m.updateMap(json.Unmarshal([]byte(s), &newMap), newMap)
-}
-
-// UnmarshalYAML implements yaml.Unmarshaler.
-func (m NotificationRateLimitMap) UnmarshalYAML(value *yaml.Node) error {
-	newMap := map[string]float64{}
-	return m.updateMap(value.DecodeWithOptions(newMap, yaml.DecodeOptions{KnownFields: true}), newMap)
-}
-
-func (m NotificationRateLimitMap) updateMap(unmarshalErr error, newMap map[string]float64) error {
-	if unmarshalErr != nil {
-		return unmarshalErr
-	}
-
-	for k, v := range newMap {
-		if !util.StringsContain(allowedIntegrationNames, k) {
-			return errors.Errorf("unknown integration name: %s", k)
-		}
-		m[k] = v
+var integrationsValidation = func(k string, v float64) error {
+	if !util.StringsContain(allowedIntegrationNames, k) {
+		return errors.Errorf("unknown integration name: %s", k)
 	}
 	return nil
 }
 
-// MarshalYAML implements yaml.Marshaler.
-func (m NotificationRateLimitMap) MarshalYAML() (interface{}, error) {
-	return map[string]float64(m), nil
+// allowedIntegrationNames is a list of all the integrations that can be rate limited.
+var allowedIntegrationNames = []string{
+	"webhook", "email", "pagerduty", "opsgenie", "wechat", "slack", "victorops", "pushover", "sns", "webex", "telegram", "discord", "msteams",
+}
+
+// NotificationRateLimitMap returns a map that can be used as a flag for setting notification rate limits.
+func NotificationRateLimitMap() LimitsMap[float64] {
+	return NewLimitsMap[float64](integrationsValidation)
 }

--- a/pkg/util/validation/notifications_limit_flag.go
+++ b/pkg/util/validation/notifications_limit_flag.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 )
 
-var integrationsValidation = func(k string, v float64) error {
+var integrationsValidation = func(k string, _ float64) error {
 	if !util.StringsContain(allowedIntegrationNames, k) {
 		return errors.Errorf("unknown integration name: %s", k)
 	}

--- a/pkg/util/validation/notifications_limit_flag.go
+++ b/pkg/util/validation/notifications_limit_flag.go
@@ -6,8 +6,9 @@
 package validation
 
 import (
-	"github.com/grafana/mimir/pkg/util"
 	"github.com/pkg/errors"
+
+	"github.com/grafana/mimir/pkg/util"
 )
 
 var integrationsValidation = func(k string, v float64) error {

--- a/pkg/util/validation/notifications_limit_flag.go
+++ b/pkg/util/validation/notifications_limit_flag.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 )
 
-var integrationsValidation = func(k string, _ float64) error {
+func validateIntegrationLimit(k string, _ float64) error {
 	if !util.StringsContain(allowedIntegrationNames, k) {
 		return errors.Errorf("unknown integration name: %s", k)
 	}
@@ -25,5 +25,5 @@ var allowedIntegrationNames = []string{
 
 // NotificationRateLimitMap returns a map that can be used as a flag for setting notification rate limits.
 func NotificationRateLimitMap() LimitsMap[float64] {
-	return NewLimitsMap[float64](integrationsValidation)
+	return NewLimitsMap[float64](validateIntegrationLimit)
 }

--- a/pkg/util/validation/notifications_limit_flag_test.go
+++ b/pkg/util/validation/notifications_limit_flag_test.go
@@ -25,7 +25,7 @@ func TestNotificationLimitsMap(t *testing.T) {
 		"basic test": {
 			args: []string{"-map-flag", "{\"email\": 100 }"},
 			expected: LimitsMap[float64]{
-				validator: integrationsValidation,
+				validator: validateIntegrationLimit,
 				data: map[string]float64{
 					"email": 100,
 				},

--- a/pkg/util/validation/notifications_limit_flag_test.go
+++ b/pkg/util/validation/notifications_limit_flag_test.go
@@ -8,6 +8,7 @@ package validation
 import (
 	"bytes"
 	"flag"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,13 +19,16 @@ import (
 func TestNotificationLimitsMap(t *testing.T) {
 	for name, tc := range map[string]struct {
 		args     []string
-		expected NotificationRateLimitMap
+		expected LimitsMap[float64]
 		error    string
 	}{
 		"basic test": {
 			args: []string{"-map-flag", "{\"email\": 100 }"},
-			expected: NotificationRateLimitMap{
-				"email": 100,
+			expected: LimitsMap[float64]{
+				validator: integrationsValidation,
+				data: map[string]float64{
+					"email": 100,
+				},
 			},
 		},
 
@@ -39,7 +43,7 @@ func TestNotificationLimitsMap(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			v := NotificationRateLimitMap{}
+			v := NotificationRateLimitMap()
 
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			fs.SetOutput(&bytes.Buffer{}) // otherwise errors would go to stderr.
@@ -51,20 +55,20 @@ func TestNotificationLimitsMap(t *testing.T) {
 				assert.Equal(t, tc.error, err.Error())
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tc.expected, v)
+				assert.True(t, maps.Equal(tc.expected.data, v.data))
 			}
 		})
 	}
 }
 
 type TestStruct struct {
-	Flag NotificationRateLimitMap `yaml:"flag"`
+	Flag LimitsMap[float64] `yaml:"flag"`
 }
 
 func TestNotificationsLimitMapYaml(t *testing.T) {
 
 	var testStruct TestStruct
-	testStruct.Flag = map[string]float64{}
+	testStruct.Flag = NotificationRateLimitMap()
 
 	require.NoError(t, testStruct.Flag.Set("{\"email\": 500 }"))
 	expected := []byte(`flag:
@@ -76,16 +80,16 @@ func TestNotificationsLimitMapYaml(t *testing.T) {
 	assert.Equal(t, expected, actual)
 
 	var actualStruct TestStruct
-	actualStruct.Flag = NotificationRateLimitMap{} // must be set, otherwise unmarshalling panics.
+	actualStruct.Flag = NotificationRateLimitMap()
 
 	err = yaml.Unmarshal(expected, &actualStruct)
 	require.NoError(t, err)
-	assert.Equal(t, testStruct, actualStruct)
+	assert.Equal(t, testStruct.Flag.data, actualStruct.Flag.data)
 }
 
 func TestUnknownIntegrationWhenLoadingYaml(t *testing.T) {
 	var s TestStruct
-	s.Flag = NotificationRateLimitMap{} // must be set, otherwise unmarshalling panics.
+	s.Flag = NotificationRateLimitMap()
 
 	yamlInput := `flag:
   unknown_integration: 500
@@ -98,7 +102,7 @@ func TestUnknownIntegrationWhenLoadingYaml(t *testing.T) {
 
 func TestWrongYamlStructureWhenLoadingYaml(t *testing.T) {
 	var s TestStruct
-	s.Flag = NotificationRateLimitMap{} // must be set, otherwise unmarshalling panics.
+	s.Flag = NotificationRateLimitMap()
 
 	yamlInput := `flag:
   email:

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -343,6 +343,10 @@ func getFieldName(field reflect.StructField) string {
 func getFieldCustomType(t reflect.Type) (string, bool) {
 	// Handle custom data types used in the config
 	switch t.String() {
+	case reflect.TypeOf(validation.LimitsMap[float64]{}).String():
+		return "map of string to float64", true
+	case reflect.TypeOf(validation.LimitsMap[int64]{}).String():
+		return "map of string to int64", true
 	case reflect.TypeOf(&url.URL{}).String():
 		return "url", true
 	case reflect.TypeOf(time.Duration(0)).String():
@@ -425,6 +429,10 @@ func getFieldType(t reflect.Type) (string, error) {
 func getCustomFieldType(t reflect.Type) (string, bool) {
 	// Handle custom data types used in the config
 	switch t.String() {
+	case reflect.TypeOf(validation.LimitsMap[float64]{}).String():
+		return "map of string to float64", true
+	case reflect.TypeOf(validation.LimitsMap[int64]{}).String():
+		return "map of string to int64", true
 	case reflect.TypeOf(&url.URL{}).String():
 		return "url", true
 	case reflect.TypeOf(time.Duration(0)).String():
@@ -471,7 +479,9 @@ func ReflectType(typ string) reflect.Type {
 	case "blocked_queries_config...":
 		return reflect.TypeOf([]*validation.BlockedQuery{})
 	case "map of string to float64":
-		return reflect.TypeOf(map[string]float64{})
+		return reflect.TypeOf(validation.LimitsMap[float64]{})
+	case "map of string to int64":
+		return reflect.TypeOf(validation.LimitsMap[int64]{})
 	case "list of durations":
 		return reflect.TypeOf(tsdb.DurationList{})
 	default:

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -345,8 +345,8 @@ func getFieldCustomType(t reflect.Type) (string, bool) {
 	switch t.String() {
 	case reflect.TypeOf(validation.LimitsMap[float64]{}).String():
 		return "map of string to float64", true
-	case reflect.TypeOf(validation.LimitsMap[int64]{}).String():
-		return "map of string to int64", true
+	case reflect.TypeOf(validation.LimitsMap[int]{}).String():
+		return "map of string to int", true
 	case reflect.TypeOf(&url.URL{}).String():
 		return "url", true
 	case reflect.TypeOf(time.Duration(0)).String():
@@ -431,8 +431,8 @@ func getCustomFieldType(t reflect.Type) (string, bool) {
 	switch t.String() {
 	case reflect.TypeOf(validation.LimitsMap[float64]{}).String():
 		return "map of string to float64", true
-	case reflect.TypeOf(validation.LimitsMap[int64]{}).String():
-		return "map of string to int64", true
+	case reflect.TypeOf(validation.LimitsMap[int]{}).String():
+		return "map of string to int", true
 	case reflect.TypeOf(&url.URL{}).String():
 		return "url", true
 	case reflect.TypeOf(time.Duration(0)).String():
@@ -480,8 +480,8 @@ func ReflectType(typ string) reflect.Type {
 		return reflect.TypeOf([]*validation.BlockedQuery{})
 	case "map of string to float64":
 		return reflect.TypeOf(validation.LimitsMap[float64]{})
-	case "map of string to int64":
-		return reflect.TypeOf(validation.LimitsMap[int64]{})
+	case "map of string to int":
+		return reflect.TypeOf(validation.LimitsMap[int]{})
 	case "list of durations":
 		return reflect.TypeOf(tsdb.DurationList{})
 	default:


### PR DESCRIPTION
#### What this PR does

Introduces a new limit named `ruler_max_rules_per_rule_group_by_namespace` which allows one to specify which namespaces do we want to be different to have a different limit in terms of rules per group.

With this change, we now have a hierarchy for this limit as follows:

1. Per tenant limit for the given namespace.
2. Default limit for the given namespace.
3. Per tenant limit set by RulerMaxRulesPerRuleGroup
4. Default limit set by RulerMaxRulesPerRuleGroup

This is part 1 of the change, and I need to extend the same level of support to the other limit related to rule groups of `MaxRuleGroupsPerTenant`.

**Marking it as a draft as I still have some work to do around the documentation and experimental guarantees** 

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
