### PR TITLE
Use github.com/okzk/sdnotify fork to unblock upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * [ENHANCEMENT] Query-frontend: added `remote_read` to `op` supported label values for the `cortex_query_frontend_queries_total` metric. #8412
 * [ENHANCEMENT] Query-frontend: log the overall length and start, end time offset from current time for remote read requests. The start and end times are calculated as the miminum and maximum times of the individual queries in the remote read request. #8404
 * [ENHANCEMENT] Storage Provider: Added option `-<prefix>.s3.dualstack-enabled` that allows disabling S3 client from resolving AWS S3 endpoint into dual-stack IPv4/IPv6 endpoint. Defaults to true. #8405
-* [ENHANCEMENT] Use sd_notify to send events to systemd at start and stop of mimir services. Default systemd mimir.service config now wait for those events with a configurable timeout `TimeoutStartSec` default is 3 min to handle long start time (ex. store-gateway). #8220 #8555 #8658
+* [ENHANCEMENT] Use sd_notify to send events to systemd at start and stop of mimir services. Default systemd mimir.service config now waits for those events with a configurable timeout `TimeoutStartSec`. The default is 3 min to handle long start time (ex. store-gateway). #8541 #8555 #8658 #8728
 * [ENHANCEMENT] Alertmanager: Reloading config and templates no longer needs to hit the disk. #4967
 * [ENHANCEMENT] Compactor: Added experimantal `-compactor.in-memory-tenant-meta-cache-size` option to set size of in-memory cache (in number of items) for parsed meta.json files. This can help when tenant has many meta.json files and their parsing before each compaction cycle is using a lot of CPU time. #8544
 * [ENHANCEMENT] Distributor: Interrupt OTLP write request translation when context is canceled or has timed out. #8524

--- a/go.mod
+++ b/go.mod
@@ -308,3 +308,6 @@ replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-aler
 
 // Replace kadm with a fork until https://github.com/twmb/franz-go/pull/775 is merged
 replace github.com/twmb/franz-go/pkg/kadm => github.com/pracucci/franz-go/pkg/kadm v0.0.0-20240711165048-831cca07c9a4
+
+// Replace sdnotify with a fork until https://github.com/okzk/sdnotify/pull/4 is merged
+replace github.com/okzk/sdnotify => github.com/grafana/sdnotify v0.0.0-20240715085559-af3a9782f811

--- a/go.sum
+++ b/go.sum
@@ -535,6 +535,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvF
 github.com/grafana/pyroscope-go/godeltaprof v0.1.6/go.mod h1:Tk376Nbldo4Cha9RgiU7ik8WKFkNpfds98aUzS8omLE=
 github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b h1:oMAq12GxTpwo9jxbnG/M4F/HdpwbibTaVoxNA0NZprY=
 github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
+github.com/grafana/sdnotify v0.0.0-20240715085559-af3a9782f811 h1:WU7qn1eruGFe2pcJqQFMxX+iXVt0dTpZz54wHD2m8lQ=
+github.com/grafana/sdnotify v0.0.0-20240715085559-af3a9782f811/go.mod h1:5g2fs20CVjVF/HgdbTTmZMJiI59yNXD/9EiSnYY+2Q8=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
@@ -768,8 +770,6 @@ github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd h1:+iAPaTbi1gZpcpDwe/BW1fx7Xoesv69hLNGPheoyhBs=
-github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd/go.mod h1:4soZNh0zW0LtYGdQ416i0jO0EIqMGcbtaspRS4BDvRQ=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=

--- a/vendor/github.com/okzk/sdnotify/notify.go
+++ b/vendor/github.com/okzk/sdnotify/notify.go
@@ -2,6 +2,11 @@
 
 package sdnotify
 
+
+func Reloading() error {
+	return nil
+}
+
 // SdNotify sends a specified string to the systemd notification socket.
 func SdNotify(state string) error {
 	// do nothing

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -877,7 +877,7 @@ github.com/oklog/run
 # github.com/oklog/ulid v1.3.1
 ## explicit
 github.com/oklog/ulid
-# github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
+# github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd => github.com/grafana/sdnotify v0.0.0-20240715085559-af3a9782f811
 ## explicit
 github.com/okzk/sdnotify
 # github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f
@@ -1655,3 +1655,4 @@ sigs.k8s.io/yaml/goyaml.v3
 # github.com/opentracing-contrib/go-grpc => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f
 # github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240625192351-66ec17e3aa45
 # github.com/twmb/franz-go/pkg/kadm => github.com/pracucci/franz-go/pkg/kadm v0.0.0-20240711165048-831cca07c9a4
+# github.com/okzk/sdnotify => github.com/grafana/sdnotify v0.0.0-20240715085559-af3a9782f811


### PR DESCRIPTION
#### What this PR does
The latest revision of github.com/okzk/sdnotify fails to build for us, since it depends on CGo. The revision changes a function we don't use, i.e. `Reloading`, but it's all the same a hassle that automatic updating of the dependency fails. I've submitted a [PR](https://github.com/okzk/sdnotify/pull/4) to sdnotify to drop the CGo dependency, in the meantime I propose we use my fork.

Also fixing the changelog entry to refer to the original PR, instead of the corresponding issue.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
