### PR TITLE
[r298] Remove `ItemCount` call from trySendNextRequestForQuerier

### DIFF
--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -364,28 +364,6 @@ func (q *RequestQueue) trySendNextRequestForQuerier(waitingConn *waitingQuerierC
 		return false
 	}
 
-	{
-		// temporary observation of query component load balancing behavior before full implementation
-		schedulerRequest, ok := req.req.(*SchedulerRequest)
-		if ok {
-			queryComponentName := schedulerRequest.ExpectedQueryComponentName()
-			exceedsThreshold, queryComponent := q.QueryComponentUtilization.ExceedsThresholdForComponentName(
-				queryComponentName,
-				int(q.connectedQuerierWorkers.Load()),
-				q.queueBroker.tree.ItemCount(),
-				q.waitingQuerierConnsToDispatch.Len(),
-			)
-
-			if exceedsThreshold {
-				level.Info(q.log).Log(
-					"msg", "experimental: querier worker connections in use by query component exceed utilization threshold. no action taken",
-					"query_component_name", queryComponentName,
-					"overloaded_query_component", queryComponent,
-				)
-			}
-		}
-	}
-
 	reqForQuerier := requestForQuerier{
 		req:             req.req,
 		lastTenantIndex: waitingConn.lastTenantIndex,


### PR DESCRIPTION
#### What this PR does

We've found internally that calling `ItemCount` is slow when there are many tenants and the queue is long. This is not necessary, so let's remove it to prevent a situation where the queue can't keep up.

#### Which issue(s) this PR fixes or relates to



#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
