### PR TITLE
Distributor: small tracing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [FEATURE] Query-frontend and querier: Add experimental support for performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13058
 * [FEATURE] Querier: Add `querier.mimir-query-engine.enable-reduce-matchers` flag that enables a new MQE AST optimization pass that eliminates duplicate or redundant matchers that are part of selector expressions. #13178
 * [ENHANCEMENT] Compactor, Store-gateway: Change default value of `-compactor.upload-sparse-index-headers` to `true`. This improves lazy loading performance in the store-gateway. #13089
+* [ENHANCEMENT] Distributor: Small improvements to tracing spans. #8613
 * [ENHANCEMENT] Store-gateway: Verify CRC32 checksums for 1 out of every 128 chunks read from object storage and the chunks cache to detect corruption. #13151
 * [ENHANCEMENT] Ingester: the per-tenant postings for matchers cache is now stable. Use the following configuration options: #13101
   * `-blocks-storage.tsdb.head-postings-for-matchers-cache-ttl`


### PR DESCRIPTION
#### What this PR does

Add spans for sending to ingesters and partitions.  This helps to group potentially hundreds of spans when viewing a trace.

Also break out the number of histograms and put that as a tag on the trace; it can be of interest.

#### Checklist

- NA Tests updated.
- NA Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- NA [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve distributor tracing by adding an OpenTracing span around backend writes and reporting samples vs. histograms as separate span attributes.
> 
> - **Distributor – tracing**:
>   - Add OpenTracing span in `sendWriteRequestToBackends` with `write.series` tag.
>   - Split span attributes in `metricsMiddleware`: `write.samples` (only samples) and new `write.histograms`; keep `write.exemplars`, `write.metadata`.
> - **Docs**:
>   - Update `CHANGELOG.md` with tracing span improvements entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c99752890c20536e7e8c43847f3d85e5f3bdaeac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->