### PR TITLE
store-gateway: Move eager loading to BucketStore

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -398,14 +398,14 @@ func (s *BucketStore) InitialSync(ctx context.Context) error {
 }
 
 func (s *BucketStore) loadBlocks(ctx context.Context, blocks map[ulid.ULID]int64) {
+	// This is not happening during a request so we can ignore the stats.
+	ignoredStats := newSafeQueryStats()
 	// We ignore the time the block was used because it can only be in the map if it was still loaded before the shutdown
 	s.blockSet.forEach(func(b *bucketBlock) {
 		if _, ok := blocks[b.meta.ULID]; !ok {
 			return
 		}
-		if lazyReader, ok := b.indexHeaderReader.(*indexheader.LazyBinaryReader); ok {
-			lazyReader.EagerLoad(ctx)
-		}
+		b.ensureIndexHeaderLoaded(ctx, ignoredStats)
 	})
 }
 

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -245,7 +245,7 @@ func NewBucketStore(
 		snapConfig := indexheader.SnapshotterConfig{
 			Path:            dir,
 			UserID:          userID,
-			PersistInterval: bucketStoreConfig.IndexHeader.LazyLoadingIdleTimeout,
+			PersistInterval: bucketStoreConfig.IndexHeader.EagerLoadingPersistInterval,
 		}
 		s.snapshotter = indexheader.NewSnapshotter(s.logger, snapConfig, s.indexReaderPool)
 	} else {

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -687,15 +687,15 @@ func TestBucketStore_EagerLoading(t *testing.T) {
 	testCases := map[string]struct {
 		eagerLoadReaderEnabled       bool
 		expectedEagerLoadedBlocks    int
-		createLoadedBlocksSnapshotFn func(blockIds []ulid.ULID) map[ulid.ULID]int64
+		createLoadedBlocksSnapshotFn func([]ulid.ULID) map[ulid.ULID]int64
 	}{
 		"block is present in pre-shutdown loaded blocks and eager-loading is disabled": {
 			eagerLoadReaderEnabled:    false,
 			expectedEagerLoadedBlocks: 0,
-			createLoadedBlocksSnapshotFn: func(blockIds []ulid.ULID) map[ulid.ULID]int64 {
+			createLoadedBlocksSnapshotFn: func(blockIDs []ulid.ULID) map[ulid.ULID]int64 {
 				snapshot := make(map[ulid.ULID]int64)
-				for _, blockId := range blockIds {
-					snapshot[blockId] = time.Now().UnixMilli()
+				for _, blockID := range blockIDs {
+					snapshot[blockID] = time.Now().UnixMilli()
 				}
 				return snapshot
 			},
@@ -703,10 +703,10 @@ func TestBucketStore_EagerLoading(t *testing.T) {
 		"block is present in pre-shutdown loaded blocks and eager-loading is enabled, loading index header during initial sync": {
 			eagerLoadReaderEnabled:    true,
 			expectedEagerLoadedBlocks: 6,
-			createLoadedBlocksSnapshotFn: func(blockIds []ulid.ULID) map[ulid.ULID]int64 {
+			createLoadedBlocksSnapshotFn: func(blockIDs []ulid.ULID) map[ulid.ULID]int64 {
 				snapshot := make(map[ulid.ULID]int64)
-				for _, blockId := range blockIds {
-					snapshot[blockId] = time.Now().UnixMilli()
+				for _, blockID := range blockIDs {
+					snapshot[blockID] = time.Now().UnixMilli()
 				}
 				return snapshot
 			},
@@ -714,10 +714,10 @@ func TestBucketStore_EagerLoading(t *testing.T) {
 		"block is present in pre-shutdown loaded blocks and eager-loading is enabled, loading index header after initial sync": {
 			eagerLoadReaderEnabled:    true,
 			expectedEagerLoadedBlocks: 6,
-			createLoadedBlocksSnapshotFn: func(blockId []ulid.ULID) map[ulid.ULID]int64 {
+			createLoadedBlocksSnapshotFn: func(blockIDs []ulid.ULID) map[ulid.ULID]int64 {
 				snapshot := make(map[ulid.ULID]int64)
-				for _, blockId := range blockId {
-					snapshot[blockId] = time.Now().UnixMilli()
+				for _, blockID := range blockIDs {
+					snapshot[blockID] = time.Now().UnixMilli()
 				}
 				return snapshot
 			},

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -8,9 +8,11 @@ package storegateway
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,7 +20,9 @@ import (
 	"github.com/grafana/dskit/grpcutil"
 	dskit_metrics "github.com/grafana/dskit/metrics"
 	"github.com/grafana/dskit/services"
+	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -35,6 +39,7 @@ import (
 	"github.com/grafana/mimir/pkg/storegateway/indexcache"
 	"github.com/grafana/mimir/pkg/storegateway/indexheader"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 var (
@@ -110,17 +115,19 @@ func prepareTestBlocks(t testing.TB, now time.Time, count int, dir string, bkt o
 type prepareStoreConfig struct {
 	tempDir              string
 	manyParts            bool
-	maxSeriesPerBatch    int
 	chunksLimiterFactory ChunksLimiterFactory
 	seriesLimiterFactory SeriesLimiterFactory
 	series               []labels.Labels
 	indexCache           indexcache.IndexCache
 	metricsRegistry      *prometheus.Registry
+	logger               log.Logger
 	postingsStrategy     postingsSelectionStrategy
 	// When nonOverlappingBlocks is false, prepare store creates 2 blocks per block range.
 	// When nonOverlappingBlocks is true, it shifts the 2nd block ahead by 2hrs for every block range.
 	// This way the first and the last blocks created have no overlapping blocks.
 	nonOverlappingBlocks bool
+	numBlocks            int
+	bucketStoreConfig    mimir_tsdb.BucketStoreConfig
 }
 
 func (c *prepareStoreConfig) apply(opts ...prepareStoreConfigOption) *prepareStoreConfig {
@@ -133,12 +140,24 @@ func (c *prepareStoreConfig) apply(opts ...prepareStoreConfigOption) *prepareSto
 func defaultPrepareStoreConfig(t testing.TB) *prepareStoreConfig {
 	return &prepareStoreConfig{
 		metricsRegistry: prometheus.NewRegistry(),
+		numBlocks:       6,
+		logger:          log.NewNopLogger(),
 		tempDir:         t.TempDir(),
 		manyParts:       false,
-		// We want to force each Series() call to use more than one batch to catch some edge cases.
-		// This should make the implementation slightly slower, although most tests time
-		// is dominated by the setup.
-		maxSeriesPerBatch:    10,
+		bucketStoreConfig: mimir_tsdb.BucketStoreConfig{
+			// We want to force each Series() call to use more than one batch to catch some edge cases.
+			// This should make the implementation slightly slower, although most tests time
+			// is dominated by the setup.
+			StreamingBatchSize:          10,
+			BlockSyncConcurrency:        20,
+			PostingOffsetsInMemSampling: mimir_tsdb.DefaultPostingOffsetInMemorySampling,
+			IndexHeader: indexheader.Config{
+				EagerLoadingStartupEnabled:  true,
+				EagerLoadingPersistInterval: time.Minute,
+				LazyLoadingEnabled:          true,
+				LazyLoadingIdleTimeout:      time.Minute,
+			},
+		},
 		seriesLimiterFactory: newStaticSeriesLimiterFactory(0),
 		chunksLimiterFactory: newStaticChunksLimiterFactory(0),
 		indexCache:           noopCache{},
@@ -166,11 +185,10 @@ func withManyParts() prepareStoreConfigOption {
 
 func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareStoreConfig) *storeSuite {
 	extLset := labels.FromStrings("ext1", "value1")
-
-	minTime, maxTime := prepareTestBlocks(t, time.Now(), 3, cfg.tempDir, bkt, cfg.series, extLset, cfg.nonOverlappingBlocks)
+	minTime, maxTime := prepareTestBlocks(t, time.Now(), cfg.numBlocks/2, cfg.tempDir, bkt, cfg.series, extLset, cfg.nonOverlappingBlocks)
 
 	s := &storeSuite{
-		logger:          log.NewNopLogger(),
+		logger:          cfg.logger,
 		metricsRegistry: cfg.metricsRegistry,
 		cache:           &swappableCache{IndexCache: cfg.indexCache},
 		minTime:         minTime,
@@ -188,17 +206,7 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 		objstore.WithNoopInstr(bkt),
 		metaFetcher,
 		cfg.tempDir,
-		mimir_tsdb.BucketStoreConfig{
-			StreamingBatchSize:          cfg.maxSeriesPerBatch,
-			BlockSyncConcurrency:        20,
-			PostingOffsetsInMemSampling: mimir_tsdb.DefaultPostingOffsetInMemorySampling,
-			IndexHeader: indexheader.Config{
-				EagerLoadingStartupEnabled:  true,
-				LazyLoadingEnabled:          true,
-				LazyLoadingIdleTimeout:      time.Minute,
-				EagerLoadingPersistInterval: time.Minute,
-			},
-		},
+		cfg.bucketStoreConfig,
 		cfg.postingsStrategy,
 		cfg.chunksLimiterFactory,
 		cfg.seriesLimiterFactory,
@@ -640,8 +648,6 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			for _, streamingBatchSize := range []int{0, 1, 5} {
 				t.Run(fmt.Sprintf("streamingBatchSize=%d", streamingBatchSize), func(t *testing.T) {
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
 					bkt := objstore.NewInMemBucket()
 
 					prepConfig := defaultPrepareStoreConfig(t)
@@ -649,7 +655,6 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 					prepConfig.seriesLimiterFactory = newStaticSeriesLimiterFactory(testData.maxSeriesLimit)
 
 					s := prepareStoreWithTestBlocks(t, bkt, prepConfig)
-					assert.NoError(t, s.store.SyncBlocks(ctx))
 
 					req := &storepb.SeriesRequest{
 						Matchers: []storepb.LabelMatcher{
@@ -676,6 +681,147 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBucketStore_EagerLoading(t *testing.T) {
+	testCases := map[string]struct {
+		eagerLoadReaderEnabled       bool
+		expectedEagerLoadedBlocks    int
+		createLoadedBlocksSnapshotFn func(blockIds []ulid.ULID) map[ulid.ULID]int64
+	}{
+		"block is present in pre-shutdown loaded blocks and eager-loading is disabled": {
+			eagerLoadReaderEnabled:    false,
+			expectedEagerLoadedBlocks: 0,
+			createLoadedBlocksSnapshotFn: func(blockIds []ulid.ULID) map[ulid.ULID]int64 {
+				snapshot := make(map[ulid.ULID]int64)
+				for _, blockId := range blockIds {
+					snapshot[blockId] = time.Now().UnixMilli()
+				}
+				return snapshot
+			},
+		},
+		"block is present in pre-shutdown loaded blocks and eager-loading is enabled, loading index header during initial sync": {
+			eagerLoadReaderEnabled:    true,
+			expectedEagerLoadedBlocks: 6,
+			createLoadedBlocksSnapshotFn: func(blockIds []ulid.ULID) map[ulid.ULID]int64 {
+				snapshot := make(map[ulid.ULID]int64)
+				for _, blockId := range blockIds {
+					snapshot[blockId] = time.Now().UnixMilli()
+				}
+				return snapshot
+			},
+		},
+		"block is present in pre-shutdown loaded blocks and eager-loading is enabled, loading index header after initial sync": {
+			eagerLoadReaderEnabled:    true,
+			expectedEagerLoadedBlocks: 6,
+			createLoadedBlocksSnapshotFn: func(blockId []ulid.ULID) map[ulid.ULID]int64 {
+				snapshot := make(map[ulid.ULID]int64)
+				for _, blockId := range blockId {
+					snapshot[blockId] = time.Now().UnixMilli()
+				}
+				return snapshot
+			},
+		},
+		"block is not present in pre-shutdown loaded blocks snapshot and eager-loading is enabled": {
+			eagerLoadReaderEnabled:    true,
+			expectedEagerLoadedBlocks: 0, // although eager loading is enabled, this test will not do eager loading because the block ID is not in the lazy loaded file.
+			createLoadedBlocksSnapshotFn: func(_ []ulid.ULID) map[ulid.ULID]int64 {
+				// let's create a random fake blockID to be stored in lazy loaded headers file
+				fakeBlockID := ulid.MustNew(ulid.Now(), nil)
+				// this snapshot will refer to fake block, hence eager load wouldn't be executed for the real block that we test
+				return map[ulid.ULID]int64{fakeBlockID: time.Now().UnixMilli()}
+			},
+		},
+		"pre-shutdown loaded blocks snapshot doesn't exist and eager-loading is enabled": {
+			eagerLoadReaderEnabled:    true,
+			expectedEagerLoadedBlocks: 0,
+		},
+	}
+
+	assertLoadedBlocks := func(t *testing.T, cfg *prepareStoreConfig, expectedLoadedBlocks int) {
+		assert.NoError(t, testutil.GatherAndCompare(cfg.metricsRegistry, strings.NewReader(fmt.Sprintf(`
+ 				# HELP cortex_bucket_store_indexheader_lazy_load_total Total number of index-header lazy load operations.
+				# TYPE cortex_bucket_store_indexheader_lazy_load_total counter
+				cortex_bucket_store_indexheader_lazy_load_total %d
+				`, expectedLoadedBlocks)),
+			"cortex_bucket_store_indexheader_lazy_load_total",
+		))
+	}
+
+	for testName, testData := range testCases {
+		testData := testData
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			bkt := objstore.NewInMemBucket()
+			cfg := defaultPrepareStoreConfig(t)
+			cfg.logger = test.NewTestingLogger(t)
+			cfg.bucketStoreConfig.IndexHeader.EagerLoadingStartupEnabled = testData.eagerLoadReaderEnabled
+			ctx := context.Background()
+
+			// Start the store so we generate some blocks and can use them in the mock snapshot.
+			store := prepareStoreWithTestBlocks(t, bkt, cfg)
+			assertLoadedBlocks(t, cfg, 0)
+
+			if testData.createLoadedBlocksSnapshotFn != nil {
+				// Create the snapshot manually so that we don't rely on the periodic snapshotting.
+				loadedBlocks := store.store.blockULIDs()
+				staticLoader := staticLoadedBlocks(testData.createLoadedBlocksSnapshotFn(loadedBlocks))
+				snapshotter := indexheader.NewSnapshotter(cfg.logger, indexheader.SnapshotterConfig{
+					PersistInterval: time.Hour,
+					Path:            cfg.tempDir,
+				}, staticLoader)
+
+				require.NoError(t, snapshotter.PersistLoadedBlocks())
+			}
+			// Stop store and start a new one using the same directory. It should pick up the stored blocks.
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, store.store))
+			cfg.metricsRegistry = prometheus.NewRegistry() // The store-gateway will reregister its metrics; replace the registry to prevent a panic
+			cfg.numBlocks = 0                              // we don't want to generate blocks again to speed the test up
+
+			store = prepareStoreWithTestBlocks(t, bkt, cfg)
+			assertLoadedBlocks(t, cfg, testData.expectedEagerLoadedBlocks)
+		})
+	}
+}
+
+func TestBucketStore_PersistsLazyLoadedBlocks(t *testing.T) {
+	t.Parallel()
+
+	const persistInterval = 100 * time.Millisecond
+	bkt := objstore.NewInMemBucket()
+	cfg := defaultPrepareStoreConfig(t)
+	cfg.logger = test.NewTestingLogger(t)
+	cfg.bucketStoreConfig.IndexHeader.EagerLoadingPersistInterval = persistInterval
+	cfg.bucketStoreConfig.IndexHeader.EagerLoadingStartupEnabled = true
+	ctx := context.Background()
+	// Set up a snapshotter in the same directory as the one the store creates.
+	snapshotter := indexheader.NewSnapshotter(cfg.logger, indexheader.SnapshotterConfig{
+		PersistInterval: time.Hour,
+		Path:            cfg.tempDir,
+	}, nil)
+
+	// Start the store so we generate some blocks and can use them in the mock snapshot.
+	store := prepareStoreWithTestBlocks(t, bkt, cfg)
+	// Wait for the snapshot to be persisted.
+	time.Sleep(persistInterval * 2)
+
+	// The snapshot should be empty.
+	assert.Empty(t, snapshotter.RestoreLoadedBlocks())
+
+	// Run a simple request to trigger loading the blocks
+	resp, err := store.store.LabelNames(ctx, &storepb.LabelNamesRequest{End: math.MaxInt64})
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Names)
+
+	// Wait for the snapshot to be persisted.
+	time.Sleep(persistInterval * 2)
+	assert.Len(t, snapshotter.RestoreLoadedBlocks(), cfg.numBlocks)
+}
+
+type staticLoadedBlocks map[ulid.ULID]int64
+
+func (b staticLoadedBlocks) LoadedBlocks() map[ulid.ULID]int64 {
+	return b
 }
 
 func assertQueryStatsLabelNamesMetricsRecorded(t *testing.T, numLabelNames int, registry *prometheus.Registry) {

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -778,7 +778,7 @@ func TestBucketStore_EagerLoading(t *testing.T) {
 			cfg.metricsRegistry = prometheus.NewRegistry() // The store-gateway will reregister its metrics; replace the registry to prevent a panic
 			cfg.numBlocks = 0                              // we don't want to generate blocks again to speed the test up
 
-			store = prepareStoreWithTestBlocks(t, bkt, cfg)
+			_ = prepareStoreWithTestBlocks(t, bkt, cfg) // we create and start the store only to trigger eager loading.
 			assertLoadedBlocks(t, cfg, testData.expectedEagerLoadedBlocks)
 		})
 	}

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1830,7 +1830,7 @@ func TestBucketStore_Series_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		indexReaderPool: indexheader.NewReaderPool(log.NewNopLogger(), indexheader.Config{
 			LazyLoadingEnabled:     false,
 			LazyLoadingIdleTimeout: 0,
-		}, gate.NewNoop(), indexheader.NewReaderPoolMetrics(nil), nil),
+		}, gate.NewNoop(), indexheader.NewReaderPoolMetrics(nil)),
 		blockSet:             newBucketBlockSet(),
 		metrics:              NewBucketStoreMetrics(nil),
 		postingsStrategy:     selectAllStrategy{},

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -253,7 +253,6 @@ func (g *StoreGateway) starting(ctx context.Context) (err error) {
 	// At this point, the instance is registered with some tokens
 	// and we can start the bucket stores.
 	g.bucketSync.WithLabelValues(syncReasonInitial).Inc()
-	g.logger.Log("msg", "starting bucket initial sync")
 	if err = services.StartAndAwaitRunning(ctx, g.stores); err != nil {
 		return errors.Wrap(err, "starting bucket stores")
 	}

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -253,6 +253,7 @@ func (g *StoreGateway) starting(ctx context.Context) (err error) {
 	// At this point, the instance is registered with some tokens
 	// and we can start the bucket stores.
 	g.bucketSync.WithLabelValues(syncReasonInitial).Inc()
+	g.logger.Log("msg", "starting bucket initial sync")
 	if err = services.StartAndAwaitRunning(ctx, g.stores); err != nil {
 		return errors.Wrap(err, "starting bucket stores")
 	}

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -254,6 +254,7 @@ func (r *LazyBinaryReader) EagerLoad(ctx context.Context) {
 		level.Warn(r.logger).Log("msg", "eager loading of lazy loaded index-header failed; skipping", "err", loaded.err)
 		return
 	}
+	level.Info(r.logger).Log("msg", "eager loaded block", "block_id", r.blockID)
 	loaded.inUse.Done()
 }
 

--- a/pkg/storegateway/indexheader/lazy_binary_reader.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader.go
@@ -247,17 +247,6 @@ func (r *LazyBinaryReader) LabelNames(ctx context.Context) ([]string, error) {
 	return loaded.reader.LabelNames(ctx)
 }
 
-// EagerLoad attempts to eagerly load this index header.
-func (r *LazyBinaryReader) EagerLoad(ctx context.Context) {
-	loaded := r.getOrLoadReader(ctx)
-	if loaded.err != nil {
-		level.Warn(r.logger).Log("msg", "eager loading of lazy loaded index-header failed; skipping", "err", loaded.err)
-		return
-	}
-	level.Info(r.logger).Log("msg", "eager loaded block", "block_id", r.blockID)
-	loaded.inUse.Done()
-}
-
 // getOrLoadReader ensures the underlying binary index-header reader has been successfully loaded.
 // Returns the reader, wait group that should be used to signal that usage of reader is finished, and an error on failure.
 // Must be called without lock.

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -222,35 +222,6 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 	})
 }
 
-func TestNewLazyBinaryReader_EagerLoadLazyLoadedIndexHeaders(t *testing.T) {
-	tmpDir, bkt, blockID := initBucketAndBlocksForTest(t)
-
-	testLazyBinaryReader(t, bkt, tmpDir, blockID, func(t *testing.T, r *LazyBinaryReader, err error) {
-		r.EagerLoad(context.Background())
-
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, r.Close())
-		})
-
-		require.Equal(t, float64(1), promtestutil.ToFloat64(r.metrics.loadCount))
-		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.unloadCount))
-
-		// The index should already be loaded, the following call will return reader already loaded above
-		v, err := r.IndexVersion(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, 2, v)
-		require.Equal(t, float64(1), promtestutil.ToFloat64(r.metrics.loadCount))
-		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.unloadCount))
-
-		labelNames, err := r.LabelNames(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, []string{"a"}, labelNames)
-		require.Equal(t, float64(1), promtestutil.ToFloat64(r.metrics.loadCount))
-		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.unloadCount))
-	})
-}
-
 func initBucketAndBlocksForTest(t testing.TB) (string, *filesystem.Bucket, ulid.ULID) {
 	ctx := context.Background()
 

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -54,7 +54,7 @@ type BlocksLoader interface {
 }
 
 func (s *Snapshotter) persist(context.Context) error {
-	err := s.PersistLoadedBlocks(s.bl)
+	err := s.PersistLoadedBlocks()
 	if err != nil {
 		// Note, the decision here is to only log the error but not failing the job. We may reconsider that later.
 		level.Warn(s.logger).Log("msg", "failed to persist list of lazy-loaded index headers", "err", err)
@@ -63,9 +63,9 @@ func (s *Snapshotter) persist(context.Context) error {
 	return nil
 }
 
-func (s *Snapshotter) PersistLoadedBlocks(bl BlocksLoader) error {
+func (s *Snapshotter) PersistLoadedBlocks() error {
 	snapshot := &indexHeadersSnapshot{
-		IndexHeaderLastUsedTime: bl.LoadedBlocks(),
+		IndexHeaderLastUsedTime: s.bl.LoadedBlocks(),
 		UserID:                  s.conf.UserID,
 	}
 	data, err := json.Marshal(snapshot)

--- a/pkg/storegateway/indexheader/snapshotter_test.go
+++ b/pkg/storegateway/indexheader/snapshotter_test.go
@@ -35,7 +35,7 @@ func TestSnapshotter_PersistAndRestoreLoadedBlocks(t *testing.T) {
 
 	// First instance persists the original snapshot.
 	s1 := NewSnapshotter(log.NewNopLogger(), config, testBlocksLoader)
-	err := s1.PersistLoadedBlocks(testBlocksLoader)
+	err := s1.PersistLoadedBlocks()
 	require.NoError(t, err)
 
 	persistedFile := filepath.Join(tmpDir, lazyLoadedHeadersListFileName)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->


This is the third PR for https://github.com/grafana/mimir/issues/8389

#### What this PR does

This PR does one major change: Move eager loading from `ReaderPool` to `BucketStore`. 

The problem with keeping eager loading in the `ReaderPool` is that it needs to have the list of previously loaded blocks injected. This is hard if we want to move the snapshotter and index reader pool to being services.

The PR also slightly changes the `Snapshotter` to receive its dependency (`BlocksLoader` which has the list of currently loaded blocks) via the constructor as opposed to via each snapshot iteration. This is now possible because there is no circular dependency between the `Snapshotter` and the `ReaderPool` (the snapshotter needed to pool to know what's loaded; the pool needed the snapshotter to know what to eager load).

#### Which issue(s) this PR fixes or relates to

related to https://github.com/grafana/mimir/issues/8389

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
