### PR TITLE
store-gateway: properly close LazyBinaryReader on shutdown

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -260,25 +260,17 @@ func NewBucketStore(
 	return s, nil
 }
 
-func (s *BucketStore) subservices() []services.Service {
-	return []services.Service{s.snapshotter, s.indexReaderPool}
-}
-
 func (s *BucketStore) start(context.Context) error {
 	// Use context.Background() so that we stop the index reader pool ourselves and do it after closing all blocks.
 	return services.StartAndAwaitRunning(context.Background(), s.indexReaderPool)
 }
 
 func (s *BucketStore) stop(err error) error {
-	subservices := s.subservices()
-
 	errs := multierror.New(err)
-	for _, svc := range subservices {
-		if err := services.StopAndAwaitTerminated(context.Background(), svc); err != nil {
-			errs.Add(fmt.Errorf("stop %T: %w", svc, err))
-		}
-	}
-
+	errs.Add(s.closeAllBlocks())
+	// The snapshotter depends on the reader pool, so we close the snapshotter first.
+	errs.Add(services.StopAndAwaitTerminated(context.Background(), s.snapshotter))
+	errs.Add(services.StopAndAwaitTerminated(context.Background(), s.indexReaderPool))
 	return errs.Err()
 }
 
@@ -349,7 +341,7 @@ func (s *BucketStore) syncBlocks(ctx context.Context) error {
 		return metaFetchErr
 	}
 
-	blockIDs := s.blockSet.blockULIDs()
+	blockIDs := s.blockSet.openBlocksULIDs()
 	for _, id := range blockIDs {
 		if _, ok := metas[id]; ok {
 			continue
@@ -534,8 +526,12 @@ func (s *BucketStore) removeBlock(id ulid.ULID) (returnErr error) {
 	return nil
 }
 
+func (s *BucketStore) closeAllBlocks() error {
+	return s.blockSet.closeAll()
+}
+
 func (s *BucketStore) removeAllBlocks() error {
-	blockIDs := s.blockSet.blockULIDs()
+	blockIDs := s.blockSet.allBlockULIDs()
 
 	errs := multierror.New()
 	for _, id := range blockIDs {
@@ -1903,12 +1899,36 @@ func (s *bucketBlockSet) forEach(fn func(b *bucketBlock)) {
 	})
 }
 
-func (s *bucketBlockSet) blockULIDs() []ulid.ULID {
+// closeAll closes all blocks in the set and returns all encountered errors after trying all blocks.
+func (s *bucketBlockSet) closeAll() error {
+	errs := multierror.New()
+	s.blockSet.Range(func(_, val any) bool {
+		errs.Add(val.(*bucketBlock).Close())
+		return true
+	})
+	return errs.Err()
+}
+
+// openBlocksULIDs returns the ULIDs of all blocks in the set which are not closed.
+func (s *bucketBlockSet) openBlocksULIDs() []ulid.ULID {
 	ulids := make([]ulid.ULID, 0, s.len())
 	s.forEach(func(b *bucketBlock) {
 		ulids = append(ulids, b.meta.ULID)
 	})
 	return ulids
+}
+
+// allBlockULIDs returns the ULIDs of all blocks in the set regardless whether they are closed or not.
+func (s *bucketBlockSet) allBlockULIDs() []ulid.ULID {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	ulids := make([]ulid.ULID, 0, len(s.blocks))
+	for _, b := range s.blocks {
+		ulids = append(ulids, b.meta.ULID)
+	}
+	return ulids
+
 }
 
 // timerange returns the minimum and maximum timestamp available in the set.

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -764,7 +764,7 @@ func TestBucketStore_EagerLoading(t *testing.T) {
 
 			if testData.createLoadedBlocksSnapshotFn != nil {
 				// Create the snapshot manually so that we don't rely on the periodic snapshotting.
-				loadedBlocks := store.store.blockSet.blockULIDs()
+				loadedBlocks := store.store.blockSet.openBlocksULIDs()
 				staticLoader := staticLoadedBlocks(testData.createLoadedBlocksSnapshotFn(loadedBlocks))
 				snapshotter := indexheader.NewSnapshotter(cfg.logger, indexheader.SnapshotterConfig{
 					PersistInterval: time.Hour,

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -8,7 +8,6 @@ package indexheader
 import (
 	"context"
 	"flag"
-	"io"
 	"time"
 
 	"github.com/pkg/errors"
@@ -31,7 +30,9 @@ var (
 
 // Reader is an interface allowing to read essential, minimal number of index fields from the small portion of index file called header.
 type Reader interface {
-	io.Closer
+	// Close should be called when this instance of Reader will no longer be used.
+	// It is illegal to call Close multiple times.
+	Close() error
 
 	// IndexVersion returns version of index.
 	IndexVersion(context.Context) (int, error)

--- a/pkg/storegateway/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storegateway/indexheader/lazy_binary_reader_test.go
@@ -53,9 +53,6 @@ func TestNewLazyBinaryReader_ShouldBuildIndexHeaderFromBucket(t *testing.T) {
 
 	testLazyBinaryReader(t, bkt, tmpDir, blockID, func(t *testing.T, r *LazyBinaryReader, err error) {
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, r.Close())
-		})
 
 		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.loadCount))
 		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.unloadCount))
@@ -84,9 +81,6 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 
 	testLazyBinaryReader(t, bkt, tmpDir, blockID, func(t *testing.T, r *LazyBinaryReader, err error) {
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, r.Close())
-		})
 
 		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.loadCount))
 		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.loadFailedCount))
@@ -102,48 +96,11 @@ func TestNewLazyBinaryReader_ShouldRebuildCorruptedIndexHeader(t *testing.T) {
 	})
 }
 
-func TestLazyBinaryReader_ShouldReopenOnUsageAfterClose(t *testing.T) {
-	tmpDir, bkt, blockID := initBucketAndBlocksForTest(t)
-
-	testLazyBinaryReader(t, bkt, tmpDir, blockID, func(t *testing.T, r *LazyBinaryReader, err error) {
-		require.NoError(t, err)
-
-		// Should lazy load the index upon first usage.
-		labelNames, err := r.LabelNames(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, []string{"a"}, labelNames)
-		require.Equal(t, float64(1), promtestutil.ToFloat64(r.metrics.loadCount))
-		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.loadFailedCount))
-
-		// Close it.
-		require.NoError(t, r.Close())
-		require.Equal(t, float64(1), promtestutil.ToFloat64(r.metrics.unloadCount))
-		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.unloadFailedCount))
-
-		// Should lazy load again upon next usage.
-		labelNames, err = r.LabelNames(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, []string{"a"}, labelNames)
-		require.Equal(t, float64(2), promtestutil.ToFloat64(r.metrics.loadCount))
-		require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.loadFailedCount))
-
-		// Closing an already closed lazy reader should be a no-op.
-		for i := 0; i < 2; i++ {
-			require.NoError(t, r.Close())
-			require.Equal(t, float64(2), promtestutil.ToFloat64(r.metrics.unloadCount))
-			require.Equal(t, float64(0), promtestutil.ToFloat64(r.metrics.unloadFailedCount))
-		}
-	})
-}
-
 func TestLazyBinaryReader_unload_ShouldReturnErrorIfNotIdle(t *testing.T) {
 	tmpDir, bkt, blockID := initBucketAndBlocksForTest(t)
 
 	testLazyBinaryReader(t, bkt, tmpDir, blockID, func(t *testing.T, r *LazyBinaryReader, err error) {
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, r.Close())
-		})
 
 		// Should lazy load the index upon first usage.
 		labelNames, err := r.LabelNames(context.Background())
@@ -179,9 +136,6 @@ func TestLazyBinaryReader_LoadUnloadRaceCondition(t *testing.T) {
 
 	testLazyBinaryReader(t, bkt, tmpDir, blockID, func(t *testing.T, r *LazyBinaryReader, err error) {
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, r.Close())
-		})
 
 		done := make(chan struct{})
 		time.AfterFunc(runDuration, func() { close(done) })
@@ -249,6 +203,9 @@ func testLazyBinaryReader(t *testing.T, bkt objstore.BucketReader, dir string, i
 	}
 
 	reader, err := NewLazyBinaryReader(ctx, factory, logger, bkt, dir, id, NewLazyBinaryReaderMetrics(nil), nil, gate.NewNoop())
+	if err == nil {
+		t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	}
 	test(t, reader, err)
 }
 
@@ -291,6 +248,8 @@ func TestLazyBinaryReader_ShouldBlockMaxConcurrency(t *testing.T) {
 		var err error
 		lazyReaders[i], err = NewLazyBinaryReader(context.Background(), factory, logger, bkt, tmpDir, blockID, NewLazyBinaryReaderMetrics(nil), nil, lazyLoadingGate)
 		require.NoError(t, err)
+		readerToClose := lazyReaders[i]
+		t.Cleanup(func() { require.NoError(t, readerToClose.Close()) })
 	}
 
 	var wg sync.WaitGroup
@@ -323,6 +282,7 @@ func TestLazyBinaryReader_ConcurrentLoadingOfSameIndexReader(t *testing.T) {
 	lazyLoadingGate := gate.NewInstrumented(prometheus.NewRegistry(), maxLazyLoadConcurrency, gate.NewBlocking(maxLazyLoadConcurrency))
 	lazyReader, err := NewLazyBinaryReader(context.Background(), factory, log.NewNopLogger(), bkt, tmpDir, blockID, NewLazyBinaryReaderMetrics(nil), nil, lazyLoadingGate)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, lazyReader.Close()) })
 
 	var clientWG sync.WaitGroup
 	clientWG.Add(numClients)
@@ -415,6 +375,7 @@ func TestLazyBinaryReader_CancellingContextReturnsCallButDoesntStopLazyLoading(t
 	lazyLoadingGate := gate.NewInstrumented(prometheus.NewRegistry(), maxLazyLoadConcurrency, gate.NewBlocking(maxLazyLoadConcurrency))
 	lazyReader, err := NewLazyBinaryReader(context.Background(), factory, log.NewNopLogger(), bkt, tmpDir, blockID, NewLazyBinaryReaderMetrics(nil), nil, lazyLoadingGate)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, lazyReader.Close()) })
 
 	var clientWG sync.WaitGroup
 	clientWG.Add(numClients)
@@ -461,6 +422,8 @@ func TestLazyBinaryReader_CancellingContextReturnsCallButDoesntStopLazyLoading_L
 	lazyLoadingGate := gate.NewInstrumented(prometheus.NewRegistry(), maxLazyLoadConcurrency, gate.NewBlocking(maxLazyLoadConcurrency))
 	lazyReader, err := NewLazyBinaryReader(context.Background(), factory, log.NewNopLogger(), bkt, tmpDir, blockID, NewLazyBinaryReaderMetrics(nil), nil, lazyLoadingGate)
 	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, lazyReader.Close()) })
 
 	var clientWG sync.WaitGroup
 	clientWG.Add(numClients)
@@ -511,6 +474,8 @@ func TestLazyBinaryReader_CancellingContextReturnsCallButDoesntStopLazyLoading_N
 
 	lazyLoadingGate := gate.NewInstrumented(prometheus.NewRegistry(), maxLazyLoadConcurrency, gate.NewBlocking(maxLazyLoadConcurrency))
 	lazyReader, err := NewLazyBinaryReader(context.Background(), factory, log.NewNopLogger(), bkt, tmpDir, blockID, NewLazyBinaryReaderMetrics(nil), nil, lazyLoadingGate)
+	t.Cleanup(func() { require.NoError(t, lazyReader.Close()) })
+
 	require.NoError(t, err)
 
 	for i := 0; i < testRuns; i++ {
@@ -537,9 +502,6 @@ func TestLazyBinaryReader_SymbolReaderAndUnload(t *testing.T) {
 
 	testLazyBinaryReader(t, bkt, tmpDir, blockID, func(t *testing.T, r *LazyBinaryReader, err error) {
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, r.Close())
-		})
 
 		closed := atomic.NewBool(false)
 
@@ -586,6 +548,8 @@ func BenchmarkNewLazyBinaryReader(b *testing.B) {
 		b.Fatal(err)
 	}
 	ctx := context.Background()
+	b.Cleanup(func() { require.NoError(b, lazyReader.Close()) })
+
 	wg := &sync.WaitGroup{}
 
 	for _, readConcurrency := range []int{1, 2, 10, 20, 50, 100} {

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -60,7 +60,7 @@ func NewReaderPool(logger log.Logger, indexHeaderConfig Config, lazyLoadingGate 
 	if !p.lazyReaderEnabled || p.lazyReaderIdleTimeout <= 0 {
 		p.Service = services.NewIdleService(nil, nil)
 	} else {
-		p.Service = services.NewTimerService(p.lazyReaderIdleTimeout/10, nil, p.closeIdleReaders, nil)
+		p.Service = services.NewTimerService(p.lazyReaderIdleTimeout/10, nil, p.unloadIdleReaders, nil)
 	}
 	return p
 }
@@ -109,7 +109,7 @@ func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt
 	return reader, err
 }
 
-func (p *ReaderPool) closeIdleReaders(context.Context) error {
+func (p *ReaderPool) unloadIdleReaders(context.Context) error {
 	idleTimeoutAgo := time.Now().Add(-p.lazyReaderIdleTimeout).UnixNano()
 
 	for _, r := range p.getIdleReadersSince(idleTimeoutAgo) {

--- a/pkg/util/test/leak.go
+++ b/pkg/util/test/leak.go
@@ -24,8 +24,6 @@ func goLeakOptions() []goleak.Option {
 		// Ignore opencensus default worker because it's started in a init() function.
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 
-		goleak.IgnoreTopFunction("github.com/grafana/mimir/pkg/storegateway/indexheader.(*LazyBinaryReader).controlLoop"),
-
 		// The FastRegexMatcher uses a global instance of ristretto.Cache which is never stopped,
 		// so we ignore its gouroutines and then ones from glog which is a ristretto dependency.
 		goleak.IgnoreTopFunction("github.com/dgraph-io/ristretto.(*defaultPolicy).processItems"),


### PR DESCRIPTION
This is the fifth and final PR for https://github.com/grafana/mimir/issues/8389. The base branch is that of https://github.com/grafana/mimir/pull/8603 and the idea is that we merge this PR after https://github.com/grafana/mimir/pull/8603.

This is a small PR, but I decided to not combine it with https://github.com/grafana/mimir/pull/8603 as in theory does more than refactor. See below.

#### What this PR does


Properly closes `LazyBinaryReader` and cleans up the control loop goroutine.

As part of that I realized that `LazyBinaryReader`'s `Close` claims that calling `Close` and later using the reader again is valid. However, the other implementation of `indexheader.Reader` - `StreamBinaryReader` does not satisfy the same contract - calling `Close` makes `StreamBinaryReader` unusable. Moreover, there is no code which actually uses this feature of `LazyBinaryReader` - an `indexheader.Reader` is never `Close`d in a couple of places.

Here are all the places which end up calling `indexheader.Reader.Close()`:
1.  [when the lazy reader is unloaded](https://github.com/grafana/mimir/blob/05dee32601c3f1832307b15f10e78212ebac43f6/pkg/storegateway/indexheader/lazy_binary_reader.go#L387-L393) - this calls `StreamBinaryReader.Close()` and discards it, so the reader cannot be used again. There are also no pending readers when this is happening.
2. [when the block is being deleted from disk](https://github.com/grafana/mimir/blob/05dee32601c3f1832307b15f10e78212ebac43f6/pkg/storegateway/bucket.go#L549-L579) - the index header is deleted from disk and we also lose the reference to the `bucketBlock`, so no chance that we need the `LazyBinaryReader` again
3. [when the store-gateway (and BucketStore) is shutting down](https://github.com/grafana/mimir/blob/05dee32601c3f1832307b15f10e78212ebac43f6/pkg/storegateway/bucket.go#L589-L591) - in this case the BucketStore doesn't need to query the block again because there will be no more queries
4. [when the BucketStore no longer owns the given tenant and is deleting all blocks for the tenant](https://github.com/grafana/mimir/blob/6bf07eb1330ce5b3b7f29c00c4dcaf871a106d73/pkg/storegateway/bucket_stores.go#L418-L442) - similar reasoning to case 2. - disk is being cleaned up too - the reader won't be used.
 


#### Which issue(s) this PR fixes or relates to

closes https://github.com/grafana/mimir/issues/8389

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
