### PR TITLE
Add profiling labels to ingester's read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [ENHANCEMENT] Query-frontend: log the start, end time and matchers for remote read requests to the query stats logs. #8326 #8370 #8373
 * [ENHANCEMENT] Query-frontend: be able to block remote read queries via the per tenant runtime override `blocked_queries`. #8372 #8415
 * [ENHANCEMENT] Query-frontend: added `remote_read` to `op` supported label values for the `cortex_query_frontend_queries_total` metric. #8412
+* [ENHANCEMENT] Ingester: read path requests now add userID and matchers labels to profiles. #8421
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2145,7 +2145,10 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 
 	streamingChunkBatchSize := req.StreamingChunksBatchSize
 
-	return i.queryStream(ctx, userID, mint, maxt, matchers, streamingChunkBatchSize, spanlog, stream)
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.QueryStream", "userID", userID, "matchers", util.MatchersStringer(matchers).String()), func(ctx context.Context) {
+		err = i.queryStream(ctx, userID, mint, maxt, matchers, streamingChunkBatchSize, spanlog, stream)
+	})
+	return err
 }
 
 func (i *Ingester) queryStream(ctx context.Context, userID string, mint model.Time, maxt model.Time, matchers []*labels.Matcher, streamingChunkBatchSize uint64, spanlog *spanlogger.SpanLogger, stream client.Ingester_QueryStreamServer) error {

--- a/pkg/ingester/label_names_and_values.go
+++ b/pkg/ingester/label_names_and_values.go
@@ -27,14 +27,13 @@ type labelValueCountResult struct {
 // labelNamesAndValues streams the messages with the labels and values of the labels matching the `matchers` param.
 // Messages are immediately sent as soon they reach message size threshold defined in `messageSizeThreshold` param.
 func labelNamesAndValues(
+	ctx context.Context,
 	index tsdb.IndexReader,
 	matchers []*labels.Matcher,
 	messageSizeThreshold int,
 	stream client.Ingester_LabelNamesAndValuesServer,
 	filter func(name, value string) (bool, error),
 ) error {
-	ctx := stream.Context()
-
 	labelNames, err := index.LabelNames(ctx, matchers...)
 	if err != nil {
 		return err
@@ -114,6 +113,7 @@ func labelNamesAndValues(
 // labelValuesCardinality returns all values and series total count for label_names labels that match the matchers.
 // Messages are immediately sent as soon they reach message size threshold.
 func labelValuesCardinality(
+	ctx context.Context,
 	lbNames []string,
 	matchers []*labels.Matcher,
 	idxReader tsdb.IndexReader,
@@ -121,8 +121,6 @@ func labelValuesCardinality(
 	msgSizeThreshold int,
 	srv client.Ingester_LabelValuesCardinalityServer,
 ) error {
-	ctx := srv.Context()
-
 	resp := client.LabelValuesCardinalityResponse{}
 	respSize := 0
 

--- a/pkg/ingester/label_names_and_values_test.go
+++ b/pkg/ingester/label_names_and_values_test.go
@@ -59,7 +59,7 @@ func TestLabelNamesAndValuesAreSentInBatches(t *testing.T) {
 	var valueFilter = func(string, string) (bool, error) {
 		return true, nil
 	}
-	require.NoError(t, labelNamesAndValues(&mockIndex{existingLabels: existingLabels}, []*labels.Matcher{}, 32, stream, valueFilter))
+	require.NoError(t, labelNamesAndValues(context.Background(), &mockIndex{existingLabels: existingLabels}, []*labels.Matcher{}, 32, stream, valueFilter))
 
 	require.Len(t, mockServer.SentResponses, 7)
 
@@ -98,7 +98,7 @@ func TestLabelNamesAndValues_FilteredValues(t *testing.T) {
 	var valueFilter = func(_, value string) (bool, error) {
 		return strings.Contains(value, "0"), nil
 	}
-	require.NoError(t, labelNamesAndValues(&mockIndex{existingLabels: existingLabels}, []*labels.Matcher{}, 32, stream, valueFilter))
+	require.NoError(t, labelNamesAndValues(context.Background(), &mockIndex{existingLabels: existingLabels}, []*labels.Matcher{}, 32, stream, valueFilter))
 
 	require.Len(t, mockServer.SentResponses, 2)
 
@@ -292,6 +292,7 @@ func TestLabelNamesAndValues_ContextCancellation(t *testing.T) {
 	doneCh := make(chan error, 1)
 	go func() {
 		err := labelNamesAndValues(
+			context.Background(),
 			idxReader,
 			[]*labels.Matcher{},
 			1*1024*1024, // 1MB


### PR DESCRIPTION
#### What this PR does

Adds labels to profiling that identify the read requests.

We're already adding the trace ID when the request is sampled, this would also add the method, userID and matchers of that read request.

This should help debugging issues when ingesters are busy running heavy
queries.

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


