### PR TITLE
Alertmanager: Add static headers to Grafana email receiver

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -561,7 +561,6 @@ func buildGrafanaReceiverIntegrations(gCfg *config.GlobalConfig, rcv *definition
 		KeyFile:       gCfg.HTTPConfig.TLSConfig.KeyFile,
 		SkipVerify:    !gCfg.SMTPRequireTLS,
 		StaticHeaders: staticHeaders,
-		// TODO: add static headers.
 	}
 
 	integrations, err := alertingNotify.BuildReceiverIntegrations(

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -96,7 +96,7 @@ route:
 	cfg, err := definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 	tmpls := make([]io.Reader, 0)
-	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}))
+	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, map[string]string{}))
 
 	now := time.Now()
 
@@ -181,7 +181,7 @@ route:
 	cfg, err := definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 	tmpls := make([]io.Reader, 0)
-	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}))
+	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, map[string]string{}))
 
 	now := time.Now()
 	inputAlerts := []*types.Alert{
@@ -532,7 +532,7 @@ route:
 	cfg, err := definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 	tmpls := make([]io.Reader, 0)
-	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}))
+	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, map[string]string{}))
 
 	doGetReceivers := func() []alertingmodels.Receiver {
 		rr := httptest.NewRecorder()

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -96,7 +96,7 @@ route:
 	cfg, err := definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 	tmpls := make([]io.Reader, 0)
-	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, map[string]string{}))
+	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, nil))
 
 	now := time.Now()
 
@@ -181,7 +181,7 @@ route:
 	cfg, err := definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 	tmpls := make([]io.Reader, 0)
-	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, map[string]string{}))
+	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, nil))
 
 	now := time.Now()
 	inputAlerts := []*types.Alert{
@@ -532,7 +532,7 @@ route:
 	cfg, err := definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 	tmpls := make([]io.Reader, 0)
-	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, map[string]string{}))
+	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, nil))
 
 	doGetReceivers := func() []alertingmodels.Receiver {
 		rr := httptest.NewRecorder()

--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -8,33 +8,43 @@ package alertmanager
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/grafana/alerting/definition"
 
 	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
 )
 
-// createUsableGrafanaConfig creates an AlertConfigDesc from a GrafanaAlertConfigDesc.
+// createUsableGrafanaConfig creates an amConfig from a GrafanaAlertConfigDesc.
 // If provided, it assigns the global section from the Mimir config to the Grafana config.
 // The SMTP and HTTP settings in this section can be used to configure Grafana receivers.
-func createUsableGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc, mCfg *alertspb.AlertConfigDesc) (alertspb.AlertConfigDesc, error) {
+func createUsableGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc, mCfg *alertspb.AlertConfigDesc) (amConfig, error) {
 	var amCfg GrafanaAlertmanagerConfig
 	if err := json.Unmarshal([]byte(gCfg.RawConfig), &amCfg); err != nil {
-		return alertspb.AlertConfigDesc{}, fmt.Errorf("failed to unmarshal Grafana Alertmanager configuration %w", err)
+		return amConfig{}, fmt.Errorf("failed to unmarshal Grafana Alertmanager configuration %w", err)
 	}
 
 	if mCfg != nil {
 		cfg, err := definition.LoadCompat([]byte(mCfg.RawConfig))
 		if err != nil {
-			return alertspb.AlertConfigDesc{}, fmt.Errorf("failed to unmarshal Mimir Alertmanager configuration: %w", err)
+			return amConfig{}, fmt.Errorf("failed to unmarshal Mimir Alertmanager configuration: %w", err)
 		}
 		amCfg.AlertmanagerConfig.Config.Global = cfg.Config.Global
 	}
 
 	rawCfg, err := json.Marshal(amCfg.AlertmanagerConfig)
 	if err != nil {
-		return alertspb.AlertConfigDesc{}, fmt.Errorf("failed to marshal Grafana Alertmanager configuration %w", err)
+		return amConfig{}, fmt.Errorf("failed to marshal Grafana Alertmanager configuration %w", err)
 	}
 
-	return alertspb.ToProto(string(rawCfg), amCfg.Templates, gCfg.User), nil
+	externalURL, err := url.Parse(gCfg.ExternalUrl)
+	if err != nil {
+		return amConfig{}, err
+	}
+
+	return amConfig{
+		AlertConfigDesc: alertspb.ToProto(string(rawCfg), amCfg.Templates, gCfg.User),
+		tmplExternalURL: externalURL,
+		staticHeaders:   gCfg.StaticHeaders,
+	}, nil
 }

--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -19,6 +19,11 @@ import (
 // If provided, it assigns the global section from the Mimir config to the Grafana config.
 // The SMTP and HTTP settings in this section can be used to configure Grafana receivers.
 func createUsableGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc, mCfg *alertspb.AlertConfigDesc) (amConfig, error) {
+	externalURL, err := url.Parse(gCfg.ExternalUrl)
+	if err != nil {
+		return amConfig{}, err
+	}
+
 	var amCfg GrafanaAlertmanagerConfig
 	if err := json.Unmarshal([]byte(gCfg.RawConfig), &amCfg); err != nil {
 		return amConfig{}, fmt.Errorf("failed to unmarshal Grafana Alertmanager configuration %w", err)
@@ -35,11 +40,6 @@ func createUsableGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc, mCfg *alert
 	rawCfg, err := json.Marshal(amCfg.AlertmanagerConfig)
 	if err != nil {
 		return amConfig{}, fmt.Errorf("failed to marshal Grafana Alertmanager configuration %w", err)
-	}
-
-	externalURL, err := url.Parse(gCfg.ExternalUrl)
-	if err != nil {
-		return amConfig{}, err
 	}
 
 	return amConfig{

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -685,70 +685,39 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgMap map[string]alertspb.AlertC
 // computeConfig takes an AlertConfigDescs struct containing Mimir and Grafana configurations.
 // It returns the final configuration and external URL the Alertmanager will use.
 func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs) (amConfig, error) {
+	cfg := amConfig{
+		AlertConfigDesc: cfgs.Mimir,
+		tmplExternalURL: am.cfg.ExternalURL.URL,
+	}
+
 	switch {
 	// Mimir configuration.
 	case !cfgs.Grafana.Promoted:
 		level.Debug(am.logger).Log("msg", "grafana configuration not promoted, using mimir config", "user", cfgs.Mimir.User)
-		return amConfig{
-			AlertConfigDesc: cfgs.Mimir,
-			tmplExternalURL: am.cfg.ExternalURL.URL,
-		}, nil
+		return cfg, nil
 
 	case cfgs.Grafana.Default:
 		level.Debug(am.logger).Log("msg", "grafana configuration is default, using mimir config", "user", cfgs.Mimir.User)
-		return amConfig{
-			AlertConfigDesc: cfgs.Mimir,
-			tmplExternalURL: am.cfg.ExternalURL.URL,
-		}, nil
+		return cfg, nil
 
 	case cfgs.Grafana.RawConfig == "":
 		level.Debug(am.logger).Log("msg", "grafana configuration is empty, using mimir config", "user", cfgs.Mimir.User)
-		return amConfig{
-			AlertConfigDesc: cfgs.Mimir,
-			tmplExternalURL: am.cfg.ExternalURL.URL,
-		}, nil
+		return cfg, nil
 
 	// Grafana configuration.
 	case cfgs.Mimir.RawConfig == am.fallbackConfig:
 		level.Debug(am.logger).Log("msg", "mimir configuration is default, using grafana config with the default globals", "user", cfgs.Mimir.User)
-		gCfg, err := createUsableGrafanaConfig(cfgs.Grafana, &cfgs.Mimir)
-		if err != nil {
-			return amConfig{}, err
-		}
-		externalURL, err := url.Parse(cfgs.Grafana.ExternalUrl)
-		if err != nil {
-			return amConfig{}, err
-		}
-		return amConfig{
-			AlertConfigDesc: gCfg,
-			tmplExternalURL: externalURL,
-			staticHeaders:   cfgs.Grafana.StaticHeaders,
-		}, nil
+		return createUsableGrafanaConfig(cfgs.Grafana, &cfgs.Mimir)
 
 	case cfgs.Mimir.RawConfig == "":
 		level.Debug(am.logger).Log("msg", "mimir configuration is empty, using grafana config", "user", cfgs.Grafana.User)
-		gCfg, err := createUsableGrafanaConfig(cfgs.Grafana, &cfgs.Mimir)
-		if err != nil {
-			return amConfig{}, err
-		}
-		externalURL, err := url.Parse(cfgs.Grafana.ExternalUrl)
-		if err != nil {
-			return amConfig{}, err
-		}
-		return amConfig{
-			AlertConfigDesc: gCfg,
-			tmplExternalURL: externalURL,
-			staticHeaders:   cfgs.Grafana.StaticHeaders,
-		}, nil
+		return createUsableGrafanaConfig(cfgs.Grafana, nil)
 
 	// Both configurations.
 	// TODO: merge configurations.
 	default:
 		level.Warn(am.logger).Log("msg", "merging configurations not implemented, using mimir config", "user", cfgs.Mimir.User)
-		return amConfig{
-			AlertConfigDesc: cfgs.Mimir,
-			tmplExternalURL: am.cfg.ExternalURL.URL,
-		}, nil
+		return cfg, nil
 	}
 }
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -643,17 +643,13 @@ func (am *MultitenantAlertmanager) isUserOwned(userID string) bool {
 func (am *MultitenantAlertmanager) syncConfigs(cfgMap map[string]alertspb.AlertConfigDescs) {
 	level.Debug(am.logger).Log("msg", "adding configurations", "num_configs", len(cfgMap))
 	for user, cfgs := range cfgMap {
-		cfg, externalURL, err := am.computeConfig(cfgs)
+		cfg, err := am.computeConfig(cfgs)
 		if err != nil {
 			am.multitenantMetrics.lastReloadSuccessful.WithLabelValues(user).Set(float64(0))
 			level.Warn(am.logger).Log("msg", "error computing config", "err", err)
 			continue
 		}
-		c := amConfig{
-			AlertConfigDesc: cfg,
-			tmplExternalURL: externalURL,
-		}
-		if err := am.setConfig(c); err != nil {
+		if err := am.setConfig(cfg); err != nil {
 			am.multitenantMetrics.lastReloadSuccessful.WithLabelValues(user).Set(float64(0))
 			level.Warn(am.logger).Log("msg", "error applying config", "err", err)
 			continue
@@ -688,52 +684,78 @@ func (am *MultitenantAlertmanager) syncConfigs(cfgMap map[string]alertspb.AlertC
 
 // computeConfig takes an AlertConfigDescs struct containing Mimir and Grafana configurations.
 // It returns the final configuration and external URL the Alertmanager will use.
-func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs) (alertspb.AlertConfigDesc, *url.URL, error) {
-	var cfg alertspb.AlertConfigDesc
-	var externalURL *url.URL
-	var err error
-
+func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs) (amConfig, error) {
 	switch {
 	// Mimir configuration.
 	case !cfgs.Grafana.Promoted:
 		level.Debug(am.logger).Log("msg", "grafana configuration not promoted, using mimir config", "user", cfgs.Mimir.User)
-		return cfgs.Mimir, am.cfg.ExternalURL.URL, nil
+		return amConfig{
+			AlertConfigDesc: cfgs.Mimir,
+			tmplExternalURL: am.cfg.ExternalURL.URL,
+		}, nil
+
 	case cfgs.Grafana.Default:
 		level.Debug(am.logger).Log("msg", "grafana configuration is default, using mimir config", "user", cfgs.Mimir.User)
-		return cfgs.Mimir, am.cfg.ExternalURL.URL, nil
+		return amConfig{
+			AlertConfigDesc: cfgs.Mimir,
+			tmplExternalURL: am.cfg.ExternalURL.URL,
+		}, nil
+
 	case cfgs.Grafana.RawConfig == "":
 		level.Debug(am.logger).Log("msg", "grafana configuration is empty, using mimir config", "user", cfgs.Mimir.User)
-		return cfgs.Mimir, am.cfg.ExternalURL.URL, nil
+		return amConfig{
+			AlertConfigDesc: cfgs.Mimir,
+			tmplExternalURL: am.cfg.ExternalURL.URL,
+		}, nil
 
 	// Grafana configuration.
 	case cfgs.Mimir.RawConfig == am.fallbackConfig:
 		level.Debug(am.logger).Log("msg", "mimir configuration is default, using grafana config with the default globals", "user", cfgs.Mimir.User)
-		cfg, err = createUsableGrafanaConfig(cfgs.Grafana, &cfgs.Mimir)
+		gCfg, err := createUsableGrafanaConfig(cfgs.Grafana, &cfgs.Mimir)
 		if err != nil {
-			return cfg, nil, err
+			return amConfig{}, err
 		}
-		externalURL, err = url.Parse(cfgs.Grafana.ExternalUrl)
+		externalURL, err := url.Parse(cfgs.Grafana.ExternalUrl)
+		if err != nil {
+			return amConfig{}, err
+		}
+		return amConfig{
+			AlertConfigDesc: gCfg,
+			tmplExternalURL: externalURL,
+			staticHeaders:   cfgs.Grafana.StaticHeaders,
+		}, nil
+
 	case cfgs.Mimir.RawConfig == "":
 		level.Debug(am.logger).Log("msg", "mimir configuration is empty, using grafana config", "user", cfgs.Grafana.User)
-		cfg, err = createUsableGrafanaConfig(cfgs.Grafana, nil)
+		gCfg, err := createUsableGrafanaConfig(cfgs.Grafana, &cfgs.Mimir)
 		if err != nil {
-			return cfg, nil, err
+			return amConfig{}, err
 		}
-		externalURL, err = url.Parse(cfgs.Grafana.ExternalUrl)
+		externalURL, err := url.Parse(cfgs.Grafana.ExternalUrl)
+		if err != nil {
+			return amConfig{}, err
+		}
+		return amConfig{
+			AlertConfigDesc: gCfg,
+			tmplExternalURL: externalURL,
+			staticHeaders:   cfgs.Grafana.StaticHeaders,
+		}, nil
 
 	// Both configurations.
 	// TODO: merge configurations.
 	default:
 		level.Warn(am.logger).Log("msg", "merging configurations not implemented, using mimir config", "user", cfgs.Mimir.User)
-		return cfgs.Mimir, am.cfg.ExternalURL.URL, nil
+		return amConfig{
+			AlertConfigDesc: cfgs.Mimir,
+			tmplExternalURL: am.cfg.ExternalURL.URL,
+		}, nil
 	}
-
-	return cfg, externalURL, err
 }
 
 type amConfig struct {
 	alertspb.AlertConfigDesc
 	tmplExternalURL *url.URL
+	staticHeaders   map[string]string
 }
 
 // setConfig applies the given configuration to the alertmanager for `userID`,
@@ -792,7 +814,7 @@ func (am *MultitenantAlertmanager) setConfig(cfg amConfig) error {
 	// If no Alertmanager instance exists for this user yet, start one.
 	if !hasExisting {
 		level.Debug(am.logger).Log("msg", "initializing new per-tenant alertmanager", "user", cfg.User)
-		newAM, err := am.newAlertmanager(cfg.User, userAmConfig, templates, rawCfg, cfg.tmplExternalURL)
+		newAM, err := am.newAlertmanager(cfg.User, userAmConfig, templates, rawCfg, cfg.tmplExternalURL, cfg.staticHeaders)
 		if err != nil {
 			return err
 		}
@@ -800,7 +822,7 @@ func (am *MultitenantAlertmanager) setConfig(cfg amConfig) error {
 	} else if configChanged(am.cfgs[cfg.User], cfg.AlertConfigDesc) {
 		level.Info(am.logger).Log("msg", "updating new per-tenant alertmanager", "user", cfg.User)
 		// If the config changed, apply the new one.
-		err := existing.ApplyConfig(userAmConfig, templates, rawCfg, cfg.tmplExternalURL)
+		err := existing.ApplyConfig(userAmConfig, templates, rawCfg, cfg.tmplExternalURL, cfg.staticHeaders)
 		if err != nil {
 			return fmt.Errorf("unable to apply Alertmanager config for user %v: %v", cfg.User, err)
 		}
@@ -814,7 +836,7 @@ func (am *MultitenantAlertmanager) getTenantDirectory(userID string) string {
 	return filepath.Join(am.cfg.DataDir, userID)
 }
 
-func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *definition.PostableApiAlertingConfig, templates []io.Reader, rawCfg string, tmplExternalURL *url.URL) (*Alertmanager, error) {
+func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *definition.PostableApiAlertingConfig, templates []io.Reader, rawCfg string, tmplExternalURL *url.URL, staticHeaders map[string]string) (*Alertmanager, error) {
 	reg := prometheus.NewRegistry()
 
 	tenantDir := am.getTenantDirectory(userID)
@@ -843,7 +865,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *defi
 		return nil, fmt.Errorf("unable to start Alertmanager for user %v: %v", userID, err)
 	}
 
-	if err := newAM.ApplyConfig(amConfig, templates, rawCfg, tmplExternalURL); err != nil {
+	if err := newAM.ApplyConfig(amConfig, templates, rawCfg, tmplExternalURL, staticHeaders); err != nil {
 		return nil, fmt.Errorf("unable to apply initial config for user %v: %v", userID, err)
 	}
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -396,9 +396,10 @@ templates:
 	require.Len(t, am.alertmanagers, 4)
 
 	// The Mimir configuration was empty, so the Grafana configuration should be chosen for user 4.
-	parsed, err := createUsableGrafanaConfig(userGrafanaCfg, nil)
+	amCfg, err := createUsableGrafanaConfig(userGrafanaCfg, nil)
 	require.NoError(t, err)
-	require.Equal(t, parsed, am.cfgs["user4"])
+	grafanaAlertConfigDesc := amCfg.AlertConfigDesc
+	require.Equal(t, grafanaAlertConfigDesc, am.cfgs["user4"])
 
 	dirs = am.getPerUserDirectories()
 	user4Dir := dirs["user4"]
@@ -428,7 +429,7 @@ templates:
 
 	err = am.loadAndSyncConfigs(context.Background(), reasonPeriodic)
 	require.NoError(t, err)
-	require.Equal(t, parsed, am.cfgs["user4"])
+	require.Equal(t, grafanaAlertConfigDesc, am.cfgs["user4"])
 
 	// Add a Mimir fallback config for the same user.
 	defaultConfig := alertspb.AlertConfigDesc{

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2632,7 +2632,7 @@ func TestComputeConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg, url, err := am.computeConfig(test.cfg)
+			cfg, err := am.computeConfig(test.cfg)
 			if test.expErr != "" {
 				require.EqualError(t, err, test.expErr)
 				return
@@ -2640,7 +2640,7 @@ func TestComputeConfig(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, test.expCfg, cfg)
-			require.Equal(t, test.expURL, url.String())
+			require.Equal(t, test.expURL, cfg.tmplExternalURL.String())
 		})
 	}
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2462,11 +2462,12 @@ func TestComputeConfig(t *testing.T) {
 	mimirExternalURL := am.cfg.ExternalURL.String()
 
 	tests := []struct {
-		name   string
-		cfg    alertspb.AlertConfigDescs
-		expErr string
-		expCfg alertspb.AlertConfigDesc
-		expURL string
+		name       string
+		cfg        alertspb.AlertConfigDescs
+		expErr     string
+		expCfg     alertspb.AlertConfigDesc
+		expURL     string
+		expHeaders map[string]string
 	}{
 		{
 			name: "no grafana configuration",
@@ -2490,11 +2491,12 @@ func TestComputeConfig(t *testing.T) {
 					RawConfig: simpleConfigOne,
 				},
 				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:        "user",
-					RawConfig:   "",
-					Default:     false,
-					Promoted:    true,
-					ExternalUrl: grafanaExternalURL,
+					User:          "user",
+					RawConfig:     "",
+					Default:       false,
+					Promoted:      true,
+					ExternalUrl:   grafanaExternalURL,
+					StaticHeaders: map[string]string{"Test-Header": "test-value"},
 				},
 			},
 			expCfg: alertspb.AlertConfigDesc{
@@ -2511,10 +2513,11 @@ func TestComputeConfig(t *testing.T) {
 					RawConfig: simpleConfigOne,
 				},
 				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:        "user",
-					RawConfig:   grafanaConfig,
-					Promoted:    false,
-					ExternalUrl: grafanaExternalURL,
+					User:          "user",
+					RawConfig:     grafanaConfig,
+					Promoted:      false,
+					ExternalUrl:   grafanaExternalURL,
+					StaticHeaders: map[string]string{"Test-Header": "test-value"},
 				},
 			},
 			expCfg: alertspb.AlertConfigDesc{
@@ -2531,11 +2534,12 @@ func TestComputeConfig(t *testing.T) {
 					RawConfig: simpleConfigOne,
 				},
 				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:        "user",
-					RawConfig:   grafanaConfig,
-					Default:     true,
-					Promoted:    true,
-					ExternalUrl: grafanaExternalURL,
+					User:          "user",
+					RawConfig:     grafanaConfig,
+					Default:       true,
+					Promoted:      true,
+					ExternalUrl:   grafanaExternalURL,
+					StaticHeaders: map[string]string{"Test-Header": "test-value"},
 				},
 			},
 			expCfg: alertspb.AlertConfigDesc{
@@ -2548,11 +2552,12 @@ func TestComputeConfig(t *testing.T) {
 			name: "no mimir configuration",
 			cfg: alertspb.AlertConfigDescs{
 				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:        "user",
-					RawConfig:   grafanaConfig,
-					Default:     false,
-					Promoted:    true,
-					ExternalUrl: grafanaExternalURL,
+					User:          "user",
+					RawConfig:     grafanaConfig,
+					Default:       false,
+					Promoted:      true,
+					ExternalUrl:   grafanaExternalURL,
+					StaticHeaders: map[string]string{"Test-Header": "test-value"},
 				},
 			},
 			expCfg: alertspb.AlertConfigDesc{
@@ -2560,7 +2565,8 @@ func TestComputeConfig(t *testing.T) {
 				RawConfig: string(rawGrafanaCfg),
 				Templates: []*alertspb.TemplateDesc{},
 			},
-			expURL: grafanaExternalURL,
+			expURL:     grafanaExternalURL,
+			expHeaders: map[string]string{"Test-Header": "test-value"},
 		},
 		{
 			name: "empty mimir configuration",
@@ -2570,11 +2576,12 @@ func TestComputeConfig(t *testing.T) {
 					RawConfig: "",
 				},
 				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:        "user",
-					RawConfig:   grafanaConfig,
-					Default:     false,
-					Promoted:    true,
-					ExternalUrl: grafanaExternalURL,
+					User:          "user",
+					RawConfig:     grafanaConfig,
+					Default:       false,
+					Promoted:      true,
+					ExternalUrl:   grafanaExternalURL,
+					StaticHeaders: map[string]string{"Test-Header-1": "test-value-1", "Test-Header-2": "test-value-2"},
 				},
 			},
 			expCfg: alertspb.AlertConfigDesc{
@@ -2582,7 +2589,8 @@ func TestComputeConfig(t *testing.T) {
 				RawConfig: string(rawGrafanaCfg),
 				Templates: []*alertspb.TemplateDesc{},
 			},
-			expURL: grafanaExternalURL,
+			expURL:     grafanaExternalURL,
+			expHeaders: map[string]string{"Test-Header-1": "test-value-1", "Test-Header-2": "test-value-2"},
 		},
 		{
 			name: "default mimir configuration",
@@ -2592,11 +2600,12 @@ func TestComputeConfig(t *testing.T) {
 					RawConfig: am.fallbackConfig,
 				},
 				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:        "user",
-					RawConfig:   grafanaConfig,
-					Default:     false,
-					Promoted:    true,
-					ExternalUrl: grafanaExternalURL,
+					User:          "user",
+					RawConfig:     grafanaConfig,
+					Default:       false,
+					Promoted:      true,
+					ExternalUrl:   grafanaExternalURL,
+					StaticHeaders: map[string]string{"Test-Header-1": "test-value-1", "Test-Header-2": "test-value-2"},
 				},
 			},
 			expCfg: alertspb.AlertConfigDesc{
@@ -2604,7 +2613,8 @@ func TestComputeConfig(t *testing.T) {
 				RawConfig: string(combinedCfg),
 				Templates: []*alertspb.TemplateDesc{},
 			},
-			expURL: grafanaExternalURL,
+			expURL:     grafanaExternalURL,
+			expHeaders: map[string]string{"Test-Header-1": "test-value-1", "Test-Header-2": "test-value-2"},
 		},
 		{
 			// TODO: change once merging configs is implemented.
@@ -2615,11 +2625,12 @@ func TestComputeConfig(t *testing.T) {
 					RawConfig: simpleConfigOne,
 				},
 				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:        "user",
-					RawConfig:   grafanaConfig,
-					Default:     false,
-					Promoted:    true,
-					ExternalUrl: grafanaExternalURL,
+					User:          "user",
+					RawConfig:     grafanaConfig,
+					Default:       false,
+					Promoted:      true,
+					ExternalUrl:   grafanaExternalURL,
+					StaticHeaders: map[string]string{"Test-Header-1": "test-value-1", "Test-Header-2": "test-value-2"},
 				},
 			},
 			expCfg: alertspb.AlertConfigDesc{
@@ -2639,8 +2650,9 @@ func TestComputeConfig(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, test.expCfg, cfg)
+			require.Equal(t, test.expCfg, cfg.AlertConfigDesc)
 			require.Equal(t, test.expURL, cfg.tmplExternalURL.String())
+			require.Equal(t, test.expHeaders, cfg.staticHeaders)
 		})
 	}
 }


### PR DESCRIPTION
This PR passes static headers to the Grafana email receiver at creation time. These headers come from Grafana.