### PR TITLE
Simplify HTTP headers propagation in PrometheusCodec.EncodeMetricsQueryRequest()

### DIFF
--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -46,6 +46,9 @@ var (
 	errNegativeStep   = apierror.New(apierror.TypeBadData, `invalid parameter "step": zero or negative query resolution step widths are not accepted. Try a positive integer`)
 	errStepTooSmall   = apierror.New(apierror.TypeBadData, "exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)")
 	allFormats        = []string{formatJSON, formatProtobuf}
+
+	// List of HTTP headers to propagate when a Prometheus request is encoded into a HTTP request.
+	prometheusCodecPropagateHeaders = []string{compat.ForceFallbackHeaderName, chunkinfologger.ChunkInfoLoggingHeader}
 )
 
 const (
@@ -592,18 +595,15 @@ func (c prometheusCodec) EncodeMetricsQueryRequest(ctx context.Context, r Metric
 		req.Header.Add(api.ReadConsistencyHeader, consistency)
 	}
 
+	// Propagate allowed HTTP headers.
 	for _, h := range r.GetHeaders() {
-		if h.Name == compat.ForceFallbackHeaderName {
-			for _, v := range h.Values {
-				// There should only be one value, but add all of them for completeness.
-				req.Header.Add(compat.ForceFallbackHeaderName, v)
-			}
+		if !slices.Contains(prometheusCodecPropagateHeaders, h.Name) {
+			continue
 		}
-		if h.Name == chunkinfologger.ChunkInfoLoggingHeader {
-			for _, v := range h.Values {
-				// There should only be one value, but add all of them for completeness.
-				req.Header.Add(chunkinfologger.ChunkInfoLoggingHeader, v)
-			}
+
+		for _, v := range h.Values {
+			// There should only be one value, but add all of them for completeness.
+			req.Header.Add(h.Name, v)
 		}
 	}
 

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -34,6 +34,8 @@ import (
 	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/api"
+	"github.com/grafana/mimir/pkg/streamingpromql/compat"
+	"github.com/grafana/mimir/pkg/util/chunkinfologger"
 	testutil "github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -68,7 +70,7 @@ func requireEqualMetricsQueryRequest(t *testing.T, expected, actual MetricsQuery
 	require.Equal(t, expected.GetHints(), actual.GetHints())
 }
 
-func TestMetricsQueryRequest(t *testing.T) {
+func TestPrometheusCodec_EncodeMetricsQueryRequest(t *testing.T) {
 	codec := newTestPrometheusCodec()
 
 	for i, tc := range []struct {
@@ -472,7 +474,7 @@ func TestMetricsQuery_WithQuery_WithExpr_TransformConsistency(t *testing.T) {
 	}
 }
 
-func TestLabelsQueryRequest(t *testing.T) {
+func TestPrometheusCodec_EncodeLabelsQueryRequest(t *testing.T) {
 	codec := newTestPrometheusCodec()
 
 	for _, testCase := range []struct {
@@ -687,7 +689,7 @@ func TestLabelsQueryRequest(t *testing.T) {
 	}
 }
 
-func TestPrometheusCodec_EncodeRequest_AcceptHeader(t *testing.T) {
+func TestPrometheusCodec_EncodeMetricsQueryRequest_AcceptHeader(t *testing.T) {
 	for _, queryResultPayloadFormat := range allFormats {
 		t.Run(queryResultPayloadFormat, func(t *testing.T) {
 			codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, queryResultPayloadFormat)
@@ -707,7 +709,7 @@ func TestPrometheusCodec_EncodeRequest_AcceptHeader(t *testing.T) {
 	}
 }
 
-func TestPrometheusCodec_EncodeRequest_ReadConsistency(t *testing.T) {
+func TestPrometheusCodec_EncodeMetricsQueryRequest_ReadConsistency(t *testing.T) {
 	for _, consistencyLevel := range api.ReadConsistencies {
 		t.Run(consistencyLevel, func(t *testing.T) {
 			codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, formatProtobuf)
@@ -717,6 +719,28 @@ func TestPrometheusCodec_EncodeRequest_ReadConsistency(t *testing.T) {
 			require.Equal(t, consistencyLevel, encodedRequest.Header.Get(api.ReadConsistencyHeader))
 		})
 	}
+}
+
+func TestPrometheusCodec_EncodeMetricsQueryRequest_ShouldPropagateHeadersInAllowList(t *testing.T) {
+	const notAllowedHeader = "X-Some-Name"
+
+	codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, formatProtobuf)
+
+	req, err := codec.EncodeMetricsQueryRequest(context.Background(), &PrometheusInstantQueryRequest{
+		headers: []*PrometheusHeader{
+			// Allowed.
+			{Name: compat.ForceFallbackHeaderName, Values: []string{"true"}},
+			{Name: chunkinfologger.ChunkInfoLoggingHeader, Values: []string{"label"}},
+
+			// Not allowed.
+			{Name: notAllowedHeader, Values: []string{"some-value"}},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"true"}, req.Header.Values(compat.ForceFallbackHeaderName))
+	require.Equal(t, []string{"label"}, req.Header.Values(chunkinfologger.ChunkInfoLoggingHeader))
+	require.Empty(t, req.Header.Values(notAllowedHeader))
 }
 
 func TestPrometheusCodec_EncodeResponse_ContentNegotiation(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

This is another preliminary to ease the review of https://github.com/grafana/mimir/pull/8808. In this PR I'm generalising the list of HTTP headers propagated by `PrometheusCodec.EncodeMetricsQueryRequest()`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
