### PR TITLE
Use offset instead of timestamp for commit meta

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -891,8 +891,7 @@ func (b *BlockBuilder) consumePartition(
 		LastBlockEnd:   commitBlockEnd,
 	}
 
-	err = commitRecord(ctx, b.logger, client, b.cfg.Kafka.ConsumerGroup, pl.Commit)
-	return pl, err
+	return pl, commitRecord(ctx, b.logger, client, b.cfg.Kafka.ConsumerGroup, pl.Commit)
 }
 
 func (b *BlockBuilder) seekPartition(client *kgo.Client, part int32, rec kgo.EpochOffset) {


### PR DESCRIPTION
The kafka record timestamps are not required to be monotonic. The logic of block builder requires the number being used be monotonic w.r.t. the order of records. The offset of record is monotonic. So use it instead.

cc @narqo 