### PR TITLE
Docs: adds xref to Adaptive Metrics

### DIFF
--- a/docs/sources/mimir/_index.md
+++ b/docs/sources/mimir/_index.md
@@ -61,3 +61,6 @@ Grafana Mimir enables users to ingest Prometheus or OpenTelemetry metrics, run q
 ## Explore
 
 {{< card-grid key="cards" type="simple" >}}
+
+<br/>
+For information about using Adaptive Metrics to save costs in Grafana Cloud, refer to [Reduce metrics costs via Adaptive Metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/) in the Grafana Cloud documentation.


### PR DESCRIPTION
#### What this PR does

This PR adds a cross-reference to the [Adaptive Metrics documentation ](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/)to the [Mimir documentation landing page](https://grafana.com/docs/mimir/latest/).

The intention is to redirect people looking for Adaptive Metrics who inadvertently land on the Mimir docs.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
