### PR TITLE
BlockBuilder: Ship blocks to the right tenant directories

### DIFF
--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -315,8 +315,10 @@ func (b *tsdbBuilder) compactAndUpload(ctx context.Context, blockUploaderForUser
 
 		delete(b.tsdbs, tenant)
 
+		// Make a copy of userID because 'tenant' changes in the next iteration.
+		userID := tenant.id
 		eg.Go(func() error {
-			uploader := blockUploaderForUser(ctx, tenant.id)
+			uploader := blockUploaderForUser(ctx, userID)
 			for _, bn := range blockNames {
 				if err := uploader(filepath.Join(dbDir, bn)); err != nil {
 					return err


### PR DESCRIPTION
One liner fix for a critical bug. Because of use of a loop iterating variable in a goroutine, we were uploading the blocks to the wrong directory. This PR captures the loop variable before using it in the goroutine.

Added a unit test to test this part.

cc @narqo 