### PR TITLE
feat: add possibility to specify additional labels to continuous test generated metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@
 * [CHANGE] `-server.metrics-port` flag is no longer available for use in the module run of mimir-continuous-test, including the grafana/mimir-continuous-test Docker image which uses the new module. Configuring this port is still possible in the binary, which is deprecated. #7747
 * [CHANGE] Allowed authenticatication to Mimir using both Tenant ID and basic/bearer auth #7619.
 * [BUGFIX] Set `User-Agent` header for all requests sent from the testing client. #7607
+* [ENHANCEMENT] Added new flag `-tests.write-read-series-test.additional-labels` to add additional labels to the series written and read in the write-read-series test. #8449
 
 ### Query-tee
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 ### Mimir Continuous Test
 
+* [ENHANCEMENT] Added new flag `-tests.write-read-series-test.additional-labels` to add additional labels to the series written and read in the write-read-series test. #8449
+
 ### Query-tee
 
 * [ENHANCEMENT] Emit trace spans from query-tee. #8419
@@ -211,7 +213,6 @@
 * [CHANGE] `-server.metrics-port` flag is no longer available for use in the module run of mimir-continuous-test, including the grafana/mimir-continuous-test Docker image which uses the new module. Configuring this port is still possible in the binary, which is deprecated. #7747
 * [CHANGE] Allowed authenticatication to Mimir using both Tenant ID and basic/bearer auth #7619.
 * [BUGFIX] Set `User-Agent` header for all requests sent from the testing client. #7607
-* [ENHANCEMENT] Added new flag `-tests.write-read-series-test.additional-labels` to add additional labels to the series written and read in the write-read-series test. #8449
 
 ### Query-tee
 

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2885,6 +2885,8 @@ Usage of ./cmd/mimir/mimir:
     	The base endpoint on the write path. The URL should have no trailing slash. The specific API path is appended by the tool to the URL, for example /api/v1/push for the remote write API endpoint, so the configured URL must not include it.
   -tests.write-protocol string
     	The protocol to use to write series data. Supported values are: prometheus, otlp-http (default "prometheus")
+  -tests.write-read-series-test.additional-labels value
+    	Optional additional labels to add to the generated metrics in format of label1=value1,label2=value2
   -tests.write-read-series-test.float-samples-enabled
     	Set to true to use float samples (default true)
   -tests.write-read-series-test.histogram-samples-enabled

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -755,6 +755,8 @@ Usage of ./cmd/mimir/mimir:
     	The base endpoint on the write path. The URL should have no trailing slash. The specific API path is appended by the tool to the URL, for example /api/v1/push for the remote write API endpoint, so the configured URL must not include it.
   -tests.write-protocol string
     	The protocol to use to write series data. Supported values are: prometheus, otlp-http (default "prometheus")
+  -tests.write-read-series-test.additional-labels value
+    	Optional additional labels to add to the generated metrics in format of label1=value1,label2=value2
   -tests.write-read-series-test.float-samples-enabled
     	Set to true to use float samples (default true)
   -tests.write-read-series-test.histogram-samples-enabled

--- a/pkg/continuoustest/client_test.go
+++ b/pkg/continuoustest/client_test.go
@@ -67,7 +67,7 @@ func TestOTLPHttpClient_WriteSeries(t *testing.T) {
 		receivedRequests = nil
 		nextStatusCode = http.StatusOK
 
-		series := generateSineWaveSeries("test", now, 10)
+		series := generateSineWaveSeries("test", now, 10, []prompb.Label{})
 		statusCode, err := c.WriteSeries(ctx, series)
 		require.NoError(t, err)
 		assert.Equal(t, 200, statusCode)
@@ -80,7 +80,7 @@ func TestOTLPHttpClient_WriteSeries(t *testing.T) {
 		receivedRequests = nil
 		nextStatusCode = http.StatusOK
 
-		series := generateSineWaveSeries("test", now, 22)
+		series := generateSineWaveSeries("test", now, 22, []prompb.Label{})
 		statusCode, err := c.WriteSeries(ctx, series)
 		require.NoError(t, err)
 		assert.Equal(t, 200, statusCode)
@@ -95,7 +95,7 @@ func TestOTLPHttpClient_WriteSeries(t *testing.T) {
 		receivedRequests = nil
 		nextStatusCode = http.StatusBadRequest
 
-		series := generateSineWaveSeries("test", now, 1)
+		series := generateSineWaveSeries("test", now, 1, []prompb.Label{})
 		statusCode, err := c.WriteSeries(ctx, series)
 		require.Error(t, err)
 		assert.Equal(t, 400, statusCode)
@@ -105,7 +105,7 @@ func TestOTLPHttpClient_WriteSeries(t *testing.T) {
 		receivedRequests = nil
 		nextStatusCode = http.StatusInternalServerError
 
-		series := generateSineWaveSeries("test", now, 1)
+		series := generateSineWaveSeries("test", now, 1, []prompb.Label{})
 		statusCode, err := c.WriteSeries(ctx, series)
 		require.Error(t, err)
 		assert.Equal(t, 500, statusCode)
@@ -152,7 +152,7 @@ func TestPromWriterClient_WriteSeries(t *testing.T) {
 		receivedRequests = nil
 		nextStatusCode = http.StatusOK
 
-		series := generateSineWaveSeries("test", now, 10)
+		series := generateSineWaveSeries("test", now, 10, []prompb.Label{})
 		statusCode, err := c.WriteSeries(ctx, series)
 		require.NoError(t, err)
 		assert.Equal(t, 200, statusCode)
@@ -165,7 +165,7 @@ func TestPromWriterClient_WriteSeries(t *testing.T) {
 		receivedRequests = nil
 		nextStatusCode = http.StatusOK
 
-		series := generateSineWaveSeries("test", now, 22)
+		series := generateSineWaveSeries("test", now, 22, []prompb.Label{})
 		statusCode, err := c.WriteSeries(ctx, series)
 		require.NoError(t, err)
 		assert.Equal(t, 200, statusCode)
@@ -180,7 +180,7 @@ func TestPromWriterClient_WriteSeries(t *testing.T) {
 		receivedRequests = nil
 		nextStatusCode = http.StatusBadRequest
 
-		series := generateSineWaveSeries("test", now, 1)
+		series := generateSineWaveSeries("test", now, 1, []prompb.Label{})
 		statusCode, err := c.WriteSeries(ctx, series)
 		require.Error(t, err)
 		assert.Equal(t, 400, statusCode)
@@ -190,7 +190,7 @@ func TestPromWriterClient_WriteSeries(t *testing.T) {
 		receivedRequests = nil
 		nextStatusCode = http.StatusInternalServerError
 
-		series := generateSineWaveSeries("test", now, 1)
+		series := generateSineWaveSeries("test", now, 1, []prompb.Label{})
 		statusCode, err := c.WriteSeries(ctx, series)
 		require.Error(t, err)
 		assert.Equal(t, 500, statusCode)

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -27,7 +27,7 @@ const (
 )
 
 type generateHistogramFunc func(t time.Time) prompb.Histogram
-type generateSeriesFunc func(name string, t time.Time, numSeries int) []prompb.TimeSeries
+type generateSeriesFunc func(name string, t time.Time, numSeries int, additionalLabels []prompb.Label) []prompb.TimeSeries
 type generateValueFunc func(t time.Time) float64
 type generateSampleHistogramFunc func(t time.Time, numSeries int) *model.SampleHistogram
 
@@ -93,8 +93,8 @@ func init() {
 	for i, histProfile := range histogramProfiles {
 		histProfile := histProfile // shadowing it to ensure it's properly updated in the closure
 		histogramProfiles[i].generateValue = nil
-		histogramProfiles[i].generateSeries = func(name string, t time.Time, numSeries int) []prompb.TimeSeries {
-			return generateHistogramSeriesInner(name, t, numSeries, histProfile.generateHistogram)
+		histogramProfiles[i].generateSeries = func(name string, t time.Time, numSeries int, additionalLabels []prompb.Label) []prompb.TimeSeries {
+			return generateHistogramSeriesInner(name, t, numSeries, histProfile.generateHistogram, additionalLabels)
 		}
 	}
 }
@@ -224,20 +224,20 @@ func generateFloatHistogram(value float64, numSeries int, gauge bool) *histogram
 	return h
 }
 
-func generateSineWaveSeries(name string, t time.Time, numSeries int) []prompb.TimeSeries {
+func generateSineWaveSeries(name string, t time.Time, numSeries int, additionalLabels []prompb.Label) []prompb.TimeSeries {
 	out := make([]prompb.TimeSeries, 0, numSeries)
 	value := generateSineWaveValue(t)
 	ts := t.UnixMilli()
 
 	for i := 0; i < numSeries; i++ {
 		out = append(out, prompb.TimeSeries{
-			Labels: []prompb.Label{{
+			Labels: append([]prompb.Label{{
 				Name:  "__name__",
 				Value: name,
 			}, {
 				Name:  "series_id",
 				Value: strconv.Itoa(i),
-			}},
+			}}, additionalLabels...),
 			Samples: []prompb.Sample{{
 				Value:     value,
 				Timestamp: ts,
@@ -248,18 +248,18 @@ func generateSineWaveSeries(name string, t time.Time, numSeries int) []prompb.Ti
 	return out
 }
 
-func generateHistogramSeriesInner(name string, t time.Time, numSeries int, histogramGenerator generateHistogramFunc) []prompb.TimeSeries {
+func generateHistogramSeriesInner(name string, t time.Time, numSeries int, histogramGenerator generateHistogramFunc, additionalLabels []prompb.Label) []prompb.TimeSeries {
 	out := make([]prompb.TimeSeries, 0, numSeries)
 
 	for i := 0; i < numSeries; i++ {
 		out = append(out, prompb.TimeSeries{
-			Labels: []prompb.Label{{
+			Labels: append([]prompb.Label{{
 				Name:  "__name__",
 				Value: name,
 			}, {
 				Name:  "series_id",
 				Value: strconv.Itoa(i),
-			}},
+			}}, additionalLabels...),
 			Histograms: []prompb.Histogram{histogramGenerator(t)},
 		})
 	}

--- a/pkg/continuoustest/write_read_series_test.go
+++ b/pkg/continuoustest/write_read_series_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -128,7 +129,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
 
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, now, 2))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, now, 2, []prompb.Label{}))
 			assert.Equal(t, int64(1000), records.lastWrittenTimestamp.Unix())
 
 			client.AssertCalled(t, "QueryRange", mock.Anything, tt.querySum(tt.metricName), time.Unix(1000, 0), time.Unix(1000, 0), writeInterval, mock.Anything)
@@ -162,7 +163,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
 
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(980, 0), 2))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(980, 0), 2, []prompb.Label{}))
 			assert.Equal(t, int64(980), records.lastWrittenTimestamp.Unix())
 
 			client.AssertCalled(t, "QueryRange", mock.Anything, tt.querySum(tt.metricName), time.Unix(980, 0), time.Unix(980, 0), writeInterval, mock.Anything)
@@ -201,9 +202,9 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
 
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(960, 0), 2))
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(980, 0), 2))
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(1000, 0), 2))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(960, 0), 2, []prompb.Label{}))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(980, 0), 2, []prompb.Label{}))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(1000, 0), 2, []prompb.Label{}))
 			assert.Equal(t, int64(1000), records.lastWrittenTimestamp.Unix())
 
 			client.AssertCalled(t, "QueryRange", mock.Anything, tt.querySum(tt.metricName), time.Unix(960, 0), time.Unix(1000, 0), writeInterval, mock.Anything)
@@ -237,7 +238,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
 
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(960, 0), 2))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(960, 0), 2, []prompb.Label{}))
 			assert.Equal(t, int64(940), records.lastWrittenTimestamp.Unix())
 		}
 
@@ -267,7 +268,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
 
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(960, 0), 2))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(960, 0), 2, []prompb.Label{}))
 			assert.Equal(t, int64(940), records.lastWrittenTimestamp.Unix())
 		}
 
@@ -298,9 +299,9 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
 
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(960, 0), 2))
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(980, 0), 2))
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(1000, 0), 2))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(960, 0), 2, []prompb.Label{}))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(980, 0), 2, []prompb.Label{}))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, time.Unix(1000, 0), 2, []prompb.Label{}))
 			assert.Equal(t, int64(1000), records.lastWrittenTimestamp.Unix())
 		}
 
@@ -347,7 +348,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
 
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, now, 2))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, now, 2, []prompb.Label{}))
 			assert.Equal(t, int64(1000), records.lastWrittenTimestamp.Unix())
 
 			client.AssertCalled(t, "QueryRange", mock.Anything, tt.querySum(tt.metricName), time.Unix(1000, 0), time.Unix(1000, 0), writeInterval, mock.Anything)
@@ -398,7 +399,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
 
-			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, now, 2))
+			client.AssertCalled(t, "WriteSeries", mock.Anything, tt.generateSeries(tt.metricName, now, 2, []prompb.Label{}))
 			assert.Equal(t, int64(1000), records.lastWrittenTimestamp.Unix())
 
 			client.AssertCalled(t, "QueryRange", mock.Anything, tt.querySum(tt.metricName), time.Unix(1000, 0), time.Unix(1000, 0), writeInterval, mock.Anything)
@@ -982,4 +983,49 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 		require.GreaterOrEqual(t, actualInstants[len(actualInstants)-1].Unix(), test.floatMetric.queryMinTime.Unix())
 		require.LessOrEqual(t, actualInstants[len(actualInstants)-1].Unix(), test.floatMetric.queryMaxTime.Unix())
 	})
+}
+func TestParseLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		labelsStr  string
+		wantLabels []prompb.Label
+		wantErr    bool
+	}{
+		{
+			name:       "Valid labels",
+			labelsStr:  "foo=bar,baz=qux",
+			wantLabels: []prompb.Label{{Name: "foo", Value: "bar"}, {Name: "baz", Value: "qux"}},
+			wantErr:    false,
+		},
+		{
+			name:       "Valid labels trimmed",
+			labelsStr:  "foo=bar, baz = qux",
+			wantLabels: []prompb.Label{{Name: "foo", Value: "bar"}, {Name: "baz", Value: "qux"}},
+			wantErr:    false,
+		},
+		{
+			name:       "Invalid label format",
+			labelsStr:  "foo=bar=baz",
+			wantLabels: nil,
+			wantErr:    true,
+		},
+		{
+			name:       "Empty labels",
+			labelsStr:  "",
+			wantLabels: nil,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLabels, err := parseLabels(tt.labelsStr)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseLabels() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.ElementsMatch(t, tt.wantLabels, gotLabels)
+		})
+	}
 }


### PR DESCRIPTION
#### What this PR does
It adds new `-tests.write-read-series-test.additional-labels` flag to the mimir continuous test, so additional labels can be added to the generated series in addition to the cardinality ones.

We would like to have this possibility so we can generate more realistic load with higher data throughput and various labels/values.

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
