### PR TITLE
Jsonnet: add config options to easily set partition ingesters replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
 ### Jsonnet
 
 * [FEATURE] Add support for automatically deleting compactor, store-gateway and read-write mode backend PVCs when the corresponding StatefulSet is scaled down. #8382
+* [ENHANCEMENT] Added the following config options to set the number of partition ingester replicas when migrating to experimental ingest storage. #8517
+  * `ingest_storage_migration_partition_ingester_zone_a_replicas`
+  * `ingest_storage_migration_partition_ingester_zone_b_replicas`
+  * `ingest_storage_migration_partition_ingester_zone_c_replicas`
 
 ### Mimirtool
 

--- a/operations/mimir/ingest-storage-migration.libsonnet
+++ b/operations/mimir/ingest-storage-migration.libsonnet
@@ -7,6 +7,10 @@
     ingest_storage_migration_partition_ingester_zone_b_enabled: false,
     ingest_storage_migration_partition_ingester_zone_c_enabled: false,
 
+    ingest_storage_migration_partition_ingester_zone_a_replicas: 1,
+    ingest_storage_migration_partition_ingester_zone_b_replicas: 1,
+    ingest_storage_migration_partition_ingester_zone_c_replicas: 1,
+
     // Controls whether write path components should tee writes both to classic ingesters and Kafka.
     ingest_storage_migration_write_to_partition_ingesters_enabled: false,
     ingest_storage_migration_write_to_classic_ingesters_enabled: false,
@@ -86,6 +90,7 @@
 
   ingester_partition_zone_a_statefulset: if !$._config.ingest_storage_migration_partition_ingester_zone_a_enabled then null else
     self.newIngesterZoneStatefulSet('a-partition', $.ingester_partition_zone_a_container, $.ingester_partition_zone_a_node_affinity_matchers) +
+    statefulSet.mixin.spec.withReplicas($._config.ingest_storage_migration_partition_ingester_zone_a_replicas) +
     partitionIngesterStatefulSetLabelsAndAnnotations +
     (if !$._config.ingest_storage_migration_partition_ingester_zone_a_scale_down then {} else statefulSet.mixin.spec.withReplicas(0)),
 
@@ -98,6 +103,7 @@
 
   ingester_partition_zone_b_statefulset: if !$._config.ingest_storage_migration_partition_ingester_zone_b_enabled then null else
     self.newIngesterZoneStatefulSet('b-partition', $.ingester_partition_zone_b_container, $.ingester_partition_zone_b_node_affinity_matchers) +
+    statefulSet.mixin.spec.withReplicas($._config.ingest_storage_migration_partition_ingester_zone_b_replicas) +
     partitionIngesterStatefulSetLabelsAndAnnotations +
     (if !$._config.ingest_storage_migration_partition_ingester_zone_b_scale_down then {} else statefulSet.mixin.spec.withReplicas(0)),
 
@@ -110,6 +116,7 @@
 
   ingester_partition_zone_c_statefulset: if !$._config.ingest_storage_migration_partition_ingester_zone_c_enabled then null else
     self.newIngesterZoneStatefulSet('c-partition', $.ingester_partition_zone_c_container, $.ingester_partition_zone_c_node_affinity_matchers) +
+    statefulSet.mixin.spec.withReplicas($._config.ingest_storage_migration_partition_ingester_zone_c_replicas) +
     partitionIngesterStatefulSetLabelsAndAnnotations +
     (if !$._config.ingest_storage_migration_partition_ingester_zone_c_scale_down then {} else statefulSet.mixin.spec.withReplicas(0)),
 


### PR DESCRIPTION
#### What this PR does

Add config options to easily set partition ingesters replicas. The jsonnet tests output hasn't changed because 1 replica per StatefulSet is the default.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
