### PR TITLE
Add row for non-ingest-storage ingester autoscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
   * Overview dashboard: status, read/write latency and queries/ingestion per sec panels, `cortex_request_duration_seconds` metric.
 * [ENHANCEMENT] Alerts: `MimirRunningIngesterReceiveDelayTooHigh` alert has been tuned to be more reactive to high receive delay. #8538
 * [ENHANCEMENT] Dashboards: improve end-to-end latency and strong read consistency panels when experimental ingest storage is enabled. #8543
+* [ENHANCEMENT] Dashboards: Add panels for monitoring ingester autoscaling when not using ingest-storage. These panels are disabled by default, but can be enabled using the `autoscaling.ingester.enabled: true` config option. #8484
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -25699,7 +25699,7 @@ data:
                 "panels": [
                    {
                       "datasource": "$datasource",
-                      "description": "### Replicas\nThe maximum and current number of ruler-querier replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                      "description": "### Replicas\nThe minimum, maximum, and current number of ruler-querier replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -39660,7 +39660,7 @@ data:
                 "panels": [
                    {
                       "datasource": "$datasource",
-                      "description": "### Replicas\nThe maximum and current number of distributor replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                      "description": "### Replicas\nThe minimum, maximum, and current number of distributor replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -39929,6 +39929,275 @@ data:
                 "panels": [
                    {
                       "datasource": "$datasource",
+                      "description": "### Replicas (leader)\nThe minimum, maximum, and current number of replicas for the leader zone of ingesters.\nOther zones scale to follow this zone (with delay for downscale).\n<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                      "fieldConfig": {
+                         "defaults": {
+                            "custom": {
+                               "drawStyle": "line",
+                               "fillOpacity": 1,
+                               "lineWidth": 1,
+                               "pointSize": 5,
+                               "showPoints": "never",
+                               "spanNulls": false,
+                               "stacking": {
+                                  "group": "A",
+                                  "mode": "none"
+                               }
+                            },
+                            "min": 0,
+                            "thresholds": {
+                               "mode": "absolute",
+                               "steps": [ ]
+                            },
+                            "unit": "short"
+                         },
+                         "overrides": [
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/Max .+/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "custom.fillOpacity",
+                                     "value": 0
+                                  },
+                                  {
+                                     "id": "custom.lineStyle",
+                                     "value": {
+                                        "fill": "dash"
+                                     }
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/Current .+/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "custom.fillOpacity",
+                                     "value": 0
+                                  }
+                               ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/Min .+/"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "custom.fillOpacity",
+                                     "value": 0
+                                  },
+                                  {
+                                     "id": "custom.lineStyle",
+                                     "value": {
+                                        "fill": "dash"
+                                     }
+                                  }
+                               ]
+                            }
+                         ]
+                      },
+                      "id": 17,
+                      "links": [ ],
+                      "options": {
+                         "legend": {
+                            "showLegend": true
+                         },
+                         "tooltip": {
+                            "mode": "single",
+                            "sort": "none"
+                         }
+                      },
+                      "span": 3,
+                      "targets": [
+                         {
+                            "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
+                            "format": "time_series",
+                            "legendFormat": "Max {{ scaletargetref_name }}",
+                            "legendLink": null
+                         },
+                         {
+                            "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # HPA doesn't go to 0 replicas, so we multiply by 0 if the HPA is not active\n  * on (cluster, namespace, horizontalpodautoscaler)\n    kube_horizontalpodautoscaler_status_condition{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\", condition=\"ScalingActive\", status=\"true\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
+                            "format": "time_series",
+                            "legendFormat": "Current {{ scaletargetref_name }}",
+                            "legendLink": null
+                         },
+                         {
+                            "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
+                            "format": "time_series",
+                            "legendFormat": "Min {{ scaletargetref_name }}",
+                            "legendLink": null
+                         }
+                      ],
+                      "title": "Replicas (leader)",
+                      "type": "timeseries"
+                   },
+                   {
+                      "datasource": "$datasource",
+                      "description": "### Replicas\nNumber of ingester replicas per zone.\n",
+                      "fieldConfig": {
+                         "defaults": {
+                            "custom": {
+                               "drawStyle": "line",
+                               "fillOpacity": 1,
+                               "lineWidth": 1,
+                               "pointSize": 5,
+                               "showPoints": "never",
+                               "spanNulls": false,
+                               "stacking": {
+                                  "group": "A",
+                                  "mode": "none"
+                               }
+                            },
+                            "min": 0,
+                            "thresholds": {
+                               "mode": "absolute",
+                               "steps": [ ]
+                            },
+                            "unit": "short"
+                         },
+                         "overrides": [ ]
+                      },
+                      "id": 18,
+                      "links": [ ],
+                      "options": {
+                         "legend": {
+                            "showLegend": true
+                         },
+                         "tooltip": {
+                            "mode": "single",
+                            "sort": "none"
+                         }
+                      },
+                      "span": 3,
+                      "targets": [
+                         {
+                            "expr": "sum by (job) (up{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\"})",
+                            "format": "time_series",
+                            "legendFormat": "{{ job }}",
+                            "legendLink": null
+                         }
+                      ],
+                      "title": "Replicas",
+                      "type": "timeseries"
+                   },
+                   {
+                      "datasource": "$datasource",
+                      "description": "### Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold and multiplied by the current number of replicas.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
+                      "fieldConfig": {
+                         "defaults": {
+                            "custom": {
+                               "drawStyle": "line",
+                               "fillOpacity": 1,
+                               "lineWidth": 1,
+                               "pointSize": 5,
+                               "showPoints": "never",
+                               "spanNulls": false,
+                               "stacking": {
+                                  "group": "A",
+                                  "mode": "none"
+                               }
+                            },
+                            "min": 0,
+                            "thresholds": {
+                               "mode": "absolute",
+                               "steps": [ ]
+                            },
+                            "unit": "short"
+                         },
+                         "overrides": [ ]
+                      },
+                      "id": 19,
+                      "links": [ ],
+                      "options": {
+                         "legend": {
+                            "showLegend": true
+                         },
+                         "tooltip": {
+                            "mode": "single",
+                            "sort": "none"
+                         }
+                      },
+                      "span": 3,
+                      "targets": [
+                         {
+                            "expr": "sum by (scaler) (\n  label_replace(\n    keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".+\"},\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left label_replace(\n    label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n      \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n    ),\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n  *\n  on(cluster, namespace, scaledObject) group_left label_replace(\n    kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n)\n",
+                            "format": "time_series",
+                            "legendFormat": "{{ scaler }}",
+                            "legendLink": null
+                         }
+                      ],
+                      "title": "Desired replicas (leader)",
+                      "type": "timeseries"
+                   },
+                   {
+                      "datasource": "$datasource",
+                      "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler woudln't work properly.\n\n",
+                      "fieldConfig": {
+                         "defaults": {
+                            "custom": {
+                               "drawStyle": "line",
+                               "fillOpacity": 1,
+                               "lineWidth": 1,
+                               "pointSize": 5,
+                               "showPoints": "never",
+                               "spanNulls": false,
+                               "stacking": {
+                                  "group": "A",
+                                  "mode": "none"
+                               }
+                            },
+                            "min": 0,
+                            "thresholds": {
+                               "mode": "absolute",
+                               "steps": [ ]
+                            },
+                            "unit": "short"
+                         },
+                         "overrides": [ ]
+                      },
+                      "id": 20,
+                      "links": [ ],
+                      "options": {
+                         "legend": {
+                            "showLegend": true
+                         },
+                         "tooltip": {
+                            "mode": "single",
+                            "sort": "none"
+                         }
+                      },
+                      "span": 3,
+                      "targets": [
+                         {
+                            "expr": "sum by(cluster, namespace, scaler, metric, scaledObject) (\n  label_replace(\n    rate(keda_scaler_errors[$__rate_interval]),\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.+)\"\n  )\n) +\non(cluster, namespace, metric, scaledObject) group_left\nlabel_replace(\n  label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"} * 0,\n      \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  ),\n  \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                            "format": "time_series",
+                            "legendFormat": "{{scaler}} failures",
+                            "legendLink": null
+                         }
+                      ],
+                      "title": "Autoscaler failures rate",
+                      "type": "timeseries"
+                   }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "Ingester – autoscaling",
+                "titleSize": "h6"
+             },
+             {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
+                   {
+                      "datasource": "$datasource",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -40088,7 +40357,7 @@ data:
                             }
                          ]
                       },
-                      "id": 17,
+                      "id": 21,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -40136,7 +40405,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 18,
+                      "id": 22,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -40363,7 +40632,7 @@ data:
                             }
                          ]
                       },
-                      "id": 19,
+                      "id": 23,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -40411,7 +40680,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 20,
+                      "id": 24,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -40638,7 +40907,7 @@ data:
                             }
                          ]
                       },
-                      "id": 21,
+                      "id": 25,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -40686,7 +40955,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 22,
+                      "id": 26,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -40809,7 +41078,7 @@ data:
                             }
                          ]
                       },
-                      "id": 23,
+                      "id": 27,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -40864,7 +41133,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 24,
+                      "id": 28,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -40987,7 +41256,7 @@ data:
                             }
                          ]
                       },
-                      "id": 25,
+                      "id": 29,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41042,7 +41311,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 26,
+                      "id": 30,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -41165,7 +41434,7 @@ data:
                             }
                          ]
                       },
-                      "id": 27,
+                      "id": 31,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41251,7 +41520,7 @@ data:
                             }
                          ]
                       },
-                      "id": 28,
+                      "id": 32,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41307,7 +41576,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 29,
+                      "id": 33,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41387,7 +41656,7 @@ data:
                             }
                          ]
                       },
-                      "id": 30,
+                      "id": 34,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41454,7 +41723,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 31,
+                      "id": 35,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41503,7 +41772,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 32,
+                      "id": 36,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41552,7 +41821,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 33,
+                      "id": 37,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41601,7 +41870,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 34,
+                      "id": 38,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41661,7 +41930,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 35,
+                      "id": 39,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41709,7 +41978,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 36,
+                      "id": 40,
                       "links": [ ],
                       "options": {
                          "legend": {

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -39929,275 +39929,6 @@ data:
                 "panels": [
                    {
                       "datasource": "$datasource",
-                      "description": "### Replicas (leader)\nThe minimum, maximum, and current number of replicas for the leader zone of ingesters.\nOther zones scale to follow this zone (with delay for downscale).\n<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
-                      "fieldConfig": {
-                         "defaults": {
-                            "custom": {
-                               "drawStyle": "line",
-                               "fillOpacity": 1,
-                               "lineWidth": 1,
-                               "pointSize": 5,
-                               "showPoints": "never",
-                               "spanNulls": false,
-                               "stacking": {
-                                  "group": "A",
-                                  "mode": "none"
-                               }
-                            },
-                            "min": 0,
-                            "thresholds": {
-                               "mode": "absolute",
-                               "steps": [ ]
-                            },
-                            "unit": "short"
-                         },
-                         "overrides": [
-                            {
-                               "matcher": {
-                                  "id": "byRegexp",
-                                  "options": "/Max .+/"
-                               },
-                               "properties": [
-                                  {
-                                     "id": "custom.fillOpacity",
-                                     "value": 0
-                                  },
-                                  {
-                                     "id": "custom.lineStyle",
-                                     "value": {
-                                        "fill": "dash"
-                                     }
-                                  }
-                               ]
-                            },
-                            {
-                               "matcher": {
-                                  "id": "byRegexp",
-                                  "options": "/Current .+/"
-                               },
-                               "properties": [
-                                  {
-                                     "id": "custom.fillOpacity",
-                                     "value": 0
-                                  }
-                               ]
-                            },
-                            {
-                               "matcher": {
-                                  "id": "byRegexp",
-                                  "options": "/Min .+/"
-                               },
-                               "properties": [
-                                  {
-                                     "id": "custom.fillOpacity",
-                                     "value": 0
-                                  },
-                                  {
-                                     "id": "custom.lineStyle",
-                                     "value": {
-                                        "fill": "dash"
-                                     }
-                                  }
-                               ]
-                            }
-                         ]
-                      },
-                      "id": 17,
-                      "links": [ ],
-                      "options": {
-                         "legend": {
-                            "showLegend": true
-                         },
-                         "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                         }
-                      },
-                      "span": 3,
-                      "targets": [
-                         {
-                            "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
-                            "format": "time_series",
-                            "legendFormat": "Max {{ scaletargetref_name }}",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # HPA doesn't go to 0 replicas, so we multiply by 0 if the HPA is not active\n  * on (cluster, namespace, horizontalpodautoscaler)\n    kube_horizontalpodautoscaler_status_condition{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\", condition=\"ScalingActive\", status=\"true\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
-                            "format": "time_series",
-                            "legendFormat": "Current {{ scaletargetref_name }}",
-                            "legendLink": null
-                         },
-                         {
-                            "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
-                            "format": "time_series",
-                            "legendFormat": "Min {{ scaletargetref_name }}",
-                            "legendLink": null
-                         }
-                      ],
-                      "title": "Replicas (leader)",
-                      "type": "timeseries"
-                   },
-                   {
-                      "datasource": "$datasource",
-                      "description": "### Replicas\nNumber of ingester replicas per zone.\n",
-                      "fieldConfig": {
-                         "defaults": {
-                            "custom": {
-                               "drawStyle": "line",
-                               "fillOpacity": 1,
-                               "lineWidth": 1,
-                               "pointSize": 5,
-                               "showPoints": "never",
-                               "spanNulls": false,
-                               "stacking": {
-                                  "group": "A",
-                                  "mode": "none"
-                               }
-                            },
-                            "min": 0,
-                            "thresholds": {
-                               "mode": "absolute",
-                               "steps": [ ]
-                            },
-                            "unit": "short"
-                         },
-                         "overrides": [ ]
-                      },
-                      "id": 18,
-                      "links": [ ],
-                      "options": {
-                         "legend": {
-                            "showLegend": true
-                         },
-                         "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                         }
-                      },
-                      "span": 3,
-                      "targets": [
-                         {
-                            "expr": "sum by (job) (up{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\"})",
-                            "format": "time_series",
-                            "legendFormat": "{{ job }}",
-                            "legendLink": null
-                         }
-                      ],
-                      "title": "Replicas",
-                      "type": "timeseries"
-                   },
-                   {
-                      "datasource": "$datasource",
-                      "description": "### Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold and multiplied by the current number of replicas.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
-                      "fieldConfig": {
-                         "defaults": {
-                            "custom": {
-                               "drawStyle": "line",
-                               "fillOpacity": 1,
-                               "lineWidth": 1,
-                               "pointSize": 5,
-                               "showPoints": "never",
-                               "spanNulls": false,
-                               "stacking": {
-                                  "group": "A",
-                                  "mode": "none"
-                               }
-                            },
-                            "min": 0,
-                            "thresholds": {
-                               "mode": "absolute",
-                               "steps": [ ]
-                            },
-                            "unit": "short"
-                         },
-                         "overrides": [ ]
-                      },
-                      "id": 19,
-                      "links": [ ],
-                      "options": {
-                         "legend": {
-                            "showLegend": true
-                         },
-                         "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                         }
-                      },
-                      "span": 3,
-                      "targets": [
-                         {
-                            "expr": "sum by (scaler) (\n  label_replace(\n    keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".+\"},\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left label_replace(\n    label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n      \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n    ),\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n  *\n  on(cluster, namespace, scaledObject) group_left label_replace(\n    kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n)\n",
-                            "format": "time_series",
-                            "legendFormat": "{{ scaler }}",
-                            "legendLink": null
-                         }
-                      ],
-                      "title": "Desired replicas (leader)",
-                      "type": "timeseries"
-                   },
-                   {
-                      "datasource": "$datasource",
-                      "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler woudln't work properly.\n\n",
-                      "fieldConfig": {
-                         "defaults": {
-                            "custom": {
-                               "drawStyle": "line",
-                               "fillOpacity": 1,
-                               "lineWidth": 1,
-                               "pointSize": 5,
-                               "showPoints": "never",
-                               "spanNulls": false,
-                               "stacking": {
-                                  "group": "A",
-                                  "mode": "none"
-                               }
-                            },
-                            "min": 0,
-                            "thresholds": {
-                               "mode": "absolute",
-                               "steps": [ ]
-                            },
-                            "unit": "short"
-                         },
-                         "overrides": [ ]
-                      },
-                      "id": 20,
-                      "links": [ ],
-                      "options": {
-                         "legend": {
-                            "showLegend": true
-                         },
-                         "tooltip": {
-                            "mode": "single",
-                            "sort": "none"
-                         }
-                      },
-                      "span": 3,
-                      "targets": [
-                         {
-                            "expr": "sum by(cluster, namespace, scaler, metric, scaledObject) (\n  label_replace(\n    rate(keda_scaler_errors[$__rate_interval]),\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.+)\"\n  )\n) +\non(cluster, namespace, metric, scaledObject) group_left\nlabel_replace(\n  label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"} * 0,\n      \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  ),\n  \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
-                            "format": "time_series",
-                            "legendFormat": "{{scaler}} failures",
-                            "legendLink": null
-                         }
-                      ],
-                      "title": "Autoscaler failures rate",
-                      "type": "timeseries"
-                   }
-                ],
-                "repeat": null,
-                "repeatIteration": null,
-                "repeatRowId": null,
-                "showTitle": true,
-                "title": "Ingester – autoscaling",
-                "titleSize": "h6"
-             },
-             {
-                "collapse": false,
-                "height": "250px",
-                "panels": [
-                   {
-                      "datasource": "$datasource",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -40357,7 +40088,7 @@ data:
                             }
                          ]
                       },
-                      "id": 21,
+                      "id": 17,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -40405,7 +40136,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 22,
+                      "id": 18,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -40632,7 +40363,7 @@ data:
                             }
                          ]
                       },
-                      "id": 23,
+                      "id": 19,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -40680,7 +40411,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 24,
+                      "id": 20,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -40907,7 +40638,7 @@ data:
                             }
                          ]
                       },
-                      "id": 25,
+                      "id": 21,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -40955,7 +40686,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 26,
+                      "id": 22,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -41078,7 +40809,7 @@ data:
                             }
                          ]
                       },
-                      "id": 27,
+                      "id": 23,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41133,7 +40864,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 28,
+                      "id": 24,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -41256,7 +40987,7 @@ data:
                             }
                          ]
                       },
-                      "id": 29,
+                      "id": 25,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41311,7 +41042,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 30,
+                      "id": 26,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -41434,7 +41165,7 @@ data:
                             }
                          ]
                       },
-                      "id": 31,
+                      "id": 27,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41520,7 +41251,7 @@ data:
                             }
                          ]
                       },
-                      "id": 32,
+                      "id": 28,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41576,7 +41307,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 33,
+                      "id": 29,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41656,7 +41387,7 @@ data:
                             }
                          ]
                       },
-                      "id": 34,
+                      "id": 30,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41723,7 +41454,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 35,
+                      "id": 31,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41772,7 +41503,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 36,
+                      "id": 32,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41821,7 +41552,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 37,
+                      "id": 33,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41870,7 +41601,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 38,
+                      "id": 34,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41930,7 +41661,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 39,
+                      "id": 35,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -41978,7 +41709,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 40,
+                      "id": 36,
                       "links": [ ],
                       "options": {
                          "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -1251,7 +1251,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of ruler-querier replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe minimum, maximum, and current number of ruler-querier replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -1334,275 +1334,6 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas (leader)\nThe minimum, maximum, and current number of replicas for the leader zone of ingesters.\nOther zones scale to follow this zone (with delay for downscale).\n<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 1,
-                           "lineWidth": 1,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "none"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "short"
-                     },
-                     "overrides": [
-                        {
-                           "matcher": {
-                              "id": "byRegexp",
-                              "options": "/Max .+/"
-                           },
-                           "properties": [
-                              {
-                                 "id": "custom.fillOpacity",
-                                 "value": 0
-                              },
-                              {
-                                 "id": "custom.lineStyle",
-                                 "value": {
-                                    "fill": "dash"
-                                 }
-                              }
-                           ]
-                        },
-                        {
-                           "matcher": {
-                              "id": "byRegexp",
-                              "options": "/Current .+/"
-                           },
-                           "properties": [
-                              {
-                                 "id": "custom.fillOpacity",
-                                 "value": 0
-                              }
-                           ]
-                        },
-                        {
-                           "matcher": {
-                              "id": "byRegexp",
-                              "options": "/Min .+/"
-                           },
-                           "properties": [
-                              {
-                                 "id": "custom.fillOpacity",
-                                 "value": 0
-                              },
-                              {
-                                 "id": "custom.lineStyle",
-                                 "value": {
-                                    "fill": "dash"
-                                 }
-                              }
-                           ]
-                        }
-                     ]
-                  },
-                  "id": 17,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "single",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 3,
-                  "targets": [
-                     {
-                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "Max {{ scaletargetref_name }}",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # HPA doesn't go to 0 replicas, so we multiply by 0 if the HPA is not active\n  * on (cluster, namespace, horizontalpodautoscaler)\n    kube_horizontalpodautoscaler_status_condition{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\", condition=\"ScalingActive\", status=\"true\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "Current {{ scaletargetref_name }}",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "Min {{ scaletargetref_name }}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Replicas (leader)",
-                  "type": "timeseries"
-               },
-               {
-                  "datasource": "$datasource",
-                  "description": "### Replicas\nNumber of ingester replicas per zone.\n",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 1,
-                           "lineWidth": 1,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "none"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "short"
-                     },
-                     "overrides": [ ]
-                  },
-                  "id": 18,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "single",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 3,
-                  "targets": [
-                     {
-                        "expr": "sum by (job) (up{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\"})",
-                        "format": "time_series",
-                        "legendFormat": "{{ job }}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Replicas",
-                  "type": "timeseries"
-               },
-               {
-                  "datasource": "$datasource",
-                  "description": "### Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold and multiplied by the current number of replicas.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 1,
-                           "lineWidth": 1,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "none"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "short"
-                     },
-                     "overrides": [ ]
-                  },
-                  "id": 19,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "single",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 3,
-                  "targets": [
-                     {
-                        "expr": "sum by (scaler) (\n  label_replace(\n    keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".+\"},\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left label_replace(\n    label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n      \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n    ),\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n  *\n  on(cluster, namespace, scaledObject) group_left label_replace(\n    kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "{{ scaler }}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Desired replicas (leader)",
-                  "type": "timeseries"
-               },
-               {
-                  "datasource": "$datasource",
-                  "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler woudln't work properly.\n\n",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 1,
-                           "lineWidth": 1,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "none"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "short"
-                     },
-                     "overrides": [ ]
-                  },
-                  "id": 20,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "single",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 3,
-                  "targets": [
-                     {
-                        "expr": "sum by(cluster, namespace, scaler, metric, scaledObject) (\n  label_replace(\n    rate(keda_scaler_errors[$__rate_interval]),\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.+)\"\n  )\n) +\non(cluster, namespace, metric, scaledObject) group_left\nlabel_replace(\n  label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"} * 0,\n      \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  ),\n  \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "{{scaler}} failures",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Autoscaler failures rate",
-                  "type": "timeseries"
-               }
-            ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
-            "title": "Ingester – autoscaling",
-            "titleSize": "h6"
-         },
-         {
-            "collapse": false,
-            "height": "250px",
-            "panels": [
-               {
-                  "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1762,7 +1493,7 @@
                         }
                      ]
                   },
-                  "id": 21,
+                  "id": 17,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1810,7 +1541,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 18,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2037,7 +1768,7 @@
                         }
                      ]
                   },
-                  "id": 23,
+                  "id": 19,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2085,7 +1816,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 20,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2312,7 +2043,7 @@
                         }
                      ]
                   },
-                  "id": 25,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2360,7 +2091,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 22,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2483,7 +2214,7 @@
                         }
                      ]
                   },
-                  "id": 27,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2538,7 +2269,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 24,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2661,7 +2392,7 @@
                         }
                      ]
                   },
-                  "id": 29,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2716,7 +2447,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 30,
+                  "id": 26,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2839,7 +2570,7 @@
                         }
                      ]
                   },
-                  "id": 31,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2925,7 +2656,7 @@
                         }
                      ]
                   },
-                  "id": 32,
+                  "id": 28,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2981,7 +2712,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3061,7 +2792,7 @@
                         }
                      ]
                   },
-                  "id": 34,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3128,7 +2859,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3177,7 +2908,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3226,7 +2957,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3275,7 +3006,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 38,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3335,7 +3066,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 39,
+                  "id": 35,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3383,7 +3114,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 40,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -1065,7 +1065,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of distributor replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe minimum, maximum, and current number of distributor replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1334,6 +1334,275 @@
             "panels": [
                {
                   "datasource": "$datasource",
+                  "description": "### Replicas (leader)\nThe minimum, maximum, and current number of replicas for the leader zone of ingesters.\nOther zones scale to follow this zone (with delay for downscale).\n<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/Max .+/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              },
+                              {
+                                 "id": "custom.lineStyle",
+                                 "value": {
+                                    "fill": "dash"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/Current .+/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/Min .+/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              },
+                              {
+                                 "id": "custom.lineStyle",
+                                 "value": {
+                                    "fill": "dash"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "id": 17,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "Max {{ scaletargetref_name }}",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # HPA doesn't go to 0 replicas, so we multiply by 0 if the HPA is not active\n  * on (cluster, namespace, horizontalpodautoscaler)\n    kube_horizontalpodautoscaler_status_condition{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\", condition=\"ScalingActive\", status=\"true\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "Current {{ scaletargetref_name }}",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "Min {{ scaletargetref_name }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Replicas (leader)",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Replicas\nNumber of ingester replicas per zone.\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 18,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by (job) (up{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\"})",
+                        "format": "time_series",
+                        "legendFormat": "{{ job }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Replicas",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold and multiplied by the current number of replicas.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 19,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by (scaler) (\n  label_replace(\n    keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".+\"},\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left label_replace(\n    label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n      \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n    ),\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n  *\n  on(cluster, namespace, scaledObject) group_left label_replace(\n    kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "{{ scaler }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Desired replicas (leader)",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler woudln't work properly.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 20,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by(cluster, namespace, scaler, metric, scaledObject) (\n  label_replace(\n    rate(keda_scaler_errors[$__rate_interval]),\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.+)\"\n  )\n) +\non(cluster, namespace, metric, scaledObject) group_left\nlabel_replace(\n  label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"} * 0,\n      \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  ),\n  \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "{{scaler}} failures",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Autoscaler failures rate",
+                  "type": "timeseries"
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Ingester – autoscaling",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1493,7 +1762,7 @@
                         }
                      ]
                   },
-                  "id": 17,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1541,7 +1810,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 18,
+                  "id": 22,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1768,7 +2037,7 @@
                         }
                      ]
                   },
-                  "id": 19,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1816,7 +2085,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 20,
+                  "id": 24,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2043,7 +2312,7 @@
                         }
                      ]
                   },
-                  "id": 21,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2091,7 +2360,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 26,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2214,7 +2483,7 @@
                         }
                      ]
                   },
-                  "id": 23,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2269,7 +2538,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 28,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2392,7 +2661,7 @@
                         }
                      ]
                   },
-                  "id": 25,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2447,7 +2716,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 30,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2570,7 +2839,7 @@
                         }
                      ]
                   },
-                  "id": 27,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2656,7 +2925,7 @@
                         }
                      ]
                   },
-                  "id": 28,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2712,7 +2981,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2792,7 +3061,7 @@
                         }
                      ]
                   },
-                  "id": 30,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2859,7 +3128,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 31,
+                  "id": 35,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2908,7 +3177,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 32,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2957,7 +3226,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 37,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3006,7 +3275,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 34,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3066,7 +3335,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 39,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3114,7 +3383,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 40,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -1251,7 +1251,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of ruler-querier replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe minimum, maximum, and current number of ruler-querier replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -1334,275 +1334,6 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas (leader)\nThe minimum, maximum, and current number of replicas for the leader zone of ingesters.\nOther zones scale to follow this zone (with delay for downscale).\n<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 1,
-                           "lineWidth": 1,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "none"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "short"
-                     },
-                     "overrides": [
-                        {
-                           "matcher": {
-                              "id": "byRegexp",
-                              "options": "/Max .+/"
-                           },
-                           "properties": [
-                              {
-                                 "id": "custom.fillOpacity",
-                                 "value": 0
-                              },
-                              {
-                                 "id": "custom.lineStyle",
-                                 "value": {
-                                    "fill": "dash"
-                                 }
-                              }
-                           ]
-                        },
-                        {
-                           "matcher": {
-                              "id": "byRegexp",
-                              "options": "/Current .+/"
-                           },
-                           "properties": [
-                              {
-                                 "id": "custom.fillOpacity",
-                                 "value": 0
-                              }
-                           ]
-                        },
-                        {
-                           "matcher": {
-                              "id": "byRegexp",
-                              "options": "/Min .+/"
-                           },
-                           "properties": [
-                              {
-                                 "id": "custom.fillOpacity",
-                                 "value": 0
-                              },
-                              {
-                                 "id": "custom.lineStyle",
-                                 "value": {
-                                    "fill": "dash"
-                                 }
-                              }
-                           ]
-                        }
-                     ]
-                  },
-                  "id": 17,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "single",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 3,
-                  "targets": [
-                     {
-                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "Max {{ scaletargetref_name }}",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # HPA doesn't go to 0 replicas, so we multiply by 0 if the HPA is not active\n  * on (cluster, namespace, horizontalpodautoscaler)\n    kube_horizontalpodautoscaler_status_condition{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\", condition=\"ScalingActive\", status=\"true\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "Current {{ scaletargetref_name }}",
-                        "legendLink": null
-                     },
-                     {
-                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "Min {{ scaletargetref_name }}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Replicas (leader)",
-                  "type": "timeseries"
-               },
-               {
-                  "datasource": "$datasource",
-                  "description": "### Replicas\nNumber of ingester replicas per zone.\n",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 1,
-                           "lineWidth": 1,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "none"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "short"
-                     },
-                     "overrides": [ ]
-                  },
-                  "id": 18,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "single",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 3,
-                  "targets": [
-                     {
-                        "expr": "sum by (job) (up{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\"})",
-                        "format": "time_series",
-                        "legendFormat": "{{ job }}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Replicas",
-                  "type": "timeseries"
-               },
-               {
-                  "datasource": "$datasource",
-                  "description": "### Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold and multiplied by the current number of replicas.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 1,
-                           "lineWidth": 1,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "none"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "short"
-                     },
-                     "overrides": [ ]
-                  },
-                  "id": 19,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "single",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 3,
-                  "targets": [
-                     {
-                        "expr": "sum by (scaler) (\n  label_replace(\n    keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".+\"},\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left label_replace(\n    label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n      \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n    ),\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n  *\n  on(cluster, namespace, scaledObject) group_left label_replace(\n    kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "{{ scaler }}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Desired replicas (leader)",
-                  "type": "timeseries"
-               },
-               {
-                  "datasource": "$datasource",
-                  "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler woudln't work properly.\n\n",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 1,
-                           "lineWidth": 1,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "none"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "short"
-                     },
-                     "overrides": [ ]
-                  },
-                  "id": 20,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "single",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 3,
-                  "targets": [
-                     {
-                        "expr": "sum by(cluster, namespace, scaler, metric, scaledObject) (\n  label_replace(\n    rate(keda_scaler_errors[$__rate_interval]),\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.+)\"\n  )\n) +\non(cluster, namespace, metric, scaledObject) group_left\nlabel_replace(\n  label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"} * 0,\n      \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  ),\n  \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
-                        "format": "time_series",
-                        "legendFormat": "{{scaler}} failures",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Autoscaler failures rate",
-                  "type": "timeseries"
-               }
-            ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
-            "title": "Ingester – autoscaling",
-            "titleSize": "h6"
-         },
-         {
-            "collapse": false,
-            "height": "250px",
-            "panels": [
-               {
-                  "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1762,7 +1493,7 @@
                         }
                      ]
                   },
-                  "id": 21,
+                  "id": 17,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1810,7 +1541,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 18,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2037,7 +1768,7 @@
                         }
                      ]
                   },
-                  "id": 23,
+                  "id": 19,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2085,7 +1816,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 20,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2312,7 +2043,7 @@
                         }
                      ]
                   },
-                  "id": 25,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2360,7 +2091,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 22,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2483,7 +2214,7 @@
                         }
                      ]
                   },
-                  "id": 27,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2538,7 +2269,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 24,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2661,7 +2392,7 @@
                         }
                      ]
                   },
-                  "id": 29,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2716,7 +2447,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 30,
+                  "id": 26,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2839,7 +2570,7 @@
                         }
                      ]
                   },
-                  "id": 31,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2925,7 +2656,7 @@
                         }
                      ]
                   },
-                  "id": 32,
+                  "id": 28,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2981,7 +2712,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3061,7 +2792,7 @@
                         }
                      ]
                   },
-                  "id": 34,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3128,7 +2859,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3177,7 +2908,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3226,7 +2957,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3275,7 +3006,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 38,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3335,7 +3066,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 39,
+                  "id": 35,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3383,7 +3114,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 40,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -1065,7 +1065,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe maximum and current number of distributor replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "description": "### Replicas\nThe minimum, maximum, and current number of distributor replicas.<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1334,6 +1334,275 @@
             "panels": [
                {
                   "datasource": "$datasource",
+                  "description": "### Replicas (leader)\nThe minimum, maximum, and current number of replicas for the leader zone of ingesters.\nOther zones scale to follow this zone (with delay for downscale).\n<br /><br />\nNote: The current number of replicas can still show 1 replica even when scaled to 0.\nBecause HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/Max .+/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              },
+                              {
+                                 "id": "custom.lineStyle",
+                                 "value": {
+                                    "fill": "dash"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/Current .+/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/Min .+/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              },
+                              {
+                                 "id": "custom.lineStyle",
+                                 "value": {
+                                    "fill": "dash"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "id": 17,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "Max {{ scaletargetref_name }}",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # HPA doesn't go to 0 replicas, so we multiply by 0 if the HPA is not active\n  * on (cluster, namespace, horizontalpodautoscaler)\n    kube_horizontalpodautoscaler_status_condition{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\", condition=\"ScalingActive\", status=\"true\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "Current {{ scaletargetref_name }}",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n  # Add the scaletargetref_name label for readability\n  + on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    0*kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"}\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "Min {{ scaletargetref_name }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Replicas (leader)",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Replicas\nNumber of ingester replicas per zone.\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 18,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by (job) (up{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\"})",
+                        "format": "time_series",
+                        "legendFormat": "{{ job }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Replicas",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold and multiplied by the current number of replicas.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 19,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by (scaler) (\n  label_replace(\n    keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".+\"},\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left label_replace(\n    label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n      \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n    ),\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n  *\n  on(cluster, namespace, scaledObject) group_left label_replace(\n    kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"},\n    \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  )\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "{{ scaler }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Desired replicas (leader)",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler woudln't work properly.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 20,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "single",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by(cluster, namespace, scaler, metric, scaledObject) (\n  label_replace(\n    rate(keda_scaler_errors[$__rate_interval]),\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.+)\"\n  )\n) +\non(cluster, namespace, metric, scaledObject) group_left\nlabel_replace(\n  label_replace(\n      kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-ingester-zone-a\"} * 0,\n      \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(.*)\"\n  ),\n  \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "{{scaler}} failures",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Autoscaler failures rate",
+                  "type": "timeseries"
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Ingester – autoscaling",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "datasource": "$datasource",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1493,7 +1762,7 @@
                         }
                      ]
                   },
-                  "id": 17,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1541,7 +1810,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 18,
+                  "id": 22,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1768,7 +2037,7 @@
                         }
                      ]
                   },
-                  "id": 19,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1816,7 +2085,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 20,
+                  "id": 24,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2043,7 +2312,7 @@
                         }
                      ]
                   },
-                  "id": 21,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2091,7 +2360,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 26,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2214,7 +2483,7 @@
                         }
                      ]
                   },
-                  "id": 23,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2269,7 +2538,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 28,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2392,7 +2661,7 @@
                         }
                      ]
                   },
-                  "id": 25,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2447,7 +2716,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 30,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2570,7 +2839,7 @@
                         }
                      ]
                   },
-                  "id": 27,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2656,7 +2925,7 @@
                         }
                      ]
                   },
-                  "id": 28,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2712,7 +2981,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2792,7 +3061,7 @@
                         }
                      ]
                   },
-                  "id": 30,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2859,7 +3128,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 31,
+                  "id": 35,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2908,7 +3177,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 32,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2957,7 +3226,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 37,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3006,7 +3275,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 34,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3066,7 +3335,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 39,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3114,7 +3383,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 40,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -642,7 +642,7 @@
         hpa_name: $._config.autoscaling_hpa_prefix + 'cortex-gw.*',
       },
       ingester: {
-        enabled: true,
+        enabled: false,
         hpa_name: $._config.autoscaling_hpa_prefix + 'ingester-zone-a',
       },
     },

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -642,7 +642,7 @@
         hpa_name: $._config.autoscaling_hpa_prefix + 'cortex-gw.*',
       },
       ingester: {
-        enabled: false,
+        enabled: true,
         hpa_name: $._config.autoscaling_hpa_prefix + 'ingester-zone-a',
       },
     },

--- a/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/remote-ruler-reads.libsonnet
@@ -75,13 +75,13 @@ local filename = 'mimir-remote-ruler-reads.json';
       $._config.autoscaling.ruler_querier.enabled,
       $.row('')
       .addPanel(
-        $.autoScalingDesiredReplicasByScalingMetricPanel('ruler_querier', 'CPU', 'cpu')
+        $.autoScalingDesiredReplicasByAverageValueScalingMetricPanel('ruler_querier', 'CPU', 'cpu')
       )
       .addPanel(
-        $.autoScalingDesiredReplicasByScalingMetricPanel('ruler_querier', 'memory', 'memory')
+        $.autoScalingDesiredReplicasByAverageValueScalingMetricPanel('ruler_querier', 'memory', 'memory')
       )
       .addPanel(
-        $.autoScalingDesiredReplicasByScalingMetricPanel('ruler_querier', 'in-flight queries', 'queries')
+        $.autoScalingDesiredReplicasByAverageValueScalingMetricPanel('ruler_querier', 'in-flight queries', 'queries')
       )
     ),
 }

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -391,9 +391,9 @@ local filename = 'mimir-writes.json';
       $._config.autoscaling.ingester.enabled,
       $.row('Ingester – autoscaling')
       .addPanel(
-        $.autoScalingActualReplicas('ingester') + { title: 'Replicas (leader)' } +
+        $.autoScalingActualReplicas('ingester') + { title: 'Replicas (leader zone)' } +
         $.panelDescription(
-          'Replicas (leader)',
+          'Replicas (leader zone)',
           |||
             The minimum, maximum, and current number of replicas for the leader zone of ingesters.
             Other zones scale to follow this zone (with delay for downscale).
@@ -416,7 +416,7 @@ local filename = 'mimir-writes.json';
         ),
       )
       .addPanel(
-        $.autoScalingDesiredReplicasByValueScalingMetricPanel('ingester', '', '') + { title: 'Desired replicas (leader)' }
+        $.autoScalingDesiredReplicasByValueScalingMetricPanel('ingester', '', '') + { title: 'Desired replicas (leader zone)' }
       )
       .addPanel(
         $.autoScalingFailuresPanel('ingester') + { title: 'Autoscaler failures rate' }

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -388,6 +388,41 @@ local filename = 'mimir-writes.json';
       $.cpuAndMemoryBasedAutoScalingRow('Distributor'),
     )
     .addRowIf(
+      $._config.autoscaling.ingester.enabled,
+      $.row('Ingester – autoscaling')
+      .addPanel(
+        $.autoScalingActualReplicas('ingester') + { title: 'Replicas (leader)' } +
+        $.panelDescription(
+          'Replicas (leader)',
+          |||
+            The minimum, maximum, and current number of replicas for the leader zone of ingesters.
+            Other zones scale to follow this zone (with delay for downscale).
+            <br /><br />
+            Note: The current number of replicas can still show 1 replica even when scaled to 0.
+            Because HPA never reports 0 replicas, the query will report 0 only if the HPA is not active.
+          |||
+        )
+      )
+      .addPanel(
+        $.timeseriesPanel('Replicas') +
+        $.panelDescription('Replicas', 'Number of ingester replicas per zone.') +
+        $.queryPanel(
+          [
+            'sum by (%s) (up{%s})' % [$._config.per_job_label, $.jobMatcher($._config.job_names.ingester)],
+          ],
+          [
+            '{{ %(per_job_label)s }}' % $._config.per_job_label,
+          ],
+        ),
+      )
+      .addPanel(
+        $.autoScalingDesiredReplicasByValueScalingMetricPanel('ingester', '', '') + { title: 'Desired replicas (leader)' }
+      )
+      .addPanel(
+        $.autoScalingFailuresPanel('ingester') + { title: 'Autoscaler failures rate' }
+      ),
+    )
+    .addRowIf(
       $._config.show_ingest_storage_panels && $._config.autoscaling.ingester.enabled,
       $.row('Ingester – autoscaling (ingest storage)')
       .addPanel(
@@ -395,7 +430,7 @@ local filename = 'mimir-writes.json';
         $.panelDescription(
           'Replicas (ReplicaTemplate)',
           |||
-            The maximum and current number of replicas for ReplicaTemplate object.
+            The minimum, maximum, and current number of replicas for the ReplicaTemplate object.
             Rollout-operator will keep ingester replicas updated based on this object.
             <br /><br />
             Note: The current number of replicas can still show 1 replica even when scaled to 0.
@@ -416,7 +451,7 @@ local filename = 'mimir-writes.json';
         ),
       )
       .addPanel(
-        $.autoScalingDesiredReplicasByScalingMetricPanel('ingester', '', '') + { title: 'Desired replicas (ReplicaTemplate)' }
+        $.autoScalingDesiredReplicasByAverageValueScalingMetricPanel('ingester', '', '') + { title: 'Desired replicas (ReplicaTemplate)' }
       )
       .addPanel(
         $.autoScalingFailuresPanel('ingester') + { title: 'Autoscaler failures rate (ReplicaTemplate)' }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds a row of panels showing the behavior of ingester autoscaling, when NOT using ingester autoscaling. It is a counterpart to https://github.com/grafana/mimir/pull/7970.

The existing autoscaling uses `AverageValue` metrics, but for ingesters we want to use the `Value` type, so I renamed the existing helper function for the current replicas panel and added a `Value` counterpart.

The panels look like this:

<img width="1738" alt="Screenshot 2024-06-21 at 3 26 57 PM" src="https://github.com/grafana/mimir/assets/1776320/48d9544d-dd11-43e9-b933-1276fe7f7d80">

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
