### PR TITLE
Add return error support to MetricsQueryRequest.WithStartEnd()

### DIFF
--- a/pkg/frontend/querymiddleware/cardinality_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_test.go
@@ -278,7 +278,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_requestEquality(t *testing.T) {
 			tenantA:       "1",
 			tenantB:       "1",
 			requestA:      rangeQuery,
-			requestB:      rangeQuery.WithStartEnd(rangeQuery.GetStart()+5*time.Minute.Milliseconds(), rangeQuery.GetEnd()+5*time.Minute.Milliseconds()),
+			requestB:      mustSucceed(rangeQuery.WithStartEnd(rangeQuery.GetStart()+5*time.Minute.Milliseconds(), rangeQuery.GetEnd()+5*time.Minute.Milliseconds())),
 			expectedEqual: true,
 		},
 		{
@@ -286,10 +286,10 @@ func Test_cardinalityEstimateBucket_QueryRequest_requestEquality(t *testing.T) {
 			tenantA:  "1",
 			tenantB:  "1",
 			requestA: rangeQuery,
-			requestB: rangeQuery.WithStartEnd(
+			requestB: mustSucceed(rangeQuery.WithStartEnd(
 				rangeQuery.GetStart()+2*cardinalityEstimateBucketSize.Milliseconds(),
 				rangeQuery.GetEnd()+2*cardinalityEstimateBucketSize.Milliseconds(),
-			),
+			)),
 			expectedEqual: false,
 		},
 		{
@@ -297,7 +297,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_requestEquality(t *testing.T) {
 			tenantA:       "1",
 			tenantB:       "1",
 			requestA:      rangeQuery,
-			requestB:      rangeQuery.WithStartEnd(rangeQuery.GetStart(), rangeQuery.GetEnd()+time.Second.Milliseconds()),
+			requestB:      mustSucceed(rangeQuery.WithStartEnd(rangeQuery.GetStart(), rangeQuery.GetEnd()+time.Second.Milliseconds())),
 			expectedEqual: true,
 		},
 		{
@@ -305,10 +305,10 @@ func Test_cardinalityEstimateBucket_QueryRequest_requestEquality(t *testing.T) {
 			tenantA:  "1",
 			tenantB:  "1",
 			requestA: rangeQuery,
-			requestB: rangeQuery.WithStartEnd(
+			requestB: mustSucceed(rangeQuery.WithStartEnd(
 				rangeQuery.GetStart()+5*time.Minute.Milliseconds(),
 				rangeQuery.GetEnd()+2*cardinalityEstimateBucketSize.Milliseconds(),
-			),
+			)),
 			expectedEqual: false,
 		},
 		// The following two test cases test consistent hashing of queries, which is used
@@ -318,10 +318,10 @@ func Test_cardinalityEstimateBucket_QueryRequest_requestEquality(t *testing.T) {
 			tenantA:  "1",
 			tenantB:  "1",
 			requestA: rangeQuerySum,
-			requestB: rangeQuerySum.WithStartEnd(
+			requestB: mustSucceed(rangeQuerySum.WithStartEnd(
 				rangeQuery.GetStart()+(cardinalityEstimateBucketSize/2).Milliseconds(),
 				rangeQuery.GetEnd()+(cardinalityEstimateBucketSize/2).Milliseconds(),
-			),
+			)),
 			expectedEqual: false,
 		},
 		{
@@ -329,10 +329,10 @@ func Test_cardinalityEstimateBucket_QueryRequest_requestEquality(t *testing.T) {
 			tenantA:  "1",
 			tenantB:  "1",
 			requestA: rangeQuery,
-			requestB: rangeQuery.WithStartEnd(
+			requestB: mustSucceed(rangeQuery.WithStartEnd(
 				rangeQuery.GetStart()+(cardinalityEstimateBucketSize/2).Milliseconds(),
 				rangeQuery.GetEnd()+(cardinalityEstimateBucketSize/2).Milliseconds(),
-			),
+			)),
 			expectedEqual: true,
 		},
 	}

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -120,7 +120,7 @@ type MetricsQueryRequest interface {
 	WithID(id int64) MetricsQueryRequest
 	// WithStartEnd clone the current request with different start and end timestamp.
 	// Implementations must ensure minT and maxT are recalculated when the start and end timestamp change.
-	WithStartEnd(startTime int64, endTime int64) MetricsQueryRequest
+	WithStartEnd(startTime int64, endTime int64) (MetricsQueryRequest, error)
 	// WithQuery clones the current request with a different query; returns error if query parse fails.
 	// Implementations must ensure minT and maxT are recalculated when the query changes.
 	WithQuery(string) (MetricsQueryRequest, error)

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -285,7 +285,6 @@ func TestMetricsQuery_MinMaxTime(t *testing.T) {
 }
 
 func TestMetricsQuery_WithStartEnd_TransformConsistency(t *testing.T) {
-
 	startTime, err := time.Parse(time.RFC3339, "2024-02-21T00:00:00-08:00")
 	require.NoError(t, err)
 	endTime, err := time.Parse(time.RFC3339, "2024-02-22T00:00:00-08:00")
@@ -353,7 +352,8 @@ func TestMetricsQuery_WithStartEnd_TransformConsistency(t *testing.T) {
 			// apply WithStartEnd
 			newStart := testCase.updatedStartTime.UnixMilli()
 			newEnd := testCase.updatedEndTime.UnixMilli()
-			updatedMetricsQuery := testCase.initialMetricsQuery.WithStartEnd(newStart, newEnd)
+			updatedMetricsQuery, err := testCase.initialMetricsQuery.WithStartEnd(newStart, newEnd)
+			require.NoError(t, err)
 
 			require.Equal(t, testCase.expectedUpdatedMinT, updatedMetricsQuery.GetMinT())
 			require.Equal(t, testCase.expectedUpdatedMaxT, updatedMetricsQuery.GetMaxT())
@@ -1612,4 +1612,12 @@ func TestPrometheusCodec_DecodeMultipleTimes(t *testing.T) {
 
 func newTestPrometheusCodec() Codec {
 	return NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, formatJSON)
+}
+
+func mustSucceed[T any](value T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+
+	return value
 }

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -158,7 +158,10 @@ func (l limitsMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Respon
 				"maxQueryLookback", maxQueryLookback,
 				"blocksRetentionPeriod", blocksRetentionPeriod)
 
-			r = r.WithStartEnd(minStartTime, r.GetEnd())
+			r, err = r.WithStartEnd(minStartTime, r.GetEnd())
+			if err != nil {
+				return nil, apierror.New(apierror.TypeInternal, err.Error())
+			}
 		}
 	}
 

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -155,7 +155,7 @@ func (r *PrometheusRangeQueryRequest) WithID(id int64) MetricsQueryRequest {
 }
 
 // WithStartEnd clones the current `PrometheusRangeQueryRequest` with a new `start` and `end` timestamp.
-func (r *PrometheusRangeQueryRequest) WithStartEnd(start int64, end int64) MetricsQueryRequest {
+func (r *PrometheusRangeQueryRequest) WithStartEnd(start int64, end int64) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.start = start
 	newRequest.end = end
@@ -164,7 +164,7 @@ func (r *PrometheusRangeQueryRequest) WithStartEnd(start int64, end int64) Metri
 			newRequest.queryExpr, newRequest.GetStart(), newRequest.GetEnd(), newRequest.GetStep(), newRequest.lookbackDelta,
 		)
 	}
-	return &newRequest
+	return &newRequest, nil
 }
 
 // WithQuery clones the current `PrometheusRangeQueryRequest` with a new query; returns error if query parse fails.
@@ -355,7 +355,7 @@ func (r *PrometheusInstantQueryRequest) WithID(id int64) MetricsQueryRequest {
 }
 
 // WithStartEnd clones the current `PrometheusInstantQueryRequest` with a new `time` timestamp.
-func (r *PrometheusInstantQueryRequest) WithStartEnd(time int64, _ int64) MetricsQueryRequest {
+func (r *PrometheusInstantQueryRequest) WithStartEnd(time int64, _ int64) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.time = time
 	if newRequest.queryExpr != nil {
@@ -363,7 +363,7 @@ func (r *PrometheusInstantQueryRequest) WithStartEnd(time int64, _ int64) Metric
 			newRequest.queryExpr, newRequest.GetStart(), newRequest.GetEnd(), newRequest.GetStep(), newRequest.lookbackDelta,
 		)
 	}
-	return &newRequest
+	return &newRequest, nil
 }
 
 // WithQuery clones the current `PrometheusInstantQueryRequest` with a new query; returns error if query parse fails.

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1686,7 +1686,7 @@ func TestQuerySharding_ShouldUseCardinalityEstimate(t *testing.T) {
 	}{
 		{
 			"range query",
-			req.WithStartEnd(util.TimeToMillis(start), util.TimeToMillis(end)).WithEstimatedSeriesCountHint(55_000),
+			mustSucceed(req.WithStartEnd(util.TimeToMillis(start), util.TimeToMillis(end))).WithEstimatedSeriesCountHint(55_000),
 			6,
 		},
 		{

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -233,7 +233,7 @@ func (r *remoteReadQueryRequest) WithHeaders([]*PrometheusHeader) MetricsQueryRe
 	panic("not implemented")
 }
 
-func (r *remoteReadQueryRequest) WithStartEnd(_ int64, _ int64) MetricsQueryRequest {
+func (r *remoteReadQueryRequest) WithStartEnd(_ int64, _ int64) (MetricsQueryRequest, error) {
 	panic("not implemented")
 }
 

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -471,7 +471,11 @@ func partitionCacheExtents(req MetricsQueryRequest, extents []Extent, minCacheEx
 
 		// If there is a bit missing at the front, make a request for that.
 		if start < extent.Start {
-			r := req.WithStartEnd(start, extent.Start)
+			r, err := req.WithStartEnd(start, extent.Start)
+			if err != nil {
+				return nil, nil, err
+			}
+
 			requests = append(requests, r)
 		}
 		res, err := extent.toResponse()
@@ -499,7 +503,11 @@ func partitionCacheExtents(req MetricsQueryRequest, extents []Extent, minCacheEx
 
 	// Lastly, make a request for any data missing at the end.
 	if start < req.GetEnd() {
-		r := req.WithStartEnd(start, req.GetEnd())
+		r, err := req.WithStartEnd(start, req.GetEnd())
+		if err != nil {
+			return nil, nil, err
+		}
+
 		requests = append(requests, r)
 	}
 

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -650,7 +650,10 @@ func splitQueryByInterval(req MetricsQueryRequest, interval time.Duration) ([]Me
 		if err != nil {
 			return nil, err
 		}
-		splitReq = splitReq.WithStartEnd(start, end)
+		splitReq, err = splitReq.WithStartEnd(start, end)
+		if err != nil {
+			return nil, err
+		}
 		reqs = append(reqs, splitReq)
 
 		start = end + splitReq.GetStep()

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -330,7 +330,9 @@ func TestSplitAndCacheMiddleware_ResultsCache(t *testing.T) {
 	assert.Equal(t, uint32(1), queryStats.LoadSplitQueries())
 
 	// Doing request with new end time should do one more query.
-	req = req.WithStartEnd(req.GetStart(), req.GetEnd()+step)
+	req, err = req.WithStartEnd(req.GetStart(), req.GetEnd()+step)
+	require.NoError(t, err)
+
 	_, err = rc.Do(ctx, req)
 	require.NoError(t, err)
 	require.Equal(t, 2, downstreamReqs)
@@ -558,7 +560,9 @@ func TestSplitAndCacheMiddleware_ResultsCache_EnabledCachingOfStepUnalignedReque
 	assert.Equal(t, uint32(1), queryStats.LoadSplitQueries())
 
 	// New request with slightly different Start time will not reuse the cached result.
-	req = req.WithStartEnd(parseTimeRFC3339(t, "2021-10-15T10:00:05Z").Unix()*1000, parseTimeRFC3339(t, "2021-10-15T12:00:05Z").Unix()*1000)
+	req, err = req.WithStartEnd(parseTimeRFC3339(t, "2021-10-15T10:00:05Z").Unix()*1000, parseTimeRFC3339(t, "2021-10-15T12:00:05Z").Unix()*1000)
+	require.NoError(t, err)
+
 	resp, err = rc.Do(ctx, req)
 	require.NoError(t, err)
 	require.Equal(t, 2, downstreamReqs)

--- a/pkg/frontend/querymiddleware/step_align.go
+++ b/pkg/frontend/querymiddleware/step_align.go
@@ -68,7 +68,12 @@ func (s *stepAlignMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Re
 				"step", r.GetStep(),
 			)
 
-			return s.next.Do(ctx, r.WithStartEnd(start, end))
+			updatedReq, err := r.WithStartEnd(start, end)
+			if err != nil {
+				return nil, err
+			}
+
+			return s.next.Do(ctx, updatedReq)
 		}
 	}
 


### PR DESCRIPTION
#### What this PR does

In #8374 I've an use case where `WithStartEnd()` may return error. In this PR I propose to add `error` return support to `WithStartEnd()`. We already use the same pattern in `WithQuery()`, reason why I don't think this change is much contentious.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
