### PR TITLE
store-gateway: add test for persisting unloaded blocks

### DIFF
--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -820,7 +820,7 @@ func TestBucketStore_PersistsLazyLoadedBlocks(t *testing.T) {
 
 	// Wait for the blocks to be unloaded.
 	// Technically we need to wait for 3x persistInterval, and we've already waited 2x since last using the blocks.
-	// But we give some more time to avoid races/
+	// But we give some more time to avoid races.
 	time.Sleep(persistInterval * 2)
 	// The snapshot should be empty.
 	blocks, err = indexheader.RestoreLoadedBlocks(cfg.tempDir)


### PR DESCRIPTION
Lazy-loaded blocks would be loaded into memory after every restart as long as they have been loaded to memory at least once before.

This was a bug in r296 and earlier (probably dating [back to November 2023](https://github.com/grafana/mimir/commit/939f522c05bc72a81c4a04b539bd933884c7f59d) and r251) but fixed in r297 by https://github.com/grafana/mimir/commit/3e68842a093c3f931ad33e92d763693fd620a772 by setting the usedAt to 0 when we unload an index header. As a result the index header isn't included in snapshots https://github.com/grafana/mimir/blob/f89d319a774c0914537f91c56e93d73d9f873304/pkg/storegateway/indexheader/reader_pool.go#L184

This PR adds a test case for it