### PR TITLE
`t.Paralell()` in top20 slowest `pkg/ingester` tests

### DIFF
--- a/pkg/ingester/circuitbreaker_test.go
+++ b/pkg/ingester/circuitbreaker_test.go
@@ -356,7 +356,9 @@ func TestCircuitBreaker_FinishRequest(t *testing.T) {
 		},
 	}
 	for testName, testCase := range testCases {
+		testCase := testCase
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			registry := prometheus.NewRegistry()
 			cfg := CircuitBreakerConfig{
 				Enabled:        true,
@@ -395,7 +397,9 @@ func TestIngester_PushToStorage_CircuitBreaker(t *testing.T) {
 
 	for initialDelayEnabled, initialDelayStatus := range map[bool]string{false: "disabled", true: "enabled"} {
 		for testName, testCase := range tests {
+			testCase := testCase
 			t.Run(fmt.Sprintf("%s with initial delay %s", testName, initialDelayStatus), func(t *testing.T) {
+				t.Parallel()
 				metricLabelAdapters := [][]mimirpb.LabelAdapter{{{Name: labels.MetricName, Value: "test"}}}
 				metricNames := []string{
 					"cortex_ingester_circuit_breaker_results_total",
@@ -698,7 +702,9 @@ func TestIngester_FinishPushRequest(t *testing.T) {
 		},
 	}
 	for testName, testCase := range testCases {
+		testCase := testCase
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			reg := prometheus.NewPedanticRegistry()
 			cfg := defaultIngesterTestConfig(t)
 			cfg.PushCircuitBreaker = CircuitBreakerConfig{

--- a/pkg/ingester/ingester_early_compaction_test.go
+++ b/pkg/ingester/ingester_early_compaction_test.go
@@ -461,6 +461,7 @@ func TestIngester_compactBlocksToReduceInMemorySeries_Concurrency(t *testing.T) 
 
 	for r := 0; r < numRuns; r++ {
 		t.Run(fmt.Sprintf("Run %d", r), func(t *testing.T) {
+			t.Parallel()
 			var (
 				ctx         = context.Background()
 				ctxWithUser = user.InjectOrgID(ctx, userID)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -203,7 +203,9 @@ func TestIngester_StartPushRequest(t *testing.T) {
 		},
 	}
 	for testName, tc := range testCases {
+		tc := tc
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			failingIng := setupIngester(tc)
 			defer services.StopAndAwaitTerminated(context.Background(), failingIng) //nolint:errcheck
 
@@ -4207,7 +4209,9 @@ func TestIngester_LabelNames_ShouldNotCreateTSDBIfDoesNotExists(t *testing.T) {
 
 func TestIngester_Push_ShouldNotCreateTSDBIngesterServiceIsNotInRunningState(t *testing.T) {
 	for _, grpcLimitEnabled := range []bool{false, true} {
+		grpcLimitEnabled := grpcLimitEnabled
 		t.Run(fmt.Sprintf("gRPC limit enabled: %t", grpcLimitEnabled), func(t *testing.T) {
+			t.Parallel()
 			cfg := defaultIngesterTestConfig(t)
 			cfg.LimitInflightRequestsUsingGrpcMethodLimiter = grpcLimitEnabled
 
@@ -5793,6 +5797,7 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 		testName := name
 		testData := test
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			limits := defaultLimitsTestConfig()
 
 			overrides, err := validation.NewOverrides(limits, nil)
@@ -6465,7 +6470,9 @@ func TestIngester_flushing(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			cfg := defaultIngesterTestConfig(t)
 			cfg.BlocksStorageConfig.TSDB.ShipConcurrency = 1
 			cfg.BlocksStorageConfig.TSDB.ShipInterval = 1 * time.Minute // Long enough to not be reached during the test.
@@ -7478,9 +7485,13 @@ func TestIngester_PushInstanceLimits(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			for _, grpcLimiterEnabled := range []bool{false, true} {
+				grpcLimiterEnabled := grpcLimiterEnabled
 				t.Run(fmt.Sprintf("with gRPC limiter: %t", grpcLimiterEnabled), func(t *testing.T) {
+					t.Parallel()
 
 					// Create a mocked ingester
 					cfg := defaultIngesterTestConfig(t)
@@ -7963,7 +7974,9 @@ func testIngesterInflightPushRequests(t *testing.T, i *Ingester, reg prometheus.
 
 func TestIngester_inflightPushRequestsBytes(t *testing.T) {
 	for _, grpcLimitEnabled := range []bool{false, true} {
+		grpcLimitEnabled := grpcLimitEnabled
 		t.Run(fmt.Sprintf("gRPC limit enabled: %t", grpcLimitEnabled), func(t *testing.T) {
+			t.Parallel()
 			var limitsMx sync.Mutex
 			limits := InstanceLimits{MaxInflightPushRequestsBytes: 0}
 
@@ -9010,7 +9023,9 @@ func TestIngesterActiveSeries(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			registry := prometheus.NewRegistry()
 
 			// Create a mocked ingester
@@ -9532,7 +9547,9 @@ func TestIngesterActiveSeriesConfigChanges(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			registry := prometheus.NewRegistry()
 
 			// Create a mocked ingester
@@ -10013,8 +10030,11 @@ func TestIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T) {
 		},
 	}
 	for testName, testCfg := range tests {
+		testCfg := testCfg
 		for _, streamChunks := range []bool{false, true} {
+			streamChunks := streamChunks
 			t.Run(fmt.Sprintf("%s/streamChunks=%v", testName, streamChunks), func(t *testing.T) {
+				t.Parallel()
 				testIngesterCanEnableIngestAndQueryNativeHistograms(t, testCfg.sampleHistograms, testCfg.expectHistogram, streamChunks)
 			})
 		}
@@ -10498,7 +10518,9 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 	}
 
 	for testName, testData := range tests {
+		testData := testData
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			registry := prometheus.NewRegistry()
 
 			ingesterCfg := defaultIngesterTestConfig(t)
@@ -10960,7 +10982,9 @@ func TestIngester_Starting(t *testing.T) {
 
 	for testName, testCase := range tests {
 		cfg := defaultIngesterTestConfig(t)
+		testCase := testCase
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
 			var checkInitalRingState func(context.Context, *failingIngester)
 			var checkFinalRingState func(context.Context, *failingIngester)
 			if testCase.isIngesterInTheRing {

--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -702,7 +702,9 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c := ownedSeriesWithIngesterRingTestContext{
 				ownedSeriesTestContextBase: ownedSeriesTestContextBase{
 					user:          ownedServiceTestUser,
@@ -1430,7 +1432,9 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c := ownedSeriesWithPartitionsRingTestContext{
 				ownedSeriesTestContextBase: ownedSeriesTestContextBase{
 					user:          ownedServiceTestUserPartitionsRing,


### PR DESCRIPTION
#### What this PR does

Adds `t.Parallel()` to the test cases of 18 of the top 20 slowest `pkg/ingester` tests.

I extracted the list of the top20 slowest ones:

```
7.487s TestIngesterNoFlushWithInFlightRequest
8.480s TestIngester_LabelValuesCardinality_AllValuesToBeReturnedInSingleMessage
8.490s TestIngester_PushToStorage_CircuitBreaker
8.505s TestIngesterActiveSeriesConfigChanges
10.516s TestIngesterActiveSeries
12.475s TestIngester_Push_ShouldNotCreateTSDBIngesterServiceIsNotInRunningState
12.492s TestIngester_Starting
12.527s TestIngester_compactBlocksToReduceInMemorySeries_Concurrency
13.489s TestIngester_StartPushRequest
13.649s TestIngester_inflightPushRequestsBytes
14.513s TestIngester_flushing
16.481s TestIngester_PushInstanceLimits
16.489s TestIngester_FinishPushRequest
18.527s TestIngester_PushWithSampledErrors
20.514s TestIngesterCanEnableIngestAndQueryNativeHistograms
20.546s TestIngester_OpenExistingTSDBOnStartup
21.792s TestIngester_inflightPushRequests
28.510s TestOwnedSeriesServiceWithIngesterRing
35.561s TestOwnedSeriesServiceWithPartitionsRing
62.614s TestIngester_Push
```

Unfortunately, `TestIngester_Push` depends on a global state in `usagestats` so it can't run in parallel, and it's the largest offender, so maybe we should fix that and make usagestats injectable?

Also, `TestIngester_inflightPushRequests` fails if ran with `t.Parallel()`, I didn't investigate why.

Finally, I'm not sure why `TestIngester_compactBlocksToReduceInMemorySeries_Concurrency` runs the same test 3 times, but it runs equally well in parallel, so I left that as is (cc @pracucci)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
