### PR TITLE
Ensure read path errors use correct HTTP status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main / unreleased
 * [ENHANCEMENT] Query-scheduler: Introduce `query-scheduler.use-multi-algorithm-query-queue`, which allows use of an experimental queue structure, with no change in external queue behavior. #7873
+* [BUGFIX] Query-frontend: Ensure that internal errors result in an HTTP 500 response code instead of 422. #8595 
 
 ### Grafana Mimir
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main / unreleased
 * [ENHANCEMENT] Query-scheduler: Introduce `query-scheduler.use-multi-algorithm-query-queue`, which allows use of an experimental queue structure, with no change in external queue behavior. #7873
-* [BUGFIX] Query-frontend: Ensure that internal errors result in an HTTP 500 response code instead of 422. #8595 
+* [BUGFIX] Query-frontend: Ensure that internal errors result in an HTTP 500 response code instead of 422. #8595
 
 ### Grafana Mimir
 

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/e2e"
 	e2ecache "github.com/grafana/e2e/cache"
 	e2edb "github.com/grafana/e2e/db"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
@@ -884,7 +885,9 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 	// missing from the storage.
 	_, err = c.Query(series1Name, series1Timestamp)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "get range reader: The specified key does not exist")
+	var apiErr *v1.Error
+	require.ErrorAs(t, err, &apiErr)
+	assert.Contains(t, apiErr.Detail, "get range reader: The specified key does not exist")
 
 	// We expect this to still be queryable as it was not in the cleared storage
 	_, err = c.Query(series2Name, series2Timestamp)

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -695,14 +695,13 @@ func (c prometheusCodec) DecodeResponse(ctx context.Context, r *http.Response, _
 		}
 	}
 
-	log := spanlogger.FromContext(ctx, logger)
-
+	spanlog := spanlogger.FromContext(ctx, logger)
 	buf, err := readResponseBody(r)
 	if err != nil {
-		log.Error(err)
+		spanlog.Error(err)
 		return nil, err
 	}
-	log.LogFields(otlog.String("message", "ParseQueryRangeResponse"),
+	spanlog.LogFields(otlog.String("message", "ParseQueryRangeResponse"),
 		otlog.Int("status_code", r.StatusCode),
 		otlog.Int("bytes", len(buf)))
 

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -808,13 +808,17 @@ type prometheusResponseData struct {
 	Result model.Value     `json:"result"`
 }
 
+func stringBody(message string) io.ReadCloser {
+	return io.NopCloser(strings.NewReader(message))
+}
+
 func TestDecodeFailedResponse(t *testing.T) {
 	codec := newTestPrometheusCodec()
 
 	t.Run("internal error", func(t *testing.T) {
 		_, err := codec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode: http.StatusInternalServerError,
-			Body:       io.NopCloser(strings.NewReader("something failed")),
+			Body:       stringBody("something failed"),
 		}, nil, log.NewNopLogger())
 		require.Error(t, err)
 
@@ -827,7 +831,7 @@ func TestDecodeFailedResponse(t *testing.T) {
 	t.Run("too many requests", func(t *testing.T) {
 		_, err := codec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode: http.StatusTooManyRequests,
-			Body:       io.NopCloser(strings.NewReader("something failed")),
+			Body:       stringBody("something failed"),
 		}, nil, log.NewNopLogger())
 		require.Error(t, err)
 
@@ -840,7 +844,7 @@ func TestDecodeFailedResponse(t *testing.T) {
 	t.Run("too large entry", func(t *testing.T) {
 		_, err := codec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode: http.StatusRequestEntityTooLarge,
-			Body:       io.NopCloser(strings.NewReader("something failed")),
+			Body:       stringBody("something failed"),
 		}, nil, log.NewNopLogger())
 		require.Error(t, err)
 
@@ -853,7 +857,7 @@ func TestDecodeFailedResponse(t *testing.T) {
 	t.Run("service unavailable", func(t *testing.T) {
 		_, err := codec.DecodeResponse(context.Background(), &http.Response{
 			StatusCode: http.StatusServiceUnavailable,
-			Body:       io.NopCloser(strings.NewReader("something failed")),
+			Body:       stringBody("something failed"),
 		}, nil, log.NewNopLogger())
 		require.Error(t, err)
 

--- a/pkg/querier/error_translate_queryable.go
+++ b/pkg/querier/error_translate_queryable.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -189,7 +192,8 @@ func (e errorTranslateSeriesSet) Next() bool {
 }
 
 func (e errorTranslateSeriesSet) At() storage.Series {
-	return e.s.At()
+	s := e.s.At()
+	return errorTranslateSeries{s: s, fn: e.fn}
 }
 
 func (e errorTranslateSeriesSet) Err() error {
@@ -198,6 +202,53 @@ func (e errorTranslateSeriesSet) Err() error {
 
 func (e errorTranslateSeriesSet) Warnings() annotations.Annotations {
 	return e.s.Warnings()
+}
+
+type errorTranslateSeries struct {
+	s  storage.Series
+	fn ErrTranslateFn
+}
+
+func (e errorTranslateSeries) Labels() labels.Labels {
+	return e.s.Labels()
+}
+
+func (e errorTranslateSeries) Iterator(iterator chunkenc.Iterator) chunkenc.Iterator {
+	i := e.s.Iterator(iterator)
+	return errorTranslateSampleIterator{i: i, fn: e.fn}
+}
+
+type errorTranslateSampleIterator struct {
+	i  chunkenc.Iterator
+	fn ErrTranslateFn
+}
+
+func (e errorTranslateSampleIterator) Next() chunkenc.ValueType {
+	return e.i.Next()
+}
+
+func (e errorTranslateSampleIterator) Seek(t int64) chunkenc.ValueType {
+	return e.i.Seek(t)
+}
+
+func (e errorTranslateSampleIterator) At() (int64, float64) {
+	return e.i.At()
+}
+
+func (e errorTranslateSampleIterator) AtHistogram(histogram *histogram.Histogram) (int64, *histogram.Histogram) {
+	return e.i.AtHistogram(histogram)
+}
+
+func (e errorTranslateSampleIterator) AtFloatHistogram(histogram *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+	return e.i.AtFloatHistogram(histogram)
+}
+
+func (e errorTranslateSampleIterator) AtT() int64 {
+	return e.i.AtT()
+}
+
+func (e errorTranslateSampleIterator) Err() error {
+	return e.fn(e.i.Err())
 }
 
 type errorTranslateChunkSeriesSet struct {
@@ -210,7 +261,8 @@ func (e errorTranslateChunkSeriesSet) Next() bool {
 }
 
 func (e errorTranslateChunkSeriesSet) At() storage.ChunkSeries {
-	return e.s.At()
+	s := e.s.At()
+	return errorTranslateChunkSeries{s: s, fn: e.fn}
 }
 
 func (e errorTranslateChunkSeriesSet) Err() error {
@@ -219,4 +271,39 @@ func (e errorTranslateChunkSeriesSet) Err() error {
 
 func (e errorTranslateChunkSeriesSet) Warnings() annotations.Annotations {
 	return e.s.Warnings()
+}
+
+type errorTranslateChunkSeries struct {
+	s  storage.ChunkSeries
+	fn ErrTranslateFn
+}
+
+func (e errorTranslateChunkSeries) Labels() labels.Labels {
+	return e.s.Labels()
+}
+
+func (e errorTranslateChunkSeries) Iterator(iterator chunks.Iterator) chunks.Iterator {
+	i := e.s.Iterator(iterator)
+	return errorTranslateChunksIterator{i: i, fn: e.fn}
+}
+
+func (e errorTranslateChunkSeries) ChunkCount() (int, error) {
+	return e.s.ChunkCount()
+}
+
+type errorTranslateChunksIterator struct {
+	i  chunks.Iterator
+	fn ErrTranslateFn
+}
+
+func (e errorTranslateChunksIterator) At() chunks.Meta {
+	return e.i.At()
+}
+
+func (e errorTranslateChunksIterator) Next() bool {
+	return e.i.Next()
+}
+
+func (e errorTranslateChunksIterator) Err() error {
+	return e.fn(e.i.Err())
 }


### PR DESCRIPTION
#### What this PR does

Extend the "error translate" `Queryable` implementation to translate errors returned by any part of the `Queryable` type hierarchy. This ensures that all errors returned by queriers are API errors.

#### Which issue(s) this PR fixes or relates to

Fixes #8139

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
