### PR TITLE
DRAFT: Split tenantQuerierAssignments and move tree queue into its own package

### DIFF
--- a/pkg/scheduler/queue/tenant_querier_assignment.go
+++ b/pkg/scheduler/queue/tenant_querier_assignment.go
@@ -79,9 +79,11 @@ type tenantQuerierAssignments struct {
 	// but hasn't notified about a graceful shutdown.
 	querierForgetDelay time.Duration
 
+	tenantsByID map[TenantID]*queueTenant
+
+	// TODO (casie): Remove all fields below this
 	// List of all tenants with queues, used for iteration when searching for next queue to handle.
 	tenantIDOrder []TenantID
-	tenantsByID   map[TenantID]*queueTenant
 	// tenantOrderIndex is the index of the _last_ tenant dequeued from; it is passed by
 	// the querier, and then updated to the index of the last tenant dequeued from, so it
 	// can be returned to the querier. Newly connected queriers should pass -1 to start at the
@@ -370,164 +372,164 @@ func (tqa *tenantQuerierAssignments) shuffleTenantQueriers(tenantID TenantID, sc
 	return true
 }
 
-// dequeueSelectNode chooses the next node to dequeue from based on tenantIDOrder and tenantOrderIndex, which are
-// shared across all nodes to maintain an O(n) (where n = # tenants) time-to-dequeue for each tenant.
-// If tenant order were maintained by individual nodes, we would end up with O(mn) (where m = # query components)
-// time-to-dequeue for a given tenant.
+//// dequeueSelectNode chooses the next node to dequeue from based on tenantIDOrder and tenantOrderIndex, which are
+//// shared across all nodes to maintain an O(n) (where n = # tenants) time-to-dequeue for each tenant.
+//// If tenant order were maintained by individual nodes, we would end up with O(mn) (where m = # query components)
+//// time-to-dequeue for a given tenant.
+////
+//// tenantOrderIndex is incremented, checks if the tenant at that index is a child of the current node (it may not be,
+//// e.g., in the case that a tenant has queries queued for one query component but not others), and if so, returns
+//// the tenant node if currentQuerier can handle queries for that tenant.
+////
+//// Note that because we use the shared  tenantIDOrder and tenantOrderIndex to manage the queue, we functionally
+//// ignore each Node's individual queueOrder and queuePosition.
+//func (tqa *tenantQuerierAssignments) dequeueSelectNode(node *Node) (*Node, bool) {
+//	// can't get a tenant if no querier set
+//	if tqa.currentQuerier == "" {
+//		return nil, true
+//	}
 //
-// tenantOrderIndex is incremented, checks if the tenant at that index is a child of the current node (it may not be,
-// e.g., in the case that a tenant has queries queued for one query component but not others), and if so, returns
-// the tenant node if currentQuerier can handle queries for that tenant.
+//	checkedAllNodes := node.childrenChecked == len(node.queueMap)+1 // must check local queue as well
 //
-// Note that because we use the shared  tenantIDOrder and tenantOrderIndex to manage the queue, we functionally
-// ignore each Node's individual queueOrder and queuePosition.
-func (tqa *tenantQuerierAssignments) dequeueSelectNode(node *Node) (*Node, bool) {
-	// can't get a tenant if no querier set
-	if tqa.currentQuerier == "" {
-		return nil, true
-	}
-
-	checkedAllNodes := node.childrenChecked == len(node.queueMap)+1 // must check local queue as well
-
-	// advance queue position for dequeue
-	tqa.tenantOrderIndex++
-	if tqa.tenantOrderIndex >= len(tqa.tenantIDOrder) {
-		tqa.tenantOrderIndex = localQueueIndex
-	}
-
-	// no children or local queue reached
-	if len(node.queueMap) == 0 || tqa.tenantOrderIndex == localQueueIndex {
-		return node, checkedAllNodes
-	}
-
-	checkIndex := tqa.tenantOrderIndex
-
-	// iterate through the tenant order until we find a tenant that is assigned to the current querier, or
-	// have checked the entire tenantIDOrder, whichever comes first
-	for iters := 0; iters < len(tqa.tenantIDOrder); iters++ {
-		if checkIndex >= len(tqa.tenantIDOrder) {
-			// do not use modulo to wrap this index; tenantOrderIndex is provided from an outer process
-			// which does not know if the tenant list has changed since the last dequeue
-			// wrapping with modulo after shrinking the list could cause us to skip tenants
-			checkIndex = 0
-		}
-		tenantID := tqa.tenantIDOrder[checkIndex]
-		tenantName := string(tenantID)
-
-		if _, ok := node.queueMap[tenantName]; !ok {
-			// tenant not in _this_ node's children, move on
-			checkIndex++
-			continue
-		}
-
-		checkedAllNodes = node.childrenChecked == len(node.queueMap)+1
-
-		// if the tenant-querier set is nil, any querier can serve this tenant
-		if tqa.tenantQuerierIDs[tenantID] == nil {
-			tqa.tenantOrderIndex = checkIndex
-			return node.queueMap[tenantName], checkedAllNodes
-		}
-		// otherwise, check if the querier is assigned to this tenant
-		if tenantQuerierSet, ok := tqa.tenantQuerierIDs[tenantID]; ok {
-			if _, ok := tenantQuerierSet[tqa.currentQuerier]; ok {
-				tqa.tenantOrderIndex = checkIndex
-				return node.queueMap[tenantName], checkedAllNodes
-			}
-		}
-		checkIndex++
-	}
-	return nil, checkedAllNodes
-}
-
-// dequeueUpdateState deletes the dequeued-from node from the following locations if it is empty:
-//   - parent's queueMap,
-//   - tenantNodes
-//   - tenantIDOrder iff there are no other nodes by the same name in tenantNodes. If the child is at the end of
-//     tenantIDOrder, it is removed outright; otherwise, it is replaced with an empty ("") element
+//	// advance queue position for dequeue
+//	tqa.tenantOrderIndex++
+//	if tqa.tenantOrderIndex >= len(tqa.tenantIDOrder) {
+//		tqa.tenantOrderIndex = localQueueIndex
+//	}
 //
-// dequeueUpdateState would normally also handle incrementing the queue position after performing a dequeue, but
-// tenantQuerierAssignments currently expects the caller to handle this by having the querier set tenantOrderIndex.
-func (tqa *tenantQuerierAssignments) dequeueUpdateState(node *Node, dequeuedFrom *Node) {
-	// if dequeuedFrom is nil or is not empty, we don't need to do anything;
-	// position updates will be handled by the caller, and we don't need to remove any nodes.
-	if dequeuedFrom == nil || !dequeuedFrom.IsEmpty() {
-		return
-	}
-
-	// delete from the node's children
-	childName := dequeuedFrom.Name()
-	delete(node.queueMap, childName)
-
-	// delete from shared tenantNodes
-	for i, tenantNode := range tqa.tenantNodes[childName] {
-		if tenantNode == dequeuedFrom {
-			tqa.tenantNodes[childName] = append(tqa.tenantNodes[childName][:i], tqa.tenantNodes[childName][i+1:]...)
-		}
-	}
-
-	// check tenantNodes; we only remove from tenantIDOrder if all nodes with this name are gone.
-	// If the removed child is at the _end_ of tenantIDOrder, we remove it outright; otherwise,
-	// we replace it with an empty string. Removal of elements from anywhere other than the end of the slice
-	// would re-index all tenant IDs, resulting in skipped tenants when starting iteration from the
-	// querier-provided lastTenantIndex.
-	removeFromSharedQueueOrder := len(tqa.tenantNodes[childName]) == 0
-
-	if removeFromSharedQueueOrder {
-		for idx, name := range tqa.tenantIDOrder {
-			if string(name) == childName {
-				tqa.tenantIDOrder[idx] = emptyTenantID
-			}
-		}
-		// clear all sequential empty elements from tenantIDOrder
-		lastElementIndex := len(tqa.tenantIDOrder) - 1
-		for i := lastElementIndex; i >= 0 && tqa.tenantIDOrder[i] == ""; i-- {
-			tqa.tenantIDOrder = tqa.tenantIDOrder[:i]
-		}
-	}
-}
-
-// addChildNode adds a child to:
-//   - the node's own queueMap
-//   - tenantNodes, which maintains a slice of all nodes with the same name. tenantNodes is checked on node deletion
-//     to ensure that we only remove a tenant from tenantIDOrder if _all_ nodes with the same name have been removed.
-//   - tenantIDOrder iff the node did not already exist in tenantNodes or tenantIDOrder. addChildNode will place
-//     a new tenant in the first empty ("") element it finds in tenantIDOrder, or at the end if no empty elements exist.
-func (tqa *tenantQuerierAssignments) addChildNode(parent, child *Node) {
-	childName := child.Name()
-	_, tenantHasAnyQueue := tqa.tenantNodes[childName]
-
-	// add childNode to node's queueMap,
-	// and to the shared tenantNodes map
-	parent.queueMap[childName] = child
-	tqa.tenantNodes[childName] = append(tqa.tenantNodes[childName], child)
-
-	// if child has any queue, it should already be in tenantIDOrder, return without altering order
-	if tenantHasAnyQueue {
-		return
-	}
-
-	// otherwise, replace the first empty element in n.tenantIDOrder with childName, or append to the end
-	for i, elt := range tqa.tenantIDOrder {
-		// if we encounter a tenant with this name in tenantIDOrder already, return without altering order.
-		// This is a weak check (childName could exist farther down tenantIDOrder, but be inserted here as well),
-		// but should be fine, since the only time we hit this case is when createOrUpdateTenant is called, which
-		// only happens immediately before enqueueing.
-		if elt == TenantID(childName) {
-			return
-		}
-		if elt == "" {
-			tqa.tenantIDOrder[i] = TenantID(childName)
-			return
-		}
-	}
-	// if we get here, we didn't find any empty elements in tenantIDOrder; append
-	tqa.tenantIDOrder = append(tqa.tenantIDOrder, TenantID(childName))
-}
-
-// updateQueuingAlgorithmState should be called before attempting to dequeue, and updates inputs required by this
-// QueuingAlgorithm to dequeue the appropriate value for the given querier. In some test cases, it need not be called
-// before consecutive dequeues for the same querier, but in all operating cases, it should be called ahead of a dequeue.
-func (tqa *tenantQuerierAssignments) updateQueuingAlgorithmState(querierID QuerierID, tenantOrderIndex int) {
-	tqa.currentQuerier = querierID
-	tqa.tenantOrderIndex = tenantOrderIndex
-}
+//	// no children or local queue reached
+//	if len(node.queueMap) == 0 || tqa.tenantOrderIndex == localQueueIndex {
+//		return node, checkedAllNodes
+//	}
+//
+//	checkIndex := tqa.tenantOrderIndex
+//
+//	// iterate through the tenant order until we find a tenant that is assigned to the current querier, or
+//	// have checked the entire tenantIDOrder, whichever comes first
+//	for iters := 0; iters < len(tqa.tenantIDOrder); iters++ {
+//		if checkIndex >= len(tqa.tenantIDOrder) {
+//			// do not use modulo to wrap this index; tenantOrderIndex is provided from an outer process
+//			// which does not know if the tenant list has changed since the last dequeue
+//			// wrapping with modulo after shrinking the list could cause us to skip tenants
+//			checkIndex = 0
+//		}
+//		tenantID := tqa.tenantIDOrder[checkIndex]
+//		tenantName := string(tenantID)
+//
+//		if _, ok := node.queueMap[tenantName]; !ok {
+//			// tenant not in _this_ node's children, move on
+//			checkIndex++
+//			continue
+//		}
+//
+//		checkedAllNodes = node.childrenChecked == len(node.queueMap)+1
+//
+//		// if the tenant-querier set is nil, any querier can serve this tenant
+//		if tqa.tenantQuerierIDs[tenantID] == nil {
+//			tqa.tenantOrderIndex = checkIndex
+//			return node.queueMap[tenantName], checkedAllNodes
+//		}
+//		// otherwise, check if the querier is assigned to this tenant
+//		if tenantQuerierSet, ok := tqa.tenantQuerierIDs[tenantID]; ok {
+//			if _, ok := tenantQuerierSet[tqa.currentQuerier]; ok {
+//				tqa.tenantOrderIndex = checkIndex
+//				return node.queueMap[tenantName], checkedAllNodes
+//			}
+//		}
+//		checkIndex++
+//	}
+//	return nil, checkedAllNodes
+//}
+//
+//// dequeueUpdateState deletes the dequeued-from node from the following locations if it is empty:
+////   - parent's queueMap,
+////   - tenantNodes
+////   - tenantIDOrder iff there are no other nodes by the same name in tenantNodes. If the child is at the end of
+////     tenantIDOrder, it is removed outright; otherwise, it is replaced with an empty ("") element
+////
+//// dequeueUpdateState would normally also handle incrementing the queue position after performing a dequeue, but
+//// tenantQuerierAssignments currently expects the caller to handle this by having the querier set tenantOrderIndex.
+//func (tqa *tenantQuerierAssignments) dequeueUpdateState(node *Node, dequeuedFrom *Node) {
+//	// if dequeuedFrom is nil or is not empty, we don't need to do anything;
+//	// position updates will be handled by the caller, and we don't need to remove any nodes.
+//	if dequeuedFrom == nil || !dequeuedFrom.IsEmpty() {
+//		return
+//	}
+//
+//	// delete from the node's children
+//	childName := dequeuedFrom.Name()
+//	delete(node.queueMap, childName)
+//
+//	// delete from shared tenantNodes
+//	for i, tenantNode := range tqa.tenantNodes[childName] {
+//		if tenantNode == dequeuedFrom {
+//			tqa.tenantNodes[childName] = append(tqa.tenantNodes[childName][:i], tqa.tenantNodes[childName][i+1:]...)
+//		}
+//	}
+//
+//	// check tenantNodes; we only remove from tenantIDOrder if all nodes with this name are gone.
+//	// If the removed child is at the _end_ of tenantIDOrder, we remove it outright; otherwise,
+//	// we replace it with an empty string. Removal of elements from anywhere other than the end of the slice
+//	// would re-index all tenant IDs, resulting in skipped tenants when starting iteration from the
+//	// querier-provided lastTenantIndex.
+//	removeFromSharedQueueOrder := len(tqa.tenantNodes[childName]) == 0
+//
+//	if removeFromSharedQueueOrder {
+//		for idx, name := range tqa.tenantIDOrder {
+//			if string(name) == childName {
+//				tqa.tenantIDOrder[idx] = emptyTenantID
+//			}
+//		}
+//		// clear all sequential empty elements from tenantIDOrder
+//		lastElementIndex := len(tqa.tenantIDOrder) - 1
+//		for i := lastElementIndex; i >= 0 && tqa.tenantIDOrder[i] == ""; i-- {
+//			tqa.tenantIDOrder = tqa.tenantIDOrder[:i]
+//		}
+//	}
+//}
+//
+//// addChildNode adds a child to:
+////   - the node's own queueMap
+////   - tenantNodes, which maintains a slice of all nodes with the same name. tenantNodes is checked on node deletion
+////     to ensure that we only remove a tenant from tenantIDOrder if _all_ nodes with the same name have been removed.
+////   - tenantIDOrder iff the node did not already exist in tenantNodes or tenantIDOrder. addChildNode will place
+////     a new tenant in the first empty ("") element it finds in tenantIDOrder, or at the end if no empty elements exist.
+//func (tqa *tenantQuerierAssignments) addChildNode(parent, child *Node) {
+//	childName := child.Name()
+//	_, tenantHasAnyQueue := tqa.tenantNodes[childName]
+//
+//	// add childNode to node's queueMap,
+//	// and to the shared tenantNodes map
+//	parent.queueMap[childName] = child
+//	tqa.tenantNodes[childName] = append(tqa.tenantNodes[childName], child)
+//
+//	// if child has any queue, it should already be in tenantIDOrder, return without altering order
+//	if tenantHasAnyQueue {
+//		return
+//	}
+//
+//	// otherwise, replace the first empty element in n.tenantIDOrder with childName, or append to the end
+//	for i, elt := range tqa.tenantIDOrder {
+//		// if we encounter a tenant with this name in tenantIDOrder already, return without altering order.
+//		// This is a weak check (childName could exist farther down tenantIDOrder, but be inserted here as well),
+//		// but should be fine, since the only time we hit this case is when createOrUpdateTenant is called, which
+//		// only happens immediately before enqueueing.
+//		if elt == TenantID(childName) {
+//			return
+//		}
+//		if elt == "" {
+//			tqa.tenantIDOrder[i] = TenantID(childName)
+//			return
+//		}
+//	}
+//	// if we get here, we didn't find any empty elements in tenantIDOrder; append
+//	tqa.tenantIDOrder = append(tqa.tenantIDOrder, TenantID(childName))
+//}
+//
+//// updateQueuingAlgorithmState should be called before attempting to dequeue, and updates inputs required by this
+//// QueuingAlgorithm to dequeue the appropriate value for the given querier. In some test cases, it need not be called
+//// before consecutive dequeues for the same querier, but in all operating cases, it should be called ahead of a dequeue.
+//func (tqa *tenantQuerierAssignments) updateQueuingAlgorithmState(querierID QuerierID, tenantOrderIndex int) {
+//	tqa.currentQuerier = querierID
+//	tqa.tenantOrderIndex = tenantOrderIndex
+//}

--- a/pkg/scheduler/queue/tree_queueing_algorithms.go
+++ b/pkg/scheduler/queue/tree_queueing_algorithms.go
@@ -103,3 +103,188 @@ func (rrs *roundRobinState) dequeueUpdateState(node *Node, dequeuedFrom *Node) {
 		node.queuePosition = localQueueIndex
 	}
 }
+
+type tenantSelectionState struct {
+	// List of all tenants with queues, used for iteration when searching for next queue to handle.
+	tenantIDOrder []TenantID
+	// tenantOrderIndex is the index of the _last_ tenant dequeued from; it is passed by
+	// the querier, and then updated to the index of the last tenant dequeued from, so it
+	// can be returned to the querier. Newly connected queriers should pass -1 to start at the
+	// beginning of tenantIDOrder.
+	tenantOrderIndex int
+	tenantNodes      map[string][]*Node
+	// Tenant assigned querier ID set as determined by shuffle sharding; this is a reference to the map
+	// maintained by tenantQuerierAssignments, and should _never_ be updated by tenantSelectionState
+	tenantQuerierIDs map[TenantID]map[QuerierID]struct{}
+	currentQuerier   QuerierID
+}
+
+// dequeueSelectNode chooses the next node to dequeue from based on tenantIDOrder and tenantOrderIndex, which are
+// shared across all nodes to maintain an O(n) (where n = # tenants) time-to-dequeue for each tenant.
+// If tenant order were maintained by individual nodes, we would end up with O(mn) (where m = # query components)
+// time-to-dequeue for a given tenant.
+//
+// tenantOrderIndex is incremented, checks if the tenant at that index is a child of the current node (it may not be,
+// e.g., in the case that a tenant has queries queued for one query component but not others), and if so, returns
+// the tenant node if currentQuerier can handle queries for that tenant.
+//
+// Note that because we use the shared  tenantIDOrder and tenantOrderIndex to manage the queue, we functionally
+// ignore each Node's individual queueOrder and queuePosition.
+func (tss *tenantSelectionState) dequeueSelectNode(node *Node) (*Node, bool) {
+	// can't get a tenant if no querier set
+	if tss.currentQuerier == "" {
+		return nil, true
+	}
+
+	checkedAllNodes := node.childrenChecked == len(node.queueMap)+1 // must check local queue as well
+
+	// advance queue position for dequeue
+	tss.tenantOrderIndex++
+	if tss.tenantOrderIndex >= len(tss.tenantIDOrder) {
+		tss.tenantOrderIndex = localQueueIndex
+	}
+
+	// no children or local queue reached
+	if len(node.queueMap) == 0 || tss.tenantOrderIndex == localQueueIndex {
+		return node, checkedAllNodes
+	}
+
+	checkIndex := tss.tenantOrderIndex
+
+	// iterate through the tenant order until we find a tenant that is assigned to the current querier, or
+	// have checked the entire tenantIDOrder, whichever comes first
+	for iters := 0; iters < len(tss.tenantIDOrder); iters++ {
+		if checkIndex >= len(tss.tenantIDOrder) {
+			// do not use modulo to wrap this index; tenantOrderIndex is provided from an outer process
+			// which does not know if the tenant list has changed since the last dequeue
+			// wrapping with modulo after shrinking the list could cause us to skip tenants
+			checkIndex = 0
+		}
+		tenantID := tss.tenantIDOrder[checkIndex]
+		tenantName := string(tenantID)
+
+		if _, ok := node.queueMap[tenantName]; !ok {
+			// tenant not in _this_ node's children, move on
+			checkIndex++
+			continue
+		}
+
+		checkedAllNodes = node.childrenChecked == len(node.queueMap)+1
+
+		// if the tenant-querier set is nil, any querier can serve this tenant
+		if tss.tenantQuerierIDs[tenantID] == nil {
+			tss.tenantOrderIndex = checkIndex
+			return node.queueMap[tenantName], checkedAllNodes
+		}
+		// otherwise, check if the querier is assigned to this tenant
+		if tenantQuerierSet, ok := tss.tenantQuerierIDs[tenantID]; ok {
+			if _, ok := tenantQuerierSet[tss.currentQuerier]; ok {
+				tss.tenantOrderIndex = checkIndex
+				return node.queueMap[tenantName], checkedAllNodes
+			}
+		}
+		checkIndex++
+	}
+	return nil, checkedAllNodes
+}
+
+// dequeueUpdateState deletes the dequeued-from node from the following locations if it is empty:
+//   - parent's queueMap,
+//   - tenantNodes
+//   - tenantIDOrder iff there are no other nodes by the same name in tenantNodes. If the child is at the end of
+//     tenantIDOrder, it is removed outright; otherwise, it is replaced with an empty ("") element
+//
+// dequeueUpdateState would normally also handle incrementing the queue position after performing a dequeue, but
+// tenantQuerierAssignments currently expects the caller to handle this by having the querier set tenantOrderIndex.
+func (tss *tenantSelectionState) dequeueUpdateState(node *Node, dequeuedFrom *Node) {
+	// if dequeuedFrom is nil or is not empty, we don't need to do anything;
+	// position updates will be handled by the caller, and we don't need to remove any nodes.
+	if dequeuedFrom == nil || !dequeuedFrom.IsEmpty() {
+		return
+	}
+
+	// delete from the node's children
+	childName := dequeuedFrom.Name()
+	delete(node.queueMap, childName)
+
+	// delete from shared tenantNodes
+	for i, tenantNode := range tss.tenantNodes[childName] {
+		if tenantNode == dequeuedFrom {
+			tss.tenantNodes[childName] = append(tss.tenantNodes[childName][:i], tss.tenantNodes[childName][i+1:]...)
+		}
+	}
+
+	// check tenantNodes; we only remove from tenantIDOrder if all nodes with this name are gone.
+	// If the removed child is at the _end_ of tenantIDOrder, we remove it outright; otherwise,
+	// we replace it with an empty string. Removal of elements from anywhere other than the end of the slice
+	// would re-index all tenant IDs, resulting in skipped tenants when starting iteration from the
+	// querier-provided lastTenantIndex.
+	removeFromSharedQueueOrder := len(tss.tenantNodes[childName]) == 0
+
+	if removeFromSharedQueueOrder {
+		for idx, name := range tss.tenantIDOrder {
+			if string(name) == childName {
+				tss.tenantIDOrder[idx] = emptyTenantID
+			}
+		}
+		// clear all sequential empty elements from tenantIDOrder
+		lastElementIndex := len(tss.tenantIDOrder) - 1
+		for i := lastElementIndex; i >= 0 && tss.tenantIDOrder[i] == ""; i-- {
+			tss.tenantIDOrder = tss.tenantIDOrder[:i]
+		}
+	}
+}
+
+// addChildNode adds a child to:
+//   - the node's own queueMap
+//   - tenantNodes, which maintains a slice of all nodes with the same name. tenantNodes is checked on node deletion
+//     to ensure that we only remove a tenant from tenantIDOrder if _all_ nodes with the same name have been removed.
+//   - tenantIDOrder iff the node did not already exist in tenantNodes or tenantIDOrder. addChildNode will place
+//     a new tenant in the first empty ("") element it finds in tenantIDOrder, or at the end if no empty elements exist.
+func (tss *tenantSelectionState) addChildNode(parent, child *Node) {
+	childName := child.Name()
+	_, tenantHasAnyQueue := tss.tenantNodes[childName]
+
+	// add childNode to node's queueMap,
+	// and to the shared tenantNodes map
+	parent.queueMap[childName] = child
+	tss.tenantNodes[childName] = append(tss.tenantNodes[childName], child)
+
+	// if child has any queue, it should already be in tenantIDOrder, return without altering order
+	if tenantHasAnyQueue {
+		return
+	}
+
+	// otherwise, replace the first empty element in n.tenantIDOrder with childName, or append to the end
+	for i, elt := range tss.tenantIDOrder {
+		// if we encounter a tenant with this name in tenantIDOrder already, return without altering order.
+		// This is a weak check (childName could exist farther down tenantIDOrder, but be inserted here as well),
+		// but should be fine, since the only time we hit this case is when createOrUpdateTenant is called, which
+		// only happens immediately before enqueueing.
+		if elt == TenantID(childName) {
+			return
+		}
+		if elt == "" {
+			tss.tenantIDOrder[i] = TenantID(childName)
+			return
+		}
+	}
+	// if we get here, we didn't find any empty elements in tenantIDOrder; append
+	tss.tenantIDOrder = append(tss.tenantIDOrder, TenantID(childName))
+}
+
+// updateQueuingAlgorithmState should be called before attempting to dequeue, and updates inputs required by this
+// QueuingAlgorithm to dequeue the appropriate value for the given querier. In some test cases, it need not be called
+// before consecutive dequeues for the same querier, but in all operating cases, it should be called ahead of a dequeue.
+func (tss *tenantSelectionState) updateQueuingAlgorithmState(querierID QuerierID, tenantOrderIndex int) {
+	tss.currentQuerier = querierID
+	tss.tenantOrderIndex = tenantOrderIndex
+}
+
+func (tss *tenantSelectionState) itemCountForTenant(tenantID string) int {
+	itemCount := 0
+	for _, tenantNode := range tss.tenantNodes[tenantID] {
+		itemCount += tenantNode.ItemCount()
+	}
+	return itemCount
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
