### PR TITLE
helm: build unique rollout-group names per chart release

### DIFF
--- a/operations/helm/charts/mimir-distributed/ci/offline/test-oss-multizone-rolloutgroup-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/test-oss-multizone-rolloutgroup-values.yaml
@@ -1,0 +1,66 @@
+# Pin kube version so results are the same for running in CI and locally where the installed kube version may be different.
+kubeVersionOverride: "1.20"
+
+alertmanager:
+  zoneAwareReplication:
+    enabled: true
+    rolloutGroupName: my-alertmanager-group
+    topologyKey: 'kubernetes.io/hostname'
+
+ingester:
+  # Test that the calculated number of replicas per zone is ceil(20/3)=7
+  replicas: 20
+  zoneAwareReplication:
+    enabled: true
+    rolloutGroupName: my-ingester-group
+    topologyKey: 'kubernetes.io/hostname'
+    zones:
+    - name: zone-a
+      extraAffinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: security
+                operator: In
+                values:
+                - S1
+            topologyKey: topology.kubernetes.io/zone
+    - name: zone-b
+      extraAffinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: security
+                operator: In
+                values:
+                - S1
+            topologyKey: topology.kubernetes.io/zone
+    - name: zone-c
+      extraAffinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: security
+                operator: In
+                values:
+                - S1
+            topologyKey: topology.kubernetes.io/zone
+
+store_gateway:
+  zoneAwareReplication:
+    enabled: true
+    rolloutGroupName: my-store-gateway-group
+    topologyKey: 'kubernetes.io/hostname'
+    zones:
+    - name: zone-a
+      nodeSelector:
+        topology.kubernetes.io/zone: zone-a
+    - name: zone-b
+      nodeSelector:
+        topology.kubernetes.io/zone: zone-b
+    - name: zone-c
+      nodeSelector:
+        topology.kubernetes.io/zone: zone-c

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -712,6 +712,7 @@ alertmanager:
   # alertmanager:
   #   zoneAwareReplication:
   #     enabled: true
+  #     rolloutGroupName: alertmanager
   #     topologyKey: 'kubernetes.io/hostname'  # This generates default anti-affinity rules
   #     zones:  # Zone list has to be fully redefined for modification. Update with you actual zones or skip to use logical zones only.
   #     - name: zone-a
@@ -729,6 +730,8 @@ alertmanager:
     enabled: false
     # -- Maximum number of alertmanagers that can be unavailable per zone during rollout
     maxUnavailable: 2
+    # -- Overrides the generated name for this rollout-group.
+    rolloutGroupName: null
     # -- topologyKey to use in pod anti-affinity. If unset, no anti-affinity rules are generated. If set, the generated anti-affinity rule makes sure that pods from different zones do not mix.
     # E.g.: topologyKey: 'kubernetes.io/hostname'
     topologyKey: null
@@ -1028,6 +1031,7 @@ ingester:
   # ingester:
   #   zoneAwareReplication:
   #     enabled: true
+  #     rolloutGroupName: ingester
   #     topologyKey: 'kubernetes.io/hostname'  # This generates default anti-affinity rules
   #     zones:  # Zone list has to be fully redefined for modification. Update with you actual zones or skip to use logical zones only.
   #     - name: zone-a
@@ -1048,6 +1052,8 @@ ingester:
     enabled: true
     # -- Maximum number of ingesters that can be unavailable per zone during rollout
     maxUnavailable: 50
+    # -- Overrides the generated name for this rollout-group.
+    rolloutGroupName: null
     # -- topologyKey to use in pod anti-affinity. If unset, no anti-affinity rules are generated. If set, the generated anti-affinity rule makes sure that pods from different zones do not mix.
     # E.g.: topologyKey: 'kubernetes.io/hostname'
     topologyKey: null
@@ -2078,6 +2084,7 @@ store_gateway:
   # store_gateway:
   #   zoneAwareReplication:
   #     enabled: true
+  #     rolloutGroupName: 'store-gateway'
   #     topologyKey: 'kubernetes.io/hostname'  # This generates default anti-affinity rules
   #     zones:  # Zone list has to be fully redefined for modification. Update with you actual zones or skip to use logical zones only.
   #     - name: zone-a
@@ -2095,6 +2102,8 @@ store_gateway:
     enabled: true
     # -- Maximum number of store-gateways that can be unavailable per zone during rollout
     maxUnavailable: 50
+    # -- Overrides the generated name for this rollout-group.
+    rolloutGroupName: null
     # -- topologyKey to use in pod anti-affinity. If unset, no anti-affinity rules are generated. If set, the generated anti-affinity rule makes sure that pods from different zones do not mix.
     # E.g.: topologyKey: 'kubernetes.io/hostname'
     topologyKey: null

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: enterprise-https-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: enterprise-https-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: enterprise-https-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: enterprise-https-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -158,7 +158,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: enterprise-https-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -171,7 +171,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: enterprise-https-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: enterprise-https-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -196,7 +196,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: enterprise-https-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -305,7 +305,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: enterprise-https-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -318,7 +318,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: enterprise-https-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: enterprise-https-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -343,7 +343,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: enterprise-https-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: enterprise-https-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: enterprise-https-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: enterprise-https-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: enterprise-https-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: enterprise-https-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: enterprise-https-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: enterprise-https-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: enterprise-https-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: enterprise-https-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: enterprise-https-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: enterprise-https-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: enterprise-https-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: enterprise-https-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: enterprise-https-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -175,7 +175,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: enterprise-https-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: enterprise-https-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -200,7 +200,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: enterprise-https-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -313,7 +313,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: enterprise-https-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -326,7 +326,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: enterprise-https-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: enterprise-https-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -351,7 +351,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: enterprise-https-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: enterprise-https-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: enterprise-https-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: enterprise-https-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: enterprise-https-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: enterprise-https-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: enterprise-https-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: enterprise-https-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: enterprise-https-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: enterprise-https-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: gateway-enterprise-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-enterprise-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: gateway-enterprise-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: gateway-enterprise-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: gateway-enterprise-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -162,7 +162,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-enterprise-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: gateway-enterprise-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -187,7 +187,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: gateway-enterprise-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -287,7 +287,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: gateway-enterprise-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -300,7 +300,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-enterprise-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: gateway-enterprise-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -325,7 +325,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: gateway-enterprise-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: gateway-enterprise-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: gateway-enterprise-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: gateway-enterprise-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: gateway-enterprise-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: gateway-enterprise-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: gateway-enterprise-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: gateway-enterprise-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-enterprise-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: gateway-enterprise-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: gateway-enterprise-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -153,7 +153,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: gateway-enterprise-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -166,7 +166,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-enterprise-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: gateway-enterprise-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -191,7 +191,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: gateway-enterprise-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -295,7 +295,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: gateway-enterprise-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -308,7 +308,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-enterprise-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: gateway-enterprise-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -333,7 +333,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: gateway-enterprise-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: gateway-enterprise-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: gateway-enterprise-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: gateway-enterprise-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: gateway-enterprise-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: gateway-enterprise-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: gateway-enterprise-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: gateway-nginx-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-nginx-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: gateway-nginx-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: gateway-nginx-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -144,7 +144,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: gateway-nginx-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -157,7 +157,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-nginx-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: gateway-nginx-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -182,7 +182,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: gateway-nginx-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -277,7 +277,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: gateway-nginx-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -290,7 +290,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-nginx-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: gateway-nginx-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -315,7 +315,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: gateway-nginx-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: gateway-nginx-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: gateway-nginx-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: gateway-nginx-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: gateway-nginx-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: gateway-nginx-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: gateway-nginx-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: gateway-nginx-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-nginx-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: gateway-nginx-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: gateway-nginx-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: gateway-nginx-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -161,7 +161,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-nginx-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: gateway-nginx-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -186,7 +186,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: gateway-nginx-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: gateway-nginx-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -298,7 +298,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: gateway-nginx-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: gateway-nginx-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -323,7 +323,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: gateway-nginx-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: gateway-nginx-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: gateway-nginx-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: gateway-nginx-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: gateway-nginx-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: gateway-nginx-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: gateway-nginx-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-global-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-global-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: keda-autoscaling-global-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: keda-autoscaling-global-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -144,7 +144,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-global-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -157,7 +157,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-global-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: keda-autoscaling-global-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -182,7 +182,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: keda-autoscaling-global-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -277,7 +277,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-global-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -290,7 +290,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-global-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: keda-autoscaling-global-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -315,7 +315,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: keda-autoscaling-global-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-global-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-global-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-global-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-global-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-global-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-global-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-global-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-global-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-global-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-global-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-global-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: keda-autoscaling-global-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: keda-autoscaling-global-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-global-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -161,7 +161,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-global-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: keda-autoscaling-global-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -186,7 +186,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: keda-autoscaling-global-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-global-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -298,7 +298,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-global-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: keda-autoscaling-global-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -323,7 +323,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: keda-autoscaling-global-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-global-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-global-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-global-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-global-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-global-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-global-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-global-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-global-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-global-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -144,7 +144,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -157,7 +157,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -182,7 +182,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -277,7 +277,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -290,7 +290,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -315,7 +315,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -161,7 +161,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -186,7 +186,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -298,7 +298,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -323,7 +323,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-metamonitoring-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: keda-autoscaling-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: keda-autoscaling-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -144,7 +144,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -157,7 +157,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: keda-autoscaling-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -182,7 +182,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: keda-autoscaling-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -277,7 +277,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -290,7 +290,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: keda-autoscaling-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -315,7 +315,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: keda-autoscaling-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: keda-autoscaling-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: keda-autoscaling-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: keda-autoscaling-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -161,7 +161,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: keda-autoscaling-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -186,7 +186,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: keda-autoscaling-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -298,7 +298,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: keda-autoscaling-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: keda-autoscaling-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -323,7 +323,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: keda-autoscaling-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: keda-autoscaling-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: large-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: large-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: large-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: large-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -70,7 +70,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - ingester
+                - large-values-mimir-ingester
               - key: zone
                 operator: NotIn
                 values:
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: large-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -173,7 +173,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: large-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: large-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -198,7 +198,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: large-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -219,7 +219,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - ingester
+                - large-values-mimir-ingester
               - key: zone
                 operator: NotIn
                 values:
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: large-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -322,7 +322,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: large-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: large-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -347,7 +347,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: large-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"
@@ -368,7 +368,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - ingester
+                - large-values-mimir-ingester
               - key: zone
                 operator: NotIn
                 values:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: large-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: large-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: large-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: large-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: large-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: large-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: large-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: large-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: large-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: large-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: large-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: large-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: large-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -70,7 +70,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - large-values-mimir-store-gateway
               - key: zone
                 operator: NotIn
                 values:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: large-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -177,7 +177,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: large-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: large-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -202,7 +202,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: large-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -223,7 +223,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - large-values-mimir-store-gateway
               - key: zone
                 operator: NotIn
                 values:
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: large-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -330,7 +330,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: large-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: large-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -355,7 +355,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: large-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"
@@ -376,7 +376,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - large-values-mimir-store-gateway
               - key: zone
                 operator: NotIn
                 values:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: large-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: large-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: large-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: large-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: large-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: large-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: large-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: large-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: large-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: openshift-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: openshift-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: openshift-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: openshift-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: openshift-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -159,7 +159,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: openshift-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: openshift-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -184,7 +184,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: openshift-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: openshift-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -294,7 +294,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: openshift-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: openshift-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -319,7 +319,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: openshift-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: openshift-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: openshift-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: openshift-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: openshift-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: openshift-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: openshift-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: openshift-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: openshift-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: openshift-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: openshift-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: openshift-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -163,7 +163,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: openshift-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: openshift-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -188,7 +188,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: openshift-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -289,7 +289,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: openshift-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -302,7 +302,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: openshift-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: openshift-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -327,7 +327,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: openshift-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: openshift-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: openshift-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: openshift-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: openshift-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: openshift-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: openshift-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: scheduler-name-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: scheduler-name-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: scheduler-name-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: scheduler-name-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -145,7 +145,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: scheduler-name-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -158,7 +158,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: scheduler-name-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: scheduler-name-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -183,7 +183,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: scheduler-name-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -279,7 +279,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: scheduler-name-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -292,7 +292,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: scheduler-name-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: scheduler-name-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -317,7 +317,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: scheduler-name-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: scheduler-name-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: scheduler-name-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: scheduler-name-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: scheduler-name-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: scheduler-name-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: scheduler-name-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: scheduler-name-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: scheduler-name-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: scheduler-name-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: scheduler-name-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: scheduler-name-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: scheduler-name-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: scheduler-name-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: scheduler-name-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -161,7 +161,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: scheduler-name-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: scheduler-name-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -186,7 +186,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: scheduler-name-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: scheduler-name-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -298,7 +298,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: scheduler-name-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: scheduler-name-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -323,7 +323,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: scheduler-name-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: scheduler-name-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: scheduler-name-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: scheduler-name-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: scheduler-name-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: scheduler-name-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: scheduler-name-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: scheduler-name-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: scheduler-name-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: scheduler-name-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: small-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: small-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: small-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: small-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -70,7 +70,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - ingester
+                - small-values-mimir-ingester
               - key: zone
                 operator: NotIn
                 values:
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: small-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -173,7 +173,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: small-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: small-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -198,7 +198,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: small-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -219,7 +219,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - ingester
+                - small-values-mimir-ingester
               - key: zone
                 operator: NotIn
                 values:
@@ -309,7 +309,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: small-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -322,7 +322,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: small-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: small-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -347,7 +347,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: small-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"
@@ -368,7 +368,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - ingester
+                - small-values-mimir-ingester
               - key: zone
                 operator: NotIn
                 values:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: small-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: small-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: small-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: small-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: small-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: small-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: small-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: small-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: small-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: small-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: small-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: small-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: small-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -70,7 +70,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - small-values-mimir-store-gateway
               - key: zone
                 operator: NotIn
                 values:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: small-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -177,7 +177,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: small-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: small-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -202,7 +202,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: small-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -223,7 +223,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - small-values-mimir-store-gateway
               - key: zone
                 operator: NotIn
                 values:
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: small-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -330,7 +330,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: small-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: small-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -355,7 +355,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: small-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"
@@ -376,7 +376,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - small-values-mimir-store-gateway
               - key: zone
                 operator: NotIn
                 values:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: small-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: small-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: small-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: small-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: small-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: small-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: small-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: small-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: small-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -162,7 +162,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -187,7 +187,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -287,7 +287,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -300,7 +300,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -325,7 +325,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -153,7 +153,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -166,7 +166,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -191,7 +191,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -295,7 +295,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -308,7 +308,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -333,7 +333,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-k8s-1.25-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -21,7 +21,7 @@ spec:
     matchLabels:
       app: enterprise-metrics-ingester
       release: test-enterprise-legacy-label-values
-      rollout-group: ingester
+      rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -45,7 +45,7 @@ spec:
         target: ingester
         release: test-enterprise-legacy-label-values
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -139,7 +139,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -151,7 +151,7 @@ spec:
     matchLabels:
       app: enterprise-metrics-ingester
       release: test-enterprise-legacy-label-values
-      rollout-group: ingester
+      rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -175,7 +175,7 @@ spec:
         target: ingester
         release: test-enterprise-legacy-label-values
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -269,7 +269,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -281,7 +281,7 @@ spec:
     matchLabels:
       app: enterprise-metrics-ingester
       release: test-enterprise-legacy-label-values
-      rollout-group: ingester
+      rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -305,7 +305,7 @@ spec:
         target: ingester
         release: test-enterprise-legacy-label-values
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
     zone: zone-a
   annotations:
     {}
@@ -28,7 +28,7 @@ spec:
   selector:
     app: enterprise-metrics-ingester
     release: test-enterprise-legacy-label-values
-    rollout-group: ingester
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -41,7 +41,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
     zone: zone-b
   annotations:
     {}
@@ -60,7 +60,7 @@ spec:
   selector:
     app: enterprise-metrics-ingester
     release: test-enterprise-legacy-label-values
-    rollout-group: ingester
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -73,7 +73,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
     zone: zone-c
   annotations:
     {}
@@ -92,5 +92,5 @@ spec:
   selector:
     app: enterprise-metrics-ingester
     release: test-enterprise-legacy-label-values
-    rollout-group: ingester
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-ingester
     zone: zone-c

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -21,7 +21,7 @@ spec:
     matchLabels:
       app: enterprise-metrics-store-gateway
       release: test-enterprise-legacy-label-values
-      rollout-group: store-gateway
+      rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -45,7 +45,7 @@ spec:
         target: store-gateway
         release: test-enterprise-legacy-label-values
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -143,7 +143,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -155,7 +155,7 @@ spec:
     matchLabels:
       app: enterprise-metrics-store-gateway
       release: test-enterprise-legacy-label-values
-      rollout-group: store-gateway
+      rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -179,7 +179,7 @@ spec:
         target: store-gateway
         release: test-enterprise-legacy-label-values
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -277,7 +277,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -289,7 +289,7 @@ spec:
     matchLabels:
       app: enterprise-metrics-store-gateway
       release: test-enterprise-legacy-label-values
-      rollout-group: store-gateway
+      rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -313,7 +313,7 @@ spec:
         target: store-gateway
         release: test-enterprise-legacy-label-values
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -28,7 +28,7 @@ spec:
   selector:
     app: enterprise-metrics-store-gateway
     release: test-enterprise-legacy-label-values
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -41,7 +41,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -60,7 +60,7 @@ spec:
   selector:
     app: enterprise-metrics-store-gateway
     release: test-enterprise-legacy-label-values
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -73,7 +73,7 @@ metadata:
     heritage: Helm
     release: test-enterprise-legacy-label-values
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -92,5 +92,5 @@ spec:
   selector:
     app: enterprise-metrics-store-gateway
     release: test-enterprise-legacy-label-values
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-enterprise-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-enterprise-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-enterprise-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-enterprise-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -159,7 +159,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-enterprise-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -184,7 +184,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-enterprise-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-enterprise-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -294,7 +294,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-enterprise-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -319,7 +319,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-enterprise-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-enterprise-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-enterprise-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-enterprise-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-enterprise-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-enterprise-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-enterprise-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-enterprise-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-enterprise-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -150,7 +150,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -163,7 +163,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-enterprise-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -188,7 +188,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-enterprise-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -289,7 +289,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -302,7 +302,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-enterprise-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-enterprise-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -327,7 +327,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-enterprise-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-enterprise-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-ingress-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ingress-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-ingress-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-ingress-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -144,7 +144,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-ingress-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -157,7 +157,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ingress-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-ingress-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -182,7 +182,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-ingress-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -277,7 +277,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-ingress-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -290,7 +290,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ingress-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-ingress-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -315,7 +315,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-ingress-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-ingress-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingress-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-ingress-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-ingress-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingress-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-ingress-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-ingress-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingress-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-ingress-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-ingress-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ingress-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-ingress-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-ingress-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-ingress-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -161,7 +161,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ingress-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-ingress-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -186,7 +186,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-ingress-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-ingress-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -298,7 +298,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ingress-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-ingress-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -323,7 +323,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-ingress-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-ingress-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingress-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-ingress-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-ingress-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingress-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-ingress-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-ingress-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingress-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-ingress-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-oss-k8s-1.25-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-k8s-1.25-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-k8s-1.25-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-oss-k8s-1.25-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -144,7 +144,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-oss-k8s-1.25-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -157,7 +157,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-k8s-1.25-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-k8s-1.25-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -182,7 +182,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-oss-k8s-1.25-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -277,7 +277,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-oss-k8s-1.25-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -290,7 +290,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-k8s-1.25-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-k8s-1.25-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -315,7 +315,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-oss-k8s-1.25-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-oss-k8s-1.25-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-k8s-1.25-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-oss-k8s-1.25-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-k8s-1.25-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-oss-k8s-1.25-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-k8s-1.25-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-k8s-1.25-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -161,7 +161,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-k8s-1.25-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -186,7 +186,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -298,7 +298,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-k8s-1.25-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -323,7 +323,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-k8s-1.25-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-a"
-    rollout-group: alertmanager
+    rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
     zone: zone-a
   annotations:
     rollout-max-unavailable: "2"
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-logical-multizone-values
       app.kubernetes.io/component: alertmanager
-      rollout-group: alertmanager
+      rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -37,7 +37,7 @@ spec:
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
         name: "alertmanager-zone-a"
-        rollout-group: alertmanager
+        rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-b"
-    rollout-group: alertmanager
+    rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
     zone: zone-b
   annotations:
     rollout-max-unavailable: "2"
@@ -150,7 +150,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-logical-multizone-values
       app.kubernetes.io/component: alertmanager
-      rollout-group: alertmanager
+      rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -164,7 +164,7 @@ spec:
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
         name: "alertmanager-zone-b"
-        rollout-group: alertmanager
+        rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -265,7 +265,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-c"
-    rollout-group: alertmanager
+    rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
     zone: zone-c
   annotations:
     rollout-max-unavailable: "2"
@@ -277,7 +277,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-logical-multizone-values
       app.kubernetes.io/component: alertmanager
-      rollout-group: alertmanager
+      rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -291,7 +291,7 @@ spec:
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
         name: "alertmanager-zone-c"
-        rollout-group: alertmanager
+        rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-a"
-    rollout-group: alertmanager
+    rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: alertmanager
-    rollout-group: alertmanager
+    rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-b"
-    rollout-group: alertmanager
+    rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: alertmanager
-    rollout-group: alertmanager
+    rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-c"
-    rollout-group: alertmanager
+    rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: alertmanager
-    rollout-group: alertmanager
+    rollout-group: test-oss-logical-multizone-values-mimir-alertmanager
     zone: zone-c

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-oss-logical-multizone-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-logical-multizone-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-logical-multizone-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-oss-logical-multizone-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -133,7 +133,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-oss-logical-multizone-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -146,7 +146,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-logical-multizone-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-logical-multizone-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -160,7 +160,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-oss-logical-multizone-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -255,7 +255,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-oss-logical-multizone-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -268,7 +268,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-logical-multizone-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-logical-multizone-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -282,7 +282,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-oss-logical-multizone-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-oss-logical-multizone-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-logical-multizone-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-oss-logical-multizone-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-logical-multizone-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-oss-logical-multizone-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-logical-multizone-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-logical-multizone-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -133,7 +133,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -146,7 +146,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-logical-multizone-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -160,7 +160,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -255,7 +255,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -268,7 +268,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-logical-multizone-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -282,7 +282,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-logical-multizone-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/configmap.yaml
@@ -1,0 +1,406 @@
+---
+# Source: mimir-distributed/charts/minio/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-minio
+  labels:
+    app: minio
+    chart: minio-5.0.14
+    release: test-oss-multizone-rolloutgroup-values
+    heritage: Helm
+data:
+  initialize: |-
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 1 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+    
+    # checkBucketExists ($bucket)
+    # Check if the bucket exists, by using the exit code of `mc ls`
+    checkBucketExists() {
+      BUCKET=$1
+      CMD=$(${MC} stat myminio/$BUCKET > /dev/null 2>&1)
+      return $?
+    }
+    
+    # createBucket ($bucket, $policy, $purge)
+    # Ensure bucket exists, purging if asked to
+    createBucket() {
+      BUCKET=$1
+      POLICY=$2
+      PURGE=$3
+      VERSIONING=$4
+      OBJECTLOCKING=$5
+    
+      # Purge the bucket, if set & exists
+      # Since PURGE is user input, check explicitly for `true`
+      if [ $PURGE = true ]; then
+        if checkBucketExists $BUCKET ; then
+          echo "Purging bucket '$BUCKET'."
+          set +e ; # don't exit if this fails
+          ${MC} rm -r --force myminio/$BUCKET
+          set -e ; # reset `e` as active
+        else
+          echo "Bucket '$BUCKET' does not exist, skipping purge."
+        fi
+      fi
+    
+    # Create the bucket if it does not exist and set objectlocking if enabled (NOTE: versioning will be not changed if OBJECTLOCKING is set because it enables versioning to the Buckets created)
+    if ! checkBucketExists $BUCKET ; then
+        if [ ! -z $OBJECTLOCKING ] ; then
+          if [ $OBJECTLOCKING = true ] ; then
+              echo "Creating bucket with OBJECTLOCKING '$BUCKET'"
+              ${MC} mb --with-lock myminio/$BUCKET
+          elif [ $OBJECTLOCKING = false ] ; then
+                echo "Creating bucket '$BUCKET'"
+                ${MC} mb myminio/$BUCKET
+          fi
+      elif [ -z $OBJECTLOCKING ] ; then
+            echo "Creating bucket '$BUCKET'"
+            ${MC} mb myminio/$BUCKET
+      else
+        echo "Bucket '$BUCKET' already exists."  
+      fi
+      fi
+    
+    
+      # set versioning for bucket if objectlocking is disabled or not set
+      if [ $OBJECTLOCKING = false ] ; then
+      if [ ! -z $VERSIONING ] ; then
+        if [ $VERSIONING = true ] ; then
+            echo "Enabling versioning for '$BUCKET'"
+            ${MC} version enable myminio/$BUCKET
+        elif [ $VERSIONING = false ] ; then
+            echo "Suspending versioning for '$BUCKET'"
+            ${MC} version suspend myminio/$BUCKET
+        fi
+        fi
+      else
+          echo "Bucket '$BUCKET' versioning unchanged."
+      fi
+    
+    
+      # At this point, the bucket should exist, skip checking for existence
+      # Set policy on the bucket
+      echo "Setting policy of bucket '$BUCKET' to '$POLICY'."
+      ${MC} anonymous set $POLICY myminio/$BUCKET
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme
+    
+    
+    
+    # Create the buckets
+    createBucket mimir-tsdb "none" false false false
+    createBucket mimir-ruler "none" false false false
+    createBucket enterprise-metrics-tsdb "none" false false false
+    createBucket enterprise-metrics-admin "none" false false false
+    createBucket enterprise-metrics-ruler "none" false false false
+    
+  add-user: |-
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # AccessKey and secretkey credentials file are added to prevent shell execution errors caused by special characters.
+    # Special characters for example : ',",<,>,{,}
+    MINIO_ACCESSKEY_SECRETKEY_TMP="/tmp/accessKey_and_secretKey_tmp"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 1 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+    
+    # checkUserExists ()
+    # Check if the user exists, by using the exit code of `mc admin user info`
+    checkUserExists() {
+      CMD=$(${MC} admin user info myminio $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) > /dev/null 2>&1)
+      return $?
+    }
+    
+    # createUser ($policy)
+    createUser() {
+      POLICY=$1
+      #check accessKey_and_secretKey_tmp file
+      if [[ ! -f $MINIO_ACCESSKEY_SECRETKEY_TMP ]];then
+        echo "credentials file does not exist"
+        return 1
+      fi
+      if [[ $(cat $MINIO_ACCESSKEY_SECRETKEY_TMP|wc -l) -ne 2 ]];then
+        echo "credentials file is invalid"
+        rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+        return 1
+      fi
+      USER=$(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP)
+      # Create the user if it does not exist
+      if ! checkUserExists ; then
+        echo "Creating user '$USER'"
+        cat $MINIO_ACCESSKEY_SECRETKEY_TMP | ${MC} admin user add myminio
+      else
+        echo "User '$USER' already exists."
+      fi
+      #clean up credentials files.
+      rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+    
+      # set policy for user
+      if [ ! -z $POLICY -a $POLICY != " " ] ; then
+          echo "Adding policy '$POLICY' for '$USER'"
+          set +e ; # policy already attach errors out, allow it.
+          ${MC} admin policy attach myminio $POLICY --user=$USER
+          set -e
+      else
+          echo "User '$USER' has no policy attached."
+      fi
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme
+    
+    
+    
+    # Create the users
+    echo console > $MINIO_ACCESSKEY_SECRETKEY_TMP
+    echo console123 >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+    createUser consoleAdmin
+    
+  add-policy: |-
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 1 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+    
+    # checkPolicyExists ($policy)
+    # Check if the policy exists, by using the exit code of `mc admin policy info`
+    checkPolicyExists() {
+      POLICY=$1
+      CMD=$(${MC} admin policy info myminio $POLICY > /dev/null 2>&1)
+      return $?
+    }
+    
+    # createPolicy($name, $filename)
+    createPolicy () {
+      NAME=$1
+      FILENAME=$2
+    
+      # Create the name if it does not exist
+      echo "Checking policy: $NAME (in /config/$FILENAME.json)"
+      if ! checkPolicyExists $NAME ; then
+        echo "Creating policy '$NAME'"
+      else
+        echo "Policy '$NAME' already exists."
+      fi
+      ${MC} admin policy create myminio $NAME /config/$FILENAME.json
+    
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme
+    
+    
+    
+  add-svcacct: |-
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # AccessKey and secretkey credentials file are added to prevent shell execution errors caused by special characters.
+    # Special characters for example : ',",<,>,{,}
+    MINIO_ACCESSKEY_SECRETKEY_TMP="/tmp/accessKey_and_secretKey_svcacct_tmp"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 2 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+    
+    # checkSvcacctExists ()
+    # Check if the svcacct exists, by using the exit code of `mc admin user svcacct info`
+    checkSvcacctExists() {
+      CMD=$(${MC} admin user svcacct info myminio $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) > /dev/null 2>&1)
+      return $?
+    }
+    
+    # createSvcacct ($user)
+    createSvcacct () {
+      USER=$1
+      FILENAME=$2
+      #check accessKey_and_secretKey_tmp file
+      if [[ ! -f $MINIO_ACCESSKEY_SECRETKEY_TMP ]];then
+        echo "credentials file does not exist"
+        return 1
+      fi
+      if [[ $(cat $MINIO_ACCESSKEY_SECRETKEY_TMP|wc -l) -ne 2 ]];then
+        echo "credentials file is invalid"
+        rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+        return 1
+      fi
+      SVCACCT=$(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP)
+      # Create the svcacct if it does not exist
+      if ! checkSvcacctExists ; then
+        echo "Creating svcacct '$SVCACCT'"
+        # Check if policy file is define
+        if [ -z $FILENAME ]; then
+          ${MC} admin user svcacct add --access-key $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --secret-key $(tail -n1 $MINIO_ACCESSKEY_SECRETKEY_TMP) myminio $USER
+        else
+          ${MC} admin user svcacct add --access-key $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --secret-key $(tail -n1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --policy /config/$FILENAME.json myminio $USER
+        fi
+      else
+        echo "Svcacct '$SVCACCT' already exists."
+      fi
+      #clean up credentials files.
+      rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme
+    
+    
+    
+  custom-command: |-
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 1 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+    
+    # runCommand ($@)
+    # Run custom mc command
+    runCommand() {
+      ${MC} "$@"
+      return $?
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/console-service.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/console-service.yaml
@@ -1,0 +1,21 @@
+---
+# Source: mimir-distributed/charts/minio/templates/console-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-minio-console
+  labels:
+    app: minio
+    chart: minio-5.0.14
+    release: test-oss-multizone-rolloutgroup-values
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9001
+      protocol: TCP
+      targetPort: 9001
+  selector:
+    app: minio
+    release: test-oss-multizone-rolloutgroup-values

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/deployment.yaml
@@ -1,0 +1,82 @@
+---
+# Source: mimir-distributed/charts/minio/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-minio
+  labels:
+    app: minio
+    chart: minio-5.0.14
+    release: test-oss-multizone-rolloutgroup-values
+    heritage: Helm
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+      release: test-oss-multizone-rolloutgroup-values
+  template:
+    metadata:
+      name: test-oss-multizone-rolloutgroup-values-minio
+      labels:
+        app: minio
+        release: test-oss-multizone-rolloutgroup-values
+      annotations:
+        checksum/secrets: 047eee57e22b99fed58ba2dde2d46be49d6f2871da3699ed3f4c667b74e62245
+        checksum/config: 755d96d1dfb4e52fabb916cd6d14d1ce8f2f3fb6d2905bfb4aa39f9fcd3452ff
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      
+      serviceAccountName: minio-sa
+      containers:
+        - name: minio
+          image: "quay.io/minio/minio:RELEASE.2023-09-30T07-02-29Z"
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio server /export -S /etc/minio/certs/ --address :9000 --console-address :9001"
+          volumeMounts:
+            - name: minio-user
+              mountPath: "/tmp/credentials"
+              readOnly: true
+            - name: export
+              mountPath: /export            
+          ports:
+            - name: http
+              containerPort: 9000
+            - name: http-console
+              containerPort: 9001
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: test-oss-multizone-rolloutgroup-values-minio
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: test-oss-multizone-rolloutgroup-values-minio
+                  key: rootPassword
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: "public"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi      
+      volumes:
+        - name: export
+          persistentVolumeClaim:
+            claimName: test-oss-multizone-rolloutgroup-values-minio
+        - name: minio-user
+          secret:
+            secretName: test-oss-multizone-rolloutgroup-values-minio

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/post-job.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/post-job.yaml
@@ -1,0 +1,74 @@
+---
+# Source: mimir-distributed/charts/minio/templates/post-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-minio-post-job
+  labels:
+    app: minio-post-job
+    chart: minio-5.0.14
+    release: test-oss-multizone-rolloutgroup-values
+    heritage: Helm
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      labels:
+        app: minio-job
+        release: test-oss-multizone-rolloutgroup-values
+    spec:
+      restartPolicy: OnFailure      
+      volumes:
+        - name: etc-path
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: minio-configuration
+          projected:
+            sources:
+              - configMap:
+                  name: test-oss-multizone-rolloutgroup-values-minio
+              - secret:
+                  name: test-oss-multizone-rolloutgroup-values-minio
+      serviceAccountName: minio-sa
+      containers:
+        - name: minio-make-bucket
+          image: "quay.io/minio/mc:RELEASE.2023-09-29T16-41-22Z"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/sh", "/config/initialize" ]
+          env:
+            - name: MINIO_ENDPOINT
+              value: test-oss-multizone-rolloutgroup-values-minio
+            - name: MINIO_PORT
+              value: "9000"
+          volumeMounts:
+            - name: etc-path
+              mountPath: /etc/minio/mc
+            - name: tmp
+              mountPath: /tmp
+            - name: minio-configuration
+              mountPath: /config
+          resources:
+            requests:
+              memory: 128Mi
+        - name: minio-make-user
+          image: "quay.io/minio/mc:RELEASE.2023-09-29T16-41-22Z"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/sh", "/config/add-user" ]
+          env:
+            - name: MINIO_ENDPOINT
+              value: test-oss-multizone-rolloutgroup-values-minio
+            - name: MINIO_PORT
+              value: "9000"
+          volumeMounts:
+            - name: etc-path
+              mountPath: /etc/minio/mc
+            - name: tmp
+              mountPath: /tmp
+            - name: minio-configuration
+              mountPath: /config
+          resources:
+            requests:
+              memory: 128Mi

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/pvc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/pvc.yaml
@@ -1,0 +1,17 @@
+---
+# Source: mimir-distributed/charts/minio/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-minio
+  labels:
+    app: minio
+    chart: minio-5.0.14
+    release: test-oss-multizone-rolloutgroup-values
+    heritage: Helm
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "5Gi"

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/secrets.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/secrets.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/minio/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-minio
+  labels:
+    app: minio
+    chart: minio-5.0.14
+    release: test-oss-multizone-rolloutgroup-values
+    heritage: Helm
+type: Opaque
+data:
+  rootUser: "Z3JhZmFuYS1taW1pcg=="
+  rootPassword: "c3VwZXJzZWNyZXQ="

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/service.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/service.yaml
@@ -1,0 +1,22 @@
+---
+# Source: mimir-distributed/charts/minio/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-minio
+  labels:
+    app: minio
+    chart: minio-5.0.14
+    release: test-oss-multizone-rolloutgroup-values
+    heritage: Helm
+    monitoring: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app: minio
+    release: test-oss-multizone-rolloutgroup-values

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/minio/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+# Source: mimir-distributed/charts/minio/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "minio-sa"

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -1,0 +1,65 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-rollout-operator
+  labels:
+    helm.sh/chart: rollout-operator-0.16.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/version: "v0.17.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rollout-operator
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rollout-operator
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-rollout-operator
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: rollout-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          image: "grafana/rollout-operator:v0.17.0"
+          imagePullPolicy: IfNotPresent
+          args:
+          - -kubernetes.namespace=citestns
+          ports:
+            - name: http-metrics
+              containerPort: 8001
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-rollout-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - watch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - update

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-rollout-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-oss-multizone-rolloutgroup-values-rollout-operator
+subjects:
+- kind: ServiceAccount
+  name: test-oss-multizone-rolloutgroup-values-rollout-operator

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-rollout-operator
+  labels:
+    helm.sh/chart: rollout-operator-0.16.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/version: "v0.17.0"
+    app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
@@ -1,0 +1,21 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-fallback-config
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {} 
+  namespace: "citestns"
+data:
+  alertmanager_fallback_config.yaml: |
+    receivers:
+        - name: default-receiver
+    route:
+        receiver: default-receiver

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: alertmanager
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -1,0 +1,450 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "alertmanager-zone-a"
+    rollout-group: my-alertmanager-group
+    zone: zone-a
+  annotations:
+    rollout-max-unavailable: "2"
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: alertmanager
+      rollout-group: my-alertmanager-group
+      zone: zone-a
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-alertmanager
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "1Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: memberlist
+        name: "alertmanager-zone-a"
+        rollout-group: my-alertmanager-group
+        zone: zone-a
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - my-alertmanager-group
+              - key: zone
+                operator: NotIn
+                values:
+                - zone-a
+            topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: alertmanager
+      terminationGracePeriodSeconds: 900
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: tmp
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}
+        - name: alertmanager-fallback-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-fallback-config
+      containers:
+        - name: alertmanager
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=alertmanager"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-alertmanager.sharding-ring.instance-availability-zone=zone-a"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: alertmanager-fallback-config
+              mountPath: /configs/
+            - name: tmp
+              mountPath: /tmp
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "alertmanager-zone-b"
+    rollout-group: my-alertmanager-group
+    zone: zone-b
+  annotations:
+    rollout-max-unavailable: "2"
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: alertmanager
+      rollout-group: my-alertmanager-group
+      zone: zone-b
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-alertmanager
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "1Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: memberlist
+        name: "alertmanager-zone-b"
+        rollout-group: my-alertmanager-group
+        zone: zone-b
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - my-alertmanager-group
+              - key: zone
+                operator: NotIn
+                values:
+                - zone-b
+            topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: alertmanager
+      terminationGracePeriodSeconds: 900
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: tmp
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}
+        - name: alertmanager-fallback-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-fallback-config
+      containers:
+        - name: alertmanager
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=alertmanager"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-alertmanager.sharding-ring.instance-availability-zone=zone-b"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: alertmanager-fallback-config
+              mountPath: /configs/
+            - name: tmp
+              mountPath: /tmp
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "alertmanager-zone-c"
+    rollout-group: my-alertmanager-group
+    zone: zone-c
+  annotations:
+    rollout-max-unavailable: "2"
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: alertmanager
+      rollout-group: my-alertmanager-group
+      zone: zone-c
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-alertmanager
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "1Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: memberlist
+        name: "alertmanager-zone-c"
+        rollout-group: my-alertmanager-group
+        zone: zone-c
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - my-alertmanager-group
+              - key: zone
+                operator: NotIn
+                values:
+                - zone-c
+            topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: alertmanager
+      terminationGracePeriodSeconds: 900
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: tmp
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}
+        - name: alertmanager-fallback-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-fallback-config
+      containers:
+        - name: alertmanager
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=alertmanager"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-alertmanager.sharding-ring.instance-availability-zone=zone-c"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: alertmanager-fallback-config
+              mountPath: /configs/
+            - name: tmp
+              mountPath: /tmp
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -1,0 +1,36 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+    - port: 9094
+      protocol: TCP
+      name: cluster
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -1,0 +1,105 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "alertmanager-zone-a"
+    rollout-group: my-alertmanager-group
+    zone: zone-a
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    rollout-group: my-alertmanager-group
+    zone: zone-a
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "alertmanager-zone-b"
+    rollout-group: my-alertmanager-group
+    zone: zone-b
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    rollout-group: my-alertmanager-group
+    zone: zone-b
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-alertmanager-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "alertmanager-zone-c"
+    rollout-group: my-alertmanager-group
+    zone: zone-c
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: alertmanager
+    rollout-group: my-alertmanager-group
+    zone: zone-c

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/compactor/compactor-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/compactor/compactor-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/compactor/compactor-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-compactor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: compactor
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -1,0 +1,119 @@
+---
+# Source: mimir-distributed/templates/compactor/compactor-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-compactor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: compactor
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-compactor
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: compactor
+      terminationGracePeriodSeconds: 900
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: compactor
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=compactor"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/compactor/compactor-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-compactor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: compactor

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -1,0 +1,126 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-distributor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: distributor
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: distributor
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=distributor"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
+            - "-server.grpc.keepalive.max-connection-age=60s"
+            - "-server.grpc.keepalive.max-connection-age-grace=5m"
+            - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "8"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: distributor
+      terminationGracePeriodSeconds: 100
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/distributor/distributor-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/distributor/distributor-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-distributor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: distributor
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-distributor-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: distributor

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-distributor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: distributor

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -1,0 +1,26 @@
+---
+# Source: mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-gossip-ring
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: gossip-ring
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: gossip-ring
+      port: 7946
+      appProtocol: tcp
+      protocol: TCP
+      targetPort: 7946
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ingester
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: ingester
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -1,0 +1,468 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ingester-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-a"
+    rollout-group: my-ingester-group
+    zone: zone-a
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 7
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: ingester
+      rollout-group: my-ingester-group
+      zone: zone-a
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-ingester-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: memberlist
+        name: "ingester-zone-a"
+        rollout-group: my-ingester-group
+        zone: zone-a
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: security
+                operator: In
+                values:
+                - S1
+            topologyKey: topology.kubernetes.io/zone
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - my-ingester-group
+              - key: zone
+                operator: NotIn
+                values:
+                - zone-a
+            topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: ingester
+      terminationGracePeriodSeconds: 1200
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: ingester
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ingester"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-ingester.ring.instance-availability-zone=zone-a"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+---
+# Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ingester-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-b"
+    rollout-group: my-ingester-group
+    zone: zone-b
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 7
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: ingester
+      rollout-group: my-ingester-group
+      zone: zone-b
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-ingester-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: memberlist
+        name: "ingester-zone-b"
+        rollout-group: my-ingester-group
+        zone: zone-b
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: security
+                operator: In
+                values:
+                - S1
+            topologyKey: topology.kubernetes.io/zone
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - my-ingester-group
+              - key: zone
+                operator: NotIn
+                values:
+                - zone-b
+            topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: ingester
+      terminationGracePeriodSeconds: 1200
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: ingester
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ingester"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-ingester.ring.instance-availability-zone=zone-b"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+---
+# Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ingester-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-c"
+    rollout-group: my-ingester-group
+    zone: zone-c
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 7
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: ingester
+      rollout-group: my-ingester-group
+      zone: zone-c
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-ingester-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: memberlist
+        name: "ingester-zone-c"
+        rollout-group: my-ingester-group
+        zone: zone-c
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: security
+                operator: In
+                values:
+                - S1
+            topologyKey: topology.kubernetes.io/zone
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - my-ingester-group
+              - key: zone
+                operator: NotIn
+                values:
+                - zone-c
+            topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: ingester
+      terminationGracePeriodSeconds: 1200
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: ingester
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ingester"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-ingester.ring.instance-availability-zone=zone-c"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ingester-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -1,0 +1,105 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ingester-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-a"
+    rollout-group: my-ingester-group
+    zone: zone-a
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    rollout-group: my-ingester-group
+    zone: zone-a
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ingester-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-b"
+    rollout-group: my-ingester-group
+    zone: zone-b
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    rollout-group: my-ingester-group
+    zone: zone-b
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ingester-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-c"
+    rollout-group: my-ingester-group
+    zone: zone-c
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ingester
+    rollout-group: my-ingester-group
+    zone: zone-c

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -1,0 +1,120 @@
+---
+# Source: mimir-distributed/templates/mimir-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-config
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+data:
+  mimir.yaml: |
+    
+    activity_tracker:
+      filepath: /active-query-tracker/activity.log
+    alertmanager:
+      data_dir: /data
+      enable_api: true
+      external_url: /alertmanager
+      fallback_config_file: /configs/alertmanager_fallback_config.yaml
+      sharding_ring:
+        zone_awareness_enabled: true
+    alertmanager_storage:
+      backend: s3
+      s3:
+        access_key_id: grafana-mimir
+        bucket_name: mimir-ruler
+        endpoint: test-oss-multizone-rolloutgroup-values-minio.citestns.svc:9000
+        insecure: true
+        secret_access_key: supersecret
+    blocks_storage:
+      backend: s3
+      bucket_store:
+        sync_dir: /data/tsdb-sync
+      s3:
+        access_key_id: grafana-mimir
+        bucket_name: mimir-tsdb
+        endpoint: test-oss-multizone-rolloutgroup-values-minio.citestns.svc:9000
+        insecure: true
+        secret_access_key: supersecret
+      tsdb:
+        dir: /data/tsdb
+        head_compaction_interval: 15m
+        wal_replay_concurrency: 3
+    compactor:
+      compaction_interval: 30m
+      data_dir: /data
+      deletion_delay: 2h
+      first_level_compaction_wait_period: 25m
+      max_closing_blocks_concurrency: 2
+      max_opening_blocks_concurrency: 4
+      sharding_ring:
+        heartbeat_period: 1m
+        heartbeat_timeout: 4m
+        wait_stability_min_duration: 1m
+      symbols_flushers_concurrency: 4
+    distributor:
+      ring:
+        heartbeat_period: 1m
+        heartbeat_timeout: 4m
+    frontend:
+      parallelize_shardable_queries: true
+      scheduler_address: test-oss-multizone-rolloutgroup-values-mimir-query-scheduler-headless.citestns.svc:9095
+    frontend_worker:
+      grpc_client_config:
+        max_send_msg_size: 419430400
+      scheduler_address: test-oss-multizone-rolloutgroup-values-mimir-query-scheduler-headless.citestns.svc:9095
+    ingester:
+      ring:
+        final_sleep: 0s
+        heartbeat_period: 2m
+        heartbeat_timeout: 10m
+        num_tokens: 512
+        tokens_file_path: /data/tokens
+        unregister_on_shutdown: false
+        zone_awareness_enabled: true
+    ingester_client:
+      grpc_client_config:
+        max_recv_msg_size: 104857600
+        max_send_msg_size: 104857600
+    limits:
+      max_cache_freshness: 10m
+      max_query_parallelism: 240
+      max_total_query_length: 12000h
+    memberlist:
+      abort_if_cluster_join_fails: false
+      compression_enabled: false
+      join_members:
+      - dns+test-oss-multizone-rolloutgroup-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
+    querier:
+      max_concurrent: 16
+    query_scheduler:
+      max_outstanding_requests_per_tenant: 800
+    ruler:
+      alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.test-oss-multizone-rolloutgroup-values-mimir-alertmanager-headless.citestns.svc.cluster.local./alertmanager
+      enable_api: true
+      rule_path: /data
+    ruler_storage:
+      backend: s3
+      s3:
+        access_key_id: grafana-mimir
+        bucket_name: mimir-ruler
+        endpoint: test-oss-multizone-rolloutgroup-values-minio.citestns.svc:9000
+        insecure: true
+        secret_access_key: supersecret
+    runtime_config:
+      file: /var/mimir/runtime.yaml
+    store_gateway:
+      sharding_ring:
+        heartbeat_period: 1m
+        heartbeat_timeout: 4m
+        kvstore:
+          prefix: multi-zone/
+        tokens_file_path: /data/tokens
+        unregister_on_shutdown: false
+        wait_stability_min_duration: 1m
+        zone_awareness_enabled: true
+    usage_stats:
+      installation_mode: helm

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -1,0 +1,47 @@
+---
+# Source: mimir-distributed/templates/minio/create-bucket-job.yaml
+# Minio provides post-install hook to create bucket
+# however the hook won't be executed if helm install is run
+# with --wait flag. Hence this job is a workaround for that.
+# See https://github.com/grafana/mimir/issues/2464
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-make-minio-buckets-5.0.14
+  namespace: "citestns"
+  labels:
+    app: mimir-distributed-make-bucket-job
+    release: test-oss-multizone-rolloutgroup-values
+    heritage: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        app: mimir-distributed-job
+        release: test-oss-multizone-rolloutgroup-values
+    spec:
+      restartPolicy: OnFailure      
+      volumes:
+        - name: minio-configuration
+          projected:
+            sources:
+            - configMap:
+                name: test-oss-multizone-rolloutgroup-values-minio
+            - secret:
+                name: test-oss-multizone-rolloutgroup-values-minio
+      containers:
+      - name: minio-mc
+        image: "quay.io/minio/mc:RELEASE.2023-09-29T16-41-22Z"
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "/config/initialize"]
+        env:
+          - name: MINIO_ENDPOINT
+            value: test-oss-multizone-rolloutgroup-values-minio
+          - name: MINIO_PORT
+            value: "9000"
+        volumeMounts:
+          - name: minio-configuration
+            mountPath: /config
+        resources:
+          requests:
+            memory: 128Mi

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -1,0 +1,138 @@
+---
+# Source: mimir-distributed/templates/nginx/nginx-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-nginx
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: nginx
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+data:
+  nginx.conf: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr error;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+    
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+    
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+    
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+            '"$request" $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+    
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
+      resolver kube-dns.kube-system.svc.cluster.local.;
+    
+      # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.
+      map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        "" "anonymous";
+      }
+    
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
+      proxy_read_timeout 300;
+      server {
+        listen 8080;
+        listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
+    
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+    
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+    
+        # Distributor endpoints
+        location /distributor {
+          set $distributor test-oss-multizone-rolloutgroup-values-mimir-distributor-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$distributor:8080$request_uri;
+        }
+        location = /api/v1/push {
+          set $distributor test-oss-multizone-rolloutgroup-values-mimir-distributor-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$distributor:8080$request_uri;
+        }
+        location /otlp/v1/metrics {
+          set $distributor test-oss-multizone-rolloutgroup-values-mimir-distributor-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$distributor:8080$request_uri;
+        }
+    
+        # Alertmanager endpoints
+        location /alertmanager {
+          set $alertmanager test-oss-multizone-rolloutgroup-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+        location = /multitenant_alertmanager/status {
+          set $alertmanager test-oss-multizone-rolloutgroup-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-oss-multizone-rolloutgroup-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+        location = /api/v1/alerts {
+          set $alertmanager test-oss-multizone-rolloutgroup-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+    
+        # Ruler endpoints
+        location /prometheus/config/v1/rules {
+          set $ruler test-oss-multizone-rolloutgroup-values-mimir-ruler.citestns.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+        location /prometheus/api/v1/rules {
+          set $ruler test-oss-multizone-rolloutgroup-values-mimir-ruler.citestns.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+    
+        location /prometheus/api/v1/alerts {
+          set $ruler test-oss-multizone-rolloutgroup-values-mimir-ruler.citestns.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+        location = /ruler/ring {
+          set $ruler test-oss-multizone-rolloutgroup-values-mimir-ruler.citestns.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+    
+        # Rest of /prometheus goes to the query frontend
+        location /prometheus {
+          set $query_frontend test-oss-multizone-rolloutgroup-values-mimir-query-frontend.citestns.svc.cluster.local.;
+          proxy_pass      http://$query_frontend:8080$request_uri;
+        }
+    
+        # Buildinfo endpoint can go to any component
+        location = /api/v1/status/buildinfo {
+          set $query_frontend test-oss-multizone-rolloutgroup-values-mimir-query-frontend.citestns.svc.cluster.local.;
+          proxy_pass      http://$query_frontend:8080$request_uri;
+        }
+    
+        # Compactor endpoint for uploading blocks
+        location /api/v1/upload/block/ {
+          set $compactor test-oss-multizone-rolloutgroup-values-mimir-compactor.citestns.svc.cluster.local.;
+          proxy_pass      http://$compactor:8080$request_uri;
+        }
+      }
+    }

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -1,0 +1,92 @@
+---
+# Source: mimir-distributed/templates/nginx/nginx-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-nginx
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: nginx
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: nginx
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: nginx
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.25-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http-metric
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http-metric
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: tmp
+              mountPath: /tmp
+            - name: docker-entrypoint-d-override
+              mountPath: /docker-entrypoint.d
+          resources:
+            {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: nginx
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-nginx
+        - name: tmp
+          emptyDir: {}
+        - name: docker-entrypoint-d-override
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/nginx/nginx-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/nginx/nginx-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/nginx/nginx-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-nginx
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: nginx
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: nginx
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/nginx/nginx-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/nginx/nginx-svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: mimir-distributed/templates/nginx/nginx-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-nginx
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: nginx
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metric
+      port: 80
+      targetPort: http-metric
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: nginx

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -1,0 +1,103 @@
+---
+# Source: mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {}
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/managed-by: Helm
+  name: test-oss-multizone-rolloutgroup-values-mimir-overrides-exporter
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: overrides-exporter
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: overrides-exporter
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: overrides-exporter
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=overrides-exporter"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+      
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-overrides-exporter
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: overrides-exporter
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-overrides-exporter
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: overrides-exporter

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/templates/podsecuritypolicy.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -1,0 +1,118 @@
+---
+# Source: mimir-distributed/templates/querier/querier-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: querier
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=querier"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "5000"
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: querier
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/querier/querier-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/querier/querier-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/querier/querier-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: querier
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/querier/querier-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: querier

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -1,0 +1,115 @@
+---
+# Source: mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: query-frontend
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: query-frontend
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=query-frontend"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            # Reduce the likelihood of queries hitting terminated query-frontends.
+            - "-server.grpc.keepalive.max-connection-age=30s"
+            - "-shutdown-delay=90s"
+          volumeMounts:
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: config
+              mountPath: /etc/mimir
+            - name: storage
+              mountPath: /data
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "5000"
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: query-frontend
+      terminationGracePeriodSeconds: 390
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: query-frontend
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-frontend

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -1,0 +1,107 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-query-scheduler
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: query-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: query-scheduler
+      annotations:
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: query-scheduler
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=query-scheduler"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: config
+              mountPath: /etc/mimir
+            - name: storage
+              mountPath: /data
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: query-scheduler
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-query-scheduler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: query-scheduler
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-query-scheduler-headless
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-scheduler

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-query-scheduler
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: query-scheduler

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/role.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/role.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [test-oss-multizone-rolloutgroup-values-mimir]

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+---
+# Source: mimir-distributed/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-oss-multizone-rolloutgroup-values-mimir
+subjects:
+- kind: ServiceAccount
+  name: test-oss-multizone-rolloutgroup-values-mimir
+- kind: ServiceAccount
+  name: test-oss-multizone-rolloutgroup-values-mimir-distributed

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -1,0 +1,117 @@
+---
+# Source: mimir-distributed/templates/ruler/ruler-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: ruler
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ruler
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ruler"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-distributor.remote-timeout=10s"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: ruler
+      terminationGracePeriodSeconds: 600
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ruler/ruler-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ruler/ruler-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/ruler/ruler-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: ruler
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -1,0 +1,26 @@
+---
+# Source: mimir-distributed/templates/ruler/ruler-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: ruler

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/runtime-configmap.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/runtime-configmap.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/templates/runtime-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+data:
+  runtime.yaml: |
+    
+    {}

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: mimir-distributed/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -1,0 +1,53 @@
+---
+# Source: mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-smoke-test
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: smoke-test
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+  namespace: "citestns"
+spec:
+  backoffLimit: 5
+  completions: 1
+  parallelism: 1
+  selector:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: smoke-test
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: smoke-test
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath="
+            - "-tests.smoke-test"
+            - "-tests.write-endpoint=http://test-oss-multizone-rolloutgroup-values-mimir-nginx.citestns.svc:80"
+            - "-tests.read-endpoint=http://test-oss-multizone-rolloutgroup-values-mimir-nginx.citestns.svc:80/prometheus"
+            - "-tests.tenant-id="
+            - "-tests.write-read-series-test.num-series=1000"
+            - "-tests.write-read-series-test.max-query-age=48h"
+            - "-server.http-listen-port=8080"
+          volumeMounts:
+      restartPolicy: OnFailure
+      volumes:

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-store-gateway
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: store-gateway
+  maxUnavailable: 1

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -1,0 +1,459 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-a"
+    rollout-group: my-store-gateway-group
+    zone: zone-a
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: store-gateway
+      rollout-group: my-store-gateway-group
+      zone: zone-a
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: memberlist
+        name: "store-gateway-zone-a"
+        rollout-group: my-store-gateway-group
+        zone: zone-a
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        topology.kubernetes.io/zone: zone-a
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - my-store-gateway-group
+              - key: zone
+                operator: NotIn
+                values:
+                - zone-a
+            topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: store-gateway
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: store-gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-store-gateway.sharding-ring.instance-availability-zone=zone-a"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-b"
+    rollout-group: my-store-gateway-group
+    zone: zone-b
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: store-gateway
+      rollout-group: my-store-gateway-group
+      zone: zone-b
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: memberlist
+        name: "store-gateway-zone-b"
+        rollout-group: my-store-gateway-group
+        zone: zone-b
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        topology.kubernetes.io/zone: zone-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - my-store-gateway-group
+              - key: zone
+                operator: NotIn
+                values:
+                - zone-b
+            topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: store-gateway
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: store-gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-store-gateway.sharding-ring.instance-availability-zone=zone-b"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-c"
+    rollout-group: my-store-gateway-group
+    zone: zone-c
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+      app.kubernetes.io/component: store-gateway
+      rollout-group: my-store-gateway-group
+      zone: zone-c
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: memberlist
+        name: "store-gateway-zone-c"
+        rollout-group: my-store-gateway-group
+        zone: zone-c
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-oss-multizone-rolloutgroup-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        topology.kubernetes.io/zone: zone-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - my-store-gateway-group
+              - key: zone
+                operator: NotIn
+                values:
+                - zone-c
+            topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+            app.kubernetes.io/component: store-gateway
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-oss-multizone-rolloutgroup-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: store-gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-store-gateway.sharding-ring.instance-availability-zone=zone-c"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway

--- a/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-rolloutgroup-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -1,0 +1,105 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-a"
+    rollout-group: my-store-gateway-group
+    zone: zone-a
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    rollout-group: my-store-gateway-group
+    zone: zone-a
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-b"
+    rollout-group: my-store-gateway-group
+    zone: zone-b
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    rollout-group: my-store-gateway-group
+    zone: zone-b
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-rolloutgroup-values-mimir-store-gateway-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-c"
+    rollout-group: my-store-gateway-group
+    zone: zone-c
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-rolloutgroup-values
+    app.kubernetes.io/component: store-gateway
+    rollout-group: my-store-gateway-group
+    zone: zone-c

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-a"
-    rollout-group: alertmanager
+    rollout-group: test-oss-multizone-values-mimir-alertmanager
     zone: zone-a
   annotations:
     rollout-max-unavailable: "2"
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-multizone-values
       app.kubernetes.io/component: alertmanager
-      rollout-group: alertmanager
+      rollout-group: test-oss-multizone-values-mimir-alertmanager
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -46,7 +46,7 @@ spec:
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
         name: "alertmanager-zone-a"
-        rollout-group: alertmanager
+        rollout-group: test-oss-multizone-values-mimir-alertmanager
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -67,7 +67,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - alertmanager
+                - test-oss-multizone-values-mimir-alertmanager
               - key: zone
                 operator: NotIn
                 values:
@@ -161,7 +161,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-b"
-    rollout-group: alertmanager
+    rollout-group: test-oss-multizone-values-mimir-alertmanager
     zone: zone-b
   annotations:
     rollout-max-unavailable: "2"
@@ -173,7 +173,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-multizone-values
       app.kubernetes.io/component: alertmanager
-      rollout-group: alertmanager
+      rollout-group: test-oss-multizone-values-mimir-alertmanager
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -196,7 +196,7 @@ spec:
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
         name: "alertmanager-zone-b"
-        rollout-group: alertmanager
+        rollout-group: test-oss-multizone-values-mimir-alertmanager
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -217,7 +217,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - alertmanager
+                - test-oss-multizone-values-mimir-alertmanager
               - key: zone
                 operator: NotIn
                 values:
@@ -311,7 +311,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-c"
-    rollout-group: alertmanager
+    rollout-group: test-oss-multizone-values-mimir-alertmanager
     zone: zone-c
   annotations:
     rollout-max-unavailable: "2"
@@ -323,7 +323,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-multizone-values
       app.kubernetes.io/component: alertmanager
-      rollout-group: alertmanager
+      rollout-group: test-oss-multizone-values-mimir-alertmanager
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -346,7 +346,7 @@ spec:
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
         name: "alertmanager-zone-c"
-        rollout-group: alertmanager
+        rollout-group: test-oss-multizone-values-mimir-alertmanager
         zone: zone-c
       annotations:
       namespace: "citestns"
@@ -367,7 +367,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - alertmanager
+                - test-oss-multizone-values-mimir-alertmanager
               - key: zone
                 operator: NotIn
                 values:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-a"
-    rollout-group: alertmanager
+    rollout-group: test-oss-multizone-values-mimir-alertmanager
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: alertmanager
-    rollout-group: alertmanager
+    rollout-group: test-oss-multizone-values-mimir-alertmanager
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-b"
-    rollout-group: alertmanager
+    rollout-group: test-oss-multizone-values-mimir-alertmanager
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: alertmanager
-    rollout-group: alertmanager
+    rollout-group: test-oss-multizone-values-mimir-alertmanager
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "alertmanager-zone-c"
-    rollout-group: alertmanager
+    rollout-group: test-oss-multizone-values-mimir-alertmanager
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: alertmanager
-    rollout-group: alertmanager
+    rollout-group: test-oss-multizone-values-mimir-alertmanager
     zone: zone-c

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-oss-multizone-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-multizone-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-multizone-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-oss-multizone-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -79,7 +79,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - ingester
+                - test-oss-multizone-values-mimir-ingester
               - key: zone
                 operator: NotIn
                 values:
@@ -167,7 +167,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-oss-multizone-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -180,7 +180,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-multizone-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-multizone-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -205,7 +205,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-oss-multizone-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -235,7 +235,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - ingester
+                - test-oss-multizone-values-mimir-ingester
               - key: zone
                 operator: NotIn
                 values:
@@ -323,7 +323,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-oss-multizone-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -336,7 +336,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-multizone-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-multizone-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -361,7 +361,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-oss-multizone-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"
@@ -391,7 +391,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - ingester
+                - test-oss-multizone-values-mimir-ingester
               - key: zone
                 operator: NotIn
                 values:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-oss-multizone-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-multizone-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-oss-multizone-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-multizone-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-oss-multizone-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-multizone-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-oss-multizone-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-multizone-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-multizone-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-oss-multizone-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -72,7 +72,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - test-oss-multizone-values-mimir-store-gateway
               - key: zone
                 operator: NotIn
                 values:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-oss-multizone-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -177,7 +177,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-multizone-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-multizone-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -202,7 +202,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-oss-multizone-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -225,7 +225,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - test-oss-multizone-values-mimir-store-gateway
               - key: zone
                 operator: NotIn
                 values:
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-oss-multizone-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -330,7 +330,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-multizone-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-multizone-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -355,7 +355,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-oss-multizone-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"
@@ -378,7 +378,7 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - test-oss-multizone-values-mimir-store-gateway
               - key: zone
                 operator: NotIn
                 values:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-oss-multizone-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-multizone-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-oss-multizone-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-multizone-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-oss-multizone-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-multizone-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -178,7 +178,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -203,7 +203,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -319,7 +319,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -332,7 +332,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -357,7 +357,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -158,7 +158,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -171,7 +171,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -196,7 +196,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -305,7 +305,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -318,7 +318,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -343,7 +343,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-oss-topology-spread-constraints-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-requests-and-limits-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-requests-and-limits-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-requests-and-limits-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-requests-and-limits-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -144,7 +144,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-requests-and-limits-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -157,7 +157,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-requests-and-limits-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-requests-and-limits-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -182,7 +182,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-requests-and-limits-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -277,7 +277,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-requests-and-limits-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -290,7 +290,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-requests-and-limits-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-requests-and-limits-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -315,7 +315,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-requests-and-limits-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-requests-and-limits-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-requests-and-limits-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-requests-and-limits-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-requests-and-limits-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-requests-and-limits-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-requests-and-limits-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-requests-and-limits-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-requests-and-limits-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-requests-and-limits-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-requests-and-limits-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-requests-and-limits-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-requests-and-limits-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-requests-and-limits-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-requests-and-limits-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -161,7 +161,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-requests-and-limits-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-requests-and-limits-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -186,7 +186,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-requests-and-limits-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-requests-and-limits-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -298,7 +298,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-requests-and-limits-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-requests-and-limits-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -323,7 +323,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-requests-and-limits-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-requests-and-limits-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-requests-and-limits-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-requests-and-limits-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-requests-and-limits-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-requests-and-limits-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-requests-and-limits-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-requests-and-limits-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-requests-and-limits-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-requests-and-limits-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -144,7 +144,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -157,7 +157,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -182,7 +182,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -277,7 +277,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -290,7 +290,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -315,7 +315,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
         zone: zone-a
       annotations:
       namespace: "citestns"
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -161,7 +161,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -186,7 +186,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
         zone: zone-b
       annotations:
       namespace: "citestns"
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -298,7 +298,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -323,7 +323,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
         zone: zone-c
       annotations:
       namespace: "citestns"

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-ruler-dedicated-query-path-values-mimir-store-gateway
     zone: zone-c

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-vault-agent-values-mimir-ingester
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-vault-agent-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-vault-agent-values-mimir-ingester
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-a"
-        rollout-group: ingester
+        rollout-group: test-vault-agent-values-mimir-ingester
         zone: zone-a
       annotations:
         vault.hashicorp.com/agent-inject: 'true'
@@ -151,7 +151,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-vault-agent-values-mimir-ingester
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -164,7 +164,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-vault-agent-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-vault-agent-values-mimir-ingester
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -189,7 +189,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-b"
-        rollout-group: ingester
+        rollout-group: test-vault-agent-values-mimir-ingester
         zone: zone-b
       annotations:
         vault.hashicorp.com/agent-inject: 'true'
@@ -291,7 +291,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-vault-agent-values-mimir-ingester
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -304,7 +304,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-vault-agent-values
       app.kubernetes.io/component: ingester
-      rollout-group: ingester
+      rollout-group: test-vault-agent-values-mimir-ingester
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -329,7 +329,7 @@ spec:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
         name: "ingester-zone-c"
-        rollout-group: ingester
+        rollout-group: test-vault-agent-values-mimir-ingester
         zone: zone-c
       annotations:
         vault.hashicorp.com/agent-inject: 'true'

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-a"
-    rollout-group: ingester
+    rollout-group: test-vault-agent-values-mimir-ingester
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-vault-agent-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-vault-agent-values-mimir-ingester
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-b"
-    rollout-group: ingester
+    rollout-group: test-vault-agent-values-mimir-ingester
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-vault-agent-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-vault-agent-values-mimir-ingester
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "ingester-zone-c"
-    rollout-group: ingester
+    rollout-group: test-vault-agent-values-mimir-ingester
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-vault-agent-values
     app.kubernetes.io/component: ingester
-    rollout-group: ingester
+    rollout-group: test-vault-agent-values-mimir-ingester
     zone: zone-c

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-vault-agent-values-mimir-store-gateway
     zone: zone-a
   annotations:
     rollout-max-unavailable: "50"
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-vault-agent-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-vault-agent-values-mimir-store-gateway
       zone: zone-a
   updateStrategy:
     type: OnDelete
@@ -49,7 +49,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-a"
-        rollout-group: store-gateway
+        rollout-group: test-vault-agent-values-mimir-store-gateway
         zone: zone-a
       annotations:
         vault.hashicorp.com/agent-inject: 'true'
@@ -155,7 +155,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-vault-agent-values-mimir-store-gateway
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
@@ -168,7 +168,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-vault-agent-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-vault-agent-values-mimir-store-gateway
       zone: zone-b
   updateStrategy:
     type: OnDelete
@@ -193,7 +193,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-b"
-        rollout-group: store-gateway
+        rollout-group: test-vault-agent-values-mimir-store-gateway
         zone: zone-b
       annotations:
         vault.hashicorp.com/agent-inject: 'true'
@@ -299,7 +299,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-vault-agent-values-mimir-store-gateway
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
@@ -312,7 +312,7 @@ spec:
       app.kubernetes.io/name: mimir
       app.kubernetes.io/instance: test-vault-agent-values
       app.kubernetes.io/component: store-gateway
-      rollout-group: store-gateway
+      rollout-group: test-vault-agent-values-mimir-store-gateway
       zone: zone-c
   updateStrategy:
     type: OnDelete
@@ -337,7 +337,7 @@ spec:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
         name: "store-gateway-zone-c"
-        rollout-group: store-gateway
+        rollout-group: test-vault-agent-values-mimir-store-gateway
         zone: zone-c
       annotations:
         vault.hashicorp.com/agent-inject: 'true'

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-a"
-    rollout-group: store-gateway
+    rollout-group: test-vault-agent-values-mimir-store-gateway
     zone: zone-a
   annotations:
     {}
@@ -31,7 +31,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-vault-agent-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-vault-agent-values-mimir-store-gateway
     zone: zone-a
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-b"
-    rollout-group: store-gateway
+    rollout-group: test-vault-agent-values-mimir-store-gateway
     zone: zone-b
   annotations:
     {}
@@ -66,7 +66,7 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-vault-agent-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-vault-agent-values-mimir-store-gateway
     zone: zone-b
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
     name: "store-gateway-zone-c"
-    rollout-group: store-gateway
+    rollout-group: test-vault-agent-values-mimir-store-gateway
     zone: zone-c
   annotations:
     {}
@@ -101,5 +101,5 @@ spec:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-vault-agent-values
     app.kubernetes.io/component: store-gateway
-    rollout-group: store-gateway
+    rollout-group: test-vault-agent-values-mimir-store-gateway
     zone: zone-c


### PR DESCRIPTION
#### What this PR does

This PR updates the helm chart, allowing Mimir's components to form a release scoped rollout groups, and not clash with any components, that aren't part of the release. That is if Mimir, Loki, Tempo are installed in the same namespace; or when multiple Mimir versions are installed in the namespace.

*TODO* I'm not yet sure how thse changes will affect the existing deployments. One needs to test this somehow.

#### Which issue(s) this PR fixes or relates to

Fixes #8406

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
