### PR TITLE
Honor start/end in the remote read request hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * [ENHANCEMENT] Query-frontend: added `remote_read` to `op` supported label values for the `cortex_query_frontend_queries_total` metric. #8412
 * [ENHANCEMENT] Query-frontend: log the overall length and start, end time offset from current time for remote read requests. The start and end times are calculated as the miminum and maximum times of the individual queries in the remote read request. #8404
 * [ENHANCEMENT] Storage Provider: Added option `-<prefix>.s3.dualstack-enabled` that allows disabling S3 client from resolving AWS S3 endpoint into dual-stack IPv4/IPv6 endpoint. Defaults to true. #8405
+* [ENHANCEMENT] Querier: honor the start/end time range specified in the read hints when executing a remote read request. #8431
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [CHANGE] Ruler: promote tenant federation from experimental to stable. #8400
 * [CHANGE] Ruler: promote `-ruler.recording-rules-evaluation-enabled` and `-ruler.alerting-rules-evaluation-enabled` from experimental to stable. #8400
 * [CHANGE] General: promote `-tenant-federation.max-tenants` from experimental to stable. #8400
+* [CHANGE] Querier: honor the start/end time range specified in the read hints when executing a remote read request. #8431
 * [FEATURE] Continuous-test: now runable as a module with `mimir -target=continuous-test`. #7747
 * [FEATURE] Store-gateway: Allow specific tenants to be enabled or disabled via `-store-gateway.enabled-tenants` or `-store-gateway.disabled-tenants` CLI flags or their corresponding YAML settings. #7653
 * [FEATURE] New `-<prefix>.s3.bucket-lookup-type` flag configures lookup style type, used to access bucket in s3 compatible providers. #7684
@@ -70,7 +71,6 @@
 * [ENHANCEMENT] Query-frontend: added `remote_read` to `op` supported label values for the `cortex_query_frontend_queries_total` metric. #8412
 * [ENHANCEMENT] Query-frontend: log the overall length and start, end time offset from current time for remote read requests. The start and end times are calculated as the miminum and maximum times of the individual queries in the remote read request. #8404
 * [ENHANCEMENT] Storage Provider: Added option `-<prefix>.s3.dualstack-enabled` that allows disabling S3 client from resolving AWS S3 endpoint into dual-stack IPv4/IPv6 endpoint. Defaults to true. #8405
-* [ENHANCEMENT] Querier: honor the start/end time range specified in the read hints when executing a remote read request. #8431
 * [BUGFIX] Distributor: prometheus retry on 5xx and 429 errors, while otlp collector only retry on 429, 502, 503 and 504, mapping other 5xx errors to the retryable ones in otlp endpoint. #8324 #8339
 * [BUGFIX] Distributor: make OTLP endpoint return marshalled proto bytes as response body for 4xx/5xx errors. #8227
 * [BUGFIX] Rules: improve error handling when querier is local to the ruler. #7567

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -306,7 +306,7 @@ func checkQueries(
 
 				for _, req := range remoteReadRequests {
 					t.Run(fmt.Sprintf("%s: remote read: %s", endpoint, req.metricName), func(t *testing.T) {
-						httpRes, result, _, err := c.RemoteRead(req.metricName, req.startTime, req.endTime)
+						httpRes, result, _, err := c.RemoteRead(remoteReadQueryByMetricName(req.metricName, req.startTime, req.endTime))
 						require.NoError(t, err)
 						require.Equal(t, http.StatusOK, httpRes.StatusCode)
 						require.NotNil(t, result)

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -256,18 +256,9 @@ func (c *Client) QueryRangeRaw(query string, start, end time.Time, step time.Dur
 // RemoteRead uses samples streaming. See RemoteReadChunks as well for chunks streaming.
 // RemoteRead returns the HTTP response with consumed body, the remote read protobuf response and an error.
 // In case the response is not a protobuf, the plaintext body content is returned instead of the protobuf message.
-func (c *Client) RemoteRead(metricName string, start, end time.Time) (_ *http.Response, _ *prompb.QueryResult, plaintextResponse []byte, _ error) {
+func (c *Client) RemoteRead(query *prompb.Query) (_ *http.Response, _ *prompb.QueryResult, plaintextResponse []byte, _ error) {
 	req := &prompb.ReadRequest{
-		Queries: []*prompb.Query{{
-			Matchers:         []*prompb.LabelMatcher{{Type: prompb.LabelMatcher_EQ, Name: labels.MetricName, Value: metricName}},
-			StartTimestampMs: start.UnixMilli(),
-			EndTimestampMs:   end.UnixMilli(),
-			Hints: &prompb.ReadHints{
-				StepMs:  1,
-				StartMs: start.UnixMilli(),
-				EndMs:   end.UnixMilli(),
-			},
-		}},
+		Queries: []*prompb.Query{query},
 	}
 	resp, err := c.doRemoteReadReq(req)
 	if err != nil {

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -27,7 +27,6 @@ import (
 	promapi "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/prompb" // OTLP protos are not compatible with gogo
 	"github.com/prometheus/prometheus/storage/remote"
@@ -291,18 +290,9 @@ func (c *Client) RemoteRead(query *prompb.Query) (_ *http.Response, _ *prompb.Qu
 // RemoteReadChunks uses chunks streaming. See RemoteRead as well for samples streaming.
 // RemoteReadChunks returns the HTTP response with consumed body, the remote read protobuf response and an error.
 // In case the response is not a protobuf, the plaintext body content is returned instead of the protobuf message.
-func (c *Client) RemoteReadChunks(metricName string, start, end time.Time) (_ *http.Response, _ []prompb.ChunkedReadResponse, plaintextResponse []byte, _ error) {
+func (c *Client) RemoteReadChunks(query *prompb.Query) (_ *http.Response, _ []prompb.ChunkedReadResponse, plaintextResponse []byte, _ error) {
 	req := &prompb.ReadRequest{
-		Queries: []*prompb.Query{{
-			Matchers:         []*prompb.LabelMatcher{{Type: prompb.LabelMatcher_EQ, Name: labels.MetricName, Value: metricName}},
-			StartTimestampMs: start.UnixMilli(),
-			EndTimestampMs:   end.UnixMilli(),
-			Hints: &prompb.ReadHints{
-				StepMs:  1,
-				StartMs: start.UnixMilli(),
-				EndMs:   end.UnixMilli(),
-			},
-		}},
+		Queries:               []*prompb.Query{query},
 		AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_STREAMED_XOR_CHUNKS},
 	}
 

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage/remote"
@@ -33,6 +34,10 @@ func TestQuerierRemoteRead(t *testing.T) {
 	flags := mergeFlags(
 		BlocksStorageFlags(),
 		BlocksStorageS3Flags(),
+		map[string]string{
+			// This test writes samples sparse in time.
+			"-blocks-storage.tsdb.block-ranges-period": "2h",
+		},
 	)
 
 	// Start dependencies.
@@ -59,40 +64,90 @@ func TestQuerierRemoteRead(t *testing.T) {
 	// Wait until the querier has updated the ring.
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
-	runTestPushSeriesForQuerierRemoteRead(t, c, querier, "series_1", generateFloatSeries)
-	runTestPushSeriesForQuerierRemoteRead(t, c, querier, "hseries_1", generateHistogramSeries)
+	t.Run("float series", func(t *testing.T) {
+		runTestPushSeriesForQuerierRemoteRead(t, c, querier, "series_1", generateFloatSeries)
+	})
+
+	t.Run("histogram series", func(t *testing.T) {
+		runTestPushSeriesForQuerierRemoteRead(t, c, querier, "hseries_1", generateHistogramSeries)
+	})
 }
 
 func runTestPushSeriesForQuerierRemoteRead(t *testing.T, c *e2emimir.Client, querier *e2emimir.MimirService, seriesName string, genSeries generateSeriesFunc) {
-	// Push a series for each user to Mimir.
 	now := time.Now()
 
-	series, expectedVectors, _ := genSeries(seriesName, now)
-	res, err := c.Push(series)
-	require.NoError(t, err)
-	require.Equal(t, 200, res.StatusCode)
+	// Generate multiple series, sparse in time.
+	series1, expectedVector1, _ := genSeries(seriesName, now.Add(-10*time.Minute))
+	series2, expectedVector2, _ := genSeries(seriesName, now)
 
-	startMs := now.Add(-1 * time.Minute)
-	endMs := now.Add(time.Minute)
+	for _, series := range [][]prompb.TimeSeries{series1, series2} {
+		res, err := c.Push(series)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+	}
 
-	client, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
-	require.NoError(t, err)
-	httpResp, resp, _, err := client.RemoteRead(seriesName, startMs, endMs)
-	require.Equal(t, http.StatusOK, httpResp.StatusCode)
-	require.NoError(t, err)
+	tests := map[string]struct {
+		query          *prompb.Query
+		expectedVector model.Vector
+	}{
+		"remote read request without hints": {
+			query: &prompb.Query{
+				Matchers:         remoteReadQueryMatchersByMetricName(seriesName),
+				StartTimestampMs: now.Add(-1 * time.Minute).UnixMilli(),
+				EndTimestampMs:   now.Add(+1 * time.Minute).UnixMilli(),
+			},
+			expectedVector: expectedVector2,
+		},
+		"remote read request with hints time range equal to query time range": {
+			query: &prompb.Query{
+				Matchers:         remoteReadQueryMatchersByMetricName(seriesName),
+				StartTimestampMs: now.Add(-1 * time.Minute).UnixMilli(),
+				EndTimestampMs:   now.Add(+1 * time.Minute).UnixMilli(),
+				Hints: &prompb.ReadHints{
+					StartMs: now.Add(-1 * time.Minute).UnixMilli(),
+					EndMs:   now.Add(+1 * time.Minute).UnixMilli(),
+				},
+			},
+			expectedVector: expectedVector2,
+		},
+		"remote read request with hints time range different than query time range": {
+			query: &prompb.Query{
+				Matchers:         remoteReadQueryMatchersByMetricName(seriesName),
+				StartTimestampMs: now.Add(-1 * time.Minute).UnixMilli(),
+				EndTimestampMs:   now.Add(+1 * time.Minute).UnixMilli(),
+				Hints: &prompb.ReadHints{
+					StartMs: now.Add(-11 * time.Minute).UnixMilli(),
+					EndMs:   now.Add(-9 * time.Minute).UnixMilli(),
+				},
+			},
+			expectedVector: expectedVector1,
+		},
+	}
 
-	// Validate the returned remote read data matches what was written
-	require.Len(t, resp.Timeseries, 1)
-	require.Len(t, resp.Timeseries[0].Labels, 1)
-	require.Equal(t, seriesName, resp.Timeseries[0].Labels[0].GetValue())
-	isSeriesFloat := len(resp.Timeseries[0].Samples) == 1
-	isSeriesHistogram := len(resp.Timeseries[0].Histograms) == 1
-	require.Equal(t, isSeriesFloat, !isSeriesHistogram)
-	if isSeriesFloat {
-		require.Equal(t, int64(expectedVectors[0].Timestamp), resp.Timeseries[0].Samples[0].Timestamp)
-		require.Equal(t, float64(expectedVectors[0].Value), resp.Timeseries[0].Samples[0].Value)
-	} else if isSeriesHistogram {
-		require.Equal(t, expectedVectors[0].Histogram, mimirpb.FromHistogramToPromHistogram(remote.HistogramProtoToHistogram(resp.Timeseries[0].Histograms[0])))
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			client, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
+			require.NoError(t, err)
+			httpResp, resp, _, err := client.RemoteRead(testData.query)
+			require.Equal(t, http.StatusOK, httpResp.StatusCode)
+			require.NoError(t, err)
+
+			// Validate the returned remote read data matches what was written
+			require.Len(t, resp.Timeseries, 1)
+			require.Len(t, resp.Timeseries[0].Labels, 1)
+			require.Equal(t, seriesName, resp.Timeseries[0].Labels[0].GetValue())
+			isSeriesFloat := len(resp.Timeseries[0].Samples) > 0
+			isSeriesHistogram := len(resp.Timeseries[0].Histograms) > 0
+			require.Equal(t, isSeriesFloat, !isSeriesHistogram)
+			if isSeriesFloat {
+				require.Len(t, resp.Timeseries[0].Samples, 1)
+				require.Equal(t, int64(testData.expectedVector[0].Timestamp), resp.Timeseries[0].Samples[0].Timestamp)
+				require.Equal(t, float64(testData.expectedVector[0].Value), resp.Timeseries[0].Samples[0].Value)
+			} else if isSeriesHistogram {
+				require.Len(t, resp.Timeseries[0].Histograms, 1)
+				require.Equal(t, testData.expectedVector[0].Histogram, mimirpb.FromHistogramToPromHistogram(remote.HistogramProtoToHistogram(resp.Timeseries[0].Histograms[0])))
+			}
+		})
 	}
 }
 

--- a/integration/querier_remote_read_test.go
+++ b/integration/querier_remote_read_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage/remote"
@@ -33,10 +32,6 @@ func TestQuerierRemoteRead(t *testing.T) {
 	flags := mergeFlags(
 		BlocksStorageFlags(),
 		BlocksStorageS3Flags(),
-		map[string]string{
-			// This test writes samples sparse in time. We don't want compaction to trigger while testing.
-			"-blocks-storage.tsdb.block-ranges-period": "2h",
-		},
 	)
 
 	// Start dependencies.
@@ -63,90 +58,40 @@ func TestQuerierRemoteRead(t *testing.T) {
 	// Wait until the querier has updated the ring.
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
-	t.Run("float series", func(t *testing.T) {
-		runTestPushSeriesForQuerierRemoteRead(t, c, querier, "series_1", generateFloatSeries)
-	})
-
-	t.Run("histogram series", func(t *testing.T) {
-		runTestPushSeriesForQuerierRemoteRead(t, c, querier, "hseries_1", generateHistogramSeries)
-	})
+	runTestPushSeriesForQuerierRemoteRead(t, c, querier, "series_1", generateFloatSeries)
+	runTestPushSeriesForQuerierRemoteRead(t, c, querier, "hseries_1", generateHistogramSeries)
 }
 
 func runTestPushSeriesForQuerierRemoteRead(t *testing.T, c *e2emimir.Client, querier *e2emimir.MimirService, seriesName string, genSeries generateSeriesFunc) {
+	// Push a series for each user to Mimir.
 	now := time.Now()
 
-	// Generate multiple series, sparse in time.
-	series1, expectedVector1, _ := genSeries(seriesName, now.Add(-10*time.Minute))
-	series2, expectedVector2, _ := genSeries(seriesName, now)
+	series, expectedVectors, _ := genSeries(seriesName, now)
+	res, err := c.Push(series)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
 
-	for _, series := range [][]prompb.TimeSeries{series1, series2} {
-		res, err := c.Push(series)
-		require.NoError(t, err)
-		require.Equal(t, 200, res.StatusCode)
-	}
+	startMs := now.Add(-1 * time.Minute)
+	endMs := now.Add(time.Minute)
 
-	tests := map[string]struct {
-		query          *prompb.Query
-		expectedVector model.Vector
-	}{
-		"remote read request without hints": {
-			query: &prompb.Query{
-				Matchers:         remoteReadQueryMatchersByMetricName(seriesName),
-				StartTimestampMs: now.Add(-1 * time.Minute).UnixMilli(),
-				EndTimestampMs:   now.Add(+1 * time.Minute).UnixMilli(),
-			},
-			expectedVector: expectedVector2,
-		},
-		"remote read request with hints time range equal to query time range": {
-			query: &prompb.Query{
-				Matchers:         remoteReadQueryMatchersByMetricName(seriesName),
-				StartTimestampMs: now.Add(-1 * time.Minute).UnixMilli(),
-				EndTimestampMs:   now.Add(+1 * time.Minute).UnixMilli(),
-				Hints: &prompb.ReadHints{
-					StartMs: now.Add(-1 * time.Minute).UnixMilli(),
-					EndMs:   now.Add(+1 * time.Minute).UnixMilli(),
-				},
-			},
-			expectedVector: expectedVector2,
-		},
-		"remote read request with hints time range different than query time range": {
-			query: &prompb.Query{
-				Matchers:         remoteReadQueryMatchersByMetricName(seriesName),
-				StartTimestampMs: now.Add(-1 * time.Minute).UnixMilli(),
-				EndTimestampMs:   now.Add(+1 * time.Minute).UnixMilli(),
-				Hints: &prompb.ReadHints{
-					StartMs: now.Add(-11 * time.Minute).UnixMilli(),
-					EndMs:   now.Add(-9 * time.Minute).UnixMilli(),
-				},
-			},
-			expectedVector: expectedVector1,
-		},
-	}
+	client, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
+	require.NoError(t, err)
+	httpResp, resp, _, err := client.RemoteRead(remoteReadQueryByMetricName(seriesName, startMs, endMs))
+	require.Equal(t, http.StatusOK, httpResp.StatusCode)
+	require.NoError(t, err)
 
-	for testName, testData := range tests {
-		t.Run(testName, func(t *testing.T) {
-			client, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
-			require.NoError(t, err)
-			httpResp, resp, _, err := client.RemoteRead(testData.query)
-			require.Equal(t, http.StatusOK, httpResp.StatusCode)
-			require.NoError(t, err)
-
-			// Validate the returned remote read data matches what was written
-			require.Len(t, resp.Timeseries, 1)
-			require.Len(t, resp.Timeseries[0].Labels, 1)
-			require.Equal(t, seriesName, resp.Timeseries[0].Labels[0].GetValue())
-			isSeriesFloat := len(resp.Timeseries[0].Samples) > 0
-			isSeriesHistogram := len(resp.Timeseries[0].Histograms) > 0
-			require.Equal(t, isSeriesFloat, !isSeriesHistogram)
-			if isSeriesFloat {
-				require.Len(t, resp.Timeseries[0].Samples, 1)
-				require.Equal(t, int64(testData.expectedVector[0].Timestamp), resp.Timeseries[0].Samples[0].Timestamp)
-				require.Equal(t, float64(testData.expectedVector[0].Value), resp.Timeseries[0].Samples[0].Value)
-			} else if isSeriesHistogram {
-				require.Len(t, resp.Timeseries[0].Histograms, 1)
-				require.Equal(t, testData.expectedVector[0].Histogram, mimirpb.FromHistogramToPromHistogram(remote.HistogramProtoToHistogram(resp.Timeseries[0].Histograms[0])))
-			}
-		})
+	// Validate the returned remote read data matches what was written
+	require.Len(t, resp.Timeseries, 1)
+	require.Len(t, resp.Timeseries[0].Labels, 1)
+	require.Equal(t, seriesName, resp.Timeseries[0].Labels[0].GetValue())
+	isSeriesFloat := len(resp.Timeseries[0].Samples) == 1
+	isSeriesHistogram := len(resp.Timeseries[0].Histograms) == 1
+	require.Equal(t, isSeriesFloat, !isSeriesHistogram)
+	if isSeriesFloat {
+		require.Equal(t, int64(expectedVectors[0].Timestamp), resp.Timeseries[0].Samples[0].Timestamp)
+		require.Equal(t, float64(expectedVectors[0].Value), resp.Timeseries[0].Samples[0].Value)
+	} else if isSeriesHistogram {
+		require.Equal(t, expectedVectors[0].Histogram, mimirpb.FromHistogramToPromHistogram(remote.HistogramProtoToHistogram(resp.Timeseries[0].Histograms[0])))
 	}
 }
 

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -586,7 +586,7 @@ overrides:
 		{
 			name: "query blocked via regex for remote read",
 			query: func(c *e2emimir.Client) (*http.Response, []byte, error) {
-				httpR, _, respBytes, err := c.RemoteRead(`blocked_series`, now.Add(-time.Hour*24*32), now)
+				httpR, _, respBytes, err := c.RemoteRead(remoteReadQueryByMetricName(`blocked_series`, now.Add(-time.Hour*24*32), now))
 				return httpR, respBytes, err
 			},
 			exclude:       []string{"querier"},
@@ -614,7 +614,7 @@ overrides:
 		{
 			name: "query blocked via equality for remote read",
 			query: func(c *e2emimir.Client) (*http.Response, []byte, error) {
-				httpR, _, respBytes, err := c.RemoteRead(`blocked_selector`, now.Add(-time.Hour*24*32), now)
+				httpR, _, respBytes, err := c.RemoteRead(remoteReadQueryByMetricName(`blocked_selector`, now.Add(-time.Hour*24*32), now))
 				return httpR, respBytes, err
 			},
 			exclude:       []string{"querier"},
@@ -710,7 +710,7 @@ overrides:
 		{
 			name: "query remote read time range exceeds the limit",
 			query: func(c *e2emimir.Client) (*http.Response, []byte, error) {
-				httpR, _, respBytes, err := c.RemoteRead(`metric`, now.Add(-time.Hour*24*32), now)
+				httpR, _, respBytes, err := c.RemoteRead(remoteReadQueryByMetricName(`metric`, now.Add(-time.Hour*24*32), now))
 				return httpR, respBytes, err
 			},
 			expStatusCode: http.StatusBadRequest,

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -719,7 +719,7 @@ overrides:
 		{
 			name: "query remote read time range exceeds the limit (streaming chunks)",
 			query: func(c *e2emimir.Client) (*http.Response, []byte, error) {
-				httpR, _, respBytes, err := c.RemoteReadChunks(`metric`, now.Add(-time.Hour*24*32), now)
+				httpR, _, respBytes, err := c.RemoteReadChunks(remoteReadQueryByMetricName(`metric`, now.Add(-time.Hour*24*32), now))
 				return httpR, respBytes, err
 			},
 			expStatusCode: http.StatusBadRequest,

--- a/integration/util.go
+++ b/integration/util.go
@@ -261,6 +261,30 @@ func GenerateNHistogramSeries(nSeries, nExemplars int, name func() string, ts ti
 	return
 }
 
+func filterSamplesByTimestamp(input []prompb.Sample, startMs, endMs int64) []prompb.Sample {
+	var filtered []prompb.Sample
+
+	for _, sample := range input {
+		if sample.Timestamp >= startMs && sample.Timestamp <= endMs {
+			filtered = append(filtered, sample)
+		}
+	}
+
+	return filtered
+}
+
+func filterHistogramsByTimestamp(input []prompb.Histogram, startMs, endMs int64) []prompb.Histogram {
+	var filtered []prompb.Histogram
+
+	for _, sample := range input {
+		if sample.Timestamp >= startMs && sample.Timestamp <= endMs {
+			filtered = append(filtered, sample)
+		}
+	}
+
+	return filtered
+}
+
 func prompbLabelsToMetric(pbLabels []prompb.Label) model.Metric {
 	metric := make(model.Metric, len(pbLabels))
 

--- a/integration/util.go
+++ b/integration/util.go
@@ -311,3 +311,22 @@ func vectorToPrompbTimeseries(vector model.Vector) []*prompb.TimeSeries {
 
 	return res
 }
+
+// remoteReadQueryByMetricName generates a prompb.Query to query series by metric name within
+// the given start / end interval.
+func remoteReadQueryByMetricName(metricName string, start, end time.Time) *prompb.Query {
+	return &prompb.Query{
+		Matchers:         remoteReadQueryMatchersByMetricName(metricName),
+		StartTimestampMs: start.UnixMilli(),
+		EndTimestampMs:   end.UnixMilli(),
+		Hints: &prompb.ReadHints{
+			StepMs:  1,
+			StartMs: start.UnixMilli(),
+			EndMs:   end.UnixMilli(),
+		},
+	}
+}
+
+func remoteReadQueryMatchersByMetricName(metricName string) []*prompb.LabelMatcher {
+	return []*prompb.LabelMatcher{{Type: prompb.LabelMatcher_EQ, Name: labels.MetricName, Value: metricName}}
+}

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -98,9 +98,10 @@ type MetricsQueryRequest interface {
 	GetPath() string
 	// GetHeaders returns the HTTP headers in the request.
 	GetHeaders() []*PrometheusHeader
-	// GetStart returns the start timestamp of the request in milliseconds.
+	// GetStart returns the start timestamp of the query time range in milliseconds.
 	GetStart() int64
-	// GetEnd returns the end timestamp of the request in milliseconds.
+	// GetEnd returns the end timestamp of the query time range in milliseconds.
+	// The start and end timestamp are set to the same value in case of an instant query.
 	GetEnd() int64
 	// GetStep returns the step of the request in milliseconds.
 	GetStep() int64

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -250,14 +250,22 @@ func (r *remoteReadQueryRequest) GetID() int64 {
 }
 
 func (r *remoteReadQueryRequest) GetMaxT() int64 {
-	// MaxT hint is ignored when the remote read query is executed.
-	// Therefore we return the end time.
+	// Mimir honors the start/end timerange defined in the read hints, but protects from the case
+	// the passed read hints are zero values (because unintentionally initialised but not set).
+	if r.query.Hints != nil && r.query.Hints.EndMs > 0 {
+		return r.query.Hints.EndMs
+	}
+
 	return r.GetEnd()
 }
 
 func (r *remoteReadQueryRequest) GetMinT() int64 {
-	// MinT hint is ignored when the remote read query is executed.
-	// Therefore we return the start time.
+	// Mimir honors the start/end timerange defined in the read hints, but protects from the case
+	// the passed read hints are zero values (because unintentionally initialised but not set).
+	if r.query.Hints != nil && r.query.Hints.StartMs > 0 {
+		return r.query.Hints.StartMs
+	}
+
 	return r.GetStart()
 }
 

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -480,6 +480,22 @@ func TestRemoteReadToMetricsQueryRequest(t *testing.T) {
 			expectedStep:  0,
 			expectedStart: 10,
 			expectedEnd:   20,
+			expectedMinT:  5,
+			expectedMaxT:  25,
+		},
+		"query with zero-value hints": {
+			query: &prompb.Query{
+				Matchers: []*prompb.LabelMatcher{
+					{Name: "__name__", Type: prompb.LabelMatcher_EQ, Value: "up"},
+				},
+				StartTimestampMs: 10,
+				EndTimestampMs:   20,
+				Hints:            &prompb.ReadHints{},
+			},
+			expectedQuery: "{__name__=\"up\"}",
+			expectedStep:  0,
+			expectedStart: 10,
+			expectedEnd:   20,
 			expectedMinT:  10,
 			expectedMaxT:  20,
 		},


### PR DESCRIPTION
#### What this PR does

Currently, Mimir ignored remote read requests hints. When Prometheus issue a remote read request, the time range in hints may be different than the start/end time range. For example, if you run `count_over_time(up[1h]) + count_over_time(up[2h])` (example query) in Prometheus you get 2 remote read requests with the following time ranges:

```
start: 1718859107525 (04:51:47) end: 1718869907525 (07:51:47) hints start: 1718862707525 (05:51:47) hints end: 1718869907525 (07:51:47)
start: 1718859107525 (04:51:47) end: 1718869907525 (07:51:47) hints start: 1718859107525 (04:51:47) hints end: 1718869907525 (07:51:47)
```

_Apparently, the start/end is always the max one, and hints may specify a smaller one (apparently, it looks the opposite than a normal query execution where start/end should be the queried time range and hints the actual time range for which you want the raw data to process in PromQL)._

Anyway, read hints are expected to be honored. Prometheus, which implements remote read endpoints too, honor the hints too.

In this PR I'm proposing to honoring read hints, but adding an extra protection for zero-valued hint values. The reason is that we don't know if in the while there are clients passing zero-valued hints (by mistake) and I would like to protect from it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
