### PR TITLE
BlockBuilder: Add many test for the BlockBuilder and few fixes

### DIFF
--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -3,6 +3,7 @@ package blockbuilder
 import (
 	"context"
 	"errors"
+	"path"
 	"testing"
 	"time"
 
@@ -10,13 +11,14 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
-	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 
-	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
-	"github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/util/testkafka"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -25,70 +27,43 @@ func TestBlockBuilder_BuildBlocks(t *testing.T) {
 	const (
 		testTopic     = "test"
 		numPartitions = 2
-
-		userID = "1"
+		userID        = "1"
 	)
-
-	testEpoch := time.Now().Truncate(time.Hour).Add(-12 * time.Hour)
 
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
 
-	cluster, err := kfake.NewCluster(
-		kfake.NumBrokers(1),
-		kfake.SeedTopics(numPartitions, testTopic),
-	)
-	require.NoError(t, err)
-	t.Cleanup(cluster.Close)
+	_, addr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
+	writeClient := newKafkaProduceClient(t, addr)
 
-	addrs := cluster.ListenAddrs()
-	require.Len(t, addrs, 1)
+	cfg := blockBuilderConfig(t, addr, testTopic)
 
-	writeClient := newKafkaProduceClient(t, addrs...)
+	var expSamples []mimirpb.Sample
 
-	// Prepopulate 2 groups of samples for T+1h and T+2h.
-	for i := int64(0); i < 10; i++ {
-		ts := testEpoch.Add(time.Duration(i/5) * time.Hour)
-		val := createWriteRequest(t, floatSample(ts.UnixMilli()), nil)
-		produceRecords(t, ctx, writeClient, ts, userID, testTopic, int32(i%numPartitions), val)
+	testEpoch := time.Now().Truncate(cfg.ConsumeInterval).Add(-6 * time.Hour).Add(30 * time.Minute)
+	for i := int64(0); i < 6; i++ {
+		ts := testEpoch.Add(-time.Minute)
+		samples := floatSample(ts.UnixMilli())
+		val := createWriteRequest(t, samples, nil)
+		produceRecords(t, ctx, writeClient, testEpoch, userID, testTopic, int32(i%numPartitions), val)
+		testEpoch = testEpoch.Add(time.Hour)
+		expSamples = append(expSamples, samples...)
 	}
 
-	cfg := Config{
-		ConsumeInterval:       time.Hour,
-		ConsumeIntervalBuffer: time.Minute,
-		Kafka: KafkaConfig{
-			Address:       addrs[0],
-			Topic:         testTopic,
-			ClientID:      "1",
-			DialTimeout:   10 * time.Second,
-			ConsumerGroup: "testgroup",
-		},
-		BlocksStorageConfig: mimir_tsdb.BlocksStorageConfig{
-			TSDB: mimir_tsdb.TSDBConfig{
-				Dir: t.TempDir(),
-			},
-		},
-	}
 	limits := defaultLimitsTestConfig()
 	limits.OutOfOrderTimeWindow = 2 * model.Duration(time.Hour)
 	limits.NativeHistogramsIngestionEnabled = true
 	overrides, err := validation.NewOverrides(limits, nil)
 
-	bb, err := New(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides)
+	bb, err := New(cfg, log.NewNopLogger(), prometheus.NewPedanticRegistry(), overrides)
 	require.NoError(t, err)
 
 	compactCalled := make(chan struct{}, 10)
-	testBuilder := testTSDBBuilder{
-		procFunc: func(ctx context.Context, rec *kgo.Record, blockMin, blockMax int64, _ bool) (bool, error) {
-			return true, nil
-		},
-		compactFunc: func(ctx context.Context, blockUploaderForUser func(context.Context, string) blockUploader) error {
-			compactCalled <- struct{}{}
-			return nil
-		},
-	}
-
 	bb.tsdbBuilder = func() builder {
+		testBuilder := newTestTSDBBuilder(cfg, overrides)
+		testBuilder.compactFunc = func() {
+			compactCalled <- struct{}{}
+		}
 		return testBuilder
 	}
 
@@ -97,8 +72,10 @@ func TestBlockBuilder_BuildBlocks(t *testing.T) {
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
 	})
 
-	// Assert that N total blocks were compacted (a block per partition per cycle's bounds).
-	for want := 4; want > 0; want-- {
+	// Since there was no commit record, the first consume cycle will consume everything
+	// in one go. So each partition will have one compact call (although they will produce
+	// more than one block).
+	for want := numPartitions; want > 0; want-- {
 		select {
 		case <-compactCalled:
 		case <-ctx.Done():
@@ -106,32 +83,60 @@ func TestBlockBuilder_BuildBlocks(t *testing.T) {
 		}
 	}
 
-	// Add samples for T+3h and trigger the cycle.
-	var lastProducedOffest int64
-	for i := 0; i < 10; i++ {
-		ts := testEpoch.Add(3 * time.Hour)
-		val := createWriteRequest(t, floatSample(ts.UnixMilli()), nil)
-		// these samples are only for first partition
-		produceResult := produceRecords(t, ctx, writeClient, ts, userID, testTopic, 1, val)
-		lastProducedOffest = produceResult[0].Record.Offset
+	bucketDir := path.Join(cfg.BlocksStorageConfig.Bucket.Filesystem.Directory, userID)
+	newDB, err := tsdb.Open(bucketDir, log.NewNopLogger(), nil, nil, nil)
+	require.NoError(t, err)
+	// Check correctness of samples in the blocks.
+	// TODO(codesome): adjust expSamples because not all samples might be processed
+	// in first consumption based on the timestamp.
+	compareQuery(t, newDB, expSamples, nil, labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"))
+
+	//// Add samples for T+3h and trigger the cycle.
+	//var lastProducedOffest int64
+	//for i := 0; i < 10; i++ {
+	//	ts := testEpoch.Add(3 * time.Hour)
+	//	val := createWriteRequest(t, floatSample(ts.UnixMilli()), nil)
+	//	// these samples are only for first partition
+	//	produceResult := produceRecords(t, ctx, writeClient, ts, userID, testTopic, 1, val)
+	//	lastProducedOffest = produceResult[0].Record.Offset
+	//}
+	//
+	//cycleEnd := testEpoch.Add(4 * time.Hour)
+	//err = bb.nextConsumeCycle(ctx, cycleEnd)
+	//require.NoError(t, err)
+	//
+	//// Assert that one block was compacted (a block per partition per cycle's bounds).
+	//select {
+	//case <-compactCalled:
+	//case <-ctx.Done():
+	//	t.Fatal(ctx.Err())
+	//}
+	//
+	//offsets, err := kadm.NewClient(writeClient).ListCommittedOffsets(ctx, testTopic)
+	//require.NoError(t, err)
+	//offset, ok := offsets.Lookup(testTopic, 1)
+	//require.True(t, ok)
+	//require.Equal(t, lastProducedOffest+1, offset.Offset) // +1 because lastProducedOffset points at already consumed record
+}
+
+func blockBuilderConfig(t *testing.T, addr, topic string) Config {
+	cfg := Config{
+		ConsumeInterval:       time.Hour,
+		ConsumeIntervalBuffer: 15 * time.Minute,
+		Kafka: KafkaConfig{
+			Address:       addr,
+			Topic:         topic,
+			ClientID:      "1",
+			DialTimeout:   10 * time.Second,
+			ConsumerGroup: "testgroup",
+		},
 	}
 
-	cycleEnd := testEpoch.Add(4 * time.Hour)
-	err = bb.nextConsumeCycle(ctx, cycleEnd)
-	require.NoError(t, err)
+	cfg.BlocksStorageConfig.TSDB.Dir = t.TempDir()
+	cfg.BlocksStorageConfig.Bucket.StorageBackendConfig.Backend = bucket.Filesystem
+	cfg.BlocksStorageConfig.Bucket.Filesystem.Directory = t.TempDir()
 
-	// Assert that one block was compacted (a block per partition per cycle's bounds).
-	select {
-	case <-compactCalled:
-	case <-ctx.Done():
-		t.Fatal(ctx.Err())
-	}
-
-	offsets, err := kadm.NewClient(writeClient).ListCommittedOffsets(ctx, testTopic)
-	require.NoError(t, err)
-	offset, ok := offsets.Lookup(testTopic, 1)
-	require.True(t, ok)
-	require.Equal(t, lastProducedOffest+1, offset.Offset) // +1 because lastProducedOffset points at already consumed record
+	return cfg
 }
 
 func produceRecords(t *testing.T, ctx context.Context, writeClient *kgo.Client, ts time.Time, userID, topic string, part int32, val []byte) kgo.ProduceResults {
@@ -159,16 +164,31 @@ func newKafkaProduceClient(t *testing.T, addrs ...string) *kgo.Client {
 }
 
 type testTSDBBuilder struct {
-	procFunc    func(ctx context.Context, rec *kgo.Record, blockMin, blockMax int64, recordProcessedBefore bool) (bool, error)
-	compactFunc func(ctx context.Context, blockUploaderForUser func(context.Context, string) blockUploader) error
+	tsdbBuilder *tsdbBuilder
+	procFunc    func(rec *kgo.Record, blockMin, blockMax int64, recordProcessedBefore bool)
+	compactFunc func()
+}
+
+func newTestTSDBBuilder(cfg Config, limits *validation.Overrides) testTSDBBuilder {
+	return testTSDBBuilder{
+		tsdbBuilder: newTSDBBuilder(log.NewNopLogger(), limits, cfg.BlocksStorageConfig),
+	}
 }
 
 func (t testTSDBBuilder) process(ctx context.Context, rec *kgo.Record, blockMin, blockMax int64, recordProcessedBefore bool) (_ bool, err error) {
-	return t.procFunc(ctx, rec, blockMin, blockMax, recordProcessedBefore)
+	ok, err := t.tsdbBuilder.process(ctx, rec, blockMin, blockMax, recordProcessedBefore)
+	if t.procFunc != nil {
+		t.procFunc(rec, blockMin, blockMax, recordProcessedBefore)
+	}
+	return ok, err
 }
 
 func (t testTSDBBuilder) compactAndUpload(ctx context.Context, blockUploaderForUser func(context.Context, string) blockUploader) error {
-	return t.compactFunc(ctx, blockUploaderForUser)
+	err := t.tsdbBuilder.compactAndUpload(ctx, blockUploaderForUser)
+	if t.compactFunc != nil {
+		t.compactFunc()
+	}
+	return err
 }
 
 func (t testTSDBBuilder) close() error {

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -357,9 +357,8 @@ type extendedAppender interface {
 }
 
 type userTSDB struct {
-	db      *tsdb.DB
-	userID  string
-	shipper BlocksUploader
+	db     *tsdb.DB
+	userID string
 }
 
 // BlocksUploader interface is used to have an easy way to mock it in tests.

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -2,7 +2,6 @@ package blockbuilder
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"math/rand"
 	"os"
@@ -290,7 +289,6 @@ func compareQuery(t *testing.T, db *tsdb.DB, expSamples []mimirpb.Sample, expHis
 	sort.Slice(expHistograms, func(i, j int) bool {
 		return expHistograms[i].Timestamp < expHistograms[j].Timestamp
 	})
-	fmt.Println("Expected samples:", expSamples)
 	require.Equal(t, expSamples, actSamples)
 	require.Equal(t, expHistograms, actHistograms)
 }


### PR DESCRIPTION
@narqo 
`TestBlockBuilder` has a lot of different cases of running a Block Builder.

I fixed the commit metadata as well where we now take the max of what is there in the commit already vs what we would have committed if we were lagging and had to re-do some time slot.

I still need to cleanup and fix `TestBlockBuilder_StartupWithExistingCommit` - there is a bug where once I create a commit using a separate kafka client, the block builder is not getting any partition assigned even after closing the client used to create the commit.

Other than that one test TODO, this PR is ready for review.