### PR TITLE
Update to Memcached 1.6.28 and memcached-exporter 0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
   * `ingest_storage_migration_partition_ingester_zone_b_replicas`
   * `ingest_storage_migration_partition_ingester_zone_c_replicas`
 * [ENHANCEMENT] Distributor: increase `-distributor.remote-timeout` when the experimental ingest storage is enabled. #8518
+* [ENHANCEMENT] Memcached: Update to Memcached 1.6.28 and memcached-exporter 0.14.4. #8557
 
 ### Mimirtool
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards. #7674
   * Overview dashboard: status, read/write latency and queries/ingestion per sec panels, `cortex_request_duration_seconds` metric.
+* [ENHANCEMENT] Memcached: Update to Memcached 1.6.28 and memcached-exporter 0.14.4. #8557
 * [ENHANCEMENT] Add missing fields in multiple topology spread constraints. #8533
 
 ## 5.4.0-rc.0

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2274,7 +2274,7 @@ memcached:
     # -- Memcached Docker image repository
     repository: memcached
     # -- Memcached Docker image tag
-    tag: 1.6.27-alpine
+    tag: 1.6.28-alpine
     # -- Memcached Docker image pull policy
     pullPolicy: IfNotPresent
 
@@ -2297,7 +2297,7 @@ memcachedExporter:
 
   image:
     repository: prom/memcached-exporter
-    tag: v0.14.3
+    tag: v0.14.4
     pullPolicy: IfNotPresent
 
   resources:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
             secretName: tls-certs
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -79,7 +79,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
             secretName: tls-certs
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -79,7 +79,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
             secretName: tls-certs
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -79,7 +79,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
             secretName: tls-certs
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -79,7 +79,7 @@ spec:
               name: tls-certs
               readOnly: true
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-cache/admin-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-cache/admin-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -73,7 +73,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       volumes:
       containers:
         - name: memcached
-          image: memcached:1.6.27-alpine
+          image: memcached:1.6.28-alpine
           imagePullPolicy: IfNotPresent
           resources:
             limits: null
@@ -74,7 +74,7 @@ spec:
             readOnlyRootFilesystem: true
           volumeMounts:
         - name: exporter
-          image: prom/memcached-exporter:v0.14.3
+          image: prom/memcached-exporter:v0.14.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9150

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1242,7 +1242,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1257,7 +1257,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1296,7 +1296,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1311,7 +1311,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1350,7 +1350,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1365,7 +1365,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1404,7 +1404,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1419,7 +1419,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
@@ -1242,7 +1242,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1257,7 +1257,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1296,7 +1296,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1311,7 +1311,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1350,7 +1350,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1365,7 +1365,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1404,7 +1404,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1419,7 +1419,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1244,7 +1244,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1259,7 +1259,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1298,7 +1298,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1313,7 +1313,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1352,7 +1352,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1367,7 +1367,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1406,7 +1406,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1421,7 +1421,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -1243,7 +1243,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1258,7 +1258,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1297,7 +1297,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1312,7 +1312,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1351,7 +1351,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1366,7 +1366,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1405,7 +1405,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1420,7 +1420,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1736,7 +1736,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1751,7 +1751,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1790,7 +1790,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1805,7 +1805,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1844,7 +1844,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1859,7 +1859,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1898,7 +1898,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1913,7 +1913,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1596,7 +1596,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1611,7 +1611,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1650,7 +1650,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1665,7 +1665,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1704,7 +1704,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1719,7 +1719,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1758,7 +1758,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1773,7 +1773,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1596,7 +1596,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1611,7 +1611,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1650,7 +1650,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1665,7 +1665,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1704,7 +1704,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1719,7 +1719,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1758,7 +1758,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1773,7 +1773,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -1100,7 +1100,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1115,7 +1115,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1154,7 +1154,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1169,7 +1169,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1208,7 +1208,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1223,7 +1223,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1262,7 +1262,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1277,7 +1277,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -1100,7 +1100,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1115,7 +1115,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1154,7 +1154,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1169,7 +1169,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1208,7 +1208,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1223,7 +1223,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1262,7 +1262,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1277,7 +1277,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1613,7 +1613,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1628,7 +1628,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1667,7 +1667,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1682,7 +1682,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1721,7 +1721,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1736,7 +1736,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1775,7 +1775,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1790,7 +1790,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -2075,7 +2075,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2090,7 +2090,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2129,7 +2129,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2144,7 +2144,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2183,7 +2183,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2198,7 +2198,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2237,7 +2237,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2252,7 +2252,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1481,7 +1481,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1496,7 +1496,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1535,7 +1535,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1550,7 +1550,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1589,7 +1589,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1604,7 +1604,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1643,7 +1643,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1658,7 +1658,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -1040,7 +1040,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1055,7 +1055,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1094,7 +1094,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1109,7 +1109,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1148,7 +1148,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1163,7 +1163,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1202,7 +1202,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1217,7 +1217,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -986,7 +986,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1001,7 +1001,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1040,7 +1040,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1055,7 +1055,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1094,7 +1094,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1109,7 +1109,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1148,7 +1148,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1163,7 +1163,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -2125,7 +2125,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2140,7 +2140,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2179,7 +2179,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2194,7 +2194,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2233,7 +2233,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2248,7 +2248,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2287,7 +2287,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2302,7 +2302,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1246,7 +1246,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1261,7 +1261,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1300,7 +1300,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1315,7 +1315,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1354,7 +1354,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1369,7 +1369,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1408,7 +1408,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1423,7 +1423,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -986,7 +986,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1001,7 +1001,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1040,7 +1040,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1055,7 +1055,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1094,7 +1094,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1109,7 +1109,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1148,7 +1148,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1163,7 +1163,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1290,7 +1290,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1305,7 +1305,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1344,7 +1344,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1359,7 +1359,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1398,7 +1398,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1413,7 +1413,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1452,7 +1452,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1467,7 +1467,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1349,7 +1349,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1364,7 +1364,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1403,7 +1403,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1418,7 +1418,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1457,7 +1457,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1472,7 +1472,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1511,7 +1511,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1526,7 +1526,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -2126,7 +2126,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2141,7 +2141,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2180,7 +2180,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2195,7 +2195,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2234,7 +2234,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2249,7 +2249,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2288,7 +2288,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2303,7 +2303,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -2622,7 +2622,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2637,7 +2637,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2676,7 +2676,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2691,7 +2691,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2730,7 +2730,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2745,7 +2745,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2784,7 +2784,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2799,7 +2799,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -2261,7 +2261,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2276,7 +2276,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2315,7 +2315,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2330,7 +2330,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2369,7 +2369,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2384,7 +2384,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2423,7 +2423,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2438,7 +2438,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -2265,7 +2265,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2280,7 +2280,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2319,7 +2319,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2334,7 +2334,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2373,7 +2373,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2388,7 +2388,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2427,7 +2427,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2442,7 +2442,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -2635,7 +2635,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2650,7 +2650,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2689,7 +2689,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2704,7 +2704,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2743,7 +2743,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2758,7 +2758,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2797,7 +2797,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2812,7 +2812,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -2645,7 +2645,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2660,7 +2660,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2699,7 +2699,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2714,7 +2714,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2753,7 +2753,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2768,7 +2768,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2807,7 +2807,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2822,7 +2822,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -2643,7 +2643,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2658,7 +2658,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2697,7 +2697,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2712,7 +2712,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2751,7 +2751,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2766,7 +2766,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2805,7 +2805,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2820,7 +2820,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5-generated.yaml
@@ -2643,7 +2643,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2658,7 +2658,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2697,7 +2697,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2712,7 +2712,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2751,7 +2751,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2766,7 +2766,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2805,7 +2805,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2820,7 +2820,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -2178,7 +2178,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2193,7 +2193,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2232,7 +2232,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2247,7 +2247,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2286,7 +2286,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2301,7 +2301,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2340,7 +2340,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2355,7 +2355,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -2202,7 +2202,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2217,7 +2217,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2256,7 +2256,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2271,7 +2271,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2310,7 +2310,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2325,7 +2325,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2364,7 +2364,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2379,7 +2379,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -2202,7 +2202,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2217,7 +2217,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2256,7 +2256,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2271,7 +2271,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2310,7 +2310,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2325,7 +2325,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2364,7 +2364,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2379,7 +2379,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -2202,7 +2202,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2217,7 +2217,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2256,7 +2256,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2271,7 +2271,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2310,7 +2310,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2325,7 +2325,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2364,7 +2364,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2379,7 +2379,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -2265,7 +2265,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2280,7 +2280,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2319,7 +2319,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2334,7 +2334,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2373,7 +2373,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2388,7 +2388,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2427,7 +2427,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2442,7 +2442,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1242,7 +1242,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1257,7 +1257,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1296,7 +1296,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1311,7 +1311,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1350,7 +1350,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1365,7 +1365,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1404,7 +1404,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1419,7 +1419,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1248,7 +1248,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1263,7 +1263,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1302,7 +1302,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1317,7 +1317,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1356,7 +1356,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1371,7 +1371,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1410,7 +1410,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1425,7 +1425,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1254,7 +1254,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1269,7 +1269,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1308,7 +1308,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1323,7 +1323,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1362,7 +1362,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1377,7 +1377,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1416,7 +1416,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1431,7 +1431,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1248,7 +1248,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1263,7 +1263,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1302,7 +1302,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1317,7 +1317,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1356,7 +1356,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1371,7 +1371,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1410,7 +1410,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1425,7 +1425,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1613,7 +1613,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1628,7 +1628,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1667,7 +1667,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1682,7 +1682,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1721,7 +1721,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1736,7 +1736,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1775,7 +1775,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1790,7 +1790,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1698,7 +1698,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1713,7 +1713,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1752,7 +1752,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1767,7 +1767,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1806,7 +1806,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1821,7 +1821,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1860,7 +1860,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1875,7 +1875,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1698,7 +1698,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1713,7 +1713,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1752,7 +1752,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1767,7 +1767,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1806,7 +1806,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1821,7 +1821,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1860,7 +1860,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1875,7 +1875,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1698,7 +1698,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1713,7 +1713,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1752,7 +1752,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1767,7 +1767,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1806,7 +1806,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1821,7 +1821,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1860,7 +1860,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1875,7 +1875,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1698,7 +1698,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1713,7 +1713,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1752,7 +1752,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1767,7 +1767,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1806,7 +1806,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1821,7 +1821,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1860,7 +1860,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1875,7 +1875,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1245,7 +1245,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1260,7 +1260,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1299,7 +1299,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1314,7 +1314,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1353,7 +1353,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1368,7 +1368,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1407,7 +1407,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1422,7 +1422,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1242,7 +1242,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1257,7 +1257,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1296,7 +1296,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1311,7 +1311,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1350,7 +1350,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1365,7 +1365,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1404,7 +1404,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1419,7 +1419,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -1305,7 +1305,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1330,7 +1330,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1382,7 +1382,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1407,7 +1407,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1459,7 +1459,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1484,7 +1484,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1536,7 +1536,7 @@ spec:
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1561,7 +1561,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1736,7 +1736,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1751,7 +1751,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1790,7 +1790,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1805,7 +1805,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1844,7 +1844,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1859,7 +1859,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1898,7 +1898,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1913,7 +1913,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1901,7 +1901,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1916,7 +1916,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1955,7 +1955,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1970,7 +1970,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2009,7 +2009,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2024,7 +2024,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -2063,7 +2063,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -2078,7 +2078,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1736,7 +1736,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1751,7 +1751,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1790,7 +1790,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1805,7 +1805,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1844,7 +1844,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1859,7 +1859,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1898,7 +1898,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1913,7 +1913,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -986,7 +986,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1001,7 +1001,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1040,7 +1040,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1055,7 +1055,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1094,7 +1094,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1109,7 +1109,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1148,7 +1148,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1163,7 +1163,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -1080,7 +1080,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1095,7 +1095,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1136,7 +1136,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1151,7 +1151,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1192,7 +1192,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1207,7 +1207,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1248,7 +1248,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1263,7 +1263,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1468,7 +1468,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1483,7 +1483,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1522,7 +1522,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1537,7 +1537,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1576,7 +1576,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1591,7 +1591,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1630,7 +1630,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1645,7 +1645,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1623,7 +1623,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1638,7 +1638,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1677,7 +1677,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1692,7 +1692,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1731,7 +1731,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1746,7 +1746,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1785,7 +1785,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1800,7 +1800,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1661,7 +1661,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1676,7 +1676,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1715,7 +1715,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1730,7 +1730,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1769,7 +1769,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1784,7 +1784,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1823,7 +1823,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1838,7 +1838,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1273,7 +1273,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1288,7 +1288,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1327,7 +1327,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1342,7 +1342,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1381,7 +1381,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1396,7 +1396,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1435,7 +1435,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1450,7 +1450,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1261,7 +1261,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1276,7 +1276,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1315,7 +1315,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1330,7 +1330,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1369,7 +1369,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1384,7 +1384,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1423,7 +1423,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1438,7 +1438,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1247,7 +1247,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1262,7 +1262,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1301,7 +1301,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1316,7 +1316,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1355,7 +1355,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1370,7 +1370,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1409,7 +1409,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1424,7 +1424,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -669,7 +669,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -684,7 +684,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -723,7 +723,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -738,7 +738,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -777,7 +777,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -792,7 +792,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -831,7 +831,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -846,7 +846,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -670,7 +670,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -685,7 +685,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -724,7 +724,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -739,7 +739,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -778,7 +778,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -793,7 +793,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -832,7 +832,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -847,7 +847,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1603,7 +1603,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1618,7 +1618,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1657,7 +1657,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1672,7 +1672,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1711,7 +1711,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1726,7 +1726,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1765,7 +1765,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1780,7 +1780,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1601,7 +1601,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1616,7 +1616,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1655,7 +1655,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1670,7 +1670,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1709,7 +1709,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1724,7 +1724,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1763,7 +1763,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1778,7 +1778,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1251,7 +1251,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1266,7 +1266,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1305,7 +1305,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1320,7 +1320,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1359,7 +1359,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1374,7 +1374,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1413,7 +1413,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1428,7 +1428,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
@@ -1255,7 +1255,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1270,7 +1270,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1309,7 +1309,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1324,7 +1324,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1363,7 +1363,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1378,7 +1378,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1417,7 +1417,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1432,7 +1432,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1252,7 +1252,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1267,7 +1267,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1306,7 +1306,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1321,7 +1321,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1360,7 +1360,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1375,7 +1375,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1414,7 +1414,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1429,7 +1429,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1252,7 +1252,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1267,7 +1267,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1306,7 +1306,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1321,7 +1321,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1360,7 +1360,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1375,7 +1375,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1414,7 +1414,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1429,7 +1429,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1242,7 +1242,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1257,7 +1257,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1296,7 +1296,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1311,7 +1311,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1350,7 +1350,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1365,7 +1365,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1404,7 +1404,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1419,7 +1419,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1247,7 +1247,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1262,7 +1262,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1301,7 +1301,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1316,7 +1316,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1355,7 +1355,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1370,7 +1370,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1409,7 +1409,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1424,7 +1424,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -889,7 +889,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -904,7 +904,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -943,7 +943,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -958,7 +958,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -997,7 +997,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1012,7 +1012,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:
@@ -1051,7 +1051,7 @@ spec:
         - -c 16384
         - -v
         - --extended=track_sizes
-        image: memcached:1.6.22-alpine
+        image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
         ports:
@@ -1066,7 +1066,7 @@ spec:
       - args:
         - --memcached.address=localhost:11211
         - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.14.3
+        image: prom/memcached-exporter:v0.14.4
         imagePullPolicy: IfNotPresent
         name: exporter
         ports:

--- a/operations/mimir/images.libsonnet
+++ b/operations/mimir/images.libsonnet
@@ -1,8 +1,8 @@
 {
   _images+:: {
     // Various third-party images.
-    memcached: 'memcached:1.6.22-alpine',
-    memcachedExporter: 'prom/memcached-exporter:v0.14.3',
+    memcached: 'memcached:1.6.28-alpine',
+    memcachedExporter: 'prom/memcached-exporter:v0.14.4',
 
     // Our services.
     mimir: 'grafana/mimir:2.12.0',


### PR DESCRIPTION
#### What this PR does

Minimal changes, mostly bug fixes and embedded proxy which we don't use.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
