### PR TITLE
Mimir query engine: Add PromQL engine test cases from Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277 #8291 #8303 #8340 #8256 #8348
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.promql-engine=mimir`. #7693 #7898 #7899 #8023 #8058 #8096 #8121 #8197 #8230 #8247 #8270 #8276 #8277 #8291 #8303 #8340 #8256 #8348 #8422
 * [FEATURE] New `/ingester/unregister-on-shutdown` HTTP endpoint allows dynamic access to ingesters' `-ingester.ring.unregister-on-shutdown` configuration. #7739
 * [FEATURE] Server: added experimental [PROXY protocol support](https://www.haproxy.org/download/2.3/doc/proxy-protocol.txt). The PROXY protocol support can be enabled via `-server.proxy-protocol-enabled=true`. When enabled, the support is added both to HTTP and gRPC listening ports. #7698
 * [FEATURE] mimirtool: Add `runtime-config verify` sub-command, for verifying Mimir runtime config files. #8123

--- a/pkg/streamingpromql/testdata/upstream/functions.test
+++ b/pkg/streamingpromql/testdata/upstream/functions.test
@@ -1424,3 +1424,12 @@ load 5m
 # 	{l="y"} -Inf
 
 clear
+
+# Test that timestamp() handles the scenario where there are more steps than samples.
+load 1m
+  metric 0+1x1000
+
+# We expect the value to be 0 for t=0s to t=59s (inclusive), then 60 for t=60s and t=61s.
+# Unsupported by streaming engine.
+# eval range from 0 to 61s step 1s timestamp(metric)
+#  {} 0x59 60 60

--- a/pkg/streamingpromql/testdata/upstream/range_queries.test
+++ b/pkg/streamingpromql/testdata/upstream/range_queries.test
@@ -1,0 +1,79 @@
+# sum_over_time with all values
+load 30s
+  bar 0 1 10 100 1000
+
+# Unsupported by streaming engine.
+# eval range from 0 to 2m step 1m sum_over_time(bar[30s])
+#   {} 0 11 1100
+
+clear
+
+# sum_over_time with trailing values
+load 30s
+  bar 0 1 10 100 1000 0 0 0 0
+
+# Unsupported by streaming engine.
+# eval range from 0 to 2m step 1m sum_over_time(bar[30s])
+#   {} 0 11 1100
+
+clear
+
+# sum_over_time with all values long
+load 30s
+  bar 0 1 10 100 1000 10000 100000 1000000 10000000
+
+# Unsupported by streaming engine.
+# eval range from 0 to 4m step 1m sum_over_time(bar[30s])
+#   {} 0 11 1100 110000 11000000
+
+clear
+
+# sum_over_time with all values random
+load 30s
+  bar 5 17 42 2 7 905 51
+
+# Unsupported by streaming engine.
+# eval range from 0 to 3m step 1m sum_over_time(bar[30s])
+#   {} 5 59 9 956
+
+clear
+
+# metric query
+load 30s
+  metric 1+1x4
+
+eval range from 0 to 2m step 1m metric
+  metric 1 3 5
+
+clear
+
+# metric query with trailing values
+load 30s
+  metric 1+1x8
+
+eval range from 0 to 2m step 1m metric
+  metric 1 3 5
+
+clear
+
+# short-circuit
+load 30s
+  foo{job="1"} 1+1x4
+  bar{job="2"} 1+1x4
+
+# Unsupported by streaming engine.
+# eval range from 0 to 2m step 1m foo > 2 or bar
+#   foo{job="1"} _ 3 5
+#   bar{job="2"} 1 3 5
+
+clear
+
+# Drop metric name
+load 30s
+  requests{job="1", __address__="bar"} 100
+
+# Unsupported by streaming engine.
+# eval range from 0 to 2m step 1m requests * 2
+#   {job="1", __address__="bar"} 200 200 200
+
+clear


### PR DESCRIPTION
#### What this PR does

This PR brings in the test cases added in https://github.com/prometheus/prometheus/pull/14305 so that they are run against the Mimir query engine.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
