### PR TITLE
Stop the ruler notifiers on re-shuffle.

### DIFF
--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -368,11 +368,17 @@ func (r *DefaultMultiTenantManager) removeUsersIf(shouldRemove func(userID strin
 	r.notifiersMtx.Lock()
 	for userID, n := range r.notifiers {
 		if shouldRemove(userID) {
-			go n.stop()
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				n.stop()
+			}()
 			delete(r.notifiers, userID)
 		}
 	}
 	r.notifiersMtx.Unlock()
+
+	wg.Wait()
 
 	r.managersTotal.Set(float64(len(r.userManagers)))
 }

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -353,11 +353,16 @@ func (r *DefaultMultiTenantManager) removeUsersIf(shouldRemove func(userID strin
 			r.notifiersMtx.Lock()
 			n, ok := r.notifiers[userID]
 			r.notifiersMtx.Unlock()
+
 			if ok {
 				n.stop()
-				delete(r.notifiers, userID)
 			}
+
+			r.notifiersMtx.Lock()
+			delete(r.notifiers, userID)
+			r.notifiersMtx.Unlock()
 		}()
+
 		delete(r.userManagers, userID)
 
 		r.mapper.cleanupUser(userID)


### PR DESCRIPTION
#### What this PR does

This PR introduces two subtle but important changes (it's mostly a proposal and feel free to argue on this):

1. We now wait until we stop _all_ of the managers. This is important, because managers don't stop rule evaluation that are in-flight, so we'll wait until we finish any sort of rule group evaluation before considering the "tenant removed".

2. Also, once we're done with rule evaluation we _actually_ stop the notifiers. Notifiers weren't stopped before which was mostly a good thing (as we would always make sure that any alerts were getting flushed).

All in all, #1 is mostly up for discussion. However, I think #2 should go in as it makes the behaviour explicit.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
