### PR TITLE
scheduler querier inflight request tracking fix: mark completed on frontend cancel

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -281,8 +281,9 @@ func (s *Scheduler) FrontendLoop(frontend schedulerpb.SchedulerForFrontend_Front
 		case schedulerpb.CANCEL:
 			requestKey := queue.NewSchedulerRequestKey(frontendAddress, msg.QueryID)
 			schedulerReq := s.cancelRequestAndRemoveFromPending(requestKey, "frontend cancelled query")
-			// we may not have reached SubmitRequestSent for this query, but RequestQueue will handle this case
-			s.requestQueue.QueryComponentUtilization.MarkRequestSent(schedulerReq)
+			// we may not have reached MarkRequestSent for this query before receiving the cancel,
+			// but RequestQueue will just no-op if the request was not yet tracked in the inflightRequests map.
+			s.requestQueue.QueryComponentUtilization.MarkRequestCompleted(schedulerReq)
 			resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
 
 		default:


### PR DESCRIPTION
mistakenly introduced in previous PR https://github.com/grafana/mimir/pull/8417

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

See before and after fix in this screenshot - restarted with new code around that 15:33 mark
Mass canceling requests no longer results in the inflight requests count exceeding the connected querier workers

![image](https://github.com/grafana/mimir/assets/13006869/012fbb72-4c10-4620-bda7-3e218783385c)


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
