### PR TITLE
feat(continuous-test): Add histograms to measure latency of requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [CHANGE] Use test metrics that do not pass through 0 to make identifying incorrect results easier. #8630
 * [ENHANCEMENT] Include human-friendly timestamps in diffs logged when a test fails. #8630
 * [BUGFIX] Initialize test result metrics to 0 at startup so that alerts can correctly identify the first failure after startup. #8630
+* [ENHANCEMENT] Add histograms to measure latency of read and write requests. #8583
 
 ### Query-tee
 

--- a/docs/sources/mimir/manage/tools/mimir-continuous-test.md
+++ b/docs/sources/mimir/manage/tools/mimir-continuous-test.md
@@ -78,6 +78,18 @@ mimir_continuous_test_writes_total{test="<name>"}
 # TYPE mimir_continuous_test_writes_failed_total counter
 mimir_continuous_test_writes_failed_total{test="<name>",status_code="<code>"}
 
+# HELP mimir_continuous_test_writes_request_duration_seconds Duration of the requests
+# TYPE mimir_continuous_test_writes_request_duration_seconds histogram
+mimir_continuous_test_writes_request_duration_seconds_bucket{test="<name>",le="0.001"}
+mimir_continuous_test_writes_request_duration_seconds_bucket{test="<name>",le="0.004"}
+mimir_continuous_test_writes_request_duration_seconds_bucket{test="<name>",le="0.016"}
+mimir_continuous_test_writes_request_duration_seconds_bucket{test="<name>",le="0.064"}
+mimir_continuous_test_writes_request_duration_seconds_bucket{test="<name>",le="0.256"}
+mimir_continuous_test_writes_request_duration_seconds_bucket{test="<name>",le="1.024"}
+mimir_continuous_test_writes_request_duration_seconds_bucket{test="<name>",le="+Inf"}
+mimir_continuous_test_writes_request_duration_seconds_sum{test="<name>"}
+mimir_continuous_test_writes_request_duration_seconds_count{test="<name>"}
+
 # HELP mimir_continuous_test_queries_total Total number of attempted query requests.
 # TYPE mimir_continuous_test_queries_total counter
 mimir_continuous_test_queries_total{test="<name>"}
@@ -93,6 +105,27 @@ mimir_continuous_test_query_result_checks_total{test="<name>"}
 # HELP mimir_continuous_test_query_result_checks_failed_total Total number of query results failed when checking for correctness.
 # TYPE mimir_continuous_test_query_result_checks_failed_total counter
 mimir_continuous_test_query_result_checks_failed_total{test="<name>"}
+
+# HELP mimir_continuous_test_queries_request_duration_seconds Duration of the requests
+# TYPE mimir_continuous_test_queries_request_duration_seconds histogram
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="false",test="<name>",le="0.001"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="false",test="<name>",le="0.004"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="false",test="<name>",le="0.016"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="false",test="<name>",le="0.064"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="false",test="<name>",le="0.256"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="false",test="<name>",le="1.024"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="false",test="<name>",le="+Inf"}
+mimir_continuous_test_queries_request_duration_seconds_sum{results_cache="false",test="<name>"}
+mimir_continuous_test_queries_request_duration_seconds_count{results_cache="false",test="<name>"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="true",test="<name>",le="0.001"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="true",test="<name>",le="0.004"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="true",test="<name>",le="0.016"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="true",test="<name>",le="0.064"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="true",test="<name>",le="0.256"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="true",test="<name>",le="1.024"}
+mimir_continuous_test_queries_request_duration_seconds_bucket{results_cache="true",test="<name>",le="+Inf"}
+mimir_continuous_test_queries_request_duration_seconds_sum{results_cache="true",test="<name>"}
+mimir_continuous_test_queries_request_duration_seconds_count{results_cache="true",test="<name>"}
 ```
 
 ### Alerts

--- a/pkg/continuoustest/metrics.go
+++ b/pkg/continuoustest/metrics.go
@@ -3,6 +3,8 @@
 package continuoustest
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -12,8 +14,10 @@ import (
 type TestMetrics struct {
 	writesTotal                  *prometheus.CounterVec
 	writesFailedTotal            *prometheus.CounterVec
+	writesLatency                *prometheus.HistogramVec
 	queriesTotal                 *prometheus.CounterVec
 	queriesFailedTotal           *prometheus.CounterVec
+	queriesLatency               *prometheus.HistogramVec
 	queryResultChecksTotal       *prometheus.CounterVec
 	queryResultChecksFailedTotal *prometheus.CounterVec
 }
@@ -30,6 +34,14 @@ func NewTestMetrics(testName string, reg prometheus.Registerer) *TestMetrics {
 			Help:        "Total number of failed write requests.",
 			ConstLabels: map[string]string{"test": testName},
 		}, []string{"status_code", "type"}),
+		writesLatency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                            "mimir_continuous_test_writes_request_duration_seconds",
+			Help:                            "Duration of the write requests.",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+			ConstLabels:                     map[string]string{"test": testName},
+		}, []string{"type"}),
 		queriesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name:        "mimir_continuous_test_queries_total",
 			Help:        "Total number of attempted query requests.",
@@ -40,6 +52,14 @@ func NewTestMetrics(testName string, reg prometheus.Registerer) *TestMetrics {
 			Help:        "Total number of failed query requests.",
 			ConstLabels: map[string]string{"test": testName},
 		}, []string{"type"}),
+		queriesLatency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                            "mimir_continuous_test_queries_request_duration_seconds",
+			Help:                            "Duration of the read requests.",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+			ConstLabels:                     map[string]string{"test": testName},
+		}, []string{"type", "results_cache"}),
 		queryResultChecksTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name:        "mimir_continuous_test_query_result_checks_total",
 			Help:        "Total number of query results checked for correctness.",

--- a/pkg/continuoustest/write_read_series_test.go
+++ b/pkg/continuoustest/write_read_series_test.go
@@ -85,8 +85,10 @@ func init() {
 	emCtx = util_test.NewExpectedMetricsContext()
 	emCtx.Add("mimir_continuous_test_writes_total", "Total number of attempted write requests.", "counter")
 	emCtx.Add("mimir_continuous_test_writes_failed_total", "Total number of failed write requests.", "counter")
+	emCtx.Add("mimir_continuous_test_writes_request_duration_seconds", "Duration of the write requests.", "histogram")
 	emCtx.Add("mimir_continuous_test_queries_total", "Total number of attempted query requests.", "counter")
 	emCtx.Add("mimir_continuous_test_queries_failed_total", "Total number of failed query requests.", "counter")
+	emCtx.Add("mimir_continuous_test_queries_request_duration_seconds", "Duration of the read requests.", "histogram")
 	emCtx.Add("mimir_continuous_test_query_result_checks_total", "Total number of query results checked for correctness.", "counter")
 	emCtx.Add("mimir_continuous_test_query_result_checks_failed_total", "Total number of query results failed when checking for correctness.", "counter")
 }


### PR DESCRIPTION
#### What this PR does

Add histograms metrics to measure latency of read and write requests.

This will allow us to better appreciate the performances of the underlying mimir cluster/instance

Read request latency metrics have a label to indicate if results cache is in use or not as this could have a huge impact on the performances.

This will allow us to setup SLO on an end-to-end write and read pipeline reflecting the normal behavior of our users.


#### Checklist

- [X] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
