### PR TITLE
store-gateway: don't wait on lazy loading if queries are canceled

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1441,7 +1441,7 @@ func blockLabelNames(ctx context.Context, indexr *bucketIndexReader, matchers []
 	if len(matchers) == 0 {
 		// Do it via index reader to have pending reader registered correctly.
 		// LabelNames are already sorted.
-		names, err := indexr.block.indexHeaderReader.LabelNames()
+		names, err := indexr.block.indexHeaderReader.LabelNames(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "label names")
 		}
@@ -1980,7 +1980,7 @@ func (b *bucketBlock) loadedIndexReader(ctx context.Context, postingsStrategy po
 
 	loadStartTime := time.Now()
 	// Call IndexVersion to lazy load the index header if it lazy-loaded.
-	_, _ = b.indexHeaderReader.IndexVersion()
+	_, _ = b.indexHeaderReader.IndexVersion(ctx)
 	stats.update(func(stats *queryStats) {
 		stats.streamingSeriesIndexHeaderLoadDuration += time.Since(loadStartTime)
 	})

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -102,7 +102,7 @@ func (g rawPostingGroup) toPostingGroup(ctx context.Context, r indexheader.Reade
 		}
 	} else {
 		var err error
-		keys, totalSize, err = g.filterNonExistingKeys(r)
+		keys, totalSize, err = g.filterNonExistingKeys(ctx, r)
 		if err != nil {
 			return postingGroup{}, errors.Wrap(err, "filter posting keys")
 		}
@@ -118,13 +118,13 @@ func (g rawPostingGroup) toPostingGroup(ctx context.Context, r indexheader.Reade
 
 // filterNonExistingKeys uses the indexheader.Reader to filter out any label values that do not exist in this index.
 // modifies the underlying keys slice of the group. Do not use the rawPostingGroup after calling toPostingGroup.
-func (g rawPostingGroup) filterNonExistingKeys(r indexheader.Reader) ([]labels.Label, int64, error) {
+func (g rawPostingGroup) filterNonExistingKeys(ctx context.Context, r indexheader.Reader) ([]labels.Label, int64, error) {
 	var (
 		writeIdx  int
 		totalSize int64
 	)
 	for _, l := range g.keys {
-		offset, err := r.PostingsOffset(l.Name, l.Value)
+		offset, err := r.PostingsOffset(ctx, l.Name, l.Value)
 		if errors.Is(err, indexheader.NotFoundRangeErr) {
 			// This label name and value doesn't exist in this block, so there are 0 postings we can match.
 			// Try with the rest of the set matchers, maybe they can match some series.

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -59,8 +59,8 @@ func newBucketIndexReader(block *bucketBlock, postingsStrategy postingsSelection
 		block:            block,
 		postingsStrategy: postingsStrategy,
 		dec: &index.Decoder{
-			LookupSymbol: func(_ context.Context, o uint32) (string, error) {
-				return block.indexHeaderReader.LookupSymbol(o)
+			LookupSymbol: func(ctx context.Context, o uint32) (string, error) {
+				return block.indexHeaderReader.LookupSymbol(ctx, o)
 			},
 		},
 		indexHeaderReader: block.indexHeaderReader,
@@ -236,7 +236,7 @@ func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.M
 
 	// As of version two all series entries are 16 byte padded. All references
 	// we get have to account for that to get the correct offset.
-	version, err := r.block.indexHeaderReader.IndexVersion()
+	version, err := r.block.indexHeaderReader.IndexVersion(ctx)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "get index version")
 	}
@@ -400,7 +400,7 @@ func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Lab
 
 	// As of version two all series entries are 16 byte padded. All references
 	// we get have to account for that to get the correct offset.
-	version, err := r.block.indexHeaderReader.IndexVersion()
+	version, err := r.block.indexHeaderReader.IndexVersion(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "get index version")
 	}
@@ -460,7 +460,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 		}
 
 		// Cache miss; save pointer for actual posting in index stored in object store.
-		ptr, err := r.block.indexHeaderReader.PostingsOffset(key.Name, key.Value)
+		ptr, err := r.block.indexHeaderReader.PostingsOffset(ctx, key.Name, key.Value)
 		if errors.Is(err, indexheader.NotFoundRangeErr) {
 			// This block does not have any posting for given key.
 			output[ix] = index.EmptyPostings()

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -876,13 +876,13 @@ type interceptedIndexReader struct {
 	onIndexVersionCalled       func() error
 }
 
-func (iir *interceptedIndexReader) LabelNames() ([]string, error) {
+func (iir *interceptedIndexReader) LabelNames(ctx context.Context) ([]string, error) {
 	if iir.onLabelNamesCalled != nil {
 		if err := iir.onLabelNamesCalled(); err != nil {
 			return nil, err
 		}
 	}
-	return iir.Reader.LabelNames()
+	return iir.Reader.LabelNames(ctx)
 }
 
 func (iir *interceptedIndexReader) LabelValuesOffsets(ctx context.Context, name string, prefix string, filter func(string) bool) ([]index.PostingListOffset, error) {
@@ -894,13 +894,13 @@ func (iir *interceptedIndexReader) LabelValuesOffsets(ctx context.Context, name 
 	return iir.Reader.LabelValuesOffsets(ctx, name, prefix, filter)
 }
 
-func (iir *interceptedIndexReader) IndexVersion() (int, error) {
+func (iir *interceptedIndexReader) IndexVersion(ctx context.Context) (int, error) {
 	if iir.onIndexVersionCalled != nil {
 		if err := iir.onIndexVersionCalled(); err != nil {
 			return 0, err
 		}
 	}
-	return iir.Reader.IndexVersion()
+	return iir.Reader.IndexVersion(ctx)
 }
 
 func deadlineExceededIndexHeader() *interceptedIndexReader {

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -34,20 +34,20 @@ type Reader interface {
 	io.Closer
 
 	// IndexVersion returns version of index.
-	IndexVersion() (int, error)
+	IndexVersion(context.Context) (int, error)
 
 	// PostingsOffset returns start and end offsets of postings for given name and value.
 	// The Start is inclusive and is the byte offset of the number_of_entries field of a posting list.
 	// The End is exclusive and is typically the byte offset of the CRC32 field.
 	// The End might be bigger than the actual posting ending, but not larger than the whole index file.
 	// NotFoundRangeErr is returned when no index can be found for given name and value.
-	PostingsOffset(name string, value string) (index.Range, error)
+	PostingsOffset(ctx context.Context, name string, value string) (index.Range, error)
 
 	// LookupSymbol returns string based on given reference.
 	// Error is return if the symbol can't be found.
-	LookupSymbol(o uint32) (string, error)
+	LookupSymbol(ctx context.Context, o uint32) (string, error)
 
-	SymbolsReader() (streamindex.SymbolsReader, error)
+	SymbolsReader(ctx context.Context) (streamindex.SymbolsReader, error)
 
 	// LabelValuesOffsets returns all label values and the offsets for their posting lists for given label name or error.
 	// The returned label values are sorted lexicographically (which the same as sorted by posting offset).
@@ -59,7 +59,7 @@ type Reader interface {
 	LabelValuesOffsets(ctx context.Context, name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error)
 
 	// LabelNames returns all label names in sorted order.
-	LabelNames() ([]string, error)
+	LabelNames(ctx context.Context) ([]string, error)
 }
 
 type Config struct {

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -257,15 +257,6 @@ func (r *LazyBinaryReader) EagerLoad(ctx context.Context) {
 	loaded.inUse.Done()
 }
 
-func (r *LazyBinaryReader) waitLoadedReader(ctx context.Context, loadDone chan struct{}) loadedReader {
-	select {
-	case <-loadDone:
-		return r.getOrLoadReader(ctx)
-	case <-ctx.Done():
-		return loadedReader{err: context.Cause(ctx)}
-	}
-}
-
 // getOrLoadReader ensures the underlying binary index-header reader has been successfully loaded.
 // Returns the reader, wait group that should be used to signal that usage of reader is finished, and an error on failure.
 // Must be called without lock.

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -350,8 +350,8 @@ func (r *LazyBinaryReader) controlLoop() {
 	for {
 		select {
 		case readerReq := <-r.loadedReader:
-			if loaded.reader == nil && loaded.err == nil {
-				// TODO dimitarvdimitrov see if we retry loading a reader
+			if loaded.reader == nil {
+				// Try to load the reader if it hasn't been loaded before or if the previous loading failed.
 				loaded = loadedReader{}
 				loaded.reader, loaded.err = r.loadReader()
 				if loaded.reader != nil {

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -411,7 +411,7 @@ func (r *LazyBinaryReader) controlLoop() {
 			r.metrics.unloadCount.Inc()
 			if err := loaded.reader.Close(); err != nil {
 				r.metrics.unloadFailedCount.Inc()
-				unloadPromise.response <- fmt.Errorf("closing bianry reader: %w", err)
+				unloadPromise.response <- fmt.Errorf("closing binary reader: %w", err)
 				continue
 			}
 

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -624,10 +624,7 @@ func BenchmarkNewLazyBinaryReader(b *testing.B) {
 				go func() {
 					defer wg.Done()
 					for i := 0; i < b.N; i++ {
-						_, err = lazyReader.IndexVersion(ctx)
-						if err != nil {
-							b.Fatal(err)
-						}
+						_, _ = lazyReader.IndexVersion(ctx) // ignore the mocked values above
 					}
 				}()
 			}

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -7,6 +7,7 @@ package indexheader
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -512,6 +513,12 @@ func TestLazyBinaryReader_CancellingContextReturnsCallButDoesntStopLazyLoading_L
 	loadStarted = make(chan struct{})
 	_, err = lazyReader.IndexVersion(context.Background()) // try to use the reader implementation now that it has loaded
 	assert.ErrorIs(t, err, assert.AnError)
+
+	// Since we got an error the previous time we try to load the reader again.
+	loadErr = fmt.Errorf("a different error")
+	loadStarted = make(chan struct{})
+	_, err = lazyReader.IndexVersion(context.Background()) // try to use the reader implementation now that it has loaded
+	assert.ErrorIs(t, err, loadErr)
 }
 
 func TestLazyBinaryReader_CancellingContextReturnsCallButDoesntStopLazyLoading_NoZombieReaders(t *testing.T) {

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -514,7 +514,7 @@ func TestLazyBinaryReader_CancellingContextReturnsCallButDoesntStopLazyLoading_L
 	assert.ErrorIs(t, err, assert.AnError)
 }
 
-func TestLazyBinaryReader_CancellingContextReturnsCallButDoesntStopLazyLoading_NoGhostReaders(t *testing.T) {
+func TestLazyBinaryReader_CancellingContextReturnsCallButDoesntStopLazyLoading_NoZombieReaders(t *testing.T) {
 	// This test makes sure that if we requested a reader, but then gave up, then the reader is properly closed and
 	// isn't open forever.
 	tmpDir, bkt, blockID := initBucketAndBlocksForTest(t)

--- a/pkg/storegateway/indexheader/reader_benchmarks_test.go
+++ b/pkg/storegateway/indexheader/reader_benchmarks_test.go
@@ -84,7 +84,7 @@ func benchmarkLookupSymbol(ctx context.Context, b *testing.B, bucketDir string, 
 
 			index := indices[random.Intn(len(indices))]
 			expectedSymbol := indicesToSymbol[index]
-			actualSymbol, err := br.LookupSymbol(index)
+			actualSymbol, err := br.LookupSymbol(context.Background(), index)
 
 			// Why do we wrap require.NoError or require.Equal in an if block here? These methods perform some synchronisation
 			// that ends up dominating the benchmark, so we only want to call them if they're needed.
@@ -128,7 +128,7 @@ func BenchmarkLabelNames(b *testing.B) {
 					b.ResetTimer()
 
 					for i := 0; i < b.N; i++ {
-						actualNames, err := br.LabelNames()
+						actualNames, err := br.LabelNames(ctx)
 
 						require.NoError(b, err)
 						require.Equal(b, nameSymbols, actualNames)
@@ -165,7 +165,7 @@ func BenchmarkLabelValuesOffsetsIndexV1(b *testing.B) {
 	require.NoError(b, WriteBinary(ctx, bkt, metaIndexV1.ULID, indexName))
 
 	benchmarkReader(b, bucketDir, metaIndexV1.ULID, func(b *testing.B, br Reader) {
-		names, err := br.LabelNames()
+		names, err := br.LabelNames(ctx)
 		require.NoError(b, err)
 
 		rand.Shuffle(len(names), func(i, j int) {
@@ -206,11 +206,11 @@ func BenchmarkLabelValuesOffsetsIndexV2(b *testing.B) {
 	indexName := filepath.Join(bucketDir, idIndexV2.String(), block.IndexHeaderFilename)
 	require.NoError(b, WriteBinary(ctx, bkt, idIndexV2, indexName))
 
-	br, err := NewStreamBinaryReader(context.Background(), log.NewNopLogger(), nil, bucketDir, idIndexV2, 32, NewStreamBinaryReaderMetrics(nil), Config{})
+	br, err := NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, bucketDir, idIndexV2, 32, NewStreamBinaryReaderMetrics(nil), Config{})
 	require.NoError(b, err)
 	b.Cleanup(func() { require.NoError(b, br.Close()) })
 
-	names, err := br.LabelNames()
+	names, err := br.LabelNames(ctx)
 	require.NoError(b, err)
 
 	rand.Shuffle(len(names), func(i, j int) {
@@ -287,7 +287,7 @@ func BenchmarkPostingsOffset(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				name := nameSymbols[random.Intn(nameCount)]
 				value := valueSymbols[random.Intn(valueCount)]
-				offset, err := br.PostingsOffset(name, value)
+				offset, err := br.PostingsOffset(ctx, name, value)
 
 				require.NoError(b, err)
 				require.NotZero(b, offset.Start)

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -162,7 +162,7 @@ func (p *ReaderPool) getIdleReadersSince(ts int64) []*LazyBinaryReader {
 
 	var idle []*LazyBinaryReader
 	for r := range p.lazyReaders {
-		if r.isIdleSince(ts) {
+		if r.IsIdleSince(ts) {
 			idle = append(idle, r)
 		}
 	}

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -118,7 +118,7 @@ func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt
 		if initialSync && p.preShutdownLoadedBlocks != nil {
 			// we only eager load if we have preShutdownLoadedBlocks for the given block id
 			if p.preShutdownLoadedBlocks[id] > 0 {
-				lazyBinaryReader.EagerLoad()
+				lazyBinaryReader.EagerLoad(ctx)
 			}
 		}
 		reader, err = lazyBinaryReader, lazyErr

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -122,7 +122,7 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 			require.Equal(t, float64(testData.expectedLoadCountMetricBeforeLabelNamesCall), promtestutil.ToFloat64(metrics.lazyReader.loadCount))
 
 			// Ensure it can read data.
-			labelNames, err := r.LabelNames()
+			labelNames, err := r.LabelNames(ctx)
 			require.NoError(t, err)
 			require.Equal(t, []string{"a"}, labelNames)
 
@@ -151,7 +151,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	defer func() { require.NoError(t, r.Close()) }()
 
 	// Ensure it can read data.
-	labelNames, err := r.LabelNames()
+	labelNames, err := r.LabelNames(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{"a"}, labelNames)
 	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.lazyReader.loadCount))
@@ -167,7 +167,7 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	require.Equal(t, float64(1), promtestutil.ToFloat64(metrics.lazyReader.unloadCount))
 
 	// Ensure it can still read data (will be re-opened).
-	labelNames, err = r.LabelNames()
+	labelNames, err = r.LabelNames(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{"a"}, labelNames)
 	require.True(t, pool.isTracking(r.(*LazyBinaryReader)))

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -189,8 +189,6 @@ func TestReaderPool_LoadedBlocks(t *testing.T) {
 	lb := LazyBinaryReader{
 		blockID: id,
 		usedAt:  atomic.NewInt64(usedAt.UnixNano()),
-		// we just set to make reader != nil
-		reader: &StreamBinaryReader{},
 	}
 	rp := ReaderPool{
 		lazyReaderEnabled: true,

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -306,11 +306,11 @@ func newBinaryTOCFromFile(d streamencoding.Decbuf, indexHeaderSize int) (*Binary
 	}, nil
 }
 
-func (r *StreamBinaryReader) IndexVersion() (int, error) {
+func (r *StreamBinaryReader) IndexVersion(context.Context) (int, error) {
 	return r.indexVersion, nil
 }
 
-func (r *StreamBinaryReader) PostingsOffset(name, value string) (index.Range, error) {
+func (r *StreamBinaryReader) PostingsOffset(_ context.Context, name string, value string) (index.Range, error) {
 	rng, found, err := r.postingsOffsetTable.PostingsOffset(name, value)
 	if err != nil {
 		return index.Range{}, err
@@ -321,7 +321,7 @@ func (r *StreamBinaryReader) PostingsOffset(name, value string) (index.Range, er
 	return rng, nil
 }
 
-func (r *StreamBinaryReader) LookupSymbol(o uint32) (string, error) {
+func (r *StreamBinaryReader) LookupSymbol(_ context.Context, o uint32) (string, error) {
 	if r.indexVersion == index.FormatV1 {
 		// For v1 little trick is needed. Refs are actual offset inside index, not index-header. This is different
 		// of the header length difference between two files.
@@ -370,7 +370,7 @@ func (c cachedLabelNamesSymbolsReader) Read(u uint32) (string, error) {
 	return c.r.Read(u)
 }
 
-func (r *StreamBinaryReader) SymbolsReader() (streamindex.SymbolsReader, error) {
+func (r *StreamBinaryReader) SymbolsReader(context.Context) (streamindex.SymbolsReader, error) {
 	return cachedLabelNamesSymbolsReader{
 		labelNames: r.nameSymbols,
 		r:          r.symbols.Reader(),
@@ -381,7 +381,7 @@ func (r *StreamBinaryReader) LabelValuesOffsets(ctx context.Context, name string
 	return r.postingsOffsetTable.LabelValuesOffsets(ctx, name, prefix, filter)
 }
 
-func (r *StreamBinaryReader) LabelNames() ([]string, error) {
+func (r *StreamBinaryReader) LabelNames(context.Context) ([]string, error) {
 	return r.postingsOffsetTable.LabelNames()
 }
 

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -1134,7 +1134,7 @@ func (s *loadingSeriesChunkRefsSetIterator) singlePassStringify(symbolizedSet sy
 	}
 	slices.Sort(allSymbols)
 
-	symReader, err := s.indexr.indexHeaderReader.SymbolsReader()
+	symReader, err := s.indexr.indexHeaderReader.SymbolsReader(s.ctx)
 	if err != nil {
 		return seriesChunkRefsSet{}, err
 	}

--- a/pkg/util/test/leak.go
+++ b/pkg/util/test/leak.go
@@ -28,6 +28,7 @@ func goLeakOptions() []goleak.Option {
 		// it gets closed when we close the BucketStore. However, we currently don't close BucketStore
 		// on store-gateway termination so it never gets terminated.
 		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.NewReaderPool.func1"),
+		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.(*LazyBinaryReader).controlLoop"),
 		// Similar to the one above, store-gateway BucketStore starts a goroutine in snapshotter
 		// that manages lazy-loaded snapshots. It stops the snapshotter on BucketStore close.
 		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.(*Snapshotter).Start.func1"),


### PR DESCRIPTION
#### Goal

Allows requests to abort waiting for lazy loading to complete if the request is cancelled. However, we don't want the `LazyBinaryReader` to abort loading the binary reader.

#### Challenge

The main challenge with the current implementation was the usage of mutexes. Doing this with mutexes is impractical because they block until the mutex is acquired and there's no way to abort waiting (without doing busy loops with `TryLock()`).

#### Implementation

Because of this challenge I chose to reimplement the synchronisation in the `LazyBinaryReader` with a control loop rather than a mutex (see `LazyBinaryReader.controlLoop`).
There is a single goroutine which ordered the reads and writes (load/unload) of the underlying binary reader.
Interacting with the state happens via sending a callback to a channel (a request).
The control goroutine receives callbacks/requests and manages the state of the underlying reader. When it's done processing the request it sends a response to the request.
Sending the request and receiving the response can both be aborted by the client upon context cancellation.

The only exception is storing the `lastUsedAt` timestamp for the reader in an atomic. The reason for this is that access to that should be fast rather than accurate. The timestamp is accessed when building a snapshot for all the used blocks. That happens under [`lazyReadersMx`](https://github.com/grafana/mimir/blob/40ee83bd595aa2316d40e5e24047a9d6cb257955/pkg/storegateway/indexheader/reader_pool.go#L263-L273), which is in turn necessary for adding new blocks. Having `lastUsedAt` be managed by the control loop means that we might block adding new blocks because one block is slow to lazy load, which is hard to debug and generally something we want to avoid.

#### Side effect 

I also noticed another inefficiency that this PR solves unintentionally. Before this PR the [lazy loading gate is acquired
before acquiring the write lock for loading the reader](https://github.com/grafana/mimir/blob/04e6b7fc0f305f344b0e487691218d898633410a/pkg/storegateway/indexheader/lazy_binary_reader.go#L274-L281). This means that if there are multiple clients (queries)
trying to load the same block, they can all consume the concurrency quota, but only one of them will actually do the loading.
The rest of the clients will occupy a slot in the concurrency gate without doing anything.

This PR resolves this by making sure that only the control goroutine tries to load an index header.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/8257

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
