### PR TITLE
WIP: Introduce per-tenant ha-tracker.failover-timeout.

### DIFF
--- a/pkg/distributor/ha_tracker_status.gohtml
+++ b/pkg/distributor/ha_tracker_status.gohtml
@@ -8,29 +8,34 @@
 <body>
 <h1>HA Tracker Status</h1>
 <p>Current time: {{ .Now }}</p>
-<table width="100%" border="1">
-    <thead>
-    <tr>
-        <th>User ID</th>
-        <th>Cluster</th>
-        <th>Replica</th>
-        <th>Elected Time</th>
-        <th>Time Until Update</th>
-        <th>Time Until Failover</th>
-    </tr>
-    </thead>
-    <tbody>
-    {{ range .Elected }}
+
+{{ range $u, $e := .ElectedPerUser }}
+<h3>{{ $u }}</h3>
+    <p>Failover timeout for user: {{ if $e }}{{ (index $e 0).FailoverTimeoutForUser }}{{ end }}</p>
+
+    <table width="100%" border="1">
+        <thead>
         <tr>
-            <td>{{ .UserID }}</td>
-            <td>{{ .Cluster }}</td>
-            <td>{{ .Replica }}</td>
-            <td>{{ .ElectedAt }}</td>
-            <td>{{ .UpdateTime }}</td>
-            <td>{{ .FailoverTime }}</td>
+            <th>Cluster</th>
+            <th>Replica</th>
+            <th>Elected Time</th>
+            <th>Time Until Update</th>
+            <th>Time Until Failover</th>
         </tr>
-    {{ end }}
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+        {{ range $e }}
+            <tr>
+                <td>{{ .UserID }}</td>
+                <td>{{ .Cluster }}</td>
+                <td>{{ .Replica }}</td>
+                <td>{{ .ElectedAt }}</td>
+                <td>{{ .UpdateTime }}</td>
+                <td>{{ .TimeToFailover }}</td>
+            </tr>
+        {{ end }}
+        </tbody>
+    </table>
+{{ end }}
 </body>
 </html>

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -107,6 +107,7 @@ type Limits struct {
 	HAClusterLabel                              string              `yaml:"ha_cluster_label" json:"ha_cluster_label"`
 	HAReplicaLabel                              string              `yaml:"ha_replica_label" json:"ha_replica_label"`
 	HAMaxClusters                               int                 `yaml:"ha_max_clusters" json:"ha_max_clusters"`
+	HAFailoverTimeout                           time.Duration       `yaml:"ha_failover_timeout" json:"ha_failover_timeout"`
 	DropLabels                                  flagext.StringSlice `yaml:"drop_labels" json:"drop_labels" category:"advanced"`
 	MaxLabelNameLength                          int                 `yaml:"max_label_name_length" json:"max_label_name_length"`
 	MaxLabelValueLength                         int                 `yaml:"max_label_value_length" json:"max_label_value_length"`
@@ -248,6 +249,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&l.HAClusterLabel, "distributor.ha-tracker.cluster", "cluster", "Prometheus label to look for in samples to identify a Prometheus HA cluster.")
 	f.StringVar(&l.HAReplicaLabel, "distributor.ha-tracker.replica", "__replica__", "Prometheus label to look for in samples to identify a Prometheus HA replica.")
 	f.IntVar(&l.HAMaxClusters, HATrackerMaxClustersFlag, 100, "Maximum number of clusters that HA tracker will keep track of for a single tenant. 0 to disable the limit.")
+	f.DurationVar(&l.HAFailoverTimeout, "distributor.ha-tracker.failover-timeout-per-tenant", 0, "Per-tenant override for -distributor.ha-tracker.failover-timeout. If set to 0, -distributor.ha-tracker.failover-timeout is used.")
 	f.Var(&l.DropLabels, "distributor.drop-label", "This flag can be used to specify label names that to drop during sample ingestion within the distributor and can be repeated in order to drop multiple labels.")
 	f.IntVar(&l.MaxLabelNameLength, MaxLabelNameLengthFlag, 1024, "Maximum length accepted for label names")
 	f.IntVar(&l.MaxLabelValueLength, MaxLabelValueLengthFlag, 2048, "Maximum length accepted for label value. This setting also applies to the metric name")


### PR DESCRIPTION
#### What this PR does

This PR makes failover-timeour for HA tracker overrideable per tenant.

(No tests, limits to be improved)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
