### PR TITLE
add read write values to continous-test

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -50,7 +50,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Helm : allow setting a read and write urls to continous-test. #7674
 
 
-## 5.4.0-rc.0
+## 5.4.0
 
 * [FEATURE] Add support for a dedicated query path for the ruler. This allows for the isolation of ruler and user query paths. Enable it via `ruler.remoteEvaluationDedicatedQueryPath: true`. #7964
 * [CHANGE] Fine-tuned `terminationGracePeriodSeconds` for the following components: #7361 #7364

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -44,10 +44,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add support for setting resource requests and limits in the Grafana Agent pods used for metamonitoring. #8715
 * [ENHANCEMENT] Add support for setting namespace for dashboard config maps. #8813
 * [ENHANCEMENT] Add support for string `extraObjects` for better support with templating. #8825
+* [ENHANCEMENT] Helm : allow setting a read and write urls to continous-test. #7674
 * [BUGFIX] Add missing container security context to run `continuous-test` under the restricted security policy. #8653
 * [BUGFIX] Add `global.extraVolumeMounts` to the exporter container on memcached statefulsets #8787
 * [BUGFIX] Fix helm releases failing when `querier.kedaAutoscaling.predictiveScalingEnabled=true`. #8731
-* [ENHANCEMENT] Helm : allow setting a read and write urls to continous-test. #7674
 
 
 ## 5.4.0

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -47,8 +47,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Add missing container security context to run `continuous-test` under the restricted security policy. #8653
 * [BUGFIX] Add `global.extraVolumeMounts` to the exporter container on memcached statefulsets #8787
 * [BUGFIX] Fix helm releases failing when `querier.kedaAutoscaling.predictiveScalingEnabled=true`. #8731
+* [ENHANCEMENT] Helm : allow setting a read and write urls to continous-test. #7674
 
-## 5.4.0
+
+## 5.4.0-rc.0
 
 * [FEATURE] Add support for a dedicated query path for the ruler. This allows for the isolation of ruler and user query paths. Enable it via `ruler.remoteEvaluationDedicatedQueryPath: true`. #7964
 * [CHANGE] Fine-tuned `terminationGracePeriodSeconds` for the following components: #7361 #7364

--- a/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
@@ -49,8 +49,8 @@ spec:
             - "-server.http-listen-port={{ include "mimir.serverHttpListenPort" . }}"
             - "-tests.write-read-series-test.num-series={{ .Values.continuous_test.numSeries }}"
             - "-tests.write-read-series-test.max-query-age={{ .Values.continuous_test.maxQueryAge }}"
-            - "-tests.write-endpoint={{ template "mimir.gatewayUrl" . }}"
-            - "-tests.read-endpoint={{ template "mimir.gatewayUrl" . }}/prometheus"
+            - "-tests.write-endpoint={{ default (include "mimir.gatewayUrl" .) .Values.continuous_test.write }}"
+            - "-tests.read-endpoint={{ default (include "mimir.gatewayUrl" .) .Values.continuous_test.read }}/prometheus"
             - "-tests.run-interval={{ .Values.continuous_test.runInterval }}"
             {{- if eq .Values.continuous_test.auth.type "tenantId" }}
             - "-tests.tenant-id={{ .Values.continuous_test.auth.tenant }}"

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4381,7 +4381,10 @@ continuous_test:
   replicas: 1
   # The image section has been removed as continuous test is now a module of the regular Mimir image.
   # See settings for the image at the top image section.
-
+  ## -- Mimir Write Endpoint if not set, its will be set to mimir.gatewayUrl
+  write:
+  # -- Mimir Read Endpoint if not set, its will be set to mimir.gatewayUrl at /prometheus
+  read:
   # -- Authentication settings of continuous test
   auth:
     # -- Type of authentication to use (tenantId, basicAuth, bearerToken)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

allows setting a read and write URLs for continous-test, i recently deployed it in my org and since we dont use the gateway i had to hack it with extraArgs

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
