### PR TITLE
distributor tests: use LabelAdapters more, to match code being tested

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -1216,12 +1216,25 @@ func TestDistributor_PushQuery(t *testing.T) {
 	}
 }
 
+// Helper function to generate LabelAdapter slice from string pairs.
+func labelAdapters(ss ...string) []mimirpb.LabelAdapter {
+	if len(ss)%2 != 0 {
+		panic("invalid number of strings")
+	}
+	res := make([]mimirpb.LabelAdapter, 0, len(ss)/2)
+	for i := 0; i < len(ss); i += 2 {
+		res = append(res, mimirpb.LabelAdapter{Name: ss[i], Value: ss[i+1]})
+	}
+	slices.SortFunc(res, func(a, b mimirpb.LabelAdapter) int { return strings.Compare(a.Name, b.Name) })
+	return res
+}
+
 func TestDistributor_Push_LabelRemoval(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "user")
 
 	type testcase struct {
-		inputSeries    labels.Labels
-		expectedSeries labels.Labels
+		inputSeries    []mimirpb.LabelAdapter
+		expectedSeries []mimirpb.LabelAdapter
 		removeReplica  bool
 		removeLabels   []string
 	}
@@ -1231,39 +1244,39 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 		{
 			removeReplica:  true,
 			removeLabels:   []string{"cluster"},
-			inputSeries:    labels.FromStrings("__name__", "some_metric", "cluster", "one", "__replica__", "two"),
-			expectedSeries: labels.FromStrings("__name__", "some_metric"),
+			inputSeries:    labelAdapters("__name__", "some_metric", "cluster", "one", "__replica__", "two"),
+			expectedSeries: labelAdapters("__name__", "some_metric"),
 		},
 		// Remove multiple labels and replica.
 		{
 			removeReplica: true,
 			removeLabels:  []string{"foo", "some"},
-			inputSeries: labels.FromStrings("__name__", "some_metric", "cluster", "one", "__replica__", "two",
+			inputSeries: labelAdapters("__name__", "some_metric", "cluster", "one", "__replica__", "two",
 				"foo", "bar", "some", "thing"),
-			expectedSeries: labels.FromStrings("__name__", "some_metric", "cluster", "one"),
+			expectedSeries: labelAdapters("__name__", "some_metric", "cluster", "one"),
 		},
 		// Remove blank labels.
 		{
-			inputSeries:    labels.FromStrings("__name__", "some_metric", "blank", "", "foo", "bar"),
-			expectedSeries: labels.FromStrings("__name__", "some_metric", "foo", "bar"),
+			inputSeries:    labelAdapters("__name__", "some_metric", "blank", "", "foo", "bar"),
+			expectedSeries: labelAdapters("__name__", "some_metric", "foo", "bar"),
 		},
 		{
-			inputSeries:    labels.FromStrings("__name__", "some_metric", "foo", "bar", "zzz_blank", ""),
-			expectedSeries: labels.FromStrings("__name__", "some_metric", "foo", "bar"),
+			inputSeries:    labelAdapters("__name__", "some_metric", "foo", "bar", "zzz_blank", ""),
+			expectedSeries: labelAdapters("__name__", "some_metric", "foo", "bar"),
 		},
 		{
-			inputSeries:    labels.FromStrings("__blank__", "", "__name__", "some_metric", "foo", "bar"),
-			expectedSeries: labels.FromStrings("__name__", "some_metric", "foo", "bar"),
+			inputSeries:    labelAdapters("__blank__", "", "__name__", "some_metric", "foo", "bar"),
+			expectedSeries: labelAdapters("__name__", "some_metric", "foo", "bar"),
 		},
 		{
-			inputSeries:    labels.FromStrings("__blank__", "", "__name__", "some_metric", "foo", "bar", "zzz_blank", ""),
-			expectedSeries: labels.FromStrings("__name__", "some_metric", "foo", "bar"),
+			inputSeries:    labelAdapters("__blank__", "", "__name__", "some_metric", "foo", "bar", "zzz_blank", ""),
+			expectedSeries: labelAdapters("__name__", "some_metric", "foo", "bar"),
 		},
 		// Don't remove any labels.
 		{
 			removeReplica:  false,
-			inputSeries:    labels.FromStrings("__name__", "some_metric", "__replica__", "two", "cluster", "one"),
-			expectedSeries: labels.FromStrings("__name__", "some_metric", "__replica__", "two", "cluster", "one"),
+			inputSeries:    labelAdapters("__name__", "some_metric", "__replica__", "two", "cluster", "one"),
+			expectedSeries: labelAdapters("__name__", "some_metric", "__replica__", "two", "cluster", "one"),
 		},
 	}
 
@@ -1292,7 +1305,7 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 			timeseries := ingesters[i].series()
 			assert.Equal(t, 1, len(timeseries))
 			for _, v := range timeseries {
-				promtestutil.RequireEqual(t, tc.expectedSeries, mimirpb.FromLabelAdaptersToLabels(v.Labels))
+				assert.Equal(t, tc.expectedSeries, v.Labels)
 			}
 		}
 	}
@@ -1301,35 +1314,35 @@ func TestDistributor_Push_LabelRemoval(t *testing.T) {
 func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "user")
 	tests := map[string]struct {
-		inputSeries    labels.Labels
-		expectedSeries labels.Labels
+		inputSeries    []mimirpb.LabelAdapter
+		expectedSeries []mimirpb.LabelAdapter
 		expectedToken  uint32
 	}{
 		"metric_1 with value_1": {
-			inputSeries:    labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
-			expectedSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
+			inputSeries:    labelAdapters("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
+			expectedSeries: labelAdapters("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
 			expectedToken:  0xec0a2e9d,
 		},
 		"metric_1 with value_1 and dropped label due to config": {
-			inputSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1",
+			inputSeries: labelAdapters("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1",
 				"dropped", "unused"),
-			expectedSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
+			expectedSeries: labelAdapters("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
 			expectedToken:  0xec0a2e9d,
 		},
 		"metric_1 with value_1 and dropped HA replica label": {
-			inputSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1",
+			inputSeries: labelAdapters("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1",
 				"__replica__", "replica_1"),
-			expectedSeries: labels.FromStrings("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
+			expectedSeries: labelAdapters("__name__", "metric_1", "cluster", "cluster_1", "key", "value_1"),
 			expectedToken:  0xec0a2e9d,
 		},
 		"metric_2 with value_1": {
-			inputSeries:    labels.FromStrings("__name__", "metric_2", "key", "value_1"),
-			expectedSeries: labels.FromStrings("__name__", "metric_2", "key", "value_1"),
+			inputSeries:    labelAdapters("__name__", "metric_2", "key", "value_1"),
+			expectedSeries: labelAdapters("__name__", "metric_2", "key", "value_1"),
 			expectedToken:  0xa60906f2,
 		},
 		"metric_1 with value_2": {
-			inputSeries:    labels.FromStrings("__name__", "metric_1", "key", "value_2"),
-			expectedSeries: labels.FromStrings("__name__", "metric_1", "key", "value_2"),
+			inputSeries:    labelAdapters("__name__", "metric_1", "key", "value_2"),
+			expectedSeries: labelAdapters("__name__", "metric_1", "key", "value_2"),
 			expectedToken:  0x18abc8a2,
 		},
 	}
@@ -1361,18 +1374,18 @@ func TestDistributor_Push_ShouldGuaranteeShardingTokenConsistencyOverTheTime(t *
 
 				series, ok := timeseries[testData.expectedToken]
 				require.True(t, ok)
-				assert.Equal(t, testData.expectedSeries, mimirpb.FromLabelAdaptersToLabels(series.Labels))
+				assert.Equal(t, testData.expectedSeries, series.Labels)
 			}
 		})
 	}
 }
 
 func TestDistributor_Push_LabelNameValidation(t *testing.T) {
-	inputLabels := labels.FromStrings(model.MetricNameLabel, "foo", "999.illegal", "baz")
+	inputLabels := labelAdapters(model.MetricNameLabel, "foo", "999.illegal", "baz")
 	ctx := user.InjectOrgID(context.Background(), "user")
 
 	tests := map[string]struct {
-		inputLabels                labels.Labels
+		inputLabels                []mimirpb.LabelAdapter
 		skipLabelNameValidationCfg bool
 		skipLabelNameValidationReq bool
 		errExpected                bool
@@ -2225,23 +2238,23 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 	const numIngesters = 5
 
 	fixtures := []struct {
-		lbls      labels.Labels
+		lbls      []mimirpb.LabelAdapter
 		value     float64
 		timestamp int64
 	}{
-		{labels.FromStrings(labels.MetricName, "test_1", "status", "200"), 1, 100000},
-		{labels.FromStrings(labels.MetricName, "test_1", "status", "500"), 1, 110000},
-		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "200"), 1, 100000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "500"), 1, 110000},
+		{labelAdapters(labels.MetricName, "test_2"), 2, 200000},
 		// The two following series have the same FastFingerprint=e002a3a451262627
-		{labels.FromStrings(labels.MetricName, "fast_fingerprint_collision", "app", "l", "uniq0", "0", "uniq1", "1"), 1, 300000},
-		{labels.FromStrings(labels.MetricName, "fast_fingerprint_collision", "app", "m", "uniq0", "1", "uniq1", "1"), 1, 300000},
+		{labelAdapters(labels.MetricName, "fast_fingerprint_collision", "app", "l", "uniq0", "0", "uniq1", "1"), 1, 300000},
+		{labelAdapters(labels.MetricName, "fast_fingerprint_collision", "app", "m", "uniq0", "1", "uniq1", "1"), 1, 300000},
 	}
 
 	tests := map[string]struct {
 		shuffleShardSize  int
 		matchers          []*labels.Matcher
 		maxSeriesPerQuery int
-		expectedResult    []labels.Labels
+		expectedResult    [][]mimirpb.LabelAdapter
 		expectedIngesters int
 		expectedError     error
 	}{
@@ -2249,14 +2262,14 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 			matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "unknown"),
 			},
-			expectedResult:    []labels.Labels{},
+			expectedResult:    nil,
 			expectedIngesters: numIngesters,
 		},
 		"should filter metrics by single matcher": {
 			matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_1"),
 			},
-			expectedResult: []labels.Labels{
+			expectedResult: [][]mimirpb.LabelAdapter{
 				fixtures[0].lbls,
 				fixtures[1].lbls,
 			},
@@ -2267,7 +2280,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 				mustNewMatcher(labels.MatchEqual, "status", "200"),
 				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_1"),
 			},
-			expectedResult: []labels.Labels{
+			expectedResult: [][]mimirpb.LabelAdapter{
 				fixtures[0].lbls,
 			},
 			expectedIngesters: numIngesters,
@@ -2276,7 +2289,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 			matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "fast_fingerprint_collision"),
 			},
-			expectedResult: []labels.Labels{
+			expectedResult: [][]mimirpb.LabelAdapter{
 				fixtures[3].lbls,
 				fixtures[4].lbls,
 			},
@@ -2287,7 +2300,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 			matchers: []*labels.Matcher{
 				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_1"),
 			},
-			expectedResult: []labels.Labels{
+			expectedResult: [][]mimirpb.LabelAdapter{
 				fixtures[0].lbls,
 				fixtures[1].lbls,
 			},
@@ -2354,7 +2367,7 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 					}
 
 					require.NoError(t, err)
-					assert.ElementsMatch(t, testData.expectedResult, metrics)
+					requireLabelAdaptersMatchLabels(t, testData.expectedResult, metrics)
 
 					// Check how many ingesters have been queried.
 					if ingestStorageEnabled {
@@ -2381,44 +2394,44 @@ func TestDistributor_ActiveSeries(t *testing.T) {
 	collision1, collision2 := labelsWithHashCollision()
 
 	pushedData := []struct {
-		lbls      labels.Labels
+		lbls      []mimirpb.LabelAdapter
 		value     float64
 		timestamp int64
 	}{
-		{labels.FromStrings(labels.MetricName, "test_1", "team", "a"), 1, 100000},
-		{labels.FromStrings(labels.MetricName, "test_1", "team", "b"), 1, 110000},
-		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
+		{labelAdapters(labels.MetricName, "test_1", "team", "a"), 1, 100000},
+		{labelAdapters(labels.MetricName, "test_1", "team", "b"), 1, 110000},
+		{labelAdapters(labels.MetricName, "test_2"), 2, 200000},
 		{collision1, 3, 300000},
 		{collision2, 4, 300000},
-		{labels.FromStrings(labels.MetricName, "large_metric", "label", strings.Repeat("1", 2*responseSizeLimitBytes)), 5, 400000},
+		{labelAdapters(labels.MetricName, "large_metric", "label", strings.Repeat("1", 2*responseSizeLimitBytes)), 5, 400000},
 	}
 
 	tests := map[string]struct {
 		shuffleShardSize            int
 		requestMatchers             []*labels.Matcher
 		expectError                 error
-		expectedSeries              []labels.Labels
+		expectedSeries              [][]mimirpb.LabelAdapter
 		expectedNumQueriedIngesters int
 	}{
 		"should return an empty response if no metric match": {
 			requestMatchers:             []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "unknown")},
-			expectedSeries:              []labels.Labels{},
+			expectedSeries:              nil,
 			expectedNumQueriedIngesters: numIngesters,
 		},
 		"should return all matching metrics": {
 			requestMatchers:             []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_1")},
-			expectedSeries:              []labels.Labels{pushedData[0].lbls, pushedData[1].lbls},
+			expectedSeries:              [][]mimirpb.LabelAdapter{pushedData[0].lbls, pushedData[1].lbls},
 			expectedNumQueriedIngesters: numIngesters,
 		},
 		"should honour shuffle shard size": {
 			shuffleShardSize:            3,
 			requestMatchers:             []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_2")},
-			expectedSeries:              []labels.Labels{pushedData[2].lbls},
+			expectedSeries:              [][]mimirpb.LabelAdapter{pushedData[2].lbls},
 			expectedNumQueriedIngesters: 3,
 		},
 		"should return all matching series even if their hash collides": {
 			requestMatchers:             []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "metric")},
-			expectedSeries:              []labels.Labels{collision1, collision2},
+			expectedSeries:              [][]mimirpb.LabelAdapter{collision1, collision2},
 			expectedNumQueriedIngesters: numIngesters,
 		},
 		"aborts if response is too large": {
@@ -2504,8 +2517,7 @@ func TestDistributor_ActiveSeries(t *testing.T) {
 					}
 
 					require.NoError(t, err)
-					slices.SortFunc(series, labels.Compare)
-					promtestutil.RequireEqual(t, testData.expectedSeries, series)
+					requireLabelAdaptersMatchLabels(t, testData.expectedSeries, series)
 
 					// Check that query stats are set correctly.
 					assert.Equal(t, uint64(len(testData.expectedSeries)), qStats.GetFetchedSeriesCount())
@@ -2528,6 +2540,21 @@ func TestDistributor_ActiveSeries(t *testing.T) {
 	}
 }
 
+// Check that all the LabelAdaptors match all the Labels. Assume LabelAdaptors are already sorted.
+func requireLabelAdaptersMatchLabels(tb testing.TB, a [][]mimirpb.LabelAdapter, b []labels.Labels) {
+	tb.Helper()
+	if len(a) == 0 && len(b) == 0 {
+		return
+	}
+	bAsLabelAdapters := make([][]mimirpb.LabelAdapter, len(b))
+	for i, s := range b {
+		bAsLabelAdapters[i] = mimirpb.FromLabelsToLabelAdapters(s)
+	}
+	slices.SortFunc(bAsLabelAdapters, mimirpb.CompareLabelAdapters)
+
+	promtestutil.RequireEqual(tb, a, bAsLabelAdapters)
+}
+
 func TestDistributor_ActiveNativeHistogramSeries(t *testing.T) {
 	const numIngesters = 5
 	const responseSizeLimitBytes = 1024
@@ -2535,16 +2562,16 @@ func TestDistributor_ActiveNativeHistogramSeries(t *testing.T) {
 	collision1, collision2 := labelsWithHashCollision()
 
 	pushedData := []struct {
-		lbls      labels.Labels
+		lbls      []mimirpb.LabelAdapter
 		value     float64
 		timestamp int64
 	}{
-		{labels.FromStrings(labels.MetricName, "test_1", "team", "a"), 1, 100000},
-		{labels.FromStrings(labels.MetricName, "test_1", "team", "b"), 1, 110000},
-		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
+		{labelAdapters(labels.MetricName, "test_1", "team", "a"), 1, 100000},
+		{labelAdapters(labels.MetricName, "test_1", "team", "b"), 1, 110000},
+		{labelAdapters(labels.MetricName, "test_2"), 2, 200000},
 		{collision1, 3, 300000},
 		{collision2, 4, 300000},
-		{labels.FromStrings(labels.MetricName, "large_metric", "label", strings.Repeat("1", 2*responseSizeLimitBytes)), 5, 400000},
+		{labelAdapters(labels.MetricName, "large_metric", "label", strings.Repeat("1", 2*responseSizeLimitBytes)), 5, 400000},
 	}
 
 	tests := map[string]struct {
@@ -3107,13 +3134,13 @@ func TestDistributor_LabelNames(t *testing.T) {
 	const numIngesters = 5
 
 	fixtures := []struct {
-		lbls      labels.Labels
+		lbls      []mimirpb.LabelAdapter
 		value     float64
 		timestamp int64
 	}{
-		{labels.FromStrings(labels.MetricName, "test_1", "status", "200"), 1, 100000},
-		{labels.FromStrings(labels.MetricName, "test_1", "status", "500", "reason", "broken"), 1, 110000},
-		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "200"), 1, 100000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "500", "reason", "broken"), 1, 110000},
+		{labelAdapters(labels.MetricName, "test_2"), 2, 200000},
 	}
 
 	tests := map[string]struct {
@@ -3311,13 +3338,13 @@ func TestDistributor_MetricsMetadata(t *testing.T) {
 func TestDistributor_LabelNamesAndValuesLimitTest(t *testing.T) {
 	// distinct values are "__name__", "label_00", "label_01" that is 24 bytes in total
 	fixtures := []struct {
-		lbls      labels.Labels
+		lbls      []mimirpb.LabelAdapter
 		value     float64
 		timestamp int64
 	}{
-		{labels.FromStrings(labels.MetricName, "label_00"), 1, 100000},
-		{labels.FromStrings(labels.MetricName, "label_11"), 1, 110000},
-		{labels.FromStrings(labels.MetricName, "label_11"), 2, 200000},
+		{labelAdapters(labels.MetricName, "label_00"), 1, 100000},
+		{labelAdapters(labels.MetricName, "label_11"), 1, 110000},
+		{labelAdapters(labels.MetricName, "label_11"), 2, 200000},
 	}
 	tests := map[string]struct {
 		sizeLimitBytes int
@@ -3380,13 +3407,13 @@ func TestDistributor_LabelNamesAndValuesLimitTest(t *testing.T) {
 
 func TestDistributor_LabelValuesForLabelName(t *testing.T) {
 	fixtures := []struct {
-		lbls      labels.Labels
+		lbls      []mimirpb.LabelAdapter
 		value     float64
 		timestamp int64
 	}{
-		{labels.FromStrings(labels.MetricName, "label_0", "status", "200"), 1, 100_000},
-		{labels.FromStrings(labels.MetricName, "label_1", "status", "500", "reason", "broken"), 1, 110_000},
-		{labels.FromStrings(labels.MetricName, "label_1"), 2, 200_000},
+		{labelAdapters(labels.MetricName, "label_0", "status", "200"), 1, 100_000},
+		{labelAdapters(labels.MetricName, "label_1", "status", "500", "reason", "broken"), 1, 110_000},
+		{labelAdapters(labels.MetricName, "label_1"), 2, 200_000},
 	}
 	tests := map[string]struct {
 		from, to            model.Time
@@ -3454,13 +3481,13 @@ func TestDistributor_LabelValuesForLabelName(t *testing.T) {
 
 func TestDistributor_LabelNamesAndValues(t *testing.T) {
 	fixtures := []struct {
-		lbls      labels.Labels
+		lbls      []mimirpb.LabelAdapter
 		value     float64
 		timestamp int64
 	}{
-		{labels.FromStrings(labels.MetricName, "label_0", "status", "200"), 1, 100000},
-		{labels.FromStrings(labels.MetricName, "label_1", "status", "500", "reason", "broken"), 1, 110000},
-		{labels.FromStrings(labels.MetricName, "label_1"), 2, 200000},
+		{labelAdapters(labels.MetricName, "label_0", "status", "200"), 1, 100000},
+		{labelAdapters(labels.MetricName, "label_1", "status", "500", "reason", "broken"), 1, 110000},
+		{labelAdapters(labels.MetricName, "label_1"), 2, 200000},
 	}
 	expectedLabelValues := []*client.LabelValues{
 		{
@@ -3556,7 +3583,7 @@ func TestDistributor_LabelNamesAndValues(t *testing.T) {
 // This test asserts that distributor waits for all ingester responses to be completed even if ZoneAwareness is enabled.
 // Also, it simulates delay from zone C to verify that there is no race condition. must be run with `-race` flag (race detection).
 func TestDistributor_LabelValuesCardinality_ExpectedAllIngestersResponsesToBeCompleted(t *testing.T) {
-	ctx, ds := prepareWithZoneAwarenessAndZoneDelay(t, createSeries(10000))
+	ctx, ds := prepareWithZoneAwarenessAndZoneDelay(t, 10000)
 
 	names := []model.LabelName{labels.MetricName}
 	response, err := ds[0].labelValuesCardinality(ctx, names, []*labels.Matcher{}, cardinality.InMemoryMethod)
@@ -3569,33 +3596,33 @@ func TestDistributor_LabelValuesCardinality_ExpectedAllIngestersResponsesToBeCom
 // This test asserts that distributor returns all possible label and values even if results from only two Zones are completed and ZoneAwareness is enabled.
 // Also, it simulates delay from zone C to verify that there is no race condition. must be run with `-race` flag (race detection).
 func TestDistributor_LabelNamesAndValues_ExpectedAllPossibleLabelNamesAndValuesToBeReturned(t *testing.T) {
-	ctx, ds := prepareWithZoneAwarenessAndZoneDelay(t, createSeries(10000))
+	ctx, ds := prepareWithZoneAwarenessAndZoneDelay(t, 10000)
 	response, err := ds[0].LabelNamesAndValues(ctx, []*labels.Matcher{}, cardinality.InMemoryMethod)
 	require.NoError(t, err)
 	require.Len(t, response.Items, 1)
 	require.Equal(t, 10000, len(response.Items[0].Values))
 }
 
-// copied from pkg/ingester/activeseries/active_series_test.go
-func labelsWithHashCollision() (labels.Labels, labels.Labels) {
+// adapted from pkg/ingester/activeseries/active_series_test.go
+func labelsWithHashCollision() ([]mimirpb.LabelAdapter, []mimirpb.LabelAdapter) {
 	// These two series have the same XXHash; thanks to https://github.com/pstibrany/labels_hash_collisions
-	ls1 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "l6CQ5y")
-	ls2 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
+	ls1 := labelAdapters("__name__", "metric", "lbl1", "value", "lbl2", "l6CQ5y")
+	ls2 := labelAdapters("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
 
-	if ls1.Hash() != ls2.Hash() {
+	if mimirpb.FromLabelAdaptersToLabels(ls1).Hash() != mimirpb.FromLabelAdaptersToLabels(ls2).Hash() {
 		// These ones are the same when using -tags stringlabels
-		ls1 = labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
-		ls2 = labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
+		ls1 = labelAdapters("__name__", "metric", "lbl", "HFnEaGl")
+		ls2 = labelAdapters("__name__", "metric", "lbl", "RqcXatm")
 	}
 
-	if ls1.Hash() != ls2.Hash() {
+	if mimirpb.FromLabelAdaptersToLabels(ls1).Hash() != mimirpb.FromLabelAdaptersToLabels(ls2).Hash() {
 		panic("This code needs to be updated: find new labels with colliding hash values.")
 	}
 
 	return ls1, ls2
 }
 
-func prepareWithZoneAwarenessAndZoneDelay(t *testing.T, fixtures []series) (context.Context, []*Distributor) {
+func prepareWithZoneAwarenessAndZoneDelay(t *testing.T, count int) (context.Context, []*Distributor) {
 	ctx := user.InjectOrgID(context.Background(), "cardinality-user")
 
 	// Create distributor
@@ -3613,29 +3640,13 @@ func prepareWithZoneAwarenessAndZoneDelay(t *testing.T, fixtures []series) (cont
 		},
 	})
 
-	// Push fixtures
-	for _, series := range fixtures {
-		req := mockWriteRequest(series.lbls, series.value, series.timestamp)
+	// Push test series.
+	for i := 0; i < count; i++ {
+		req := mockWriteRequest(labelAdapters(labels.MetricName, "metric"+strconv.Itoa(i)), 1, int64(100000+i))
 		_, err := ds[0].Push(ctx, req)
 		require.NoError(t, err)
 	}
 	return ctx, ds
-}
-
-type series struct {
-	lbls      labels.Labels
-	value     float64
-	timestamp int64
-}
-
-func createSeries(count int) []series {
-	fixtures := make([]series, 0, count)
-	for i := 0; i < count; i++ {
-		fixtures = append(fixtures, series{
-			labels.FromStrings(labels.MetricName, "metric"+strconv.Itoa(i)), 1, int64(100000 + i),
-		})
-	}
-	return fixtures
 }
 
 func TestDistributor_UserStats(t *testing.T) {
@@ -4046,13 +4057,13 @@ func TestDistributor_LabelValuesCardinality(t *testing.T) {
 	const replicationFactor = 3
 
 	fixtures := []struct {
-		labels    labels.Labels
+		labels    []mimirpb.LabelAdapter
 		value     float64
 		timestamp int64
 	}{
-		{labels.FromStrings(labels.MetricName, "test_1", "status", "200"), 1, 100000},
-		{labels.FromStrings(labels.MetricName, "test_1", "status", "500", "reason", "broken"), 1, 110000},
-		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "200"), 1, 100000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "500", "reason", "broken"), 1, 110000},
+		{labelAdapters(labels.MetricName, "test_2"), 2, 200000},
 	}
 
 	tests := map[string]struct {
@@ -4476,13 +4487,13 @@ func TestDistributor_LabelValuesCardinality_AvailabilityAndConsistency(t *testin
 
 func TestDistributor_LabelValuesCardinality_Limit(t *testing.T) {
 	fixtures := []struct {
-		labels    labels.Labels
+		labels    []mimirpb.LabelAdapter
 		value     float64
 		timestamp int64
 	}{
-		{labels.FromStrings(labels.MetricName, "test_1", "status", "200"), 1, 100000},
-		{labels.FromStrings(labels.MetricName, "test_1", "status", "500", "reason", "broken"), 1, 110000},
-		{labels.FromStrings(labels.MetricName, "test_2"), 2, 200000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "200"), 1, 100000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "500", "reason", "broken"), 1, 110000},
+		{labelAdapters(labels.MetricName, "test_2"), 2, 200000},
 	}
 
 	tests := map[string]struct {
@@ -5037,7 +5048,7 @@ func mustNewMatcher(t labels.MatchType, n, v string) *labels.Matcher {
 	return m
 }
 
-func mockWriteRequest(lbls labels.Labels, value float64, timestampMs int64) *mimirpb.WriteRequest {
+func mockWriteRequest(la []mimirpb.LabelAdapter, value float64, timestampMs int64) *mimirpb.WriteRequest {
 	samples := []mimirpb.Sample{
 		{
 			TimestampMs: timestampMs,
@@ -5045,14 +5056,14 @@ func mockWriteRequest(lbls labels.Labels, value float64, timestampMs int64) *mim
 		},
 	}
 
-	return mimirpb.ToWriteRequest([][]mimirpb.LabelAdapter{mimirpb.FromLabelsToLabelAdapters(lbls)}, samples, nil, nil, mimirpb.API)
+	return mimirpb.ToWriteRequest([][]mimirpb.LabelAdapter{la}, samples, nil, nil, mimirpb.API)
 }
 
-func mockWriteHistogramRequest(lbls labels.Labels, value float64, timestampMs int64) *mimirpb.WriteRequest {
+func mockWriteHistogramRequest(lbls []mimirpb.LabelAdapter, value float64, timestampMs int64) *mimirpb.WriteRequest {
 	histograms := []mimirpb.Histogram{mimirpb.FromHistogramToHistogramProto(timestampMs, util_test.GenerateTestHistogram(int(value)))}
 
 	req := mimirpb.NewWriteRequest(nil, mimirpb.API)
-	return req.AddHistogramSeries([][]mimirpb.LabelAdapter{mimirpb.FromLabelsToLabelAdapters(lbls)}, histograms, nil)
+	return req.AddHistogramSeries([][]mimirpb.LabelAdapter{lbls}, histograms, nil)
 }
 
 type ingesterState int
@@ -6918,20 +6929,20 @@ func TestDistributor_Push_Relabel(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "user")
 
 	type testcase struct {
-		inputSeries          labels.Labels
-		expectedSeries       labels.Labels
+		inputSeries          []mimirpb.LabelAdapter
+		expectedSeries       []mimirpb.LabelAdapter
 		metricRelabelConfigs []*relabel.Config
 	}
 
 	cases := []testcase{
 		// No relabel config.
 		{
-			inputSeries:    labels.FromStrings("__name__", "foo", "cluster", "one"),
-			expectedSeries: labels.FromStrings("__name__", "foo", "cluster", "one"),
+			inputSeries:    labelAdapters("__name__", "foo", "cluster", "one"),
+			expectedSeries: labelAdapters("__name__", "foo", "cluster", "one"),
 		},
 		{
-			inputSeries:    labels.FromStrings("__name__", "foo", "cluster", "one"),
-			expectedSeries: labels.FromStrings("__name__", "foo", "cluster", "two"),
+			inputSeries:    labelAdapters("__name__", "foo", "cluster", "one"),
+			expectedSeries: labelAdapters("__name__", "foo", "cluster", "two"),
 			metricRelabelConfigs: []*relabel.Config{
 				{
 					SourceLabels: []model.LabelName{"cluster"},
@@ -6968,7 +6979,7 @@ func TestDistributor_Push_Relabel(t *testing.T) {
 			timeseries := ingesters[i].series()
 			assert.Equal(t, 1, len(timeseries))
 			for _, v := range timeseries {
-				assert.Equal(t, tc.expectedSeries, mimirpb.FromLabelAdaptersToLabels(v.Labels))
+				assert.Equal(t, tc.expectedSeries, v.Labels)
 			}
 		}
 	}
@@ -7443,7 +7454,7 @@ func TestDistributor_CleanupIsDoneAfterLastIngesterReturns(t *testing.T) {
 	})
 	ingesters[2].pushDelay = time.Second // give the test enough time to do assertions
 
-	lbls := labels.FromStrings("__name__", "metric_1", "key", "value_1")
+	lbls := labelAdapters("__name__", "metric_1", "key", "value_1")
 	ctx := user.InjectOrgID(context.Background(), "user")
 
 	_, err := distributors[0].Push(ctx, mockWriteRequest(lbls, 1, 1))
@@ -7451,7 +7462,7 @@ func TestDistributor_CleanupIsDoneAfterLastIngesterReturns(t *testing.T) {
 
 	// First push request returned, but there's still an ingester call inflight.
 	// This means that the push request is counted as inflight, so another incoming request should be rejected.
-	_, err = distributors[0].Push(ctx, mockWriteRequest(labels.EmptyLabels(), 1, 1))
+	_, err = distributors[0].Push(ctx, mockWriteRequest(nil, 1, 1))
 	checkGRPCError(t, status.New(codes.Internal, errMaxInflightRequestsReached.Error()), nil, err)
 }
 


### PR DESCRIPTION
#### What this PR does

This avoids some conversions to and from Labels.  The motivation comes from testing with `-tags dedupelabels`, where comparisons are more complicated, but it seems overall better to match the data structures in tests against the real code.

#### Checklist

- [x] Tests updated.
- NA Documentation added.
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
