### PR TITLE
Fix the flag names for BlockBuilder

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -241,9 +241,7 @@ func (b *BlockBuilder) running(ctx context.Context) error {
 			// will immediately start the next consumption.
 			nextCycleTime = nextCycleTime.Add(b.cfg.ConsumeInterval)
 			waitTime = time.Until(nextCycleTime)
-			if waitTime < 0 {
-				// TODO(codesome): track "-waitTime", which is the time we ran over. Should have an alert on this.
-			}
+			// TODO(codesome): track "-waitTime" (when waitTime < 0), which is the time we ran over. Should have an alert on this.
 		case <-ctx.Done():
 			return nil
 		}

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -651,10 +651,10 @@ type Config struct {
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	cfg.Kafka.RegisterFlags(f)
+	cfg.Kafka.RegisterFlagsWithPrefix("block-builder.", f)
 
-	f.DurationVar(&cfg.ConsumeInterval, "consume-internal", time.Hour, "Interval between block consumption cycles.")
-	f.DurationVar(&cfg.ConsumeIntervalBuffer, "consume-internal-buffer", 5*time.Minute, "Extra buffer between subsequent block consumption cycles to avoid small blocks.")
+	f.DurationVar(&cfg.ConsumeInterval, "block-builder.consume-interval", time.Hour, "Interval between block consumption cycles.")
+	f.DurationVar(&cfg.ConsumeIntervalBuffer, "block-builder.consume-interval-buffer", 15*time.Minute, "Extra buffer between subsequent block consumption cycles to avoid small blocks.")
 }
 
 func (cfg *Config) Validate() error {
@@ -678,16 +678,12 @@ type KafkaConfig struct {
 	ConsumerGroup string        `yaml:"consumer_group"`
 }
 
-func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
-	cfg.RegisterFlagsWithPrefix("block-builder.kafka", f)
-}
-
 func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.StringVar(&cfg.Address, prefix+".address", "", "The Kafka seed broker address.")
-	f.StringVar(&cfg.Topic, prefix+".topic", "", "The Kafka topic name.")
-	f.StringVar(&cfg.ClientID, prefix+".client-id", "", "The Kafka client ID.")
-	f.DurationVar(&cfg.DialTimeout, prefix+".dial-timeout", 2*time.Second, "The maximum time allowed to open a connection to a Kafka broker.")
-	f.StringVar(&cfg.ConsumerGroup, prefix+".consumer-group", "", "The consumer group used by the consumer to track the last consumed offset.")
+	f.StringVar(&cfg.Address, prefix+"kafka.address", "", "The Kafka seed broker address.")
+	f.StringVar(&cfg.Topic, prefix+"kafka.topic", "", "The Kafka topic name.")
+	f.StringVar(&cfg.ClientID, prefix+"kafka.client-id", "", "The Kafka client ID.")
+	f.DurationVar(&cfg.DialTimeout, prefix+"kafka.dial-timeout", 5*time.Second, "The maximum time allowed to open a connection to a Kafka broker.")
+	f.StringVar(&cfg.ConsumerGroup, prefix+"kafka.consumer-group", "", "The consumer group used by the consumer to track the last consumed offset.")
 }
 
 func (cfg *KafkaConfig) Validate() error {

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package blockbuilder
 
 import (

--- a/pkg/blockbuilder/blockbuilder_metrics.go
+++ b/pkg/blockbuilder/blockbuilder_metrics.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package blockbuilder
 
 import (

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -297,7 +297,6 @@ func TestBlockBuilder(t *testing.T) {
 	t.Run("out of order w.r.t. old cycle and future record with valid sample", func(t *testing.T) {
 		// TODO(codesome): figure out what's up with these scenario
 		t.Skip()
-		return
 
 		kafkaTime = cycleEnd
 

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package blockbuilder
 
 import (

--- a/pkg/blockbuilder/partitions.go
+++ b/pkg/blockbuilder/partitions.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package blockbuilder
 
 import "slices"

--- a/pkg/blockbuilder/partitions_test.go
+++ b/pkg/blockbuilder/partitions_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package blockbuilder
 
 import (

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package blockbuilder
 
 import (

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -405,20 +405,20 @@ func (u *userTSDB) compactEverything(ctx context.Context) error {
 	return nil
 }
 
-func (u *userTSDB) PreCreation(metric labels.Labels) error {
+func (u *userTSDB) PreCreation(_ labels.Labels) error {
 	// TODO: Implement
 	return nil
 }
 
-func (u *userTSDB) PostCreation(metric labels.Labels) {
+func (u *userTSDB) PostCreation(_ labels.Labels) {
 	// TODO: Implement
 }
 
-func (u *userTSDB) PostDeletion(metrics map[chunks.HeadSeriesRef]labels.Labels) {
+func (u *userTSDB) PostDeletion(_ map[chunks.HeadSeriesRef]labels.Labels) {
 	// TODO: Implement
 }
 
-func (u *userTSDB) blocksToDelete(blocks []*tsdb.Block) map[ulid.ULID]struct{} {
+func (u *userTSDB) blocksToDelete(_ []*tsdb.Block) map[ulid.ULID]struct{} {
 	// TODO(codesome): delete all the blocks that have been shipped.
 	return map[ulid.ULID]struct{}{}
 }

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package blockbuilder
 
 import (


### PR DESCRIPTION
The flags were missing a `block-builder.` prefix.

I also fix the lint errors in this PR.