### PR TITLE
Chore: remove unused min/max in chunk merge iterator

### DIFF
--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -8,7 +8,6 @@ package batch
 import (
 	"fmt"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
@@ -56,7 +55,7 @@ type iterator interface {
 }
 
 // NewChunkMergeIterator returns a chunkenc.Iterator that merges Mimir chunks together.
-func NewChunkMergeIterator(it chunkenc.Iterator, chunks []chunk.Chunk, _, _ model.Time) chunkenc.Iterator {
+func NewChunkMergeIterator(it chunkenc.Iterator, chunks []chunk.Chunk) chunkenc.Iterator {
 	converted := make([]GenericChunk, len(chunks))
 	for i, c := range chunks {
 		converted[i] = NewGenericChunk(int64(c.From), int64(c.Through), c.Data.NewIterator)

--- a/pkg/querier/batch/batch_test.go
+++ b/pkg/querier/batch/batch_test.go
@@ -45,7 +45,7 @@ func BenchmarkNewChunkMergeIterator_CreateAndIterate(b *testing.B) {
 					fh *histogram.FloatHistogram
 				)
 				for n := 0; n < b.N; n++ {
-					it = NewChunkMergeIterator(it, chunks, 0, 0)
+					it = NewChunkMergeIterator(it, chunks)
 					for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
 						switch valType {
 						case chunkenc.ValFloat:
@@ -74,7 +74,7 @@ func TestSeekCorrectlyDealWithSinglePointChunks(t *testing.T) {
 	chunkTwo := mkChunk(t, model.Time(10*step/time.Millisecond), 1, chunk.PrometheusXorChunk)
 	chunks := []chunk.Chunk{chunkOne, chunkTwo}
 
-	sut := NewChunkMergeIterator(nil, chunks, 0, 0)
+	sut := NewChunkMergeIterator(nil, chunks)
 
 	// Following calls mimics Prometheus's query engine behaviour for VectorSelector.
 	require.Equal(t, chunkenc.ValFloat, sut.Next())

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -146,8 +146,6 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 		serieses = append(serieses, &chunkSeries{
 			labels: ls,
 			chunks: chunks,
-			mint:   minT,
-			maxt:   maxT,
 		})
 	}
 
@@ -158,8 +156,6 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 	if len(results.StreamingSeries) > 0 {
 		streamingSeries := make([]storage.Series, 0, len(results.StreamingSeries))
 		streamingChunkSeriesConfig := &streamingChunkSeriesContext{
-			mint:         minT,
-			maxt:         maxT,
 			queryMetrics: q.queryMetrics,
 			queryStats:   stats.FromContext(ctx),
 		}

--- a/pkg/querier/distributor_queryable_streaming.go
+++ b/pkg/querier/distributor_queryable_streaming.go
@@ -5,7 +5,6 @@ package querier
 import (
 	"fmt"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
@@ -16,7 +15,6 @@ import (
 )
 
 type streamingChunkSeriesContext struct {
-	mint, maxt   int64
 	queryMetrics *stats.QueryMetrics
 	queryStats   *stats.Stats
 }
@@ -76,5 +74,5 @@ func (s *streamingChunkSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator 
 		return series.NewErrIterator(err)
 	}
 
-	return batch.NewChunkMergeIterator(it, chunks, model.Time(s.context.mint), model.Time(s.context.maxt))
+	return batch.NewChunkMergeIterator(it, chunks)
 }

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -42,8 +42,6 @@ func TestStreamingChunkSeries_HappyPath(t *testing.T) {
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{{SeriesIndex: 0, Chunks: []client.Chunk{chunkUniqueToSecondSource, chunkPresentInBothSources}}})},
 		},
 		context: &streamingChunkSeriesContext{
-			mint:         minT,
-			maxt:         maxT,
 			queryMetrics: stats.NewQueryMetrics(reg),
 			queryStats:   queryStats,
 		},
@@ -54,7 +52,7 @@ func TestStreamingChunkSeries_HappyPath(t *testing.T) {
 
 	expectedChunks, err := client.FromChunks(series.labels, []client.Chunk{chunkUniqueToFirstSource, chunkUniqueToSecondSource, chunkPresentInBothSources})
 	require.NoError(t, err)
-	assertChunkIteratorsEqual(t, iterator, batch.NewChunkMergeIterator(nil, expectedChunks, minT, maxT))
+	assertChunkIteratorsEqual(t, iterator, batch.NewChunkMergeIterator(nil, expectedChunks))
 
 	m, err := metrics.NewMetricFamilyMapFromGatherer(reg)
 	require.NoError(t, err)
@@ -106,8 +104,6 @@ func TestStreamingChunkSeries_StreamReaderReturnsError(t *testing.T) {
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{})},
 		},
 		context: &streamingChunkSeriesContext{
-			mint:         1000,
-			maxt:         6000,
 			queryMetrics: stats.NewQueryMetrics(reg),
 			queryStats:   queryStats,
 		},
@@ -125,8 +121,6 @@ func TestStreamingChunkSeries_CreateIteratorTwice(t *testing.T) {
 			{SeriesIndex: 0, StreamReader: createTestStreamReader([]client.QueryStreamSeriesChunks{{SeriesIndex: 0, Chunks: []client.Chunk{createTestChunk(t, 1500, 1.23)}}})},
 		},
 		context: &streamingChunkSeriesContext{
-			mint:         1000,
-			maxt:         6000,
 			queryMetrics: stats.NewQueryMetrics(prometheus.NewPedanticRegistry()),
 			queryStats:   &stats.Stats{},
 		},

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -25,10 +25,6 @@ import (
 )
 
 func TestStreamingChunkSeries_HappyPath(t *testing.T) {
-	const (
-		minT = 1000
-		maxT = 6000
-	)
 	chunkUniqueToFirstSource := createTestChunk(t, 1500, 1.23)
 	chunkUniqueToSecondSource := createTestChunk(t, 2000, 4.56)
 	chunkPresentInBothSources := createTestChunk(t, 2500, 7.89)

--- a/pkg/querier/partitioner_test.go
+++ b/pkg/querier/partitioner_test.go
@@ -73,7 +73,7 @@ func testPartitionChunksOutputIsSortedByLabels(t *testing.T, encoding chunk.Enco
 		allChunks = append(allChunks, ch)
 	}
 
-	res := partitionChunks(allChunks, 0, 1000)
+	res := partitionChunks(allChunks)
 
 	// collect labels from each series
 	var seriesLabels []labels.Labels

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -516,7 +516,7 @@ func (mq multiQuerier) mergeSeriesSets(sets []storage.SeriesSet) storage.SeriesS
 	}
 
 	// partitionChunks returns set with sorted series, so it can be used by NewMergeSeriesSet
-	chunksSet := partitionChunks(chunks, mq.minT, mq.maxT)
+	chunksSet := partitionChunks(chunks)
 
 	if len(otherSets) == 0 {
 		return chunksSet


### PR DESCRIPTION
#### What this PR does

While working on #8463 I noticed that the chunk merge iterator takes the querier's min/max in input but it's never used. In this PR I'm cleaning it up.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
