### PR TITLE
2.13 release: update backward_compatibility.go

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -143,7 +143,7 @@ If something is not clear, you can get back to this document to learn more about
         For instance, if versions 3.1, 3.0 and 2.10 are configured in `renovate.json`, `renovate.json` should keep updated the following branches:
         `main`, `release-3.1` and `release-3.0`.
   - [ ] Announce the release on socials
-  - [ ] Open a PR to add the new version to the backward compatibility integration test (`integration/backward_compatibility_test.go`)
+  - [ ] Open a PR to add the new version to the backward compatibility integration test (`integration/backward_compatibility.go`)
     - Keep the last 3 minor releases
   - [ ] Open a PR to update the mixin in ["Self-hosted Grafana Mimir" integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mimir/)
     - _This is addressed by Grafana Labs_

--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,15 +7,15 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"grafana/mimir:2.10.0": e2emimir.ChainFlagMappers(
-		removePartitionRingFlags,
-		removeRemoteReadLimitsFlags,
-	),
 	"grafana/mimir:2.11.0": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeRemoteReadLimitsFlags,
 	),
 	"grafana/mimir:2.12.0": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+		removeRemoteReadLimitsFlags,
+	),
+	"grafana/mimir:2.13.0": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeRemoteReadLimitsFlags,
 	),


### PR DESCRIPTION
related to https://github.com/grafana/mimir/issues/8390
