### PR TITLE
Update release notes for v2.12

### DIFF
--- a/docs/sources/mimir/release-notes/v2.12.md
+++ b/docs/sources/mimir/release-notes/v2.12.md
@@ -169,9 +169,9 @@ Use them with caution and report any issues you encounter:
   This feature requires [zone-aware replication](https://grafana.com/docs/mimir/latest/configure/configure-zone-aware-replication/) to be enabled, and the replication factor to be equal to the number of zones.
 
 - **Support for UTF-8 in Alertmanager** can be enabled via the `-alertmanager.utf8-strict-mode-enabled` CLI flag.
-  When enabled, Alertmanager will be able to receive alerts with labels containing UTF-8 characters,
-  and match these alerts in routes, inhibition rules, and silences. This feature has a number of
-  backwards-incompatible changes. Follow the instructions [here](https://grafana.com/docs/mimir/v2.12.x/references/architecture/components/alertmanager/#enable-utf8) to enable it.
+  When enabled, Alertmanager can receive alerts with labels containing UTF-8 characters,
+  and match these alerts in routes, inhibition rules, and silences. This feature has backwards-incompatible changes.
+  Follow the instructions [here](https://grafana.com/docs/mimir/v2.12.x/references/architecture/components/alertmanager/#enable-utf8) to enable it.
 
 ## Bug fixes
 

--- a/docs/sources/mimir/release-notes/v2.12.md
+++ b/docs/sources/mimir/release-notes/v2.12.md
@@ -168,6 +168,11 @@ Use them with caution and report any issues you encounter:
   These counts are more reactive to ring and shard changes than in-memory series, and can be used when enforcing tenant series limits by enabling the `-ingester.use-ingester-owned-series-for-limits` CLI flag.
   This feature requires [zone-aware replication](https://grafana.com/docs/mimir/latest/configure/configure-zone-aware-replication/) to be enabled, and the replication factor to be equal to the number of zones.
 
+- **Support for UTF-8 in Alertmanager** can be enabled via the `-alertmanager.utf8-strict-mode-enabled` CLI flag.
+  When enabled, Alertmanager will be able to receive alerts with labels containing UTF-8 characters,
+  and match these alerts in routes, inhibition rules, and silences. This feature has a number of
+  backwards-incompatible changes. Follow the instructions [here](https://grafana.com/docs/mimir/v2.12.x/references/architecture/components/alertmanager/#enable-utf8) to enable it.
+
 ## Bug fixes
 
 - Distributor: fixed an issue where `-distributor.metric-relabeling-enabled` could cause distributors to panic.


### PR DESCRIPTION
#### What this PR does

This commit updates the release notes for v2.12 to include a missing experimental feature that adds support for UTF-8 in Alertmanager, released in Mimir v2.12.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
