### PR TITLE
Remove unused `HTTPHeader` struct

### DIFF
--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -321,11 +321,6 @@ var (
 	ErrBadRuleGroup = errors.New("unable to decode rule group")
 )
 
-type HTTPHeader struct {
-	Key   string
-	Value string
-}
-
 func marshalAndSend(output interface{}, w http.ResponseWriter, logger log.Logger, headers ...http.Header) {
 	d, err := yaml.Marshal(&output)
 	if err != nil {

--- a/pkg/ruler/namespace_protection.go
+++ b/pkg/ruler/namespace_protection.go
@@ -31,14 +31,14 @@ func (r *Ruler) IsNamespaceProtected(userID string, namespace string) bool {
 	return false
 }
 
-// ProtectedNamespacesHeaderFromString returns a HTTPHeader with the given namespace as the value and ProtectedNamespacesHeader as the key.
+// ProtectedNamespacesHeaderFromString returns a http.Header with the given namespace as the value and ProtectedNamespacesHeader as the key.
 func ProtectedNamespacesHeaderFromString(namespace string) http.Header {
 	return http.Header{
 		ProtectedNamespacesHeader: []string{namespace},
 	}
 }
 
-// ProtectedNamespacesHeaderFromSet returns a HTTPHeader with the given namespaces command-separated as the value and ProtectedNamespacesHeader as the key.
+// ProtectedNamespacesHeaderFromSet returns a http.Header with the given namespaces command-separated as the value and ProtectedNamespacesHeader as the key.
 func ProtectedNamespacesHeaderFromSet(namespacesSet map[string]struct{}) http.Header {
 	if len(namespacesSet) == 0 {
 		return nil


### PR DESCRIPTION
#### What this PR does

On my last commit of https://github.com/grafana/mimir/pull/8444, I refactored away the use of the `HTTPHeader` struct, I just forgot to remove it - so this PR does that.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
