### PR TITLE
Remove buffered logger flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] Added new metric `cortex_compactor_disk_out_of_space_errors_total` which counts how many times a compaction failed due to the compactor being out of disk. #8237
 * [CHANGE] Anonymous usage statistics tracking: report active series in addition to in-memory series. #8279
 * [CHANGE] Ruler: `evaluation_delay` field in the rule group configuration has been deprecated. Please use `query_offset` instead (it has the same exact meaning and behaviour). #8295
+* [CHANGE] General: remove `-log.buffered`. The configuration option has been enabled by default and deprecated since Mimir 2.11.
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1537,8 +1537,6 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Period with which to update the per-tenant TSDB configuration. (default 15s)
   -ingester.use-ingester-owned-series-for-limits
     	[experimental] When enabled, only series currently owned by ingester according to the ring are used when checking user per-tenant series limit.
-  -log.buffered
-    	[deprecated] Use a buffered logger to reduce write contention. (default true)
   -log.format string
     	Output log messages in the given format. Valid formats: [logfmt, json] (default "logfmt")
   -log.level value

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -57,7 +57,6 @@ type mainFlags struct {
 	ballastBytes             int     `category:"advanced"`
 	mutexProfileFraction     int     `category:"advanced"`
 	blockProfileRate         int     `category:"advanced"`
-	useBufferedLogger        bool    `category:"deprecated"` // Deprecated: deprecated in Mimir 2.11, remove it in 2.13.
 	rateLimitedLogsEnabled   bool    `category:"experimental"`
 	rateLimitedLogsPerSecond float64 `category:"experimental"`
 	rateLimitedLogsBurstSize int     `category:"experimental"`
@@ -71,7 +70,6 @@ func (mf *mainFlags) registerFlags(fs *flag.FlagSet) {
 	fs.IntVar(&mf.ballastBytes, "mem-ballast-size-bytes", 0, "Size of memory ballast to allocate.")
 	fs.IntVar(&mf.mutexProfileFraction, "debug.mutex-profile-fraction", 0, "Fraction of mutex contention events that are reported in the mutex profile. On average 1/rate events are reported. 0 to disable.")
 	fs.IntVar(&mf.blockProfileRate, "debug.block-profile-rate", 0, "Fraction of goroutine blocking events that are reported in the blocking profile. 1 to include every blocking event in the profile, 0 to disable.")
-	fs.BoolVar(&mf.useBufferedLogger, "log.buffered", true, "Use a buffered logger to reduce write contention.")
 	fs.BoolVar(&mf.rateLimitedLogsEnabled, "log.rate-limit-enabled", false, "Use rate limited logger to reduce the number of logged messages per second.")
 	fs.Float64Var(&mf.rateLimitedLogsPerSecond, "log.rate-limit-logs-per-second", 10000, "Maximum number of messages per second to be logged.")
 	fs.IntVar(&mf.rateLimitedLogsBurstSize, "log.rate-limit-logs-burst-size", 1000, "Burst size, i.e., maximum number of messages that can be logged at once, temporarily exceeding the configured maximum logs per second.")
@@ -174,7 +172,7 @@ func main() {
 	clampGOMAXPROCS()
 
 	reg := prometheus.DefaultRegisterer
-	cfg.Server.Log = util_log.InitLogger(cfg.Server.LogFormat, cfg.Server.LogLevel, mainFlags.useBufferedLogger, util_log.RateLimitedLoggerCfg{
+	cfg.Server.Log = util_log.InitLogger(cfg.Server.LogFormat, cfg.Server.LogLevel, true, util_log.RateLimitedLoggerCfg{
 		Enabled:       mainFlags.rateLimitedLogsEnabled,
 		LogsPerSecond: mainFlags.rateLimitedLogsPerSecond,
 		LogsBurstSize: mainFlags.rateLimitedLogsBurstSize,

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -204,11 +204,6 @@ The following features are currently experimental:
 Deprecated features are usable up until the release that indicates their removal.
 For details about what _deprecated_ means, see [Parameter lifecycle]({{< relref "./configuration-parameters#parameter-lifecycle" >}}).
 
-The following features or configuration parameters are currently deprecated and will be **removed in Mimir 2.13**:
-
-- Logging
-  - `-log.buffered`
-
 The following features or configuration parameters are currently deprecated and will be **removed in Mimir 2.14**:
 
 - Distributor


### PR DESCRIPTION
This was deprecated in 2.11 and is being removed for the 2.13 release

related to https://github.com/grafana/mimir/issues/8390

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
