### PR TITLE
blockbuilder: add new option that sets the offset to start consuming from

### DIFF
--- a/pkg/blockbuilder/blockbuilder_metrics.go
+++ b/pkg/blockbuilder/blockbuilder_metrics.go
@@ -8,8 +8,9 @@ import (
 )
 
 type blockBuilderMetrics struct {
-	consumeCycleDuration     prometheus.Histogram
+	consumeCyclesTotal       prometheus.Counter
 	consumeCycleFailures     prometheus.Counter
+	consumeCycleDuration     prometheus.Histogram
 	processPartitionDuration *prometheus.HistogramVec
 	compactAndUploadDuration *prometheus.HistogramVec
 	fetchRecordsTotal        prometheus.Counter
@@ -21,6 +22,10 @@ type blockBuilderMetrics struct {
 func newBlockBuilderMetrics(reg prometheus.Registerer) blockBuilderMetrics {
 	var m blockBuilderMetrics
 
+	m.consumeCyclesTotal = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_blockbuilder_consume_cycles_total",
+		Help: "Total number of consume cycles.",
+	})
 	m.consumeCycleFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "cortex_blockbuilder_consume_cycle_failed_total",
 		Help: "Total number of failed consume cycles.",


### PR DESCRIPTION
This is ~a potentially simpler version~ a different solution to same issue from #8676, which rely on [kgo.ConsumeResetOffset](https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#ConsumeResetOffset) option. 

cc @codesome 

**TODO** This is still a draft, 

- [ ] I'm yet to try adding a unit test to this one
- [ ] we must figure out how to deal with lag, which is currently calculated from the partitions start, regardless