### PR TITLE
continuous-test improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@
 
 ### Mimir Continuous Test
 
+* [CHANGE] Use test metrics that do not pass through 0 to make identifying incorrect results easier. #8630
+* [ENHANCEMENT] Include human-friendly timestamps in diffs logged when a test fails. #8630
+* [BUGFIX] Initialize test result metrics to 0 at startup so that alerts can correctly identify the first failure after startup. #8630
+
 ### Query-tee
 
 * [ENHANCEMENT] Emit trace spans from query-tee. #8419

--- a/pkg/continuoustest/metrics.go
+++ b/pkg/continuoustest/metrics.go
@@ -52,3 +52,13 @@ func NewTestMetrics(testName string, reg prometheus.Registerer) *TestMetrics {
 		}, []string{"type"}),
 	}
 }
+
+func (m *TestMetrics) InitializeCountersToZero(testType string) {
+	// Note that we don't initialize writesFailedTotal as we don't want to create series for every possible status code.
+
+	m.writesTotal.WithLabelValues(testType)
+	m.queriesTotal.WithLabelValues(testType)
+	m.queriesFailedTotal.WithLabelValues(testType)
+	m.queryResultChecksTotal.WithLabelValues(testType)
+	m.queryResultChecksFailedTotal.WithLabelValues(testType)
+}

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -22,7 +22,7 @@ const (
 	maxComparisonDeltaFloat     = 0.001
 	maxComparisonDeltaHistogram = 0.01
 
-	floatMetricName = "mimir_continuous_test_sine_wave"
+	floatMetricName = "mimir_continuous_test_sine_wave_v2"
 	floatTypeLabel  = "float"
 )
 
@@ -43,7 +43,7 @@ type histogramProfile struct {
 var (
 	histogramProfiles = []histogramProfile{
 		{
-			metricName: "mimir_continuous_test_histogram_int_counter",
+			metricName: "mimir_continuous_test_histogram_int_counter_v2",
 			typeLabel:  "histogram_int_counter",
 			generateHistogram: func(t time.Time) prompb.Histogram {
 				ts := t.UnixMilli()
@@ -54,7 +54,7 @@ var (
 			},
 		},
 		{
-			metricName: "mimir_continuous_test_histogram_float_counter",
+			metricName: "mimir_continuous_test_histogram_float_counter_v2",
 			typeLabel:  "histogram_float_counter",
 			generateHistogram: func(t time.Time) prompb.Histogram {
 				ts := t.UnixMilli()
@@ -65,7 +65,7 @@ var (
 			},
 		},
 		{
-			metricName: "mimir_continuous_test_histogram_int_gauge",
+			metricName: "mimir_continuous_test_histogram_int_gauge_v2",
 			typeLabel:  "histogram_int_gauge",
 			generateHistogram: func(t time.Time) prompb.Histogram {
 				ts := t.UnixMilli()
@@ -76,7 +76,7 @@ var (
 			},
 		},
 		{
-			metricName: "mimir_continuous_test_histogram_float_gauge",
+			metricName: "mimir_continuous_test_histogram_float_gauge_v2",
 			typeLabel:  "histogram_float_gauge",
 			generateHistogram: func(t time.Time) prompb.Histogram {
 				ts := t.UnixMilli()
@@ -270,7 +270,7 @@ func generateHistogramSeriesInner(name string, t time.Time, numSeries int, histo
 func generateSineWaveValue(t time.Time) float64 {
 	period := 10 * time.Minute
 	radians := 2 * math.Pi * float64(t.UnixNano()) / float64(period.Nanoseconds())
-	return math.Sin(radians)
+	return math.Sin(radians) + 2
 }
 
 func generateHistogramIntValue(t time.Time, gauge bool) int64 {

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -431,7 +431,9 @@ func formatExpectedAndActualValuesComparison(matrix model.Matrix, expectedSeries
 		match := compareFloatValues(actual, expected, maxComparisonDeltaFloat)
 
 		builder.WriteString(strconv.FormatInt(int64(sample.Timestamp), 10))
-		builder.WriteString("  ")
+		builder.WriteString(" (")
+		builder.WriteString(sample.Timestamp.Time().UTC().Format(time.RFC3339))
+		builder.WriteString(")  ")
 		builder.WriteString(strconv.FormatFloat(expected, 'f', precision, 64))
 		builder.WriteString("  ")
 		builder.WriteString(strconv.FormatFloat(actual, 'f', precision, 64))

--- a/pkg/continuoustest/util_test.go
+++ b/pkg/continuoustest/util_test.go
@@ -337,9 +337,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 1,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  -0.9135  -0.9135
-1701142020000  -0.9511  -0.9511
-1701142030000  -0.9781  -0.9781
+1701142010000  1.0865  1.0865
+1701142020000  1.0489  1.0489
+1701142030000  1.0219  1.0219
 `,
 		},
 		"all values match, multiple expected series": {
@@ -350,9 +350,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 3,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  -2.7406  -2.7406
-1701142020000  -2.8532  -2.8532
-1701142030000  -2.9344  -2.9344
+1701142010000  3.2594  3.2594
+1701142020000  3.1468  3.1468
+1701142030000  3.0656  3.0656
 `,
 		},
 		"one value differs": {
@@ -363,9 +363,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 3,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  -2.7406  -2.7406
-1701142020000  -2.8532  -1.8532  (value differs!)
-1701142030000  -2.9344  -2.9344
+1701142010000  3.2594  3.2594
+1701142020000  3.1468  4.1468  (value differs!)
+1701142030000  3.0656  3.0656
 `,
 		},
 		"multiple values differ": {
@@ -376,9 +376,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 3,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  -2.7406  -2.7406
-1701142020000  -2.8532  -1.8532  (value differs!)
-1701142030000  -2.9344  -3.9344  (value differs!)
+1701142010000  3.2594  3.2594
+1701142020000  3.1468  4.1468  (value differs!)
+1701142030000  3.0656  2.0656  (value differs!)
 `,
 		},
 	}

--- a/pkg/continuoustest/util_test.go
+++ b/pkg/continuoustest/util_test.go
@@ -337,9 +337,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 1,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  1.0865  1.0865
-1701142020000  1.0489  1.0489
-1701142030000  1.0219  1.0219
+1701142010000 (2023-11-28T03:26:50Z)  1.0865  1.0865
+1701142020000 (2023-11-28T03:27:00Z)  1.0489  1.0489
+1701142030000 (2023-11-28T03:27:10Z)  1.0219  1.0219
 `,
 		},
 		"all values match, multiple expected series": {
@@ -350,9 +350,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 3,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  3.2594  3.2594
-1701142020000  3.1468  3.1468
-1701142030000  3.0656  3.0656
+1701142010000 (2023-11-28T03:26:50Z)  3.2594  3.2594
+1701142020000 (2023-11-28T03:27:00Z)  3.1468  3.1468
+1701142030000 (2023-11-28T03:27:10Z)  3.0656  3.0656
 `,
 		},
 		"one value differs": {
@@ -363,9 +363,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 3,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  3.2594  3.2594
-1701142020000  3.1468  4.1468  (value differs!)
-1701142030000  3.0656  3.0656
+1701142010000 (2023-11-28T03:26:50Z)  3.2594  3.2594
+1701142020000 (2023-11-28T03:27:00Z)  3.1468  4.1468  (value differs!)
+1701142030000 (2023-11-28T03:27:10Z)  3.0656  3.0656
 `,
 		},
 		"multiple values differ": {
@@ -376,9 +376,9 @@ func TestFormatExpectedAndActualValuesComparison(t *testing.T) {
 			},
 			series: 3,
 			expectedOutput: `Timestamp      Expected  Actual
-1701142010000  3.2594  3.2594
-1701142020000  3.1468  4.1468  (value differs!)
-1701142030000  3.0656  2.0656  (value differs!)
+1701142010000 (2023-11-28T03:26:50Z)  3.2594  3.2594
+1701142020000 (2023-11-28T03:27:00Z)  3.1468  4.1468  (value differs!)
+1701142030000 (2023-11-28T03:27:10Z)  3.0656  2.0656  (value differs!)
 `,
 		},
 	}

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -85,6 +85,8 @@ func (t *WriteReadSeriesTest) Init(ctx context.Context, now time.Time) error {
 		if err != nil {
 			return err
 		}
+
+		t.metrics.InitializeCountersToZero(floatTypeLabel)
 	}
 	if t.cfg.WithHistograms {
 		for i, histProfile := range histogramProfiles {
@@ -92,6 +94,8 @@ func (t *WriteReadSeriesTest) Init(ctx context.Context, now time.Time) error {
 			if err != nil {
 				return err
 			}
+
+			t.metrics.InitializeCountersToZero(histProfile.typeLabel)
 		}
 	}
 	return nil

--- a/pkg/continuoustest/write_read_series_test.go
+++ b/pkg/continuoustest/write_read_series_test.go
@@ -444,7 +444,8 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			client.On("QueryRange", mock.Anything, tt.querySum(tt.metricName), now.Add(-24*time.Hour).Add(writeInterval), now, writeInterval, mock.Anything).Return(model.Matrix{}, nil)
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		reg := prometheus.NewPedanticRegistry()
+		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -456,6 +457,14 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			require.Zero(t, records.queryMinTime)
 			require.Zero(t, records.queryMaxTime)
 		}
+
+		em := util_test.ExpectedMetrics{Context: emCtx}
+		em.AddMultiple("mimir_continuous_test_writes_total", makeExpectedMetricsMap(testTuples, `test="write-read-series",type="%s"`, 0))
+		em.AddMultiple("mimir_continuous_test_queries_total", makeExpectedMetricsMap(testTuples, `test="write-read-series",type="%s"`, 0))
+		em.AddMultiple("mimir_continuous_test_queries_failed_total", makeExpectedMetricsMap(testTuples, `test="write-read-series",type="%s"`, 0))
+		em.AddMultiple("mimir_continuous_test_query_result_checks_total", makeExpectedMetricsMap(testTuples, `test="write-read-series",type="%s"`, 0))
+		em.AddMultiple("mimir_continuous_test_query_result_checks_failed_total", makeExpectedMetricsMap(testTuples, `test="write-read-series",type="%s"`, 0))
+		assert.NoError(t, testutil.GatherAndCompare(reg, em.GetOutput(), em.GetNames()...))
 	})
 
 	t.Run("previously written data points are in the range [-2h, -1m]", func(t *testing.T) {

--- a/pkg/continuoustest/write_read_series_test.go
+++ b/pkg/continuoustest/write_read_series_test.go
@@ -100,8 +100,13 @@ func makeExpectedMetricsMap(testTuples []WriteReadSeriesTestTuple, template stri
 }
 
 func TestWriteReadSeriesTest_Run(t *testing.T) {
-	testWriteReadSeriesTestRun(t, cfgFloat, floatTestTuples)
-	testWriteReadSeriesTestRun(t, cfgHist, histTestTuples)
+	t.Run("floats", func(t *testing.T) {
+		testWriteReadSeriesTestRun(t, cfgFloat, floatTestTuples)
+	})
+
+	t.Run("histograms", func(t *testing.T) {
+		testWriteReadSeriesTestRun(t, cfgHist, histTestTuples)
+	})
 }
 
 func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, testTuples []WriteReadSeriesTestTuple) {
@@ -416,8 +421,13 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 }
 
 func TestWriteReadSeriesTest_Init(t *testing.T) {
-	testWriteReadSeriesTestInit(t, cfgFloat, floatTestTuples)
-	testWriteReadSeriesTestInit(t, cfgHist, histTestTuples)
+	t.Run("floats", func(t *testing.T) {
+		testWriteReadSeriesTestInit(t, cfgFloat, floatTestTuples)
+	})
+
+	t.Run("histograms", func(t *testing.T) {
+		testWriteReadSeriesTestInit(t, cfgHist, histTestTuples)
+	})
 }
 
 func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, testTuples []WriteReadSeriesTestTuple) {


### PR DESCRIPTION
#### What this PR does

This PR makes a number of small improvements to continuous-test:

* It changes the test series to not pass through 0. This makes it easier to tell if a series is missing or incorrect at timesteps that we would otherwise expect to have a 0 value.
* It initialises most of the test-specific metrics to 0 at startup. This ensures that the `MimirContinuousTestFailed` alert fires for the first failure after continuous-test starts.
* It adds human-friendly timestamps to the diffs included in failure messages.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
