### PR TITLE
frontend: clone headers in `WithXXX` query request methods

### DIFF
--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -911,6 +911,9 @@ func DecodeCachedHTTPResponse(res *CachedHTTPResponse) *http.Response {
 // This function is designed to be used in MetricsQueryRequest cloning method to avoid modifying
 // original request headers, which may cause undesired side effects during the processing in the middleware chain.
 func cloneHeaders(headers []*PrometheusHeader) []*PrometheusHeader {
+	if headers == nil {
+		return nil
+	}
 	cp := make([]*PrometheusHeader, len(headers))
 	for i, h := range headers {
 		cp[i] = &PrometheusHeader{Name: h.Name, Values: slices.Clone(h.Values)}

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"time"
 	"unsafe"
 
@@ -150,6 +151,7 @@ func (r *PrometheusRangeQueryRequest) GetHints() *Hints {
 // WithID clones the current `PrometheusRangeQueryRequest` with the provided ID.
 func (r *PrometheusRangeQueryRequest) WithID(id int64) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.id = id
 	return &newRequest
 }
@@ -157,6 +159,7 @@ func (r *PrometheusRangeQueryRequest) WithID(id int64) MetricsQueryRequest {
 // WithStartEnd clones the current `PrometheusRangeQueryRequest` with a new `start` and `end` timestamp.
 func (r *PrometheusRangeQueryRequest) WithStartEnd(start int64, end int64) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.start = start
 	newRequest.end = end
 	if newRequest.queryExpr != nil {
@@ -175,6 +178,7 @@ func (r *PrometheusRangeQueryRequest) WithQuery(query string) (MetricsQueryReque
 	}
 
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.queryExpr = queryExpr
 	if newRequest.queryExpr != nil {
 		newRequest.minT, newRequest.maxT = decodeQueryMinMaxTime(
@@ -187,13 +191,14 @@ func (r *PrometheusRangeQueryRequest) WithQuery(query string) (MetricsQueryReque
 // WithHeaders clones the current `PrometheusRangeQueryRequest` with new headers.
 func (r *PrometheusRangeQueryRequest) WithHeaders(headers []*PrometheusHeader) MetricsQueryRequest {
 	newRequest := *r
-	newRequest.headers = headers
+	newRequest.headers = cloneHeaders(headers)
 	return &newRequest
 }
 
 // WithExpr clones the current `PrometheusRangeQueryRequest` with a new query expression.
 func (r *PrometheusRangeQueryRequest) WithExpr(queryExpr parser.Expr) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.queryExpr = queryExpr
 	if newRequest.queryExpr != nil {
 		newRequest.minT, newRequest.maxT = decodeQueryMinMaxTime(
@@ -207,6 +212,7 @@ func (r *PrometheusRangeQueryRequest) WithExpr(queryExpr parser.Expr) MetricsQue
 // added Hint value for TotalQueries.
 func (r *PrometheusRangeQueryRequest) WithTotalQueriesHint(totalQueries int32) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	if newRequest.hints == nil {
 		newRequest.hints = &Hints{TotalQueries: totalQueries}
 	} else {
@@ -220,6 +226,7 @@ func (r *PrometheusRangeQueryRequest) WithTotalQueriesHint(totalQueries int32) M
 // with an added Hint value for EstimatedCardinality.
 func (r *PrometheusRangeQueryRequest) WithEstimatedSeriesCountHint(count uint64) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	if newRequest.hints == nil {
 		newRequest.hints = &Hints{
 			CardinalityEstimate: &EstimatedSeriesCount{count},
@@ -350,6 +357,7 @@ func (r *PrometheusInstantQueryRequest) GetHints() *Hints {
 
 func (r *PrometheusInstantQueryRequest) WithID(id int64) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.id = id
 	return &newRequest
 }
@@ -357,6 +365,7 @@ func (r *PrometheusInstantQueryRequest) WithID(id int64) MetricsQueryRequest {
 // WithStartEnd clones the current `PrometheusInstantQueryRequest` with a new `time` timestamp.
 func (r *PrometheusInstantQueryRequest) WithStartEnd(time int64, _ int64) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.time = time
 	if newRequest.queryExpr != nil {
 		newRequest.minT, newRequest.maxT = decodeQueryMinMaxTime(
@@ -374,6 +383,7 @@ func (r *PrometheusInstantQueryRequest) WithQuery(query string) (MetricsQueryReq
 	}
 
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.queryExpr = queryExpr
 	if newRequest.queryExpr != nil {
 		newRequest.minT, newRequest.maxT = decodeQueryMinMaxTime(
@@ -386,13 +396,14 @@ func (r *PrometheusInstantQueryRequest) WithQuery(query string) (MetricsQueryReq
 // WithHeaders clones the current `PrometheusRangeQueryRequest` with new headers.
 func (r *PrometheusInstantQueryRequest) WithHeaders(headers []*PrometheusHeader) MetricsQueryRequest {
 	newRequest := *r
-	newRequest.headers = headers
+	newRequest.headers = cloneHeaders(headers)
 	return &newRequest
 }
 
 // WithExpr clones the current `PrometheusInstantQueryRequest` with a new query expression.
 func (r *PrometheusInstantQueryRequest) WithExpr(queryExpr parser.Expr) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.queryExpr = queryExpr
 	if newRequest.queryExpr != nil {
 		newRequest.minT, newRequest.maxT = decodeQueryMinMaxTime(
@@ -404,6 +415,7 @@ func (r *PrometheusInstantQueryRequest) WithExpr(queryExpr parser.Expr) MetricsQ
 
 func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	if newRequest.hints == nil {
 		newRequest.hints = &Hints{TotalQueries: totalQueries}
 	} else {
@@ -415,6 +427,7 @@ func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32)
 
 func (r *PrometheusInstantQueryRequest) WithEstimatedSeriesCountHint(count uint64) MetricsQueryRequest {
 	newRequest := *r
+	newRequest.headers = cloneHeaders(r.headers)
 	if newRequest.hints == nil {
 		newRequest.hints = &Hints{
 			CardinalityEstimate: &EstimatedSeriesCount{count},
@@ -892,4 +905,12 @@ func DecodeCachedHTTPResponse(res *CachedHTTPResponse) *http.Response {
 		Header:        headers,
 		ContentLength: int64(len(res.Body)),
 	}
+}
+
+func cloneHeaders(headers []*PrometheusHeader) []*PrometheusHeader {
+	cp := make([]*PrometheusHeader, len(headers))
+	for i, h := range headers {
+		cp[i] = &PrometheusHeader{Name: h.Name, Values: slices.Clone(h.Values)}
+	}
+	return cp
 }

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -907,6 +907,9 @@ func DecodeCachedHTTPResponse(res *CachedHTTPResponse) *http.Response {
 	}
 }
 
+// cloneHeaders makes a deep copy of the passed headers parameters.
+// This function is designed to be used in MetricsQueryRequest cloning method to avoid modifying
+// original request headers, which may cause undesired side effects during the processing in the middleware chain.
 func cloneHeaders(headers []*PrometheusHeader) []*PrometheusHeader {
 	cp := make([]*PrometheusHeader, len(headers))
 	for i, h := range headers {

--- a/pkg/frontend/querymiddleware/model_extra_test.go
+++ b/pkg/frontend/querymiddleware/model_extra_test.go
@@ -4,8 +4,6 @@ package querymiddleware
 
 import (
 	"context"
-	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/exp/slices"
 	"io"
 	"net/http"
 	"net/url"
@@ -14,8 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 func TestEncodeAndDecodeCachedHTTPResponse(t *testing.T) {
@@ -80,10 +80,7 @@ func TestMetricQueryRequestCloneHeaders(t *testing.T) {
 		}
 		require.Equal(t, "test-value", headersMap["X-Test-Header"])
 		require.Equal(t, "application/x-www-form-urlencoded", headersMap["Content-Type"])
-
-		// Check that the lengths are the same
-		require.Len(t, cloned, len(original))
-
+		
 		// Check that the elements are equal but not the same instances
 		for i := range original {
 			if cloned[i] == original[i] {

--- a/pkg/frontend/querymiddleware/model_extra_test.go
+++ b/pkg/frontend/querymiddleware/model_extra_test.go
@@ -3,10 +3,16 @@
 package querymiddleware
 
 import (
+	"context"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/exp/slices"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,6 +67,102 @@ func TestEncodeAndDecodeCachedHTTPResponse(t *testing.T) {
 			actualBody, err = io.ReadAll(testData.httpRes.Body)
 			require.NoError(t, err)
 			assert.Equal(t, testData.expectedBody, actualBody)
+		})
+	}
+}
+
+func TestMetricQueryRequestCloneHeaders(t *testing.T) {
+	validateClonedHeaders := func(t *testing.T, cloned, original []*PrometheusHeader) {
+		// Check header elements
+		headersMap := make(map[string]string)
+		for _, header := range cloned {
+			headersMap[header.Name] = header.Values[0]
+		}
+		require.Equal(t, "test-value", headersMap["X-Test-Header"])
+		require.Equal(t, "application/x-www-form-urlencoded", headersMap["Content-Type"])
+
+		// Check that the lengths are the same
+		require.Len(t, cloned, len(original))
+
+		// Check that the elements are equal but not the same instances
+		for i := range original {
+			if cloned[i] == original[i] {
+				t.Errorf("expected element %d to be a different instance, but it is the same", i)
+			}
+			require.Equalf(t, original[i].Name, cloned[i].Name, "expected element %d to have Name %s, got %s", i, original[i].Name, cloned[i].Name)
+			require.True(t, slices.Equal(original[i].Values, cloned[i].Values), "expected values to be equal")
+		}
+	}
+
+	for _, asRangeQuery := range []bool{true, false} {
+		t.Run("asRangeQuery="+strconv.FormatBool(asRangeQuery), func(t *testing.T) {
+			var (
+				urlPath string
+				params  = url.Values{}
+			)
+
+			params.Add("query", "up")
+			if asRangeQuery {
+				params.Add("start", "0")
+				params.Add("end", "1")
+				params.Add("step", "1")
+
+				urlPath = "/api/v1/query_range"
+			} else {
+				urlPath = "/api/v1/query"
+			}
+
+			httpReq, err := http.NewRequest(http.MethodPost, urlPath, strings.NewReader(params.Encode()))
+			require.NoError(t, err)
+
+			httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			httpReq.Header.Set("X-Test-Header", "test-value")
+
+			c := NewPrometheusCodec(prometheus.NewPedanticRegistry(), time.Minute*5, "json")
+			originalReq, err := c.DecodeMetricsQueryRequest(context.Background(), httpReq)
+			require.NoError(t, err)
+
+			t.Run("WithHeaders", func(t *testing.T) {
+				newHeaders := []*PrometheusHeader{
+					{Name: "Content-Type", Values: []string{"application/x-www-form-urlencoded"}},
+					{Name: "X-Test-Header", Values: []string{"test-value"}},
+				}
+
+				r := originalReq.WithHeaders(newHeaders)
+				require.NoError(t, err)
+
+				validateClonedHeaders(t, r.GetHeaders(), newHeaders)
+			})
+			t.Run("WithID", func(t *testing.T) {
+				r := originalReq.WithID(1234)
+				require.NoError(t, err)
+
+				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
+			})
+			t.Run("WithQuery", func(t *testing.T) {
+				r, err := originalReq.WithQuery("count")
+				require.NoError(t, err)
+
+				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
+			})
+			t.Run("WithTotalQueriesHint", func(t *testing.T) {
+				r := originalReq.WithTotalQueriesHint(10)
+				require.NoError(t, err)
+
+				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
+			})
+			t.Run("WithExpr", func(t *testing.T) {
+				r := originalReq.WithExpr(nil)
+				require.NoError(t, err)
+
+				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
+			})
+			t.Run("WithEstimatedSeriesCountHint", func(t *testing.T) {
+				r := originalReq.WithEstimatedSeriesCountHint(10)
+				require.NoError(t, err)
+
+				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
+			})
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

follow-up of https://github.com/grafana/mimir/pull/8342

This PR extends the cloning of headers in all `WithXXX` methods for instant and range query requests.

#### Which issue(s) this PR fixes or relates to

Fixes N/A
