### PR TITLE
Add tool for querying a bucket index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 ### Tools
 
 * [CHANGE] `wal-reader`: Renamed `-series-entries` to `-print-series`. Renamed `-print-series-with-samples` to `-print-samples`. #8568
+* [FEATURE] `query-bucket-index`: add new tool to query a bucket index file and print the blocks that would be used for a given query time range. #8818
 * [ENHANCEMENT] `wal-reader`: References to unknown series from Samples, Exemplars, histogram or tombstones records are now always logged. #8568
 * [ENHANCEMENT] `tsdb-series`: added `-stats` option to print min/max time of chunks, total number of samples and DPM for each series. #8420
 * [ENHANCEMENT] `tsdb-print-chunk`: print counter reset information for native histograms. #8812

--- a/tools/query-bucket-index/README.md
+++ b/tools/query-bucket-index/README.md
@@ -1,0 +1,20 @@
+`query-bucket-index` can be used to query a bucket index file (either a gzip-compressed JSON file, or an uncompressed JSON file) for a given query time range.
+
+The output is provided in CSV format.
+
+For example, running `go run . -bucket-index bucket-index.json.gz -start 2024-07-24T12:00:00Z -end 2024-07-24T13:00:00Z` will print the blocks that would be
+queried for a query from 2024-07-24 12:00:00 UTC to 2024-07-24 13:00:00 UTC based on the gzip-compressed bucket index `bucket-index.json.gz`.
+
+Sample output:
+
+```
+Block ID,Min time,Max time,Uploaded at,Shard ID,Source,Compaction level,Deletion marker present?,Deletion time
+01J3JW2VVE4HYNAQ5RGRAK54N9,2024-07-24T12:00:00Z,2024-07-24T14:00:00Z,2024-07-24T17:23:12Z,3_of_4,compactor,4,true,2024-07-25T01:41:46Z
+01J3JWBDSEJ4K9MABF569E2E3Z,2024-07-24T12:00:00Z,2024-07-24T14:00:00Z,2024-07-24T17:27:40Z,4_of_4,compactor,4,false,
+01J3JWMA3FGGB5253479FBCKYB,2024-07-24T12:00:00Z,2024-07-24T14:00:00Z,2024-07-24T17:31:40Z,2_of_4,compactor,4,true,2024-07-25T01:36:18Z
+01J3KP1M6VCNY8J56GBT80JBRT,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T01:08:56Z,1_of_4,compactor,5,true,2024-07-25T03:18:33Z
+01J3KQ28GNX4EN7AG22HV9ZNGB,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T01:41:46Z,3_of_4,compactor,5,false,
+01J3KQD3C45M9F6WZ6EN5EQ2Q2,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T01:36:17Z,2_of_4,compactor,5,false,
+01J3KXB2Z1Y5W01MRF3AHM1MN1,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T03:18:32Z,1_of_4,compactor,6,true,2024-07-25T03:23:16Z
+01J3KXHZEKA00XYXF6JP4BH3QM,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T03:23:10Z,1_of_4,compactor,6,false,
+```

--- a/tools/query-bucket-index/main.go
+++ b/tools/query-bucket-index/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package main
 
 import (

--- a/tools/query-bucket-index/main.go
+++ b/tools/query-bucket-index/main.go
@@ -20,6 +20,9 @@ import (
 	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
 )
 
+// Invoke this with a command like:
+//
+//	go run . -bucket-index bucket-index.json.gz -start 2024-07-24T12:00:00Z -end 2024-07-24T13:00:00Z
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/tools/query-bucket-index/main.go
+++ b/tools/query-bucket-index/main.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"slices"
 	"strconv"
@@ -22,7 +22,7 @@ import (
 
 func main() {
 	if err := run(); err != nil {
-		slog.Error("application failed", "err", err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/tools/query-bucket-index/main.go
+++ b/tools/query-bucket-index/main.go
@@ -60,7 +60,7 @@ func run() error {
 
 	w := csv.NewWriter(os.Stdout)
 	err = w.Write([]string{
-		"ULID",
+		"Block ID",
 		"Min time",
 		"Max time",
 		"Uploaded at",

--- a/tools/query-bucket-index/main.go
+++ b/tools/query-bucket-index/main.go
@@ -108,7 +108,10 @@ func parseFlags() (string, bool, time.Time, time.Time, error) {
 	var startT, endT flagext.Time
 	flag.Var(&startT, "start", "Start time")
 	flag.Var(&endT, "end", "End time")
-	flag.Parse()
+
+	if err := flagext.ParseFlagsWithoutArguments(flag.CommandLine); err != nil {
+		return "", false, time.Time{}, time.Time{}, err
+	}
 
 	if *bucketIndexFile == "" {
 		return "", false, time.Time{}, time.Time{}, errors.New("must provide bucket index file")

--- a/tools/query-bucket-index/main.go
+++ b/tools/query-bucket-index/main.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"flag"
+	"log/slog"
+	"os"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/prometheus/model/timestamp"
+
+	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("application failed", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	bucketIndexFile, startT, endT, err := parseFlags()
+	if err != nil {
+		return err
+	}
+
+	bucketIndex, err := readBucketIndex(bucketIndexFile)
+	if err != nil {
+		return err
+	}
+
+	blocks, deletionMarkers, err := getBlocks(bucketIndex, timestamp.FromTime(startT), timestamp.FromTime(endT))
+	if err != nil {
+		return err
+	}
+
+	slices.SortFunc(blocks, func(a, b *bucketindex.Block) int {
+		if a.ID.String() > b.ID.String() {
+			return 1
+		} else if a.ID.String() < b.ID.String() {
+			return -1
+		}
+
+		return 0
+	})
+
+	w := csv.NewWriter(os.Stdout)
+	err = w.Write([]string{
+		"ULID",
+		"Min time",
+		"Max time",
+		"Uploaded at",
+		"Shard ID",
+		"Source",
+		"Compaction level",
+		"Deletion marker present?",
+		"Deletion time",
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, block := range blocks {
+		deletionMarker, deletionMarkerPresent := deletionMarkers[block.ID]
+		deletionTime := ""
+
+		if deletionMarkerPresent {
+			deletionTime = time.Unix(deletionMarker.DeletionTime, 0).UTC().Format(time.RFC3339)
+		}
+
+		err := w.Write([]string{
+			block.ID.String(),
+			timestamp.Time(block.MinTime).Format(time.RFC3339),
+			timestamp.Time(block.MaxTime).Format(time.RFC3339),
+			time.Unix(block.UploadedAt, 0).UTC().Format(time.RFC3339),
+			block.CompactorShardID,
+			block.Source,
+			strconv.Itoa(block.CompactionLevel),
+			strconv.FormatBool(deletionMarkerPresent),
+			deletionTime,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	w.Flush()
+
+	return w.Error()
+}
+
+func parseFlags() (string, time.Time, time.Time, error) {
+	bucketIndexFile := flag.String("bucket-index", "", "Path to bucket index file (uncompressed JSON)")
+
+	var startT, endT flagext.Time
+	flag.Var(&startT, "start", "Start time")
+	flag.Var(&endT, "end", "End time")
+	flag.Parse()
+
+	if *bucketIndexFile == "" {
+		return "", time.Time{}, time.Time{}, errors.New("must provide bucket index file")
+	}
+
+	if time.Time(startT).IsZero() {
+		return "", time.Time{}, time.Time{}, errors.New("must provide start time")
+	}
+
+	if time.Time(endT).IsZero() {
+		return "", time.Time{}, time.Time{}, errors.New("must provide start time")
+	}
+
+	return *bucketIndexFile, time.Time(startT), time.Time(endT), nil
+}
+
+func readBucketIndex(bucketIndexFile string) (*bucketindex.Index, error) {
+	f, err := os.Open(bucketIndexFile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	index := &bucketindex.Index{}
+	d := json.NewDecoder(f)
+	if err := d.Decode(index); err != nil {
+		return nil, err
+	}
+
+	return index, nil
+}
+
+// This is based on BucketIndexBlocksFinder.GetBlocks.
+func getBlocks(index *bucketindex.Index, minT, maxT int64) (bucketindex.Blocks, map[ulid.ULID]*bucketindex.BlockDeletionMark, error) {
+	matchingBlocks := map[ulid.ULID]*bucketindex.Block{}
+	matchingDeletionMarks := map[ulid.ULID]*bucketindex.BlockDeletionMark{}
+
+	for _, block := range index.Blocks {
+		if !block.Within(minT, maxT) {
+			continue
+		}
+
+		matchingBlocks[block.ID] = block
+	}
+
+	for _, mark := range index.BlockDeletionMarks {
+		// Filter deletion marks by matching blocks only.
+		if _, ok := matchingBlocks[mark.ID]; !ok {
+			continue
+		}
+
+		matchingDeletionMarks[mark.ID] = mark
+	}
+
+	// Convert matching blocks into a list.
+	blocks := make(bucketindex.Blocks, 0, len(matchingBlocks))
+	for _, b := range matchingBlocks {
+		blocks = append(blocks, b)
+	}
+
+	return blocks, matchingDeletionMarks, nil
+}


### PR DESCRIPTION
#### What this PR does

This PR adds a tool, `query-bucket-index`, that displays the blocks that would be used from a given bucket index for a given query time range.

The output is provided in CSV format.

Sample output:

```
$ go run . -bucket-index bucket-index.json.gz -start 2024-07-24T12:00:00Z -end 2024-07-24T13:00:00Z

Block ID,Min time,Max time,Uploaded at,Shard ID,Source,Compaction level,Deletion marker present?,Deletion time
01J3JW2VVE4HYNAQ5RGRAK54N9,2024-07-24T12:00:00Z,2024-07-24T14:00:00Z,2024-07-24T17:23:12Z,3_of_4,compactor,4,true,2024-07-25T01:41:46Z
01J3JWBDSEJ4K9MABF569E2E3Z,2024-07-24T12:00:00Z,2024-07-24T14:00:00Z,2024-07-24T17:27:40Z,4_of_4,compactor,4,false,
01J3JWMA3FGGB5253479FBCKYB,2024-07-24T12:00:00Z,2024-07-24T14:00:00Z,2024-07-24T17:31:40Z,2_of_4,compactor,4,true,2024-07-25T01:36:18Z
01J3KP1M6VCNY8J56GBT80JBRT,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T01:08:56Z,1_of_4,compactor,5,true,2024-07-25T03:18:33Z
01J3KQ28GNX4EN7AG22HV9ZNGB,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T01:41:46Z,3_of_4,compactor,5,false,
01J3KQD3C45M9F6WZ6EN5EQ2Q2,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T01:36:17Z,2_of_4,compactor,5,false,
01J3KXB2Z1Y5W01MRF3AHM1MN1,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T03:18:32Z,1_of_4,compactor,6,true,2024-07-25T03:23:16Z
01J3KXHZEKA00XYXF6JP4BH3QM,2024-07-24T12:00:00Z,2024-07-25T00:00:00Z,2024-07-25T03:23:10Z,1_of_4,compactor,6,false,
```

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
