### PR TITLE
Remove 2.13 release from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "extends": [
       "config:base"
     ],
-    "baseBranches": ["main", "release-2.13", "release-2.12", "release-2.11"],
+    "baseBranches": ["main", "release-2.13", "release-2.12"],
     "postUpdateOptions": [
       "gomodTidy",
       "gomodUpdateImportPaths"
@@ -11,7 +11,7 @@
     "schedule": ["before 9am on Monday"],
     "packageRules": [
       {
-        "matchBaseBranches": ["release-2.13", "release-2.12", "release-2.11"],
+        "matchBaseBranches": ["release-2.13", "release-2.12"],
         "packagePatterns": ["*"],
         "enabled": false
       },


### PR DESCRIPTION
related to https://github.com/grafana/mimir/issues/8390

we keep only 2 releases updated