### PR TITLE
store-gateway: Add services for BucketStore(s)

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -264,12 +264,12 @@ func NewBucketStore(
 	return s, nil
 }
 
-func (s *BucketStore) start(ctx context.Context) error {
-	return nil // TODO dimitarvdimitrov
+func (s *BucketStore) start(context.Context) error {
+	return nil
 }
 
-func (s *BucketStore) stop(err error) error {
-	return nil // TODO dimitarvdimitrov
+func (s *BucketStore) stop(error) error {
+	return nil
 }
 
 // RemoveBlocksAndClose remove all blocks from local disk and releases all resources associated with the BucketStore.

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/grpcutil"
 	dskit_metrics "github.com/grafana/dskit/metrics"
+	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
@@ -215,11 +216,12 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 	if cfg.manyParts {
 		s.store.partitioners = blockPartitioners{naivePartitioner{}, naivePartitioner{}, naivePartitioner{}}
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	assert.NoError(t, store.SyncBlocks(ctx))
+	ctx := context.Background()
+	require.NoError(t, services.StartAndAwaitRunning(ctx, store))
+	require.NoError(t, store.InitialSync(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, store))
+	})
 	return s
 }
 

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -93,7 +93,7 @@ type BucketStores struct {
 	blocksLoaded      *prometheus.Desc
 }
 
-// NewBucketStores makes a new BucketStores.
+// NewBucketStores makes a new BucketStores. After starting the returned BucketStores
 func NewBucketStores(cfg tsdb.BlocksStorageConfig, shardingStrategy ShardingStrategy, bucketClient objstore.Bucket, allowedTenants *util.AllowedTenants, limits *validation.Overrides, logger log.Logger, reg prometheus.Registerer) (*BucketStores, error) {
 	chunksCacheClient, err := cache.CreateClient("chunks-cache", cfg.BucketStore.ChunksCache.BackendConfig, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	if err != nil {
@@ -203,7 +203,7 @@ func (u *BucketStores) initialSync(ctx context.Context) error {
 		return store.InitialSync(ctx)
 	}); err != nil {
 		level.Warn(u.logger).Log("msg", "failed to synchronize TSDB blocks", "err", err)
-		return err
+		return fmt.Errorf("initial synchronisation with bucket: %w", err)
 	}
 
 	level.Info(u.logger).Log("msg", "successfully synchronized TSDB blocks for all users")

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -582,13 +582,13 @@ func selectPostingsStrategy(l log.Logger, name string, worstCaseSeriesPreference
 
 // closeBucketStoreAndDeleteLocalFilesForExcludedTenants closes bucket store and removes local "sync" directories
 // for tenants that are not included in the current shard.
-func (u *BucketStores) closeBucketStoreAndDeleteLocalFilesForExcludedTenants(includedUserIds []string) {
+func (u *BucketStores) closeBucketStoreAndDeleteLocalFilesForExcludedTenants(includedUserIDs []string) {
 	files, err := os.ReadDir(u.cfg.BucketStore.SyncDir)
 	if err != nil {
 		return
 	}
 
-	includedUserIDsMap := util.StringsMap(includedUserIds)
+	includedUserIDsMap := util.StringsMap(includedUserIDs)
 	for _, f := range files {
 		if !f.IsDir() {
 			continue

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/services"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -50,8 +51,11 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
+func TestMain(m *testing.M) {
+	test.VerifyNoLeakTestMain(m)
+}
+
 func TestBucketStores_InitialSync(t *testing.T) {
-	test.VerifyNoLeak(t)
 
 	userToMetric := map[string]string{
 		"user-1": "series_1",
@@ -72,7 +76,7 @@ func TestBucketStores_InitialSync(t *testing.T) {
 
 	var allowedTenants *util.AllowedTenants
 	reg := prometheus.NewPedanticRegistry()
-	stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
+	stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewLogfmtLogger(os.Stdout), reg)
 	require.NoError(t, err)
 
 	// Query series before the initial sync.
@@ -85,7 +89,10 @@ func TestBucketStores_InitialSync(t *testing.T) {
 	for userID := range userToMetric {
 		createBucketIndex(t, bucket, userID)
 	}
-	require.NoError(t, stores.InitialSync(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, stores))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), stores))
+	})
 
 	// Query series after the initial sync.
 	for userID, metricName := range userToMetric {
@@ -136,8 +143,6 @@ func TestBucketStores_InitialSync(t *testing.T) {
 }
 
 func TestBucketStores_InitialSyncShouldRetryOnFailure(t *testing.T) {
-	test.VerifyNoLeak(t)
-
 	const tenantID = "user-1"
 	ctx := context.Background()
 	cfg := prepareStorageConfig(t)
@@ -159,7 +164,10 @@ func TestBucketStores_InitialSyncShouldRetryOnFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initial sync should succeed even if a transient error occurs.
-	require.NoError(t, stores.InitialSync(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, stores))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), stores))
+	})
 
 	// Query series after the initial sync.
 	seriesSet, warnings, err := querySeries(t, stores, tenantID, "series_1", 20, 40)
@@ -200,8 +208,6 @@ func TestBucketStores_InitialSyncShouldRetryOnFailure(t *testing.T) {
 }
 
 func TestBucketStores_SyncBlocks(t *testing.T) {
-	test.VerifyNoLeak(t)
-
 	const (
 		userID     = "user-1"
 		metricName = "series_1"
@@ -223,7 +229,10 @@ func TestBucketStores_SyncBlocks(t *testing.T) {
 	// Run an initial sync to discover 1 block.
 	generateStorageBlock(t, storageDir, userID, metricName, 10, 100, 15)
 	createBucketIndex(t, bucket, userID)
-	require.NoError(t, stores.InitialSync(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, stores))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), stores))
+	})
 
 	// Query a range for which we have no samples.
 	seriesSet, warnings, err := querySeries(t, stores, userID, metricName, 150, 180)
@@ -275,15 +284,13 @@ func TestBucketStores_SyncBlocks(t *testing.T) {
 	assert.Greater(t, testutil.ToFloat64(stores.syncLastSuccess), float64(0))
 }
 
-func TestBucketStores_syncUsersBlocks(t *testing.T) {
-	test.VerifyNoLeak(t)
-
+func TestBucketStores_ownedUsers(t *testing.T) {
 	allUsers := []string{"user-1", "user-2", "user-3"}
 
 	tests := map[string]struct {
 		shardingStrategy ShardingStrategy
 		allowedTenants   *util.AllowedTenants
-		expectedStores   int32
+		expectedStores   int
 	}{
 		"when sharding is disabled all users should be synced": {
 			shardingStrategy: newNoShardingStrategy(),
@@ -313,7 +320,6 @@ func TestBucketStores_syncUsersBlocks(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			cfg := prepareStorageConfig(t)
-			cfg.BucketStore.TenantSyncConcurrency = 2
 
 			bucketClient := &bucket.ClientMock{}
 			bucketClient.MockIter("", allUsers, nil)
@@ -322,15 +328,11 @@ func TestBucketStores_syncUsersBlocks(t *testing.T) {
 			require.NoError(t, err)
 
 			// Sync user stores and count the number of times the callback is called.
-			var storesCount atomic.Int32
-			err = stores.syncUsersBlocks(context.Background(), func(context.Context, *BucketStore) error {
-				storesCount.Inc()
-				return nil
-			})
+			ownedUsers, err := stores.ownedUsers(context.Background())
 
 			assert.NoError(t, err)
 			bucketClient.AssertNumberOfCalls(t, "Iter", 1)
-			assert.Equal(t, testData.expectedStores, storesCount.Load())
+			assert.Len(t, ownedUsers, testData.expectedStores)
 		})
 	}
 }
@@ -344,8 +346,6 @@ func TestBucketStores_Series_ShouldCorrectlyQuerySeriesSpanningMultipleChunks(t 
 }
 
 func TestBucketStores_ChunksAndSeriesLimiterFactoriesInitializedByEnforcedLimits(t *testing.T) {
-	test.VerifyNoLeak(t)
-
 	const (
 		userID                = "user-1"
 		overriddenChunksLimit = 1000000
@@ -391,8 +391,12 @@ func TestBucketStores_ChunksAndSeriesLimiterFactoriesInitializedByEnforcedLimits
 			reg := prometheus.NewPedanticRegistry()
 			stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bucket, allowedTenants, overrides, log.NewNopLogger(), reg)
 			require.NoError(t, err)
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), stores))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), stores))
+			})
 
-			store, err := stores.getOrCreateStore(userID)
+			store, err := stores.getOrCreateStore(context.Background(), userID)
 			require.NoError(t, err)
 
 			chunksLimit := overrides.MaxChunksPerQuery(userID)
@@ -446,7 +450,10 @@ func testBucketStoresSeriesShouldCorrectlyQuerySeriesSpanningMultipleChunks(t *t
 	require.NoError(t, err)
 
 	createBucketIndex(t, bucket, userID)
-	require.NoError(t, stores.InitialSync(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, stores))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), stores))
+	})
 
 	tests := map[string]struct {
 		reqMinTime int64
@@ -549,7 +556,10 @@ func TestBucketStore_Series_ShouldQueryBlockWithOutOfOrderChunks(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bkt, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
 	require.NoError(t, err)
-	require.NoError(t, stores.InitialSync(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, stores))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), stores))
+	})
 
 	tests := map[string]struct {
 		minT                                int64
@@ -682,8 +692,6 @@ func setUserIDToGRPCContext(ctx context.Context, userID string) context.Context 
 }
 
 func TestBucketStores_deleteLocalFilesForExcludedTenants(t *testing.T) {
-	test.VerifyNoLeak(t)
-
 	const (
 		user1 = "user-1"
 		user2 = "user-2"
@@ -718,7 +726,10 @@ func TestBucketStores_deleteLocalFilesForExcludedTenants(t *testing.T) {
 
 	// Perform sync.
 	sharding.users = []string{user1, user2}
-	require.NoError(t, stores.InitialSync(ctx))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, stores))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), stores))
+	})
 	require.Equal(t, []string{user1, user2}, getUsersInDir(t, cfg.BucketStore.SyncDir))
 
 	metricNames := []string{"cortex_bucket_store_block_drops_total", "cortex_bucket_store_block_loads_total", "cortex_bucket_store_blocks_loaded"}

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafana/dskit/gate"
 	"github.com/grafana/dskit/grpcutil"
 	dskit_metrics "github.com/grafana/dskit/metrics"
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/regexp"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -1512,6 +1513,7 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 			testData.options...,
 		)
 		require.NoError(t, err)
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), st))
 
 		t.Run(testName, func(t test.TB) {
 			t.Cleanup(func() {
@@ -1643,6 +1645,7 @@ func TestBucketStore_Series_Concurrency(t *testing.T) {
 						WithLogger(logger),
 					)
 					require.NoError(t, err)
+					require.NoError(t, services.StartAndAwaitRunning(ctx, store))
 					require.NoError(t, store.SyncBlocks(ctx))
 
 					t.Cleanup(func() {
@@ -1971,6 +1974,7 @@ func TestBucketStore_Series_ErrorUnmarshallingRequestHints(t *testing.T) {
 		WithIndexCache(indexCache),
 	)
 	assert.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), store))
 	defer func() { assert.NoError(t, store.RemoveBlocksAndClose()) }()
 
 	assert.NoError(t, store.SyncBlocks(context.Background()))
@@ -2028,6 +2032,7 @@ func TestBucketStore_Series_CanceledRequest(t *testing.T) {
 		WithQueryGate(gate.NewBlocking(0)),
 	)
 	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), store))
 	defer func() { assert.NoError(t, store.RemoveBlocksAndClose()) }()
 
 	req := &storepb.SeriesRequest{
@@ -2095,6 +2100,7 @@ func TestBucketStore_Series_TimeoutGate(t *testing.T) {
 		WithQueryGate(timeoutGate{timeout: maxConcurrentWaitTimeout, delegate: gate.NewBlocking(maxConcurrent)}),
 	)
 	assert.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), store))
 	defer func() { assert.NoError(t, store.RemoveBlocksAndClose()) }()
 	require.NoError(t, store.SyncBlocks(context.Background()))
 
@@ -2176,6 +2182,7 @@ func TestBucketStore_Series_InvalidRequest(t *testing.T) {
 		WithLogger(logger),
 	)
 	assert.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), store))
 	defer func() { assert.NoError(t, store.RemoveBlocksAndClose()) }()
 
 	// Use an invalid matcher regex to trigger an error.
@@ -2303,7 +2310,9 @@ func testBucketStoreSeriesBlockWithMultipleChunks(
 		WithIndexCache(indexCache),
 	)
 	assert.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), store))
 	assert.NoError(t, store.SyncBlocks(context.Background()))
+	t.Cleanup(func() { assert.NoError(t, store.RemoveBlocksAndClose()) })
 
 	srv := newStoreGatewayTestServer(t, store)
 
@@ -2466,7 +2475,9 @@ func TestBucketStore_Series_Limits(t *testing.T) {
 						NewBucketStoreMetrics(nil),
 					)
 					assert.NoError(t, err)
+					assert.NoError(t, services.StartAndAwaitRunning(ctx, store))
 					assert.NoError(t, store.SyncBlocks(ctx))
+					t.Cleanup(func() { assert.NoError(t, store.RemoveBlocksAndClose()) })
 
 					srv := newStoreGatewayTestServer(t, store)
 					for _, streamingBatchSize := range []int{0, 1, 5} {
@@ -2666,6 +2677,7 @@ func setupStoreForHintsTest(t *testing.T, maxSeriesPerBatch int, opts ...BucketS
 		opts...,
 	)
 	assert.NoError(tb, err)
+	assert.NoError(tb, services.StartAndAwaitRunning(context.Background(), store))
 	assert.NoError(tb, store.SyncBlocks(context.Background()))
 
 	cleanupFuncs = append(cleanupFuncs, func() { assert.NoError(t, store.RemoveBlocksAndClose()) })

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -250,14 +250,14 @@ func (g *StoreGateway) starting(ctx context.Context) (err error) {
 		}
 	}
 
-	// At this point, if sharding is enabled, the instance is registered with some tokens
-	// and we can run the initial synchronization.
+	// At this point, the instance is registered with some tokens
+	// and we can start the bucket stores.
 	g.bucketSync.WithLabelValues(syncReasonInitial).Inc()
 	if err = services.StartAndAwaitRunning(ctx, g.stores); err != nil {
-		return errors.Wrap(err, "initial blocks synchronization")
+		return errors.Wrap(err, "starting bucket stores")
 	}
 
-	// Now that the initial sync is done, we should have loaded all blocks
+	// After starting the store, we should have loaded all blocks
 	// assigned to our shard, so we can switch to ACTIVE and start serving
 	// requests.
 	if err = g.ringLifecycler.ChangeState(ctx, ring.ACTIVE); err != nil {

--- a/pkg/storegateway/gateway_prepare_shutdown_http_test.go
+++ b/pkg/storegateway/gateway_prepare_shutdown_http_test.go
@@ -37,6 +37,7 @@ func createStoreGateway(t *testing.T, reg prometheus.Registerer) (*StoreGateway,
 
 	g, err := newStoreGateway(gatewayCfg, storageCfg, bucket, ringStore, defaultLimitsOverrides(t), log.NewNopLogger(), reg, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(context.Background(), g)) })
 	return g, ringStore
 }
 

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -205,6 +205,7 @@ func TestStoreGateway_InitialSyncFailure(t *testing.T) {
 
 	// We expect a clean shutdown, including unregistering the instance from the ring.
 	assert.False(t, g.ringLifecycler.IsRegistered())
+	_ = services.StopAndAwaitTerminated(ctx, g) // There will be an error since the initial sync failed
 }
 
 // TestStoreGateway_InitialSyncWithWaitRingTokensStability tests the store-gateway cold start case.


### PR DESCRIPTION
#### What this PR does

This PR is the first in the refactoring for https://github.com/grafana/mimir/issues/8389. In this PR

1. `BucketStore` (single tenant) and `BucketStores` (multi-tenant) are now `services.Service`, which means they can be properly started and stopped
  2. `BucketStore` currently does nothing on its lifecycle. This is because none of its dependencies are services.
  3. `BucketStores` performs its initial sync in its startup routine and shuts down all of the `BucketStore` instances it hosts in its shutdown routine.
4. Add lifecycle handling to various tests
5. Break up `syncUsersBlocksWithRetries` into `ownedUsers` and `syncUsersBlocks`  so that  `TestBucketStores_ownedUsers` only tests what it needs to - user sharding - and not the whole startup procedure.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/8389

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
