### PR TITLE
objtools: fix 5GiB+ server-side copies on S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@
 * [ENHANCEMENT] ulidtime: add option to show random part of ULID, timestamp in milliseconds and header. #7615
 * [ENHANCEMENT] copyblocks: add a flag to configure part-size for multipart uploads in s3 client-side copying. #8292
 * [ENHANCEMENT] copyblocks: enable pprof HTTP endpoints. #8292
+* [BUGFIX] objtools: use a multipart upload to server-side copy objects greater than 5GiB in size on S3. #8427
 
 ## 2.12.0
 

--- a/pkg/util/objtools/s3.go
+++ b/pkg/util/objtools/s3.go
@@ -112,7 +112,7 @@ func (bkt *s3Bucket) ServerSideCopy(ctx context.Context, objectName string, dstB
 
 	parts := stat.Size / maxSingleCopySize
 	if stat.Size%maxSingleCopySize != 0 {
-		parts += 1
+		parts++
 	}
 	srcOptions := make([]minio.CopySrcOptions, 0, parts)
 	start := int64(0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

S3 only allows `CopyObject` to be used on objects <= 5GiB in size ([docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/copy-object.html)). This limitation was encountered when trying to use `undelete-blocks` on a large block (I anonymized object information):

> 2024/06/18 12:14:08 ERROR failed to undelete block tenant=(tenant) block=(block) err="The specified copy source is larger than the maximum allowable size for a copy source: 5368709120\nfailed to restore object (tenant)/(block)/index with version (version)

This fix works around this by first checking the object to be copied with a `HEAD` request to find out its size. If it is small enough to be copied with `CopyObject` it is. Otherwise if it is too large then a multipart upload is used where each part is an increasing byte range of the object. Minio unfortunately adds an unnecessary `HEAD` request for each part, but there's no way to work around that while using their client.

Opening as a draft until this is manually tested.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2163

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
