### PR TITLE
Mimir query engine: add support for basic trigonometric and mathematical functions

### DIFF
--- a/pkg/streamingpromql/functions.go
+++ b/pkg/streamingpromql/functions.go
@@ -89,10 +89,32 @@ func createRateFunctionOperator(args []types.Operator, pool *pooling.LimitingPoo
 
 // These functions return an instant-vector.
 var instantVectorFunctionOperatorFactories = map[string]InstantVectorFunctionOperatorFactory{
+	"abs":             TransformationFunctionOperatorFactory("abs", functions.Abs),
 	"acos":            TransformationFunctionOperatorFactory("acos", functions.Acos),
+	"acosh":           TransformationFunctionOperatorFactory("acosh", functions.Acosh),
+	"asin":            TransformationFunctionOperatorFactory("asin", functions.Asin),
+	"asinh":           TransformationFunctionOperatorFactory("asinh", functions.Asinh),
+	"atan":            TransformationFunctionOperatorFactory("atan", functions.Atan),
+	"atanh":           TransformationFunctionOperatorFactory("atanh", functions.Atanh),
+	"ceil":            TransformationFunctionOperatorFactory("ceil", functions.Ceil),
+	"cos":             TransformationFunctionOperatorFactory("cos", functions.Cos),
+	"cosh":            TransformationFunctionOperatorFactory("cosh", functions.Cosh),
+	"deg":             TransformationFunctionOperatorFactory("deg", functions.Deg),
+	"exp":             TransformationFunctionOperatorFactory("exp", functions.Exp),
+	"floor":           TransformationFunctionOperatorFactory("floor", functions.Floor),
 	"histogram_count": TransformationFunctionOperatorFactory("histogram_count", functions.HistogramCount),
 	"histogram_sum":   TransformationFunctionOperatorFactory("histogram_sum", functions.HistogramSum),
+	"ln":              TransformationFunctionOperatorFactory("ln", functions.Ln),
+	"log10":           TransformationFunctionOperatorFactory("log10", functions.Log10),
+	"log2":            TransformationFunctionOperatorFactory("log2", functions.Log2),
+	"rad":             TransformationFunctionOperatorFactory("rad", functions.Rad),
 	"rate":            createRateFunctionOperator,
+	"sgn":             TransformationFunctionOperatorFactory("sgn", functions.Sgn),
+	"sin":             TransformationFunctionOperatorFactory("sin", functions.Sin),
+	"sinh":            TransformationFunctionOperatorFactory("sinh", functions.Sinh),
+	"sqrt":            TransformationFunctionOperatorFactory("sqrt", functions.Sqrt),
+	"tan":             TransformationFunctionOperatorFactory("tan", functions.Tan),
+	"tanh":            TransformationFunctionOperatorFactory("tanh", functions.Tanh),
 }
 
 func RegisterInstantVectorFunctionOperatorFactory(functionName string, factory InstantVectorFunctionOperatorFactory) error {

--- a/pkg/streamingpromql/functions/math.go
+++ b/pkg/streamingpromql/functions/math.go
@@ -6,4 +6,45 @@ import (
 	"math"
 )
 
+var Abs = FloatTransformationDropHistogramsFunc(math.Abs)
 var Acos = FloatTransformationDropHistogramsFunc(math.Acos)
+var Acosh = FloatTransformationDropHistogramsFunc(math.Acosh)
+var Asin = FloatTransformationDropHistogramsFunc(math.Asin)
+var Asinh = FloatTransformationDropHistogramsFunc(math.Asinh)
+var Atan = FloatTransformationDropHistogramsFunc(math.Atan)
+var Atanh = FloatTransformationDropHistogramsFunc(math.Atanh)
+var Ceil = FloatTransformationDropHistogramsFunc(math.Ceil)
+var Cos = FloatTransformationDropHistogramsFunc(math.Cos)
+var Cosh = FloatTransformationDropHistogramsFunc(math.Cosh)
+var Exp = FloatTransformationDropHistogramsFunc(math.Exp)
+var Floor = FloatTransformationDropHistogramsFunc(math.Floor)
+var Ln = FloatTransformationDropHistogramsFunc(math.Log)
+var Log10 = FloatTransformationDropHistogramsFunc(math.Log10)
+var Log2 = FloatTransformationDropHistogramsFunc(math.Log2)
+var Sin = FloatTransformationDropHistogramsFunc(math.Sin)
+var Sinh = FloatTransformationDropHistogramsFunc(math.Sinh)
+var Sqrt = FloatTransformationDropHistogramsFunc(math.Sqrt)
+var Tan = FloatTransformationDropHistogramsFunc(math.Tan)
+var Tanh = FloatTransformationDropHistogramsFunc(math.Tanh)
+
+var Deg = FloatTransformationDropHistogramsFunc(func(f float64) float64 {
+	return f * 180 / math.Pi
+})
+
+var Rad = FloatTransformationDropHistogramsFunc(func(f float64) float64 {
+	return f * math.Pi / 180
+})
+
+var Sgn = FloatTransformationDropHistogramsFunc(func(f float64) float64 {
+	if f < 0 {
+		return -1
+	}
+
+	if f > 0 {
+		return 1
+	}
+
+	// This behaviour is undocumented, but if f is +/- NaN, Prometheus' engine returns that value.
+	// Otherwise, if the value is 0, we should return 0.
+	return f
+})

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -42,9 +42,24 @@ eval range from 0 to 5m step 1m rate(some_metric_with_stale_marker[2m])
 
 clear
 
-# Test simple functions
+# Test simple functions not covered by the upstream tests
 load 1m
-  some_metric{env="prod"} 0 0.5 NaN
+  some_metric{env="prod"} 0 0.5 -0.5 NaN -NaN 2.1 -2.1
 
-eval range from 0 to 2m step 1m acos(some_metric)
-  {env="prod"} 1.5707963267948966 1.0471975511965976 NaN
+eval range from 0 to 4m step 1m abs(some_metric)
+  {env="prod"} 0 0.5 0.5 NaN NaN
+
+eval range from 0 to 4m step 1m acos(some_metric)
+  {env="prod"} 1.5707963267948966 1.0471975511965976 2.0943951023931957 NaN NaN
+
+eval range from 0 to 4m step 1m asin(some_metric)
+  {env="prod"} 0 0.5235987755982989 -0.5235987755982989 NaN NaN
+
+eval range from 0 to 4m step 1m atanh(some_metric)
+  {env="prod"} 0 0.5493061443340548 -0.5493061443340548 NaN NaN
+
+eval range from 0 to 6m step 1m ceil(some_metric)
+  {env="prod"} 0 1 -0 NaN -NaN 3 -2
+
+eval range from 0 to 6m step 1m floor(some_metric)
+  {env="prod"} 0 0 -1 NaN -NaN 2 -3

--- a/pkg/streamingpromql/testdata/upstream/functions.test
+++ b/pkg/streamingpromql/testdata/upstream/functions.test
@@ -506,14 +506,13 @@ load 5m
 	test_sgn{src="sgn-e"}	0
 	test_sgn{src="sgn-f"}	100
 
-# Unsupported by streaming engine.
-# eval instant at 0m sgn(test_sgn)
-# 	{src="sgn-a"}	-1
-# 	{src="sgn-b"}	1
-# 	{src="sgn-c"}	NaN
-# 	{src="sgn-d"}	-1
-# 	{src="sgn-e"}	0
-# 	{src="sgn-f"}	1
+eval instant at 0m sgn(test_sgn)
+ 	{src="sgn-a"}	-1
+ 	{src="sgn-b"}	1
+ 	{src="sgn-c"}	NaN
+ 	{src="sgn-d"}	-1
+ 	{src="sgn-e"}	0
+ 	{src="sgn-f"}	1
 
 
 # Tests for sort/sort_desc.
@@ -1353,10 +1352,9 @@ load 5m
 	exp_root_log{l="x"} 10
 	exp_root_log{l="y"} 20
 
-# Unsupported by streaming engine.
-# eval instant at 5m exp(exp_root_log)
-# 	{l="x"} 22026.465794806718
-# 	{l="y"} 485165195.4097903
+eval instant at 5m exp(exp_root_log)
+ 	{l="x"} 22026.465794806718
+ 	{l="y"} 485165195.4097903
 
 # Unsupported by streaming engine.
 # eval instant at 5m exp(exp_root_log - 10)
@@ -1368,10 +1366,9 @@ load 5m
 # 	{l="x"} 4.5399929762484854e-05
 # 	{l="y"} 1
 
-# Unsupported by streaming engine.
-# eval instant at 5m ln(exp_root_log)
-# 	{l="x"} 2.302585092994046
-# 	{l="y"} 2.995732273553991
+eval instant at 5m ln(exp_root_log)
+ 	{l="x"} 2.302585092994046
+ 	{l="y"} 2.995732273553991
 
 # Unsupported by streaming engine.
 # eval instant at 5m ln(exp_root_log - 10)
@@ -1383,20 +1380,17 @@ load 5m
 # 	{l="y"} -Inf
 # 	{l="x"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m exp(ln(exp_root_log))
-# 	{l="y"} 20
-# 	{l="x"} 10
+eval instant at 5m exp(ln(exp_root_log))
+ 	{l="y"} 20
+ 	{l="x"} 10
 
-# Unsupported by streaming engine.
-# eval instant at 5m sqrt(exp_root_log)
-# 	{l="x"} 3.1622776601683795
-# 	{l="y"} 4.47213595499958
+eval instant at 5m sqrt(exp_root_log)
+ 	{l="x"} 3.1622776601683795
+ 	{l="y"} 4.47213595499958
 
-# Unsupported by streaming engine.
-# eval instant at 5m log2(exp_root_log)
-# 	{l="x"} 3.3219280948873626
-# 	{l="y"} 4.321928094887363
+eval instant at 5m log2(exp_root_log)
+ 	{l="x"} 3.3219280948873626
+ 	{l="y"} 4.321928094887363
 
 # Unsupported by streaming engine.
 # eval instant at 5m log2(exp_root_log - 10)
@@ -1408,10 +1402,9 @@ load 5m
 # 	{l="x"} NaN
 # 	{l="y"} -Inf
 
-# Unsupported by streaming engine.
-# eval instant at 5m log10(exp_root_log)
-# 	{l="x"} 1
-# 	{l="y"} 1.301029995663981
+eval instant at 5m log10(exp_root_log)
+ 	{l="x"} 1
+ 	{l="y"} 1.301029995663981
 
 # Unsupported by streaming engine.
 # eval instant at 5m log10(exp_root_log - 10)

--- a/pkg/streamingpromql/testdata/upstream/trig_functions.test
+++ b/pkg/streamingpromql/testdata/upstream/trig_functions.test
@@ -10,23 +10,20 @@ load 5m
 	trig{l="y"} 20
 	trig{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m sin(trig)
-# 	{l="x"} -0.5440211108893699
-# 	{l="y"} 0.9129452507276277
-# 	{l="NaN"} NaN
+eval instant at 5m sin(trig)
+ 	{l="x"} -0.5440211108893699
+ 	{l="y"} 0.9129452507276277
+ 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m cos(trig)
-# 	{l="x"} -0.8390715290764524
-# 	{l="y"} 0.40808206181339196
-# 	{l="NaN"} NaN
+eval instant at 5m cos(trig)
+ 	{l="x"} -0.8390715290764524
+ 	{l="y"} 0.40808206181339196
+ 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m tan(trig)
-# 	{l="x"} 0.6483608274590867
-# 	{l="y"} 2.2371609442247427
-# 	{l="NaN"} NaN
+eval instant at 5m tan(trig)
+ 	{l="x"} 0.6483608274590867
+ 	{l="y"} 2.2371609442247427
+ 	{l="NaN"} NaN
 
 # Unsupported by streaming engine.
 # eval instant at 5m asin(trig - 10.1)
@@ -40,41 +37,35 @@ load 5m
 # 	{l="y"} NaN
 # 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m atan(trig)
-# 	{l="x"} 1.4711276743037345
-# 	{l="y"} 1.5208379310729538
-# 	{l="NaN"} NaN
+eval instant at 5m atan(trig)
+ 	{l="x"} 1.4711276743037345
+ 	{l="y"} 1.5208379310729538
+ 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m sinh(trig)
-# 	{l="x"} 11013.232920103324
-# 	{l="y"} 2.4258259770489514e+08
-# 	{l="NaN"} NaN
+eval instant at 5m sinh(trig)
+ 	{l="x"} 11013.232920103324
+ 	{l="y"} 2.4258259770489514e+08
+ 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m cosh(trig)
-# 	{l="x"} 11013.232920103324
-# 	{l="y"} 2.4258259770489514e+08
-# 	{l="NaN"} NaN
+eval instant at 5m cosh(trig)
+ 	{l="x"} 11013.232920103324
+ 	{l="y"} 2.4258259770489514e+08
+ 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m tanh(trig)
-# 	{l="x"} 0.9999999958776927
-# 	{l="y"} 1
-# 	{l="NaN"} NaN
+eval instant at 5m tanh(trig)
+ 	{l="x"} 0.9999999958776927
+ 	{l="y"} 1
+ 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m asinh(trig)
-# 	{l="x"} 2.99822295029797
-# 	{l="y"} 3.6895038689889055
-# 	{l="NaN"} NaN
+eval instant at 5m asinh(trig)
+ 	{l="x"} 2.99822295029797
+ 	{l="y"} 3.6895038689889055
+ 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m acosh(trig)
-# 	{l="x"} 2.993222846126381
-# 	{l="y"} 3.6882538673612966
-# 	{l="NaN"} NaN
+eval instant at 5m acosh(trig)
+ 	{l="x"} 2.993222846126381
+ 	{l="y"} 3.6882538673612966
+ 	{l="NaN"} NaN
 
 # Unsupported by streaming engine.
 # eval instant at 5m atanh(trig - 10.1)
@@ -82,11 +73,10 @@ load 5m
 # 	{l="y"} NaN
 # 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m rad(trig)
-# 	{l="x"} 0.17453292519943295
-# 	{l="y"} 0.3490658503988659
-# 	{l="NaN"} NaN
+eval instant at 5m rad(trig)
+ 	{l="x"} 0.17453292519943295
+ 	{l="y"} 0.3490658503988659
+ 	{l="NaN"} NaN
 
 # Unsupported by streaming engine.
 # eval instant at 5m rad(trig - 10)
@@ -100,11 +90,10 @@ load 5m
 # 	{l="y"} 0
 # 	{l="NaN"} NaN
 
-# Unsupported by streaming engine.
-# eval instant at 5m deg(trig)
-# 	{l="x"} 572.9577951308232
-# 	{l="y"} 1145.9155902616465
-# 	{l="NaN"} NaN
+eval instant at 5m deg(trig)
+	{l="x"} 572.9577951308232
+ 	{l="y"} 1145.9155902616465
+ 	{l="NaN"} NaN
 
 # Unsupported by streaming engine.
 # eval instant at 5m deg(trig - 10)
@@ -123,4 +112,4 @@ clear
 # Unsupported by streaming engine.
 # eval instant at 0s pi()
 # 	3.141592653589793
-# 
+#


### PR DESCRIPTION
#### What this PR does

This PR adds support for a number of basic trigonometric and mathematical functions to the Mimir query engine:

* `abs`
* `acosh`
* `asin`
* `asinh`
* `atan`
* `atanh`
* `ceil`
* `cos`
* `cosh`
* `deg`
* `exp`
* `floor`
* `ln`
* `log10`
* `log2`
* `rad`
* `sgn`
* `sin`
* `sinh`
* `sqrt`
* `tan`
* `tanh`

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
