### PR TITLE
Close store-gateway streams as soon as they're not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [BUGFIX] Ingester: fixed timestamp reported in the "the sample has been rejected because its timestamp is too old" error when the write request contains only histograms. #8462
 * [BUGFIX] Store-gateway: store sparse index headers atomically to disk. #8485
 * [BUGFIX] Query scheduler: fix a panic in request queueing. #8451
+* [BUGFIX] Querier: fix issue where "context canceled" is logged for trace spans for requests to store-gateways that return no series when chunks streaming is enabled. #8510
 
 ### Mixin
 


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where store-gateway streams aren't immediately cleaned up once we no longer need them - either because the request resulted in no series, or because chunks streaming is not in use and all chunks have been received.

For example, if the querier is configured to stream chunks from store-gateways and a store-gateway returns no series, we would have held the stream open until the query was finished.

Amongst other things, this fixes the issue where trace spans for requests to store-gateways that return no series are misleadingly reported as having failed with a "context canceled" error. (This is because the stream is later closed when the overall query context is cancelled when the query is completed.)

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
