### PR TITLE
Fetch records concurrently with benchmarks

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -586,6 +586,8 @@ func (b *BlockBuilder) consumePartition(
 				loopDone = true
 			}
 		})
+
+		b.kafkaClient.AllowRebalance()
 	}
 
 	close(recsC)

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -5,7 +5,6 @@ package blockbuilder
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -474,7 +473,6 @@ func TestBlockBuilder_StartupWithExistingCommit(t *testing.T) {
 	)
 }
 
-// Testing block builder starting up with an existing kafka commit.
 func BenchmarkBlockBuilder(b *testing.B) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	b.Cleanup(func() { cancel(errors.New("test done")) })
@@ -506,14 +504,11 @@ func BenchmarkBlockBuilder(b *testing.B) {
 		return testBuilder
 	}
 
-	// It was difficult to reliably get the time taken to consume the records and produce a block
-	// by using b.ResetTimer. So for now, printing the required time to analyse.
-	// TODO(codesome): figure out how we can get the required numbers without prints.
 	require.NoError(b, bb.starting(ctx))
-	start := time.Now()
+	b.ResetTimer()
 	require.NoError(b, bb.NextConsumeCycle(ctx, cycleEnd))
 	<-compactCalled
-	fmt.Println("Time taken to consume samples:", time.Since(start))
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds()), "ns/op")
 	require.NoError(b, bb.stopping(nil))
 }
 


### PR DESCRIPTION
A quick change to see if we make fetching records and processing them concurrent, do we see any gains. I wrote a quick benchmark, and the numbers vary greatly with different number of records/samples/series. With the benchmark as is, I see ~16% gains.

Although https://github.com/grafana/mimir/pull/8711 is underway, it will be nice to try this out in the meantime.

```
benchmark                    old ns/op      new ns/op      delta
BenchmarkBlockBuilder-10     3157905625     2640359666     -16.39%
```