### PR TITLE
Remove panic calls from remoteReadQueryRequest

### DIFF
--- a/pkg/frontend/querymiddleware/cardinality.go
+++ b/pkg/frontend/querymiddleware/cardinality.go
@@ -76,7 +76,10 @@ func (c *cardinalityEstimation) Do(ctx context.Context, request MetricsQueryRequ
 
 	estimatedCardinality, estimateAvailable := c.lookupCardinalityForKey(ctx, k)
 	if estimateAvailable {
-		request = request.WithEstimatedSeriesCountHint(estimatedCardinality)
+		request, err = request.WithEstimatedSeriesCountHint(estimatedCardinality)
+		if err != nil {
+			return c.next.Do(ctx, request)
+		}
 		spanLog.LogFields(
 			otlog.Bool("estimate available", true),
 			otlog.Uint64("estimated cardinality", estimatedCardinality),

--- a/pkg/frontend/querymiddleware/cardinality.go
+++ b/pkg/frontend/querymiddleware/cardinality.go
@@ -76,10 +76,11 @@ func (c *cardinalityEstimation) Do(ctx context.Context, request MetricsQueryRequ
 
 	estimatedCardinality, estimateAvailable := c.lookupCardinalityForKey(ctx, k)
 	if estimateAvailable {
-		request, err = request.WithEstimatedSeriesCountHint(estimatedCardinality)
+		newRequest, err := request.WithEstimatedSeriesCountHint(estimatedCardinality)
 		if err != nil {
 			return c.next.Do(ctx, request)
 		}
+		request = newRequest
 		spanLog.LogFields(
 			otlog.Bool("estimate available", true),
 			otlog.Uint64("estimated cardinality", estimatedCardinality),

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -117,7 +117,7 @@ type MetricsQueryRequest interface {
 	// These hints can be used to optimize the query execution.
 	GetHints() *Hints
 	// WithID clones the current request with the provided ID.
-	WithID(id int64) MetricsQueryRequest
+	WithID(id int64) (MetricsQueryRequest, error)
 	// WithStartEnd clone the current request with different start and end timestamp.
 	// Implementations must ensure minT and maxT are recalculated when the start and end timestamp change.
 	WithStartEnd(startTime int64, endTime int64) (MetricsQueryRequest, error)

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -125,10 +125,10 @@ type MetricsQueryRequest interface {
 	// Implementations must ensure minT and maxT are recalculated when the query changes.
 	WithQuery(string) (MetricsQueryRequest, error)
 	// WithHeaders clones the current request with different headers.
-	WithHeaders([]*PrometheusHeader) MetricsQueryRequest
+	WithHeaders([]*PrometheusHeader) (MetricsQueryRequest, error)
 	// WithExpr clones the current `PrometheusRangeQueryRequest` with a new query expression.
 	// Implementations must ensure minT and maxT are recalculated when the query changes.
-	WithExpr(parser.Expr) MetricsQueryRequest
+	WithExpr(parser.Expr) (MetricsQueryRequest, error)
 	// WithTotalQueriesHint adds the number of total queries to this request's Hints.
 	WithTotalQueriesHint(int32) MetricsQueryRequest
 	// WithEstimatedSeriesCountHint WithEstimatedCardinalityHint adds a cardinality estimate to this request's Hints.

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -130,9 +130,9 @@ type MetricsQueryRequest interface {
 	// Implementations must ensure minT and maxT are recalculated when the query changes.
 	WithExpr(parser.Expr) (MetricsQueryRequest, error)
 	// WithTotalQueriesHint adds the number of total queries to this request's Hints.
-	WithTotalQueriesHint(int32) MetricsQueryRequest
+	WithTotalQueriesHint(int32) (MetricsQueryRequest, error)
 	// WithEstimatedSeriesCountHint WithEstimatedCardinalityHint adds a cardinality estimate to this request's Hints.
-	WithEstimatedSeriesCountHint(uint64) MetricsQueryRequest
+	WithEstimatedSeriesCountHint(uint64) (MetricsQueryRequest, error)
 	// AddSpanTags writes information about this request to an OpenTracing span
 	AddSpanTags(opentracing.Span)
 }

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -459,7 +459,7 @@ func TestMetricsQuery_WithQuery_WithExpr_TransformConsistency(t *testing.T) {
 
 			// test WithExpr on the same query as WithQuery
 			queryExpr, err := parser.ParseExpr(testCase.updatedQuery)
-			updatedMetricsQuery = testCase.initialMetricsQuery.WithExpr(queryExpr)
+			updatedMetricsQuery = mustSucceed(testCase.initialMetricsQuery.WithExpr(queryExpr))
 
 			if err != nil || testCase.expectedErr != nil {
 				require.IsType(t, testCase.expectedErr, err)

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -210,7 +210,7 @@ func (r *PrometheusRangeQueryRequest) WithExpr(queryExpr parser.Expr) (MetricsQu
 
 // WithTotalQueriesHint clones the current `PrometheusRangeQueryRequest` with an
 // added Hint value for TotalQueries.
-func (r *PrometheusRangeQueryRequest) WithTotalQueriesHint(totalQueries int32) MetricsQueryRequest {
+func (r *PrometheusRangeQueryRequest) WithTotalQueriesHint(totalQueries int32) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(r.headers)
 	if newRequest.hints == nil {
@@ -219,12 +219,12 @@ func (r *PrometheusRangeQueryRequest) WithTotalQueriesHint(totalQueries int32) M
 		*newRequest.hints = *(r.hints)
 		newRequest.hints.TotalQueries = totalQueries
 	}
-	return &newRequest
+	return &newRequest, nil
 }
 
 // WithEstimatedSeriesCountHint clones the current `PrometheusRangeQueryRequest`
 // with an added Hint value for EstimatedCardinality.
-func (r *PrometheusRangeQueryRequest) WithEstimatedSeriesCountHint(count uint64) MetricsQueryRequest {
+func (r *PrometheusRangeQueryRequest) WithEstimatedSeriesCountHint(count uint64) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(r.headers)
 	if newRequest.hints == nil {
@@ -235,7 +235,7 @@ func (r *PrometheusRangeQueryRequest) WithEstimatedSeriesCountHint(count uint64)
 		*newRequest.hints = *(r.hints)
 		newRequest.hints.CardinalityEstimate = &EstimatedSeriesCount{count}
 	}
-	return &newRequest
+	return &newRequest, nil
 }
 
 // AddSpanTags writes the current `PrometheusRangeQueryRequest` parameters to the specified span tags
@@ -413,7 +413,7 @@ func (r *PrometheusInstantQueryRequest) WithExpr(queryExpr parser.Expr) (Metrics
 	return &newRequest, nil
 }
 
-func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32) MetricsQueryRequest {
+func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(r.headers)
 	if newRequest.hints == nil {
@@ -422,10 +422,10 @@ func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32)
 		*newRequest.hints = *(r.hints)
 		newRequest.hints.TotalQueries = totalQueries
 	}
-	return &newRequest
+	return &newRequest, nil
 }
 
-func (r *PrometheusInstantQueryRequest) WithEstimatedSeriesCountHint(count uint64) MetricsQueryRequest {
+func (r *PrometheusInstantQueryRequest) WithEstimatedSeriesCountHint(count uint64) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(r.headers)
 	if newRequest.hints == nil {
@@ -436,7 +436,7 @@ func (r *PrometheusInstantQueryRequest) WithEstimatedSeriesCountHint(count uint6
 		*newRequest.hints = *(r.hints)
 		newRequest.hints.CardinalityEstimate = &EstimatedSeriesCount{count}
 	}
-	return &newRequest
+	return &newRequest, nil
 }
 
 // AddSpanTags writes query information about the current `PrometheusInstantQueryRequest`

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -149,11 +149,11 @@ func (r *PrometheusRangeQueryRequest) GetHints() *Hints {
 }
 
 // WithID clones the current `PrometheusRangeQueryRequest` with the provided ID.
-func (r *PrometheusRangeQueryRequest) WithID(id int64) MetricsQueryRequest {
+func (r *PrometheusRangeQueryRequest) WithID(id int64) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.id = id
-	return &newRequest
+	return &newRequest, nil
 }
 
 // WithStartEnd clones the current `PrometheusRangeQueryRequest` with a new `start` and `end` timestamp.
@@ -355,11 +355,11 @@ func (r *PrometheusInstantQueryRequest) GetHints() *Hints {
 	return r.hints
 }
 
-func (r *PrometheusInstantQueryRequest) WithID(id int64) MetricsQueryRequest {
+func (r *PrometheusInstantQueryRequest) WithID(id int64) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.id = id
-	return &newRequest
+	return &newRequest, nil
 }
 
 // WithStartEnd clones the current `PrometheusInstantQueryRequest` with a new `time` timestamp.

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -189,14 +189,14 @@ func (r *PrometheusRangeQueryRequest) WithQuery(query string) (MetricsQueryReque
 }
 
 // WithHeaders clones the current `PrometheusRangeQueryRequest` with new headers.
-func (r *PrometheusRangeQueryRequest) WithHeaders(headers []*PrometheusHeader) MetricsQueryRequest {
+func (r *PrometheusRangeQueryRequest) WithHeaders(headers []*PrometheusHeader) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(headers)
-	return &newRequest
+	return &newRequest, nil
 }
 
 // WithExpr clones the current `PrometheusRangeQueryRequest` with a new query expression.
-func (r *PrometheusRangeQueryRequest) WithExpr(queryExpr parser.Expr) MetricsQueryRequest {
+func (r *PrometheusRangeQueryRequest) WithExpr(queryExpr parser.Expr) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.queryExpr = queryExpr
@@ -205,7 +205,7 @@ func (r *PrometheusRangeQueryRequest) WithExpr(queryExpr parser.Expr) MetricsQue
 			newRequest.queryExpr, newRequest.GetStart(), newRequest.GetEnd(), newRequest.GetStep(), newRequest.lookbackDelta,
 		)
 	}
-	return &newRequest
+	return &newRequest, nil
 }
 
 // WithTotalQueriesHint clones the current `PrometheusRangeQueryRequest` with an
@@ -394,14 +394,14 @@ func (r *PrometheusInstantQueryRequest) WithQuery(query string) (MetricsQueryReq
 }
 
 // WithHeaders clones the current `PrometheusRangeQueryRequest` with new headers.
-func (r *PrometheusInstantQueryRequest) WithHeaders(headers []*PrometheusHeader) MetricsQueryRequest {
+func (r *PrometheusInstantQueryRequest) WithHeaders(headers []*PrometheusHeader) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(headers)
-	return &newRequest
+	return &newRequest, nil
 }
 
 // WithExpr clones the current `PrometheusInstantQueryRequest` with a new query expression.
-func (r *PrometheusInstantQueryRequest) WithExpr(queryExpr parser.Expr) MetricsQueryRequest {
+func (r *PrometheusInstantQueryRequest) WithExpr(queryExpr parser.Expr) (MetricsQueryRequest, error) {
 	newRequest := *r
 	newRequest.headers = cloneHeaders(r.headers)
 	newRequest.queryExpr = queryExpr
@@ -410,7 +410,7 @@ func (r *PrometheusInstantQueryRequest) WithExpr(queryExpr parser.Expr) MetricsQ
 			newRequest.queryExpr, newRequest.GetStart(), newRequest.GetEnd(), newRequest.GetStep(), newRequest.lookbackDelta,
 		)
 	}
-	return &newRequest
+	return &newRequest, nil
 }
 
 func (r *PrometheusInstantQueryRequest) WithTotalQueriesHint(totalQueries int32) MetricsQueryRequest {

--- a/pkg/frontend/querymiddleware/model_extra_test.go
+++ b/pkg/frontend/querymiddleware/model_extra_test.go
@@ -122,7 +122,8 @@ func TestMetricQueryRequestCloneHeaders(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Run("WithID", func(t *testing.T) {
-				r := originalReq.WithID(1234)
+				r, err := originalReq.WithID(1234)
+				require.NoError(t, err)
 				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
 			})
 			t.Run("WithHeaders", func(t *testing.T) {

--- a/pkg/frontend/querymiddleware/model_extra_test.go
+++ b/pkg/frontend/querymiddleware/model_extra_test.go
@@ -132,7 +132,8 @@ func TestMetricQueryRequestCloneHeaders(t *testing.T) {
 					{Name: "X-Test-Header", Values: []string{"test-value"}},
 				}
 
-				r := originalReq.WithHeaders(newHeaders)
+				r, err := originalReq.WithHeaders(newHeaders)
+				require.NoError(t, err)
 				validateClonedHeaders(t, r.GetHeaders(), newHeaders)
 			})
 			t.Run("WithStartEnd", func(t *testing.T) {
@@ -152,7 +153,8 @@ func TestMetricQueryRequestCloneHeaders(t *testing.T) {
 				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
 			})
 			t.Run("WithExpr", func(t *testing.T) {
-				r := originalReq.WithExpr(nil)
+				r, err := originalReq.WithExpr(nil)
+				require.NoError(t, err)
 				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
 			})
 			t.Run("WithEstimatedSeriesCountHint", func(t *testing.T) {

--- a/pkg/frontend/querymiddleware/model_extra_test.go
+++ b/pkg/frontend/querymiddleware/model_extra_test.go
@@ -149,7 +149,8 @@ func TestMetricQueryRequestCloneHeaders(t *testing.T) {
 				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
 			})
 			t.Run("WithTotalQueriesHint", func(t *testing.T) {
-				r := originalReq.WithTotalQueriesHint(10)
+				r, err := originalReq.WithTotalQueriesHint(10)
+				require.NoError(t, err)
 				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
 			})
 			t.Run("WithExpr", func(t *testing.T) {
@@ -158,7 +159,8 @@ func TestMetricQueryRequestCloneHeaders(t *testing.T) {
 				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
 			})
 			t.Run("WithEstimatedSeriesCountHint", func(t *testing.T) {
-				r := originalReq.WithEstimatedSeriesCountHint(10)
+				r, err := originalReq.WithEstimatedSeriesCountHint(10)
+				require.NoError(t, err)
 				validateClonedHeaders(t, r.GetHeaders(), originalReq.GetHeaders())
 			})
 		})

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1686,12 +1686,12 @@ func TestQuerySharding_ShouldUseCardinalityEstimate(t *testing.T) {
 	}{
 		{
 			"range query",
-			mustSucceed(req.WithStartEnd(util.TimeToMillis(start), util.TimeToMillis(end))).WithEstimatedSeriesCountHint(55_000),
+			mustSucceed(mustSucceed(req.WithStartEnd(util.TimeToMillis(start), util.TimeToMillis(end))).WithEstimatedSeriesCountHint(55_000)),
 			6,
 		},
 		{
 			"instant query",
-			req.WithEstimatedSeriesCountHint(29_000),
+			mustSucceed(req.WithEstimatedSeriesCountHint(29_000)),
 			3,
 		},
 		{

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -277,8 +277,8 @@ func (r *remoteReadQueryRequest) GetHeaders() []*PrometheusHeader {
 	return nil
 }
 
-func (r *remoteReadQueryRequest) WithID(_ int64) MetricsQueryRequest {
-	panic("not implemented")
+func (r *remoteReadQueryRequest) WithID(_ int64) (MetricsQueryRequest, error) {
+	return nil, apierror.New(apierror.TypeInternal, "remoteReadQueryRequest.WithID not implemented")
 }
 
 func (r *remoteReadQueryRequest) WithEstimatedSeriesCountHint(_ uint64) MetricsQueryRequest {

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -285,16 +285,16 @@ func (r *remoteReadQueryRequest) WithEstimatedSeriesCountHint(_ uint64) MetricsQ
 	panic("not implemented")
 }
 
-func (r *remoteReadQueryRequest) WithExpr(_ parser.Expr) MetricsQueryRequest {
-	panic("not implemented")
+func (r *remoteReadQueryRequest) WithExpr(_ parser.Expr) (MetricsQueryRequest, error) {
+	return nil, apierror.New(apierror.TypeInternal, "remoteReadQueryRequest.WithExpr not implemented")
 }
 
 func (r *remoteReadQueryRequest) WithQuery(_ string) (MetricsQueryRequest, error) {
 	panic("not implemented")
 }
 
-func (r *remoteReadQueryRequest) WithHeaders(_ []*PrometheusHeader) MetricsQueryRequest {
-	panic("not implemented")
+func (r *remoteReadQueryRequest) WithHeaders(_ []*PrometheusHeader) (MetricsQueryRequest, error) {
+	return nil, apierror.New(apierror.TypeInternal, "remoteReadQueryRequest.WithHeaders not implemented")
 }
 
 // WithStartEnd clones the current remoteReadQueryRequest with a new start and end timestamp.

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -281,8 +281,8 @@ func (r *remoteReadQueryRequest) WithID(_ int64) (MetricsQueryRequest, error) {
 	return nil, apierror.New(apierror.TypeInternal, "remoteReadQueryRequest.WithID not implemented")
 }
 
-func (r *remoteReadQueryRequest) WithEstimatedSeriesCountHint(_ uint64) MetricsQueryRequest {
-	panic("not implemented")
+func (r *remoteReadQueryRequest) WithEstimatedSeriesCountHint(_ uint64) (MetricsQueryRequest, error) {
+	return nil, apierror.New(apierror.TypeInternal, "remoteReadQueryRequest.WithEstimatedSeriesCountHint not implemented")
 }
 
 func (r *remoteReadQueryRequest) WithExpr(_ parser.Expr) (MetricsQueryRequest, error) {
@@ -290,7 +290,7 @@ func (r *remoteReadQueryRequest) WithExpr(_ parser.Expr) (MetricsQueryRequest, e
 }
 
 func (r *remoteReadQueryRequest) WithQuery(_ string) (MetricsQueryRequest, error) {
-	panic("not implemented")
+	return nil, apierror.New(apierror.TypeInternal, "remoteReadQueryRequest.WithQuery not implemented")
 }
 
 func (r *remoteReadQueryRequest) WithHeaders(_ []*PrometheusHeader) (MetricsQueryRequest, error) {
@@ -320,8 +320,8 @@ func (r *remoteReadQueryRequest) WithStartEnd(start int64, end int64) (MetricsQu
 	return remoteReadToMetricsQueryRequest(r.path, clonedQuery)
 }
 
-func (r *remoteReadQueryRequest) WithTotalQueriesHint(_ int32) MetricsQueryRequest {
-	panic("not implemented")
+func (r *remoteReadQueryRequest) WithTotalQueriesHint(_ int32) (MetricsQueryRequest, error) {
+	return nil, apierror.New(apierror.TypeInternal, "remoteReadQueryRequest.WithTotalQueriesHint not implemented")
 }
 
 // cloneRemoteReadQuery returns a deep copy of the input prompb.Query. To keep this function safe,

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -542,7 +542,11 @@ func (s *splitRequests) prepareDownstreamRequests() ([]MetricsQueryRequest, erro
 			if err != nil {
 				return nil, err
 			}
-			splitReq.downstreamRequests[i] = newRequest.WithTotalQueriesHint(int32(numDownstreamRequests))
+			newRequest, err = newRequest.WithTotalQueriesHint(int32(numDownstreamRequests))
+			if err != nil {
+				return nil, err
+			}
+			splitReq.downstreamRequests[i] = newRequest
 			nextReqID++
 		}
 

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -215,7 +215,10 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req MetricsQueryReques
 	}
 
 	// Prepare and execute the downstream requests.
-	execReqs := splitReqs.prepareDownstreamRequests()
+	execReqs, err := splitReqs.prepareDownstreamRequests()
+	if err != nil {
+		return nil, err
+	}
 
 	// Update query stats.
 	// Only consider the actual number of downstream requests, not the cache hits.
@@ -519,12 +522,12 @@ func (s *splitRequests) countDownstreamResponseBytes() int {
 
 // prepareDownstreamRequests injects a unique ID and hints to all downstream requests and
 // initialize downstream responses slice to have the same length of requests.
-func (s *splitRequests) prepareDownstreamRequests() []MetricsQueryRequest {
+func (s *splitRequests) prepareDownstreamRequests() ([]MetricsQueryRequest, error) {
 	// Count the total number of downstream requests to run and build the hints we're going
 	// to attach to each request.
 	numDownstreamRequests := s.countDownstreamRequests()
 	if numDownstreamRequests == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Build the whole list of requests to execute. For each downstream request,
@@ -535,7 +538,11 @@ func (s *splitRequests) prepareDownstreamRequests() []MetricsQueryRequest {
 	execReqs := make([]MetricsQueryRequest, 0, numDownstreamRequests)
 	for _, splitReq := range *s {
 		for i := 0; i < len(splitReq.downstreamRequests); i++ {
-			splitReq.downstreamRequests[i] = splitReq.downstreamRequests[i].WithID(nextReqID).WithTotalQueriesHint(int32(numDownstreamRequests))
+			newRequest, err := splitReq.downstreamRequests[i].WithID(nextReqID)
+			if err != nil {
+				return nil, err
+			}
+			splitReq.downstreamRequests[i] = newRequest.WithTotalQueriesHint(int32(numDownstreamRequests))
 			nextReqID++
 		}
 
@@ -543,7 +550,7 @@ func (s *splitRequests) prepareDownstreamRequests() []MetricsQueryRequest {
 		splitReq.downstreamResponses = make([]Response, len(splitReq.downstreamRequests))
 	}
 
-	return execReqs
+	return execReqs, nil
 }
 
 // storeDownstreamResponses associates the given executed requestResponse with the downstream requests

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -1319,9 +1319,9 @@ func TestSplitRequests_prepareDownstreamRequests(t *testing.T) {
 				{downstreamRequests: []MetricsQueryRequest{&PrometheusRangeQueryRequest{start: 3}}},
 			},
 			expected: []MetricsQueryRequest{
-				(&PrometheusRangeQueryRequest{start: 1}).WithID(1).WithTotalQueriesHint(3),
-				(&PrometheusRangeQueryRequest{start: 2}).WithID(2).WithTotalQueriesHint(3),
-				(&PrometheusRangeQueryRequest{start: 3}).WithID(3).WithTotalQueriesHint(3),
+				mustSucceed((&PrometheusRangeQueryRequest{start: 1}).WithID(1)).WithTotalQueriesHint(3),
+				mustSucceed((&PrometheusRangeQueryRequest{start: 2}).WithID(2)).WithTotalQueriesHint(3),
+				mustSucceed((&PrometheusRangeQueryRequest{start: 3}).WithID(3)).WithTotalQueriesHint(3),
 			},
 		},
 	}
@@ -1333,7 +1333,7 @@ func TestSplitRequests_prepareDownstreamRequests(t *testing.T) {
 				require.Empty(t, req.downstreamResponses)
 			}
 
-			assert.Equal(t, testData.expected, testData.input.prepareDownstreamRequests())
+			assert.Equal(t, testData.expected, mustSucceed(testData.input.prepareDownstreamRequests()))
 
 			// Ensure responses slices have been initialized.
 			for _, req := range testData.input {

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -1319,9 +1319,9 @@ func TestSplitRequests_prepareDownstreamRequests(t *testing.T) {
 				{downstreamRequests: []MetricsQueryRequest{&PrometheusRangeQueryRequest{start: 3}}},
 			},
 			expected: []MetricsQueryRequest{
-				mustSucceed((&PrometheusRangeQueryRequest{start: 1}).WithID(1)).WithTotalQueriesHint(3),
-				mustSucceed((&PrometheusRangeQueryRequest{start: 2}).WithID(2)).WithTotalQueriesHint(3),
-				mustSucceed((&PrometheusRangeQueryRequest{start: 3}).WithID(3)).WithTotalQueriesHint(3),
+				mustSucceed(mustSucceed((&PrometheusRangeQueryRequest{start: 1}).WithID(1)).WithTotalQueriesHint(3)),
+				mustSucceed(mustSucceed((&PrometheusRangeQueryRequest{start: 2}).WithID(2)).WithTotalQueriesHint(3)),
+				mustSucceed(mustSucceed((&PrometheusRangeQueryRequest{start: 3}).WithID(3)).WithTotalQueriesHint(3)),
 			},
 		},
 	}

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -175,8 +175,11 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Metr
 	if err != nil {
 		return nil, err
 	}
-	req = newRequest.WithTotalQueriesHint(int32(mapperStats.GetSplitQueries()))
-	shardedQueryable := newShardedQueryable(req, s.next)
+	newRequest, err = newRequest.WithTotalQueriesHint(int32(mapperStats.GetSplitQueries()))
+	if err != nil {
+		return nil, err
+	}
+	shardedQueryable := newShardedQueryable(newRequest, s.next)
 
 	qry, err := newQuery(ctx, req, s.engine, lazyquery.NewLazyQueryable(shardedQueryable))
 	if err != nil {

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -171,7 +171,11 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Metr
 	s.metrics.splitQueriesPerQuery.Observe(float64(mapperStats.GetSplitQueries()))
 
 	// Send hint with number of embedded queries to the sharding middleware
-	req = req.WithExpr(instantSplitQuery).WithTotalQueriesHint(int32(mapperStats.GetSplitQueries()))
+	newRequest, err := req.WithExpr(instantSplitQuery)
+	if err != nil {
+		return nil, err
+	}
+	req = newRequest.WithTotalQueriesHint(int32(mapperStats.GetSplitQueries()))
 	shardedQueryable := newShardedQueryable(req, s.next)
 
 	qry, err := newQuery(ctx, req, s.engine, lazyquery.NewLazyQueryable(shardedQueryable))

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -171,15 +171,15 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Metr
 	s.metrics.splitQueriesPerQuery.Observe(float64(mapperStats.GetSplitQueries()))
 
 	// Send hint with number of embedded queries to the sharding middleware
-	newRequest, err := req.WithExpr(instantSplitQuery)
+	req, err = req.WithExpr(instantSplitQuery)
 	if err != nil {
 		return nil, err
 	}
-	newRequest, err = newRequest.WithTotalQueriesHint(int32(mapperStats.GetSplitQueries()))
+	req, err = req.WithTotalQueriesHint(int32(mapperStats.GetSplitQueries()))
 	if err != nil {
 		return nil, err
 	}
-	shardedQueryable := newShardedQueryable(newRequest, s.next)
+	shardedQueryable := newShardedQueryable(req, s.next)
 
 	qry, err := newQuery(ctx, req, s.engine, lazyquery.NewLazyQueryable(shardedQueryable))
 	if err != nil {


### PR DESCRIPTION
#### What this PR does

Get rid of `panic` calls in the newly introduced `remoteReadQueryRequest`

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir-squad/issues/2148 (internal)

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
