### PR TITLE
Update renovate.json with 2.13 release

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "extends": [
       "config:base"
     ],
-    "baseBranches": ["main", "release-2.12", "release-2.11", "release-2.10"],
+    "baseBranches": ["main", "release-2.13", "release-2.12", "release-2.11"],
     "postUpdateOptions": [
       "gomodTidy",
       "gomodUpdateImportPaths"
@@ -11,7 +11,7 @@
     "schedule": ["before 9am on Monday"],
     "packageRules": [
       {
-        "matchBaseBranches": ["release-2.12","release-2.11"],
+        "matchBaseBranches": ["release-2.13", "release-2.12", "release-2.11"],
         "packagePatterns": ["*"],
         "enabled": false
       },


### PR DESCRIPTION
#### What this PR does

See title. 2.10 was left there for too long. The plan is to remove 2.11 once 2.13 has a promoted RC

#### Which issue(s) this PR fixes or relates to

related to https://github.com/grafana/mimir/issues/8390

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
