### PR TITLE
Chore: improve queryBlockerMiddleware unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 * [ENHANCEMENT] Ingester: reduce locked time while matching postings for a label, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Ingester: reduce the amount of locks taken during the Head compaction's garbage-collection process, improving the write latency and compaction speed. #8327
 * [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326 #8370 #8373
-* [ENHANCEMENT] Query-frontend: be able to block remote read queries via the per tenant runtime override `blocked_queries`. #8372
+* [ENHANCEMENT] Query-frontend: be able to block remote read queries via the per tenant runtime override `blocked_queries`. #8372 #8415
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/pkg/frontend/querymiddleware/blocker_test.go
+++ b/pkg/frontend/querymiddleware/blocker_test.go
@@ -194,6 +194,15 @@ func TestQueryBlockerMiddleware_RemoteRead(t *testing.T) {
 			expectedBlocked: true,
 		},
 		{
+			name: "blocks query via regex pattern, with begin/end curly brackets used as a trick to match only remote read requests",
+			limits: mockLimits{
+				blockedQueries: []*validation.BlockedQuery{
+					{Pattern: "\\{.*metric_counter.*\\}", Regex: true},
+				},
+			},
+			expectedBlocked: true,
+		},
+		{
 			name: "not blocks query via regex pattern",
 			limits: mockLimits{
 				blockedQueries: []*validation.BlockedQuery{

--- a/pkg/frontend/querymiddleware/blocker_test.go
+++ b/pkg/frontend/querymiddleware/blocker_test.go
@@ -11,26 +11,25 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/util/globalerror"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
-func Test_queryBlocker_Do(t *testing.T) {
+func TestQueryBlockerMiddleware_RangeAndInstantQuery(t *testing.T) {
 	tests := []struct {
-		name           string
-		request        MetricsQueryRequest
-		shouldContinue bool
-		limits         mockLimits
+		name            string
+		query           string
+		limits          mockLimits
+		expectedBlocked bool
 	}{
 		{
-			name:           "doesn't block queries due to empty limits",
-			limits:         mockLimits{},
-			shouldContinue: true,
-			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, "rate(metric_counter[5m])"),
-			}),
+			name:   "doesn't block queries due to empty limits",
+			limits: mockLimits{},
+			query:  "rate(metric_counter[5m])",
 		},
 		{
 			name: "blocks single line query non regex pattern",
@@ -39,9 +38,8 @@ func Test_queryBlocker_Do(t *testing.T) {
 					{Pattern: "rate(metric_counter[5m])", Regex: false},
 				},
 			},
-			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, "rate(metric_counter[5m])"),
-			}),
+			query:           "rate(metric_counter[5m])",
+			expectedBlocked: true,
 		},
 		{
 			name: "not blocks single line query non regex pattern",
@@ -50,11 +48,7 @@ func Test_queryBlocker_Do(t *testing.T) {
 					{Pattern: "rate(metric_counter[5m])", Regex: false},
 				},
 			},
-			shouldContinue: true,
-
-			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, "rate(metric_counter[15m])"),
-			}),
+			query: "rate(metric_counter[15m])",
 		},
 		{
 			name: "blocks multiple line query non regex pattern",
@@ -63,10 +57,12 @@ func Test_queryBlocker_Do(t *testing.T) {
 					{Pattern: `rate(metric_counter[5m]) / rate(other_counter[5m])`, Regex: false},
 				},
 			},
-			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, `rate(metric_counter[5m])/
-rate(other_counter[5m])`),
-			}),
+			query: `
+				rate(metric_counter[5m])
+				/
+				rate(other_counter[5m])
+			`,
+			expectedBlocked: true,
 		},
 		{
 			name: "not blocks multiple line query non regex pattern",
@@ -75,12 +71,11 @@ rate(other_counter[5m])`),
 					{Pattern: "rate(metric_counter[5m])", Regex: false},
 				},
 			},
-			shouldContinue: true,
-
-			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, `rate(metric_counter[15m])/
-rate(other_counter[15m])`),
-			}),
+			query: `
+				rate(metric_counter[15m])
+				/
+				rate(other_counter[15m])
+			`,
 		},
 		{
 			name: "blocks single line query regex pattern",
@@ -89,9 +84,8 @@ rate(other_counter[15m])`),
 					{Pattern: ".*metric_counter.*", Regex: true},
 				},
 			},
-			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, "rate(metric_counter[5m])"),
-			}),
+			query:           "rate(metric_counter[5m])",
+			expectedBlocked: true,
 		},
 		{
 			name: "blocks multiple line query regex pattern",
@@ -101,44 +95,143 @@ rate(other_counter[15m])`),
 					{Pattern: "(?s).*metric_counter.*", Regex: true},
 				},
 			},
-			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, `rate(other_counter[15m])/
-		rate(metric_counter[15m])`),
-			}),
+			query: `
+				rate(other_counter[15m])
+				/
+				rate(metric_counter[15m])
+			`,
+			expectedBlocked: true,
 		},
 		{
-			name: "blocks single line query invalid regex pattern",
+			name: "invalid regex pattern",
 			limits: mockLimits{
 				blockedQueries: []*validation.BlockedQuery{
 					{Pattern: "[a-9}", Regex: true},
 				},
 			},
-			shouldContinue: true,
-
-			request: MetricsQueryRequest(&PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, "rate(metric_counter[5m])"),
-			}),
+			query: "rate(metric_counter[5m])",
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			reqs := map[string]MetricsQueryRequest{
+				"range query": &PrometheusRangeQueryRequest{
+					queryExpr: parseQuery(t, tt.query),
+				},
+				"instant query": &PrometheusRangeQueryRequest{
+					queryExpr: parseQuery(t, tt.query),
+				},
+			}
+
+			for reqType, req := range reqs {
+				t.Run(reqType, func(t *testing.T) {
+					reg := prometheus.NewPedanticRegistry()
+					logger := log.NewNopLogger()
+					mw := newQueryBlockerMiddleware(tt.limits, logger, reg)
+					_, err := mw.Wrap(&mockNextHandler{t: t, shouldContinue: !tt.expectedBlocked}).Do(user.InjectOrgID(context.Background(), "test"), req)
+
+					if tt.expectedBlocked {
+						require.Error(t, err)
+						require.Contains(t, err.Error(), globalerror.QueryBlocked)
+						require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+							# HELP cortex_query_frontend_rejected_queries_total Number of queries that were rejected by the cluster administrator.
+							# TYPE cortex_query_frontend_rejected_queries_total counter
+							cortex_query_frontend_rejected_queries_total{reason="blocked", user="test"} 1
+						`)))
+					} else {
+						require.NoError(t, err)
+						require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(``)))
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestQueryBlockerMiddleware_RemoteRead(t *testing.T) {
+	// All tests run on the same query.
+	query := &prompb.Query{
+		Matchers: []*prompb.LabelMatcher{
+			{Type: prompb.LabelMatcher_EQ, Name: labels.MetricName, Value: "metric_counter"},
+			{Type: prompb.LabelMatcher_RE, Name: "pod", Value: "app-.*"},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		limits          mockLimits
+		expectedBlocked bool
+	}{
+		{
+			name:   "doesn't block queries due to empty limits",
+			limits: mockLimits{},
+		},
+		{
+			name: "blocks query via non regex pattern",
+			limits: mockLimits{
+				blockedQueries: []*validation.BlockedQuery{
+					{Pattern: `{__name__="metric_counter",pod=~"app-.*"}`, Regex: false},
+				},
+			},
+			expectedBlocked: true,
+		},
+		{
+			name: "not blocks query via non regex pattern",
+			limits: mockLimits{
+				blockedQueries: []*validation.BlockedQuery{
+					{Pattern: `{__name__="another_metric",pod=~"app-.*"}`, Regex: false},
+				},
+			},
+		},
+		{
+			name: "blocks query via regex pattern",
+			limits: mockLimits{
+				blockedQueries: []*validation.BlockedQuery{
+					{Pattern: ".*metric_counter.*", Regex: true},
+				},
+			},
+			expectedBlocked: true,
+		},
+		{
+			name: "not blocks query via regex pattern",
+			limits: mockLimits{
+				blockedQueries: []*validation.BlockedQuery{
+					{Pattern: ".*another_metric.*", Regex: true},
+				},
+			},
+		},
+		{
+			name: "invalid regex pattern",
+			limits: mockLimits{
+				blockedQueries: []*validation.BlockedQuery{
+					{Pattern: "[a-9}", Regex: true},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := remoteReadToMetricsQueryRequest(remoteReadPathSuffix, query)
+			require.NoError(t, err)
+
 			reg := prometheus.NewPedanticRegistry()
 			logger := log.NewNopLogger()
 			mw := newQueryBlockerMiddleware(tt.limits, logger, reg)
-			_, err := mw.Wrap(&mockNextHandler{t: t, shouldContinue: tt.shouldContinue}).Do(user.InjectOrgID(context.Background(), "test"), tt.request)
-			if tt.shouldContinue {
-				assert.NoError(t, err)
+			_, err = mw.Wrap(&mockNextHandler{t: t, shouldContinue: !tt.expectedBlocked}).Do(user.InjectOrgID(context.Background(), "test"), req)
+
+			if tt.expectedBlocked {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), globalerror.QueryBlocked)
+				require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+							# HELP cortex_query_frontend_rejected_queries_total Number of queries that were rejected by the cluster administrator.
+							# TYPE cortex_query_frontend_rejected_queries_total counter
+							cortex_query_frontend_rejected_queries_total{reason="blocked", user="test"} 1
+						`)))
 			} else {
-				assert.Error(t, err)
-			}
-			if err != nil {
-				assert.Contains(t, err.Error(), globalerror.QueryBlocked)
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-                        # HELP cortex_query_frontend_rejected_queries_total Number of queries that were rejected by the cluster administrator.
-                        # TYPE cortex_query_frontend_rejected_queries_total counter
-						cortex_query_frontend_rejected_queries_total{reason="blocked", user="test"} 1
-					`),
-				))
+				require.NoError(t, err)
+				require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(``)))
 			}
 		})
 	}


### PR DESCRIPTION
#### What this PR does

While working on https://github.com/grafana/mimir/pull/8372 we noticed that `queryBlockerMiddleware` unit tests were just covering range queries. In this PR I'm adding instant queries and remote read requests too. I've introduced a new dedicated for remote reads because we don't receive a query expression but just label matchers.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
