### PR TITLE
query-tee: ignore series count mismatches if all samples are within recent sample window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 * [ENHANCEMENT] Add `time` parameter to proxied instant queries if it is not included in the incoming request. This is optional but enabled by default, and can be disabled with `-proxy.add-missing-time-parameter-to-instant-queries=false`. #8419
 * [ENHANCEMENT] Add support for sending only a proportion of requests to all backends, with the remainder only sent to the preferred backend. The default behaviour is to send all requests to all backends. This can be configured with `-proxy.secondary-backends-request-proportion`. #8532
 * [ENHANCEMENT] Compare native histograms in query results when comparing results between two backends. #8724
+* [ENHANCEMENT] Don't consider responses to be different during response comparison if both backends' responses contain a different number of series, but all samples are within the recent sample window. #8749
 * [BUGFIX] Ensure any errors encountered while forwarding a request to a backend (eg. DNS resolution failures) are logged. #8419
 
 ### Documentation


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where query-tee considers two responses to be different if they have different numbers of series, but all of the samples are within the recent sample window and so would be ignored during comparison.

For example, imagine it is now T=10, and the recent sample window is 2. Backend A returns a vector with 11 series, all with samples at T=10, and backend B returns 12 series, all with samples at T=10. (This can happen if the two queries are racing with writes for the queried data.) 

Without this change, query-tee would consider the comparison failed, but if both responses had the same number of series, it would consider the comparison successful regardless of the sample values.

With this change, query-tee will consider both responses as equivalent.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
