### PR TITLE
mixin: fix naming consistency between gateway and query-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Mixin
 
-* [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards. #7674
+* [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards. #7674 #8502
   * Overview dashboard: status, read/write latency and queries/ingestion per sec panels, `cortex_request_duration_seconds` metric.
 
 ### Jsonnet

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -87,7 +87,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       readRequestsPerSecond: 'cortex_request_duration_seconds_count{%(queryFrontendMatcher)s, route=~"%(readHTTPRoutesRegex)s"}' % variables,
 
       local p = self,
-      readRequestsPerSecondMetric: 'cortex_request_duration_seconds',
+      requestsPerSecondMetric: 'cortex_request_duration_seconds',
       readRequestsPerSecondSelector: '%(queryFrontendMatcher)s, route=~"%(readHTTPRoutesRegex)s"' % variables,
       // These query routes are used in the overview and other dashboard, everythign else is considered "other" queries.
       // Has to be a list to keep the same colors as before, see overridesNonErrorColorsPalette.
@@ -140,7 +140,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       labelValuesCardinalityQueriesPerSecond: queryPerSecond('labelValuesCardinality'),
 
       // Read failures rate as percentage of total requests.
-      readFailuresRate: $.ncHistogramFailureRate(p.readRequestsPerSecondMetric, p.readRequestsPerSecondSelector),
+      readFailuresRate: $.ncHistogramFailureRate(p.requestsPerSecondMetric, p.readRequestsPerSecondSelector),
     },
 
     ruler: {

--- a/operations/mimir-mixin/dashboards/overview.libsonnet
+++ b/operations/mimir-mixin/dashboards/overview.libsonnet
@@ -178,9 +178,9 @@ local filename = 'mimir-overview.json';
         $.timeseriesPanel(std.stripChars('Read requests / sec %(gatewayEnabledPanelTitleSuffix)s' % helpers, ' ')) +
         $.qpsPanelNativeHistogram(
           if $._config.gateway_enabled then
-            $.queries.gateway.readRequestsPerSecondMetric
+            $.queries.gateway.requestsPerSecondMetric
           else
-            $.queries.query_frontend.readRequestsPerSecondMetric,
+            $.queries.query_frontend.requestsPerSecondMetric,
           if $._config.gateway_enabled then
             $.queries.gateway.readRequestsPerSecondSelector
           else


### PR DESCRIPTION
#### What this PR does

Fix bug in #7674 . Deployment with gateway enabled ended in:
```
valuating jsonnet in path ...': RUNTIME ERROR: Field does not exist: readRequestsPerSecondMetric
        /vendor/github.com/grafana/mimir/operations/mimir-mixin/dashboards/overview.libsonnet:181:13-58
       /vendor/grafana-builder/grafana.libsonnet:534:86-96   thunk from <thunk from <thunk from <object <anonymous>>>>
        /vendor/mixin-utils/utils.libsonnet:78:17-23  object <anonymous>
        <std>:773:15-21 thunk <val> from <function <format_codes_obj>>
        <std>:780:27-30 thunk from <thunk <s> from <function <format_codes_obj>>>
        <std>:604:22-25 thunk from <function <format_code>>
        <std>:604:9-26  function <format_code>
        <std>:780:15-50 thunk <s> from <function <format_codes_obj>>
        <std>:785:24-25 thunk from <thunk <s_padded> from <function <format_codes_obj>>>
        <std>:492:30-33 thunk from <thunk from <function <pad_left>>>
        ...
        /drone/src/ksonnet/lib/crossplane-library/grafana/library.libsonnet:2188:39-44  object <anonymous>
        Field "configJson"
        Field "parameters"
        Field "spec"
        Array element 25
        Field "resources"
        Field "data"
        Field "ops-us-east-0"
        Field "envs"
        During manifestation

```

#### Which issue(s) this PR fixes or relates to

Related to #7674

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
