### PR TITLE
Updated metrics and logs for blockbuilder

### DIFF
--- a/pkg/blockbuilder/blockbuilder_metrics.go
+++ b/pkg/blockbuilder/blockbuilder_metrics.go
@@ -10,7 +10,8 @@ import (
 type blockBuilderMetrics struct {
 	consumeCycleDuration     prometheus.Histogram
 	consumeCycleFailures     prometheus.Counter
-	processPartitionDuration prometheus.Histogram
+	processPartitionDuration *prometheus.HistogramVec
+	compactAndUploadDuration *prometheus.HistogramVec
 	fetchRecordsTotal        prometheus.Counter
 	fetchErrors              prometheus.Counter
 	assignedPartitions       *prometheus.GaugeVec
@@ -31,11 +32,17 @@ func newBlockBuilderMetrics(reg prometheus.Registerer) blockBuilderMetrics {
 		NativeHistogramBucketFactor: 1.1,
 	})
 
-	m.processPartitionDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+	m.processPartitionDuration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:                        "cortex_blockbuilder_process_partition_duration_seconds",
 		Help:                        "Time spent processing one partition.",
 		NativeHistogramBucketFactor: 1.1,
-	})
+	}, []string{"partition"})
+
+	m.compactAndUploadDuration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name:                        "cortex_blockbuilder_compact_and_upload_duration_seconds",
+		Help:                        "Time spent compacting and uploading one partition.",
+		NativeHistogramBucketFactor: 1.1,
+	}, []string{"partition"})
 
 	m.fetchRecordsTotal = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "cortex_blockbuilder_fetch_records_total",

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -526,12 +526,12 @@ func (t testTSDBBuilder) process(ctx context.Context, rec *kgo.Record, blockMin,
 	return ok, err
 }
 
-func (t testTSDBBuilder) compactAndUpload(ctx context.Context, blockUploaderForUser func(context.Context, string) blockUploader) error {
-	err := t.tsdbBuilder.compactAndUpload(ctx, blockUploaderForUser)
+func (t testTSDBBuilder) compactAndUpload(ctx context.Context, blockUploaderForUser func(context.Context, string) blockUploader) (int, error) {
+	numBlocks, err := t.tsdbBuilder.compactAndUpload(ctx, blockUploaderForUser)
 	if t.compactFunc != nil {
 		t.compactFunc()
 	}
-	return err
+	return numBlocks, err
 }
 
 func (t testTSDBBuilder) close() error {

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -328,8 +328,6 @@ func (b *tsdbBuilder) compactAndUpload(ctx context.Context, blockUploaderForUser
 	}
 	err := eg.Wait()
 
-	level.Info(b.logger).Log("msg", "compaction and upload done", "num_blocks", numBlocks)
-
 	// Clear the map so that it can be released from the memory. Not setting to nil in case
 	// we want to reuse the tsdbBuilder.
 	b.tsdbs = make(map[tsdbTenant]*userTSDB)

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -229,7 +229,7 @@ func TestTSDBBuilder(t *testing.T) {
 
 			// This should create the appropriate blocks and close the DB.
 			shipperDir := t.TempDir()
-			err = builder.compactAndUpload(context.Background(), mockUploaderFunc(t, shipperDir))
+			_, err = builder.compactAndUpload(context.Background(), mockUploaderFunc(t, shipperDir))
 			require.NoError(t, err)
 			require.Nil(t, builder.getTSDB(tenant))
 


### PR DESCRIPTION
- Updating the lag metric more frequently
    - During partition consumption
    - Every 5 mins when consumption is not going on
- Add a metric to track time taken for compaction and upload
- Add logs for compaction and upload
- Made the processPartitionDuration metric to be per partition
- More info in some existing logs