### PR TITLE
Use minT and maxT fields as cache in PrometheusInstantQueryRequest

### DIFF
--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -332,19 +332,13 @@ func (r *PrometheusInstantQueryRequest) GetStep() int64 {
 // GetMinT returns the minimum timestamp in milliseconds of data to be queried,
 // as determined from the start timestamp and any range vector or offset in the query.
 func (r *PrometheusInstantQueryRequest) GetMinT() int64 {
-	minT, _ := decodeQueryMinMaxTime(
-		r.queryExpr, r.GetStart(), r.GetEnd(), r.GetStep(), r.lookbackDelta,
-	)
-	return minT
+	return r.minT
 }
 
 // GetMaxT returns the maximum timestamp in milliseconds of data to be queried,
 // as determined from the end timestamp and any offset in the query.
 func (r *PrometheusInstantQueryRequest) GetMaxT() int64 {
-	_, maxT := decodeQueryMinMaxTime(
-		r.queryExpr, r.GetStart(), r.GetEnd(), r.GetStep(), r.lookbackDelta,
-	)
-	return maxT
+	return r.maxT
 }
 
 func (r *PrometheusInstantQueryRequest) GetOptions() Options {

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -477,8 +477,8 @@ func TestPartitionCacheExtents(t *testing.T) {
 					start: 120,
 					end:   160,
 					step:  10,
-					minT:	 120,
-					maxT:	 160,
+					minT:  120,
+					maxT:  160,
 				},
 			},
 			expectedCachedResponse: []Response{

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -408,6 +408,8 @@ func TestPartitionCacheExtents(t *testing.T) {
 					start: 0,
 					end:   100,
 					step:  10,
+					minT:  0,
+					maxT:  100,
 				},
 			},
 		},
@@ -426,6 +428,8 @@ func TestPartitionCacheExtents(t *testing.T) {
 					start: 0,
 					end:   50,
 					step:  10,
+					minT:  0,
+					maxT:  50,
 				},
 			},
 			expectedCachedResponse: []Response{
@@ -448,6 +452,8 @@ func TestPartitionCacheExtents(t *testing.T) {
 					start: 120,
 					end:   160,
 					step:  10,
+					minT:  120,
+					maxT:  160,
 				},
 			},
 			expectedCachedResponse: []Response{
@@ -471,6 +477,8 @@ func TestPartitionCacheExtents(t *testing.T) {
 					start: 120,
 					end:   160,
 					step:  10,
+					minT:	 120,
+					maxT:	 160,
 				},
 			},
 			expectedCachedResponse: []Response{
@@ -527,11 +535,13 @@ func TestPartitionCacheExtents(t *testing.T) {
 				mkAPIResponse(486, 625, 33),
 			},
 			expectedRequests: []MetricsQueryRequest{
-				&PrometheusRangeQueryRequest{start: 123, end: 486, step: 33},
+				&PrometheusRangeQueryRequest{start: 123, end: 486, step: 33, minT: 123, maxT: 486},
 				&PrometheusRangeQueryRequest{
 					start: 651,  // next number after 625 (end of extent) such that it is equal to input.Start + N * input.Step.
 					end:   1000, // until the end
 					step:  33,   // unchanged
+					minT:  651,
+					maxT:  1000,
 				},
 			},
 		},

--- a/pkg/frontend/querymiddleware/step_align_test.go
+++ b/pkg/frontend/querymiddleware/step_align_test.go
@@ -32,6 +32,8 @@ func TestStepAlignMiddleware_SingleUser(t *testing.T) {
 				start: 0,
 				end:   100,
 				step:  10,
+				minT:  0,
+				maxT:  0,
 			},
 		},
 
@@ -46,6 +48,8 @@ func TestStepAlignMiddleware_SingleUser(t *testing.T) {
 				start: 0,
 				end:   100,
 				step:  10,
+				minT:  0,
+				maxT:  100,
 			},
 		},
 	} {
@@ -92,6 +96,8 @@ func TestStepAlignMiddleware_MultipleUsers(t *testing.T) {
 				start: 0,
 				end:   100,
 				step:  10,
+				minT:  0,
+				maxT:  0,
 			},
 		},
 		{
@@ -111,6 +117,8 @@ func TestStepAlignMiddleware_MultipleUsers(t *testing.T) {
 				start: 0,
 				end:   100,
 				step:  10,
+				minT:  0,
+				maxT:  100,
 			},
 		},
 		{
@@ -130,6 +138,8 @@ func TestStepAlignMiddleware_MultipleUsers(t *testing.T) {
 				start: 2,
 				end:   102,
 				step:  10,
+				minT:  0,
+				maxT:  0,
 			},
 		},
 	} {


### PR DESCRIPTION
#### What this PR does

Use minT and maxT fields as cache in PrometheusInstantQueryRequest for GetMinT and GetMaxT

The values were calculated then ignored.
Makes the behavior the same as PrometheusRangeQueryRequest.

Added unit tests where relevant.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir-squad/issues/2148 (internal)

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
