### PR TITLE
Commit properly when we have to retain the old commit

### DIFF
--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -295,10 +295,6 @@ func TestBlockBuilder(t *testing.T) {
 	})
 
 	t.Run("out of order w.r.t. old cycle and future record with valid sample", func(t *testing.T) {
-		// TODO(codesome): figure out what's up with these scenario
-		t.Skip()
-		return
-
 		kafkaTime = cycleEnd
 
 		// Out of order sample w.r.t. samples in last cycle. But for this cycle,
@@ -429,7 +425,8 @@ func TestBlockBuilder_StartupWithExistingCommit(t *testing.T) {
 	lastRec := commitRec
 	blockEnd := commitRec.Timestamp.Truncate(cfg.ConsumeInterval).Add(cfg.ConsumeInterval)
 
-	err = commitRecord(ctx, logger, kc, testTopic, commitRec, lastRec.Timestamp.UnixMilli(), blockEnd.UnixMilli())
+	meta := marshallCommitMeta(commitRec.Timestamp.UnixMilli(), lastRec.Timestamp.UnixMilli(), blockEnd.UnixMilli())
+	err = commitRecord(ctx, logger, kc, testTopic, commitRec, meta)
 	require.NoError(t, err)
 	kc.CloseAllowingRebalance()
 

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -395,6 +395,7 @@ func TestBlockBuilder_StartupWithExistingCommit(t *testing.T) {
 
 	cfg, overrides := blockBuilderConfig(t, addr)
 
+	// Producing some records
 	kafkaTime := time.Now().Truncate(cfg.ConsumeInterval).Add(-7 * time.Hour).Add(29 * time.Minute)
 	var expSamples []mimirpb.Sample
 	for i := int64(0); i < 12; i++ {
@@ -406,6 +407,8 @@ func TestBlockBuilder_StartupWithExistingCommit(t *testing.T) {
 		expSamples = append(expSamples, samples...)
 	}
 
+	// Fetching all the records that were produced in order to choose
+	// a record and then commit it.
 	opts := []kgo.Opt{
 		kgo.ClientID("1"), kgo.SeedBrokers(addr), kgo.ConsumeTopics(testTopic),
 		kgo.ConsumerGroup(testGroup),
@@ -423,6 +426,7 @@ func TestBlockBuilder_StartupWithExistingCommit(t *testing.T) {
 	}
 	require.Len(t, recs, len(expSamples))
 
+	// Choosing the midpoint record to commit and as the last seen record as well.
 	commitRec := recs[len(recs)/2]
 	lastRec := commitRec
 	blockEnd := commitRec.Timestamp.Truncate(cfg.ConsumeInterval).Add(cfg.ConsumeInterval)


### PR DESCRIPTION
When commit record stays same as the previous cycle, we were handling it wrongly. Instead of keeping the old commit, we were taking the `lastRec` as the `commitRec` because of how `commitRec` was set. We identify that the first record was not fully processed, so the `commitRec` is set to the `lastRec` which is nil. So `commitRec` got wrongly overridden by the `lastRec` in this case.

In this PR what I am doing is passing around the last commit information. And when the first record is the one that is not fully processed, I am setting `commitRec` with the old commit info. That way comitting it correctly. We do need to re-commit in order to update the "last seen" timestamp in the metadata.

This was why the out-of-order test was failing (test was checking the right stuff apparently).