### PR TITLE
Type=notify and TimeoutStartSec to wait for ready when starting 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * [ENHANCEMENT] Query-frontend: added `remote_read` to `op` supported label values for the `cortex_query_frontend_queries_total` metric. #8412
 * [ENHANCEMENT] Query-frontend: log the overall length and start, end time offset from current time for remote read requests. The start and end times are calculated as the miminum and maximum times of the individual queries in the remote read request. #8404
 * [ENHANCEMENT] Storage Provider: Added option `-<prefix>.s3.dualstack-enabled` that allows disabling S3 client from resolving AWS S3 endpoint into dual-stack IPv4/IPv6 endpoint. Defaults to true. #8405
-* [ENHANCEMENT] Use sd_notify to send events at start and stop of services. To be used when running with systemd and Type=notify. #8220
+* [ENHANCEMENT] Use sd_notify to send events to systemd at start and stop of mimir services. Default systemd mimir.service config now wait for those events with a configurable timeout `TimeoutStartSec` default is 3 min to handle long start time (ex. store-gateway). #8220 #8555
 * [ENHANCEMENT] Alertmanager: Reloading config and templates no longer needs to hit the disk. #4967
 * [ENHANCEMENT] Compactor: Added experimantal `-compactor.in-memory-tenant-meta-cache-size` option to set size of in-memory cache (in number of items) for parsed meta.json files. This can help when tenant has many meta.json files and their parsing before each compaction cycle is using a lot of CPU time. #8544
 * [ENHANCEMENT] Distributor: Interrupt OTLP write request translation when context is canceled or has timed out. #8524

--- a/packaging/nfpm/mimir/mimir.service
+++ b/packaging/nfpm/mimir/mimir.service
@@ -11,6 +11,8 @@ After=network-online.target
 
 [Service]
 Restart=always
+Type=notify
+TimeoutStartSec=3min
 User=mimir
 EnvironmentFile=$OS_ENV_DIR/mimir
 ExecStart=/usr/local/bin/mimir --config.file=/etc/mimir/config.yml --runtime-config.file=/etc/mimir/runtime_config.yml --log.level $LOG_LEVEL $CUSTOM_ARGS


### PR DESCRIPTION
#### What this PR does

Following #8541 this activate the necessary settings to use the sd_notify event.

#### Which issue(s) this PR fixes or relates to

Fixes #8220 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
