### PR TITLE
Use latest writers toolkit link conventions

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Determine Mimir version targeted by Helm chart documentation
       id: mimir_version
       run: |
-        MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_DOCS_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
+        MIMIR_VERSION=$(sed -ne '/^---$/,/^---$/{ s/^ *MIMIR_VERSION: "\([^"]\{1,\}\)"/\1/p; }' docs/sources/helm-charts/mimir-distributed/_index.md)
         echo "version=${MIMIR_VERSION}" | tee "${GITHUB_OUTPUT}"
     - name: Determine Mimir branch for targeted version
       id: mimir_branch

--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -8,17 +8,13 @@ keywords:
   - Grafana Enterprise Metrics
   - Grafana metrics
 cascade:
-  MIMIR_DOCS_VERSION: "v2.13.x"
-  gem_docs_version: "v2.13.x"
-refs:
-  grafana-mimir:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/
+  MIMIR_VERSION: "v2.13.x"
+  GEM_VERSION: "v2.13.x"
 ---
 
 # Grafana mimir-distributed Helm chart documentation
 
-The mimir-distributed Helm chart for [Grafana Mimir] and [Grafana Enterprise Metrics](/docs/enterprise-metrics/{{< param "gem_docs_version" >}}/) (GEM) allows you to configure, install, and upgrade Grafana Mimir or Grafana Enterprise Metrics within a Kubernetes cluster.
+The mimir-distributed Helm chart for [Grafana Mimir](https://grafana.com/docs/mimir/<MIMIR_VERSION>/) and [Grafana Enterprise Metrics](https://grafana.com/docs/enterprise-metrics/<GEM_VERSION>/) (GEM) allows you to configure, install, and upgrade Grafana Mimir or Grafana Enterprise Metrics within a Kubernetes cluster.
 
 > **Note:** By default, the mimir-distributed Helm chart documentation applies to both Grafana Mimir and GEM. If it only applies to GEM, it is explicitly stated.
 

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-grafana-enterprise-metrics.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-grafana-enterprise-metrics.md
@@ -14,11 +14,11 @@ From the Grafana Helm chart point of view, the main differences between Grafana 
 
 ## Before you begin
 
-- Follow the instructions and [Choose a name for your GEM cluster](/docs/enterprise-metrics/{{< param "gem_docs_version" >}}/setup/#choose-a-name-for-your-gem-cluster).
+- Follow the instructions and [Choose a name for your GEM cluster](https://grafana.com/docs/enterprise-metrics/<GEM_VERSION>/setup/#choose-a-name-for-your-gem-cluster).
 
   It is recommended, but not required to use the same name as the Helm release. For example if the cluster name is `mygem`, you'd install the chart with `helm install mygem grafana/mimir-distributed`.
 
-- Follow the instruction in [Get a GEM license](/docs/enterprise-metrics/{{< param "gem_docs_version" >}}/setup/#get-a-gem-license) to acquire a license.
+- Follow the instruction in [Get a GEM license](https://grafana.com/docs/enterprise-metrics/<GEM_VERSION>/setup/#get-a-gem-license) to acquire a license.
 
 ## Handling the license file
 

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-hashicorp-vault-agent.md
@@ -2,10 +2,6 @@
 title: "Configure Grafana Mimir to allow Vault Agent to inject certificates and keys into Pods"
 menuTitle: "Vault Agent"
 description: "Learn how to configure Grafana Mimir to receive client and server certificates and keys via Hashicorp Vault Agent"
-refs:
-  securing-grafana-mimir-communications-with-tls:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/secure/securing-communications-with-tls/
 ---
 
 # Configure Grafana Mimir to allow Vault Agent to inject certificates and keys into Pods
@@ -69,4 +65,4 @@ spec:
 
 For more information about Vault and Vault Agent, see [Injecting Vault Secrets Into Kubernetes Pods via a Sidecar](https://www.hashicorp.com/blog/injecting-vault-secrets-into-kubernetes-pods-via-a-sidecar).
 
-To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS].
+To configure TLS in Mimir, refer to [Securing Grafana Mimir communications with TLS](https://grafana.com/docs/mimir/<MIMIR_VERSION>/manage/secure/securing-communications-with-tls/).

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-native-histograms-ingestion.md
@@ -2,29 +2,13 @@
 title: "Configure native histograms"
 menuTitle: "Native histograms"
 description: "Learn how to configure Grafana Mimir to ingest and query native histograms."
-refs:
-  remote-write-api:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/http-api/#remote-write
-  visualize-native-histograms:
-    - pattern: /
-      destination: https://grafana.com/docs/mimir/<MIMIR_DOCS_VERSION>/visualize/native-histograms/
-  configure-native-histograms:
-    - pattern: /
-      destination: https://grafana.com/docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-native-histograms-ingestion/
-  send-native-histograms-to-mimir:
-    - pattern: /
-      destination: https://grafana.com/docs/mimir/<MIMIR_DOCS_VERSION>/send/native-histograms/
-  grafana-mimir-query-sharding:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/query-sharding/
 ---
 
 # Configure native histograms
 
-To enable support for ingesting Prometheus native histograms over the [remote write API] endpoint, set the configuration parameter `native_histograms_ingestion_enabled` to true.
+To enable support for ingesting Prometheus native histograms over the [remote write API](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/http-api/#remote-write) endpoint, set the configuration parameter `native_histograms_ingestion_enabled` to true.
 
-To enable support for querying native histograms together with [Grafana Mimir query sharding], set the configuration parameter `query_result_response_format` to `protobuf`.
+To enable support for querying native histograms together with [Grafana Mimir query sharding](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/query-sharding/), set the configuration parameter `query_result_response_format` to `protobuf`.
 
 Example values file:
 
@@ -41,8 +25,8 @@ mimir:
 Native histograms is an experimental feature of Grafana Mimir.
 {{% /admonition %}}
 
-To configure bucket limits for native histograms, refer to [Configure native histograms].
+To configure bucket limits for native histograms, refer to [Configure native histograms](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-native-histograms-ingestion/).
 
-To configure Grafana Agent or Prometheus to write native histograms to Grafana Mimir, refer to [Send native histograms to Mimir].
+To configure Grafana Agent or Prometheus to write native histograms to Grafana Mimir, refer to [Send native histograms to Mimir](https://grafana.com/docs/mimir/<MIMIR_VERSION>/send/native-histograms/).
 
-To visualize native histograms in Mimir, refer to [Visualize native histograms].
+To visualize native histograms in Mimir, refer to [Visualize native histograms](https://grafana.com/docs/mimir/<MIMIR_VERSION>/visualize/native-histograms/).

--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
@@ -2,10 +2,6 @@
 title: "Configure Redis cache"
 menuTitle: "Redis cache"
 description: "Learn how to configure Grafana Mimir to use external Redis as cache"
-refs:
-  the-configuration-parameters-reference:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configuration-parameters/#redis
 ---
 
 # Configure Redis cache
@@ -25,7 +21,7 @@ results-cache:
   enabled: false
 ```
 
-Next, configure Mimir to connect to Redis using `structuredConfig`. Refer to [the configuration parameters reference] for Redis connection configuration options. For example:
+Next, configure Mimir to connect to Redis using `structuredConfig`. Refer to [the configuration parameters reference](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configuration-parameters/#redis) for Redis connection configuration options. For example:
 
 ```yaml
 mimir:

--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-from-single-zone-with-helm.md
@@ -3,29 +3,13 @@ title: "Migrate from single zone to zone-aware replication in Mimir Helm chart v
 menuTitle: "Migrate from single zone to zone-aware replication in Mimir Helm chart version 4.0"
 description: "Learn how to migrate from having a single availability zone to full zone-aware replication using the Grafana Mimir Helm chart"
 weight: 10
-refs:
-  shuffle-sharding:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-shuffle-sharding/
-  store-gateway:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/store-gateway/
-  alertmanager:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/alertmanager/
-  ingester:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/ingester/
-  zone-aware-replication:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-zone-aware-replication/
 ---
 
 # Migrate from single zone to zone-aware replication in Mimir Helm chart version 4.0
 
 The `mimir-distributed` Helm chart version 4.0 enables zone-aware replication by default. This is a breaking change for existing installations and requires a migration.
 
-This document explains how to migrate stateful components from single zone to [zone-aware replication] with Helm. The three components in question are the [alertmanager], the [store-gateway] and the [ingester].
+This document explains how to migrate stateful components from single zone to [zone-aware replication](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-zone-aware-replication/) with Helm. The three components in question are the [alertmanager](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/components/alertmanager/), the [store-gateway](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/components/store-gateway/) and the [ingester](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/components/ingester/).
 
 The migration path of Alertmanager and store-gateway is straight forward, however migrating ingesters is more complicated.
 
@@ -628,7 +612,7 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    1. If the current `<N>` above in `ingester.zoneAwareReplication.migration.replicas` is less than `ingester.replicas`, go back and increase `<N>` with at most 21 and repeat these four steps.
 
-1. If you are using [shuffle sharding], it must be turned off on the read path at this point.
+1. If you are using [shuffle sharding](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-shuffle-sharding/), it must be turned off on the read path at this point.
 
    1. Update your configuration with these values and keep them until otherwise instructed.
 
@@ -778,7 +762,7 @@ Before starting this procedure, set up your zones according to [Configure zone-a
 
    The 3 hours is calculated from 2h TSDB block range period + `blocks_storage.tsdb.head_compaction_idle_timeout` Grafana Mimir parameters to give enough time for ingesters to remove stale series from memory. Stale series will be there due to series being moved between ingesters.
 
-1. If you are using [shuffle sharding]:
+1. If you are using [shuffle sharding](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-shuffle-sharding/):
 
    1. Wait an extra 12 hours.
 

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/_index.md
@@ -6,28 +6,6 @@ aliases:
 menuTitle: "Run Mimir in production"
 description: "Learn how to run Grafana Mimir in production using the mimir-distributed Helm chart."
 weight: 40
-refs:
-  ingesters-failure-and-data-loss:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/ingester/#ingesters-failure-and-data-loss
-  collecting-metrics-and-logs-from-grafana-mimir:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs/
-  planning-grafana-mimir-capacity:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/run-production-environment/planning-capacity/
-  configure-grafana-mimir-object-storage-backend:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-object-storage-backend/
-  replication-across-availability-zones:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-zone-aware-replication/
-  installing-grafana-mimir-dashboards-and-alerts:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts/
-  store-gateway:-blocks-sharding-and-replication:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/store-gateway/#blocks-sharding-and-replication
 ---
 
 # Run Grafana Mimir in production using the Helm chart
@@ -84,7 +62,7 @@ usage patterns. Therefore, use the sizing plans as starting
 point for sizing your Grafana Mimir cluster, rather than as strict guidelines.
 To get a better idea of how to plan capacity, refer to the YAML comments at
 the beginning of `small.yaml` and `large.yaml` files, which relate to read and write workloads.
-See also [Planning Grafana Mimir capacity].
+See also [Planning Grafana Mimir capacity](https://grafana.com/docs/mimir/<MIMIR_VERSION>/manage/run-production-environment/planning-capacity/).
 
 To use a sizing plan, copy it from the [mimir](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed)
 GitHub repository, and pass it as a values file to the `helm` command. Note that sizing plans may change with new
@@ -113,8 +91,8 @@ number_of_nodes >= max(number_of_ingesters_pods, number_of_store_gateway_pods)
 ```
 
 For more information about the failure modes of either the ingester or store-gateway
-component, refer to [Ingesters failure and data loss]
-or [Store-gateway: Blocks sharding and replication].
+component, refer to [Ingesters failure and data loss](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/components/ingester/#ingesters-failure-and-data-loss)
+or [Store-gateway: Blocks sharding and replication](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/components/store-gateway/#blocks-sharding-and-replication).
 
 ## Decide whether you need geographical redundancy, fast rolling updates, or both.
 
@@ -127,7 +105,7 @@ configure the Helm chart to deploy Grafana Mimir with zone-aware replication.
 
 ### New installations
 
-Grafana Mimir supports [replication across availability zones]
+Grafana Mimir supports [replication across availability zones](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-zone-aware-replication/)
 within your Kubernetes cluster.
 This further increases fault tolerance of the Mimir cluster. Even if you
 do not currently have multiple zones across your Kubernetes cluster, you
@@ -182,7 +160,7 @@ zone-aware replication.
 ## Configure Mimir to use object storage
 
 For the different object storage types that Mimir supports, and examples,
-see [Configure Grafana Mimir object storage backend].
+see [Configure Grafana Mimir object storage backend](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-object-storage-backend/).
 
 1. Add the following YAML to your values file, if you are not using the sizing
    plans that are mentioned in [Plan capacity](#plan-capacity):

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configuration-with-helm.md
@@ -6,15 +6,11 @@ weight: 80
 aliases:
   - docs/mimir/latest/operators-guide/run-production-environment-with-helm/configuration-with-helm
   - docs/mimir/latest/operators-guide/running-production-environment-with-helm/configuration-with-helm
-refs:
-  configuration-parameters:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configuration-parameters/
 ---
 
 # Manage the configuration of Grafana Mimir with Helm
 
-The `mimir-distributed` Helm chart provides interfaces to set Grafana Mimir [configuration parameters] and customize how Grafana Mimir is deployed on a Kubernetes cluster. This document describes the configuration parameters.
+The `mimir-distributed` Helm chart provides interfaces to set Grafana Mimir [configuration parameters](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configuration-parameters/) and customize how Grafana Mimir is deployed on a Kubernetes cluster. This document describes the configuration parameters.
 
 ## Overview
 

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/configure-helm-ha-deduplication-consul/index.md
@@ -9,25 +9,18 @@ title:
   Configuring Grafana Mimir-Distributed Helm Chart for high-availability deduplication
   with Consul
 weight: 70
-refs:
-  distributor:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/references/architecture/components/distributor/
-  configure-high-availability:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/configure/configure-high-availability-deduplication/
 ---
 
 # Configuring Grafana Mimir-Distributed Helm Chart for high-availability deduplication with Consul
 
 Grafana Mimir can deduplicate data from a high-availability (HA) Prometheus setup. You can configure
-the deduplication by using the Grafana Mimir helm chart deployment that uses external Consul. For more information, see [Configure high availability].
+the deduplication by using the Grafana Mimir helm chart deployment that uses external Consul. For more information, see [Configure high availability](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-high-availability-deduplication/).
 
 ## Before you begin
 
 You need to have a Grafana Mimir installed via the mimir-distributed Helm chart.
 
-For conceptual information about how Mimir deduplicates incoming HA samples, refer to [Configure high availability].
+For conceptual information about how Mimir deduplicates incoming HA samples, refer to [Configure high availability](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-high-availability-deduplication/).
 
 You also need to configure HA for Prometheus or Grafana Agent. Lastly, you need a key-value store such as Consul KV.
 
@@ -49,7 +42,7 @@ global:
 
 Reload or restart Prometheus or Grafana Agent after you update the configuration.
 
-> **Note:** [Configure high availability].
+> **Note:** [Configure high availability](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-high-availability-deduplication/).
 > document contains the same information on Prometheus setup for HA dedup.
 
 ## Install Consul using Helm
@@ -158,7 +151,7 @@ If the table is empty, it means there is something wrong with the configuration.
 
 If you have set up [metamonitoring]({{< relref "../monitor-system-health.md" >}}) or if you
 run GEM with built-in system monitoring,
-Mimir [distributor]
+Mimir [distributor](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/components/distributor/)
 exposes some metrics related to HA deduplication. The relevant metrics are those with `cortex_ha_tracker_` prefix.
 
 ### Ensure HA metrics are deduplicated

--- a/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
+++ b/docs/sources/helm-charts/mimir-distributed/run-production-environment-with-helm/monitor-system-health.md
@@ -5,13 +5,6 @@ description: Learn how to collect metrics and logs from Grafana Mimir or GEM its
 menuTitle: Monitor system health
 title: Monitor the health of your system
 weight: 60
-refs:
-  collect-metrics-and-logs-without-the-helm-chart:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-without-the-helm-chart
-  installing-grafana-mimir-dashboards-and-alerts:
-    - pattern: /
-      destination: /docs/mimir/<MIMIR_DOCS_VERSION>/manage/monitor-grafana-mimir/installing-dashboards-and-alerts/
 ---
 
 # Monitor the health of your system
@@ -34,10 +27,10 @@ The Helm chart does not collect Prometheus node_exporter metrics;
 metrics from node_exporter must all have an instance label on them
 that has the same value as the instance label on Mimir metrics.
 For the list of necessary node_exporter metrics see the metrics
-prefixed with `node` in [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mimir/#metrics).
+prefixed with `node` in [Grafana Cloud: Self-hosted Grafana Mimir integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mimir/#metrics).
 
 You can configure your collection of metrics and logs
-by using the [Grafana Agent operator](/docs/agent/latest/operator/).
+by using the [Grafana Agent operator](https://grafana.com/docs/agent/latest/operator/).
 The Helm chart can install and use the Grafana Agent operator.
 
 > **Note:** Before the Helm chart can use the operator,
@@ -150,4 +143,4 @@ metaMonitoring:
 
 To monitor the health of your system without using the Helm chart, see [Collect metrics and logs without the Helm chart](https://grafana.com/docs/mimir/<MIMIR_VERSION>/manage/monitor-grafana-mimir/collecting-metrics-and-logs/#collect-metrics-and-logs-without-the-helm-chart).
 
-You can also use the self-hosted Grafana Cloud integration to monitor your Mimir system. Refer to [Grafana Cloud: Self-hosted Grafana Mimir integration](/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mimir/) for more information.
+You can also use the self-hosted Grafana Cloud integration to monitor your Mimir system. Refer to [Grafana Cloud: Self-hosted Grafana Mimir integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mimir/) for more information.

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,6 +1,6 @@
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 
-MIMIR_DOCS_VERSION := $(shell sed -n 's, *MIMIR_DOCS_VERSION: "\([^"]*\)",\1,p' "$(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md")
+MIMIR_DOCS_VERSION := $(shell sed -n 's, *MIMIR_VERSION: "\([^"]*\)",\1,p' "$(GIT_ROOT)/docs/sources/helm-charts/mimir-distributed/_index.md")
 ifeq ($(MIMIR_DOCS_VERSION),next)
 MIMIR_DOCS_BRANCH := main
 else

--- a/operations/helm/charts/mimir-distributed/RELEASE.md
+++ b/operations/helm/charts/mimir-distributed/RELEASE.md
@@ -89,7 +89,7 @@ Weekly releases have the version `x.y.z-weekly.w`, for example `3.1.0-weekly.196
 
    - Update the Mimir and GEM documentation version parameters in [\_index.md](https://github.com/grafana/mimir/blob/main/docs/sources/helm-charts/mimir-distributed/_index.md)
 
-     The two parameters are `MIMIR_DOCS_VERSION` and `gem_docs_version`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
+     The two parameters are `MIMIR_VERSION` and `GEM_VERSION`. With the exception of the release notes, the Helm chart documentation should refer to the documentation or Mimir and GEM that is actually included in the Helm chart.
 
    - From the root directory of the repository, run `make doc` to update [README.md](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/README.md) file.
 


### PR DESCRIPTION
#### What this PR does

Use the latest writer's toolkit recommended link syntax in the helm chart docs: https://grafana.com/docs/writers-toolkit/write/links/#link-to-grafanacom-pages

Replaces the special parameter MIMIR_DOCS_VERSION that we introduced for this purpose. The new method cannot verify the links anymore in CI, but there's a daily check in the common docs repo that does that - which also includes the enterprise docs as well!

#### Which issue(s) this PR fixes or relates to

Fixes: #8744

#### Checklist

- N/A Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
