### PR TITLE
Removing legacy coded related to -ingester.return-only-grpc-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [CHANGE] Store-gateway: Remove experimental parameter `-blocks-storage.bucket-store.series-selection-strategy`. The default strategy is now `worst-case`. #8702
 * [CHANGE] Store-gateway: Rename `-blocks-storage.bucket-store.series-selection-strategies.worst-case-series-preference` to `-blocks-storage.bucket-store.series-fetch-preference` and promote to stable. #8702
 * [CHANGE] Querier, store-gateway: remove deprecated `-querier.prefer-streaming-chunks-from-store-gateways=true`. Streaming from store-gateways is now always enabled. #8696
-* [CHANGE] Ingester: remove deprecated `-ingester.return-only-grpc-errors`. #8699
+* [CHANGE] Ingester: remove deprecated `-ingester.return-only-grpc-errors`. #8699 #8828
 * [CHANGE] Distributor, ruler: remove deprecated `-ingester.client.report-grpc-codes-in-instrumentation-label-enabled`. #8700
 * [CHANGE] Ingester client: experimental support for client-side circuit breakers, their configuration options (`-ingester.client.circuit-breaker.*`) and metrics (`cortex_ingester_client_circuit_breaker_results_total`, `cortex_ingester_client_circuit_breaker_transitions_total`) were removed. #8802
 * [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #8422 #8430 #8454 #8455 #8360 #8490 #8508 #8577 #8671

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1377,13 +1377,6 @@ func (d *Distributor) handlePushError(ctx context.Context, pushErr error) error 
 		return pushErr
 	}
 
-	// This code is needed for backwards compatibility, since ingesters may still return errors
-	// created by httpgrpc.Errorf(). If pushErr is one of those errors, we just propagate it.
-	_, ok := httpgrpc.HTTPResponseFromError(pushErr)
-	if ok {
-		return pushErr
-	}
-
 	serviceOverloadErrorEnabled := false
 	userID, err := tenant.TenantID(ctx)
 	if err == nil {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"math"
 	"math/rand"
-	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -7393,8 +7392,6 @@ func TestHandlePushError(t *testing.T) {
 	testErrorMsg := "this is a test error message"
 	userID := "test"
 	errWithUserID := fmt.Errorf("user=%s: %s", userID, testErrorMsg)
-	httpGrpc4xxErr := httpgrpc.Errorf(http.StatusBadRequest, testErrorMsg)
-	httpGrpc5xxErr := httpgrpc.Errorf(http.StatusServiceUnavailable, testErrorMsg)
 	test := map[string]struct {
 		pushError          error
 		expectedGRPCError  *status.Status
@@ -7407,14 +7404,6 @@ func TestHandlePushError(t *testing.T) {
 		"a context.DeadlineExceeded error gives context.DeadlineExceeded": {
 			pushError:          context.DeadlineExceeded,
 			expectedOtherError: context.DeadlineExceeded,
-		},
-		"a 4xx HTTP gRPC error gives the same 4xx HTTP gRPC error": {
-			pushError:          httpGrpc4xxErr,
-			expectedOtherError: httpGrpc4xxErr,
-		},
-		"a 5xx HTTP gRPC error gives the same 5xx HTTP gRPC error": {
-			pushError:          httpGrpc5xxErr,
-			expectedOtherError: httpGrpc5xxErr,
 		},
 		"an Error gives the error returned by toErrorWithGRPCStatus()": {
 			pushError:         mockDistributorErr(testErrorMsg),

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -260,9 +260,8 @@ func otlpHandler(
 				errorMsg string
 			)
 			if st, ok := grpcutil.ErrorToStatus(err); ok {
-				// TODO: This code is needed for backwards compatibility,
-				// and can be removed once -ingester.return-only-grpc-errors
-				// is removed.
+				// This code is needed for a correct handling of errors returned by the supplier function.
+				// These errors are created by using the httpgrpc package.
 				httpCode = httpRetryableToOTLPRetryable(int(st.Code()))
 				grpcCode = st.Code()
 				errorMsg = st.Message()

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -179,9 +179,8 @@ func handler(
 				msg  string
 			)
 			if resp, ok := httpgrpc.HTTPResponseFromError(err); ok {
-				// TODO: This code is needed for backwards compatibility,
-				// and can be removed once -ingester.return-only-grpc-errors
-				// is removed.
+				// This code is needed for a correct handling of errors returned by the supplier function.
+				// These errors are created by using the httpgrpc package.
 				code, msg = int(resp.Code), string(resp.Body)
 			} else {
 				code = toHTTPStatus(ctx, err, limits)

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -8,12 +8,9 @@ package ingester
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/failsafe-go/failsafe-go/circuitbreaker"
-	"github.com/grafana/dskit/grpcutil"
-	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/common/model"
@@ -49,17 +46,6 @@ func newErrorWithStatus(originalErr error, code codes.Code) globalerror.ErrorWit
 		errorDetails = &mimirpb.ErrorDetails{Cause: ingesterErr.errorCause()}
 	}
 	return globalerror.WrapErrorWithGRPCStatus(originalErr, code, errorDetails)
-}
-
-// newErrorWithHTTPStatus creates a new ErrorWithStatus backed by the given error,
-// and containing the given HTTP status code.
-func newErrorWithHTTPStatus(err error, code int) globalerror.ErrorWithStatus {
-	errWithHTTPStatus := httpgrpc.Errorf(code, err.Error())
-	stat, _ := grpcutil.ErrorToStatus(errWithHTTPStatus)
-	return globalerror.ErrorWithStatus{
-		UnderlyingErr: err,
-		Status:        stat,
-	}
 }
 
 // ingesterError is a marker interface for the errors returned by ingester, and that are safe to wrap.
@@ -567,31 +553,6 @@ func mapPushErrorToErrorWithStatus(err error) error {
 		}
 	}
 	return newErrorWithStatus(wrappedErr, errCode)
-}
-
-// mapPushErrorToErrorWithHTTPOrGRPCStatus maps ingesterError objects to an appropriate
-// globalerror.ErrorWithStatus, which may contain both HTTP and gRPC error codes.
-func mapPushErrorToErrorWithHTTPOrGRPCStatus(err error) error {
-	var ingesterErr ingesterError
-	if errors.As(err, &ingesterErr) {
-		switch ingesterErr.errorCause() {
-		case mimirpb.BAD_DATA:
-			return newErrorWithHTTPStatus(err, http.StatusBadRequest)
-		case mimirpb.TENANT_LIMIT:
-			return newErrorWithHTTPStatus(err, http.StatusBadRequest)
-		case mimirpb.SERVICE_UNAVAILABLE:
-			return newErrorWithStatus(err, codes.Unavailable)
-		case mimirpb.INSTANCE_LIMIT:
-			return newErrorWithStatus(middleware.DoNotLogError{Err: err}, codes.Unavailable)
-		case mimirpb.TSDB_UNAVAILABLE:
-			return newErrorWithHTTPStatus(err, http.StatusServiceUnavailable)
-		case mimirpb.METHOD_NOT_ALLOWED:
-			return newErrorWithStatus(err, codes.Unimplemented)
-		case mimirpb.CIRCUIT_BREAKER_OPEN:
-			return newErrorWithStatus(err, codes.Unavailable)
-		}
-	}
-	return err
 }
 
 // mapReadErrorToErrorWithStatus maps the given error to the corresponding error of type globalerror.ErrorWithStatus.

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -6,13 +6,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/grpcutil"
-	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/common/model"
@@ -324,11 +322,6 @@ func TestNewErrorWithStatus(t *testing.T) {
 			require.Equal(t, codes.Unimplemented, st.Code())
 			require.Equal(t, st.Message(), data.expectedErrorMessage)
 
-			// Ensure httpgrpc's HTTPResponseFromError doesn't recognize errWithStatus.
-			resp, ok := httpgrpc.HTTPResponseFromError(errWithStatus)
-			require.False(t, ok)
-			require.Nil(t, resp)
-
 			if data.doNotLog {
 				var optional middleware.OptionalLogging
 				require.ErrorAs(t, errWithStatus, &optional)
@@ -338,40 +331,6 @@ func TestNewErrorWithStatus(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestErrorWithHTTPStatus(t *testing.T) {
-	metricLabelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: "test"}}
-	err := newSampleTimestampTooOldError(timestamp, metricLabelAdapters)
-	errWithHTTPStatus := newErrorWithHTTPStatus(err, http.StatusBadRequest)
-	require.Error(t, errWithHTTPStatus)
-
-	// Ensure gogo's status.FromError recognizes errWithHTTPStatus.
-	//lint:ignore faillint We want to explicitly assert on status.FromError()
-	stat, ok := status.FromError(errWithHTTPStatus)
-	require.True(t, ok)
-	require.Equal(t, http.StatusBadRequest, int(stat.Code()))
-	require.Errorf(t, err, stat.Message())
-	require.NotEmpty(t, stat.Details())
-
-	// Ensure dskit's grpcutil.ErrorToStatus recognizes errWithHTTPStatus.
-	stat, ok = grpcutil.ErrorToStatus(errWithHTTPStatus)
-	require.True(t, ok)
-	require.Equal(t, http.StatusBadRequest, int(stat.Code()))
-	require.Errorf(t, err, stat.Message())
-
-	// Ensure grpc's status.FromError recognizes errWithHTTPStatus.
-	//lint:ignore faillint We want to explicitly assert on status.FromError()
-	st, ok := grpcstatus.FromError(errWithHTTPStatus)
-	require.True(t, ok)
-	require.Equal(t, http.StatusBadRequest, int(st.Code()))
-	require.Errorf(t, err, st.Message())
-
-	// Ensure httpgrpc's HTTPResponseFromError recognizes errWithHTTPStatus.
-	resp, ok := httpgrpc.HTTPResponseFromError(errWithHTTPStatus)
-	require.True(t, ok)
-	require.Equal(t, int32(http.StatusBadRequest), resp.Code)
-	require.Errorf(t, err, errWithHTTPStatus.Error())
 }
 
 func TestWrapOrAnnotateWithUser(t *testing.T) {
@@ -577,197 +536,6 @@ func TestMapPushErrorToErrorWithStatus(t *testing.T) {
 			require.Equal(t, tc.expectedCode, stat.Code())
 			require.Equal(t, tc.expectedMessage, stat.Message())
 			checkErrorWithStatusDetails(t, stat.Details(), tc.expectedDetails)
-			if tc.doNotLogExpected {
-				var doNotLogError middleware.DoNotLogError
-				require.ErrorAs(t, handledErr, &doNotLogError)
-
-				shouldLog, _ := doNotLogError.ShouldLog(context.Background())
-				require.False(t, shouldLog)
-			}
-		})
-	}
-}
-
-func TestMapPushErrorToErrorWithHTTPOrGRPCStatus(t *testing.T) {
-	const originalMsg = "this is an error"
-	originalErr := errors.New(originalMsg)
-	family := "testmetric"
-	labelAdapters := []mimirpb.LabelAdapter{{Name: labels.MetricName, Value: family}, {Name: "foo", Value: "biz"}}
-	timestamp := model.Time(1)
-
-	testCases := map[string]struct {
-		err                 error
-		doNotLogExpected    bool
-		expectedTranslation error
-	}{
-		"a generic error is not translated": {
-			err:                 originalErr,
-			expectedTranslation: originalErr,
-		},
-		"a DoNotLog error of a generic error is not translated": {
-			err:                 middleware.DoNotLogError{Err: originalErr},
-			expectedTranslation: middleware.DoNotLogError{Err: originalErr},
-			doNotLogExpected:    true,
-		},
-		"an unavailableError gets translated into an ErrorWithStatus Unavailable error": {
-			err:                 newUnavailableError(services.Stopping),
-			expectedTranslation: newErrorWithStatus(newUnavailableError(services.Stopping), codes.Unavailable),
-		},
-		"a wrapped unavailableError gets translated into a non-loggable ErrorWithStatus Unavailable error": {
-			err: fmt.Errorf("wrapped: %w", newUnavailableError(services.Stopping)),
-			expectedTranslation: newErrorWithStatus(
-				fmt.Errorf("wrapped: %w", newUnavailableError(services.Stopping)),
-				codes.Unavailable,
-			),
-		},
-		"an instanceLimitReachedError gets translated into a non-loggable ErrorWithStatus Unavailable error": {
-			err: newInstanceLimitReachedError("instance limit reached"),
-			expectedTranslation: newErrorWithStatus(
-				middleware.DoNotLogError{Err: newInstanceLimitReachedError("instance limit reached")},
-				codes.Unavailable,
-			),
-			doNotLogExpected: true,
-		},
-		"a wrapped instanceLimitReachedError gets translated into a non-loggable ErrorWithStatus Unavailable error": {
-			err: fmt.Errorf("wrapped: %w", newInstanceLimitReachedError("instance limit reached")),
-			expectedTranslation: newErrorWithStatus(
-				middleware.DoNotLogError{Err: fmt.Errorf("wrapped: %w", newInstanceLimitReachedError("instance limit reached"))},
-				codes.Unavailable,
-			),
-			doNotLogExpected: true,
-		},
-		"a tsdbUnavailableError gets translated into an errorWithHTTPStatus 503 error": {
-			err: newTSDBUnavailableError("tsdb stopping"),
-			expectedTranslation: newErrorWithHTTPStatus(
-				newTSDBUnavailableError("tsdb stopping"),
-				http.StatusServiceUnavailable,
-			),
-		},
-		"a wrapped tsdbUnavailableError gets translated into an errorWithHTTPStatus 503 error": {
-			err: fmt.Errorf("wrapped: %w", newTSDBUnavailableError("tsdb stopping")),
-			expectedTranslation: newErrorWithHTTPStatus(
-				fmt.Errorf("wrapped: %w", newTSDBUnavailableError("tsdb stopping")),
-				http.StatusServiceUnavailable,
-			),
-		},
-		"a sampleError gets translated into an errorWithHTTPStatus 400 error": {
-			err: newSampleError("id", "sample error", timestamp, labelAdapters),
-			expectedTranslation: newErrorWithHTTPStatus(
-				newSampleError("id", "sample error", timestamp, labelAdapters),
-				http.StatusBadRequest,
-			),
-		},
-		"a wrapped sample gets translated into an errorWithHTTPStatus 400 error": {
-			err: fmt.Errorf("wrapped: %w", newSampleError("id", "sample error", timestamp, labelAdapters)),
-			expectedTranslation: newErrorWithHTTPStatus(
-				fmt.Errorf("wrapped: %w", newSampleError("id", "sample error", timestamp, labelAdapters)),
-				http.StatusBadRequest,
-			),
-		},
-		"a exemplarError gets translated into an errorWithHTTPStatus 400 error": {
-			err: newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters),
-			expectedTranslation: newErrorWithHTTPStatus(
-				newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters),
-				http.StatusBadRequest,
-			),
-		},
-		"a wrapped exemplarError gets translated into an errorWithHTTPStatus 400 error": {
-			err: fmt.Errorf("wrapped: %w", newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters)),
-			expectedTranslation: newErrorWithHTTPStatus(
-				fmt.Errorf("wrapped: %w", newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters)),
-				http.StatusBadRequest,
-			),
-		},
-		"a perUserSeriesLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: newPerUserSeriesLimitReachedError(10),
-			expectedTranslation: newErrorWithHTTPStatus(
-				newPerUserSeriesLimitReachedError(10),
-				http.StatusBadRequest,
-			),
-		},
-		"a wrapped perUserSeriesLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: fmt.Errorf("wrapped: %w", newPerUserSeriesLimitReachedError(10)),
-			expectedTranslation: newErrorWithHTTPStatus(
-				fmt.Errorf("wrapped: %w", newPerUserSeriesLimitReachedError(10)),
-				http.StatusBadRequest,
-			),
-		},
-		"a perMetricSeriesLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: newPerMetricSeriesLimitReachedError(10, labelAdapters),
-			expectedTranslation: newErrorWithHTTPStatus(
-				newPerMetricSeriesLimitReachedError(10, labelAdapters),
-				http.StatusBadRequest,
-			),
-		},
-		"a wrapped perMetricSeriesLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: fmt.Errorf("wrapped: %w", newPerMetricSeriesLimitReachedError(10, labelAdapters)),
-			expectedTranslation: newErrorWithHTTPStatus(
-				fmt.Errorf("wrapped: %w", newPerMetricSeriesLimitReachedError(10, labelAdapters)),
-				http.StatusBadRequest,
-			),
-		},
-		"a perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: newPerUserMetadataLimitReachedError(10),
-			expectedTranslation: newErrorWithHTTPStatus(
-				newPerUserMetadataLimitReachedError(10),
-				http.StatusBadRequest,
-			),
-		},
-		"a wrapped perUserMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: fmt.Errorf("wrapped: %w", newPerUserMetadataLimitReachedError(10)),
-			expectedTranslation: newErrorWithHTTPStatus(
-				fmt.Errorf("wrapped: %w", newPerUserMetadataLimitReachedError(10)),
-				http.StatusBadRequest,
-			),
-		},
-		"a perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: newPerMetricMetadataLimitReachedError(10, family),
-			expectedTranslation: newErrorWithHTTPStatus(
-				newPerMetricMetadataLimitReachedError(10, family),
-				http.StatusBadRequest,
-			),
-		},
-		"a wrapped perMetricMetadataLimitReachedError gets translated into an errorWithHTTPStatus 400 error": {
-			err: fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, family)),
-			expectedTranslation: newErrorWithHTTPStatus(
-				fmt.Errorf("wrapped: %w", newPerMetricMetadataLimitReachedError(10, family)),
-				http.StatusBadRequest,
-			),
-		},
-		"an ingesterPushGrpcDisabledError gets translated into an ErrorWithStatus Unimplemented error": {
-			err: ingesterPushGrpcDisabledError{},
-			expectedTranslation: newErrorWithStatus(
-				ingesterPushGrpcDisabledError{},
-				codes.Unimplemented,
-			),
-		},
-		"a wrapped ingesterPushGrpcDisabledError gets translated into an ErrorWithStatus Unimplemented error": {
-			err: fmt.Errorf("wrapped: %w", ingesterPushGrpcDisabledError{}),
-			expectedTranslation: newErrorWithStatus(
-				fmt.Errorf("wrapped: %w", ingesterPushGrpcDisabledError{}),
-				codes.Unimplemented,
-			),
-		},
-		"a circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable error": {
-			err: newCircuitBreakerOpenError("foo", 1*time.Second),
-			expectedTranslation: newErrorWithStatus(
-				newCircuitBreakerOpenError("foo", 1*time.Second),
-				codes.Unavailable,
-			),
-		},
-		"a wrapped circuitBreakerOpenError gets translated into an ErrorWithStatus Unavailable error": {
-			err: fmt.Errorf("wrapped: %w", newCircuitBreakerOpenError("foo", 1*time.Second)),
-			expectedTranslation: newErrorWithStatus(
-				fmt.Errorf("wrapped: %w", newCircuitBreakerOpenError("foo", 1*time.Second)),
-				codes.Unavailable,
-			),
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			handledErr := mapPushErrorToErrorWithHTTPOrGRPCStatus(tc.err)
-			require.Equal(t, tc.expectedTranslation, handledErr)
 			if tc.doNotLogExpected {
 				var doNotLogError middleware.DoNotLogError
 				require.ErrorAs(t, handledErr, &doNotLogError)


### PR DESCRIPTION
#### What this PR does
In #8699 we got rid of the `-ingester.return-only-grpc-codes` CLI option. This PR removes the legacy code that was present only because of the removed CLI flag.

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/6008 (migration plan)

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
