### PR TITLE
query-tee: add support for comparing native histograms in results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 * [ENHANCEMENT] Log user agent when processing a request. #8419
 * [ENHANCEMENT] Add `time` parameter to proxied instant queries if it is not included in the incoming request. This is optional but enabled by default, and can be disabled with `-proxy.add-missing-time-parameter-to-instant-queries=false`. #8419
 * [ENHANCEMENT] Add support for sending only a proportion of requests to all backends, with the remainder only sent to the preferred backend. The default behaviour is to send all requests to all backends. This can be configured with `-proxy.secondary-backends-request-proportion`. #8532
+* [ENHANCEMENT] Compare native histograms in query results when comparing results between two backends. #8724
 * [BUGFIX] Ensure any errors encountered while forwarding a request to a backend (eg. DNS resolution failures) are logged. #8419
 
 ### Documentation

--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -160,14 +160,14 @@ func compareMatrix(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 			actualSamplePair := actualMetric.Values[i]
 			err := compareSamplePair(expectedSamplePair, actualSamplePair, opts)
 			if err != nil {
-				return errors.Wrapf(err, "float sample pair not matching for metric %s", expectedMetric.Metric)
+				return errors.Wrapf(err, "float sample pair does not match for metric %s", expectedMetric.Metric)
 			}
 		}
 
 		for i, expectedHistogramPair := range expectedMetric.Histograms {
 			actualHistogramPair := actualMetric.Histograms[i]
 			if err := compareSampleHistogramPair(expectedHistogramPair, actualHistogramPair, opts); err != nil {
-				return errors.Wrapf(err, "histogram sample pair not matching for metric %s", expectedMetric.Metric)
+				return errors.Wrapf(err, "histogram sample pair does not match for metric %s", expectedMetric.Metric)
 			}
 		}
 	}
@@ -215,12 +215,12 @@ func compareVector(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 				Value:     actualMetric.Value,
 			}, opts)
 			if err != nil {
-				return errors.Wrapf(err, "float sample pair not matching for metric %s", expectedMetric.Metric)
+				return errors.Wrapf(err, "float sample pair does not match for metric %s", expectedMetric.Metric)
 			}
 		} else if expectedMetric.Histogram != nil && actualMetric.Histogram == nil {
-			return fmt.Errorf("sample pair not matching for metric %s: expected histogram but got float value", expectedMetric.Metric)
+			return fmt.Errorf("sample pair does not match for metric %s: expected histogram but got float value", expectedMetric.Metric)
 		} else if expectedMetric.Histogram == nil && actualMetric.Histogram != nil {
-			return fmt.Errorf("sample pair not matching for metric %s: expected float value but got histogram", expectedMetric.Metric)
+			return fmt.Errorf("sample pair does not match for metric %s: expected float value but got histogram", expectedMetric.Metric)
 		} else { // Expected value is a histogram and the actual value is a histogram.
 			err := compareSampleHistogramPair(model.SampleHistogramPair{
 				Timestamp: expectedMetric.Timestamp,
@@ -230,7 +230,7 @@ func compareVector(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 				Histogram: actualMetric.Histogram,
 			}, opts)
 			if err != nil {
-				return errors.Wrapf(err, "histogram sample pair not matching for metric %s", expectedMetric.Metric)
+				return errors.Wrapf(err, "histogram sample pair does not match for metric %s", expectedMetric.Metric)
 			}
 		}
 	}

--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -334,18 +334,19 @@ func compareSampleHistogramPair(expected, actual model.SampleHistogramPair, opts
 }
 
 func compareSampleHistogramBuckets(opts SampleComparisonOptions) func(expected, actual *model.HistogramBucket) bool {
-	return func(expected, actual *model.HistogramBucket) bool {
-		if !compareSampleValue(float64(expected.Lower), float64(actual.Lower), opts) {
+	return func(first, second *model.HistogramBucket) bool {
+		if !compareSampleValue(float64(first.Lower), float64(second.Lower), opts) {
 			return false
 		}
 
-		if !compareSampleValue(float64(expected.Upper), float64(actual.Upper), opts) {
+		if !compareSampleValue(float64(first.Upper), float64(second.Upper), opts) {
 			return false
 		}
 
-		if !compareSampleValue(float64(expected.Count), float64(actual.Count), opts) {
+		if !compareSampleValue(float64(first.Count), float64(second.Count), opts) {
 			return false
 		}
-		return expected.Boundaries == actual.Boundaries
+
+		return first.Boundaries == second.Boundaries
 	}
 }

--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	util_log "github.com/grafana/mimir/pkg/util/log"
@@ -64,12 +63,12 @@ func (s *SamplesComparator) Compare(expectedResponse, actualResponse []byte) (Co
 
 	err := json.Unmarshal(expectedResponse, &expected)
 	if err != nil {
-		return ComparisonFailed, errors.Wrap(err, "unable to unmarshal expected response")
+		return ComparisonFailed, fmt.Errorf("unable to unmarshal expected response: %w", err)
 	}
 
 	err = json.Unmarshal(actualResponse, &actual)
 	if err != nil {
-		return ComparisonFailed, errors.Wrap(err, "unable to unmarshal actual response")
+		return ComparisonFailed, fmt.Errorf("unable to unmarshal actual response: %w", err)
 	}
 
 	if expected.Status != actual.Status {
@@ -160,14 +159,14 @@ func compareMatrix(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 			actualSamplePair := actualMetric.Values[i]
 			err := compareSamplePair(expectedSamplePair, actualSamplePair, opts)
 			if err != nil {
-				return errors.Wrapf(err, "float sample pair does not match for metric %s", expectedMetric.Metric)
+				return fmt.Errorf("float sample pair does not match for metric %s: %w", expectedMetric.Metric, err)
 			}
 		}
 
 		for i, expectedHistogramPair := range expectedMetric.Histograms {
 			actualHistogramPair := actualMetric.Histograms[i]
 			if err := compareSampleHistogramPair(expectedHistogramPair, actualHistogramPair, opts); err != nil {
-				return errors.Wrapf(err, "histogram sample pair does not match for metric %s", expectedMetric.Metric)
+				return fmt.Errorf("histogram sample pair does not match for metric %s: %w", expectedMetric.Metric, err)
 			}
 		}
 	}
@@ -215,7 +214,7 @@ func compareVector(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 				Value:     actualMetric.Value,
 			}, opts)
 			if err != nil {
-				return errors.Wrapf(err, "float sample pair does not match for metric %s", expectedMetric.Metric)
+				return fmt.Errorf("float sample pair does not match for metric %s: %w", expectedMetric.Metric, err)
 			}
 		} else if expectedMetric.Histogram != nil && actualMetric.Histogram == nil {
 			return fmt.Errorf("sample pair does not match for metric %s: expected histogram but got float value", expectedMetric.Metric)
@@ -230,7 +229,7 @@ func compareVector(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 				Histogram: actualMetric.Histogram,
 			}, opts)
 			if err != nil {
-				return errors.Wrapf(err, "histogram sample pair does not match for metric %s", expectedMetric.Metric)
+				return fmt.Errorf("histogram sample pair does not match for metric %s: %w", expectedMetric.Metric, err)
 			}
 		}
 	}

--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -132,16 +132,15 @@ func compareMatrix(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 		}
 
 		actualMetric := actual[actualMetricIndex]
-		expectedMetricLen := len(expectedMetric.Values)
-		actualMetricLen := len(actualMetric.Values)
+		expectedFloatMetricLen := len(expectedMetric.Values)
+		actualFloatMetricLen := len(actualMetric.Values)
 
-		if expectedMetricLen != actualMetricLen {
-			err := fmt.Errorf("expected %d samples for metric %s but got %d", expectedMetricLen,
-				expectedMetric.Metric, actualMetricLen)
-			if expectedMetricLen > 0 && actualMetricLen > 0 {
+		if expectedFloatMetricLen != actualFloatMetricLen {
+			err := fmt.Errorf("expected %d float samples for metric %s but got %d", expectedFloatMetricLen, expectedMetric.Metric, actualFloatMetricLen)
+			if expectedFloatMetricLen > 0 && actualFloatMetricLen > 0 {
 				level.Error(util_log.Logger).Log("msg", err.Error(), "oldest-expected-ts", expectedMetric.Values[0].Timestamp,
-					"newest-expected-ts", expectedMetric.Values[expectedMetricLen-1].Timestamp,
-					"oldest-actual-ts", actualMetric.Values[0].Timestamp, "newest-actual-ts", actualMetric.Values[actualMetricLen-1].Timestamp)
+					"newest-expected-ts", expectedMetric.Values[expectedFloatMetricLen-1].Timestamp,
+					"oldest-actual-ts", actualMetric.Values[0].Timestamp, "newest-actual-ts", actualMetric.Values[actualFloatMetricLen-1].Timestamp)
 			}
 			return err
 		}

--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/go-kit/log/level"
@@ -149,7 +150,7 @@ func compareMatrix(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 			actualSamplePair := actualMetric.Values[i]
 			err := compareSamplePair(expectedSamplePair, actualSamplePair, opts)
 			if err != nil {
-				return errors.Wrapf(err, "sample pair not matching for metric %s", expectedMetric.Metric)
+				return errors.Wrapf(err, "float sample pair not matching for metric %s", expectedMetric.Metric)
 			}
 		}
 	}
@@ -187,15 +188,33 @@ func compareVector(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 		}
 
 		actualMetric := actual[actualMetricIndex]
-		err := compareSamplePair(model.SamplePair{
-			Timestamp: expectedMetric.Timestamp,
-			Value:     expectedMetric.Value,
-		}, model.SamplePair{
-			Timestamp: actualMetric.Timestamp,
-			Value:     actualMetric.Value,
-		}, opts)
-		if err != nil {
-			return errors.Wrapf(err, "sample pair not matching for metric %s", expectedMetric.Metric)
+
+		if expectedMetric.Histogram == nil && actualMetric.Histogram == nil {
+			err := compareSamplePair(model.SamplePair{
+				Timestamp: expectedMetric.Timestamp,
+				Value:     expectedMetric.Value,
+			}, model.SamplePair{
+				Timestamp: actualMetric.Timestamp,
+				Value:     actualMetric.Value,
+			}, opts)
+			if err != nil {
+				return errors.Wrapf(err, "float sample pair not matching for metric %s", expectedMetric.Metric)
+			}
+		} else if expectedMetric.Histogram != nil && actualMetric.Histogram == nil {
+			return fmt.Errorf("sample pair not matching for metric %s: expected histogram but got float value", expectedMetric.Metric)
+		} else if expectedMetric.Histogram == nil && actualMetric.Histogram != nil {
+			return fmt.Errorf("sample pair not matching for metric %s: expected float value but got histogram", expectedMetric.Metric)
+		} else { // Expected value is a histogram and the actual value is a histogram.
+			err := compareSampleHistogramPair(model.SampleHistogramPair{
+				Timestamp: expectedMetric.Timestamp,
+				Histogram: expectedMetric.Histogram,
+			}, model.SampleHistogramPair{
+				Timestamp: actualMetric.Timestamp,
+				Histogram: actualMetric.Histogram,
+			}, opts)
+			if err != nil {
+				return errors.Wrapf(err, "histogram sample pair not matching for metric %s", expectedMetric.Metric)
+			}
 		}
 	}
 
@@ -230,26 +249,64 @@ func compareSamplePair(expected, actual model.SamplePair, opts SampleComparisonO
 	if opts.SkipRecentSamples > 0 && time.Since(expected.Timestamp.Time()) < opts.SkipRecentSamples {
 		return nil
 	}
-	if !compareSampleValue(expected.Value, actual.Value, opts) {
+	if !compareSampleValue(float64(expected.Value), float64(actual.Value), opts) {
 		return fmt.Errorf("expected value %s for timestamp %v but got %s", expected.Value, expected.Timestamp, actual.Value)
 	}
 
 	return nil
 }
 
-func compareSampleValue(first, second model.SampleValue, opts SampleComparisonOptions) bool {
-	f := float64(first)
-	s := float64(second)
-
-	if (math.IsNaN(f) && math.IsNaN(s)) ||
-		(math.IsInf(f, 1) && math.IsInf(s, 1)) ||
-		(math.IsInf(f, -1) && math.IsInf(s, -1)) {
+func compareSampleValue(first, second float64, opts SampleComparisonOptions) bool {
+	if (math.IsNaN(first) && math.IsNaN(second)) ||
+		(math.IsInf(first, 1) && math.IsInf(second, 1)) ||
+		(math.IsInf(first, -1) && math.IsInf(second, -1)) {
 		return true
 	} else if opts.Tolerance <= 0 {
-		return math.Float64bits(f) == math.Float64bits(s)
+		return math.Float64bits(first) == math.Float64bits(second)
 	}
-	if opts.UseRelativeError && s != 0 {
-		return math.Abs(f-s)/math.Abs(s) <= opts.Tolerance
+	if opts.UseRelativeError && second != 0 {
+		return math.Abs(first-second)/math.Abs(second) <= opts.Tolerance
 	}
-	return math.Abs(f-s) <= opts.Tolerance
+	return math.Abs(first-second) <= opts.Tolerance
+}
+
+func compareSampleHistogramPair(expected, actual model.SampleHistogramPair, opts SampleComparisonOptions) error {
+	if expected.Timestamp != actual.Timestamp {
+		return fmt.Errorf("expected timestamp %v but got %v", expected.Timestamp, actual.Timestamp)
+	}
+
+	if opts.SkipRecentSamples > 0 && time.Since(expected.Timestamp.Time()) < opts.SkipRecentSamples {
+		return nil
+	}
+
+	if !compareSampleValue(float64(expected.Histogram.Sum), float64(actual.Histogram.Sum), opts) {
+		return fmt.Errorf("expected sum %s for timestamp %v but got %s", expected.Histogram.Sum, expected.Timestamp, actual.Histogram.Sum)
+	}
+
+	if !compareSampleValue(float64(expected.Histogram.Count), float64(actual.Histogram.Count), opts) {
+		return fmt.Errorf("expected count %s for timestamp %v but got %s", expected.Histogram.Count, expected.Timestamp, actual.Histogram.Count)
+	}
+
+	if !slices.EqualFunc(expected.Histogram.Buckets, actual.Histogram.Buckets, compareSampleHistogramBuckets(opts)) {
+		return fmt.Errorf("expected buckets %s for timestamp %v but got %s", expected.Histogram.Buckets, expected.Timestamp, actual.Histogram.Buckets)
+	}
+
+	return nil
+}
+
+func compareSampleHistogramBuckets(opts SampleComparisonOptions) func(expected, actual *model.HistogramBucket) bool {
+	return func(expected, actual *model.HistogramBucket) bool {
+		if !compareSampleValue(float64(expected.Lower), float64(actual.Lower), opts) {
+			return false
+		}
+
+		if !compareSampleValue(float64(expected.Upper), float64(actual.Upper), opts) {
+			return false
+		}
+
+		if !compareSampleValue(float64(expected.Count), float64(actual.Count), opts) {
+			return false
+		}
+		return expected.Boundaries == actual.Boundaries
+	}
 }

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -64,7 +64,7 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"values":[[1,"1"]]}
 						]`),
-			err: errors.New("expected 2 samples for metric {foo=\"bar\"} but got 1"),
+			err: errors.New("expected 2 float samples for metric {foo=\"bar\"} but got 1"),
 		},
 		{
 			name: "difference in sample timestamp",

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -75,7 +75,7 @@ func TestCompareMatrix(t *testing.T) {
 							{"metric":{"foo":"bar"},"values":[[1,"1"],[3,"2"]]}
 						]`),
 			// timestamps are parsed from seconds to ms which are then added to errors as is so adding 3 0s to expected error.
-			err: errors.New(`float sample pair not matching for metric {foo="bar"}: expected timestamp 2 but got 3`),
+			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected timestamp 2 but got 3`),
 		},
 		{
 			name: "difference in float sample value",
@@ -85,7 +85,7 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"values":[[1,"1"],[2,"3"]]}
 						]`),
-			err: errors.New(`float sample pair not matching for metric {foo="bar"}: expected value 2 for timestamp 2 but got 3`),
+			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected value 2 for timestamp 2 but got 3`),
 		},
 		{
 			name: "actual float samples match expected",
@@ -174,7 +174,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected timestamp 1 but got 2`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected timestamp 1 but got 2`),
 		},
 		{
 			name: "difference in histogram sample count",
@@ -206,7 +206,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected count 2 for timestamp 1 but got 5`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected count 2 for timestamp 1 but got 5`),
 		},
 		{
 			name: "difference in histogram sample sum",
@@ -238,7 +238,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected sum 3 for timestamp 1 but got 5`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected sum 3 for timestamp 1 but got 5`),
 		},
 		{
 			name: "difference in histogram sample buckets length",
@@ -271,7 +271,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):2 [2,4):2]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):2 [2,4):2]`),
 		},
 		{
 			name: "difference in histogram sample buckets boundaries",
@@ -303,7 +303,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [(0,2):2]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [(0,2):2]`),
 		},
 		{
 			name: "difference in histogram sample buckets lower boundary",
@@ -335,7 +335,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[1,2):2]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[1,2):2]`),
 		},
 		{
 			name: "difference in histogram sample buckets upper boundary",
@@ -367,7 +367,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,3):2]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,3):2]`),
 		},
 		{
 			name: "difference in histogram sample buckets count",
@@ -399,7 +399,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):3]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):3]`),
 		},
 		{
 			name: "single actual histogram value matches expected",
@@ -521,7 +521,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected sum 5 for timestamp 2 but got 6`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected sum 5 for timestamp 2 but got 6`),
 		},
 		{
 			name: "actual result has different number of histogram samples to expected result",
@@ -624,7 +624,7 @@ func TestCompareVector(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"value":[2,"1"]}
 						]`),
-			err: errors.New(`float sample pair not matching for metric {foo="bar"}: expected timestamp 1 but got 2`),
+			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected timestamp 1 but got 2`),
 		},
 		{
 			name: "difference in float sample value",
@@ -634,7 +634,7 @@ func TestCompareVector(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"value":[1,"2"]}
 						]`),
-			err: errors.New(`float sample pair not matching for metric {foo="bar"}: expected value 1 for timestamp 1 but got 2`),
+			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected value 1 for timestamp 1 but got 2`),
 		},
 		{
 			name: "correct float samples",
@@ -665,7 +665,7 @@ func TestCompareVector(t *testing.T) {
 								"value":[1,"1"]
 							}
 						]`),
-			err: errors.New(`sample pair not matching for metric {foo="bar"}: expected histogram but got float value`),
+			err: errors.New(`sample pair does not match for metric {foo="bar"}: expected histogram but got float value`),
 		},
 		{
 			name: "expected sample has float value but actual sample has histogram",
@@ -687,7 +687,7 @@ func TestCompareVector(t *testing.T) {
 								}]
 							}
 						]`),
-			err: errors.New(`sample pair not matching for metric {foo="bar"}: expected float value but got histogram`),
+			err: errors.New(`sample pair does not match for metric {foo="bar"}: expected float value but got histogram`),
 		},
 		{
 			name: "difference in histogram sample timestamp",
@@ -715,7 +715,7 @@ func TestCompareVector(t *testing.T) {
 								}]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected timestamp 1 but got 2`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected timestamp 1 but got 2`),
 		},
 		{
 			name: "difference in histogram sample count",
@@ -743,7 +743,7 @@ func TestCompareVector(t *testing.T) {
 								}]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected count 2 for timestamp 1 but got 5`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected count 2 for timestamp 1 but got 5`),
 		},
 		{
 			name: "difference in histogram sample sum",
@@ -771,7 +771,7 @@ func TestCompareVector(t *testing.T) {
 								}]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected sum 3 for timestamp 1 but got 5`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected sum 3 for timestamp 1 but got 5`),
 		},
 		{
 			name: "difference in histogram sample buckets length",
@@ -800,7 +800,7 @@ func TestCompareVector(t *testing.T) {
 								}]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):2 [2,4):2]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):2 [2,4):2]`),
 		},
 		{
 			name: "difference in histogram sample buckets boundaries",
@@ -828,7 +828,7 @@ func TestCompareVector(t *testing.T) {
 								}]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [(0,2):2]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [(0,2):2]`),
 		},
 		{
 			name: "difference in histogram sample buckets lower boundary",
@@ -856,7 +856,7 @@ func TestCompareVector(t *testing.T) {
 								}]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[1,2):2]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[1,2):2]`),
 		},
 		{
 			name: "difference in histogram sample buckets upper boundary",
@@ -884,7 +884,7 @@ func TestCompareVector(t *testing.T) {
 								}]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,3):2]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,3):2]`),
 		},
 		{
 			name: "difference in histogram sample buckets count",
@@ -912,7 +912,7 @@ func TestCompareVector(t *testing.T) {
 								}]
 							}
 						]`),
-			err: errors.New(`histogram sample pair not matching for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):3]`),
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):3]`),
 		},
 		{
 			name: "actual histogram value matches expected",
@@ -1166,7 +1166,7 @@ func TestCompareSamplesResponse(t *testing.T) {
 							"status": "success",
 							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[1,"773054.789"]}]}
 						}`),
-			err: errors.New(`float sample pair not matching for metric {foo="bar"}: expected value 773054.5916666666 for timestamp 1 but got 773054.789`),
+			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected value 773054.5916666666 for timestamp 1 but got 773054.789`),
 		},
 		{
 			name:      "should fail if large values are significantly different, over the tolerance without using relative error",
@@ -1179,7 +1179,7 @@ func TestCompareSamplesResponse(t *testing.T) {
 							"status": "success",
 							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[1,"4.923488536785281e+41"]}]}
 						}`),
-			err: errors.New(`float sample pair not matching for metric {foo="bar"}: expected value 492348853678528200000000000000000000000000 for timestamp 1 but got 492348853678528100000000000000000000000000`),
+			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected value 492348853678528200000000000000000000000000 for timestamp 1 but got 492348853678528100000000000000000000000000`),
 		},
 		{
 			name:      "should not fail if large values are significantly different, over the tolerance using relative error",

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -1255,8 +1255,8 @@ func TestCompareSamplesResponse(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			samplesComparator := NewSamplesComparator(SampleComparisonOptions{
-				Tolerance:         float64(tc.tolerance),
-				UseRelativeError:  bool(tc.useRelativeError),
+				Tolerance:         tc.tolerance,
+				UseRelativeError:  tc.useRelativeError,
 				SkipRecentSamples: tc.skipRecentSamples,
 			})
 			result, err := samplesComparator.Compare(tc.expected, tc.actual)


### PR DESCRIPTION
#### What this PR does

This PR adds support for comparing native histograms in query results to query-tee.

Previously, any native histograms in query results were ignored.

I've also taken this opportunity to clarify some of the error messages generated when results do not match, and to replace the use of `errors.Wrap` with `fmt.Errorf` in `response_comparator.go`.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
