### PR TITLE
Dashboards: add compactor autoscaling panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * [ENHANCEMENT] Dashboards: Add panels for monitoring ingester autoscaling when not using ingest-storage. These panels are disabled by default, but can be enabled using the `autoscaling.ingester.enabled: true` config option. #8484
 * [ENHANCEMENT] Dashboards: add panels to show writes to experimental ingest storage backend in the "Mimir / Ruler" dashboard, when `_config.show_ingest_storage_panels` is enabled. #8732
 * [ENHANCEMENT] Dashboards: show all series in tooltips on time series dashboard panels. #8748
+* [ENHANCEMENT] Dashboards: add compactor autoscaling panels to "Mimir / Compactor" dashboard. The panels are disabled by default, but can be enabled setting `_config.autoscaling.compactor.enabled` to `true`. #8777
 * [BUGFIX] Dashboards: fix "current replicas" in autoscaling panels when HPA is not active. #8566
 * [BUGFIX] Alerts: do not fire `MimirRingMembersMismatch` during the migration to experimental ingest storage. #8727
 

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -646,6 +646,10 @@
         enabled: false,
         hpa_name: $._config.autoscaling_hpa_prefix + 'ingester-zone-a',
       },
+      compactor: {
+        enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'compactor',
+      },
     },
 
 

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -360,5 +360,9 @@ local fixTargetsForTransformations(panel, refIds) = panel {
     .addRows($.getObjectStoreRows('Object Store', 'compactor'))
     .addRow(
       $.kvStoreRow('Key-value store for compactors ring', 'compactor', '.+')
+    )
+    .addRowIf(
+      $._config.autoscaling.compactor.enabled,
+      $.cpuBasedAutoScalingRow('Compactor'),
     ),
 }

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -777,6 +777,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
       |||
     ),
 
+  cpuBasedAutoScalingRow(componentTitle)::
+    local componentName = std.strReplace(std.asciiLower(componentTitle), '-', '_');
+    super.row('%s – autoscaling' % [componentTitle])
+    .addPanel(
+      $.autoScalingActualReplicas(componentName)
+    )
+    .addPanel(
+      $.autoScalingDesiredReplicasByAverageValueScalingMetricPanel(componentName, 'CPU', 'cpu')
+    )
+    .addPanel(
+      $.autoScalingFailuresPanel(componentName)
+    ),
+
   cpuAndMemoryBasedAutoScalingRow(componentTitle)::
     local componentName = std.strReplace(std.asciiLower(componentTitle), '-', '_');
     super.row('%s – autoscaling' % [componentTitle])


### PR DESCRIPTION
#### What this PR does

At Grafana Labs we're experimenting with compactor autoscaling. If successful, we'll upstream the support to OSS jsonnet and Helm. Until then, I would like to add compactor autoscaling panels in the "Mimir / Compactor" dashboard. Since it's disabled by default, there are no changes to compiled dashboard.

**Preview**:
![Screenshot 2024-07-20 at 12 21 33](https://github.com/user-attachments/assets/949e067d-4c63-4f11-9812-bf5ba45bcb8d)



#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
