### PR TITLE
Add optional container name and pod regex in newResourceScaledObject function

### DIFF
--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -1,0 +1,5107 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: compactor
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: distributor
+  name: distributor
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: distributor
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ingester
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached
+  name: memcached
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-frontend
+  name: memcached-frontend
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-frontend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-index-queries
+  name: memcached-index-queries
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-index-queries
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-metadata
+  name: memcached-metadata
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-metadata
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: querier
+  name: querier
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: querier
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: query-frontend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: query-scheduler
+  name: query-scheduler
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: query-scheduler
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  maxUnavailable: 2
+  selector:
+    matchLabels:
+      name: store-gateway
+---
+apiVersion: v1
+data:
+  overrides.yaml: |
+    overrides: {}
+kind: ConfigMap
+metadata:
+  name: overrides
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: compactor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: compactor-grpc
+    port: 9095
+    targetPort: 9095
+  - name: compactor-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: compactor
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: distributor
+  name: distributor
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: distributor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: distributor-grpc
+    port: 9095
+    targetPort: 9095
+  - name: distributor-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: distributor
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gossip-ring
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - appProtocol: tcp
+    name: gossip-ring
+    port: 7946
+    protocol: TCP
+    targetPort: 7946
+  selector:
+    gossip_ring_member: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  ports:
+  - name: ingester-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ingester-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ingester-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: ingester
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached
+  name: memcached
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-frontend
+  name: memcached-frontend
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-index-queries
+  name: memcached-index-queries
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-index-queries
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-metadata
+  name: memcached-metadata
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-metadata
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: querier
+  name: querier
+  namespace: default
+spec:
+  ports:
+  - name: querier-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: querier-grpc
+    port: 9095
+    targetPort: 9095
+  - name: querier-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: querier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend
+  namespace: default
+spec:
+  ports:
+  - name: query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-scheduler
+  name: query-scheduler
+  namespace: default
+spec:
+  ports:
+  - name: query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-scheduler
+  name: query-scheduler-discovery
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  publishNotReadyAddresses: true
+  selector:
+    name: query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  - name: store-gateway-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: store-gateway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: distributor
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: distributor
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: distributor
+    spec:
+      containers:
+      - args:
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.etcd.endpoints=etcd-client.default.svc.cluster.local.:2379
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=etcd
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.ring.heartbeat-period=1m
+        - -distributor.ring.heartbeat-timeout=4m
+        - -distributor.ring.prefix=
+        - -distributor.ring.store=memberlist
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -mem-ballast-size-bytes=1073741824
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=60s
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=distributor
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "8"
+        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
+          value: "1000"
+        image: grafana/mimir:2.12.0
+        imagePullPolicy: IfNotPresent
+        name: distributor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 100
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: querier
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 6
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: querier
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -distributor.health-check-ingesters=true
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -mem-ballast-size-bytes=268435456
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
+        - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-timeout=4m
+        - -store-gateway.sharding-ring.prefix=
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -target=querier
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "5"
+        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
+          value: "5000"
+        image: grafana/mimir:2.12.0
+        imagePullPolicy: IfNotPresent
+        name: querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: query-frontend
+    spec:
+      containers:
+      - args:
+        - -query-frontend.cache-results=true
+        - -query-frontend.max-cache-freshness=10m
+        - -query-frontend.max-total-query-length=12000h
+        - -query-frontend.query-sharding-target-series-per-shard=2500
+        - -query-frontend.results-cache.backend=memcached
+        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local.:11211
+        - -query-frontend.results-cache.memcached.max-item-size=5242880
+        - -query-frontend.results-cache.memcached.timeout=500ms
+        - -query-frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=30s
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=query-frontend
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
+          value: "5000"
+        image: grafana/mimir:2.12.0
+        imagePullPolicy: IfNotPresent
+        name: query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 1200Mi
+          requests:
+            cpu: "2"
+            memory: 600Mi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 390
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-scheduler
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: query-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: query-scheduler
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: query-scheduler
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=query-scheduler
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:2.12.0
+        imagePullPolicy: IfNotPresent
+        name: query-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: compactor
+  serviceName: compactor
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: compactor
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -compactor.block-ranges=2h,12h,24h
+        - -compactor.blocks-retention-period=0
+        - -compactor.cleanup-interval=15m
+        - -compactor.compaction-concurrency=1
+        - -compactor.compaction-interval=30m
+        - -compactor.compactor-tenant-shard-size=1
+        - -compactor.data-dir=/data
+        - -compactor.deletion-delay=2h
+        - -compactor.first-level-compaction-wait-period=25m
+        - -compactor.max-closing-blocks-concurrency=2
+        - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.ring.heartbeat-period=1m
+        - -compactor.ring.heartbeat-timeout=4m
+        - -compactor.ring.prefix=
+        - -compactor.ring.store=memberlist
+        - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.split-and-merge-shards=0
+        - -compactor.split-groups=1
+        - -compactor.symbols-flushers-concurrency=4
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=compactor
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:2.12.0
+        imagePullPolicy: IfNotPresent
+        name: compactor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 6Gi
+          requests:
+            cpu: 1
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /data
+          name: compactor-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: compactor-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      name: ingester
+  serviceName: ingester
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ingester
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: ingester
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.wal-replay-concurrency=3
+        - -common.storage.backend=gcs
+        - -distributor.health-check-ingesters=true
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.ring.heartbeat-period=2m
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.num-tokens=512
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.tokens-file-path=/data/tokens
+        - -ingester.ring.unregister-on-shutdown=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=500
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=ingester
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
+          value: "1000"
+        image: grafana/mimir:2.12.0
+        imagePullPolicy: IfNotPresent
+        name: ingester
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: ingester-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ingester-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached
+  serviceName: memcached
+  template:
+    metadata:
+      labels:
+        name: memcached
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 6144
+        - -I 1m
+        - -c 16384
+        - -v
+        - --extended=track_sizes
+        image: memcached:1.6.22-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 9Gi
+          requests:
+            cpu: 500m
+            memory: 6552Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.14.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-frontend
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-frontend
+  serviceName: memcached-frontend
+  template:
+    metadata:
+      labels:
+        name: memcached-frontend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-frontend
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 16384
+        - -v
+        - --extended=track_sizes
+        image: memcached:1.6.22-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.14.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-index-queries
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-index-queries
+  serviceName: memcached-index-queries
+  template:
+    metadata:
+      labels:
+        name: memcached-index-queries
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-index-queries
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 16384
+        - -v
+        - --extended=track_sizes
+        image: memcached:1.6.22-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.14.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-metadata
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: memcached-metadata
+  serviceName: memcached-metadata
+  template:
+    metadata:
+      labels:
+        name: memcached-metadata
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-metadata
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 512
+        - -I 1m
+        - -c 16384
+        - -v
+        - --extended=track_sizes
+        image: memcached:1.6.22-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 768Mi
+          requests:
+            cpu: 500m
+            memory: 638Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.14.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      name: store-gateway
+  serviceName: store-gateway
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: store-gateway
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: store-gateway
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-period=1m
+        - -store-gateway.sharding-ring.heartbeat-timeout=4m
+        - -store-gateway.sharding-ring.prefix=
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -target=store-gateway
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "5"
+        - name: GOMEMLIMIT
+          value: "12884901888"
+        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
+          value: "1000"
+        image: grafana/mimir:2.12.0
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: etcd.database.coreos.com/v1beta2
+kind: EtcdCluster
+metadata:
+  annotations:
+    etcd.database.coreos.com/scope: clusterwide
+  name: etcd
+  namespace: default
+spec:
+  pod:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              etcd_cluster: etcd
+          topologyKey: kubernetes.io/hostname
+    annotations:
+      prometheus.io/port: "2379"
+      prometheus.io/scrape: "true"
+    etcdEnv:
+    - name: ETCD_AUTO_COMPACTION_RETENTION
+      value: 1h
+    labels:
+      name: etcd
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+  size: 3
+  version: 3.3.13
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_0.7__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_0.7__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_0.7___cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_0.7__",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_false_false_0.7__",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_false_0.7__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_0.7___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_0.7___memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_false_0.7__",namespace="default"})
+              and
+              max by (pod) (up{container="test_false_false_0.7__",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_false_0.7__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_0.7__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_0.7__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_false_0.7__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_0.7___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_0.7__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_0.7__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_0.7__pod_zone_a.*_cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_0.7__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_0.7__pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_false_0.7__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_0.7__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_0.7__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_0.7__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_0.7_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_0.7_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_0.7_test_container__cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_0.7_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_0.7_test_container__memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (up{container="test_container",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_0.7_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_0.7_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_0.7_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_0.7_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_0.7_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_0.7_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_0.7_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_1.5__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_1.5__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1.5___cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1.5__",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_false_false_1.5__",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_false_1.5__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_1.5___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1.5___memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_false_1.5__",namespace="default"})
+              and
+              max by (pod) (up{container="test_false_false_1.5__",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_false_1.5__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_1.5__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_1.5__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_false_1.5__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_1.5___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_1.5__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_1.5__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1.5__pod_zone_a.*_cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_1.5__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1.5__pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_false_1.5__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_1.5__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_1.5__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_1.5__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_1.5_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_1.5_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1.5_test_container__cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_1.5_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1.5_test_container__memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (up{container="test_container",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_1.5_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_1.5_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_1.5_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1.5_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_1.5_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1.5_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_1.5_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_1__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_1__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1___cpu_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1__",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_false_false_1__",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_false_1__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_1___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1___memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_false_1__",namespace="default"})
+              and
+              max by (pod) (up{container="test_false_false_1__",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_false_1__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_1__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_1__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_false_1__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_1___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_1__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_1__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1__pod_zone_a.*_cpu_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_1__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1__pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_false_1__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_1__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_1__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_1__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_1_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_1_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1_test_container__cpu_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_1_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1_test_container__memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (up{container="test_container",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_1_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_false_1_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_false_1_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_false_1_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_false_1_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_false_1_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_0.7__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_0.7__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_0.7___cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_0.7__",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_true_0.7__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_0.7___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_0.7___memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_true_0.7__",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_true_0.7__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_0.7__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_0.7__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_true_0.7__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_0.7___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_0.7__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_0.7__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_0.7__pod_zone_a.*_cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_0.7__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_0.7__pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_true_0.7__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_0.7__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_0.7__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_0.7__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_0.7_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_0.7_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_0.7_test_container__cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_0.7_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_0.7_test_container__memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_0.7_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_0.7_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_0.7_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_0.7_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_0.7_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_0.7_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_0.7_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_1.5__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_1.5__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1.5___cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1.5__",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_true_1.5__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_1.5___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1.5___memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_true_1.5__",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_true_1.5__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_1.5__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_1.5__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_true_1.5__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_1.5___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_1.5__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_1.5__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1.5__pod_zone_a.*_cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_1.5__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1.5__pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_true_1.5__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_1.5__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_1.5__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_1.5__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_1.5_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_1.5_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1.5_test_container__cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_1.5_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1.5_test_container__memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_1.5_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_1.5_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_1.5_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1.5_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_1.5_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1.5_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_1.5_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_1__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_1__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1___cpu_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1__",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_true_1__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_1___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1___memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_true_1__",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_true_1__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_1__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_1__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_true_1__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_1___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_1__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_1__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1__pod_zone_a.*_cpu_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_false_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_1__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1__pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_false_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_false_true_1__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_1__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_1__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_false_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_1__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_1_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_1_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1_test_container__cpu_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_1_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1_test_container__memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_1_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_false_true_1_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_false_true_1_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: test_false_true_1_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: test_false_true_1_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: test_false_true_1_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_0.7__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_0.7__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_0.7___cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_0.7__",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_true_false_0.7__",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_false_0.7__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_0.7___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_0.7___memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_false_0.7__",namespace="default"})
+              and
+              max by (pod) (up{container="test_true_false_0.7__",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_false_0.7__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_0.7__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_0.7__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_false_0.7__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_0.7___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_0.7__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_0.7__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_0.7__pod_zone_a.*_cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_0.7__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_0.7__pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_false_0.7__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_0.7__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_0.7__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_0.7__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_0.7_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_0.7_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_0.7_test_container__cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_0.7_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_0.7_test_container__memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (up{container="test_container",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_0.7_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_0.7_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_0.7_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_0.7_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_0.7_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_0.7_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_0.7_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_1.5__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_1.5__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1.5___cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1.5__",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_true_false_1.5__",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_false_1.5__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_1.5___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1.5___memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_false_1.5__",namespace="default"})
+              and
+              max by (pod) (up{container="test_true_false_1.5__",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_false_1.5__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_1.5__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_1.5__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_false_1.5__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_1.5___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_1.5__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_1.5__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1.5__pod_zone_a.*_cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_1.5__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1.5__pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_false_1.5__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_1.5__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_1.5__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_1.5__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_1.5_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_1.5_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1.5_test_container__cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_1.5_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1.5_test_container__memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (up{container="test_container",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_1.5_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_1.5_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_1.5_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1.5_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |-
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_1.5_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1.5_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_1.5_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_1__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_1__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1___cpu_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1__",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_true_false_1__",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_false_1__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_1___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1___memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_false_1__",namespace="default"})
+              and
+              max by (pod) (up{container="test_true_false_1__",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_false_1__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_1__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_1__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_false_1__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_1___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_1__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_1__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1__pod_zone_a.*_cpu_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_1__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1__pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_false_1__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_1__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_1__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_1__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_1_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_1_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1_test_container__cpu_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_1_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1_test_container__memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (up{container="test_container",namespace="default"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_1_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_false_1_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_false_1_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_false_1_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_false_1_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        max_over_time(
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_false_1_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_0.7__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_0.7__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_0.7___cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_0.7__",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_true_0.7__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_0.7___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_0.7___memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_true_0.7__",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_true_0.7__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_0.7__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_0.7__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_true_0.7__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_0.7___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_0.7__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_0.7__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_0.7__pod_zone_a.*_cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_0.7__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_0.7__pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_true_0.7__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_0.7__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_0.7__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_0.7__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_0.7_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_0.7_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_0.7_test_container__cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_0.7_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_0.7_test_container__memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_0.7_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_0.7_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 7
+  minReplicaCount: 3
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_0.7_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_0.7_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 0.70
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_0.7_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_0.7_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_0.7_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_1.5__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_1.5__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1.5___cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1.5__",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_true_1.5__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_1.5___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1.5___memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_true_1.5__",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_true_1.5__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_1.5__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_1.5__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_true_1.5__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_1.5___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_1.5__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_1.5__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1.5__pod_zone_a.*_cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_1.5__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1.5__pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_true_1.5__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_1.5__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_1.5__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_1.5__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_1.5_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_1.5_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1.5_test_container__cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_1.5_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1.5_test_container__memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_1.5_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_1.5_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 15
+  minReplicaCount: 7
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_1.5_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1.5_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |-
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+         * 1.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_1.5_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1.5_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_1.5_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_1__
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_1__
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1___cpu_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1__",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_true_1__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_1___cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1___memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_true_1__",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_true_1__", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_1__", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_1__", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_true_1__",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_1___memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_1__pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_1__pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1__pod_zone_a.*_cpu_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_true_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_1__pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1__pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_true_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_true_true_1__pod-zone-a.*", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_1__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_1__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_true_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_1__pod_zone_a.*_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_1_test_container_
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_1_test_container_
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1_test_container__cpu_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_1_test_container__cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1_test_container__memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_1_test_container__memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test_true_true_1_test_container_pod-zone-a.*
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 5
+  pollingInterval: 10
+  scaleTargetRef:
+    name: test_true_true_1_test_container_pod-zone-a.*
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1_test_container_pod_zone_a.*_cpu_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "8000"
+    name: cortex_test_true_true_1_test_container_pod_zone_a.*_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_test_true_true_1_test_container_pod_zone_a.*_memory_hpa_default
+      query: |
+        quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="test_container", namespace="default", resource="memory",pod=~"pod-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
+        )
+        and
+        count (
+          count_over_time(
+            present_over_time(
+              container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[1m]
+            )[15m:1m]
+          ) >= 15
+        )
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "858993459"
+    name: cortex_test_true_true_1_test_container_pod_zone_a.*_memory_hpa_default
+    type: prometheus

--- a/operations/mimir-tests/test-new-resource-scaled-object.jsonnet
+++ b/operations/mimir-tests/test-new-resource-scaled-object.jsonnet
@@ -1,0 +1,33 @@
+local mimir = import 'mimir/mimir.libsonnet';
+
+mimir {
+  _config+:: {
+    namespace: 'default',
+    external_url: 'http://test',
+
+    storage_backend: 'gcs',
+    blocks_storage_bucket_name: 'blocks-bucket',
+  },
+}
+{
+  ['test_%s_%s_%g_%s_%s' % [with_cortex_prefix, with_ready_trigger, weight, container, pod_regex]]:
+    $.newResourceScaledObject(
+      'test_%s_%s_%g_%s_%s' % [with_cortex_prefix, with_ready_trigger, weight, container, pod_regex],
+      cpu_requests='10',
+      memory_requests='1Gi',
+      min_replicas=5,
+      max_replicas=10,
+      cpu_target_utilization=0.8,
+      memory_target_utilization=0.8,
+      with_cortex_prefix=with_cortex_prefix,
+      with_ready_trigger=with_ready_trigger,
+      weight=weight,
+      container_name=container,
+      pod_regex=pod_regex
+    )
+  for with_cortex_prefix in [false, true]
+  for with_ready_trigger in [false, true]
+  for weight in [0.7, 1, 1.5]
+  for container in ['', 'test_container']
+  for pod_regex in ['', 'pod-zone-a.*']
+}

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -276,9 +276,9 @@
       |||
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}[5m]))
             and
-            max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"}[1m])) > 0
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"%(pod_matcher)s}[1m])) > 0
           )[15m:]
         ) * 1000
       |||
@@ -293,9 +293,9 @@
       |||
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}[5m]))
             and
-            max by (pod) (up{container="%(container)s",namespace="%(namespace)s"}) > 0
+            max by (pod) (up{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}) > 0
           )[15m:]
         ) * 1000
       |||
@@ -307,7 +307,7 @@
       count (
         count_over_time(
           present_over_time(
-            container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"}[1m]
+            container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}[1m]
           )[15m:1m]
         ) >= 15
       )
@@ -325,9 +325,9 @@
           quantile_over_time(0.95,
             sum(
               (
-                sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"})
+                sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s})
                 and
-                max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"}[1m])) > 0
+                max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"%(pod_matcher)s}[1m])) > 0
               ) or vector(0)
             )[15m:]
           )
@@ -343,9 +343,9 @@
           max_over_time(
             sum(
               (
-                sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"})
+                sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s})
                 and
-                max by (pod) (up{container="%(container)s",namespace="%(namespace)s"}) > 0
+                max by (pod) (up{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}) > 0
               ) or vector(0)
             )[15m:]
           )
@@ -358,18 +358,18 @@
       |||
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="%(container)s", namespace="%(namespace)s", resource="memory"}[15m]))
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="%(container)s", namespace="%(namespace)s", resource="memory"%(pod_matcher)s}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="%(container)s", namespace="%(namespace)s"}[15m]) > 0)
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="%(container)s", namespace="%(namespace)s"%(pod_matcher)s}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="%(container)s", namespace="%(namespace)s", reason="OOMKilled"})
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="%(container)s", namespace="%(namespace)s", reason="OOMKilled"%(pod_matcher)s})
           or vector(0)
         )
         and
         count (
           count_over_time(
             present_over_time(
-              container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"}[1m]
+              container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}[1m]
             )[15m:1m]
           ) >= 15
         )
@@ -389,8 +389,16 @@
     weight=1,
     scale_down_period=null,
     extra_triggers=[],
+    container_name='',
+    pod_regex='',
   ):: self.newScaledObject(
     name, $._config.namespace, {
+      local queryParameters = {
+        container: if container_name != '' then container_name else name,
+        namespace: $._config.namespace,
+        pod_matcher: if pod_regex == '' then '' else ',pod=~"%s"' % pod_regex,
+      },
+
       min_replica_count: replicasWithWeight(min_replicas, weight),
       max_replica_count: replicasWithWeight(max_replicas, weight),
 
@@ -401,10 +409,7 @@
           metric_name: '%s%s_cpu_hpa_%s' %
                        ([if with_cortex_prefix then 'cortex_' else ''] + [std.strReplace(name, '-', '_'), $._config.namespace]),
 
-          query: metricWithWeight(cpuHPAQuery(with_ready_trigger) % {
-            container: name,
-            namespace: $._config.namespace,
-          }, weight),
+          query: metricWithWeight(cpuHPAQuery(with_ready_trigger) % queryParameters, weight),
 
           // Threshold is expected to be a string
           threshold: std.toString(std.floor(cpuToMilliCPUInt(cpu_requests) * cpu_target_utilization)),
@@ -416,10 +421,7 @@
           metric_name: '%s%s_memory_hpa_%s' %
                        ([if with_cortex_prefix then 'cortex_' else ''] + [std.strReplace(name, '-', '_'), $._config.namespace]),
 
-          query: memoryHPAQuery(with_ready_trigger) % {
-            container: name,
-            namespace: $._config.namespace,
-          },
+          query: memoryHPAQuery(with_ready_trigger) % queryParameters,
 
           // Threshold is expected to be a string
           threshold: std.toString(std.floor($.util.siToBytes(memory_requests) * memory_target_utilization)),

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -276,9 +276,9 @@
       |||
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
             and
-            max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"%(pod_matcher)s}[1m])) > 0
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"%(extra_matchers)s}[1m])) > 0
           )[15m:]
         ) * 1000
       |||
@@ -293,9 +293,9 @@
       |||
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
             and
-            max by (pod) (up{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}) > 0
+            max by (pod) (up{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}) > 0
           )[15m:]
         ) * 1000
       |||
@@ -307,7 +307,7 @@
       count (
         count_over_time(
           present_over_time(
-            container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}[1m]
+            container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[1m]
           )[15m:1m]
         ) >= 15
       )
@@ -325,9 +325,9 @@
           quantile_over_time(0.95,
             sum(
               (
-                sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s})
+                sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s})
                 and
-                max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"%(pod_matcher)s}[1m])) > 0
+                max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"%(extra_matchers)s}[1m])) > 0
               ) or vector(0)
             )[15m:]
           )
@@ -343,9 +343,9 @@
           max_over_time(
             sum(
               (
-                sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s})
+                sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s})
                 and
-                max by (pod) (up{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}) > 0
+                max by (pod) (up{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}) > 0
               ) or vector(0)
             )[15m:]
           )
@@ -358,18 +358,18 @@
       |||
         +
         sum(
-          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="%(container)s", namespace="%(namespace)s", resource="memory"%(pod_matcher)s}[15m]))
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="%(container)s", namespace="%(namespace)s", resource="memory"%(extra_matchers)s}[15m]))
           and
-          max by (pod) (changes(kube_pod_container_status_restarts_total{container="%(container)s", namespace="%(namespace)s"%(pod_matcher)s}[15m]) > 0)
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="%(container)s", namespace="%(namespace)s"%(extra_matchers)s}[15m]) > 0)
           and
-          max by (pod) (kube_pod_container_status_last_terminated_reason{container="%(container)s", namespace="%(namespace)s", reason="OOMKilled"%(pod_matcher)s})
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="%(container)s", namespace="%(namespace)s", reason="OOMKilled"%(extra_matchers)s})
           or vector(0)
         )
         and
         count (
           count_over_time(
             present_over_time(
-              container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(pod_matcher)s}[1m]
+              container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[1m]
             )[15m:1m]
           ) >= 15
         )
@@ -396,7 +396,7 @@
       local queryParameters = {
         container: if container_name != '' then container_name else name,
         namespace: $._config.namespace,
-        pod_matcher: if pod_regex == '' then '' else ',pod=~"%s"' % pod_regex,
+        extra_matchers: if pod_regex == '' then '' else ',pod=~"%s"' % pod_regex,
       },
 
       min_replica_count: replicasWithWeight(min_replicas, weight),


### PR DESCRIPTION
#### What this PR does

This PR modifies jsonnet function `newResourceScaledObject` and adds optional `container_name` and `pod_regex` arguments, to specify alternative container name and optionally match only selected pods in scaling query.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
