### PR TITLE
feat(config): multiline strings env variable are flatten during expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [BUGFIX] Alertmanager: Fixes a number of bugs in silences which could cause an existing silence to be deleted/expired when updating the silence failed. This could happen when the replacing silence was invalid or exceeded limits. #8525
 * [BUGFIX] Alertmanager: Fix help message for utf-8-strict-mode. #8572
 * [BUGFIX] Query-frontend: Ensure that internal errors result in an HTTP 500 response code instead of 422. #8595 #8666
+* [BUGFIX] Configuration: Multi line envs variables are flatten during injection to be compatible with YAML syntax
 
 ### Mixin
 

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -319,6 +319,11 @@ func expandEnvironmentVariables(config []byte) []byte {
 		if v == "" && len(keyAndDefault) == 2 {
 			v = keyAndDefault[1] // Set value to the default.
 		}
+
+		if strings.Contains(v, "\n") {
+			return strings.Replace(v, "\n", "", -1)
+		}
+
 		return v
 	}))
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

To support GoogleCloud Service account keys injected via env variables, the system has to manage multilines strings. Because YAML parsing is complicated, this PR assumes the multilines env variables can be flatten (removing `\n`) before injection. This is applied ONLY to multilines variables, so it won't break compatibility with already existing expanded variables.

#### Which issue(s) this PR fixes or relates to

Fixes #8704

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
