### PR TITLE
golangci-lint: Enable loggercheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - misspell
     - errorlint
     - forbidigo
+    - loggercheck
 
 linters-settings:
   errcheck:

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -276,7 +276,7 @@ func (c *Config) Validate(log log.Logger) error {
 		if c.isAnyModuleEnabled(Ingester, Write, All) || !errors.Is(err, ingester.ErrSpreadMinimizingValidation) {
 			return errors.Wrap(err, "invalid ingester config")
 		}
-		level.Debug(log).Log("ingester config is invalid; moving on because the \"ingester\" module is not in this process's targets", "err", err.Error())
+		level.Debug(log).Log("msg", "ingester config is invalid; moving on because the \"ingester\" module is not in this process's targets", "err", err.Error())
 	}
 	if err := c.Worker.Validate(); err != nil {
 		return errors.Wrap(err, "invalid frontend_worker config")


### PR DESCRIPTION
#### What this PR does
Enable `loggercheck` linter in golangci-lint, and fix a caught error. `loggercheck` makes sure that arguments to logging calls are paired.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
