### PR TITLE
mixin: show all series in dashboard panel tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [ENHANCEMENT] Dashboards: improve end-to-end latency and strong read consistency panels when experimental ingest storage is enabled. #8543
 * [ENHANCEMENT] Dashboards: Add panels for monitoring ingester autoscaling when not using ingest-storage. These panels are disabled by default, but can be enabled using the `autoscaling.ingester.enabled: true` config option. #8484
 * [ENHANCEMENT] Dashboards: add panels to show writes to experimental ingest storage backend in the "Mimir / Ruler" dashboard, when `_config.show_ingest_storage_panels` is enabled. #8732
+* [ENHANCEMENT] Dashboards: show all series in tooltips on time series dashboard panels. #8748
 * [BUGFIX] Dashboards: fix "current replicas" in autoscaling panels when HPA is not active. #8566
 * [BUGFIX] Alerts: do not fire `MimirRingMembersMismatch` during the migration to experimental ingest storage. #8727
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -364,7 +364,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -412,7 +412,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -472,7 +472,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -520,7 +520,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -583,7 +583,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1168,7 +1168,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1217,7 +1217,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1320,7 +1320,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1386,7 +1386,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1477,7 +1477,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1531,7 +1531,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1586,7 +1586,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1676,7 +1676,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1709,7 +1709,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1758,7 +1758,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1837,7 +1837,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -1928,7 +1928,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2007,7 +2007,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2086,7 +2086,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2165,7 +2165,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2255,7 +2255,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2303,7 +2303,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2351,7 +2351,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2442,7 +2442,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2496,7 +2496,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2544,7 +2544,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2604,7 +2604,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2654,7 +2654,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2766,7 +2766,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2865,7 +2865,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -2950,7 +2950,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -3035,7 +3035,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -3660,7 +3660,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -3708,7 +3708,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -3768,7 +3768,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -3816,7 +3816,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -3867,7 +3867,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -4128,7 +4128,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -4173,7 +4173,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -4509,7 +4509,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -4631,7 +4631,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -4680,7 +4680,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -4730,7 +4730,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -4820,7 +4820,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -4869,7 +4869,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -4929,7 +4929,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5008,7 +5008,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5105,7 +5105,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5160,7 +5160,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5250,7 +5250,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5283,7 +5283,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5332,7 +5332,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5411,7 +5411,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5502,7 +5502,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5581,7 +5581,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5660,7 +5660,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5739,7 +5739,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -5965,7 +5965,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6014,7 +6014,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6258,7 +6258,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6318,7 +6318,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6532,7 +6532,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6565,7 +6565,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6625,7 +6625,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6658,7 +6658,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6719,7 +6719,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6798,7 +6798,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6877,7 +6877,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -6968,7 +6968,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -7047,7 +7047,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -7126,7 +7126,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -7652,7 +7652,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -7700,7 +7700,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -7751,7 +7751,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -7809,7 +7809,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -7881,7 +7881,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -7929,7 +7929,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -7980,7 +7980,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8038,7 +8038,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8110,7 +8110,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8158,7 +8158,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8209,7 +8209,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8267,7 +8267,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8491,7 +8491,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8539,7 +8539,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8647,7 +8647,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8695,7 +8695,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8746,7 +8746,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8806,7 +8806,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8854,7 +8854,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -8962,7 +8962,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -9010,7 +9010,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -9118,7 +9118,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -9166,7 +9166,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -9217,7 +9217,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -9724,7 +9724,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -9779,7 +9779,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -9857,7 +9857,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -10070,7 +10070,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -10125,7 +10125,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -10413,7 +10413,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -10531,7 +10531,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -10591,7 +10591,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -10670,7 +10670,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -10778,7 +10778,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -10832,7 +10832,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -10910,7 +10910,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11154,7 +11154,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11233,7 +11233,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11311,7 +11311,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11360,7 +11360,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11421,7 +11421,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11499,7 +11499,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11548,7 +11548,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11609,7 +11609,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11658,7 +11658,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11708,7 +11708,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11770,7 +11770,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11820,7 +11820,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11911,7 +11911,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -11972,7 +11972,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12033,7 +12033,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12106,7 +12106,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12185,7 +12185,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12281,7 +12281,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12331,7 +12331,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12391,7 +12391,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12482,7 +12482,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12537,7 +12537,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12627,7 +12627,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12675,7 +12675,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12723,7 +12723,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12881,7 +12881,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -12942,7 +12942,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13021,7 +13021,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13106,7 +13106,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13172,7 +13172,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13221,7 +13221,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13301,7 +13301,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13392,7 +13392,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13441,7 +13441,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13490,7 +13490,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13704,7 +13704,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13752,7 +13752,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13803,7 +13803,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13861,7 +13861,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13933,7 +13933,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -13981,7 +13981,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14032,7 +14032,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14090,7 +14090,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14162,7 +14162,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14210,7 +14210,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14261,7 +14261,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14319,7 +14319,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14391,7 +14391,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14439,7 +14439,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14490,7 +14490,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14548,7 +14548,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14620,7 +14620,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14668,7 +14668,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14719,7 +14719,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14777,7 +14777,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14849,7 +14849,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14897,7 +14897,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -14948,7 +14948,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -15006,7 +15006,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -15230,7 +15230,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -15278,7 +15278,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -16637,7 +16637,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -17384,7 +17384,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -17432,7 +17432,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -17483,7 +17483,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -18246,7 +18246,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -18295,7 +18295,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -18554,7 +18554,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -18604,7 +18604,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -18747,7 +18747,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -18797,7 +18797,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -18847,7 +18847,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -18907,7 +18907,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -18956,7 +18956,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -19167,7 +19167,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -19216,7 +19216,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -19474,7 +19474,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -19523,7 +19523,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -19781,7 +19781,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -19830,7 +19830,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20002,7 +20002,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20063,7 +20063,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20112,7 +20112,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20308,7 +20308,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20357,7 +20357,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20447,7 +20447,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20496,7 +20496,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20560,7 +20560,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20620,7 +20620,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20669,7 +20669,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20732,7 +20732,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20792,7 +20792,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20841,7 +20841,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20904,7 +20904,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -20964,7 +20964,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21013,7 +21013,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21076,7 +21076,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21136,7 +21136,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21169,7 +21169,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21218,7 +21218,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21297,7 +21297,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21388,7 +21388,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21467,7 +21467,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21546,7 +21546,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21625,7 +21625,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21715,7 +21715,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21748,7 +21748,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21797,7 +21797,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21876,7 +21876,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -21967,7 +21967,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22046,7 +22046,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22125,7 +22125,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22204,7 +22204,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22448,7 +22448,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22496,7 +22496,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22547,7 +22547,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22605,7 +22605,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22677,7 +22677,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22725,7 +22725,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22776,7 +22776,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22834,7 +22834,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22906,7 +22906,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -22954,7 +22954,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -23005,7 +23005,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -23063,7 +23063,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -23135,7 +23135,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -23183,7 +23183,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -23234,7 +23234,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -23292,7 +23292,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -24761,7 +24761,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -24810,7 +24810,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25069,7 +25069,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25119,7 +25119,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25262,7 +25262,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25312,7 +25312,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25362,7 +25362,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25558,7 +25558,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25607,7 +25607,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25779,7 +25779,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25840,7 +25840,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25901,7 +25901,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25950,7 +25950,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -25999,7 +25999,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -27422,7 +27422,7 @@ data:
                       "showLegend": true
                    },
                    "tooltip": {
-                      "mode": "single",
+                      "mode": "multi",
                       "sort": "none"
                    }
                 },
@@ -27977,7 +27977,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -28037,7 +28037,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -28233,7 +28233,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -28282,7 +28282,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -28508,7 +28508,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -28557,7 +28557,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -28783,7 +28783,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -28832,7 +28832,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -28923,7 +28923,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29002,7 +29002,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29098,7 +29098,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29159,7 +29159,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29208,7 +29208,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29257,7 +29257,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29317,7 +29317,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29365,7 +29365,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29413,7 +29413,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29473,7 +29473,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29533,7 +29533,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29566,7 +29566,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29615,7 +29615,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29694,7 +29694,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29785,7 +29785,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29864,7 +29864,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -29943,7 +29943,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -30022,7 +30022,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -30674,7 +30674,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -30728,7 +30728,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -30782,7 +30782,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -30836,7 +30836,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -30890,7 +30890,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -30945,7 +30945,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31011,7 +31011,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31059,7 +31059,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31107,7 +31107,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31155,7 +31155,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31203,7 +31203,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31252,7 +31252,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31312,7 +31312,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31360,7 +31360,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31408,7 +31408,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31456,7 +31456,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31504,7 +31504,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -31553,7 +31553,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32220,7 +32220,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32459,7 +32459,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32508,7 +32508,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32576,7 +32576,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32650,7 +32650,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32717,7 +32717,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32785,7 +32785,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32840,7 +32840,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32889,7 +32889,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -32950,7 +32950,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33018,7 +33018,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33073,7 +33073,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33128,7 +33128,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33195,7 +33195,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33244,7 +33244,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33293,7 +33293,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33342,7 +33342,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33403,7 +33403,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33452,7 +33452,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33532,7 +33532,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33587,7 +33587,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33635,7 +33635,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33683,7 +33683,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -33995,7 +33995,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -34059,7 +34059,7 @@ data:
                             "showLegend": false
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -34119,7 +34119,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -34204,7 +34204,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -34258,7 +34258,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -34324,7 +34324,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -34372,7 +34372,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -34432,7 +34432,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -34480,7 +34480,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -34590,7 +34590,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -35193,7 +35193,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -35405,7 +35405,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -35617,7 +35617,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -36620,7 +36620,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -36668,7 +36668,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -36719,7 +36719,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -36777,7 +36777,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -36849,7 +36849,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -36897,7 +36897,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -36948,7 +36948,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -37006,7 +37006,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -37078,7 +37078,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -37126,7 +37126,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -37177,7 +37177,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -37235,7 +37235,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -37459,7 +37459,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -37507,7 +37507,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -38350,7 +38350,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -38398,7 +38398,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -38449,7 +38449,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -39211,7 +39211,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -39260,7 +39260,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -39519,7 +39519,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -39568,7 +39568,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -39740,7 +39740,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -39801,7 +39801,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -39850,7 +39850,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -39899,7 +39899,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -40095,7 +40095,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -40144,7 +40144,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -40370,7 +40370,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -40419,7 +40419,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -40645,7 +40645,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -40694,7 +40694,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -40816,7 +40816,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -40872,7 +40872,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -40994,7 +40994,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41050,7 +41050,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41172,7 +41172,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41258,7 +41258,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41314,7 +41314,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41394,7 +41394,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41461,7 +41461,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41510,7 +41510,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41559,7 +41559,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41608,7 +41608,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41668,7 +41668,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },
@@ -41716,7 +41716,7 @@ data:
                             "showLegend": true
                          },
                          "tooltip": {
-                            "mode": "single",
+                            "mode": "multi",
                             "sort": "none"
                          }
                       },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager-resources.json
@@ -324,7 +324,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -372,7 +372,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -432,7 +432,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -480,7 +480,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -543,7 +543,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-alertmanager.json
@@ -439,7 +439,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -488,7 +488,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -591,7 +591,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -657,7 +657,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -748,7 +748,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -802,7 +802,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -857,7 +857,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -947,7 +947,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -980,7 +980,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1029,7 +1029,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1108,7 +1108,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1199,7 +1199,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1278,7 +1278,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1357,7 +1357,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1436,7 +1436,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1526,7 +1526,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1574,7 +1574,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1622,7 +1622,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1713,7 +1713,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1767,7 +1767,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1815,7 +1815,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1875,7 +1875,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1925,7 +1925,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2037,7 +2037,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2136,7 +2136,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2221,7 +2221,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2306,7 +2306,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor-resources.json
@@ -435,7 +435,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -483,7 +483,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -543,7 +543,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -591,7 +591,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -642,7 +642,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-compactor.json
@@ -113,7 +113,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -158,7 +158,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -494,7 +494,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -616,7 +616,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -665,7 +665,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -715,7 +715,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -805,7 +805,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -854,7 +854,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -914,7 +914,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -993,7 +993,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1090,7 +1090,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1145,7 +1145,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1235,7 +1235,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1268,7 +1268,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1317,7 +1317,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1396,7 +1396,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1487,7 +1487,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1566,7 +1566,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1645,7 +1645,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1724,7 +1724,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1950,7 +1950,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1999,7 +1999,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-config.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -126,7 +126,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-object-store.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -99,7 +99,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -159,7 +159,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -192,7 +192,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -253,7 +253,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -332,7 +332,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -411,7 +411,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -502,7 +502,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -581,7 +581,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -660,7 +660,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-networking.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -165,7 +165,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -223,7 +223,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -295,7 +295,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -343,7 +343,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -394,7 +394,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -452,7 +452,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -524,7 +524,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -572,7 +572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -623,7 +623,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -681,7 +681,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview-resources.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -222,7 +222,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -270,7 +270,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -321,7 +321,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -381,7 +381,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -429,7 +429,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -537,7 +537,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -585,7 +585,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -693,7 +693,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -741,7 +741,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -792,7 +792,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-overview.json
@@ -361,7 +361,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -416,7 +416,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -494,7 +494,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -707,7 +707,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -762,7 +762,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1050,7 +1050,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1168,7 +1168,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1228,7 +1228,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1307,7 +1307,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1415,7 +1415,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1469,7 +1469,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1547,7 +1547,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -67,7 +67,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -146,7 +146,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -224,7 +224,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -273,7 +273,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -334,7 +334,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -412,7 +412,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -461,7 +461,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -522,7 +522,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -571,7 +571,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -621,7 +621,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -683,7 +683,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -733,7 +733,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -824,7 +824,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -885,7 +885,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -946,7 +946,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1019,7 +1019,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1098,7 +1098,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1194,7 +1194,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1244,7 +1244,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1304,7 +1304,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1395,7 +1395,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1450,7 +1450,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1540,7 +1540,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1588,7 +1588,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1636,7 +1636,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1794,7 +1794,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1855,7 +1855,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1934,7 +1934,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2019,7 +2019,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2085,7 +2085,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2134,7 +2134,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2214,7 +2214,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2305,7 +2305,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2354,7 +2354,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2403,7 +2403,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-networking.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -165,7 +165,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -223,7 +223,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -295,7 +295,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -343,7 +343,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -394,7 +394,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -452,7 +452,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -524,7 +524,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -572,7 +572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -623,7 +623,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -681,7 +681,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -753,7 +753,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -801,7 +801,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -852,7 +852,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -910,7 +910,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -982,7 +982,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1030,7 +1030,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1081,7 +1081,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1139,7 +1139,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1211,7 +1211,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1259,7 +1259,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1310,7 +1310,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1368,7 +1368,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads-resources.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1365,7 +1365,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2052,7 +2052,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2100,7 +2100,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2151,7 +2151,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-reads.json
@@ -617,7 +617,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -666,7 +666,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -925,7 +925,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -975,7 +975,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1118,7 +1118,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1168,7 +1168,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1218,7 +1218,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1278,7 +1278,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1327,7 +1327,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1538,7 +1538,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1587,7 +1587,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1845,7 +1845,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1894,7 +1894,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2152,7 +2152,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2201,7 +2201,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2373,7 +2373,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2434,7 +2434,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2483,7 +2483,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2679,7 +2679,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2728,7 +2728,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2818,7 +2818,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2867,7 +2867,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2931,7 +2931,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2991,7 +2991,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3040,7 +3040,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3103,7 +3103,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3163,7 +3163,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3212,7 +3212,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3275,7 +3275,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3335,7 +3335,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3384,7 +3384,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3447,7 +3447,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3507,7 +3507,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3540,7 +3540,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3589,7 +3589,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3668,7 +3668,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3759,7 +3759,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3838,7 +3838,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3917,7 +3917,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3996,7 +3996,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4086,7 +4086,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4119,7 +4119,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4168,7 +4168,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4247,7 +4247,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4338,7 +4338,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4417,7 +4417,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4496,7 +4496,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4575,7 +4575,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads-networking.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -165,7 +165,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -223,7 +223,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -295,7 +295,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -343,7 +343,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -394,7 +394,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -452,7 +452,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -524,7 +524,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -572,7 +572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -623,7 +623,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -681,7 +681,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -753,7 +753,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -801,7 +801,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -852,7 +852,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -910,7 +910,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-remote-ruler-reads.json
@@ -313,7 +313,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -362,7 +362,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -621,7 +621,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -671,7 +671,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -814,7 +814,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -864,7 +864,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -914,7 +914,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1110,7 +1110,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1159,7 +1159,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1331,7 +1331,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1392,7 +1392,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1453,7 +1453,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1502,7 +1502,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1551,7 +1551,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-rollout-progress.json
@@ -1275,7 +1275,7 @@
                   "showLegend": true
                },
                "tooltip": {
-                  "mode": "single",
+                  "mode": "multi",
                   "sort": "none"
                }
             },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
@@ -410,7 +410,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -470,7 +470,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -666,7 +666,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -715,7 +715,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -941,7 +941,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -990,7 +990,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1216,7 +1216,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1265,7 +1265,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1356,7 +1356,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1435,7 +1435,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1531,7 +1531,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1592,7 +1592,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1641,7 +1641,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1690,7 +1690,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1750,7 +1750,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1798,7 +1798,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1846,7 +1846,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1906,7 +1906,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1966,7 +1966,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1999,7 +1999,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2048,7 +2048,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2127,7 +2127,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2218,7 +2218,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2297,7 +2297,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2376,7 +2376,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2455,7 +2455,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-slow-queries.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -120,7 +120,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -174,7 +174,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -228,7 +228,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -282,7 +282,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -337,7 +337,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -403,7 +403,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -451,7 +451,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -499,7 +499,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -547,7 +547,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -595,7 +595,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -644,7 +644,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -704,7 +704,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -752,7 +752,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -800,7 +800,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -848,7 +848,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -896,7 +896,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -945,7 +945,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -109,7 +109,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -348,7 +348,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -397,7 +397,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -465,7 +465,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -539,7 +539,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -606,7 +606,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -674,7 +674,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -729,7 +729,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -778,7 +778,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -839,7 +839,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -907,7 +907,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -962,7 +962,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1017,7 +1017,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1084,7 +1084,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1133,7 +1133,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1182,7 +1182,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1231,7 +1231,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1292,7 +1292,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1341,7 +1341,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1421,7 +1421,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1476,7 +1476,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1524,7 +1524,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1572,7 +1572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1884,7 +1884,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1948,7 +1948,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2008,7 +2008,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2093,7 +2093,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2147,7 +2147,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2213,7 +2213,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2261,7 +2261,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2321,7 +2321,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2369,7 +2369,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2479,7 +2479,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-top-tenants.json
@@ -393,7 +393,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -605,7 +605,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -817,7 +817,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-networking.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -165,7 +165,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -223,7 +223,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -295,7 +295,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -343,7 +343,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -394,7 +394,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -452,7 +452,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -524,7 +524,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -572,7 +572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -623,7 +623,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -681,7 +681,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-resources.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -897,7 +897,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -945,7 +945,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -996,7 +996,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -616,7 +616,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -665,7 +665,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -924,7 +924,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -973,7 +973,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1145,7 +1145,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1206,7 +1206,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1255,7 +1255,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1304,7 +1304,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1500,7 +1500,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1549,7 +1549,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1775,7 +1775,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1824,7 +1824,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2050,7 +2050,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2099,7 +2099,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2221,7 +2221,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2277,7 +2277,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2399,7 +2399,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2455,7 +2455,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2577,7 +2577,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2663,7 +2663,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2719,7 +2719,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2799,7 +2799,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2866,7 +2866,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2915,7 +2915,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2964,7 +2964,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3013,7 +3013,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3073,7 +3073,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3121,7 +3121,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager-resources.json
@@ -348,7 +348,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -396,7 +396,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -456,7 +456,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -504,7 +504,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -567,7 +567,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-alertmanager.json
@@ -439,7 +439,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -488,7 +488,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -591,7 +591,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -657,7 +657,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -748,7 +748,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -802,7 +802,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -857,7 +857,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -947,7 +947,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -980,7 +980,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1029,7 +1029,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1108,7 +1108,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1199,7 +1199,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1278,7 +1278,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1357,7 +1357,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1436,7 +1436,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1526,7 +1526,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1574,7 +1574,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1622,7 +1622,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1713,7 +1713,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1767,7 +1767,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1815,7 +1815,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1875,7 +1875,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1925,7 +1925,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2037,7 +2037,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2136,7 +2136,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2221,7 +2221,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2306,7 +2306,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor-resources.json
@@ -471,7 +471,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -519,7 +519,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -579,7 +579,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -627,7 +627,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -678,7 +678,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-compactor.json
@@ -113,7 +113,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -158,7 +158,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -494,7 +494,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -616,7 +616,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -665,7 +665,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -715,7 +715,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -805,7 +805,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -854,7 +854,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -914,7 +914,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -993,7 +993,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1090,7 +1090,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1145,7 +1145,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1235,7 +1235,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1268,7 +1268,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1317,7 +1317,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1396,7 +1396,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1487,7 +1487,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1566,7 +1566,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1645,7 +1645,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1724,7 +1724,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1950,7 +1950,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1999,7 +1999,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-config.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -126,7 +126,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-object-store.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -99,7 +99,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -159,7 +159,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -192,7 +192,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -253,7 +253,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -332,7 +332,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -411,7 +411,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -502,7 +502,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -581,7 +581,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -660,7 +660,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview-networking.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -165,7 +165,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -223,7 +223,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -295,7 +295,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -343,7 +343,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -394,7 +394,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -452,7 +452,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -524,7 +524,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -572,7 +572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -623,7 +623,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -681,7 +681,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview-resources.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -222,7 +222,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -270,7 +270,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -321,7 +321,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -381,7 +381,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -429,7 +429,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -537,7 +537,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -585,7 +585,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -693,7 +693,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -741,7 +741,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -792,7 +792,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-overview.json
@@ -361,7 +361,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -416,7 +416,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -494,7 +494,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -707,7 +707,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -762,7 +762,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1050,7 +1050,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1168,7 +1168,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1228,7 +1228,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1307,7 +1307,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1415,7 +1415,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1469,7 +1469,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1547,7 +1547,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -67,7 +67,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -146,7 +146,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -224,7 +224,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -273,7 +273,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -334,7 +334,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -412,7 +412,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -461,7 +461,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -522,7 +522,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -571,7 +571,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -621,7 +621,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -683,7 +683,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -733,7 +733,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -824,7 +824,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -885,7 +885,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -946,7 +946,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1019,7 +1019,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1098,7 +1098,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1194,7 +1194,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1244,7 +1244,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1304,7 +1304,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1395,7 +1395,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1450,7 +1450,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1540,7 +1540,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1588,7 +1588,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1636,7 +1636,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1794,7 +1794,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1855,7 +1855,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1934,7 +1934,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2019,7 +2019,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2085,7 +2085,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2134,7 +2134,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2214,7 +2214,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2305,7 +2305,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2354,7 +2354,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2403,7 +2403,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-networking.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -165,7 +165,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -223,7 +223,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -295,7 +295,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -343,7 +343,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -394,7 +394,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -452,7 +452,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -524,7 +524,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -572,7 +572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -623,7 +623,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -681,7 +681,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -753,7 +753,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -801,7 +801,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -852,7 +852,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -910,7 +910,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -982,7 +982,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1030,7 +1030,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1081,7 +1081,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1139,7 +1139,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1211,7 +1211,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1259,7 +1259,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1310,7 +1310,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1368,7 +1368,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads-resources.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1473,7 +1473,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2220,7 +2220,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2268,7 +2268,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2319,7 +2319,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-reads.json
@@ -617,7 +617,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -666,7 +666,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -925,7 +925,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -975,7 +975,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1118,7 +1118,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1168,7 +1168,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1218,7 +1218,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1278,7 +1278,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1327,7 +1327,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1538,7 +1538,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1587,7 +1587,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1845,7 +1845,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1894,7 +1894,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2152,7 +2152,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2201,7 +2201,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2373,7 +2373,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2434,7 +2434,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2483,7 +2483,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2679,7 +2679,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2728,7 +2728,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2818,7 +2818,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2867,7 +2867,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2931,7 +2931,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2991,7 +2991,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3040,7 +3040,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3103,7 +3103,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3163,7 +3163,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3212,7 +3212,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3275,7 +3275,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3335,7 +3335,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3384,7 +3384,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3447,7 +3447,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3507,7 +3507,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3540,7 +3540,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3589,7 +3589,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3668,7 +3668,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3759,7 +3759,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3838,7 +3838,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3917,7 +3917,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3996,7 +3996,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4086,7 +4086,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4119,7 +4119,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4168,7 +4168,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4247,7 +4247,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4338,7 +4338,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4417,7 +4417,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4496,7 +4496,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -4575,7 +4575,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads-networking.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -165,7 +165,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -223,7 +223,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -295,7 +295,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -343,7 +343,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -394,7 +394,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -452,7 +452,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -524,7 +524,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -572,7 +572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -623,7 +623,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -681,7 +681,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -753,7 +753,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -801,7 +801,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -852,7 +852,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -910,7 +910,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-remote-ruler-reads.json
@@ -313,7 +313,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -362,7 +362,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -621,7 +621,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -671,7 +671,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -814,7 +814,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -864,7 +864,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -914,7 +914,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1110,7 +1110,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1159,7 +1159,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1331,7 +1331,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1392,7 +1392,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1453,7 +1453,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1502,7 +1502,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1551,7 +1551,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-rollout-progress.json
@@ -1275,7 +1275,7 @@
                   "showLegend": true
                },
                "tooltip": {
-                  "mode": "single",
+                  "mode": "multi",
                   "sort": "none"
                }
             },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -410,7 +410,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -470,7 +470,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -666,7 +666,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -715,7 +715,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -941,7 +941,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -990,7 +990,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1216,7 +1216,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1265,7 +1265,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1356,7 +1356,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1435,7 +1435,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1531,7 +1531,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1592,7 +1592,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1641,7 +1641,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1690,7 +1690,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1750,7 +1750,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1798,7 +1798,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1846,7 +1846,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1906,7 +1906,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1966,7 +1966,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1999,7 +1999,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2048,7 +2048,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2127,7 +2127,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2218,7 +2218,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2297,7 +2297,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2376,7 +2376,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2455,7 +2455,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-slow-queries.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -120,7 +120,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -174,7 +174,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -228,7 +228,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -282,7 +282,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -337,7 +337,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -403,7 +403,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -451,7 +451,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -499,7 +499,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -547,7 +547,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -595,7 +595,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -644,7 +644,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -704,7 +704,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -752,7 +752,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -800,7 +800,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -848,7 +848,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -896,7 +896,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -945,7 +945,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -109,7 +109,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -348,7 +348,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -397,7 +397,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -465,7 +465,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -539,7 +539,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -606,7 +606,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -674,7 +674,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -729,7 +729,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -778,7 +778,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -839,7 +839,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -907,7 +907,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -962,7 +962,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1017,7 +1017,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1084,7 +1084,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1133,7 +1133,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1182,7 +1182,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1231,7 +1231,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1292,7 +1292,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1341,7 +1341,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1421,7 +1421,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1476,7 +1476,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1524,7 +1524,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1572,7 +1572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1884,7 +1884,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1948,7 +1948,7 @@
                         "showLegend": false
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2008,7 +2008,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2093,7 +2093,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2147,7 +2147,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2213,7 +2213,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2261,7 +2261,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2321,7 +2321,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2369,7 +2369,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2479,7 +2479,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-top-tenants.json
@@ -393,7 +393,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -605,7 +605,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -817,7 +817,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-networking.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -165,7 +165,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -223,7 +223,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -295,7 +295,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -343,7 +343,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -394,7 +394,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -452,7 +452,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -524,7 +524,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -572,7 +572,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -623,7 +623,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -681,7 +681,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -66,7 +66,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -114,7 +114,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -957,7 +957,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1005,7 +1005,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1056,7 +1056,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -616,7 +616,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -665,7 +665,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -924,7 +924,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -973,7 +973,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1145,7 +1145,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1206,7 +1206,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1255,7 +1255,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1304,7 +1304,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1500,7 +1500,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1549,7 +1549,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1775,7 +1775,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -1824,7 +1824,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2050,7 +2050,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2099,7 +2099,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2221,7 +2221,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2277,7 +2277,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2399,7 +2399,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2455,7 +2455,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2577,7 +2577,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2663,7 +2663,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2719,7 +2719,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2799,7 +2799,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2866,7 +2866,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2915,7 +2915,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -2964,7 +2964,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3013,7 +3013,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3073,7 +3073,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },
@@ -3121,7 +3121,7 @@
                         "showLegend": true
                      },
                      "tooltip": {
-                        "mode": "single",
+                        "mode": "multi",
                         "sort": "none"
                      }
                   },

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -194,6 +194,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
           min: 0,
         },
       },
+      options+: {
+        tooltip+: {
+          mode: 'multi',
+        },
+      },
     },
 
   qpsPanel(selector, statusLabelName='status_code')::


### PR DESCRIPTION
#### What this PR does

This PR changes the default tooltip configuration for all time series dashboard panels to show all series.

Some dashboard panels (particularly those that show statistics from many pods) already had this configured, this PR extends that to be the default everywhere.

Showing all series in tooltips makes it much easier to see the values of each series, particularly in panels with many series.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
