### PR TITLE
store-gateway: Make index reader pool a service

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -279,7 +279,6 @@ func (s *BucketStore) stop(err error) error {
 		}
 	}
 
-	s.indexReaderPool.Close()
 	return errs.Err()
 }
 

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -261,11 +261,12 @@ func NewBucketStore(
 }
 
 func (s *BucketStore) subservices() []services.Service {
-	return []services.Service{s.snapshotter}
+	return []services.Service{s.snapshotter, s.indexReaderPool}
 }
 
 func (s *BucketStore) start(context.Context) error {
-	return nil
+	// Use context.Background() so that we stop the index reader pool ourselves and do it after closing all blocks.
+	return services.StartAndAwaitRunning(context.Background(), s.indexReaderPool)
 }
 
 func (s *BucketStore) stop(err error) error {

--- a/pkg/util/test/leak.go
+++ b/pkg/util/test/leak.go
@@ -24,10 +24,6 @@ func goLeakOptions() []goleak.Option {
 		// Ignore opencensus default worker because it's started in a init() function.
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 
-		// The store-gateway BucketStore starts a goroutine in the index-header readers pool and
-		// it gets closed when we close the BucketStore. However, we currently don't close BucketStore
-		// on store-gateway termination so it never gets terminated.
-		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.NewReaderPool.func1"),
 		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.(*LazyBinaryReader).controlLoop"),
 
 		// The FastRegexMatcher uses a global instance of ristretto.Cache which is never stopped,


### PR DESCRIPTION
This is the fourth PR for https://github.com/grafana/mimir/issues/8389


#### What this PR does

Makes `ReaderPool` a `service.Service`. Its lifecycle is controlled by the `BucketStore`. The `BucketStore` will stop the `ReaderPool` whenever it is shutting down. This prevents leaking goroutines.

#### Which issue(s) this PR fixes or relates to

related to https://github.com/grafana/mimir/issues/8389

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
