### PR TITLE
store-gateway: Make Snapshotter a service

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -293,6 +293,8 @@ func (s *BucketStore) stop(err error) error {
 			errs.Add(fmt.Errorf("stop %T: %w", svc, err))
 		}
 	}
+
+	s.indexReaderPool.Close()
 	return errs.Err()
 }
 

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -129,12 +129,6 @@ type BucketStore struct {
 	postingsStrategy postingsSelectionStrategy
 }
 
-type noopShapshotter struct {
-	services.Service
-}
-
-func (noopShapshotter) RestoreLoadedBlocks() map[ulid.ULID]int64 { return nil }
-
 type noopCache struct{}
 
 func (noopCache) StorePostings(string, ulid.ULID, labels.Label, []byte, time.Duration) {}
@@ -265,7 +259,7 @@ func NewBucketStore(
 		}
 		s.snapshotter = indexheader.NewSnapshotter(s.logger, snapConfig, s.indexReaderPool)
 	} else {
-		s.snapshotter = noopShapshotter{services.NewIdleService(nil, nil)}
+		s.snapshotter = services.NewIdleService(nil, nil)
 	}
 
 	if err := os.MkdirAll(dir, 0750); err != nil {

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -74,6 +74,11 @@ type BucketStoreStats struct {
 	BlocksLoadedTotal int
 }
 
+type snapshotter interface {
+	services.Service
+	RestoreLoadedBlocks() map[ulid.ULID]int64
+}
+
 // BucketStore implements the store API backed by a bucket. It loads all index
 // files to local disk.
 //
@@ -93,8 +98,7 @@ type BucketStore struct {
 	indexReaderPool *indexheader.ReaderPool
 	seriesHashCache *hashcache.SeriesHashCache
 
-	snapshotter          *indexheader.Snapshotter
-	snapshotterStartOnce sync.Once
+	snapshotter snapshotter
 
 	// Set of blocks that have the same labels
 	blockSet *bucketBlockSet
@@ -129,6 +133,12 @@ type BucketStore struct {
 	// postingsStrategy is a strategy shared among all tenants.
 	postingsStrategy postingsSelectionStrategy
 }
+
+type noopShapshotter struct {
+	services.Service
+}
+
+func (noopShapshotter) RestoreLoadedBlocks() map[ulid.ULID]int64 { return nil }
 
 type noopCache struct{}
 
@@ -240,17 +250,17 @@ func NewBucketStore(
 		option(s)
 	}
 
-	snapConfig := indexheader.SnapshotterConfig{
-		Path:   dir,
-		UserID: userID,
-	}
-	s.snapshotter = indexheader.NewSnapshotter(s.logger, snapConfig)
-
-	var lazyLoadedBlocks map[ulid.ULID]int64
 	if bucketStoreConfig.IndexHeader.EagerLoadingStartupEnabled {
-		lazyLoadedBlocks = s.snapshotter.RestoreLoadedBlocks()
+		snapConfig := indexheader.SnapshotterConfig{
+			Path:            dir,
+			UserID:          userID,
+			PersistInterval: bucketStoreConfig.IndexHeader.LazyLoadingIdleTimeout,
+		}
+		s.snapshotter = indexheader.NewSnapshotter(s.logger, snapConfig, s.indexReaderPool)
+	} else {
+		s.snapshotter = noopShapshotter{services.NewIdleService(nil, nil)}
 	}
-	s.indexReaderPool = indexheader.NewReaderPool(s.logger, bucketStoreConfig.IndexHeader, s.lazyLoadingGate, metrics.indexHeaderReaderMetrics, lazyLoadedBlocks)
+	s.indexReaderPool = indexheader.NewReaderPool(s.logger, bucketStoreConfig.IndexHeader, s.lazyLoadingGate, metrics.indexHeaderReaderMetrics, s.snapshotter.RestoreLoadedBlocks())
 
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, errors.Wrap(err, "create dir")
@@ -260,23 +270,38 @@ func NewBucketStore(
 	return s, nil
 }
 
+func (s *BucketStore) subservices() []services.Service {
+	return []services.Service{s.snapshotter}
+}
+
 func (s *BucketStore) start(context.Context) error {
 	return nil
 }
 
-func (s *BucketStore) stop(error) error {
-	return nil
+func (s *BucketStore) stop(err error) error {
+	subservices := s.subservices()
+
+	errs := multierror.New(err)
+	for _, svc := range subservices {
+		if err := services.StopAndAwaitTerminated(context.Background(), svc); err != nil {
+			errs.Add(fmt.Errorf("stop %T: %w", svc, err))
+		}
+	}
+	return errs.Err()
 }
 
 // RemoveBlocksAndClose remove all blocks from local disk and releases all resources associated with the BucketStore.
 func (s *BucketStore) RemoveBlocksAndClose() error {
-	removeBlocksErr := s.removeAllBlocks()
-
+	errs := multierror.New()
+	if err := services.StopAndAwaitTerminated(context.Background(), s); err != nil {
+		errs.Add(fmt.Errorf("stopping subservices: %w", err))
+	}
 	// Release other resources even if it failed to close some blocks.
-	s.snapshotter.Stop()
-	s.indexReaderPool.Close()
+	if err := s.removeAllBlocks(); err != nil {
+		errs.Add(fmt.Errorf("remove all blocks: %w", err))
+	}
 
-	return multierror.New(removeBlocksErr, services.StopAndAwaitTerminated(context.Background(), s)).Err()
+	return errs.Err()
 }
 
 // Stats returns statistics about the BucketStore instance.
@@ -347,9 +372,9 @@ func (s *BucketStore) syncBlocks(ctx context.Context, initialSync bool) error {
 
 	// Start snapshotter in the end of the sync, but do that only once per BucketStore's lifetime.
 	// We do that here, so the snapshotter watched after blocks from both initial sync and those discovered later.
-	s.snapshotterStartOnce.Do(func() {
-		s.snapshotter.Start(ctx, s.indexReaderPool)
-	})
+	// If it's already started this will return an error. We ignore that because syncBlocks can run multiple times
+	// We pass context.Background() because we want to stop it ourselves as opposed to stopping it as soon as the runtime context is cancelled..
+	_ = s.snapshotter.StartAsync(context.Background())
 
 	return nil
 }

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -296,7 +296,8 @@ func (s *BucketStore) RemoveBlocksAndClose() error {
 	if err := services.StopAndAwaitTerminated(context.Background(), s); err != nil {
 		errs.Add(fmt.Errorf("stopping subservices: %w", err))
 	}
-	// Release other resources even if it failed to close some blocks.
+	// Remove the blocks even if the service didn't gracefully stop.
+	// We want to free up disk resources given these blocks will likely not be queried again.
 	if err := s.removeAllBlocks(); err != nil {
 		errs.Add(fmt.Errorf("remove all blocks: %w", err))
 	}

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -193,9 +193,10 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 			BlockSyncConcurrency:        20,
 			PostingOffsetsInMemSampling: mimir_tsdb.DefaultPostingOffsetInMemorySampling,
 			IndexHeader: indexheader.Config{
-				EagerLoadingStartupEnabled: true,
-				LazyLoadingEnabled:         true,
-				LazyLoadingIdleTimeout:     time.Minute,
+				EagerLoadingStartupEnabled:  true,
+				LazyLoadingEnabled:          true,
+				LazyLoadingIdleTimeout:      time.Minute,
+				EagerLoadingPersistInterval: time.Minute,
 			},
 		},
 		cfg.postingsStrategy,

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -77,7 +77,7 @@ type Config struct {
 	VerifyOnLoad bool `yaml:"verify_on_load" category:"advanced"`
 
 	// EagerLoadingPersistInterval is injected for testing purposes only.
-	EagerLoadingPersistInterval time.Duration `yaml:"-" category:"hidden"`
+	EagerLoadingPersistInterval time.Duration `yaml:"-" doc:"hidden"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -87,8 +87,8 @@ func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.IntVar(&cfg.LazyLoadingConcurrency, prefix+"lazy-loading-concurrency", 4, "Maximum number of concurrent index header loads across all tenants. If set to 0, concurrency is unlimited.")
 	f.DurationVar(&cfg.LazyLoadingConcurrencyQueueTimeout, prefix+"lazy-loading-concurrency-queue-timeout", 0, "Timeout for the queue of index header loads. If the queue is full and the timeout is reached, the load will return an error. 0 means no timeout and the load will wait indefinitely.")
 	f.BoolVar(&cfg.EagerLoadingStartupEnabled, prefix+"eager-loading-startup-enabled", true, "If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. Ignored if index-header lazy loading is disabled.")
-	f.BoolVar(&cfg.VerifyOnLoad, prefix+"verify-on-load", false, "If true, verify the checksum of index headers upon loading them (either on startup or lazily when lazy loading is enabled). Setting to true helps detect disk corruption at the cost of slowing down index header loading.")
 	f.DurationVar(&cfg.EagerLoadingPersistInterval, prefix+"eager-loading-persist-interval", time.Minute, "Interval at which the store-gateway persists block IDs of lazy loaded index-headers. Ignored if index-header eager loading is disabled.")
+	f.BoolVar(&cfg.VerifyOnLoad, prefix+"verify-on-load", false, "If true, verify the checksum of index headers upon loading them (either on startup or lazily when lazy loading is enabled). Setting to true helps detect disk corruption at the cost of slowing down index header loading.")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -75,6 +75,9 @@ type Config struct {
 	LazyLoadingConcurrencyQueueTimeout time.Duration `yaml:"lazy_loading_concurrency_queue_timeout" category:"experimental"`
 
 	VerifyOnLoad bool `yaml:"verify_on_load" category:"advanced"`
+
+	// EagerLoadingPersistInterval is injected for testing purposes only.
+	EagerLoadingPersistInterval time.Duration `yaml:"-" category:"hidden"`
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
@@ -85,6 +88,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.LazyLoadingConcurrencyQueueTimeout, prefix+"lazy-loading-concurrency-queue-timeout", 0, "Timeout for the queue of index header loads. If the queue is full and the timeout is reached, the load will return an error. 0 means no timeout and the load will wait indefinitely.")
 	f.BoolVar(&cfg.EagerLoadingStartupEnabled, prefix+"eager-loading-startup-enabled", true, "If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. Ignored if index-header lazy loading is disabled.")
 	f.BoolVar(&cfg.VerifyOnLoad, prefix+"verify-on-load", false, "If true, verify the checksum of index headers upon loading them (either on startup or lazily when lazy loading is enabled). Setting to true helps detect disk corruption at the cost of slowing down index header loading.")
+	f.DurationVar(&cfg.EagerLoadingPersistInterval, prefix+"eager-loading-persist-interval", time.Minute, "Interval at which the store-gateway persists block IDs of lazy loaded index-headers. Ignored if index-header eager loading is disabled.")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/storegateway/indexheader/snapshotter_test.go
+++ b/pkg/storegateway/indexheader/snapshotter_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
 	"github.com/oklog/ulid"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +34,7 @@ func TestSnapshotter_PersistAndRestoreLoadedBlocks(t *testing.T) {
 	}
 
 	// First instance persists the original snapshot.
-	s1 := NewSnapshotter(log.NewNopLogger(), config)
+	s1 := NewSnapshotter(log.NewNopLogger(), config, testBlocksLoader)
 	err := s1.PersistLoadedBlocks(testBlocksLoader)
 	require.NoError(t, err)
 
@@ -45,7 +46,7 @@ func TestSnapshotter_PersistAndRestoreLoadedBlocks(t *testing.T) {
 	require.JSONEq(t, expected, string(data))
 
 	// Another instance restores the snapshot persisted earlier.
-	s2 := NewSnapshotter(log.NewNopLogger(), config)
+	s2 := NewSnapshotter(log.NewNopLogger(), config, testBlocksLoader)
 
 	restoredBlocks := s2.RestoreLoadedBlocks()
 	require.Equal(t, origBlocks, restoredBlocks)
@@ -63,35 +64,19 @@ func TestSnapshotter_StartStop(t *testing.T) {
 		})
 
 		config := SnapshotterConfig{
-			Path:   tmpDir,
-			UserID: "anonymous",
+			Path:            tmpDir,
+			UserID:          "anonymous",
+			PersistInterval: 100 * time.Millisecond,
 		}
-		s := NewSnapshotter(log.NewNopLogger(), config)
-
-		s.Start(context.Background(), testBlocksLoader)
-		s.Stop()
+		s := NewSnapshotter(log.NewNopLogger(), config, testBlocksLoader)
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), s))
+		time.Sleep(config.PersistInterval * 2) // give enough time to persist the snapshot
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), s))
 
 		persistedFile := filepath.Join(tmpDir, lazyLoadedHeadersListFileName)
 		data, err := os.ReadFile(persistedFile)
 		require.NoError(t, err)
 		require.NotEmpty(t, data)
-	})
-
-	t.Run("stop but no start", func(t *testing.T) {
-		tmpDir := t.TempDir()
-
-		config := SnapshotterConfig{
-			Path:   tmpDir,
-			UserID: "anonymous",
-		}
-		s := NewSnapshotter(log.NewNopLogger(), config)
-
-		// Nothing was started but an attempt to stop shouldn't hang.
-		s.Stop()
-
-		persistedFile := filepath.Join(tmpDir, lazyLoadedHeadersListFileName)
-		_, err := os.ReadFile(persistedFile)
-		require.ErrorIs(t, err, os.ErrNotExist)
 	})
 }
 

--- a/pkg/storegateway/indexheader/snapshotter_test.go
+++ b/pkg/storegateway/indexheader/snapshotter_test.go
@@ -45,11 +45,9 @@ func TestSnapshotter_PersistAndRestoreLoadedBlocks(t *testing.T) {
 	expected := fmt.Sprintf(`{"index_header_last_used_time":{"%s":%d},"user_id":"anonymous"}`, testBlockID, usedAt.UnixMilli())
 	require.JSONEq(t, expected, string(data))
 
-	// Another instance restores the snapshot persisted earlier.
-	s2 := NewSnapshotter(log.NewNopLogger(), config, testBlocksLoader)
-
-	restoredBlocks := s2.RestoreLoadedBlocks()
+	restoredBlocks, err := RestoreLoadedBlocks(config.Path)
 	require.Equal(t, origBlocks, restoredBlocks)
+	require.NoError(t, err)
 }
 
 func TestSnapshotter_StartStop(t *testing.T) {

--- a/pkg/util/test/leak.go
+++ b/pkg/util/test/leak.go
@@ -29,9 +29,6 @@ func goLeakOptions() []goleak.Option {
 		// on store-gateway termination so it never gets terminated.
 		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.NewReaderPool.func1"),
 		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.(*LazyBinaryReader).controlLoop"),
-		// Similar to the one above, store-gateway BucketStore starts a goroutine in snapshotter
-		// that manages lazy-loaded snapshots. It stops the snapshotter on BucketStore close.
-		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.(*Snapshotter).Start.func1"),
 
 		// The FastRegexMatcher uses a global instance of ristretto.Cache which is never stopped,
 		// so we ignore its gouroutines and then ones from glog which is a ristretto dependency.


### PR DESCRIPTION
#### What this PR does

This is the second PR for https://github.com/grafana/mimir/issues/8389. 

The changes here are:

1. `indexheader.Snapshotter` is now a `services.Service` with a simple timing loop
2. The BuketStore stops the snapshotter whenever it's shutting down
3. Make the interval of Snapshotter a hidden configuration flag for easier testing


#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
