### PR TITLE
Jsonnet: increase -distributor.remote-timeout when ingest storage is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
   * `ingest_storage_migration_partition_ingester_zone_a_replicas`
   * `ingest_storage_migration_partition_ingester_zone_b_replicas`
   * `ingest_storage_migration_partition_ingester_zone_c_replicas`
+* [ENHANCEMENT] Distributor: increase `-distributor.remote-timeout` when the experimental ingest storage is enabled. #8518
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -861,6 +861,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -861,6 +861,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -871,6 +871,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -871,6 +871,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -871,6 +871,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
@@ -871,6 +871,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -802,6 +802,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -802,6 +802,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -802,6 +802,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -802,6 +802,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -861,6 +861,7 @@ spec:
         - -distributor.ingestion-burst-size=200000
         - -distributor.ingestion-rate-limit=10000
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
         - -distributor.ring.heartbeat-period=1m
         - -distributor.ring.heartbeat-timeout=4m
         - -distributor.ring.prefix=

--- a/operations/mimir/ingest-storage-migration.libsonnet
+++ b/operations/mimir/ingest-storage-migration.libsonnet
@@ -139,11 +139,11 @@
   },
 
   distributor_args+::
-    (if !$._config.ingest_storage_migration_write_to_partition_ingesters_enabled then {} else writeToPartitionIngestersArgs) +
+    (if !$._config.ingest_storage_migration_write_to_partition_ingesters_enabled then {} else (writeToPartitionIngestersArgs + $.ingest_storage_distributor_args)) +
     (if !$._config.ingest_storage_migration_write_to_classic_ingesters_enabled then {} else writeToClassicIngestersArgs),
 
   ruler_args+::
-    (if !$._config.ingest_storage_migration_write_to_partition_ingesters_enabled then {} else writeToPartitionIngestersArgs) +
+    (if !$._config.ingest_storage_migration_write_to_partition_ingesters_enabled then {} else (writeToPartitionIngestersArgs + $.ingest_storage_ruler_args)) +
     (if !$._config.ingest_storage_migration_write_to_classic_ingesters_enabled then {} else writeToClassicIngestersArgs),
 
   //

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -68,10 +68,22 @@
   //
 
   distributor_args+:: if !$._config.ingest_storage_enabled then {} else
-    $.ingest_storage_kafka_producer_args,
+    $.ingest_storage_kafka_producer_args +
+    $.ingest_storage_distributor_args,
 
   ruler_args+:: if !$._config.ingest_storage_enabled then {} else
-    $.ingest_storage_kafka_producer_args,
+    $.ingest_storage_kafka_producer_args +
+    $.ingest_storage_ruler_args,
+
+  ingest_storage_distributor_args+:: {
+    // Increase the default remote write timeout (applied to writing to Kafka too) because writing
+    // to Kafka-compatible backend may be slower than writing to ingesters.
+    'distributor.remote-timeout': '5s',
+  },
+
+  ingest_storage_ruler_args+:: {
+    // No need to increase -distributor.remote-timeout because the ruler's default is higher.
+  },
 
   ingest_storage_ingester_args+:: {
     // Disallow Push gRPC API; everything must come from ingest storage.


### PR DESCRIPTION
#### What this PR does

Increase -distributor.remote-timeout when ingest storage is used. Depending on which Kafka-compatible backend is used, the latency ingesting write requests may be higher than classic ingesters.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
