### PR TITLE
Upgrade delve to 1.22 in development environments

### DIFF
--- a/development/mimir-ingest-storage/dev.dockerfile
+++ b/development/mimir-ingest-storage/dev.dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_IMAGE # Use ./compose-up.sh to build this image.
 FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.0
 
 FROM alpine:3.19.1
 

--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_IMAGE # Use ./compose-up.sh to build this image.
 FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.0
 
 FROM alpine:3.19.1
 

--- a/development/mimir-read-write-mode/dev.dockerfile
+++ b/development/mimir-read-write-mode/dev.dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_IMAGE # Use ./compose-up.sh to build this image.
 FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.0
 
 FROM alpine:3.19.1
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Currently debug does not work with our local development environments since our [toolchain uses](https://github.com/grafana/mimir/blob/main/go.mod#L5) a version of Go not supported by the delve we use:

```sh
Version of Delve is too old for Go version 1.22.5 (maximum supported version 1.21, suppress this error with --check-go-version=false)
```

This PR updates our delve.