### PR TITLE
query-scheduler querier inflight requests: convert to summary metric

### DIFF
--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -113,10 +113,13 @@ func New(cfg Config, limits Limits, log log.Logger, registerer prometheus.Regist
 		Name: "cortex_query_frontend_enqueue_duration_seconds",
 		Help: "Time spent by requests waiting to join the queue or be rejected.",
 	})
-	querierInflightRequests := promauto.With(registerer).NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "cortex_query_frontend_querier_inflight_requests",
-			Help: "Number of inflight requests being processed on all querier-scheduler connections.",
+	querierInflightRequests := promauto.With(registerer).NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:       "cortex_query_scheduler_querier_inflight_requests",
+			Help:       "Number of inflight requests being processed on all querier-scheduler connections. . Quantile buckets keep track of inflight requests over the last 60s.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
+			MaxAge:     time.Minute,
+			AgeBuckets: 6,
 		},
 		[]string{"query_component"},
 	)

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -115,8 +115,8 @@ func New(cfg Config, limits Limits, log log.Logger, registerer prometheus.Regist
 	})
 	querierInflightRequests := promauto.With(registerer).NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name:       "cortex_query_scheduler_querier_inflight_requests",
-			Help:       "Number of inflight requests being processed on all querier-scheduler connections. . Quantile buckets keep track of inflight requests over the last 60s.",
+			Name:       "cortex_query_frontend_querier_inflight_requests",
+			Help:       "Number of inflight requests being processed on all querier-scheduler connections. Quantile buckets keep track of inflight requests over the last 60s.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 			MaxAge:     time.Minute,
 			AgeBuckets: 6,

--- a/pkg/scheduler/queue/query_component_utilization.go
+++ b/pkg/scheduler/queue/query_component_utilization.go
@@ -156,6 +156,7 @@ func (qcl *QueryComponentUtilization) ExceedsThresholdForComponentName(
 	return false, ""
 }
 
+// MarkRequestSent is called when a request is sent to a querier
 func (qcl *QueryComponentUtilization) MarkRequestSent(req *SchedulerRequest) {
 	if req != nil {
 		qcl.inflightRequestsMu.Lock()
@@ -166,6 +167,7 @@ func (qcl *QueryComponentUtilization) MarkRequestSent(req *SchedulerRequest) {
 	}
 }
 
+// MarkRequestCompleted is called when a querier completes or fails a request
 func (qcl *QueryComponentUtilization) MarkRequestCompleted(req *SchedulerRequest) {
 	if req != nil {
 		qcl.inflightRequestsMu.Lock()
@@ -179,12 +181,10 @@ func (qcl *QueryComponentUtilization) MarkRequestCompleted(req *SchedulerRequest
 	}
 }
 
-// incrementForComponentName is called when a request is sent to a querier
 func (qcl *QueryComponentUtilization) incrementForComponentName(expectedQueryComponent string) {
 	qcl.updateForComponentName(expectedQueryComponent, 1)
 }
 
-// decrementForComponentName is called when a querier completes or fails a request
 func (qcl *QueryComponentUtilization) decrementForComponentName(expectedQueryComponent string) {
 	qcl.updateForComponentName(expectedQueryComponent, -1)
 }

--- a/pkg/scheduler/queue/query_component_utilization.go
+++ b/pkg/scheduler/queue/query_component_utilization.go
@@ -167,9 +167,6 @@ func (qcl *QueryComponentUtilization) updateForComponentName(expectedQueryCompon
 	if isStoreGateway {
 		qcl.storeGatewayInflightRequests += increment
 	}
-
-	//qcl.querierInflightRequestsMetric.WithLabelValues(string(Ingester)).Observe(float64(qcl.ingesterInflightRequests))
-	//qcl.querierInflightRequestsMetric.WithLabelValues(string(StoreGateway)).Observe(float64(qcl.storeGatewayInflightRequests))
 	qcl.querierInflightRequestsTotal += increment
 }
 

--- a/pkg/scheduler/queue/query_component_utilization.go
+++ b/pkg/scheduler/queue/query_component_utilization.go
@@ -53,7 +53,10 @@ type QueryComponentUtilization struct {
 	// for queries to the less-loaded query component when the query queue becomes backlogged.
 	targetReservedCapacity float64
 
-	inflightRequestsMu           sync.RWMutex
+	inflightRequestsMu sync.RWMutex
+	// inflightRequests tracks requests from the time the request was successfully sent to a querier
+	// to the time the request was completed by the querier or failed due to cancel, timeout, or disconnect.
+	inflightRequests             map[RequestKey]*SchedulerRequest
 	ingesterInflightRequests     int
 	storeGatewayInflightRequests int
 	querierInflightRequestsTotal int
@@ -85,6 +88,7 @@ func NewQueryComponentUtilization(
 	return &QueryComponentUtilization{
 		targetReservedCapacity: targetReservedCapacity,
 
+		inflightRequests:             map[RequestKey]*SchedulerRequest{},
 		ingesterInflightRequests:     0,
 		storeGatewayInflightRequests: 0,
 		querierInflightRequestsTotal: 0,
@@ -152,21 +156,42 @@ func (qcl *QueryComponentUtilization) ExceedsThresholdForComponentName(
 	return false, ""
 }
 
-// IncrementForComponentName is called when a request is sent to a querier
-func (qcl *QueryComponentUtilization) IncrementForComponentName(expectedQueryComponent string) {
+func (qcl *QueryComponentUtilization) MarkRequestSent(req *SchedulerRequest) {
+	if req != nil {
+		qcl.inflightRequestsMu.Lock()
+		defer qcl.inflightRequestsMu.Unlock()
+
+		qcl.inflightRequests[req.Key()] = req
+		qcl.incrementForComponentName(req.ExpectedQueryComponentName())
+	}
+}
+
+func (qcl *QueryComponentUtilization) MarkRequestCompleted(req *SchedulerRequest) {
+	if req != nil {
+		qcl.inflightRequestsMu.Lock()
+		defer qcl.inflightRequestsMu.Unlock()
+
+		reqKey := req.Key()
+		if req, ok := qcl.inflightRequests[reqKey]; ok {
+			qcl.decrementForComponentName(req.ExpectedQueryComponentName())
+		}
+		delete(qcl.inflightRequests, reqKey)
+	}
+}
+
+// incrementForComponentName is called when a request is sent to a querier
+func (qcl *QueryComponentUtilization) incrementForComponentName(expectedQueryComponent string) {
 	qcl.updateForComponentName(expectedQueryComponent, 1)
 }
 
-// DecrementForComponentName is called when a querier completes or fails a request
-func (qcl *QueryComponentUtilization) DecrementForComponentName(expectedQueryComponent string) {
+// decrementForComponentName is called when a querier completes or fails a request
+func (qcl *QueryComponentUtilization) decrementForComponentName(expectedQueryComponent string) {
 	qcl.updateForComponentName(expectedQueryComponent, -1)
 }
 
 func (qcl *QueryComponentUtilization) updateForComponentName(expectedQueryComponent string, increment int) {
 	isIngester, isStoreGateway := queryComponentFlags(expectedQueryComponent)
-
-	qcl.inflightRequestsMu.Lock()
-	defer qcl.inflightRequestsMu.Unlock()
+	// lock is expected to be obtained by the calling method to mark the request as sent or completed
 	if isIngester {
 		qcl.ingesterInflightRequests += increment
 	}

--- a/pkg/scheduler/queue/query_component_utilization.go
+++ b/pkg/scheduler/queue/query_component_utilization.go
@@ -168,9 +168,14 @@ func (qcl *QueryComponentUtilization) updateForComponentName(expectedQueryCompon
 		qcl.storeGatewayInflightRequests += increment
 	}
 
+	//qcl.querierInflightRequestsMetric.WithLabelValues(string(Ingester)).Observe(float64(qcl.ingesterInflightRequests))
+	//qcl.querierInflightRequestsMetric.WithLabelValues(string(StoreGateway)).Observe(float64(qcl.storeGatewayInflightRequests))
+	qcl.querierInflightRequestsTotal += increment
+}
+
+func (qcl *QueryComponentUtilization) ObserveInflightRequests() {
 	qcl.querierInflightRequestsMetric.WithLabelValues(string(Ingester)).Observe(float64(qcl.ingesterInflightRequests))
 	qcl.querierInflightRequestsMetric.WithLabelValues(string(StoreGateway)).Observe(float64(qcl.storeGatewayInflightRequests))
-	qcl.querierInflightRequestsTotal += increment
 }
 
 // GetForComponent is a test-only util

--- a/pkg/scheduler/queue/query_component_utilization_test.go
+++ b/pkg/scheduler/queue/query_component_utilization_test.go
@@ -223,11 +223,21 @@ func TestExceedsUtilizationThresholdForQueryComponents(t *testing.T) {
 			require.NoError(t, err)
 
 			for i := 0; i < testCase.ingesterInflightRequests; i++ {
-				queryComponentUtilization.IncrementForComponentName(ingesterQueueDimension)
+				ingesterInflightRequest := &SchedulerRequest{
+					FrontendAddr:              "frontend-a",
+					QueryID:                   uint64(i),
+					AdditionalQueueDimensions: []string{ingesterQueueDimension},
+				}
+				queryComponentUtilization.MarkRequestSent(ingesterInflightRequest)
 			}
 
 			for i := 0; i < testCase.storeGatewayInflightRequests; i++ {
-				queryComponentUtilization.IncrementForComponentName(storeGatewayQueueDimension)
+				storeGatewayInflightRequest := &SchedulerRequest{
+					FrontendAddr:              "frontend-b",
+					QueryID:                   uint64(i),
+					AdditionalQueueDimensions: []string{storeGatewayQueueDimension},
+				}
+				queryComponentUtilization.MarkRequestSent(storeGatewayInflightRequest)
 			}
 
 			exceedsThreshold, queryComponent := queryComponentUtilization.ExceedsThresholdForComponentName(

--- a/pkg/scheduler/queue/query_component_utilization_test.go
+++ b/pkg/scheduler/queue/query_component_utilization_test.go
@@ -15,7 +15,7 @@ func testQuerierInflightRequestsGauge() *prometheus.SummaryVec {
 	return promauto.With(prometheus.NewPedanticRegistry()).NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "test_cortex_query_scheduler_querier_inflight_requests",
-			Help:       "[test] Number of inflight requests being processed on all querier-scheduler connections. . Quantile buckets keep track of inflight requests over the last 60s.",
+			Help:       "[test] Number of inflight requests being processed on all querier-scheduler connections. Quantile buckets keep track of inflight requests over the last 60s.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 			MaxAge:     time.Minute,
 			AgeBuckets: 6,

--- a/pkg/scheduler/queue/query_component_utilization_test.go
+++ b/pkg/scheduler/queue/query_component_utilization_test.go
@@ -4,17 +4,24 @@ package queue
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/stretchr/testify/require"
 )
 
-func testQuerierInflightRequestsGauge() *prometheus.GaugeVec {
-	return promauto.With(prometheus.NewPedanticRegistry()).NewGaugeVec(prometheus.GaugeOpts{
-		Name: "test_query_scheduler_querier_inflight_requests",
-		Help: "[test] Number of inflight requests being processed on a querier-scheduler connection.",
-	}, []string{"query_component"})
+func testQuerierInflightRequestsGauge() *prometheus.SummaryVec {
+	return promauto.With(prometheus.NewPedanticRegistry()).NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:       "test_cortex_query_scheduler_querier_inflight_requests",
+			Help:       "[test] Number of inflight requests being processed on all querier-scheduler connections. . Quantile buckets keep track of inflight requests over the last 60s.",
+			Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
+			MaxAge:     time.Minute,
+			AgeBuckets: 6,
+		},
+		[]string{"query_component"},
+	)
 }
 
 func TestExceedsUtilizationThresholdForQueryComponents(t *testing.T) {

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -133,8 +133,6 @@ type RequestQueue struct {
 	stopRequested chan struct{} // Written to by stop() to wake up dispatcherLoop() in response to a stop request.
 	stopCompleted chan struct{} // Closed by dispatcherLoop() after a stop is requested and the dispatcher has stopped.
 
-	observeInflightRequests chan struct{}
-
 	requestsToEnqueue             chan requestToEnqueue
 	requestsSent                  chan *SchedulerRequest
 	requestsCompleted             chan *SchedulerRequest
@@ -203,8 +201,6 @@ func NewRequestQueue(
 		// channels must not be buffered so that we can detect when dispatcherLoop() has finished.
 		stopRequested: make(chan struct{}),
 		stopCompleted: make(chan struct{}),
-
-		observeInflightRequests: make(chan struct{}),
 
 		requestsToEnqueue:             make(chan requestToEnqueue),
 		requestsSent:                  make(chan *SchedulerRequest),

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -181,9 +181,9 @@ func NewRequestQueue(
 	queueLength *prometheus.GaugeVec,
 	discardedRequests *prometheus.CounterVec,
 	enqueueDuration prometheus.Histogram,
-	querierInflightRequestsGauge *prometheus.GaugeVec,
+	querierInflightRequestsMetric *prometheus.SummaryVec,
 ) (*RequestQueue, error) {
-	queryComponentCapacity, err := NewQueryComponentUtilization(DefaultReservedQueryComponentCapacity, querierInflightRequestsGauge)
+	queryComponentCapacity, err := NewQueryComponentUtilization(DefaultReservedQueryComponentCapacity, querierInflightRequestsMetric)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -134,7 +134,7 @@ func TestMultiDimensionalQueueFairnessSlowConsumerEffects(t *testing.T) {
 			promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 			promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 			promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-			promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+			promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 		)
 		require.NoError(t, err)
 
@@ -239,7 +239,7 @@ func BenchmarkConcurrentQueueOperations(b *testing.B) {
 								promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 								promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 								promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-								promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+								promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 							)
 							require.NoError(b, err)
 
@@ -411,7 +411,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBe
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -480,7 +480,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ReshardNotifiedCorrectlyForMultip
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -564,7 +564,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnAfterContextCancelled
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -605,7 +605,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnImmediatelyIfQuerierI
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -634,7 +634,7 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -148,7 +148,7 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 	querierInflightRequestsMetric := promauto.With(registerer).NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "cortex_query_scheduler_querier_inflight_requests",
-			Help:       "Number of inflight requests being processed on all querier-scheduler connections. . Quantile buckets keep track of inflight requests over the last 60s.",
+			Help:       "Number of inflight requests being processed on all querier-scheduler connections. Quantile buckets keep track of inflight requests over the last 60s.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.02, 0.8: 0.02, 0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 			MaxAge:     time.Minute,
 			AgeBuckets: 6,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -282,7 +282,7 @@ func (s *Scheduler) FrontendLoop(frontend schedulerpb.SchedulerForFrontend_Front
 			requestKey := queue.NewSchedulerRequestKey(frontendAddress, msg.QueryID)
 			schedulerReq := s.cancelRequestAndRemoveFromPending(requestKey, "frontend cancelled query")
 			// we may not have reached SubmitRequestSent for this query, but RequestQueue will handle this case
-			s.requestQueue.SubmitRequestCompleted(schedulerReq)
+			s.requestQueue.QueryComponentUtilization.MarkRequestSent(schedulerReq)
 			resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
 
 		default:
@@ -451,9 +451,9 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 		*/
 
 		if schedulerReq.Ctx.Err() != nil {
-			// remove from pending requests;
-			// no need to SubmitRequestCompleted to RequestQueue as we had not yet SubmitRequestSent
+			// remove from pending requests
 			s.cancelRequestAndRemoveFromPending(schedulerReq.Key(), "request cancelled")
+			s.requestQueue.QueryComponentUtilization.MarkRequestCompleted(schedulerReq)
 			lastUserIndex = lastUserIndex.ReuseLastTenant()
 			continue
 		}
@@ -474,8 +474,8 @@ func (s *Scheduler) NotifyQuerierShutdown(_ context.Context, req *schedulerpb.No
 }
 
 func (s *Scheduler) forwardRequestToQuerier(querier schedulerpb.SchedulerForQuerier_QuerierLoopServer, req *queue.SchedulerRequest, queueTime time.Duration) error {
-	s.requestQueue.SubmitRequestSent(req)
-	defer s.requestQueue.SubmitRequestCompleted(req)
+	s.requestQueue.QueryComponentUtilization.MarkRequestSent(req)
+	defer s.requestQueue.QueryComponentUtilization.MarkRequestCompleted(req)
 	defer s.cancelRequestAndRemoveFromPending(req.Key(), "request complete")
 
 	// Handle the stream sending & receiving on a goroutine so we can


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The use of a gauge was preventing us from almost ever seeing the peak values in the scraped data.

Using this summary instead with and querying like
```promql
sum by(query_component) (last_over_time(cortex_query_scheduler_querier_inflight_requests{quantile="0.99"}[1m]))
```
gives us a better look at real-time peak values for these statistics which will be used for query-scheduler load balancing decisions

#### Which issue(s) this PR fixes or relates to

previously, querying these metrics never reached their theoretical max, which is equal to all querier worker connections ever though we could see in logs that it was maxed out. This is fixed now:

![image](https://github.com/grafana/mimir/assets/13006869/ca2e5abf-c89a-49b7-b3db-ed01104e7143)


#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
