### PR TITLE
Alertmanager: Promote Grafana state

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -128,6 +129,9 @@ type Alertmanager struct {
 	receivers       []*nfstatus.Receiver
 	templatesMtx    sync.RWMutex
 	templates       []alertingTemplates.TemplateDefinition
+
+	// promoted indicates if the Grafana Alertmanager configuration and state are being used.
+	promoted atomic.Bool
 
 	// Pipeline created during last ApplyConfig call. Used for testing only.
 	lastPipeline notify.Stage

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -130,8 +130,8 @@ type Alertmanager struct {
 	templatesMtx    sync.RWMutex
 	templates       []alertingTemplates.TemplateDefinition
 
-	// promoted indicates if the Grafana Alertmanager configuration and state are being used.
-	promoted atomic.Bool
+	// usingGrafanaState indicates if the Grafana Alertmanager state is being used.
+	usingGrafanaState atomic.Bool
 
 	// Pipeline created during last ApplyConfig call. Used for testing only.
 	lastPipeline notify.Stage

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -64,6 +63,7 @@ import (
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
+	"go.uber.org/atomic"
 	"golang.org/x/time/rate"
 
 	"github.com/grafana/mimir/pkg/alertmanager/alertstore"

--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -43,8 +43,9 @@ func createUsableGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc, mCfg *alert
 	}
 
 	return amConfig{
-		AlertConfigDesc: alertspb.ToProto(string(rawCfg), amCfg.Templates, gCfg.User),
-		tmplExternalURL: externalURL,
-		staticHeaders:   gCfg.StaticHeaders,
+		AlertConfigDesc:    alertspb.ToProto(string(rawCfg), amCfg.Templates, gCfg.User),
+		tmplExternalURL:    externalURL,
+		staticHeaders:      gCfg.StaticHeaders,
+		usingGrafanaConfig: true,
 	}, nil
 }

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -726,7 +726,7 @@ func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs)
 	}
 }
 
-// syncStates promotes/unpromoted the Grafana state and updates 'promoted' flag if needed.
+// syncStates promotes/unpromotes the Grafana state and updates the 'promoted' flag if needed.
 func (am *MultitenantAlertmanager) syncStates(ctx context.Context, cfg amConfig) error {
 	am.alertmanagersMtx.Lock()
 	userAM, ok := am.alertmanagers[cfg.User]

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -745,7 +745,7 @@ func (am *MultitenantAlertmanager) syncStates(ctx context.Context, cfg amConfig)
 		return nil
 	}
 
-	// Promote the Grafana Alertmanager state and mark the Alertmanager al promoted.
+	// Promote the Grafana Alertmanager state and mark the Alertmanager as promoted.
 	level.Debug(am.logger).Log("msg", "promoting Grafana state", "user", cfg.User)
 	s, err := am.store.GetFullGrafanaState(ctx, cfg.User)
 	if err != nil {

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -3169,17 +3169,17 @@ func TestSyncStates(t *testing.T) {
 
 			require.NoError(t, am.setConfig(amConfig{
 				AlertConfigDesc: alertspb.AlertConfigDesc{
-					User:      user,
+					User:      test.cfg.User,
 					RawConfig: simpleConfigOne,
 				},
 				tmplExternalURL: externalURL,
 			}))
-			require.NotNil(t, am.alertmanagers[user])
-			am.alertmanagers[user].usingGrafanaState.Store(test.initialPromoted)
+			require.NotNil(t, am.alertmanagers[test.cfg.User])
+			am.alertmanagers[test.cfg.User].usingGrafanaState.Store(test.initialPromoted)
 
 			require.NoError(t, am.syncStates(ctx, test.cfg))
-			am.alertmanagers[user].usingGrafanaState.Store(test.initialPromoted)
-			require.Equal(t, test.expPromoted, am.alertmanagers[user].usingGrafanaState.Load())
+			require.NotNil(t, am.alertmanagers[test.cfg.User])
+			require.Equal(t, test.expPromoted, am.alertmanagers[test.cfg.User].usingGrafanaState.Load())
 		})
 	}
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2865,7 +2865,7 @@ func Test_configChanged(t *testing.T) {
 	}
 }
 
-func TestPromoteAndDeleteState(t *testing.T) {
+func TestSyncStates(t *testing.T) {
 	user := "test-user"
 	externalURL, err := url.Parse("http://test.com")
 	require.NoError(t, err)
@@ -2940,21 +2940,31 @@ func TestPromoteAndDeleteState(t *testing.T) {
 
 	ctx := context.Background()
 	tests := []struct {
-		name              string
-		cfg               amConfig
-		mimirState        *alertspb.FullStateDesc
-		parts             map[string][]byte
-		expNoAlertmanager bool
-		expErr            string
+		name                 string
+		cfg                  amConfig
+		mimirState           *alertspb.FullStateDesc
+		parts                map[string][]byte
+		expNoNewAlertmanager bool
+		expErr               string
 	}{
+		{
+			name: "not using grafana config should be a no-op",
+			cfg: amConfig{
+				AlertConfigDesc: alertspb.AlertConfigDesc{
+					User: user,
+				},
+			},
+			expNoNewAlertmanager: true,
+		},
 		{
 			name: "no grafana state should be a no-op",
 			cfg: amConfig{
 				AlertConfigDesc: alertspb.AlertConfigDesc{
 					User: user,
 				},
+				usingGrafanaConfig: true,
 			},
-			expNoAlertmanager: true,
+			expNoNewAlertmanager: true,
 		},
 		{
 			name: "invalid alertmanager configuration should cause an error",
@@ -2963,7 +2973,8 @@ func TestPromoteAndDeleteState(t *testing.T) {
 					User:      user,
 					RawConfig: "invalid",
 				},
-				tmplExternalURL: externalURL,
+				tmplExternalURL:    externalURL,
+				usingGrafanaConfig: true,
 			},
 			parts:  map[string][]byte{"notifications": grafanaNflog},
 			expErr: fmt.Sprintf("error creating new Alertmanager for user %[1]s: no usable Alertmanager configuration for %[1]s", user),
@@ -2975,7 +2986,8 @@ func TestPromoteAndDeleteState(t *testing.T) {
 					User:      user,
 					RawConfig: simpleConfigOne,
 				},
-				tmplExternalURL: externalURL,
+				tmplExternalURL:    externalURL,
+				usingGrafanaConfig: true,
 			},
 			parts:  map[string][]byte{"invalid": []byte("invalid")},
 			expErr: "unknown part key \"invalid\"",
@@ -2987,7 +2999,8 @@ func TestPromoteAndDeleteState(t *testing.T) {
 					User:      user,
 					RawConfig: simpleConfigOne,
 				},
-				tmplExternalURL: externalURL,
+				tmplExternalURL:    externalURL,
+				usingGrafanaConfig: true,
 			},
 			parts: map[string][]byte{"notifications": grafanaNflog},
 		},
@@ -2998,7 +3011,8 @@ func TestPromoteAndDeleteState(t *testing.T) {
 					User:      user,
 					RawConfig: simpleConfigOne,
 				},
-				tmplExternalURL: externalURL,
+				tmplExternalURL:    externalURL,
+				usingGrafanaConfig: true,
 			},
 			mimirState: &testMimirState,
 			parts:      map[string][]byte{"notifications": grafanaNflog, "silences": grafanaSilences},
@@ -3037,7 +3051,7 @@ func TestPromoteAndDeleteState(t *testing.T) {
 			}
 
 			if test.expErr != "" {
-				err := am.promoteAndDeleteState(ctx, test.cfg)
+				err := am.syncStates(ctx, test.cfg)
 				require.Error(t, err)
 				require.Equal(t, test.expErr, err.Error())
 				require.Nil(t, am.alertmanagers[user])
@@ -3048,11 +3062,13 @@ func TestPromoteAndDeleteState(t *testing.T) {
 			if am, ok := am.alertmanagers[user]; ok {
 				am.silences.SetBroadcast(func(_ []byte) {})
 			}
-			require.NoError(t, am.promoteAndDeleteState(ctx, test.cfg))
-			if test.expNoAlertmanager {
+
+			require.NoError(t, am.syncStates(ctx, test.cfg))
+			if test.expNoNewAlertmanager {
 				require.Nil(t, am.alertmanagers[user])
 				return
 			}
+			require.True(t, am.alertmanagers[user].promoted.Load())
 
 			// Grafana state should be deleted after merging.
 			_, err = store.GetFullGrafanaState(ctx, user)
@@ -3089,6 +3105,77 @@ func TestPromoteAndDeleteState(t *testing.T) {
 				require.True(t, strings.Contains(nflogPart, "mimir webhook"))
 				require.True(t, strings.Contains(silencesPart, "mimir silence"))
 			}
+		})
+	}
+
+	preExistingAlertmanagerTests := []struct {
+		name            string
+		cfg             amConfig
+		initialPromoted bool
+		expPromoted     bool
+	}{
+		{
+			name: "not using grafana config should toggle the promoted flag off",
+			cfg: amConfig{
+				AlertConfigDesc: alertspb.AlertConfigDesc{
+					User:      user,
+					RawConfig: simpleConfigOne,
+				},
+				tmplExternalURL: externalURL,
+			},
+			initialPromoted: true,
+			expPromoted:     false,
+		},
+		{
+			name: "not using grafana config should be a no-op if the alertmanager is not promoted",
+			cfg: amConfig{
+				AlertConfigDesc: alertspb.AlertConfigDesc{
+					User:      user,
+					RawConfig: simpleConfigOne,
+				},
+				tmplExternalURL: externalURL,
+			},
+			initialPromoted: false,
+			expPromoted:     false,
+		},
+		{
+			name: "attempting to promote an already promoted alertmanager should not change the flag",
+			cfg: amConfig{
+				AlertConfigDesc: alertspb.AlertConfigDesc{
+					User:      user,
+					RawConfig: simpleConfigOne,
+				},
+				tmplExternalURL:    externalURL,
+				usingGrafanaConfig: true,
+			},
+			initialPromoted: true,
+			expPromoted:     true,
+		},
+	}
+
+	for _, test := range preExistingAlertmanagerTests {
+		t.Run(test.name, func(t *testing.T) {
+			store := prepareInMemoryAlertStore()
+			am := setupSingleMultitenantAlertmanager(t,
+				mockAlertmanagerConfig(t),
+				store,
+				nil,
+				featurecontrol.NoopFlags{},
+				log.NewNopLogger(),
+				prometheus.NewPedanticRegistry(),
+			)
+
+			am.setConfig(amConfig{
+				AlertConfigDesc: alertspb.AlertConfigDesc{
+					User:      user,
+					RawConfig: simpleConfigOne,
+				},
+				tmplExternalURL: externalURL,
+			})
+			am.alertmanagers[user].promoted.Store(test.initialPromoted)
+
+			require.NoError(t, am.syncStates(ctx, test.cfg))
+			require.Equal(t, test.expPromoted, am.alertmanagers[test.cfg.User].promoted.Load())
 		})
 	}
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -3068,7 +3068,8 @@ func TestSyncStates(t *testing.T) {
 				require.Nil(t, am.alertmanagers[user])
 				return
 			}
-			require.True(t, am.alertmanagers[user].promoted.Load())
+			require.NotNil(t, am.alertmanagers[user])
+			require.True(t, am.alertmanagers[user].usingGrafanaState.Load())
 
 			// Grafana state should be deleted after merging.
 			_, err = store.GetFullGrafanaState(ctx, user)
@@ -3076,6 +3077,7 @@ func TestSyncStates(t *testing.T) {
 			require.Equal(t, "alertmanager storage object not found", err.Error())
 
 			// States should be merged.
+			require.NotNil(t, am.alertmanagers[user])
 			s, err := am.alertmanagers[user].getFullState()
 			require.NoError(t, err)
 
@@ -3172,10 +3174,12 @@ func TestSyncStates(t *testing.T) {
 				},
 				tmplExternalURL: externalURL,
 			}))
-			am.alertmanagers[user].promoted.Store(test.initialPromoted)
+			require.NotNil(t, am.alertmanagers[user])
+			am.alertmanagers[user].usingGrafanaState.Store(test.initialPromoted)
 
 			require.NoError(t, am.syncStates(ctx, test.cfg))
-			require.Equal(t, test.expPromoted, am.alertmanagers[test.cfg.User].promoted.Load())
+			am.alertmanagers[user].usingGrafanaState.Store(test.initialPromoted)
+			require.Equal(t, test.expPromoted, am.alertmanagers[user].usingGrafanaState.Load())
 		})
 	}
 }

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -3165,13 +3165,13 @@ func TestSyncStates(t *testing.T) {
 				prometheus.NewPedanticRegistry(),
 			)
 
-			am.setConfig(amConfig{
+			require.NoError(t, am.setConfig(amConfig{
 				AlertConfigDesc: alertspb.AlertConfigDesc{
 					User:      user,
 					RawConfig: simpleConfigOne,
 				},
 				tmplExternalURL: externalURL,
-			})
+			}))
 			am.alertmanagers[user].promoted.Store(test.initialPromoted)
 
 			require.NoError(t, am.syncStates(ctx, test.cfg))


### PR DESCRIPTION
### Description

This PR enables Mimir to use a Grafana state if a Grafana configuration is being used to update the Alertmanager.

If a user is about to use a Grafana configuration in their Alertmanager, we check the database for Grafana state. We then use those entries to update the Alertmanager's notification log and silences.

After successfully merging states, we delete the Grafana state to avoid re-applying it. If we don't find Grafana state for a user, that (usually) means that we've already merged and deleted it, and the Alertmanager restarted, making its internal `promoted` flag equal to `false`.

### Note for reviewers

To test this PR it's necessary to enable the Grafana Alertmanager compatibility (take the config in [this PoC](https://github.com/grafana/mimir/pull/8637/files) as a model) and a Grafana instance running locally with the remote Alertmanager option enabled in _remote secondary_ mode (take the config in [this PoC as a model](https://github.com/grafana/grafana/pull/82021/files)). I recommend having a webhook listener ready to receive notifications, you can use https://webhook.site/.

Steps:
1. Create an alert rule and route it to your contact point of choice
2. Let it fire and send a notification
3. Turn Grafana off, it should send the latest configuration and state as part of its shutdown process
4. Start Grafana once again, this time in _remote primary_ mode
5. The Cloud Alertmanager should receive the alert, but no duplicated notifications should be received

The Cloud Alertmanager will merge states, so it will realize that a notification has already been sent when checking its notification log.

Related PoC: https://github.com/grafana/mimir/pull/8637