### PR TITLE
Add 'op=remote_read' support to cortex_query_frontend_queries_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 * [ENHANCEMENT] Ingester: reduce the amount of locks taken during the Head compaction's garbage-collection process, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326 #8370 #8373
 * [ENHANCEMENT] Query-frontend: be able to block remote read queries via the per tenant runtime override `blocked_queries`. #8372 #8415
-* [ENHANCEMENT] Query-frontend: added `remote_read` to `op` supported label values for the `cortex_query_frontend_queries_total` metric.
+* [ENHANCEMENT] Query-frontend: added `remote_read` to `op` supported label values for the `cortex_query_frontend_queries_total` metric. #8412
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [ENHANCEMENT] Ingester: reduce the amount of locks taken during the Head compaction's garbage-collection process, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326 #8370 #8373
 * [ENHANCEMENT] Query-frontend: be able to block remote read queries via the per tenant runtime override `blocked_queries`. #8372 #8415
+* [ENHANCEMENT] Query-frontend: added `remote_read` to `op` supported label values for the `cortex_query_frontend_queries_total` metric.
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -44,6 +44,7 @@ const (
 
 	queryTypeInstant                      = "query"
 	queryTypeRange                        = "query_range"
+	queryTypeRemoteRead                   = "remote_read"
 	queryTypeCardinality                  = "cardinality"
 	queryTypeLabels                       = "label_names_and_values"
 	queryTypeActiveSeries                 = "active_series"
@@ -449,6 +450,8 @@ func newQueryCountTripperware(registerer prometheus.Registerer) Tripperware {
 				op = queryTypeRange
 			case IsInstantQuery(r.URL.Path):
 				op = queryTypeInstant
+			case IsRemoteReadQuery(r.URL.Path):
+				op = queryTypeRemoteRead
 			case IsCardinalityQuery(r.URL.Path):
 				op = queryTypeCardinality
 			case IsActiveSeriesQuery(r.URL.Path):

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -260,11 +260,7 @@ func TestTripperware_Metrics(t *testing.T) {
 		expectedMetrics  string
 	}{
 		"range query, start/end is aligned to step": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=120", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request: httptest.NewRequest("GET", "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=120", http.NoBody),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -276,11 +272,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"range query, start/end is not aligned to step, aligning disabled": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request: httptest.NewRequest("GET", "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7", http.NoBody),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -292,11 +284,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"range query, start/end is not aligned to step, aligning enabled": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request:          httptest.NewRequest("GET", "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7", http.NoBody),
 			stepAlignEnabled: true,
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
@@ -309,11 +297,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"instant query": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/query?query=up&time=1536673680", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request: httptest.NewRequest("GET", "/api/v1/query?query=up&time=1536673680", http.NoBody),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -409,11 +393,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"label names": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/labels?start=1536673680&end=1536716880", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request: httptest.NewRequest("GET", "/api/v1/labels?start=1536673680&end=1536716880", http.NoBody),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -425,11 +405,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"label values": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/label/test/values?start=1536673680&end=1536716880", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request: httptest.NewRequest("GET", "/api/v1/label/test/values?start=1536673680&end=1536716880", http.NoBody),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -441,11 +417,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"cardinality label names": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/cardinality/label_names?selector=%7Bjob%3D%22test%22%7D", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request: httptest.NewRequest("GET", "/api/v1/cardinality/label_names?selector=%7Bjob%3D%22test%22%7D", http.NoBody),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -457,11 +429,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"cardinality active series": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/cardinality/active_series?selector=%7Bjob%3D%22test%22%7D", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request: httptest.NewRequest("GET", "/api/v1/cardinality/active_series?selector=%7Bjob%3D%22test%22%7D", http.NoBody),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -473,11 +441,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"cardinality active native histogram metrics": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/cardinality/active_native_histogram_metrics?selector=%7Bjob%3D%22test%22%7D", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request: httptest.NewRequest("GET", "/api/v1/cardinality/active_native_histogram_metrics?selector=%7Bjob%3D%22test%22%7D", http.NoBody),
 			expectedMetrics: `
 			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 			# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -489,11 +453,7 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"unknown query type": {
-			request: func() *http.Request {
-				req, err := http.NewRequest("GET", "/api/v1/unknown", http.NoBody)
-				require.NoError(t, err)
-				return req
-			}(),
+			request: httptest.NewRequest("GET", "/api/v1/unknown", http.NoBody),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -255,12 +255,16 @@ func TestTripperware_InstantQuery(t *testing.T) {
 
 func TestTripperware_Metrics(t *testing.T) {
 	tests := map[string]struct {
-		path             string
+		request          *http.Request
 		stepAlignEnabled bool
 		expectedMetrics  string
 	}{
 		"range query, start/end is aligned to step": {
-			path: "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=120",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=120", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -272,7 +276,11 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"range query, start/end is not aligned to step, aligning disabled": {
-			path: "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -284,7 +292,11 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"range query, start/end is not aligned to step, aligning enabled": {
-			path:             "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/query_range?query=up&start=1536673680&end=1536716880&step=7", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			stepAlignEnabled: true,
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
@@ -297,7 +309,11 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"instant query": {
-			path: "/api/v1/query?query=up&time=1536673680",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/query?query=up&time=1536673680", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -308,8 +324,96 @@ func TestTripperware_Metrics(t *testing.T) {
 				cortex_query_frontend_queries_total{op="query",user="user-1"} 1
 			`,
 		},
+		"remote read, start/end is aligned to step": {
+			request: func() *http.Request {
+				return makeTestHTTPRequestFromRemoteRead(&prompb.ReadRequest{
+					Queries: []*prompb.Query{
+						{
+							Matchers:         []*prompb.LabelMatcher{{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"}},
+							StartTimestampMs: 1536673680,
+							EndTimestampMs:   1536716880,
+							Hints: &prompb.ReadHints{
+								StepMs:  120,
+								StartMs: 1536673680,
+								EndMs:   1536716880,
+							},
+						},
+					},
+				})
+			}(),
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="remote_read",user="user-1"} 1
+			`,
+		},
+		"remote read, start/end is not aligned to step, aligning disabled": {
+			request: func() *http.Request {
+				return makeTestHTTPRequestFromRemoteRead(&prompb.ReadRequest{
+					Queries: []*prompb.Query{
+						{
+							Matchers:         []*prompb.LabelMatcher{{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"}},
+							StartTimestampMs: 1536673680,
+							EndTimestampMs:   1536716880,
+							Hints: &prompb.ReadHints{
+								StepMs:  7,
+								StartMs: 1536673680,
+								EndMs:   1536716880,
+							},
+						},
+					},
+				})
+			}(),
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="remote_read",user="user-1"} 1
+			`,
+		},
+		"remote read, start/end is not aligned to step, aligning enabled": {
+			request: func() *http.Request {
+				return makeTestHTTPRequestFromRemoteRead(&prompb.ReadRequest{
+					Queries: []*prompb.Query{
+						{
+							Matchers:         []*prompb.LabelMatcher{{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "some_metric"}},
+							StartTimestampMs: 1536673680,
+							EndTimestampMs:   1536716880,
+							Hints: &prompb.ReadHints{
+								StepMs:  7,
+								StartMs: 1536673680,
+								EndMs:   1536716880,
+							},
+						},
+					},
+				})
+			}(),
+			stepAlignEnabled: true,
+			// Even if forced aligning is enabled, the step will not be aligned because in Mimir we don't take
+			// in account the step when processing remote read requests.
+			expectedMetrics: `
+				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
+				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
+				cortex_query_frontend_non_step_aligned_queries_total 0
+
+				# HELP cortex_query_frontend_queries_total Total queries sent per tenant.
+				# TYPE cortex_query_frontend_queries_total counter
+				cortex_query_frontend_queries_total{op="remote_read",user="user-1"} 1
+			`,
+		},
 		"label names": {
-			path: "/api/v1/labels?start=1536673680&end=1536716880",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/labels?start=1536673680&end=1536716880", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -321,7 +425,11 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"label values": {
-			path: "/api/v1/label/test/values?start=1536673680&end=1536716880",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/label/test/values?start=1536673680&end=1536716880", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -333,7 +441,11 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"cardinality label names": {
-			path: "/api/v1/cardinality/label_names?selector=%7Bjob%3D%22test%22%7D",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/cardinality/label_names?selector=%7Bjob%3D%22test%22%7D", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -345,7 +457,11 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"cardinality active series": {
-			path: "/api/v1/cardinality/active_series?selector=%7Bjob%3D%22test%22%7D",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/cardinality/active_series?selector=%7Bjob%3D%22test%22%7D", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -357,7 +473,11 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"cardinality active native histogram metrics": {
-			path: "/api/v1/cardinality/active_native_histogram_metrics?selector=%7Bjob%3D%22test%22%7D",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/cardinality/active_native_histogram_metrics?selector=%7Bjob%3D%22test%22%7D", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			expectedMetrics: `
 			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 			# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -369,7 +489,11 @@ func TestTripperware_Metrics(t *testing.T) {
 			`,
 		},
 		"unknown query type": {
-			path: "/api/v1/unknown",
+			request: func() *http.Request {
+				req, err := http.NewRequest("GET", "/api/v1/unknown", http.NoBody)
+				require.NoError(t, err)
+				return req
+			}(),
 			expectedMetrics: `
 				# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
 				# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
@@ -405,9 +529,11 @@ func TestTripperware_Metrics(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
 			tw, err := NewTripperware(
-				Config{DeprecatedAlignQueriesWithStep: testData.stepAlignEnabled},
+				Config{},
 				log.NewNopLogger(),
-				mockLimits{},
+				mockLimits{
+					alignQueriesWithStep: testData.stepAlignEnabled,
+				},
 				newTestPrometheusCodec(),
 				nil,
 				promql.EngineOpts{
@@ -421,11 +547,8 @@ func TestTripperware_Metrics(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			req, err := http.NewRequest("GET", testData.path, http.NoBody)
-			require.NoError(t, err)
-
 			ctx := user.InjectOrgID(context.Background(), "user-1")
-			req = req.WithContext(ctx)
+			req := testData.request.WithContext(ctx)
 			require.NoError(t, user.InjectOrgIDIntoHTTPRequest(ctx, req))
 
 			resp, err := tw(downstream).RoundTrip(req)
@@ -482,8 +605,16 @@ func TestMiddlewaresConsistency(t *testing.T) {
 			exceptions: []string{"splitInstantQueryByIntervalMiddleware"},
 		},
 		"remote read": {
-			instances:  remoteReadMiddlewares,
-			exceptions: []string{"instrumentMiddleware", "querySharding", "queryStatsMiddleware", "retry", "splitAndCacheMiddleware", "splitInstantQueryByIntervalMiddleware", "stepAlignMiddleware"},
+			instances: remoteReadMiddlewares,
+			exceptions: []string{
+				"instrumentMiddleware",
+				"querySharding", // No query sharding support.
+				"queryStatsMiddleware",
+				"retry",
+				"splitAndCacheMiddleware",               // No time splitting and results cache support.
+				"splitInstantQueryByIntervalMiddleware", // Not applicable because specific to instant queries.
+				"stepAlignMiddleware",                   // Not applicable because remote read requests don't take step in account when running in Mimir.
+			},
 		},
 	}
 


### PR DESCRIPTION
#### What this PR does

In this PR I'm adding `op=remote_read` support to `cortex_query_frontend_queries_total` metric and adding remote read cases to `TestTripperware_Metrics`. It's important to note that Mimir doesn't use the step when executing a remote read request, so all logic around step-alignment should be (intentionally) skipped for remote reads.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
