### PR TITLE
grpcurl-query-ingesters: print counter reset information for native histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
 * [ENHANCEMENT] `wal-reader`: References to unknown series from Samples, Exemplars, histogram or tombstones records are now always logged. #8568
 * [ENHANCEMENT] `tsdb-series`: added `-stats` option to print min/max time of chunks, total number of samples and DPM for each series. #8420
 * [ENHANCEMENT] `tsdb-print-chunk`: print counter reset information for native histograms. #8812
+* [ENHANCEMENT] `grpcurl-query-ingesters`: print counter reset information for native histograms. #8820
 
 ## 2.13.0
 

--- a/tools/grpcurl-query-ingesters/main.go
+++ b/tools/grpcurl-query-ingesters/main.go
@@ -89,10 +89,10 @@ func dumpResponse(res QueryStreamResponse) {
 					fmt.Println("  - Sample:", sampleType.String(), "ts:", chunkIterator.Timestamp(), "value:", chunkIterator.Value().Value)
 				case chunkenc.ValHistogram:
 					ts, h = chunkIterator.AtHistogram(h)
-					fmt.Println("  - Sample:", sampleType.String(), "ts:", ts, "value:", h)
+					fmt.Println("  - Sample:", sampleType.String(), "ts:", ts, "value:", h, "hint:", counterResetHintString(h.CounterResetHint))
 				case chunkenc.ValFloatHistogram:
 					ts, fh := chunkIterator.AtFloatHistogram(fh)
-					fmt.Println("  - Sample:", sampleType.String(), "ts:", ts, "value:", fh)
+					fmt.Println("  - Sample:", sampleType.String(), "ts:", ts, "value:", fh, "hint:", counterResetHintString(fh.CounterResetHint))
 				default:
 					panic(fmt.Errorf("unknown sample type %s", sampleType.String()))
 				}
@@ -102,5 +102,20 @@ func dumpResponse(res QueryStreamResponse) {
 				panic(chunkIterator.Err())
 			}
 		}
+	}
+}
+
+func counterResetHintString(crh histogram.CounterResetHint) string {
+	switch crh {
+	case histogram.UnknownCounterReset:
+		return "UnknownCounterReset"
+	case histogram.CounterReset:
+		return "CounterReset"
+	case histogram.NotCounterReset:
+		return "NotCounterReset"
+	case histogram.GaugeType:
+		return "GaugeType"
+	default:
+		return "unrecognized counter reset hint"
 	}
 }


### PR DESCRIPTION
#### What this PR does
This PR adds counter hint reset to the data printed by `grpcurl-query-ingesters`.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
