### PR TITLE
Refactor atomicfs package to expose file-like API

### DIFF
--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -93,13 +93,8 @@ func (s *Snapshotter) PersistLoadedBlocks(bl blocksLoader) error {
 		return err
 	}
 
-	// Create temporary path for fsync.
-	// We don't use temporary folder because the process might not have access to the temporary folder.
-	tmpPath := filepath.Join(s.conf.Path, "tmp-"+lazyLoadedHeadersListFileName)
-	// the actual path we want to store the file in
 	finalPath := filepath.Join(s.conf.Path, lazyLoadedHeadersListFileName)
-
-	return atomicfs.CreateFileAndMove(tmpPath, finalPath, bytes.NewReader(data))
+	return atomicfs.CreateFile(finalPath, bytes.NewReader(data))
 }
 
 func (s *Snapshotter) RestoreLoadedBlocks() map[ulid.ULID]int64 {

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -273,7 +273,7 @@ func writeSparseHeadersToFile(logger *spanlogger.SpanLogger, id ulid.ULID, spars
 		return fmt.Errorf("failed to close gzip sparse index-header: %w", err)
 	}
 
-	if err := atomicfs.CreateFileAndMove(sparseHeadersPath+".tmp", sparseHeadersPath, gzipped); err != nil {
+	if err := atomicfs.CreateFile(sparseHeadersPath, gzipped); err != nil {
 		return fmt.Errorf("failed to write sparse index-header file: %w", err)
 	}
 

--- a/pkg/util/atomicfs/fsync.go
+++ b/pkg/util/atomicfs/fsync.go
@@ -3,44 +3,70 @@
 package atomicfs
 
 import (
-	"bytes"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/grafana/dskit/multierror"
 )
 
-// CreateFile creates a file in the filePath, write the data into the file and then execute
-// fsync operation to make sure the file and its content are stored atomically. If the file already
-// exists, it will be overwritten.
-func CreateFile(filePath string, data io.Reader) error {
-	// Write the file, fsync it, then fsync the containing directory in order to guarantee
-	// it is persisted to disk. From https://man7.org/linux/man-pages/man2/fsync.2.html
-	//
-	// > Calling fsync() does not necessarily ensure that the entry in the
-	// > directory containing the file has also reached disk.  For that an
-	// > explicit fsync() on a file descriptor for the directory is also
-	// > needed.
-	file, err := os.Create(filePath)
+// Create creates a new file at a temporary path that will be renamed to the
+// supplied path on close, ensuring all data and the containing directory have
+// been fsynced to disk.
+func Create(path string) (*File, error) {
+	// Important that the temporary file is in the same directory as the final file.
+	final := filepath.Clean(path)
+	tmp := tempPath(final)
+
+	file, err := os.Create(tmp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	merr := multierror.New()
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(data)
-	merr.Add(err)
-	_, err = file.Write(buf.Bytes())
-	merr.Add(err)
-	merr.Add(file.Sync())
-	merr.Add(file.Close())
+	return &File{
+		File:      file,
+		finalPath: final,
+	}, nil
+}
 
+// tempPath returns a path for the temporary version of a file. This function exists
+// to ensure the logic here stays in sync with unit tests that check for this file being
+// cleaned up.
+func tempPath(final string) string {
+	return final + ".tmp"
+}
+
+// File is a wrapper around an os.File instance that uses a temporary file for writes
+// that is renamed to its final path when Close is called. The Close method will also
+// ensure that all data from the file has been fsynced as well as the containing
+// directory. If the temporary file cannot be renamed or fsynced on Close, it is
+// removed.
+type File struct {
+	*os.File
+	finalPath string
+}
+
+func (a *File) Close() error {
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(a.File.Name())
+		}
+	}()
+
+	merr := multierror.New()
+	merr.Add(a.File.Sync())
+	merr.Add(a.File.Close())
 	if err := merr.Err(); err != nil {
 		return err
 	}
 
-	dir, err := os.OpenFile(path.Dir(file.Name()), os.O_RDONLY, 0777)
+	if err := os.Rename(a.File.Name(), a.finalPath); err != nil {
+		return err
+	}
+
+	cleanup = false
+	dir, err := os.Open(filepath.Dir(a.finalPath))
 	if err != nil {
 		return err
 	}
@@ -50,15 +76,16 @@ func CreateFile(filePath string, data io.Reader) error {
 	return merr.Err()
 }
 
-// CreateFileAndMove creates a file in the tmpPath, write the data into the file and then execute
-// fsync operation to make sure the file and its content are stored atomically. After that it will move
-// file to the finalPath to make sure if there is a failure in writing to the tmpPath, we can retry and
-// ensure integrity of the file in the finalPath.
-func CreateFileAndMove(tmpPath, finalPath string, data io.Reader) error {
-	if err := CreateFile(tmpPath, data); err != nil {
+// CreateFile safely writes the contents of data to filePath, ensuring that all data
+// has been fsynced as well as the containing directory of the file.
+func CreateFile(filePath string, data io.Reader) error {
+	f, err := Create(filePath)
+	if err != nil {
 		return err
 	}
-	defer os.Remove(tmpPath)
-	// we rely on the atomicity of this on Unix systems for this method to behave correctly
-	return os.Rename(tmpPath, finalPath)
+
+	_, err = io.Copy(f, data)
+	merr := multierror.New(err)
+	merr.Add(f.Close())
+	return merr.Err()
 }


### PR DESCRIPTION
#### What this PR does

The current atomicfs package exposes methods that operate on paths and write the entire contents of a file, buffering it in memory first. This means that they cannot operate on large files.

This change exposes an `os.File` like API so that the contents of a file can be written without needing to keep the entire file in memory. It also keeps a `CreateFile` method for simplicity  _but_ changes its implementation to not require reading the entire `io.Reader` into memory first.

This also changes the behavior of the atomicfs package so that files are _always_ renamed from a temporary file to the final path. The only place in Mimir using atomicfs that did not already make use of renaming these files is the shutdown marker functionality.

#### Which issue(s) this PR fixes or relates to

Related #8485

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
