### PR TITLE
blockbuilder: fix logging and metrics

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -552,7 +552,7 @@ func (b *BlockBuilder) consumePartition(
 						Topic:       lastCommit.Topic,
 						Partition:   lastCommit.Partition,
 						LeaderEpoch: lastCommit.LeaderEpoch,
-						Offset:      lastCommit.At - 1, // TODO(v): lastCommit.At can we zero if there wasn't any commit yet
+						Offset:      lastCommit.At - 1, // TODO(v): lastCommit.At can be zero if there wasn't any commit yet
 					}
 				}
 			}


### PR DESCRIPTION
This one is a follow-up to #8652

The changes here are the following:

- fix the KV pairs in the "done consuming partition" logs
- make sure we update the partition lag metric, when there is no lag
- rename internal variables to be more consistent