### PR TITLE
Alertmanager: Remove unused SendEmail method from sender

### DIFF
--- a/pkg/alertmanager/sender.go
+++ b/pkg/alertmanager/sender.go
@@ -117,9 +117,3 @@ func (s *Sender) SendWebhook(ctx context.Context, cmd *alertingReceivers.SendWeb
 	level.Debug(s.log).Log("msg", "Webhook failed", "url", cmd.URL, "statuscode", resp.Status, "body", string(body))
 	return fmt.Errorf("webhook response status %v", resp.Status)
 }
-
-// SendEmail implements alertingReceivers.EmailSender.
-// TODO: no-op for now, implement.
-func (s *Sender) SendEmail(_ context.Context, _ *alertingReceivers.SendEmailSettings) error {
-	return errors.New("e-mail sending not implemented")
-}


### PR DESCRIPTION
We're using the [default email sender from grafana/alerting](https://github.com/grafana/alerting/blob/5b0553a572d3b7890c7f50a2ec55841a6d65550e/receivers/email_sender.go#L75-L83), we don't need to implement the `EmailSender` interface in the `Sender` struct.