### PR TITLE
query-tee: always return response from preferred backend if one is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ### Query-tee
 
-* [CHANGE] If a preferred backend is configured, then query-tee will now always return its response, regardless of the response status code. Previously, query-tee would only return the response from the preferred backend if it did not have a 5xx status code. #8634
+* [CHANGE] If a preferred backend is configured, then query-tee always returns its response, regardless of the response status code. Previously, query-tee would only return the response from the preferred backend if it did not have a 5xx status code. #8634
 * [ENHANCEMENT] Emit trace spans from query-tee. #8419
 * [ENHANCEMENT] Log trace ID (if present) with all log messages written while processing a request. #8419
 * [ENHANCEMENT] Log user agent when processing a request. #8419

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 
 ### Query-tee
 
+* [CHANGE] If a preferred backend is configured, then query-tee will now always return its response, regardless of the response status code. Previously, query-tee would only return the response from the preferred backend if it did not have a 5xx status code. #8634
 * [ENHANCEMENT] Emit trace spans from query-tee. #8419
 * [ENHANCEMENT] Log trace ID (if present) with all log messages written while processing a request. #8419
 * [ENHANCEMENT] Log user agent when processing a request. #8419

--- a/docs/sources/mimir/manage/tools/query-tee.md
+++ b/docs/sources/mimir/manage/tools/query-tee.md
@@ -112,7 +112,7 @@ When a preferred backend is not configured, the query-tee uses the following alg
 1. If no backend response status code is 2xx or 4xx, the query-tee selects the first received response regardless of the status code.
 
 {{< admonition type="note" >}}
-The query-tee considers a 4xx response as a valid response to select because a 4xx status code generally an invalid request and not a server-side issue.
+The query-tee considers a 4xx response as a valid response to select because a 4xx status code is generally an invalid request and not a server-side issue.
 {{< /admonition >}}
 
 ### Backend results comparison

--- a/docs/sources/mimir/manage/tools/query-tee.md
+++ b/docs/sources/mimir/manage/tools/query-tee.md
@@ -104,11 +104,7 @@ The query-tee returns the `Content-Type` header, HTTP status code, and body of t
 The preferred backend can be configured via `-backend.preferred=<hostname>`.
 The value of the preferred backend configuration option must be the hostname of one of the configured backends.
 
-When a preferred backend is configured, the query-tee uses the following algorithm to select the backend response to send back to the client:
-
-1. If the preferred backend response status code is 2xx or 4xx, the query-tee selects the response from the preferred backend.
-1. If at least one backend response status code is 2xx or 4xx, the query-tee selects the first received response whose status code is 2xx or 4xx.
-1. If no backend response status code is 2xx or 4xx, the query-tee selects the first received response regardless of the status code.
+When a preferred backend is configured, the query-tee always returns the response from the preferred backend.
 
 When a preferred backend is not configured, the query-tee uses the following algorithm to select the backend response to send back to the client:
 
@@ -116,7 +112,7 @@ When a preferred backend is not configured, the query-tee uses the following alg
 1. If no backend response status code is 2xx or 4xx, the query-tee selects the first received response regardless of the status code.
 
 {{< admonition type="note" >}}
-The query-tee considers a 4xx response as a valid response to select because a 4xx status code generally an invalid request and not a server side issue.
+The query-tee considers a 4xx response as a valid response to select because a 4xx status code generally an invalid request and not a server-side issue.
 {{< /admonition >}}
 
 ### Backend results comparison

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -69,7 +69,7 @@ func (p *ProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	go p.executeBackendRequests(r, backends, resCh)
 
 	// Wait for the first response that's feasible to be sent back to the client.
-	downstreamRes := p.waitBackendResponseForDownstream(backends, resCh)
+	downstreamRes := p.waitBackendResponseForDownstream(resCh)
 
 	if downstreamRes.err != nil {
 		http.Error(w, downstreamRes.err.Error(), http.StatusInternalServerError)
@@ -296,7 +296,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, backends []Pro
 	}
 }
 
-func (p *ProxyEndpoint) waitBackendResponseForDownstream(backends []ProxyBackendInterface, resCh chan *backendResponse) *backendResponse {
+func (p *ProxyEndpoint) waitBackendResponseForDownstream(resCh chan *backendResponse) *backendResponse {
 	var firstResponse *backendResponse
 
 	for res := range resCh {

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -297,7 +297,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, backends []Pro
 }
 
 func (p *ProxyEndpoint) waitBackendResponseForDownstream(backends []ProxyBackendInterface, resCh chan *backendResponse) *backendResponse {
-	responses := make([]*backendResponse, 0, len(backends))
+	var firstResponse *backendResponse
 
 	for res := range resCh {
 		// If the response came from the preferred backend, return it immediately.
@@ -306,12 +306,14 @@ func (p *ProxyEndpoint) waitBackendResponseForDownstream(backends []ProxyBackend
 			return res
 		}
 
-		// Otherwise we keep track of it for later.
-		responses = append(responses, res)
+		// Otherwise if this was the first response, keep track of it for later.
+		if firstResponse == nil {
+			firstResponse = res
+		}
 	}
 
 	// No successful response, so let's pick the first one.
-	return responses[0]
+	return firstResponse
 }
 
 func (p *ProxyEndpoint) compareResponses(expectedResponse, actualResponse *backendResponse) (ComparisonResult, error) {

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -67,7 +67,7 @@ func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
 				{backend: backendOther1, status: 200},
 				{backend: backendPref, status: 500},
 			},
-			expected: backendOther1,
+			expected: backendPref,
 		},
 		"the preferred backend is the 2nd response received but only the last one is successful": {
 			backends: []ProxyBackendInterface{backendPref, backendOther1, backendOther2},
@@ -76,7 +76,15 @@ func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
 				{backend: backendPref, status: 500},
 				{backend: backendOther2, status: 200},
 			},
-			expected: backendOther2,
+			expected: backendPref,
+		},
+		"there's a preferred backend configured and no received response is successful": {
+			backends: []ProxyBackendInterface{backendPref, backendOther1},
+			responses: []*backendResponse{
+				{backend: backendOther1, status: 500},
+				{backend: backendPref, status: 500},
+			},
+			expected: backendPref,
 		},
 		"there's no preferred backend configured and the 1st response is successful": {
 			backends: []ProxyBackendInterface{backendOther1, backendOther2},
@@ -93,11 +101,11 @@ func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
 			},
 			expected: backendOther2,
 		},
-		"no received response is successful": {
-			backends: []ProxyBackendInterface{backendPref, backendOther1},
+		"there's no preferred backend configured and no received response is successful": {
+			backends: []ProxyBackendInterface{backendOther1, backendOther2},
 			responses: []*backendResponse{
 				{backend: backendOther1, status: 500},
-				{backend: backendPref, status: 500},
+				{backend: backendOther2, status: 500},
 			},
 			expected: backendOther1,
 		},

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -127,7 +127,7 @@ func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
 			}()
 
 			// Wait for the selected backend response.
-			actual := endpoint.waitBackendResponseForDownstream(testData.backends, resCh)
+			actual := endpoint.waitBackendResponseForDownstream(resCh)
 			assert.Equal(t, testData.expected, actual.backend)
 		})
 	}

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -285,11 +285,11 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 			requestPath:   "/api/v1/query",
 			requestMethod: http.MethodGet,
 			backends: []mockedBackend{
-				{handler: mockQueryResponse("/api/v1/query", 500, "")},
-				{handler: mockQueryResponse("/api/v1/query", 200, querySingleMetric1)},
+				{handler: mockQueryResponse("/api/v1/query", 500, querySingleMetric1)},
+				{handler: mockQueryResponse("/api/v1/query", 200, querySingleMetric2)},
 			},
 			preferredBackendIdx: 0,
-			expectedStatus:      200,
+			expectedStatus:      500,
 			expectedRes:         querySingleMetric1,
 		},
 		"non-preferred backend returns 5xx": {
@@ -307,12 +307,12 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 			requestPath:   "/api/v1/query",
 			requestMethod: http.MethodGet,
 			backends: []mockedBackend{
-				{handler: mockQueryResponse("/api/v1/query", 500, "")},
+				{handler: mockQueryResponse("/api/v1/query", 500, querySingleMetric1)},
 				{handler: mockQueryResponse("/api/v1/query", 500, "")},
 			},
 			preferredBackendIdx: 0,
 			expectedStatus:      500,
-			expectedRes:         "",
+			expectedRes:         querySingleMetric1,
 		},
 		"request to route with outgoing request transformer": {
 			requestPath:   "/api/v1/query_with_transform",
@@ -698,9 +698,7 @@ func mockQueryResponseWithExpectedBody(path string, expectedBody string, status 
 
 		// Send back the mocked response.
 		w.WriteHeader(status)
-		if status == http.StatusOK {
-			_, _ = w.Write([]byte(res))
-		}
+		_, _ = w.Write([]byte(res))
 	}
 }
 


### PR DESCRIPTION
#### What this PR does

This PR changes the behaviour of query-tee to always return the response from the preferred backend, if one is configured.

Previously, query-tee would only return the response from the preferred backend if it succeeded, or if all other requests failed and the response from the preferred backend was the first response received. This behaviour was somewhat surprising, and doesn't fit with the scenarios we usually use query-tee for, such as safely comparing a change to the query path.

Now, even if the response from the preferred backend is not successful, it will still be returned.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
