### PR TITLE
blockbuilder: improve how group handles rebalancing

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -290,7 +290,6 @@ func (b *BlockBuilder) NextConsumeCycle(ctx context.Context, cycleEnd time.Time)
 			} else {
 				level.Info(b.logger).Log(
 					"msg", "nothing to consume in partition",
-					"err", pl.Err,
 					"part", part,
 					"offset", pl.Commit.At,
 					"end_offset", pl.End.Offset,

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -40,6 +40,7 @@ func blockBuilderConfig(t *testing.T, addr string) (Config, *validation.Override
 			Topic:         testTopic,
 			ClientID:      "1",
 			DialTimeout:   10 * time.Second,
+			PollTimeout:   500 * time.Millisecond,
 			ConsumerGroup: testGroup,
 		},
 	}
@@ -273,10 +274,6 @@ func TestBlockBuilder(t *testing.T) {
 			filterHistogramSamples(kafkaHSamples, cycleEnd.Add(-cfg.ConsumeIntervalBuffer)),
 			labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
 		)
-	})
-
-	t.Run("restart scenario when there is a kafka commit", func(t *testing.T) {
-		// TODO(codesome): likely requires a new test because startup uses wall clock
 	})
 
 	t.Run("normal case of no lag", func(t *testing.T) {

--- a/pkg/blockbuilder/partitions.go
+++ b/pkg/blockbuilder/partitions.go
@@ -38,6 +38,7 @@ func (p *partitions) update(list []int32) {
 	slices.Sort(list)
 
 	head := p.list[:p.cur]
+	cur := len(head) - 1
 
 	for i := 0; i < len(head); i++ {
 		j, ok := slices.BinarySearch(list, head[i])
@@ -47,14 +48,16 @@ func (p *partitions) update(list []int32) {
 		} else {
 			// Remove from the head item that isn't present the list.
 			head = append(head[:i], head[i+1:]...)
+			if cur != i {
+				// Shift the cursor beyond the head if the last item in the head was removed. Otherwise,
+				// the cursor stays at the end of the head.
+				cur--
+			}
 			i = i - 1
 		}
 	}
 
-	p.cur = len(head) - 1
-	if p.cur < 0 {
-		p.cur = 0
-	}
+	p.cur = cur
 	p.list = slices.Concat(head, list)
 }
 

--- a/pkg/blockbuilder/partitions.go
+++ b/pkg/blockbuilder/partitions.go
@@ -1,0 +1,73 @@
+package blockbuilder
+
+import "slices"
+
+// partitions represent a queue of partitions currently assigned to the consumer.
+type partitions struct {
+	list []int32
+	cur  int
+}
+
+// next returns the next item in the queue of assigned partitions.
+func (p *partitions) next() int32 {
+	if len(p.list) == 0 {
+		return -1
+	}
+
+	if p.cur >= len(p.list) {
+		return -1
+	}
+
+	i := p.cur
+	p.cur++
+
+	return p.list[i]
+}
+
+// update replaces the queue with a new list of assigned partitions.
+// It doesn't reset the queue's cursor. That is, the later call to next will return the last active item
+// if the item exists in the new list.
+func (p *partitions) update(list []int32) {
+	if len(p.list) == 0 || p.cur == 0 || p.cur == len(p.list) {
+		p.list = list
+		p.cur = 0
+		return
+	}
+
+	list = slices.Clone(list)
+	slices.Sort(list)
+
+	head := p.list[:p.cur]
+
+	for i := 0; i < len(head); i++ {
+		j, ok := slices.BinarySearch(list, head[i])
+		if ok {
+			// Remove from the list item that stays in the head.
+			list = append(list[:j], list[j+1:]...)
+		} else {
+			// Remove from the head item that isn't present the list.
+			head = append(head[:i], head[i+1:]...)
+			i = i - 1
+		}
+	}
+
+	p.cur = len(head) - 1
+	if p.cur < 0 {
+		p.cur = 0
+	}
+	p.list = slices.Concat(head, list)
+}
+
+func (p *partitions) len() int {
+	return len(p.list)
+}
+
+func (p *partitions) reset() {
+	p.cur = 0
+}
+
+func (p *partitions) collect() []int32 {
+	list := make([]int32, len(p.list))
+	copy(list, p.list)
+	return list
+}

--- a/pkg/blockbuilder/partitions_test.go
+++ b/pkg/blockbuilder/partitions_test.go
@@ -21,8 +21,39 @@ func TestPartitions(t *testing.T) {
 		ps.update([]int32{5, 6, 7})
 		require.Equal(t, []int32{5, 6, 7}, ps.collect())
 
-		got := ps.next()
-		require.Equal(t, int32(5), got)
+		for _, want := range []int32{5, 6, 7} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+
+		// The call to next returns -1 after we've exhausted the queue.
+		require.Equal(t, int32(-1), ps.next())
+	})
+
+	t.Run("replace exhausted", func(t *testing.T) {
+		var ps partitions
+
+		ps.update([]int32{1, 2, 3})
+		require.Equal(t, []int32{1, 2, 3}, ps.collect())
+
+		for _, want := range []int32{1, 2, 3} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+
+		// The call to next returns -1 after we've exhausted the queue.
+		require.Equal(t, int32(-1), ps.next())
+
+		ps.update([]int32{5, 6, 7})
+		require.Equal(t, []int32{5, 6, 7}, ps.collect())
+
+		for _, want := range []int32{5, 6, 7} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+
+		// The call to next returns -1 after we've exhausted the queue.
+		require.Equal(t, int32(-1), ps.next())
 	})
 
 	t.Run("replace with self", func(t *testing.T) {
@@ -43,6 +74,9 @@ func TestPartitions(t *testing.T) {
 			got := ps.next()
 			require.Equal(t, want, got)
 		}
+
+		// The call to next returns -1 after we've exhausted the queue.
+		require.Equal(t, int32(-1), ps.next())
 	})
 
 	t.Run("replace with empty", func(t *testing.T) {
@@ -59,8 +93,7 @@ func TestPartitions(t *testing.T) {
 		ps.update([]int32{})
 		require.Equal(t, []int32{}, ps.collect())
 
-		got := ps.next()
-		require.Equal(t, int32(-1), got)
+		require.Equal(t, int32(-1), ps.next())
 	})
 
 	t.Run("shrink", func(t *testing.T) {
@@ -77,10 +110,14 @@ func TestPartitions(t *testing.T) {
 		ps.update([]int32{1, 3, 5})
 		require.Equal(t, []int32{1, 3, 5}, ps.collect())
 
-		for _, want := range []int32{1, 3} {
+		// The queue starts with its last cursor after the update. Because 2 (the cursor) isn't the new list
+		// and 1 was processed before 2, the queue starts with 3.
+		for _, want := range []int32{3, 5} {
 			got := ps.next()
 			require.Equal(t, want, got)
 		}
+
+		require.Equal(t, int32(-1), ps.next())
 	})
 
 	t.Run("expand", func(t *testing.T) {
@@ -97,10 +134,13 @@ func TestPartitions(t *testing.T) {
 		ps.update([]int32{0, 1, 2, 3, 4, 5})
 		require.Equal(t, []int32{1, 4, 0, 2, 3, 5}, ps.collect())
 
-		for _, want := range []int32{4, 0} {
+		// The queue starts with its last cursor after the update. That is 1 is skipped, and the queue starts with 4.
+		for _, want := range []int32{4, 0, 2, 3, 5} {
 			got := ps.next()
 			require.Equal(t, want, got)
 		}
+
+		require.Equal(t, int32(-1), ps.next())
 	})
 }
 
@@ -109,8 +149,9 @@ func TestPartitions_reset(t *testing.T) {
 
 	ps.update([]int32{1, 2, 3})
 	for i := 0; i < 3; i++ {
+		want := int32(i + 1)
 		got := ps.next()
-		require.Positive(t, got)
+		require.Equal(t, want, got)
 	}
 
 	require.Equal(t, int32(-1), ps.next())
@@ -118,7 +159,8 @@ func TestPartitions_reset(t *testing.T) {
 	ps.reset()
 
 	for i := 0; i < 3; i++ {
+		want := int32(i + 1)
 		got := ps.next()
-		require.Positive(t, got)
+		require.Equal(t, want, got)
 	}
 }

--- a/pkg/blockbuilder/partitions_test.go
+++ b/pkg/blockbuilder/partitions_test.go
@@ -1,0 +1,124 @@
+package blockbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitions(t *testing.T) {
+	t.Run("replace", func(t *testing.T) {
+		var ps partitions
+
+		ps.update([]int32{1, 2, 3})
+		require.Equal(t, []int32{1, 2, 3}, ps.collect())
+
+		for _, want := range []int32{1, 2} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+
+		ps.update([]int32{5, 6, 7})
+		require.Equal(t, []int32{5, 6, 7}, ps.collect())
+
+		got := ps.next()
+		require.Equal(t, int32(5), got)
+	})
+
+	t.Run("replace with self", func(t *testing.T) {
+		var ps partitions
+
+		ps.update([]int32{1, 2, 3})
+		require.Equal(t, []int32{1, 2, 3}, ps.collect())
+
+		for _, want := range []int32{1, 2} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+
+		ps.update([]int32{1, 2, 3})
+		require.Equal(t, []int32{1, 2, 3}, ps.collect())
+
+		for _, want := range []int32{2, 3} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+	})
+
+	t.Run("replace with empty", func(t *testing.T) {
+		var ps partitions
+
+		ps.update([]int32{1, 2, 3})
+		require.Equal(t, []int32{1, 2, 3}, ps.collect())
+
+		for _, want := range []int32{1, 2} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+
+		ps.update([]int32{})
+		require.Equal(t, []int32{}, ps.collect())
+
+		got := ps.next()
+		require.Equal(t, int32(-1), got)
+	})
+
+	t.Run("shrink", func(t *testing.T) {
+		var ps partitions
+
+		ps.update([]int32{1, 2, 3, 4})
+		require.Equal(t, []int32{1, 2, 3, 4}, ps.collect())
+
+		for _, want := range []int32{1, 2} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+
+		ps.update([]int32{1, 3, 5})
+		require.Equal(t, []int32{1, 3, 5}, ps.collect())
+
+		for _, want := range []int32{1, 3} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+	})
+
+	t.Run("expand", func(t *testing.T) {
+		var ps partitions
+
+		ps.update([]int32{1, 4, 7})
+		require.Equal(t, []int32{1, 4, 7}, ps.collect())
+
+		for _, want := range []int32{1, 4} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+
+		ps.update([]int32{0, 1, 2, 3, 4, 5})
+		require.Equal(t, []int32{1, 4, 0, 2, 3, 5}, ps.collect())
+
+		for _, want := range []int32{4, 0} {
+			got := ps.next()
+			require.Equal(t, want, got)
+		}
+	})
+}
+
+func TestPartitions_reset(t *testing.T) {
+	var ps partitions
+
+	ps.update([]int32{1, 2, 3})
+	for i := 0; i < 3; i++ {
+		got := ps.next()
+		require.Positive(t, got)
+	}
+
+	require.Equal(t, int32(-1), ps.next())
+
+	ps.reset()
+
+	for i := 0; i < 3; i++ {
+		got := ps.next()
+		require.Positive(t, got)
+	}
+}


### PR DESCRIPTION
~~I'm still in the process of testing the corned cases against the changes, but so far they look promising~~

The primary idea of the changeset is to replace how a cycle works with the assigned partitions. Since now on, we look at the assignment as a queue, that we traverse start to end. Inside the partition processing, we now allow a rebalance between the subsequent calls to `kafka.PolRrecords`. If Kafka broker calls for rebalance, the partition processing bails, and the cycle continues with the next partition in the newly assigned queue. The "trick" is to make sure the cycle skips the partitions that had been already processed before the rebalance (refer to the implementation of `partitions.update()`).