### PR TITLE
BlockBuilder: Re-use existing ingest.KafkaConfig

### DIFF
--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/bucket"
+	"github.com/grafana/mimir/pkg/storage/ingest"
 	"github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/testkafka"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -35,7 +36,7 @@ func blockBuilderConfig(t *testing.T, addr string) (Config, *validation.Override
 	cfg := Config{
 		ConsumeInterval:       time.Hour,
 		ConsumeIntervalBuffer: 15 * time.Minute,
-		Kafka: KafkaConfig{
+		Kafka: ingest.KafkaConfig{
 			Address:       addr,
 			Topic:         testTopic,
 			ClientID:      "1",

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -1043,7 +1043,12 @@ func (t *Mimir) initUsageStats() (services.Service, error) {
 }
 
 func (t *Mimir) initBlockBuilder() (_ services.Service, err error) {
+	if !t.Cfg.IngestStorage.Enabled {
+		return nil, nil
+	}
+
 	t.Cfg.BlockBuilder.BlocksStorageConfig = t.Cfg.BlocksStorage
+	t.Cfg.BlockBuilder.Kafka = t.Cfg.IngestStorage.KafkaConfig
 	t.BlockBuilder, err = blockbuilder.New(t.Cfg.BlockBuilder, util_log.Logger, t.Registerer, t.Overrides)
 	if err != nil {
 		return


### PR DESCRIPTION
We were duplicating a subset of existing kafka config. How about we reuse it?