### PR TITLE
Merge overlapping chunks for a single series from a single store-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [BUGFIX] Alertmanager: Fix help message for utf-8-strict-mode. #8572
 * [BUGFIX] Query-frontend: Ensure that internal errors result in an HTTP 500 response code instead of 422. #8595 #8666
 * [BUGFIX] Configuration: Multi line envs variables are flatten during injection to be compatible with YAML syntax
+* [BUGFIX] Querier: fix issue where queries can return incorrect results if a single store-gateway returns overlapping chunks for a series. #8827
 
 ### Mixin
 

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -102,7 +102,6 @@ func newIteratorAdapter(it *iteratorAdapter, underlying iterator) chunkenc.Itera
 
 // Seek implements chunkenc.Iterator.
 func (a *iteratorAdapter) Seek(t int64) chunkenc.ValueType {
-
 	// Optimisation: fulfill the seek using current batch if possible.
 	if a.curr.Length > 0 && a.curr.Index < a.curr.Length {
 		if t <= a.curr.Timestamps[a.curr.Index] {
@@ -199,5 +198,5 @@ func (a *iteratorAdapter) AtT() int64 {
 
 // Err implements chunkenc.Iterator.
 func (a *iteratorAdapter) Err() error {
-	return nil
+	return a.underlying.Err()
 }

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
 	"github.com/grafana/mimir/pkg/storage/chunk"
@@ -55,17 +56,17 @@ type iterator interface {
 }
 
 // NewChunkMergeIterator returns a chunkenc.Iterator that merges Mimir chunks together.
-func NewChunkMergeIterator(it chunkenc.Iterator, chunks []chunk.Chunk) chunkenc.Iterator {
+func NewChunkMergeIterator(it chunkenc.Iterator, lbls labels.Labels, chunks []chunk.Chunk) chunkenc.Iterator {
 	converted := make([]GenericChunk, len(chunks))
 	for i, c := range chunks {
 		converted[i] = NewGenericChunk(int64(c.From), int64(c.Through), c.Data.NewIterator)
 	}
 
-	return NewGenericChunkMergeIterator(it, converted)
+	return NewGenericChunkMergeIterator(it, lbls, converted)
 }
 
 // NewGenericChunkMergeIterator returns a chunkenc.Iterator that merges generic chunks together.
-func NewGenericChunkMergeIterator(it chunkenc.Iterator, chunks []GenericChunk) chunkenc.Iterator {
+func NewGenericChunkMergeIterator(it chunkenc.Iterator, lbls labels.Labels, chunks []GenericChunk) chunkenc.Iterator {
 	var iter *mergeIterator
 
 	adapter, ok := it.(*iteratorAdapter)
@@ -75,7 +76,7 @@ func NewGenericChunkMergeIterator(it chunkenc.Iterator, chunks []GenericChunk) c
 		iter = newMergeIterator(nil, chunks)
 	}
 
-	return newIteratorAdapter(adapter, iter)
+	return newIteratorAdapter(adapter, iter, lbls)
 }
 
 // iteratorAdapter turns a batchIterator into a chunkenc.Iterator.
@@ -85,18 +86,21 @@ type iteratorAdapter struct {
 	batchSize  int
 	curr       chunk.Batch
 	underlying iterator
+	labels     labels.Labels
 }
 
-func newIteratorAdapter(it *iteratorAdapter, underlying iterator) chunkenc.Iterator {
+func newIteratorAdapter(it *iteratorAdapter, underlying iterator, lbls labels.Labels) chunkenc.Iterator {
 	if it != nil {
 		it.batchSize = 1
 		it.underlying = underlying
 		it.curr = chunk.Batch{}
+		it.labels = lbls
 		return it
 	}
 	return &iteratorAdapter{
 		batchSize:  1,
 		underlying: underlying,
+		labels:     lbls,
 	}
 }
 
@@ -198,5 +202,9 @@ func (a *iteratorAdapter) AtT() int64 {
 
 // Err implements chunkenc.Iterator.
 func (a *iteratorAdapter) Err() error {
-	return a.underlying.Err()
+	if err := a.underlying.Err(); err != nil {
+		return fmt.Errorf("error reading chunks for series %s: %w", a.labels, err)
+	}
+
+	return nil
 }

--- a/pkg/querier/batch/batch_test.go
+++ b/pkg/querier/batch/batch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
 
@@ -32,6 +33,8 @@ func BenchmarkNewChunkMergeIterator_CreateAndIterate(b *testing.B) {
 		{numChunks: 1, numSamplesPerChunk: 100, duplicationFactor: 3},
 	}
 
+	lbls := labels.EmptyLabels()
+
 	for _, scenario := range scenarios {
 		for _, encoding := range []chunk.Encoding{chunk.PrometheusXorChunk, chunk.PrometheusHistogramChunk, chunk.PrometheusFloatHistogramChunk} {
 			name := fmt.Sprintf("chunks: %d samples per chunk: %d duplication factor: %d encoding: %s", scenario.numChunks, scenario.numSamplesPerChunk, scenario.duplicationFactor, encoding)
@@ -45,7 +48,7 @@ func BenchmarkNewChunkMergeIterator_CreateAndIterate(b *testing.B) {
 					fh *histogram.FloatHistogram
 				)
 				for n := 0; n < b.N; n++ {
-					it = NewChunkMergeIterator(it, chunks)
+					it = NewChunkMergeIterator(it, lbls, chunks)
 					for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
 						switch valType {
 						case chunkenc.ValFloat:
@@ -74,7 +77,7 @@ func TestSeekCorrectlyDealWithSinglePointChunks(t *testing.T) {
 	chunkTwo := mkChunk(t, model.Time(10*step/time.Millisecond), 1, chunk.PrometheusXorChunk)
 	chunks := []chunk.Chunk{chunkOne, chunkTwo}
 
-	sut := NewChunkMergeIterator(nil, chunks)
+	sut := NewChunkMergeIterator(nil, labels.EmptyLabels(), chunks)
 
 	// Following calls mimics Prometheus's query engine behaviour for VectorSelector.
 	require.Equal(t, chunkenc.ValFloat, sut.Next())

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -36,10 +36,10 @@ func testChunkIter(t *testing.T, encoding chunk.Encoding) {
 	iter := &chunkIterator{}
 
 	iter.reset(chunk)
-	testIter(t, 100, newIteratorAdapter(nil, iter), encoding)
+	testIter(t, 100, newIteratorAdapter(nil, iter, labels.EmptyLabels()), encoding)
 
 	iter.reset(chunk)
-	testSeek(t, 100, newIteratorAdapter(nil, iter), encoding)
+	testSeek(t, 100, newIteratorAdapter(nil, iter, labels.EmptyLabels()), encoding)
 }
 
 func mkChunk(t require.TestingT, from model.Time, points int, encoding chunk.Encoding) chunk.Chunk {

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -69,6 +69,10 @@ func newMergeIterator(it iterator, cs []GenericChunk) *mergeIterator {
 }
 
 func (c *mergeIterator) Seek(t int64, size int) chunkenc.ValueType {
+	if c.currErr != nil {
+		// We've already failed. Stop.
+		return chunkenc.ValNone
+	}
 
 	// Optimisation to see if the seek is within our current caches batches.
 found:
@@ -109,6 +113,11 @@ found:
 }
 
 func (c *mergeIterator) Next(size int) chunkenc.ValueType {
+	if c.currErr != nil {
+		// We've already failed. Stop.
+		return chunkenc.ValNone
+	}
+
 	// Pop the last built batch in a way that doesn't extend the slice.
 	if c.batches.len() > 0 {
 		// The first batch is not needed anymore, so we remove it.

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/mimir/pkg/storage/chunk"
 )
@@ -23,15 +24,15 @@ func TestMergeIter(t *testing.T) {
 			chunk4 := mkGenericChunk(t, model.TimeFromUnix(75), 100, enc)
 			chunk5 := mkGenericChunk(t, model.TimeFromUnix(100), 100, enc)
 
-			iter := NewGenericChunkMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+			iter := NewGenericChunkMergeIterator(nil, labels.EmptyLabels(), []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
 			testIter(t, 200, iter, enc)
-			iter = NewGenericChunkMergeIterator(nil, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+			iter = NewGenericChunkMergeIterator(nil, labels.EmptyLabels(), []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
 			testSeek(t, 200, iter, enc)
 
 			// Re-use iterator.
-			iter = NewGenericChunkMergeIterator(iter, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+			iter = NewGenericChunkMergeIterator(iter, labels.EmptyLabels(), []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
 			testIter(t, 200, iter, enc)
-			iter = NewGenericChunkMergeIterator(iter, []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
+			iter = NewGenericChunkMergeIterator(iter, labels.EmptyLabels(), []GenericChunk{chunk1, chunk2, chunk3, chunk4, chunk5})
 			testSeek(t, 200, iter, enc)
 		})
 	}
@@ -53,10 +54,10 @@ func TestMergeHarder(t *testing.T) {
 				from = from.Add(time.Duration(offset) * time.Second)
 			}
 			iter := newMergeIterator(nil, chunks)
-			testIter(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter), enc)
+			testIter(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter, labels.EmptyLabels()), enc)
 
 			iter = newMergeIterator(nil, chunks)
-			testSeek(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter), enc)
+			testSeek(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter, labels.EmptyLabels()), enc)
 		})
 	}
 }

--- a/pkg/querier/batch/non_overlapping_test.go
+++ b/pkg/querier/batch/non_overlapping_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/mimir/pkg/storage/chunk"
 )
@@ -18,17 +19,17 @@ func TestNonOverlappingIter(t *testing.T) {
 	for i := int64(0); i < 100; i++ {
 		cs = append(cs, mkGenericChunk(t, model.TimeFromUnix(i*10), 10, chunk.PrometheusXorChunk))
 	}
-	testIter(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil)), chunk.PrometheusXorChunk)
+	testIter(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil), labels.EmptyLabels()), chunk.PrometheusXorChunk)
 	it := newNonOverlappingIterator(nil, cs, nil, nil)
-	adapter := newIteratorAdapter(nil, it)
+	adapter := newIteratorAdapter(nil, it, labels.EmptyLabels())
 	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk)
 
 	// Do the same operations while re-using the iterators.
 	it = newNonOverlappingIterator(it, cs, nil, nil)
-	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it)
+	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it, labels.EmptyLabels())
 	testIter(t, 10*100, adapter, chunk.PrometheusXorChunk)
 	it = newNonOverlappingIterator(it, cs, nil, nil)
-	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it)
+	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it, labels.EmptyLabels())
 	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk)
 }
 
@@ -41,6 +42,6 @@ func TestNonOverlappingIterSparse(t *testing.T) {
 		mkGenericChunk(t, model.TimeFromUnix(95), 1, chunk.PrometheusXorChunk),
 		mkGenericChunk(t, model.TimeFromUnix(96), 4, chunk.PrometheusXorChunk),
 	}
-	testIter(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil)), chunk.PrometheusXorChunk)
-	testSeek(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil)), chunk.PrometheusXorChunk)
+	testIter(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil), labels.EmptyLabels()), chunk.PrometheusXorChunk)
+	testSeek(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil), labels.EmptyLabels()), chunk.PrometheusXorChunk)
 }

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -7,8 +7,6 @@ package querier
 
 import (
 	"fmt"
-	"github.com/grafana/mimir/pkg/querier/batch"
-	"github.com/grafana/mimir/pkg/storage/chunk"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -18,6 +16,8 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/querier/batch"
+	"github.com/grafana/mimir/pkg/storage/chunk"
 	"github.com/grafana/mimir/pkg/storage/series"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 )
@@ -146,7 +146,7 @@ func newBlockQuerierSeriesIterator(reuse chunkenc.Iterator, lbls labels.Labels, 
 		genericChunks = append(genericChunks, genericChunk)
 	}
 
-	return batch.NewGenericChunkMergeIterator(reuse, genericChunks)
+	return batch.NewGenericChunkMergeIterator(reuse, lbls, genericChunks)
 }
 
 func chunkEncodingForAggrChunk(c storepb.AggrChunk, lbls labels.Labels) (chunk.Encoding, error) {

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -6,11 +6,12 @@
 package querier
 
 import (
-	"math"
+	"fmt"
+	"github.com/grafana/mimir/pkg/querier/batch"
+	"github.com/grafana/mimir/pkg/storage/chunk"
 	"sort"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -115,164 +116,48 @@ func (bqs *blockQuerierSeries) Iterator(reuse chunkenc.Iterator) chunkenc.Iterat
 		return series.NewErrIterator(errors.New("no chunks"))
 	}
 
-	it, err := newBlockQuerierSeriesIterator(reuse, bqs.Labels(), bqs.chunks)
-	if err != nil {
-		return series.NewErrIterator(err)
-	}
-
-	return it
+	return newBlockQuerierSeriesIterator(reuse, bqs.Labels(), bqs.chunks)
 }
 
-func newBlockQuerierSeriesIterator(reuse chunkenc.Iterator, lbls labels.Labels, chunks []storepb.AggrChunk) (*blockQuerierSeriesIterator, error) {
-	var it *blockQuerierSeriesIterator
-	r, ok := reuse.(*blockQuerierSeriesIterator)
-	if ok {
-		it = r
-		it.i = 0
-	} else {
-		it = &blockQuerierSeriesIterator{}
-	}
-	if cap(it.iterators) < len(chunks) {
-		it.iterators = make([]iteratorWithMaxTime, len(chunks))
-	}
-	it.iterators = it.iterators[:len(chunks)]
-	it.labels = lbls
-	it.lastT = math.MinInt64
+func newBlockQuerierSeriesIterator(reuse chunkenc.Iterator, lbls labels.Labels, chunks []storepb.AggrChunk) chunkenc.Iterator {
+	genericChunks := make([]batch.GenericChunk, 0, len(chunks))
 
-	for i, c := range chunks {
-		var (
-			ch  chunkenc.Chunk
-			err error
-		)
-		switch c.Raw.Type {
-		case storepb.Chunk_XOR:
-			ch, err = chunkenc.FromData(chunkenc.EncXOR, c.Raw.Data)
-		case storepb.Chunk_Histogram:
-			ch, err = chunkenc.FromData(chunkenc.EncHistogram, c.Raw.Data)
-		case storepb.Chunk_FloatHistogram:
-			ch, err = chunkenc.FromData(chunkenc.EncFloatHistogram, c.Raw.Data)
-		default:
-			return nil, errors.Wrapf(err, "failed to initialize chunk from unknown type (%v) encoded raw data (series: %v min time: %d max time: %d)", c.Raw.Type, lbls, c.MinTime, c.MaxTime)
-		}
+	for _, c := range chunks {
+		c := c
 
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to initialize chunk from %v type encoded raw data (series: %v min time: %d max time: %d)", c.Raw.Type, lbls, c.MinTime, c.MaxTime)
-		}
-
-		it.iterators[i].Iterator = ch.Iterator(it.iterators[i].Iterator)
-		it.iterators[i].maxT = c.MaxTime
-	}
-
-	return it, nil
-}
-
-// iteratorWithMaxTime is an iterator which is aware of the maxT of its embedded iterator.
-type iteratorWithMaxTime struct {
-	chunkenc.Iterator
-	maxT int64
-}
-
-// blockQuerierSeriesIterator implements a series iterator on top
-// of a list of time-sorted, non-overlapping chunks.
-type blockQuerierSeriesIterator struct {
-	// only used for error reporting
-	labels labels.Labels
-
-	iterators []iteratorWithMaxTime
-	i         int
-	lastT     int64
-}
-
-func (it *blockQuerierSeriesIterator) Seek(t int64) chunkenc.ValueType {
-	for ; it.i < len(it.iterators); it.i++ {
-		// We check the maxT property of each iterator because if the time range which its data covers ends at a lower
-		// time than the seeked <t> then we don't even need to try to seek to it, as this wouldn't succeed.
-		if it.iterators[it.i].maxT >= t {
-			// Once we found an iterator which covers a time range that reaches beyond the seeked <t>
-			// we try to seek to and return the result.
-			if typ := it.iterators[it.i].Seek(t); typ != chunkenc.ValNone {
-				it.lastT = it.iterators[it.i].AtT()
-				return typ
+		genericChunk := batch.NewGenericChunk(c.MinTime, c.MaxTime, func(reuse chunk.Iterator) chunk.Iterator {
+			encoding, err := chunkEncodingForAggrChunk(c, lbls)
+			if err != nil {
+				return chunk.ErrorIterator(err.Error())
 			}
-		}
+
+			ch, err := chunk.NewForEncoding(encoding)
+			if err != nil {
+				return chunk.ErrorIterator(fmt.Sprintf("cannot create new chunk for series %s: %s", lbls.String(), err.Error()))
+			}
+
+			if err := ch.UnmarshalFromBuf(c.Raw.Data); err != nil {
+				return chunk.ErrorIterator(fmt.Sprintf("cannot unmarshal chunk for series %s: %s", lbls.String(), err.Error()))
+			}
+
+			return ch.NewIterator(reuse)
+		})
+
+		genericChunks = append(genericChunks, genericChunk)
 	}
 
-	return chunkenc.ValNone
+	return batch.NewGenericChunkMergeIterator(reuse, genericChunks)
 }
 
-func (it *blockQuerierSeriesIterator) At() (int64, float64) {
-	if it.i >= len(it.iterators) {
-		return 0, 0
+func chunkEncodingForAggrChunk(c storepb.AggrChunk, lbls labels.Labels) (chunk.Encoding, error) {
+	switch c.Raw.Type {
+	case storepb.Chunk_XOR:
+		return chunk.PrometheusXorChunk, nil
+	case storepb.Chunk_Histogram:
+		return chunk.PrometheusHistogramChunk, nil
+	case storepb.Chunk_FloatHistogram:
+		return chunk.PrometheusFloatHistogramChunk, nil
+	default:
+		return 0, fmt.Errorf("failed to initialize chunk from unknown encoded raw data type %v (series: %v, min time: %d, max time: %d)", c.Raw.Type, lbls, c.MinTime, c.MaxTime)
 	}
-
-	t, v := it.iterators[it.i].At()
-	it.lastT = t
-	return t, v
-}
-
-func (it *blockQuerierSeriesIterator) AtHistogram(h *histogram.Histogram) (int64, *histogram.Histogram) {
-	if it.i >= len(it.iterators) {
-		return 0, nil
-	}
-
-	t, h := it.iterators[it.i].AtHistogram(h)
-	it.lastT = t
-	return t, h
-}
-
-func (it *blockQuerierSeriesIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
-	if it.i >= len(it.iterators) {
-		return 0, nil
-	}
-
-	t, fh := it.iterators[it.i].AtFloatHistogram(fh)
-	it.lastT = t
-	return t, fh
-}
-
-func (it *blockQuerierSeriesIterator) AtT() int64 {
-	if it.i >= len(it.iterators) {
-		return 0
-	}
-
-	t := it.iterators[it.i].AtT()
-	it.lastT = t
-	return t
-}
-
-func (it *blockQuerierSeriesIterator) Next() chunkenc.ValueType {
-	if it.i >= len(it.iterators) {
-		return chunkenc.ValNone
-	}
-
-	if typ := it.iterators[it.i].Next(); typ != chunkenc.ValNone {
-		it.lastT = it.iterators[it.i].AtT()
-		return typ
-	}
-	if it.iterators[it.i].Err() != nil {
-		return chunkenc.ValNone
-	}
-
-	it.i++
-
-	if it.i >= len(it.iterators) {
-		return chunkenc.ValNone
-	}
-
-	// Chunks are guaranteed to be ordered but not generally guaranteed to not overlap.
-	// We must ensure to skip any overlapping range between adjacent chunks.
-	// .Seek() will update it.lastT if it succeeds
-	return it.Seek(it.lastT + 1)
-}
-
-func (it *blockQuerierSeriesIterator) Err() error {
-	if it.i >= len(it.iterators) {
-		return nil
-	}
-
-	err := it.iterators[it.i].Err()
-	if err != nil {
-		return errors.Wrapf(err, "cannot iterate chunk for series: %v", it.labels)
-	}
-	return nil
 }

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -136,12 +136,7 @@ func (bqs *blockStreamingQuerierSeries) Iterator(reuse chunkenc.Iterator) chunke
 		return allChunks[i].MinTime < allChunks[j].MinTime
 	})
 
-	it, err := newBlockQuerierSeriesIterator(reuse, bqs.Labels(), allChunks)
-	if err != nil {
-		return series.NewErrIterator(err)
-	}
-
-	return it
+	return newBlockQuerierSeriesIterator(reuse, bqs.Labels(), allChunks)
 }
 
 // storeGatewayStreamReader is responsible for managing the streaming of chunks from a storegateway and buffering

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -110,7 +110,7 @@ func TestBlockQuerierSeries(t *testing.T) {
 				},
 			},
 			expectedMetric: labels.FromStrings("foo", "bar"),
-			expectedErr:    `cannot iterate chunk for series: {foo="bar"}: EOF`,
+			expectedErr:    `cannot unmarshal chunk for series {foo="bar"}: EOF`,
 		},
 	}
 
@@ -608,18 +608,19 @@ func TestBlockQuerierSeriesIterator_ShouldMergeOverlappingChunks(t *testing.T) {
 
 	for idx, permutation := range permutations {
 		t.Run(fmt.Sprintf("permutation %d", idx), func(t *testing.T) {
-			it, err := newBlockQuerierSeriesIterator(nil, labels.EmptyLabels(), permutation)
-			require.NoError(t, err)
+			it := newBlockQuerierSeriesIterator(nil, labels.EmptyLabels(), permutation)
 
 			var actual []promql.FPoint
 			for it.Next() != chunkenc.ValNone {
 				ts, value := it.At()
 				actual = append(actual, promql.FPoint{T: ts, F: value})
+
+				require.Equal(t, ts, it.AtT())
 			}
 
 			require.NoError(t, it.Err())
 
-			assert.Equal(t, []promql.FPoint{
+			require.Equal(t, []promql.FPoint{
 				{T: 1, F: 1},
 				{T: 2, F: 2},
 				{T: 3, F: 3},
@@ -632,4 +633,88 @@ func TestBlockQuerierSeriesIterator_ShouldMergeOverlappingChunks(t *testing.T) {
 			}, actual)
 		})
 	}
+}
+
+func TestBlockQuerierSeriesIterator_ShouldMergeNonOverlappingChunks(t *testing.T) {
+	chunk1 := createAggrChunkWithSamples(promql.FPoint{T: 1, F: 1}, promql.FPoint{T: 2, F: 2}, promql.FPoint{T: 3, F: 3})
+	chunk2 := createAggrChunkWithSamples(promql.FPoint{T: 4, F: 4}, promql.FPoint{T: 5, F: 5}, promql.FPoint{T: 6, F: 6})
+
+	it := newBlockQuerierSeriesIterator(nil, labels.EmptyLabels(), []storepb.AggrChunk{chunk1, chunk2})
+
+	var actual []promql.FPoint
+	for it.Next() != chunkenc.ValNone {
+		ts, value := it.At()
+		actual = append(actual, promql.FPoint{T: ts, F: value})
+
+		require.Equal(t, ts, it.AtT())
+	}
+
+	require.NoError(t, it.Err())
+
+	require.Equal(t, []promql.FPoint{
+		{T: 1, F: 1},
+		{T: 2, F: 2},
+		{T: 3, F: 3},
+		{T: 4, F: 4},
+		{T: 5, F: 5},
+		{T: 6, F: 6},
+	}, actual)
+}
+
+func TestBlockQuerierSeriesIterator_SeekWithNonOverlappingChunks(t *testing.T) {
+	chunk1 := createAggrChunkWithSamples(promql.FPoint{T: 1, F: 1}, promql.FPoint{T: 2, F: 2}, promql.FPoint{T: 3, F: 3})
+	chunk2 := createAggrChunkWithSamples(promql.FPoint{T: 4, F: 4}, promql.FPoint{T: 5, F: 5}, promql.FPoint{T: 6, F: 6})
+	chunk3 := createAggrChunkWithSamples(promql.FPoint{T: 7, F: 7}, promql.FPoint{T: 8, F: 8}, promql.FPoint{T: 9, F: 9})
+
+	it := newBlockQuerierSeriesIterator(nil, labels.EmptyLabels(), []storepb.AggrChunk{chunk1, chunk2, chunk3})
+
+	// Seek to middle of first chunk.
+	require.Equal(t, chunkenc.ValFloat, it.Seek(2))
+	ts, value := it.At()
+	require.Equal(t, int64(2), ts)
+	require.Equal(t, 2.0, value)
+
+	// Seek to end of first chunk.
+	require.Equal(t, chunkenc.ValFloat, it.Seek(3))
+	ts, value = it.At()
+	require.Equal(t, int64(3), ts)
+	require.Equal(t, 3.0, value)
+
+	// Seek to the start of the second chunk.
+	require.Equal(t, chunkenc.ValFloat, it.Seek(4))
+	ts, value = it.At()
+	require.Equal(t, int64(4), ts)
+	require.Equal(t, 4.0, value)
+
+	// Seek to the middle of the last chunk, and check all the remaining points are as we expect.
+	require.Equal(t, chunkenc.ValFloat, it.Seek(8))
+
+	var actual []promql.FPoint
+	for {
+		ts, value := it.At()
+		actual = append(actual, promql.FPoint{T: ts, F: value})
+
+		require.Equal(t, ts, it.AtT())
+
+		// Keep consuming points until we've exhausted all remaining points.
+		if it.Next() == chunkenc.ValNone {
+			break
+		}
+	}
+
+	require.NoError(t, it.Err())
+
+	require.Equal(t, []promql.FPoint{
+		{T: 8, F: 8},
+		{T: 9, F: 9},
+	}, actual)
+}
+
+func TestBlockQuerierSeriesIterator_SeekPastEnd(t *testing.T) {
+	chunk1 := createAggrChunkWithSamples(promql.FPoint{T: 1, F: 1}, promql.FPoint{T: 2, F: 2}, promql.FPoint{T: 3, F: 3})
+	chunk2 := createAggrChunkWithSamples(promql.FPoint{T: 4, F: 4}, promql.FPoint{T: 5, F: 5}, promql.FPoint{T: 6, F: 6})
+	chunk3 := createAggrChunkWithSamples(promql.FPoint{T: 7, F: 7}, promql.FPoint{T: 8, F: 8}, promql.FPoint{T: 9, F: 9})
+
+	it := newBlockQuerierSeriesIterator(nil, labels.EmptyLabels(), []storepb.AggrChunk{chunk1, chunk2, chunk3})
+	require.Equal(t, chunkenc.ValNone, it.Seek(10))
 }

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -110,7 +110,7 @@ func TestBlockQuerierSeries(t *testing.T) {
 				},
 			},
 			expectedMetric: labels.FromStrings("foo", "bar"),
-			expectedErr:    `cannot unmarshal chunk for series {foo="bar"}: EOF`,
+			expectedErr:    `error reading chunks for series {foo="bar"}: EOF`,
 		},
 	}
 

--- a/pkg/querier/distributor_queryable_streaming.go
+++ b/pkg/querier/distributor_queryable_streaming.go
@@ -90,5 +90,5 @@ func (s *streamingChunkSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator 
 		return series.NewErrIterator(err)
 	}
 
-	return batch.NewChunkMergeIterator(it, chunks)
+	return batch.NewChunkMergeIterator(it, s.labels, chunks)
 }

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -48,7 +48,7 @@ func TestStreamingChunkSeries_HappyPath(t *testing.T) {
 
 	expectedChunks, err := client.FromChunks(series.labels, []client.Chunk{chunkUniqueToFirstSource, chunkUniqueToSecondSource, chunkPresentInBothSources})
 	require.NoError(t, err)
-	assertChunkIteratorsEqual(t, iterator, batch.NewChunkMergeIterator(nil, expectedChunks))
+	assertChunkIteratorsEqual(t, iterator, batch.NewChunkMergeIterator(nil, series.labels, expectedChunks))
 
 	m, err := metrics.NewMetricFamilyMapFromGatherer(reg)
 	require.NoError(t, err)

--- a/pkg/querier/partitioner.go
+++ b/pkg/querier/partitioner.go
@@ -47,7 +47,7 @@ func (s *chunkSeries) Labels() labels.Labels {
 
 // Iterator returns a new iterator of the data of the series.
 func (s *chunkSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
-	return batch.NewChunkMergeIterator(it, s.chunks)
+	return batch.NewChunkMergeIterator(it, s.labels, s.chunks)
 }
 
 // Chunks implements SeriesWithChunks interface.

--- a/pkg/storage/chunk/prometheus_chunk.go
+++ b/pkg/storage/chunk/prometheus_chunk.go
@@ -24,7 +24,7 @@ type prometheusChunk struct {
 
 func (p *prometheusChunk) NewIterator(iterator Iterator) Iterator {
 	if p.chunk == nil {
-		return errorIterator("Prometheus chunk is not set")
+		return ErrorIterator("Prometheus chunk is not set")
 	}
 
 	if pit, ok := iterator.(*prometheusChunkIterator); ok {
@@ -298,19 +298,19 @@ func (p *prometheusChunkIterator) Err() error {
 	return p.it.Err()
 }
 
-type errorIterator string
+type ErrorIterator string
 
-func (e errorIterator) Scan() chunkenc.ValueType                      { return chunkenc.ValNone }
-func (e errorIterator) FindAtOrAfter(_ model.Time) chunkenc.ValueType { return chunkenc.ValNone }
-func (e errorIterator) Value() model.SamplePair                       { panic("no values") }
-func (e errorIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
+func (e ErrorIterator) Scan() chunkenc.ValueType                      { return chunkenc.ValNone }
+func (e ErrorIterator) FindAtOrAfter(_ model.Time) chunkenc.ValueType { return chunkenc.ValNone }
+func (e ErrorIterator) Value() model.SamplePair                       { panic("no values") }
+func (e ErrorIterator) AtHistogram(*histogram.Histogram) (int64, *histogram.Histogram) {
 	panic("no integer histograms")
 }
-func (e errorIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+func (e ErrorIterator) AtFloatHistogram(*histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
 	panic("no float histograms")
 }
-func (e errorIterator) Timestamp() int64 { panic("no samples") }
-func (e errorIterator) Batch(_ int, _ chunkenc.ValueType, _ *zeropool.Pool[*histogram.Histogram], _ *zeropool.Pool[*histogram.FloatHistogram]) Batch {
+func (e ErrorIterator) Timestamp() int64 { panic("no samples") }
+func (e ErrorIterator) Batch(_ int, _ chunkenc.ValueType, _ *zeropool.Pool[*histogram.Histogram], _ *zeropool.Pool[*histogram.FloatHistogram]) Batch {
 	panic("no values")
 }
-func (e errorIterator) Err() error { return errors.New(string(e)) }
+func (e ErrorIterator) Err() error { return errors.New(string(e)) }

--- a/pkg/storage/chunk/prometheus_chunk.go
+++ b/pkg/storage/chunk/prometheus_chunk.go
@@ -205,9 +205,13 @@ func (p *prometheusChunkIterator) Scan() chunkenc.ValueType {
 }
 
 func (p *prometheusChunkIterator) FindAtOrAfter(time model.Time) chunkenc.ValueType {
-	// FindAtOrAfter must return OLDEST value at given time. That means we need to start with a fresh iterator,
-	// otherwise we cannot guarantee OLDEST.
-	p.it = p.c.Iterator(p.it)
+	if p.it.AtT() > int64(time) {
+		// FindAtOrAfter must return OLDEST value at given time.
+		// If we are already beyond the desired time, then we need to start with a fresh iterator,
+		// otherwise we cannot guarantee OLDEST.
+		p.it = p.c.Iterator(p.it)
+	}
+
 	return p.it.Seek(int64(time))
 }
 

--- a/pkg/storegateway/storepb/custom.go
+++ b/pkg/storegateway/storepb/custom.go
@@ -9,6 +9,8 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/mimir/pkg/storage/chunk"
 )
 
 func NewSeriesResponse(series *Series) *SeriesResponse {
@@ -130,4 +132,17 @@ func MatchersToPromMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
 		res = append(res, m)
 	}
 	return res, nil
+}
+
+func (c AggrChunk) GetChunkEncoding() (chunk.Encoding, bool) {
+	switch c.Raw.Type {
+	case Chunk_XOR:
+		return chunk.PrometheusXorChunk, true
+	case Chunk_Histogram:
+		return chunk.PrometheusHistogramChunk, true
+	case Chunk_FloatHistogram:
+		return chunk.PrometheusFloatHistogramChunk, true
+	default:
+		return 0, false
+	}
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where overlapping chunks for a single series from a single store-gateway can result in samples that exist in only some chunks being dropped from query results.

#### Which issue(s) this PR fixes or relates to

Fixes the issue in https://github.com/grafana/mimir/pull/8799

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
