### PR TITLE
docs: re-adds instructions for generating test metrics

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -143,7 +143,7 @@ Using a custom namespace solves problems later on because you do not have to ove
 The Grafana Mimir Helm chart can collect metrics, logs, or both, about Grafana Mimir itself. This is called _metamonitoring_.
 In the example that follows, metamonitoring scrapes metrics about Grafana Mimir itself, and then writes those metrics to the same Grafana Mimir instance.
 
-1. Deploy the Grafana Agent Operator Custom Resource Definitions (CRDs). For more information, refer to [Deploy the Agent Operator Custom Resource Definitions (CRDs)](https://grafana.com/docs/agent/<AGENT_VERSION>/operator/getting-started/#deploy-the-agent-operator-custom-resource-definitions-crds) in the Grafana Agent documentation.
+1. Deploy the Grafana Agent Operator Custom Resource Definitions (CRDs). For more information, refer to [Deploy the Agent Operator Custom Resource Definitions (CRDs)](https://grafana.com/docs/agent/latest/operator/getting-started/#deploy-the-agent-operator-custom-resource-definitions-crds) in the Grafana Agent documentation.
 
 1. Create a YAML file called `custom.yaml` for your Helm values overrides.
    Add the following YAML snippet to `custom.yaml` to enable metamonitoring in Mimir:

--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -166,8 +166,8 @@ In the example that follows, metamonitoring scrapes metrics about Grafana Mimir 
 
 1. Upgrade Grafana Mimir by using the `helm` command:
 
-    ```bash
-    helm -n mimir-test upgrade mimir grafana/mimir-distributed -f custom.yaml
+   ```bash
+   helm -n mimir-test upgrade mimir grafana/mimir-distributed -f custom.yaml
    ```
 
 ## Start Grafana in Kubernetes and query metrics

--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -136,7 +136,52 @@ Using a custom namespace solves problems later on because you do not have to ove
 
 1. Wait until all of the pods have a status of `Running` or `Completed`, which might take a few minutes.
 
+## Generate some test metrics
+
+The Grafana Mimir Helm chart can collect metrics, logs, or both, about Grafana Mimir itself. This is called _metamonitoring_.
+In the example that follows, metamonitoring scrapes metrics about Grafana Mimir itself, and then writes those metrics to the same Grafana Mimir instance.
+
+1. Download the Grafana Agent Operator Custom Resource Definitions (CRDs) from
+   https://github.com/grafana/agent/tree/main/operations/agent-static-operator/crds.
+
+   Helm only installs Custom Resource Definitions on an initial chart installation and not on a chart upgrade.
+   For details, see [Some caveats and explanations](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations).
+
+   If you did not enable metamonitoring when the chart was first installed, you must manually install the CRDs before performing a Helm upgrade to enable metamonitoring.
+
+1. Install the CRDs on your cluster:
+
+   ```bash
+   kubectl create -f operations/agent-static-operator/crds/
+   ```
+
+1. Create a YAML file called `custom.yaml` for your Helm values overrides.
+   Add the following YAML snippet to `custom.yaml` to enable metamonitoring in Mimir:
+
+   ```yaml
+   metaMonitoring:
+     serviceMonitor:
+       enabled: true
+     grafanaAgent:
+       enabled: true
+       installOperator: true
+       metrics:
+         additionalRemoteWriteConfigs:
+           - url: "http://mimir-nginx.mimir-test.svc:80/api/v1/push"
+   ```
+  {{< admonition type="note" >}}
+  In a production environment the `url` above would point to an external system, independent of your Grafana Mimir instance, such as an instance of Grafana Cloud Metrics.
+  {{< /admonition >}}
+
+  1. Upgrade Grafana Mimir by using the `helm` command:
+
+   ```bash
+   helm -n mimir-test upgrade mimir grafana/mimir-distributed -f custom.yaml
+   ```
+
 ## Start Grafana in Kubernetes and query metrics
+
+{{< docs/shared source="alloy" lookup="agent-deprecation.md" version="next" >}}
 
 1. Install Grafana in the same Kubernetes cluster.
 

--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -143,19 +143,7 @@ Using a custom namespace solves problems later on because you do not have to ove
 The Grafana Mimir Helm chart can collect metrics, logs, or both, about Grafana Mimir itself. This is called _metamonitoring_.
 In the example that follows, metamonitoring scrapes metrics about Grafana Mimir itself, and then writes those metrics to the same Grafana Mimir instance.
 
-1. Download the Grafana Agent Operator Custom Resource Definitions (CRDs) from
-   https://github.com/grafana/agent/tree/main/operations/agent-static-operator/crds.
-
-   Helm only installs Custom Resource Definitions on an initial chart installation and not on a chart upgrade.
-   For details, see [Some caveats and explanations](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations).
-
-   If you did not enable metamonitoring when the chart was first installed, you must manually install the CRDs before performing a Helm upgrade to enable metamonitoring.
-
-1. Install the CRDs on your cluster:
-
-   ```bash
-   kubectl create -f operations/agent-static-operator/crds/
-   ```
+1. Deploy the Grafana Agent Operator Custom Resource Definitions (CRDs). For more information, refer to [Deploy the Agent Operator Custom Resource Definitions (CRDs)](https://grafana.com/docs/agent/<AGENT_VERSION>/operator/getting-started/#deploy-the-agent-operator-custom-resource-definitions-crds) in the Grafana Agent documentation.
 
 1. Create a YAML file called `custom.yaml` for your Helm values overrides.
    Add the following YAML snippet to `custom.yaml` to enable metamonitoring in Mimir:

--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -138,6 +138,8 @@ Using a custom namespace solves problems later on because you do not have to ove
 
 ## Generate some test metrics
 
+{{< docs/shared source="alloy" lookup="agent-deprecation.md" version="next" >}}
+
 The Grafana Mimir Helm chart can collect metrics, logs, or both, about Grafana Mimir itself. This is called _metamonitoring_.
 In the example that follows, metamonitoring scrapes metrics about Grafana Mimir itself, and then writes those metrics to the same Grafana Mimir instance.
 
@@ -169,19 +171,18 @@ In the example that follows, metamonitoring scrapes metrics about Grafana Mimir 
          additionalRemoteWriteConfigs:
            - url: "http://mimir-nginx.mimir-test.svc:80/api/v1/push"
    ```
-  {{< admonition type="note" >}}
-  In a production environment the `url` above would point to an external system, independent of your Grafana Mimir instance, such as an instance of Grafana Cloud Metrics.
-  {{< /admonition >}}
 
-  1. Upgrade Grafana Mimir by using the `helm` command:
+   {{< admonition type="note" >}}
+   In a production environment the `url` above would point to an external system, independent of your Grafana Mimir instance, such as an instance of Grafana Cloud Metrics.
+   {{< /admonition >}}
 
-   ```bash
-   helm -n mimir-test upgrade mimir grafana/mimir-distributed -f custom.yaml
+1. Upgrade Grafana Mimir by using the `helm` command:
+
+    ```bash
+    helm -n mimir-test upgrade mimir grafana/mimir-distributed -f custom.yaml
    ```
 
 ## Start Grafana in Kubernetes and query metrics
-
-{{< docs/shared source="alloy" lookup="agent-deprecation.md" version="next" >}}
 
 1. Install Grafana in the same Kubernetes cluster.
 


### PR DESCRIPTION
#### What this PR does
As part of https://github.com/grafana/mimir/pull/8489, we [removed instructions for generating test metrics in Mimir](https://github.com/grafana/mimir/pull/8489/files#r1674528190). The thinking was that this functionality used the deprecated Agent Operator and that Mimir would eventually start generating metrics for itself anyways.

@krajorama  brought to my attention that it's actually only GEM that can self-generate test metrics, not Mimir. Now, until the [Helm chart is updated to use Alloy](https://github.com/grafana/mimir/issues/5860), there is no way to get test metrics in Mimir.

This PR replaces the instructions for generating test metrics with the additional caveat that Agent is deprecated and will EOL Nov. 1 2025. 

When the Helm chart is updated, we will update these docs again to use Alloy.

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
