### PR TITLE
Query-tee improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,11 @@
 * [ENHANCEMENT] Add two new metrics for measuring the relative duration between backends: #7782 #8013 #8330
   * `cortex_querytee_backend_response_relative_duration_seconds`
   * `cortex_querytee_backend_response_relative_duration_proportional`
+* [ENHANCEMENT] Emit trace spans from query-tee. #8419
+* [ENHANCEMENT] Log trace ID (if present) with all log messages written while processing a request. #8419
+* [ENHANCEMENT] Log user agent when processing a request. #8419
+* [ENHANCEMENT] Add `time` parameter to proxied instant queries if it is not included in the incoming request. This is optional but enabled by default, and can be disabled with `-proxy.add-missing-time-parameter-to-instant-queries=false`. #8419
+* [BUGFIX] Ensure any errors encountered while forwarding a request to a backend (eg. DNS resolution failures) are logged. #8419
 
 ### Documentation
 

--- a/cmd/query-tee/main.go
+++ b/cmd/query-tee/main.go
@@ -107,8 +107,15 @@ func mimirReadRoutes(cfg Config) []querytee.Route {
 		UseRelativeError:  cfg.ProxyConfig.UseRelativeError,
 		SkipRecentSamples: cfg.ProxyConfig.SkipRecentSamples,
 	})
+
+	var instantQueryTransformers []querytee.RequestTransformer
+
+	if cfg.ProxyConfig.AddMissingTimeParamToInstantQueries {
+		instantQueryTransformers = append(instantQueryTransformers, querytee.AddMissingTimeParam)
+	}
+
 	return []querytee.Route{
-		{Path: prefix + "/api/v1/query", RouteName: "api_v1_query", Methods: []string{"GET", "POST"}, ResponseComparator: samplesComparator},
+		{Path: prefix + "/api/v1/query", RouteName: "api_v1_query", Methods: []string{"GET", "POST"}, ResponseComparator: samplesComparator, RequestTransformers: instantQueryTransformers},
 		{Path: prefix + "/api/v1/query_range", RouteName: "api_v1_query_range", Methods: []string{"GET", "POST"}, ResponseComparator: samplesComparator},
 		{Path: prefix + "/api/v1/query_exemplars", RouteName: "api_v1_query_exemplars", Methods: []string{"GET", "POST"}, ResponseComparator: nil},
 		{Path: prefix + "/api/v1/labels", RouteName: "api_v1_labels", Methods: []string{"GET", "POST"}, ResponseComparator: nil},

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -23,6 +23,12 @@ cd "$SCRIPT_DIR" && make
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
 CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
-
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" distributor-1
+
+if [ "$(yq '.services.query-tee' "${SCRIPT_DIR}"/docker-compose.yml)" != "null" ]; then
+  # If query-tee is enabled, build its binary and image as well.
+  CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/../../cmd/query-tee "${SCRIPT_DIR}"/../../cmd/query-tee
+  docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" query-tee
+fi
+
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/tools/querytee/instant_query_transform.go
+++ b/tools/querytee/instant_query_transform.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querytee
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/spanlogger"
+)
+
+var timeNow = time.Now // Interception point to allow tests to set the current time for AddMissingTimeParam.
+
+// AddMissingTimeParam adds a 'time' parameter to any query request that does not have one.
+//
+// Instant queries without a 'time' parameter use the current time on the executing backend.
+// However, this can vary between backends for the same request, which can comparison failures.
+//
+// So, to make comparisons more reliable, we add the 'time' parameter in the proxy to ensure all
+// backends use the same value.
+func AddMissingTimeParam(r *http.Request, body []byte, logger *spanlogger.SpanLogger) (*http.Request, []byte, error) {
+	parsedBody, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if parsedBody.Has("time") {
+		return r, body, nil
+	}
+
+	queryParams := r.URL.Query()
+
+	if queryParams.Has("time") {
+		return r, body, nil
+	}
+
+	// No 'time' parameter in either the body or URL. Add it.
+	level.Debug(logger).Log("msg", "instant query had no explicit time parameter, adding it based on the current time")
+
+	if len(body) > 0 {
+		// Request has a body, add the 'time' parameter there.
+		parsedBody.Set("time", timeNow().Format(time.RFC3339))
+		body = []byte(parsedBody.Encode())
+
+		// Outgoing requests should only rely on the request body, but we update Form here for consistency.
+		r.Form = parsedBody
+
+		// Update the content length to reflect the new body.
+		r.ContentLength = int64(len(body))
+		r.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+		return r, body, nil
+	}
+
+	// Otherwise, add it to the URL.
+	queryParams.Set("time", timeNow().Format(time.RFC3339))
+	r.URL.RawQuery = queryParams.Encode()
+	return r, body, nil
+}

--- a/tools/querytee/instant_query_transform.go
+++ b/tools/querytee/instant_query_transform.go
@@ -17,7 +17,7 @@ var timeNow = time.Now // Interception point to allow tests to set the current t
 // AddMissingTimeParam adds a 'time' parameter to any query request that does not have one.
 //
 // Instant queries without a 'time' parameter use the current time on the executing backend.
-// However, this can vary between backends for the same request, which can comparison failures.
+// However, this can vary between backends for the same request, which can cause comparison failures.
 //
 // So, to make comparisons more reliable, we add the 'time' parameter in the proxy to ensure all
 // backends use the same value.

--- a/tools/querytee/instant_query_transform_test.go
+++ b/tools/querytee/instant_query_transform_test.go
@@ -117,6 +117,59 @@ func TestAddMissingTimeParam(t *testing.T) {
 			},
 			expectedBody: url.Values{},
 		},
+		"POST with parameters in both URL and body, and no time in either place": {
+			method: http.MethodPost,
+			urlParams: url.Values{
+				"query": []string{"sum(abc)"},
+			},
+			body: url.Values{
+				"timeout": []string{"60s"},
+			},
+
+			expectedURLParams: url.Values{
+				"query": []string{"sum(abc)"},
+			},
+			expectedBody: url.Values{
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-10T20:30:40Z"},
+			},
+		},
+		"POST with parameters in both URL and body, and time in URL": {
+			method: http.MethodPost,
+			urlParams: url.Values{
+				"query": []string{"sum(abc)"},
+				"time":  []string{"2024-06-19T01:23:45Z"},
+			},
+			body: url.Values{
+				"timeout": []string{"60s"},
+			},
+
+			expectedURLParams: url.Values{
+				"query": []string{"sum(abc)"},
+				"time":  []string{"2024-06-19T01:23:45Z"},
+			},
+			expectedBody: url.Values{
+				"timeout": []string{"60s"},
+			},
+		},
+		"POST with parameters in both URL and body, and time in body": {
+			method: http.MethodPost,
+			urlParams: url.Values{
+				"query": []string{"sum(abc)"},
+			},
+			body: url.Values{
+				"time":    []string{"2024-06-19T01:23:45Z"},
+				"timeout": []string{"60s"},
+			},
+
+			expectedURLParams: url.Values{
+				"query": []string{"sum(abc)"},
+			},
+			expectedBody: url.Values{
+				"time":    []string{"2024-06-19T01:23:45Z"},
+				"timeout": []string{"60s"},
+			},
+		},
 	}
 
 	logger, _ := spanlogger.New(context.Background(), "test")

--- a/tools/querytee/instant_query_transform_test.go
+++ b/tools/querytee/instant_query_transform_test.go
@@ -25,10 +25,10 @@ func TestAddMissingTimeParam(t *testing.T) {
 	testCases := map[string]struct {
 		method    string
 		urlParams url.Values
-		form      url.Values
+		body      url.Values
 
 		expectedURLParams url.Values
-		expectedForm      url.Values
+		expectedBody      url.Values
 	}{
 		"GET with time in URL": {
 			method: http.MethodGet,
@@ -43,7 +43,7 @@ func TestAddMissingTimeParam(t *testing.T) {
 				"timeout": []string{"60s"},
 				"time":    []string{"2024-06-19T01:23:45Z"},
 			},
-			expectedForm: url.Values{},
+			expectedBody: url.Values{},
 		},
 		"GET without time in URL": {
 			method: http.MethodGet,
@@ -57,18 +57,18 @@ func TestAddMissingTimeParam(t *testing.T) {
 				"timeout": []string{"60s"},
 				"time":    []string{"2024-06-10T20:30:40Z"},
 			},
-			expectedForm: url.Values{},
+			expectedBody: url.Values{},
 		},
 		"POST with time in body": {
 			method: http.MethodPost,
-			form: url.Values{
+			body: url.Values{
 				"query":   []string{"sum(abc)"},
 				"timeout": []string{"60s"},
 				"time":    []string{"2024-06-19T01:23:45Z"},
 			},
 
 			expectedURLParams: url.Values{},
-			expectedForm: url.Values{
+			expectedBody: url.Values{
 				"query":   []string{"sum(abc)"},
 				"timeout": []string{"60s"},
 				"time":    []string{"2024-06-19T01:23:45Z"},
@@ -76,13 +76,13 @@ func TestAddMissingTimeParam(t *testing.T) {
 		},
 		"POST without time in body": {
 			method: http.MethodPost,
-			form: url.Values{
+			body: url.Values{
 				"query":   []string{"sum(abc)"},
 				"timeout": []string{"60s"},
 			},
 
 			expectedURLParams: url.Values{},
-			expectedForm: url.Values{
+			expectedBody: url.Values{
 				"query":   []string{"sum(abc)"},
 				"timeout": []string{"60s"},
 				"time":    []string{"2024-06-10T20:30:40Z"},
@@ -101,7 +101,7 @@ func TestAddMissingTimeParam(t *testing.T) {
 				"timeout": []string{"60s"},
 				"time":    []string{"2024-06-19T01:23:45Z"},
 			},
-			expectedForm: url.Values{},
+			expectedBody: url.Values{},
 		},
 		"POST without time in URL": {
 			method: http.MethodPost,
@@ -115,7 +115,7 @@ func TestAddMissingTimeParam(t *testing.T) {
 				"timeout": []string{"60s"},
 				"time":    []string{"2024-06-10T20:30:40Z"},
 			},
-			expectedForm: url.Values{},
+			expectedBody: url.Values{},
 		},
 	}
 
@@ -128,21 +128,17 @@ func TestAddMissingTimeParam(t *testing.T) {
 			var body []byte
 
 			if testCase.method == http.MethodGet {
-				require.Nil(t, testCase.form, "invalid test case: GET request should not have body")
+				require.Nil(t, testCase.body, "invalid test case: GET request should not have body")
 				req, err = http.NewRequest(testCase.method, "/blah?"+testCase.urlParams.Encode(), nil)
 				require.NoError(t, err)
 				body = nil
 			} else {
-				encoded := testCase.form.Encode()
+				encoded := testCase.body.Encode()
 				reader := strings.NewReader(encoded)
 				req, err = http.NewRequest(testCase.method, "/blah?"+testCase.urlParams.Encode(), reader)
 				require.NoError(t, err)
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				req.Header.Set("Content-Length", strconv.Itoa(reader.Len()))
-
-				// ProxyEndpoint.executeBackendRequests parses the form body, so we do the same, for consistency.
-				require.NoError(t, req.ParseForm())
-
 				body = []byte(encoded)
 			}
 
@@ -152,20 +148,29 @@ func TestAddMissingTimeParam(t *testing.T) {
 			require.Equal(t, "/blah", transformed.URL.Path)
 			require.Equal(t, testCase.expectedURLParams, transformed.URL.Query())
 
-			if len(testCase.expectedForm) == 0 {
+			if len(testCase.expectedBody) == 0 {
 				require.Empty(t, transformedBody)
+				require.Empty(t, transformed.PostForm)
 			} else {
 				parsedBody, err := url.ParseQuery(string(transformedBody))
 				require.NoError(t, err)
-				require.Equal(t, testCase.expectedForm, parsedBody)
+				require.Equal(t, testCase.expectedBody, parsedBody)
 
-				// Make sure we've updated both places, for consistency.
-				require.Equal(t, testCase.expectedForm, transformed.Form)
+				// Make sure we've updated both the body and PostForm, for consistency.
+				require.Equal(t, testCase.expectedBody, transformed.PostForm)
 
 				// Make sure we've updated the Content-Length header to match the new request body length.
 				require.Equal(t, int64(len(transformedBody)), transformed.ContentLength)
 				require.Equal(t, strconv.Itoa(len(transformedBody)), transformed.Header.Get("Content-Length"))
 			}
+
+			expectedForm := testCase.expectedURLParams
+
+			for k, v := range testCase.expectedBody {
+				expectedForm[k] = v
+			}
+
+			require.Equal(t, expectedForm, transformed.Form)
 		})
 	}
 }

--- a/tools/querytee/instant_query_transform_test.go
+++ b/tools/querytee/instant_query_transform_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querytee
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+func TestAddMissingTimeParam(t *testing.T) {
+	// Mock the current time.
+	originalTimeNow := timeNow
+	timeNow = func() time.Time { return time.Date(2024, 6, 10, 20, 30, 40, 0, time.UTC) }
+	t.Cleanup(func() { timeNow = originalTimeNow })
+
+	testCases := map[string]struct {
+		method    string
+		urlParams url.Values
+		form      url.Values
+
+		expectedURLParams url.Values
+		expectedForm      url.Values
+	}{
+		"GET with time in URL": {
+			method: http.MethodGet,
+			urlParams: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-19T01:23:45Z"},
+			},
+
+			expectedURLParams: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-19T01:23:45Z"},
+			},
+			expectedForm: url.Values{},
+		},
+		"GET without time in URL": {
+			method: http.MethodGet,
+			urlParams: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+			},
+
+			expectedURLParams: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-10T20:30:40Z"},
+			},
+			expectedForm: url.Values{},
+		},
+		"POST with time in body": {
+			method: http.MethodPost,
+			form: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-19T01:23:45Z"},
+			},
+
+			expectedURLParams: url.Values{},
+			expectedForm: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-19T01:23:45Z"},
+			},
+		},
+		"POST without time in body": {
+			method: http.MethodPost,
+			form: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+			},
+
+			expectedURLParams: url.Values{},
+			expectedForm: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-10T20:30:40Z"},
+			},
+		},
+		"POST with time in URL": {
+			method: http.MethodPost,
+			urlParams: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-19T01:23:45Z"},
+			},
+
+			expectedURLParams: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-19T01:23:45Z"},
+			},
+			expectedForm: url.Values{},
+		},
+		"POST without time in URL": {
+			method: http.MethodPost,
+			urlParams: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+			},
+
+			expectedURLParams: url.Values{
+				"query":   []string{"sum(abc)"},
+				"timeout": []string{"60s"},
+				"time":    []string{"2024-06-10T20:30:40Z"},
+			},
+			expectedForm: url.Values{},
+		},
+	}
+
+	logger, _ := spanlogger.New(context.Background(), "test")
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var req *http.Request
+			var err error
+			var body []byte
+
+			if testCase.method == http.MethodGet {
+				require.Nil(t, testCase.form, "invalid test case: GET request should not have body")
+				req, err = http.NewRequest(testCase.method, "/blah?"+testCase.urlParams.Encode(), nil)
+				require.NoError(t, err)
+				body = nil
+			} else {
+				encoded := testCase.form.Encode()
+				reader := strings.NewReader(encoded)
+				req, err = http.NewRequest(testCase.method, "/blah?"+testCase.urlParams.Encode(), reader)
+				require.NoError(t, err)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				req.Header.Set("Content-Length", strconv.Itoa(reader.Len()))
+
+				// ProxyEndpoint.executeBackendRequests parses the form body, so we do the same, for consistency.
+				require.NoError(t, req.ParseForm())
+
+				body = []byte(encoded)
+			}
+
+			transformed, transformedBody, err := AddMissingTimeParam(req, body, logger)
+			require.NoError(t, err)
+			require.Equal(t, testCase.method, transformed.Method)
+			require.Equal(t, "/blah", transformed.URL.Path)
+			require.Equal(t, testCase.expectedURLParams, transformed.URL.Query())
+
+			if len(testCase.expectedForm) == 0 {
+				require.Empty(t, transformedBody)
+			} else {
+				parsedBody, err := url.ParseQuery(string(transformedBody))
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedForm, parsedBody)
+
+				// Make sure we've updated both places, for consistency.
+				require.Equal(t, testCase.expectedForm, transformed.Form)
+
+				// Make sure we've updated the Content-Length header to match the new request body length.
+				require.Equal(t, int64(len(transformedBody)), transformed.ContentLength)
+				require.Equal(t, strconv.Itoa(len(transformedBody)), transformed.Header.Get("Content-Length"))
+			}
+		})
+	}
+}

--- a/tools/querytee/proxy_backend.go
+++ b/tools/querytee/proxy_backend.go
@@ -15,6 +15,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -22,7 +24,7 @@ type ProxyBackendInterface interface {
 	Name() string
 	Endpoint() *url.URL
 	Preferred() bool
-	ForwardRequest(orig *http.Request, body io.ReadCloser) (time.Duration, int, []byte, *http.Response, error)
+	ForwardRequest(ctx context.Context, orig *http.Request, body io.ReadCloser) (time.Duration, int, []byte, *http.Response, error)
 }
 
 // ProxyBackend holds the information of a single backend.
@@ -39,6 +41,23 @@ type ProxyBackend struct {
 
 // NewProxyBackend makes a new ProxyBackend
 func NewProxyBackend(name string, endpoint *url.URL, timeout time.Duration, preferred bool, skipTLSVerify bool) ProxyBackendInterface {
+	innerTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: skipTLSVerify,
+		},
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100, // see https://github.com/golang/go/issues/13801
+		IdleConnTimeout:     90 * time.Second,
+		DisableCompression:  true,
+	}
+
+	tracingTransport := &nethttp.Transport{RoundTripper: innerTransport}
+
 	return &ProxyBackend{
 		name:      name,
 		endpoint:  endpoint,
@@ -48,20 +67,7 @@ func NewProxyBackend(name string, endpoint *url.URL, timeout time.Duration, pref
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return errors.New("the query-tee proxy does not follow redirects")
 			},
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: skipTLSVerify,
-				},
-				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).DialContext,
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 100, // see https://github.com/golang/go/issues/13801
-				IdleConnTimeout:     90 * time.Second,
-				DisableCompression:  true,
-			},
+			Transport: tracingTransport,
 		},
 	}
 }
@@ -78,11 +84,14 @@ func (b *ProxyBackend) Preferred() bool {
 	return b.preferred
 }
 
-func (b *ProxyBackend) ForwardRequest(orig *http.Request, body io.ReadCloser) (time.Duration, int, []byte, *http.Response, error) {
-	req, err := b.createBackendRequest(orig, body)
+func (b *ProxyBackend) ForwardRequest(ctx context.Context, orig *http.Request, body io.ReadCloser) (time.Duration, int, []byte, *http.Response, error) {
+	req, err := b.createBackendRequest(ctx, orig, body)
 	if err != nil {
 		return 0, 0, nil, nil, err
 	}
+
+	req, ht := nethttp.TraceRequest(opentracing.GlobalTracer(), req)
+	defer ht.Finish()
 
 	start := time.Now()
 	status, responseBody, resp, err := b.doBackendRequest(req)
@@ -91,8 +100,8 @@ func (b *ProxyBackend) ForwardRequest(orig *http.Request, body io.ReadCloser) (t
 	return elapsed, status, responseBody, resp, err
 }
 
-func (b *ProxyBackend) createBackendRequest(orig *http.Request, body io.ReadCloser) (*http.Request, error) {
-	req := orig.Clone(context.Background())
+func (b *ProxyBackend) createBackendRequest(ctx context.Context, orig *http.Request, body io.ReadCloser) (*http.Request, error) {
+	req := orig.Clone(ctx)
 	req.Body = body
 	// RequestURI can't be set on a cloned request. It's only for handlers.
 	req.RequestURI = ""
@@ -135,7 +144,7 @@ func (b *ProxyBackend) createBackendRequest(orig *http.Request, body io.ReadClos
 
 func (b *ProxyBackend) doBackendRequest(req *http.Request) (int, []byte, *http.Response, error) {
 	// Honor the read timeout.
-	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	ctx, cancel := context.WithTimeout(req.Context(), b.timeout)
 	defer cancel()
 
 	// Execute the request.

--- a/tools/querytee/proxy_backend_test.go
+++ b/tools/querytee/proxy_backend_test.go
@@ -6,6 +6,7 @@
 package querytee
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -88,7 +89,7 @@ func Test_ProxyBackend_createBackendRequest_HTTPBasicAuthentication(t *testing.T
 			if !ok {
 				t.Fatalf("Type assertion to *ProxyBackend failed")
 			}
-			r, err := bp.createBackendRequest(orig, nil)
+			r, err := bp.createBackendRequest(context.Background(), orig, nil)
 			require.NoError(t, err)
 
 			actualUser, actualPass, _ := r.BasicAuth()

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -90,7 +90,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 		responsesMtx = sync.Mutex{}
 		timingMtx    = sync.Mutex{}
 		query        = req.URL.RawQuery
-		logger, ctx  = spanlogger.NewWithLogger(req.Context(), p.logger, "Incoming request")
+		logger, ctx  = spanlogger.NewWithLogger(req.Context(), p.logger, "Incoming proxied request")
 	)
 
 	defer logger.Finish()
@@ -142,7 +142,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 			// Don't cancel the child request's context when the parent context (from the incoming HTTP request) is cancelled after we return a response.
 			// This allows us to continue running slower requests after returning a response to the caller.
 			ctx := context.WithoutCancel(ctx)
-			logger, ctx := spanlogger.NewWithLogger(ctx, p.logger, fmt.Sprintf("Outgoing request to %s", b.Name()))
+			logger, ctx := spanlogger.NewWithLogger(ctx, p.logger, "Outgoing proxied request")
 			defer logger.Finish()
 			setSpanAndLogTags(logger)
 			logger.SetSpanAndLogTag("backend", b.Name())

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -99,6 +99,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 		logger.SetSpanAndLogTag("query", query)
 		logger.SetSpanAndLogTag("route_name", p.routeName)
 		logger.SetSpanAndLogTag("user", req.Header.Get("X-Scope-OrgID"))
+		logger.SetSpanAndLogTag("user_agent", req.Header.Get("User-Agent"))
 	}
 
 	setSpanAndLogTags(logger)

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -94,16 +94,6 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 
 	defer logger.Finish()
 
-	setSpanAndLogTags := func(logger *spanlogger.SpanLogger) {
-		logger.SetSpanAndLogTag("path", req.URL.Path)
-		logger.SetSpanAndLogTag("query", query)
-		logger.SetSpanAndLogTag("route_name", p.route.RouteName)
-		logger.SetSpanAndLogTag("user", req.Header.Get("X-Scope-OrgID"))
-		logger.SetSpanAndLogTag("user_agent", req.Header.Get("User-Agent"))
-	}
-
-	setSpanAndLogTags(logger)
-
 	if req.Body != nil {
 		body, err = io.ReadAll(req.Body)
 		if err != nil {
@@ -122,6 +112,16 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 		}
 		query = req.Form.Encode()
 	}
+
+	setSpanAndLogTags := func(logger *spanlogger.SpanLogger) {
+		logger.SetSpanAndLogTag("path", req.URL.Path)
+		logger.SetSpanAndLogTag("query", query)
+		logger.SetSpanAndLogTag("route_name", p.route.RouteName)
+		logger.SetSpanAndLogTag("user", req.Header.Get("X-Scope-OrgID"))
+		logger.SetSpanAndLogTag("user_agent", req.Header.Get("User-Agent"))
+	}
+
+	setSpanAndLogTags(logger)
 
 	level.Debug(logger).Log("msg", "Received request")
 

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -36,11 +36,10 @@ type ProxyEndpoint struct {
 	// Whether for this endpoint there's a preferred backend configured.
 	hasPreferredBackend bool
 
-	// The route name used to track metrics.
-	routeName string
+	route Route
 }
 
-func NewProxyEndpoint(backends []ProxyBackendInterface, routeName string, metrics *ProxyMetrics, logger log.Logger, comparator ResponsesComparator, slowResponseThreshold time.Duration) *ProxyEndpoint {
+func NewProxyEndpoint(backends []ProxyBackendInterface, route Route, metrics *ProxyMetrics, logger log.Logger, comparator ResponsesComparator, slowResponseThreshold time.Duration) *ProxyEndpoint {
 	hasPreferredBackend := false
 	for _, backend := range backends {
 		if backend.Preferred() {
@@ -51,7 +50,7 @@ func NewProxyEndpoint(backends []ProxyBackendInterface, routeName string, metric
 
 	return &ProxyEndpoint{
 		backends:              backends,
-		routeName:             routeName,
+		route:                 route,
 		metrics:               metrics,
 		logger:                logger,
 		comparator:            comparator,
@@ -78,7 +77,7 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	p.metrics.responsesTotal.WithLabelValues(downstreamRes.backend.Name(), r.Method, p.routeName).Inc()
+	p.metrics.responsesTotal.WithLabelValues(downstreamRes.backend.Name(), r.Method, p.route.RouteName).Inc()
 }
 
 func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *backendResponse) {
@@ -98,7 +97,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 	setSpanAndLogTags := func(logger *spanlogger.SpanLogger) {
 		logger.SetSpanAndLogTag("path", req.URL.Path)
 		logger.SetSpanAndLogTag("query", query)
-		logger.SetSpanAndLogTag("route_name", p.routeName)
+		logger.SetSpanAndLogTag("route_name", p.route.RouteName)
 		logger.SetSpanAndLogTag("user", req.Header.Get("X-Scope-OrgID"))
 		logger.SetSpanAndLogTag("user_agent", req.Header.Get("User-Agent"))
 	}
@@ -109,6 +108,8 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 		body, err = io.ReadAll(req.Body)
 		if err != nil {
 			level.Warn(logger).Log("msg", "Unable to read request body", "err", err)
+			resCh <- &backendResponse{err: err}
+			close(resCh)
 			return
 		}
 		if err := req.Body.Close(); err != nil {
@@ -123,6 +124,23 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 	}
 
 	level.Debug(logger).Log("msg", "Received request")
+
+	for _, transform := range p.route.RequestTransformers {
+		req, body, err = transform(req, body, logger)
+
+		if err != nil {
+			level.Error(logger).Log("msg", "Transforming request failed", "err", err)
+			resCh <- &backendResponse{err: err}
+			close(resCh)
+			return
+		}
+
+		// Update the query used in logging based on the updated request.
+		query = req.URL.RawQuery
+		if body != nil {
+			query = req.Form.Encode()
+		}
+	}
 
 	// Keep track of the fastest and slowest backends
 	var (
@@ -196,7 +214,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 			}
 
 			l.Log("msg", "Backend response", "status", status, "elapsed", elapsed)
-			p.metrics.requestDuration.WithLabelValues(res.backend.Name(), req.Method, p.routeName, strconv.Itoa(res.statusCode())).Observe(elapsed.Seconds())
+			p.metrics.requestDuration.WithLabelValues(res.backend.Name(), req.Method, p.route.RouteName, strconv.Itoa(res.statusCode())).Observe(elapsed.Seconds())
 			logger.SetTag("status", status)
 
 			// Keep track of the response if required.
@@ -252,9 +270,9 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 
 		relativeDuration := actualResponse.elapsedTime - expectedResponse.elapsedTime
 		proportionalDurationDifference := relativeDuration.Seconds() / expectedResponse.elapsedTime.Seconds()
-		p.metrics.relativeDuration.WithLabelValues(p.routeName).Observe(relativeDuration.Seconds())
-		p.metrics.proportionalDuration.WithLabelValues(p.routeName).Observe(proportionalDurationDifference)
-		p.metrics.responsesComparedTotal.WithLabelValues(p.routeName, string(result)).Inc()
+		p.metrics.relativeDuration.WithLabelValues(p.route.RouteName).Observe(relativeDuration.Seconds())
+		p.metrics.proportionalDuration.WithLabelValues(p.route.RouteName).Observe(proportionalDurationDifference)
+		p.metrics.responsesComparedTotal.WithLabelValues(p.route.RouteName, string(result)).Inc()
 	}
 }
 

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -188,6 +188,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 
 			lvl(logger).Log("msg", "Backend response", "status", status, "elapsed", elapsed)
 			p.metrics.requestDuration.WithLabelValues(res.backend.Name(), req.Method, p.routeName, strconv.Itoa(res.statusCode())).Observe(elapsed.Seconds())
+			logger.SetTag("status", status)
 
 			// Keep track of the response if required.
 			if p.comparator != nil {

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -184,6 +184,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, resCh chan *ba
 			lvl := level.Debug
 			if !res.succeeded() {
 				lvl = level.Warn
+				logger.Error(err)
 			}
 
 			lvl(logger).Log("msg", "Backend response", "status", status, "elapsed", elapsed)

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -7,6 +7,7 @@ package querytee
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -762,7 +763,7 @@ func (b *mockProxyBackend) Preferred() bool {
 	return b.preferred
 }
 
-func (b *mockProxyBackend) ForwardRequest(_ *http.Request, _ io.ReadCloser) (time.Duration, int, []byte, *http.Response, error) {
+func (b *mockProxyBackend) ForwardRequest(_ context.Context, _ *http.Request, _ io.ReadCloser) (time.Duration, int, []byte, *http.Response, error) {
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
+	testRoute := Route{RouteName: "test"}
 	backendURL1, err := url.Parse("http://backend-1/")
 	require.NoError(t, err)
 	backendURL2, err := url.Parse("http://backend-2/")
@@ -106,7 +107,7 @@ func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
-			endpoint := NewProxyEndpoint(testData.backends, "test", NewProxyMetrics(nil), log.NewNopLogger(), nil, 0)
+			endpoint := NewProxyEndpoint(testData.backends, testRoute, NewProxyMetrics(nil), log.NewNopLogger(), nil, 0)
 
 			// Send the responses from a dedicated goroutine.
 			resCh := make(chan *backendResponse)
@@ -131,6 +132,7 @@ func Test_ProxyEndpoint_Requests(t *testing.T) {
 		testHandler  http.HandlerFunc
 	)
 
+	testRoute := Route{RouteName: "test"}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer wg.Done()
 		defer requestCount.Add(1)
@@ -150,7 +152,7 @@ func Test_ProxyEndpoint_Requests(t *testing.T) {
 		NewProxyBackend("backend-1", backendURL1, time.Second, true, false),
 		NewProxyBackend("backend-2", backendURL2, time.Second, false, false),
 	}
-	endpoint := NewProxyEndpoint(backends, "test", NewProxyMetrics(nil), log.NewNopLogger(), nil, 0)
+	endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(nil), log.NewNopLogger(), nil, 0)
 
 	for _, tc := range []struct {
 		name    string
@@ -234,6 +236,8 @@ func Test_ProxyEndpoint_Requests(t *testing.T) {
 }
 
 func Test_ProxyEndpoint_Comparison(t *testing.T) {
+	testRoute := Route{RouteName: "test"}
+
 	scenarios := map[string]struct {
 		preferredResponseStatusCode  int
 		secondaryResponseStatusCode  int
@@ -324,7 +328,7 @@ func Test_ProxyEndpoint_Comparison(t *testing.T) {
 				comparisonError:  scenario.comparatorError,
 			}
 
-			endpoint := NewProxyEndpoint(backends, "test", NewProxyMetrics(reg), logger, comparator, 0)
+			endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, 0)
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "http://test/api/v1/test", nil)
@@ -353,6 +357,8 @@ func Test_ProxyEndpoint_Comparison(t *testing.T) {
 }
 
 func Test_ProxyEndpoint_LogSlowQueries(t *testing.T) {
+	testRoute := Route{RouteName: "test"}
+
 	scenarios := map[string]struct {
 		slowResponseThreshold         time.Duration
 		preferredResponseLatency      time.Duration
@@ -424,7 +430,7 @@ func Test_ProxyEndpoint_LogSlowQueries(t *testing.T) {
 				comparisonResult: ComparisonSuccess,
 			}
 
-			endpoint := NewProxyEndpoint(backends, "test", NewProxyMetrics(reg), logger, comparator, scenario.slowResponseThreshold)
+			endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, scenario.slowResponseThreshold)
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "http://test/api/v1/test", nil)
@@ -449,6 +455,8 @@ func Test_ProxyEndpoint_LogSlowQueries(t *testing.T) {
 }
 
 func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
+	testRoute := Route{RouteName: "test"}
+
 	scenarios := map[string]struct {
 		latencyPairs                  []latencyPair
 		expectedDurationSampleSum     float64
@@ -491,7 +499,7 @@ func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
 				comparisonResult: ComparisonSuccess,
 			}
 
-			endpoint := NewProxyEndpoint(backends, "test", NewProxyMetrics(reg), logger, comparator, 0)
+			endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, 0)
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "http://test/api/v1/test", nil)


### PR DESCRIPTION
#### What this PR does

This PR makes a number of improvements to query-tee. The most notable changes are:

* Query-tee now emits trace spans when proxying requests: one span is emitted for each incoming request and another for each outgoing request.
* All log messages associated with a request are tagged with that request's trace ID, just like Mimir itself.
* Query-tee now correctly configures the Jaeger tracing backend, using the same environment variables as Mimir itself.
* Log fields such as `path`, `query` and `route_name` are now set on all log messages emitted while processing a request.
* The user agent is now logged while processing a request.
* All errors encountered while making a request to a backend are logged, such as DNS failures. (Previously, query-tee relied on the comparator to do this, but the comparator is only used when comparing requests.)
* Incoming instant query requests without an explicit value for the `time` parameter now have this explicitly set for outgoing requests to backends, to prevent comparison failures due to different backends using a slightly different timestamp. This is optional, but enabled by default.
* The microservices Docker Compose environment can now optionally stand up a query-tee instance for testing.

I've tried to make each commit self-contained, and I recommend reviewing each commit separately.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
