### PR TITLE
query-tee: Add support for sending only a proportion of requests to secondary backends

### DIFF
--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -228,7 +228,7 @@ func (p *Proxy) Start() error {
 		if p.cfg.CompareResponses {
 			comparator = route.ResponseComparator
 		}
-		router.Path(route.Path).Methods(route.Methods...).Handler(NewProxyEndpoint(p.backends, route, p.metrics, p.logger, comparator, p.cfg.LogSlowQueryResponseThreshold))
+		router.Path(route.Path).Methods(route.Methods...).Handler(NewProxyEndpoint(p.backends, route, p.metrics, p.logger, comparator, p.cfg.LogSlowQueryResponseThreshold, p.cfg.SecondaryBackendsRequestProportion))
 	}
 
 	if p.cfg.PassThroughNonRegisteredRoutes {

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -24,8 +24,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var errMinBackends = errors.New("at least 1 backend is required")
-
 type ProxyConfig struct {
 	ServerHTTPServiceAddress            string
 	ServerHTTPServicePort               int
@@ -42,6 +40,7 @@ type ProxyConfig struct {
 	SkipRecentSamples                   time.Duration
 	BackendSkipTLSVerify                bool
 	AddMissingTimeParamToInstantQueries bool
+	SecondaryBackendsRequestProportion  float64
 }
 
 func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
@@ -65,6 +64,7 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.SkipRecentSamples, "proxy.compare-skip-recent-samples", 2*time.Minute, "The window from now to skip comparing samples. 0 to disable.")
 	f.BoolVar(&cfg.PassThroughNonRegisteredRoutes, "proxy.passthrough-non-registered-routes", false, "Passthrough requests for non-registered routes to preferred backend.")
 	f.BoolVar(&cfg.AddMissingTimeParamToInstantQueries, "proxy.add-missing-time-parameter-to-instant-queries", true, "Add a 'time' parameter to proxied instant query requests if they do not have one.")
+	f.Float64Var(&cfg.SecondaryBackendsRequestProportion, "proxy.secondary-backends-request-proportion", 1.0, "Proportion of requests to send to secondary backends. Must be between 0 and 1 (inclusive), and if not 1, then -backend.preferred must be set.")
 }
 
 type Route struct {
@@ -102,6 +102,14 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 
 	if cfg.PassThroughNonRegisteredRoutes && cfg.PreferredBackend == "" {
 		return nil, fmt.Errorf("when enabling passthrough for non-registered routes -backend.preferred flag must be set to hostname of backend where those requests needs to be passed")
+	}
+
+	if cfg.SecondaryBackendsRequestProportion < 0 || cfg.SecondaryBackendsRequestProportion > 1 {
+		return nil, errors.New("secondary request proportion must be between 0 and 1 (inclusive)")
+	}
+
+	if cfg.SecondaryBackendsRequestProportion < 1 && cfg.PreferredBackend == "" {
+		return nil, errors.New("preferred backend must be set when secondary backends request proportion is not 1")
 	}
 
 	p := &Proxy{
@@ -143,7 +151,7 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 
 	// At least 1 backend is required
 	if len(p.backends) < 1 {
-		return nil, errMinBackends
+		return nil, errors.New("at least 1 backend is required")
 	}
 
 	// If the preferred backend is configured, then it must exist among the actual backends.

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -119,7 +119,7 @@ func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
 			}()
 
 			// Wait for the selected backend response.
-			actual := endpoint.waitBackendResponseForDownstream(resCh)
+			actual := endpoint.waitBackendResponseForDownstream(testData.backends, resCh)
 			assert.Equal(t, testData.expected, actual.backend)
 		})
 	}

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -107,7 +107,7 @@ func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
 		testData := testData
 
 		t.Run(testName, func(t *testing.T) {
-			endpoint := NewProxyEndpoint(testData.backends, testRoute, NewProxyMetrics(nil), log.NewNopLogger(), nil, 0)
+			endpoint := NewProxyEndpoint(testData.backends, testRoute, NewProxyMetrics(nil), log.NewNopLogger(), nil, 0, 1.0)
 
 			// Send the responses from a dedicated goroutine.
 			resCh := make(chan *backendResponse)
@@ -152,7 +152,7 @@ func Test_ProxyEndpoint_Requests(t *testing.T) {
 		NewProxyBackend("backend-1", backendURL1, time.Second, true, false),
 		NewProxyBackend("backend-2", backendURL2, time.Second, false, false),
 	}
-	endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(nil), log.NewNopLogger(), nil, 0)
+	endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(nil), log.NewNopLogger(), nil, 0, 1.0)
 
 	for _, tc := range []struct {
 		name    string
@@ -328,7 +328,7 @@ func Test_ProxyEndpoint_Comparison(t *testing.T) {
 				comparisonError:  scenario.comparatorError,
 			}
 
-			endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, 0)
+			endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, 0, 1.0)
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "http://test/api/v1/test", nil)
@@ -430,7 +430,7 @@ func Test_ProxyEndpoint_LogSlowQueries(t *testing.T) {
 				comparisonResult: ComparisonSuccess,
 			}
 
-			endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, scenario.slowResponseThreshold)
+			endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, scenario.slowResponseThreshold, 1.0)
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "http://test/api/v1/test", nil)
@@ -499,7 +499,7 @@ func Test_ProxyEndpoint_RelativeDurationMetric(t *testing.T) {
 				comparisonResult: ComparisonSuccess,
 			}
 
-			endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, 0)
+			endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, 0, 1.0)
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "http://test/api/v1/test", nil)
@@ -785,4 +785,75 @@ func (b *mockProxyBackend) ForwardRequest(_ context.Context, _ *http.Request, _ 
 	latency := b.fakeResponseLatencies[b.responseIndex]
 	b.responseIndex++
 	return latency, 200, []byte("{}"), resp, nil
+}
+
+func TestProxyEndpoint_BackendSelection(t *testing.T) {
+	const runCount = 1000
+
+	testCases := map[string]struct {
+		backends                            []ProxyBackendInterface
+		secondaryBackendRequestProportion   float64
+		expectedPreferredOnlySelectionCount int // Out of 1000 runs
+	}{
+		"single preferred backend, secondary request proportion 0.0": {
+			backends:                            []ProxyBackendInterface{newMockProxyBackend("preferred-backend", 0, true, nil)},
+			secondaryBackendRequestProportion:   0.0,
+			expectedPreferredOnlySelectionCount: runCount,
+		},
+		"single preferred backend, secondary request proportion 1.0": {
+			backends:                            []ProxyBackendInterface{newMockProxyBackend("preferred-backend", 0, true, nil)},
+			secondaryBackendRequestProportion:   1.0,
+			expectedPreferredOnlySelectionCount: runCount,
+		},
+		"single non-preferred backend, secondary request proportion 0.0": {
+			backends:                            []ProxyBackendInterface{newMockProxyBackend("preferred-backend", 0, false, nil)},
+			secondaryBackendRequestProportion:   0.0,
+			expectedPreferredOnlySelectionCount: runCount,
+		},
+		"single non-preferred backend, secondary request proportion 1.0": {
+			backends:                            []ProxyBackendInterface{newMockProxyBackend("preferred-backend", 0, false, nil)},
+			secondaryBackendRequestProportion:   1.0,
+			expectedPreferredOnlySelectionCount: runCount,
+		},
+		"multiple backends, secondary request proportion 0.0": {
+			backends:                            []ProxyBackendInterface{newMockProxyBackend("preferred-backend", 0, true, nil), newMockProxyBackend("non-preferred-backend", 0, false, nil)},
+			secondaryBackendRequestProportion:   0.0,
+			expectedPreferredOnlySelectionCount: runCount,
+		},
+		"multiple backends, secondary request proportion 0.2": {
+			backends:                            []ProxyBackendInterface{newMockProxyBackend("preferred-backend", 0, true, nil), newMockProxyBackend("non-preferred-backend", 0, false, nil)},
+			secondaryBackendRequestProportion:   0.2,
+			expectedPreferredOnlySelectionCount: 800,
+		},
+		"multiple backends, secondary request proportion 1.0": {
+			backends:                            []ProxyBackendInterface{newMockProxyBackend("preferred-backend", 0, true, nil), newMockProxyBackend("non-preferred-backend", 0, false, nil)},
+			secondaryBackendRequestProportion:   1.0,
+			expectedPreferredOnlySelectionCount: 0,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			proxyEndpoint := NewProxyEndpoint(testCase.backends, Route{}, nil, nil, nil, 0, testCase.secondaryBackendRequestProportion)
+			preferredOnlySelectionCount := 0
+
+			for i := 0; i < runCount; i++ {
+				backends := proxyEndpoint.selectBackends()
+				require.GreaterOrEqual(t, len(backends), 1)
+
+				if len(backends) == 1 {
+					preferredOnlySelectionCount++
+				}
+			}
+
+			if testCase.expectedPreferredOnlySelectionCount == 0 || testCase.expectedPreferredOnlySelectionCount == runCount {
+				// We expect to have selected only the preferred backend either every time or never.
+				require.Equal(t, testCase.expectedPreferredOnlySelectionCount, preferredOnlySelectionCount)
+			} else {
+				// We expect to have selected only the preferred backend just some of the time.
+				// Allow for some variation due to randomness.
+				require.InEpsilonf(t, testCase.expectedPreferredOnlySelectionCount, preferredOnlySelectionCount, 0.1, "expected to choose only the preferred backend %v times, but chose it %v times", testCase.expectedPreferredOnlySelectionCount, preferredOnlySelectionCount)
+			}
+		})
+	}
 }

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -68,11 +68,116 @@ func testRequestTransformer2(r *http.Request, body []byte, _ *spanlogger.SpanLog
 }
 
 func Test_NewProxy(t *testing.T) {
-	cfg := ProxyConfig{}
+	testCases := map[string]struct {
+		cfg           ProxyConfig
+		expectedError string
+	}{
+		"empty config": {
+			cfg: ProxyConfig{
+				SecondaryBackendsRequestProportion: 1.0,
+			},
+			expectedError: "at least 1 backend is required",
+		},
+		"single endpoint, preferred backend set and exists": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah",
+				PreferredBackend:                   "blah",
+				SecondaryBackendsRequestProportion: 1.0,
+			},
+			expectedError: "",
+		},
+		"single endpoint, preferred backend set and does not exist": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah",
+				PreferredBackend:                   "blah-2",
+				SecondaryBackendsRequestProportion: 1.0,
+			},
+			expectedError: "the preferred backend (hostname) has not been found among the list of configured backends",
+		},
+		"multiple endpoints, preferred backend set and exists": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah,http://other-blah",
+				PreferredBackend:                   "blah",
+				SecondaryBackendsRequestProportion: 1.0,
+			},
+			expectedError: "",
+		},
+		"multiple endpoints, preferred backend set and does not exist": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah,http://other-blah",
+				PreferredBackend:                   "blah-2",
+				SecondaryBackendsRequestProportion: 1.0,
+			},
+			expectedError: "the preferred backend (hostname) has not been found among the list of configured backends",
+		},
+		"invalid endpoint": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "://blah",
+				SecondaryBackendsRequestProportion: 1.0,
+			},
+			expectedError: `invalid backend endpoint ://blah: parse "://blah": missing protocol scheme`,
+		},
+		"multiple endpoints, secondary request proportion less than 0": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah,http://other-blah",
+				PreferredBackend:                   "blah",
+				SecondaryBackendsRequestProportion: -0.1,
+			},
+			expectedError: "secondary request proportion must be between 0 and 1 (inclusive)",
+		},
+		"multiple endpoints, secondary request proportion greater than 1": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah,http://other-blah",
+				PreferredBackend:                   "blah",
+				SecondaryBackendsRequestProportion: 1.1,
+			},
+			expectedError: "secondary request proportion must be between 0 and 1 (inclusive)",
+		},
+		"multiple endpoints, secondary request proportion 1 and preferred backend set": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah,http://other-blah",
+				PreferredBackend:                   "blah",
+				SecondaryBackendsRequestProportion: 1.0,
+			},
+			expectedError: "",
+		},
+		"multiple endpoints, secondary request proportion 1 and preferred backend not set": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah,http://other-blah",
+				SecondaryBackendsRequestProportion: 1.0,
+			},
+			expectedError: "",
+		},
+		"multiple endpoints, secondary request proportion not 1 and preferred backend set": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah,http://other-blah",
+				PreferredBackend:                   "blah",
+				SecondaryBackendsRequestProportion: 0.7,
+			},
+			expectedError: "",
+		},
+		"multiple endpoints, secondary request proportion not 1 and preferred backend not set": {
+			cfg: ProxyConfig{
+				BackendEndpoints:                   "http://blah,http://other-blah",
+				SecondaryBackendsRequestProportion: 0.7,
+			},
+			expectedError: "preferred backend must be set when secondary backends request proportion is not 1",
+		},
+	}
 
-	p, err := NewProxy(cfg, log.NewNopLogger(), testRoutes, nil)
-	assert.Equal(t, errMinBackends, err)
-	assert.Nil(t, p)
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			p, err := NewProxy(testCase.cfg, log.NewNopLogger(), testRoutes, nil)
+
+			if testCase.expectedError == "" {
+				require.NoError(t, err)
+				require.NotNil(t, p)
+			} else {
+				require.EqualError(t, err, testCase.expectedError)
+				require.Nil(t, p)
+			}
+		})
+	}
 }
 
 func Test_Proxy_RequestsForwarding(t *testing.T) {

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -331,13 +331,14 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 
 			// Start the proxy.
 			cfg := ProxyConfig{
-				BackendEndpoints:         strings.Join(backendURLs, ","),
-				PreferredBackend:         strconv.Itoa(testData.preferredBackendIdx),
-				ServerHTTPServiceAddress: "localhost",
-				ServerHTTPServicePort:    0,
-				ServerGRPCServiceAddress: "localhost",
-				ServerGRPCServicePort:    0,
-				BackendReadTimeout:       time.Second,
+				BackendEndpoints:                   strings.Join(backendURLs, ","),
+				PreferredBackend:                   strconv.Itoa(testData.preferredBackendIdx),
+				ServerHTTPServiceAddress:           "localhost",
+				ServerHTTPServicePort:              0,
+				ServerGRPCServiceAddress:           "localhost",
+				ServerGRPCServicePort:              0,
+				BackendReadTimeout:                 time.Second,
+				SecondaryBackendsRequestProportion: 1.0,
 			}
 
 			if len(backendURLs) == 2 {


### PR DESCRIPTION
#### What this PR does

This PR adds support for sending only a proportion of requests to secondary backends in query-tee.

When `-proxy.secondary-backends-request-proportion` is 1.0 (the default), all requests are sent to all configured backends, the same as before.

When `-proxy.secondary-backends-request-proportion` is 0.0, all requests are sent only to the preferred backend.

When `-proxy.secondary-backends-request-proportion` is a value between 0 and 1, that proportion of incoming requests are sent to all backends, and the remainder are sent to the preferred backend only. For example, if `-proxy.secondary-backends-request-proportion` is 0.2, then 20% of requests are sent to all backends, and the remaining 80% are sent to the preferred backend only.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
