### PR TITLE
Chore: add instant query to query-frontend limitsMiddleware tests

### DIFF
--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -200,19 +200,19 @@ func TestLimitsMiddleware_MaxQueryLookback_InstantQuery(t *testing.T) {
 		expectedSkipped       bool
 		expectedTime          time.Time
 	}{
-		"should not manipulate request time if maxQueryLookback and blocksRetentionPeriod are both disabled": {
+		"should allow executing a query if maxQueryLookback and blocksRetentionPeriod are both disabled": {
 			maxQueryLookback:      0,
 			blocksRetentionPeriod: 0,
 			reqTime:               time.Unix(0, 0),
 			expectedTime:          time.Unix(0, 0),
 		},
-		"should not manipulate request time for a query within maxQueryLookback and blocksRetentionPeriod": {
+		"should allow executing a query with time within maxQueryLookback and blocksRetentionPeriod": {
 			maxQueryLookback:      thirtyDays,
 			blocksRetentionPeriod: thirtyDays,
 			reqTime:               now.Add(-time.Hour),
 			expectedTime:          now.Add(-time.Hour),
 		},
-		"should not manipulate request time for a query close to maxQueryLookback and blocksRetentionPeriod": {
+		"should allow executing a query with time close to maxQueryLookback and blocksRetentionPeriod": {
 			maxQueryLookback:      thirtyDays,
 			blocksRetentionPeriod: thirtyDays,
 			reqTime:               now.Add(-thirtyDays).Add(time.Hour),


### PR DESCRIPTION
#### What this PR does

While working on https://github.com/grafana/mimir/pull/8374 we noticed that we don't test `limitsMiddleware` against instant queries. In this PR I'm doing it. Specifically:

- `TestLimitsMiddleware_MaxQueryLookback`: create a new `TestLimitsMiddleware_MaxQueryLookback_InstantQuery` because the assertions for instant queries are different than range queries and remote reads
- `TestLimitsMiddleware_MaxQueryExpressionSizeBytes`: added instant queries
- `TestLimitsMiddleware_MaxQueryLength`: doesn't apply to instant queries because we run the check against the input query time range (and instant queries don't have a time range)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
