### PR TITLE
Generalise and make some functions of astmapper public

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
@@ -138,8 +138,10 @@ func TestSharding_BinaryExpressionsDontTakeExponentialTime(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	mapper, err := NewSharding(ctx, 2, log.NewNopLogger(), NewMapperStats())
+
+	summer, err := NewQueryShardSummer(ctx, 2, VectorSquasher, log.NewNopLogger(), NewMapperStats())
 	require.NoError(t, err)
+	mapper := NewSharding(summer)
 
 	_, err = mapper.Map(expr)
 	require.NoError(t, err)

--- a/pkg/frontend/querymiddleware/astmapper/embedded.go
+++ b/pkg/frontend/querymiddleware/astmapper/embedded.go
@@ -62,7 +62,7 @@ func (c jsonCodec) Decode(encoded string) (queries []string, err error) {
 // VectorSquash reduces an AST into a single vector query which can be hijacked by a Queryable impl.
 // It always uses a VectorSelector as the substitution expr.
 // This is important because logical/set binops can only be applied against vectors and not matrices.
-func vectorSquasher(exprs ...parser.Expr) (parser.Expr, error) {
+func VectorSquasher(exprs ...parser.Expr) (parser.Expr, error) {
 	// concat OR legs
 	strs := make([]string, 0, len(exprs))
 	for _, expr := range exprs {

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -380,7 +380,7 @@ func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, rangeInterval ti
 		embeddedQueries = append([]parser.Expr{splitExpr}, embeddedQueries...)
 	}
 
-	squashExpr, err := vectorSquasher(embeddedQueries...)
+	squashExpr, err := VectorSquasher(embeddedQueries...)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/frontend/querymiddleware/astmapper/sharding.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding.go
@@ -19,7 +19,7 @@ import (
 
 // NewSharding creates a new query sharding mapper.
 func NewSharding(ctx context.Context, shards int, logger log.Logger, stats *MapperStats) (ASTMapper, error) {
-	shardSummer, err := newShardSummer(ctx, shards, vectorSquasher, logger, stats)
+	shardSummer, err := newShardSummer(ctx, shards, vectorSquasher, logger, stats, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -41,13 +41,26 @@ type shardSummer struct {
 	logger       log.Logger
 	stats        *MapperStats
 
+	splitLabel string
+	clusters   []string
+
 	canShardAllVectorSelectorsCache map[string]bool
 }
 
-// newShardSummer instantiates an ASTMapper which will fan out sum queries by shard
-func newShardSummer(ctx context.Context, shards int, squasher squasher, logger log.Logger, stats *MapperStats) (ASTMapper, error) {
+// newShardSummer instantiates an ASTMapper which will fan out sum queries by shard. If clusters is defined,
+// the mapper will be used to rewrite the queries for cross-cluster query federation. Otherwise, it will
+// rewrite the queries for query sharding.
+func newShardSummer(ctx context.Context, shards int, squasher squasher, logger log.Logger, stats *MapperStats, clusters []string) (ASTMapper, error) {
 	if squasher == nil {
 		return nil, errors.Errorf("squasher required and not passed")
+	}
+
+	var splitLabel string
+	if len(clusters) > 0 {
+		shards = len(clusters)
+		splitLabel = sharding.ClusterLabel
+	} else {
+		splitLabel = sharding.ShardLabel
 	}
 
 	return NewASTExprMapper(&shardSummer{
@@ -58,6 +71,9 @@ func newShardSummer(ctx context.Context, shards int, squasher squasher, logger l
 		currentShard: nil,
 		logger:       logger,
 		stats:        stats,
+
+		splitLabel: splitLabel,
+		clusters:   clusters,
 
 		canShardAllVectorSelectorsCache: make(map[string]bool),
 	}), nil
@@ -98,7 +114,7 @@ func (summer *shardSummer) MapExpr(expr parser.Expr) (mapped parser.Expr, finish
 
 	case *parser.VectorSelector:
 		if summer.currentShard != nil {
-			mapped, err := shardVectorSelector(*summer.currentShard, summer.shards, e)
+			mapped, err := summer.shardVectorSelector(e)
 			return mapped, true, err
 		}
 		return e, true, nil
@@ -522,8 +538,14 @@ func (summer *shardSummer) shardAndSquashBinOp(expr *parser.BinaryExpr) (parser.
 	return summer.squash(children...)
 }
 
-func shardVectorSelector(curshard, shards int, selector *parser.VectorSelector) (parser.Expr, error) {
-	shardMatcher, err := labels.NewMatcher(labels.MatchEqual, sharding.ShardLabel, sharding.ShardSelector{ShardIndex: uint64(curshard), ShardCount: uint64(shards)}.LabelValue())
+func (summer *shardSummer) shardVectorSelector(selector *parser.VectorSelector) (parser.Expr, error) {
+	var splitLabelValue string
+	if len(summer.clusters) > 0 {
+		splitLabelValue = summer.clusters[*summer.currentShard]
+	} else {
+		splitLabelValue = sharding.ShardSelector{ShardIndex: uint64(*summer.currentShard), ShardCount: uint64(summer.shards)}.LabelValue()
+	}
+	shardMatcher, err := labels.NewMatcher(labels.MatchEqual, summer.splitLabel, splitLabelValue)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -577,7 +577,7 @@ func TestShardSummerWithEncoding(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
 			stats := NewMapperStats()
-			summer, err := newShardSummer(context.Background(), c.shards, vectorSquasher, log.NewNopLogger(), stats, nil)
+			summer, err := newShardSummer(context.Background(), c.shards, vectorSquasher, log.NewNopLogger(), stats)
 			require.Nil(t, err)
 			expr, err := parser.ParseExpr(c.input)
 			require.Nil(t, err)
@@ -585,41 +585,6 @@ func TestShardSummerWithEncoding(t *testing.T) {
 			res, err := summer.Map(expr)
 			require.Nil(t, err)
 			assert.Equal(t, c.shards, stats.GetShardedQueries())
-			expected, err := parser.ParseExpr(c.expected)
-			require.Nil(t, err)
-
-			require.Equal(t, expected.String(), res.String())
-		})
-	}
-}
-
-func TestShardSummerWithClusters(t *testing.T) {
-	clusters := []string{
-		"cluster-a",
-		"cluster-b",
-		"cluster-c",
-		"cluster-d",
-	}
-	clustersSize := len(clusters)
-	for i, c := range []struct {
-		input    string
-		expected string
-	}{
-		{
-			input:    `sum(rate(bar1{baz="blip"}[1m]))`,
-			expected: `sum(__embedded_queries__{__queries__="{\"Concat\":[\"sum(rate(bar1{__cluster__=\\\"cluster-a\\\",baz=\\\"blip\\\"}[1m]))\",\"sum(rate(bar1{__cluster__=\\\"cluster-b\\\",baz=\\\"blip\\\"}[1m]))\",\"sum(rate(bar1{__cluster__=\\\"cluster-c\\\",baz=\\\"blip\\\"}[1m]))\",\"sum(rate(bar1{__cluster__=\\\"cluster-d\\\",baz=\\\"blip\\\"}[1m]))\"]}"})`,
-		},
-	} {
-		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
-			stats := NewMapperStats()
-			summer, err := newShardSummer(context.Background(), 0, vectorSquasher, log.NewNopLogger(), stats, clusters)
-			require.Nil(t, err)
-			expr, err := parser.ParseExpr(c.input)
-			require.Nil(t, err)
-
-			res, err := summer.Map(expr)
-			require.Nil(t, err)
-			assert.Equal(t, clustersSize, stats.GetShardedQueries())
 			expected, err := parser.ParseExpr(c.expected)
 			require.Nil(t, err)
 

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -523,8 +523,9 @@ func TestShardSummer(t *testing.T) {
 
 		t.Run(tt.in, func(t *testing.T) {
 			stats := NewMapperStats()
-			mapper, err := NewSharding(context.Background(), 3, log.NewNopLogger(), stats)
+			summer, err := NewQueryShardSummer(context.Background(), 3, VectorSquasher, log.NewNopLogger(), stats)
 			require.NoError(t, err)
+			mapper := NewSharding(summer)
 			expr, err := parser.ParseExpr(tt.in)
 			require.NoError(t, err)
 			out, err := parser.ParseExpr(tt.out)
@@ -556,7 +557,7 @@ func concat(queries ...string) string {
 		exprs = append(exprs, n)
 
 	}
-	mapped, err := vectorSquasher(exprs...)
+	mapped, err := VectorSquasher(exprs...)
 	if err != nil {
 		panic(err)
 	}
@@ -577,7 +578,7 @@ func TestShardSummerWithEncoding(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("[%d]", i), func(t *testing.T) {
 			stats := NewMapperStats()
-			summer, err := newShardSummer(context.Background(), c.shards, vectorSquasher, log.NewNopLogger(), stats)
+			summer, err := NewQueryShardSummer(context.Background(), c.shards, VectorSquasher, log.NewNopLogger(), stats)
 			require.Nil(t, err)
 			expr, err := parser.ParseExpr(c.input)
 			require.Nil(t, err)

--- a/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
+++ b/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
@@ -39,7 +39,7 @@ func (f *subtreeFolder) MapExpr(expr parser.Expr) (mapped parser.Expr, finished 
 
 	// Change the expr if it contains vector selectors, as only those need to be embedded.
 	if hasVectorSelector {
-		expr, err := vectorSquasher(expr)
+		expr, err := VectorSquasher(expr)
 		return expr, true, err
 	}
 	return expr, false, nil

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -253,10 +253,11 @@ func (s *querySharding) shardQuery(ctx context.Context, query string, totalShard
 	ctx, cancel := context.WithTimeout(ctx, shardingTimeout)
 	defer cancel()
 
-	mapper, err := astmapper.NewSharding(ctx, totalShards, s.logger, stats)
+	summer, err := astmapper.NewQueryShardSummer(ctx, totalShards, astmapper.VectorSquasher, s.logger, stats)
 	if err != nil {
 		return "", nil, err
 	}
+	mapper := astmapper.NewSharding(summer)
 
 	// The mapper can modify the input expression in-place, so we must re-parse the original query
 	// each time before passing it to the mapper.

--- a/pkg/storage/sharding/label.go
+++ b/pkg/storage/sharding/label.go
@@ -12,11 +12,8 @@ import (
 )
 
 const (
-	// ShardLabel is a reserved label referencing a shard on read path used for query sharding.
+	// ShardLabel is a reserved label referencing a shard on read path.
 	ShardLabel = "__query_shard__"
-
-	// ClusterLabel is a reserved label referencing a cluster for cross-cluster query federation.
-	ClusterLabel = "__cluster__"
 )
 
 // ShardSelector holds information about the configured query shard.

--- a/pkg/storage/sharding/label.go
+++ b/pkg/storage/sharding/label.go
@@ -12,8 +12,11 @@ import (
 )
 
 const (
-	// ShardLabel is a reserved label referencing a shard on read path.
+	// ShardLabel is a reserved label referencing a shard on read path used for query sharding.
 	ShardLabel = "__query_shard__"
+
+	// ClusterLabel is a reserved label referencing a cluster for cross-cluster query federation.
+	ClusterLabel = "__cluster__"
 )
 
 // ShardSelector holds information about the configured query shard.


### PR DESCRIPTION
#### What this PR does

Generalises astmapper's shardSummer, and make some functions public to allow reuse outside of query sharding

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

None as these are minor, non-user-facing changes.