### PR TITLE
fix(helm): only set blocks_storage.backend=s3 when using minio

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -64,6 +64,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Helm: Expose AM configs in the `gateway` NGINX configuration. #8248
 * [BUGFIX] Helm: fix ServiceMonitor and PVC template to not show diff in ArgoCD. #8829
 * [BUGFIX] Alertmanager: Set -server.http-idle-timeout to avoid EOF errors in ruler. #8192
+* [BUGFIX] Helm: Only set blocks_storage.backend=s3 when using MinIO. #8643
 
 ## 5.3.0
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -183,7 +183,6 @@ mimir:
 
     # This configures how the store-gateway synchronizes blocks stored in the bucket. It uses Minio by default for getting started (configured via flags) but this should be changed for production deployments.
     blocks_storage:
-      backend: s3
       bucket_store:
         {{- if index .Values "chunks-cache" "enabled" }}
         chunks_cache:
@@ -213,6 +212,7 @@ mimir:
         {{- end }}
         sync_dir: /data/tsdb-sync
       {{- if .Values.minio.enabled }}
+      backend: s3
       s3:
         access_key_id: {{ .Values.minio.rootUser }}
         bucket_name: {{ include "mimir.minioBucketPrefix" . }}-tsdb

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -20,7 +20,6 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     blocks_storage:
-      backend: s3
       bucket_store:
         chunks_cache:
           backend: memcached

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -30,7 +30,6 @@ data:
     auth:
       type: enterprise
     blocks_storage:
-      backend: s3
       bucket_store:
         sync_dir: /data/tsdb-sync
       tsdb:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -20,7 +20,6 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     blocks_storage:
-      backend: s3
       bucket_store:
         sync_dir: /data/tsdb-sync
       tsdb:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -20,7 +20,6 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     blocks_storage:
-      backend: s3
       bucket_store:
         chunks_cache:
           backend: memcached


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Changes the config template in `values.yaml` to only set `blocks_storage.backend=s3` when using MinIO, allowing it to fall through to `common.storage.backend`. Currently you have to set both to be able to use a different backend (e.g. gcs).

#### Which issue(s) this PR fixes or relates to

Fixes #6538

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
