### PR TITLE
helm: Fix predictive querier scaling name conflict

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -35,6 +35,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add missing fields in multiple topology spread constraints. #8533
 * [ENHANCEMENT] Add support for setting the image pull secrets, node selectors, tolerations and topology spread constraints for the Grafana Agent pods used for metamonitoring. #8670
 * [BUGFIX] Add missing container security context to run `continuous-test` under the restricted security policy. #8653
+* [BUGFIX] Fix helm releases failing when `querier.kedaAutoscaling.predictiveScalingEnabled=true`. [#8730](https://github.com/grafana/mimir/issues/8730)
 
 ## 5.4.0
 

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-so.yaml
@@ -53,7 +53,7 @@ spec:
       {{- if .Values.kedaAutoscaling.customHeaders }}
       customHeaders: {{ (include "mimir.lib.mapToCSVString" (dict "map" .Values.kedaAutoscaling.customHeaders)) | quote }}
       {{- end }}
-    name: cortex_querier_hpa_default
+    name: cortex_querier_hpa_default_predictive
     type: prometheus
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Fixes naming conflict for predictive querier autoscaling by changing the name of the predictive policy. 

#### Which issue(s) this PR fixes or relates to

Fixes #8730 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
