### PR TITLE
fix: remove double check for existence of config

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -455,7 +455,7 @@ Examples:
   "tokengen" "tokengenJob"
 -}}
 {{- $componentSection := index $componentsMap .component -}}
-{{- if not $componentSection -}}{{- printf "No component section mapping for %s not found in values; submit a bug report if you are a user, edit mimir.componentSectionFromName if you are a contributor" .component | fail -}}{{- end -}}
+{{- if not $componentSection -}}{{- $componentSection := .component -}}{{- end -}}
 {{- $section := .ctx.Values -}}
 {{- range regexSplit "\\." $componentSection -1 -}}
   {{- $section = index $section . -}}


### PR DESCRIPTION
#### What this PR does

There is absolutely no reason for the `No component section mapping for xxx not found in values; submit a bug report if you are a user, edit mimir.componentSectionFromName if you are a contributor` error when the next line checks if it can find the config section. Just fall-back to the name given.

