### PR TITLE
Dashboards: improve end-to-end latency and strong read consistency panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards. #7674 #8502
   * Overview dashboard: status, read/write latency and queries/ingestion per sec panels, `cortex_request_duration_seconds` metric.
 * [ENHANCEMENT] Alerts: `MimirRunningIngesterReceiveDelayTooHigh` alert has been tuned to be more reactive to high receive delay. #8538
+* [ENHANCEMENT] Dashboards: improve end-to-end latency and strong read consistency panels when experimental ingest storage is enabled. #8543
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -11729,7 +11729,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Query-frontend - query splitting and results cache",
+                "title": "Query-frontend – query splitting and results cache",
                 "titleSize": "h6"
              },
              {
@@ -11871,7 +11871,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Query-frontend - query sharding",
+                "title": "Query-frontend – query sharding",
                 "titleSize": "h6"
              },
              {
@@ -20133,7 +20133,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Querier - autoscaling",
+                "title": "Querier – autoscaling",
                 "titleSize": "h6"
              },
              {
@@ -40923,7 +40923,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Ingester - shipper",
+                "title": "Ingester – shipper",
                 "titleSize": "h6"
              },
              {
@@ -41101,7 +41101,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Ingester - TSDB head",
+                "title": "Ingester – TSDB head",
                 "titleSize": "h6"
              },
              {
@@ -41421,7 +41421,7 @@ data:
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Ingester - TSDB write ahead log (WAL)",
+                "title": "Ingester – TSDB write ahead log (WAL)",
                 "titleSize": "h6"
              },
              {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -642,7 +642,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-frontend - query splitting and results cache",
+            "title": "Query-frontend – query splitting and results cache",
             "titleSize": "h6"
          },
          {
@@ -784,7 +784,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-frontend - query sharding",
+            "title": "Query-frontend – query sharding",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -2504,7 +2504,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Querier - autoscaling",
+            "title": "Querier – autoscaling",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -2328,7 +2328,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Ingester - shipper",
+            "title": "Ingester – shipper",
             "titleSize": "h6"
          },
          {
@@ -2506,7 +2506,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Ingester - TSDB head",
+            "title": "Ingester – TSDB head",
             "titleSize": "h6"
          },
          {
@@ -2826,7 +2826,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Ingester - TSDB write ahead log (WAL)",
+            "title": "Ingester – TSDB write ahead log (WAL)",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -642,7 +642,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-frontend - query splitting and results cache",
+            "title": "Query-frontend – query splitting and results cache",
             "titleSize": "h6"
          },
          {
@@ -784,7 +784,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Query-frontend - query sharding",
+            "title": "Query-frontend – query sharding",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -2504,7 +2504,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Querier - autoscaling",
+            "title": "Querier – autoscaling",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -2328,7 +2328,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Ingester - shipper",
+            "title": "Ingester – shipper",
             "titleSize": "h6"
          },
          {
@@ -2506,7 +2506,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Ingester - TSDB head",
+            "title": "Ingester – TSDB head",
             "titleSize": "h6"
          },
          {
@@ -2826,7 +2826,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Ingester - TSDB write ahead log (WAL)",
+            "title": "Ingester – TSDB write ahead log (WAL)",
             "titleSize": "h6"
          },
          {

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -1632,4 +1632,59 @@ local utils = import 'mixin-utils/utils.libsonnet';
         )
       ),
     ],
+
+  ingestStorageIngesterEndToEndLatencyWhenStartingPanel()::
+    $.timeseriesPanel('Kafka record end-to-end latency when starting') +
+    $.panelDescription(
+      'Kafka record end-to-end latency when starting',
+      |||
+        Time between writing request by distributor to Kafka and reading the record by ingester during catch-up phase, when ingesters are starting.
+        If ingesters are not starting and catching up in the selected time range, this panel will be empty.
+      |||
+    ) +
+    $.queryPanel(
+      [
+        'histogram_avg(sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="starting"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+        'histogram_quantile(0.99, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="starting"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+        'histogram_quantile(0.999, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="starting"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+        'histogram_quantile(1.0, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="starting"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+      ],
+      [
+        'avg',
+        '99th percentile',
+        '99.9th percentile',
+        '100th percentile',
+      ],
+    ) + {
+      fieldConfig+: {
+        defaults+: { unit: 's' },
+      },
+    },
+
+  ingestStorageIngesterEndToEndLatencyWhenRunningPanel()::
+    $.timeseriesPanel('Kafka record end-to-end latency when ingesters are running') +
+    $.panelDescription(
+      'Kafka record end-to-end latency when ingesters are running',
+      |||
+        Time between writing request by distributor to Kafka and reading the record by ingester, when ingesters are running.
+      |||
+    ) +
+    $.queryPanel(
+      [
+        'histogram_avg(sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="running"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+        'histogram_quantile(0.99, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="running"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+        'histogram_quantile(0.999, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="running"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+        'histogram_quantile(1.0, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="running"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+      ],
+      [
+        'avg',
+        '99th percentile',
+        '99.9th percentile',
+        '100th percentile',
+      ],
+    ) + {
+      fieldConfig+: {
+        defaults+: { unit: 's' },
+      },
+    },
 }

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -56,7 +56,7 @@ local filename = 'mimir-queries.json';
       )
     )
     .addRow(
-      $.row('Query-frontend - query splitting and results cache')
+      $.row('Query-frontend – query splitting and results cache')
       .addPanel(
         $.timeseriesPanel('Intervals per query') +
         $.queryPanel('sum(rate(cortex_frontend_split_queries_total{%s}[$__rate_interval])) / sum(rate(cortex_frontend_query_range_duration_seconds_count{%s, method="split_by_interval_and_results_cache"}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.query_frontend), $.jobMatcher($._config.job_names.query_frontend)], 'splitting rate') +
@@ -120,7 +120,7 @@ local filename = 'mimir-queries.json';
       )
     )
     .addRow(
-      $.row('Query-frontend - query sharding')
+      $.row('Query-frontend – query sharding')
       .addPanel(
         $.timeseriesPanel('Sharded queries ratio') +
         $.queryPanel(|||
@@ -149,6 +149,33 @@ local filename = 'mimir-queries.json';
         ),
       )
     )
+    .addRowIf(
+      $._config.show_ingest_storage_panels,
+      $.row('Query-frontend – strong consistency (ingest storage)')
+      .addPanel(
+        $.timeseriesPanel('Queries with strong read consistency ratio') +
+        $.panelDescription(
+          'Queries with strong read consistency ratio',
+          |||
+            Ratio between queries with strong read consistency and all other queries on query-frontends.
+          |||
+        ) +
+        $.queryPanel(
+          [
+            |||
+              # Display the ratio by container so that it gives a quick visual clue whether requests are coming
+              # from user queries (query-frontend) or rule evaluations (ruler-query-frontend).
+              sum by(container) (rate(cortex_query_frontend_queries_consistency_total{%s,consistency="strong"}[$__rate_interval]))
+              /
+              sum by(container) (rate(cortex_query_frontend_queries_total{%s}[$__rate_interval]))
+            ||| % [$.namespaceMatcher(), $.namespaceMatcher()],
+          ],
+          ['{{container}}'],
+        )
+        + { fieldConfig+: { defaults+: { unit: 'percentunit', min: 0, max: 1 } } }
+        + $.stack
+      )
+    )
     .addRow(
       $.row('Ingester')
       .addPanel(
@@ -169,7 +196,7 @@ local filename = 'mimir-queries.json';
     )
     .addRowIf(
       $._config.show_ingest_storage_panels,
-      ($.row('Ingester (ingest storage: strong consistency)'))
+      ($.row('Ingester – strong consistency (ingest storage)'))
       .addPanel(
         $.timeseriesPanel('Requests with strong read consistency / sec') +
         $.panelDescription(
@@ -260,9 +287,9 @@ local filename = 'mimir-queries.json';
     )
     .addRowIf(
       $._config.show_ingest_storage_panels,
-      ($.row('Ingester (ingest storage: last produced offset)'))
+      $.row('')
       .addPanel(
-        $.timeseriesPanel('Last produced offset requests / sec') +
+        $.timeseriesPanel('Fetch last produced offset requests / sec') +
         $.panelDescription(
           'Rate of requests to fetch last produced offset for partition',
           |||
@@ -291,7 +318,7 @@ local filename = 'mimir-queries.json';
         } + $.aliasColors({ successful: $._colors.success, failed: $._colors.failed }) + $.stack,
       )
       .addPanel(
-        $.timeseriesPanel('Last produced offset latency') +
+        $.timeseriesPanel('Fetch last produced offset latency') +
         $.panelDescription(
           'Latency',
           |||
@@ -316,6 +343,9 @@ local filename = 'mimir-queries.json';
             defaults+: { unit: 's' },
           },
         },
+      )
+      .addPanel(
+        $.ingestStorageIngesterEndToEndLatencyWhenRunningPanel(),
       )
     )
     .addRow(

--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -181,7 +181,7 @@ local filename = 'mimir-reads.json';
     )
     .addRowIf(
       $._config.autoscaling.querier.enabled,
-      $.row('Querier - autoscaling')
+      $.row('Querier – autoscaling')
       .addPanel(
         local title = 'Replicas';
         $.timeseriesPanel(title) +

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -234,7 +234,7 @@ local filename = 'mimir-writes.json';
     )
     .addRowIf(
       $._config.show_ingest_storage_panels,
-      ($.row('Ingester (ingest storage)'))
+      ($.row('Ingester – Kafka records processing (ingest storage)'))
       .addPanel(
         $.timeseriesPanel('Kafka fetches / sec') +
         $.panelDescription(
@@ -317,66 +317,17 @@ local filename = 'mimir-writes.json';
     )
     .addRowIf(
       $._config.show_ingest_storage_panels,
-      ($.row('Ingester (ingest storage – end-to-end latency)'))
+      $.row('Ingester – end-to-end latency (ingest storage)')
       .addPanel(
-        $.timeseriesPanel('Kafka record end-to-end latency when ingesters are running') +
-        $.panelDescription(
-          'Kafka record end-to-end latency when ingesters are running',
-          |||
-            Time between writing request by distributor to Kafka and reading the record by ingester, when ingesters are running.
-          |||
-        ) +
-        $.queryPanel(
-          [
-            'histogram_avg(sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="running"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-            'histogram_quantile(0.99, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="running"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-            'histogram_quantile(0.999, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="running"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-            'histogram_quantile(1.0, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="running"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-          ],
-          [
-            'avg',
-            '99th percentile',
-            '99.9th percentile',
-            '100th percentile',
-          ],
-        ) + {
-          fieldConfig+: {
-            defaults+: { unit: 's' },
-          },
-        },
+        $.ingestStorageIngesterEndToEndLatencyWhenRunningPanel(),
       )
       .addPanel(
-        $.timeseriesPanel('Kafka record end-to-end latency when starting') +
-        $.panelDescription(
-          'Kafka record end-to-end latency when starting',
-          |||
-            Time between writing request by distributor to Kafka and reading the record by ingester during catch-up phase, when ingesters are starting.
-            If ingesters are not starting and catching up in the selected time range, this panel will be empty.
-          |||
-        ) +
-        $.queryPanel(
-          [
-            'histogram_avg(sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="starting"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-            'histogram_quantile(0.99, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="starting"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-            'histogram_quantile(0.999, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="starting"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-            'histogram_quantile(1.0, sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{%s, phase="starting"}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-          ],
-          [
-            'avg',
-            '99th percentile',
-            '99.9th percentile',
-            '100th percentile',
-          ],
-        ) + {
-          fieldConfig+: {
-            defaults+: { unit: 's' },
-          },
-        },
+        $.ingestStorageIngesterEndToEndLatencyWhenStartingPanel(),
       )
     )
     .addRowIf(
       $._config.show_ingest_storage_panels,
-      ($.row('Ingester (ingest storage - last consumed offset)'))
+      ($.row('Ingester – last consumed offset (ingest storage)'))
       .addPanel(
         $.timeseriesPanel('Last consumed offset commits / sec') +
         $.panelDescription(
@@ -438,7 +389,7 @@ local filename = 'mimir-writes.json';
     )
     .addRowIf(
       $._config.show_ingest_storage_panels && $._config.autoscaling.ingester.enabled,
-      $.row('Ingester (ingest storage) – autoscaling')
+      $.row('Ingester – autoscaling (ingest storage)')
       .addPanel(
         $.autoScalingActualReplicas('ingester') + { title: 'Replicas (ReplicaTemplate)' } +
         $.panelDescription(
@@ -481,7 +432,7 @@ local filename = 'mimir-writes.json';
       $.kvStoreRow('Ingester - key-value store for the ingesters ring', 'ingester', 'ingester-.*')
     )
     .addRow(
-      $.row('Ingester - shipper')
+      $.row('Ingester – shipper')
       .addPanel(
         $.timeseriesPanel('Uploaded blocks / sec') +
         $.successFailurePanel(
@@ -510,7 +461,7 @@ local filename = 'mimir-writes.json';
       )
     )
     .addRow(
-      $.row('Ingester - TSDB head')
+      $.row('Ingester – TSDB head')
       .addPanel(
         $.timeseriesPanel('Compactions / sec') +
         $.successFailurePanel(
@@ -540,7 +491,7 @@ local filename = 'mimir-writes.json';
       )
     )
     .addRow(
-      $.row('Ingester - TSDB write ahead log (WAL)')
+      $.row('Ingester – TSDB write ahead log (WAL)')
       .addPanel(
         $.timeseriesPanel('WAL truncations / sec') +
         $.successFailurePanel(


### PR DESCRIPTION
#### What this PR does

In this PR I propose to do small changes to improve dashboard panels about end-to-end latency and strong read consistency:

- Added query-frontend strong consistency queries ratio to "Mimir / Queries" dashboard. We already have a panel tracking it from ingester's PoV but I would like to track it from query-frontend PoV too. The query-frontend metric is tracked before the query is enqueued, while the ingester metrics are tracked only once the query hit ingesters.
- Added end-to-end latency panel to "Mimir / Queries" dashboard. We also have it in "Mimir / Writes" dashboard (where I suggest to keep it), but I propose to add it to "Mimir / Queries" dashboard too because this (along with "Reads" dashboard) are the main entrypoints when there's an issue on the read path.
- Converted hyphens to dashes in dashboards I've reviewed / touched, which I hope will make @pstibrany proud of me 😄 

How the 2 lines row in "Mimir / Queries" dashboard look like:

![Screenshot 2024-06-27 at 11 06 43](https://github.com/grafana/mimir/assets/1701904/13e2771d-0289-4c67-a5cc-2dbf4b57f588)

Notes to reviewers:

- The new panels are not included in the compiled dashboards because `show_ingest_storage_panels` is disabled by default

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
