### PR TITLE
store-gateway: dont leak goroutines when preloading

### DIFF
--- a/pkg/storegateway/series_chunks.go
+++ b/pkg/storegateway/series_chunks.go
@@ -262,7 +262,11 @@ func (p *preloadingSetIterator[Set]) preload() {
 	}
 
 	if p.from.Err() != nil {
-		p.preloaded <- preloadedSeriesChunksSet[Set]{err: p.from.Err()}
+		select {
+		case <-p.ctx.Done():
+			// If the client gives up on reading from the stream, then we will never return this error
+		case p.preloaded <- preloadedSeriesChunksSet[Set]{err: p.from.Err()}:
+		}
 	}
 }
 


### PR DESCRIPTION
#### What this PR does


I discovered this while working on https://github.com/grafana/mimir/issues/8389. This shouldn't be a bug today because nothing above the preloading iterator looks at the context (IIRC this was the reason I didn't check the context in the first place). But it can become a problem in the future. I also verified in a few production clusters at GL and couldn't spot a gradual increase in the number of goroutines.

It's blocking detecting leaking goroutines in my work for https://github.com/grafana/mimir/issues/8389, so I'd like to fix it first.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
