### PR TITLE
Fix TestLabelNames_Cancelled flakyness

### DIFF
--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -207,7 +207,9 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 	)
 	assert.NoError(t, err)
 	t.Cleanup(func() {
-		assert.NoError(t, s.store.RemoveBlocksAndClose())
+		// Make sure to wait until all store dependencies have been stopped / closed
+		// in order to avoid flaky tests.
+		assert.NoError(t, s.store.RemoveBlocksCloseAndWait(context.Background()))
 	})
 
 	s.store = store


### PR DESCRIPTION
#### What this PR does

`TestLabelNames_Cancelled` is flaky because of [this](https://github.com/grafana/mimir/issues/8428#issuecomment-2179991237). To fix it, I propose to wait until snapshotter is effectively stopped in tests.

I start from the assumption that `Snapshotter.Start()` won't be called more than once, otherwise it panics. But `Snapshotter` didn't support multiple start-stop cycles even before (because it would panic in `Snapshotter.Stop()`.

#### Which issue(s) this PR fixes or relates to

Fixes #8428

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
