### PR TITLE
Update values.yaml

### DIFF
--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -951,6 +951,7 @@ ingester:
     # If true and ingester.statefulSet.enabled is true,
     # Ingester will create/use a Persistent Volume Claim
     # If false, use emptyDir
+    # It is advisable to enable volume persistence in ingester to avoid losing metrics.
     #
     enabled: true
 


### PR DESCRIPTION
It is advisable to enable persistence in the ingester to avoid losing metrics.
