### PR TITLE
Add unit test to check remote write v1 histogram equivalence

### DIFF
--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -220,7 +220,7 @@ func TestFromFPointsToSamples(t *testing.T) {
 // Check that Prometheus FPoint and Mimir Sample types converted
 // into each other with unsafe.Pointer are compatible
 func TestPrometheusFPointInSyncWithMimirPbSample(t *testing.T) {
-	test.RequireSameShape(t, promql.FPoint{}, Sample{}, true)
+	test.RequireSameShape(t, promql.FPoint{}, Sample{}, true, false)
 }
 
 func BenchmarkFromFPointsToSamples(b *testing.B) {
@@ -248,7 +248,7 @@ func TestFromHPointsToHistograms(t *testing.T) {
 // Check that Prometheus HPoint and Mimir FloatHistogramPair types converted
 // into each other with unsafe.Pointer are compatible
 func TestPrometheusHPointInSyncWithMimirPbFloatHistogramPair(t *testing.T) {
-	test.RequireSameShape(t, promql.HPoint{}, FloatHistogramPair{}, true)
+	test.RequireSameShape(t, promql.HPoint{}, FloatHistogramPair{}, true, false)
 }
 
 func BenchmarkFromHPointsToHistograms(b *testing.B) {
@@ -625,7 +625,7 @@ func TestFromFloatHistogramToPromHistogram(t *testing.T) {
 // Check that Prometheus and Mimir SampleHistogram types converted
 // into each other with unsafe.Pointer are compatible
 func TestPrometheusSampleHistogramInSyncWithMimirPbSampleHistogram(t *testing.T) {
-	test.RequireSameShape(t, model.SampleHistogram{}, SampleHistogram{}, false)
+	test.RequireSameShape(t, model.SampleHistogram{}, SampleHistogram{}, false, false)
 }
 
 // Check that Prometheus Label and MimirPb LabelAdapter types
@@ -738,4 +738,8 @@ func TestCompareLabelAdapters(t *testing.T) {
 		got = CompareLabelAdapters(test.compared, labels)
 		require.Equal(t, -sign(test.expected), sign(got), "unexpected comparison result for reverse test case %d", i)
 	}
+}
+
+func TestRemoteWriteV1HistogramEquivalence(t *testing.T) {
+	test.RequireSameShape(t, prompb.Histogram{}, Histogram{}, false, true)
 }

--- a/pkg/mimirpb/query_response_extra_test.go
+++ b/pkg/mimirpb/query_response_extra_test.go
@@ -77,7 +77,7 @@ func extractPrometheusStrings(t *testing.T, constantType string) []string {
 // FloatHistogram types converted into each other with unsafe.Pointer
 // are compatible
 func TestFloatHistogramProtobufTypeRemainsInSyncWithPrometheus(t *testing.T) {
-	test.RequireSameShape(t, histogram.FloatHistogram{}, FloatHistogram{}, false)
+	test.RequireSameShape(t, histogram.FloatHistogram{}, FloatHistogram{}, false, false)
 }
 
 // This example is from an investigation into a bug in the ruler. Keeping it here for future reference.


### PR DESCRIPTION
This will become even more important with the upcoming V2 of the protocol which has an additional field in histograms called custom_values for custom bucket native histograms.

https://github.com/prometheus/prometheus/blob/cdebf06ad97d19c5cf5ed4d1e384503adee7c0b7/prompb/io/prometheus/write/v2/types.proto#L228
