### PR TITLE
Remote read first class: query stats middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326 #8370 #8373
 * [ENHANCEMENT] Query-frontend: be able to block remote read queries via the per tenant runtime override `blocked_queries`. #8372 #8415
 * [ENHANCEMENT] Query-frontend: added `remote_read` to `op` supported label values for the `cortex_query_frontend_queries_total` metric. #8412
+* [ENHANCEMENT] Query-frontend: log the overall length and start, end time offset from current time for remote read requests. The start and end times are calculated as the miminum and maximum times of the individual queries in the remote read request. #8404
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -194,7 +194,16 @@ func newQuery(ctx context.Context, r MetricsQueryRequest, engine *promql.Engine,
 			r.GetQuery(),
 			util.TimeFromMillis(r.GetTime()),
 		)
-
+	case *remoteReadQueryRequest:
+		return engine.NewRangeQuery(
+			ctx,
+			queryable,
+			nil,
+			r.GetQuery(),
+			util.TimeFromMillis(r.GetStart()),
+			util.TimeFromMillis(r.GetEnd()),
+			time.Duration(r.GetStep())*time.Millisecond,
+		)
 	default:
 		return nil, fmt.Errorf("unsupported query type %T", r)
 	}

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -198,9 +198,12 @@ func newQuery(ctx context.Context, r MetricsQueryRequest, engine *promql.Engine,
 		return engine.NewRangeQuery(
 			ctx,
 			queryable,
-			nil,
+			// We are setting the lookback period to 1 minute and add that amount to
+			// the start time so that query stats are accurate - remote read does not
+			// apply lookback period.
+			promql.NewPrometheusQueryOpts(false, 1*time.Minute),
 			r.GetQuery(),
-			util.TimeFromMillis(r.GetStart()),
+			util.TimeFromMillis(r.GetStart()).Add(1*time.Minute),
 			util.TimeFromMillis(r.GetEnd()),
 			time.Duration(r.GetStep())*time.Millisecond,
 		)

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -198,12 +198,14 @@ func newQuery(ctx context.Context, r MetricsQueryRequest, engine *promql.Engine,
 		return engine.NewRangeQuery(
 			ctx,
 			queryable,
-			// We are setting the lookback period to 1 minute and add that amount to
-			// the start time so that query stats are accurate - remote read does not
-			// apply lookback period.
-			promql.NewPrometheusQueryOpts(false, 1*time.Minute),
+			// Lookback period is not applied to remote read queries in the same way
+			// as regular queries. However we cannot set a zero lookback period
+			// because the engine will just use the default 5 minutes instead. So we
+			// set a lookback period of 1ns and add that amount to the start time so
+			// the engine will calculate an effective 0 lookback period.
+			promql.NewPrometheusQueryOpts(false, 1*time.Nanosecond),
 			r.GetQuery(),
-			util.TimeFromMillis(r.GetStart()).Add(1*time.Minute),
+			util.TimeFromMillis(r.GetStart()).Add(1*time.Nanosecond),
 			util.TimeFromMillis(r.GetEnd()),
 			time.Duration(r.GetStep())*time.Millisecond,
 		)

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -250,10 +250,14 @@ func (r *remoteReadQueryRequest) GetID() int64 {
 }
 
 func (r *remoteReadQueryRequest) GetMaxT() int64 {
+	// MaxT hint is ignored when the remote read query is executed.
+	// Therefore we return the end time.
 	return r.GetEnd()
 }
 
 func (r *remoteReadQueryRequest) GetMinT() int64 {
+	// MinT hint is ignored when the remote read query is executed.
+	// Therefore we return the start time.
 	return r.GetStart()
 }
 

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -241,9 +241,7 @@ func (r *remoteReadQueryRequest) GetHints() *Hints {
 }
 
 func (r *remoteReadQueryRequest) GetStep() int64 {
-	if r.query.Hints != nil {
-		return r.query.Hints.GetStepMs()
-	}
+	// Step is ignored when the remote read query is executed.
 	return 0
 }
 

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -337,3 +337,35 @@ func cloneRemoteReadQuery(orig *prompb.Query) (*prompb.Query, error) {
 
 	return cloned, nil
 }
+
+type remoteReadSanitizerMiddleware struct {
+	next MetricsQueryHandler
+}
+
+func newRemoteReadSanitizerMiddleware() MetricsQueryMiddleware {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+		return &remoteReadSanitizerMiddleware{
+			next: next,
+		}
+	})
+}
+
+func (r *remoteReadSanitizerMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+	query, ok := req.(*remoteReadQueryRequest)
+	if !ok {
+		return nil, apierror.New(apierror.TypeInternal, "unexpected data type")
+	}
+	if query.query.Hints == nil || query.query.Hints.StepMs == 0 {
+		return r.next.Do(ctx, req)
+	}
+	clonedQuery, err := cloneRemoteReadQuery(query.query)
+	if err != nil {
+		return nil, err
+	}
+	clonedQuery.Hints.StepMs = 0
+	req, err = remoteReadToMetricsQueryRequest(query.path, clonedQuery)
+	if err != nil {
+		return nil, err
+	}
+	return r.next.Do(ctx, req)
+}

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -533,7 +533,7 @@ func TestRemoteReadSanitizerMiddleware_ClearsStepHint(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var downstreamReq MetricsQueryRequest
-			capture := HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+			capture := HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
 				downstreamReq = req
 				return nil, nil
 			})

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -533,7 +533,7 @@ func TestRemoteReadSanitizerMiddleware_ClearsStepHint(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var downstreamReq MetricsQueryRequest
-			capture := HandlerFunc(func(_ context.Context, req MetricsQueryRequest) (Response, error) {
+			capture := HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
 				downstreamReq = req
 				return nil, nil
 			})

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -438,9 +438,13 @@ func makeTestRemoteReadRequest() *prompb.ReadRequest {
 
 // This is not a full test yet, only tests what's needed for the query blocker.
 func TestRemoteReadToMetricsQueryRequest(t *testing.T) {
-	remoteReadRequest := &prompb.ReadRequest{
-		Queries: []*prompb.Query{
-			{
+	testCases := map[string]struct {
+		query         *prompb.Query
+		expectedQuery string
+		expectedStep  int64
+	}{
+		"query without hints": {
+			query: &prompb.Query{
 				Matchers: []*prompb.LabelMatcher{
 					{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"},
 					{Name: "foo", Type: prompb.LabelMatcher_RE, Value: ".*bar.*"},
@@ -448,25 +452,103 @@ func TestRemoteReadToMetricsQueryRequest(t *testing.T) {
 				StartTimestampMs: 10,
 				EndTimestampMs:   20,
 			},
-			{
+			expectedQuery: "{__name__=\"some_metric\",foo=~\".*bar.*\"}",
+			expectedStep:  0,
+		},
+		"query with hints": {
+			query: &prompb.Query{
 				Matchers: []*prompb.LabelMatcher{
 					{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "up"},
 				},
+				StartTimestampMs: 10,
+				EndTimestampMs:   20,
 				Hints: &prompb.ReadHints{
-					StepMs: 1000,
+					StartMs: 5,
+					EndMs:   20,
+					StepMs:  1000,
 				},
 			},
+			expectedQuery: "{__name__=\"up\"}",
+			expectedStep:  1000,
 		},
 	}
 
-	expectedGetQuery := []string{
-		"{__name__=\"some_metric\",foo=~\".*bar.*\"}",
-		"{__name__=\"up\"}",
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			metricsQR, err := remoteReadToMetricsQueryRequest("something", tc.query)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedQuery, metricsQR.GetQuery())
+			require.Equal(t, tc.expectedStep, metricsQR.GetStep())
+		})
 	}
+}
 
-	for i, query := range remoteReadRequest.Queries {
-		metricsQR, err := remoteReadToMetricsQueryRequest("something", query)
-		require.NoError(t, err)
-		require.Equal(t, expectedGetQuery[i], metricsQR.GetQuery())
+func TestRemoteReadSanitizerMiddleware_ClearsStepHint(t *testing.T) {
+	testCases := map[string]struct {
+		query        *prompb.Query
+		expectChange bool
+	}{
+		"query without hints": {
+			query: &prompb.Query{
+				Matchers: []*prompb.LabelMatcher{
+					{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"},
+					{Name: "foo", Type: prompb.LabelMatcher_RE, Value: ".*bar.*"},
+				},
+				StartTimestampMs: 10,
+				EndTimestampMs:   20,
+			},
+		},
+		"query with hints and zero step": {
+			query: &prompb.Query{
+				Matchers: []*prompb.LabelMatcher{
+					{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"},
+					{Name: "foo", Type: prompb.LabelMatcher_RE, Value: ".*bar.*"},
+				},
+				StartTimestampMs: 10,
+				EndTimestampMs:   20,
+				Hints: &prompb.ReadHints{
+					StartMs: 10,
+					EndMs:   20,
+					StepMs:  0,
+				},
+			},
+		},
+		"query with hints and non zero step": {
+			query: &prompb.Query{
+				Matchers: []*prompb.LabelMatcher{
+					{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"},
+					{Name: "foo", Type: prompb.LabelMatcher_RE, Value: ".*bar.*"},
+				},
+				StartTimestampMs: 10,
+				EndTimestampMs:   20,
+				Hints: &prompb.ReadHints{
+					StartMs: 10,
+					EndMs:   20,
+					StepMs:  1000,
+				},
+			},
+			expectChange: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var downstreamReq MetricsQueryRequest
+			capture := HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+				downstreamReq = req
+				return nil, nil
+			})
+			middleware := remoteReadSanitizerMiddleware{next: capture}
+			req, err := remoteReadToMetricsQueryRequest("/read", tc.query)
+			require.NoError(t, err)
+			_, err = middleware.Do(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, downstreamReq)
+			require.Zero(t, downstreamReq.GetStep())
+			if tc.expectChange {
+				require.NotSame(t, req, downstreamReq)
+			} else {
+				require.Same(t, req, downstreamReq)
+			}
+		})
 	}
 }

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -312,6 +312,8 @@ func newQueryMiddlewares(
 	queryStatsMiddleware := newQueryStatsMiddleware(registerer, engine)
 
 	remoteReadMiddleware = append(remoteReadMiddleware,
+		// Track query range statistics. Added first before any subsequent middleware modifies the request.
+		queryStatsMiddleware,
 		newLimitsMiddleware(limits, log),
 		queryBlockerMiddleware)
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -314,7 +314,7 @@ func newQueryMiddlewares(
 
 	remoteReadMiddleware = append(remoteReadMiddleware,
 		// Track query range statistics. Added first before any subsequent middleware modifies the request.
-		newRemoteReadSanitizerMiddleware(log),
+		newRemoteReadSanitizerMiddleware(),
 		queryStatsMiddleware,
 		newLimitsMiddleware(limits, log),
 		queryBlockerMiddleware)

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -314,7 +314,7 @@ func newQueryMiddlewares(
 
 	remoteReadMiddleware = append(remoteReadMiddleware,
 		// Track query range statistics. Added first before any subsequent middleware modifies the request.
-		newRemoteReadSanitizerMiddleware(),
+		newRemoteReadSanitizerMiddleware(log),
 		queryStatsMiddleware,
 		newLimitsMiddleware(limits, log),
 		queryBlockerMiddleware)

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -314,6 +314,7 @@ func newQueryMiddlewares(
 
 	remoteReadMiddleware = append(remoteReadMiddleware,
 		// Track query range statistics. Added first before any subsequent middleware modifies the request.
+		newRemoteReadSanitizerMiddleware(),
 		queryStatsMiddleware,
 		newLimitsMiddleware(limits, log),
 		queryBlockerMiddleware)

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -314,7 +314,6 @@ func newQueryMiddlewares(
 
 	remoteReadMiddleware = append(remoteReadMiddleware,
 		// Track query range statistics. Added first before any subsequent middleware modifies the request.
-		newRemoteReadSanitizerMiddleware(),
 		queryStatsMiddleware,
 		newLimitsMiddleware(limits, log),
 		queryBlockerMiddleware)

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -483,7 +483,7 @@ func TestMiddlewaresConsistency(t *testing.T) {
 		},
 		"remote read": {
 			instances:  remoteReadMiddlewares,
-			exceptions: []string{"instrumentMiddleware", "querySharding", "queryStatsMiddleware", "retry", "splitAndCacheMiddleware", "splitInstantQueryByIntervalMiddleware", "stepAlignMiddleware"},
+			exceptions: []string{"instrumentMiddleware", "querySharding", "retry", "splitAndCacheMiddleware", "splitInstantQueryByIntervalMiddleware", "stepAlignMiddleware"},
 		},
 	}
 

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -558,11 +558,11 @@ func TestMiddlewaresConsistency(t *testing.T) {
 	}{
 		"instant query": {
 			instances:  queryInstantMiddlewares,
-			exceptions: []string{"remoteReadSanitizerMiddleware", "splitAndCacheMiddleware", "stepAlignMiddleware"},
+			exceptions: []string{"splitAndCacheMiddleware", "stepAlignMiddleware"},
 		},
 		"range query": {
 			instances:  queryRangeMiddlewares,
-			exceptions: []string{"remoteReadSanitizerMiddleware", "splitInstantQueryByIntervalMiddleware"},
+			exceptions: []string{"splitInstantQueryByIntervalMiddleware"},
 		},
 		"remote read": {
 			instances: remoteReadMiddlewares,

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -558,11 +558,11 @@ func TestMiddlewaresConsistency(t *testing.T) {
 	}{
 		"instant query": {
 			instances:  queryInstantMiddlewares,
-			exceptions: []string{"splitAndCacheMiddleware", "stepAlignMiddleware"},
+			exceptions: []string{"remoteReadSanitizerMiddleware", "splitAndCacheMiddleware", "stepAlignMiddleware"},
 		},
 		"range query": {
 			instances:  queryRangeMiddlewares,
-			exceptions: []string{"splitInstantQueryByIntervalMiddleware"},
+			exceptions: []string{"remoteReadSanitizerMiddleware", "splitInstantQueryByIntervalMiddleware"},
 		},
 		"remote read": {
 			instances: remoteReadMiddlewares,

--- a/pkg/frontend/querymiddleware/stats.go
+++ b/pkg/frontend/querymiddleware/stats.go
@@ -98,8 +98,12 @@ func (s queryStatsMiddleware) populateQueryDetails(ctx context.Context, req Metr
 	if details == nil {
 		return
 	}
-	details.Start = time.UnixMilli(req.GetStart())
-	details.End = time.UnixMilli(req.GetEnd())
+	if details.Start.IsZero() || details.Start.After(time.UnixMilli(req.GetStart())) {
+		details.Start = time.UnixMilli(req.GetStart())
+	}
+	if details.End.IsZero() || details.End.Before(time.UnixMilli(req.GetEnd())) {
+		details.End = time.UnixMilli(req.GetEnd())
+	}
 	details.Step = time.Duration(req.GetStep()) * time.Millisecond
 
 	query, err := newQuery(ctx, req, s.engine, queryStatsErrQueryable)
@@ -113,10 +117,10 @@ func (s queryStatsMiddleware) populateQueryDetails(ctx context.Context, req Metr
 		return
 	}
 	minT, maxT := promql.FindMinMaxTime(evalStmt)
-	if minT != 0 {
+	if minT != 0 && (details.MinT.IsZero() || details.MinT.After(time.UnixMilli(minT))) {
 		details.MinT = time.UnixMilli(minT)
 	}
-	if maxT != 0 {
+	if maxT != 0 && (details.MaxT.IsZero() || details.MaxT.Before(time.UnixMilli(maxT))) {
 		details.MaxT = time.UnixMilli(maxT)
 	}
 }

--- a/pkg/frontend/querymiddleware/stats.go
+++ b/pkg/frontend/querymiddleware/stats.go
@@ -98,6 +98,9 @@ func (s queryStatsMiddleware) populateQueryDetails(ctx context.Context, req Metr
 	if details == nil {
 		return
 	}
+	// This middleware may run multiple times for the same request in case of a remote read request
+	// (once for each query in the request). In such case, we compute the start/end time as the min/max
+	// timestamp we see across all queries in the request.
 	if details.Start.IsZero() || details.Start.After(time.UnixMilli(req.GetStart())) {
 		details.Start = time.UnixMilli(req.GetStart())
 	}
@@ -117,6 +120,9 @@ func (s queryStatsMiddleware) populateQueryDetails(ctx context.Context, req Metr
 		return
 	}
 	minT, maxT := promql.FindMinMaxTime(evalStmt)
+	// This middleware may run multiple times for the same request in case of a remote read request
+	// (once for each query in the request). In such case, we compute the minT/maxT time as the min/max
+	// timestamp we see across all queries in the request.
 	if minT != 0 && (details.MinT.IsZero() || details.MinT.After(time.UnixMilli(minT))) {
 		details.MinT = time.UnixMilli(minT)
 	}

--- a/pkg/frontend/querymiddleware/stats_test.go
+++ b/pkg/frontend/querymiddleware/stats_test.go
@@ -174,7 +174,7 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				QuerierStats: &querier_stats.Stats{},
 				Start:        start.Truncate(time.Millisecond).Add(-30 * time.Minute),
 				End:          end.Truncate(time.Millisecond).Add(10 * time.Minute),
-				MinT:         start.Truncate(time.Millisecond).Add(-30 * time.Minute).Add(-5 * time.Minute), // 5 minute is the Promql engine lookback duration.
+				MinT:         start.Truncate(time.Millisecond).Add(-30 * time.Minute),
 				MaxT:         end.Truncate(time.Millisecond).Add(10 * time.Minute),
 			},
 		},

--- a/pkg/frontend/querymiddleware/stats_test.go
+++ b/pkg/frontend/querymiddleware/stats_test.go
@@ -195,22 +195,8 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 							},
 							Hints: &prompb.ReadHints{
 								// These are ignored in queries, we expect no effect on statistics.
-								StartMs: 42,
-								EndMs:   2 * 42,
-							},
-						},
-					)),
-					mustSucceed(remoteReadToMetricsQueryRequest(
-						"/read",
-						&prompb.Query{
-							StartTimestampMs: start.Truncate(time.Millisecond).Add(-30 * time.Minute).UnixMilli(),
-							EndTimestampMs:   end.Truncate(time.Millisecond).UnixMilli(),
-							Matchers: []*prompb.LabelMatcher{
-								{
-									Type:  prompb.LabelMatcher_RE,
-									Name:  "app",
-									Value: "test",
-								},
+								StartMs: start.Truncate(time.Millisecond).Add(-10 * time.Minute).UnixMilli(),
+								EndMs:   end.Truncate(time.Millisecond).Add(20 * time.Minute).UnixMilli(),
 							},
 						},
 					)),
@@ -222,16 +208,16 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 			cortex_query_frontend_non_step_aligned_queries_total 0
 			# HELP cortex_query_frontend_regexp_matcher_count Total number of regexp matchers
 			# TYPE cortex_query_frontend_regexp_matcher_count counter
-			cortex_query_frontend_regexp_matcher_count 2
+			cortex_query_frontend_regexp_matcher_count 1
 			# HELP cortex_query_frontend_regexp_matcher_optimized_count Total number of optimized regexp matchers
 			# TYPE cortex_query_frontend_regexp_matcher_optimized_count counter
-			cortex_query_frontend_regexp_matcher_optimized_count 2
+			cortex_query_frontend_regexp_matcher_optimized_count 1
 			`),
 			expectedQueryDetails: QueryDetails{
 				QuerierStats: &querier_stats.Stats{},
-				Start:        start.Truncate(time.Millisecond).Add(-30 * time.Minute),
+				Start:        start.Truncate(time.Millisecond),
 				End:          end.Truncate(time.Millisecond).Add(10 * time.Minute),
-				MinT:         start.Truncate(time.Millisecond).Add(-30 * time.Minute),
+				MinT:         start.Truncate(time.Millisecond),
 				MaxT:         end.Truncate(time.Millisecond).Add(10 * time.Minute),
 			},
 		},

--- a/pkg/frontend/querymiddleware/stats_test.go
+++ b/pkg/frontend/querymiddleware/stats_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,24 +24,22 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 	const tenantID = "test"
 	type args struct {
 		ctx context.Context
-		req MetricsQueryRequest
+		req []MetricsQueryRequest // Stats are cumulative, in particular because we don't split up remote read queries.
 	}
-	tests := []struct {
-		name                 string
+	tests := map[string]struct {
 		args                 args
 		expectedMetrics      *strings.Reader
 		expectedQueryDetails QueryDetails
 	}{
-		{
-			name: "happy path",
+		"happy path range query": {
 			args: args{
-				req: &PrometheusRangeQueryRequest{
+				req: []MetricsQueryRequest{&PrometheusRangeQueryRequest{
 					path:      "/query_range",
 					start:     util.TimeToMillis(start),
 					end:       util.TimeToMillis(end),
 					step:      step.Milliseconds(),
 					queryExpr: parseQuery(t, `sum(sum_over_time(metric{app="test",namespace=~"short"}[5m]))`),
-				},
+				}},
 			},
 			expectedMetrics: strings.NewReader(`
 			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
@@ -62,17 +61,16 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				Step:         step,
 			},
 		},
-		{
-			name: "explicit consistency",
+		"explicit consistency range query": {
 			args: args{
 				ctx: querierapi.ContextWithReadConsistency(context.Background(), querierapi.ReadConsistencyStrong),
-				req: &PrometheusRangeQueryRequest{
+				req: []MetricsQueryRequest{&PrometheusRangeQueryRequest{
 					path:      "/query_range",
 					start:     util.TimeToMillis(start),
 					end:       util.TimeToMillis(end),
 					step:      step.Milliseconds(),
 					queryExpr: parseQuery(t, `sum(sum_over_time(metric{app="test",namespace=~"short"}[5m]))`),
-				},
+				}},
 			},
 			expectedMetrics: strings.NewReader(`
 			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
@@ -97,9 +95,92 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				Step:         step,
 			},
 		},
+		"instant query": {
+			args: args{
+				req: []MetricsQueryRequest{NewPrometheusInstantQueryRequest(
+					"/query",
+					nil,
+					start.Truncate(time.Millisecond).UnixMilli(),
+					5*time.Minute,
+					parseQuery(t, `sum(metric{app="test",namespace=~"short"})`),
+					Options{},
+					nil,
+				)},
+			},
+			expectedMetrics: strings.NewReader(`
+			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+			# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+			cortex_query_frontend_non_step_aligned_queries_total 0
+			# HELP cortex_query_frontend_regexp_matcher_count Total number of regexp matchers
+			# TYPE cortex_query_frontend_regexp_matcher_count counter
+			cortex_query_frontend_regexp_matcher_count 1
+			# HELP cortex_query_frontend_regexp_matcher_optimized_count Total number of optimized regexp matchers
+			# TYPE cortex_query_frontend_regexp_matcher_optimized_count counter
+			cortex_query_frontend_regexp_matcher_optimized_count 1
+			`),
+			expectedQueryDetails: QueryDetails{
+				QuerierStats: &querier_stats.Stats{},
+				Start:        start.Truncate(time.Millisecond),
+				End:          start.Truncate(time.Millisecond),
+				MinT:         start.Truncate(time.Millisecond).Add(-5 * time.Minute),
+				MaxT:         start.Truncate(time.Millisecond),
+			},
+		},
+		"remote read queries without hint": {
+			args: args{
+				req: []MetricsQueryRequest{
+					mustSucceed(remoteReadToMetricsQueryRequest(
+						"/read",
+						&prompb.Query{
+							StartTimestampMs: start.Truncate(time.Millisecond).UnixMilli(),
+							EndTimestampMs:   end.Truncate(time.Millisecond).Add(10 * time.Minute).UnixMilli(),
+							Matchers: []*prompb.LabelMatcher{
+								{
+									Type:  prompb.LabelMatcher_RE,
+									Name:  "app",
+									Value: "test",
+								},
+							},
+						},
+					)),
+					mustSucceed(remoteReadToMetricsQueryRequest(
+						"/read",
+						&prompb.Query{
+							StartTimestampMs: start.Truncate(time.Millisecond).Add(-30 * time.Minute).UnixMilli(),
+							EndTimestampMs:   end.Truncate(time.Millisecond).UnixMilli(),
+							Matchers: []*prompb.LabelMatcher{
+								{
+									Type:  prompb.LabelMatcher_RE,
+									Name:  "app",
+									Value: "test",
+								},
+							},
+						},
+					)),
+				},
+			},
+			expectedMetrics: strings.NewReader(`
+			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+			# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+			cortex_query_frontend_non_step_aligned_queries_total 0
+			# HELP cortex_query_frontend_regexp_matcher_count Total number of regexp matchers
+			# TYPE cortex_query_frontend_regexp_matcher_count counter
+			cortex_query_frontend_regexp_matcher_count 2
+			# HELP cortex_query_frontend_regexp_matcher_optimized_count Total number of optimized regexp matchers
+			# TYPE cortex_query_frontend_regexp_matcher_optimized_count counter
+			cortex_query_frontend_regexp_matcher_optimized_count 2
+			`),
+			expectedQueryDetails: QueryDetails{
+				QuerierStats: &querier_stats.Stats{},
+				Start:        start.Truncate(time.Millisecond).Add(-30 * time.Minute),
+				End:          end.Truncate(time.Millisecond).Add(10 * time.Minute),
+				MinT:         start.Truncate(time.Millisecond).Add(-30 * time.Minute).Add(-5 * time.Minute), // 5 minute is the Promql engine lookback duration.
+				MaxT:         end.Truncate(time.Millisecond).Add(10 * time.Minute),
+			},
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
 			mw := newQueryStatsMiddleware(reg, newEngine())
 			ctx := context.Background()
@@ -109,9 +190,11 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 			actualDetails, ctx := ContextWithEmptyDetails(ctx)
 			ctx = user.InjectOrgID(ctx, tenantID)
 
-			_, err := mw.Wrap(mockHandlerWith(nil, nil)).Do(ctx, tt.args.req)
+			for _, req := range tt.args.req {
+				_, err := mw.Wrap(mockHandlerWith(nil, nil)).Do(ctx, req)
+				require.NoError(t, err)
+			}
 
-			require.NoError(t, err)
 			assert.NoError(t, testutil.GatherAndCompare(reg, tt.expectedMetrics))
 			assert.Equal(t, tt.expectedQueryDetails, *actualDetails)
 		})

--- a/pkg/ingester/client/compat_test.go
+++ b/pkg/ingester/client/compat_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,6 +86,43 @@ func TestLabelNamesRequest(t *testing.T) {
 	assert.Equal(t, int64(mint), actualMinT)
 	assert.Equal(t, int64(maxt), actualMaxT)
 	assert.Equal(t, matchers, actualMatchers)
+}
+
+// This test checks that we ignore remote read hints when unmarshalling a
+// remote read request. This is because the query frontend does the same
+// and we want them to be in sync.
+func TestRemoteReadRequestIgnoresHints(t *testing.T) {
+	promRemoteReadRequest := &prompb.ReadRequest{
+		Queries: []*prompb.Query{
+			{
+				Hints: &prompb.ReadHints{
+					StartMs: 1,
+					EndMs:   2,
+					StepMs:  3,
+				},
+			},
+		},
+	}
+	data, err := promRemoteReadRequest.Marshal()
+	require.NoError(t, err)
+
+	remoteReadRequest := &ReadRequest{}
+	err = remoteReadRequest.Unmarshal(data)
+	require.NoError(t, err)
+
+	data2, err := remoteReadRequest.Marshal()
+	require.NoError(t, err)
+
+	restored := &prompb.ReadRequest{}
+	err = restored.Unmarshal(data2)
+	require.NoError(t, err)
+
+	require.Equal(t, len(promRemoteReadRequest.Queries), len(restored.Queries))
+	for i := range promRemoteReadRequest.Queries {
+		require.Nil(t, restored.Queries[i].Hints)
+		promRemoteReadRequest.Queries[i].Hints = nil
+		require.Equal(t, promRemoteReadRequest.Queries[i], restored.Queries[i])
+	}
 }
 
 // The main usecase for `LabelsToKeyString` is to generate hashKeys


### PR DESCRIPTION
#### What this PR does

Query-frontend: add length, time_since_min_time and time_since_max_time statistics to the query stats logs.
These are generated by the `queryStatsMiddleware` and this PR will enable this middleware for remote read requests.

There are two decisions made by the PR:
- since a remote read request contains multiple queries, we define the overall start, minT and end, maxT times as the minimum and maximum of the individual query times. The assumption is that one remote read contains related queries.
- Mimir ingesters to not take into account the query step hint from remote read requests. To avoid making decisions and updating metrics based on the ignored step hint, we clear the step hint from the request before other middlewares.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir-squad/issues/2148 (interna)

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
