### PR TITLE
Dashboards: add strong consistency panels for query-frontend in 'Mimir / Queries' dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
   * Queries dashboard: `cortex_request_duration_seconds` metric. #8800
   * Remote ruler reads dashboard: `cortex_request_duration_seconds` metric. #8801
 * [ENHANCEMENT] Alerts: `MimirRunningIngesterReceiveDelayTooHigh` alert has been tuned to be more reactive to high receive delay. #8538
-* [ENHANCEMENT] Dashboards: improve end-to-end latency and strong read consistency panels when experimental ingest storage is enabled. #8543
+* [ENHANCEMENT] Dashboards: improve end-to-end latency and strong read consistency panels when experimental ingest storage is enabled. #8543 #8830
 * [ENHANCEMENT] Dashboards: Add panels for monitoring ingester autoscaling when not using ingest-storage. These panels are disabled by default, but can be enabled using the `autoscaling.ingester.enabled: true` config option. #8484
 * [ENHANCEMENT] Dashboards: Add panels for monitoring store-gateway autoscaling. These panels are disabled by default, but can be enabled using the `autoscaling.store_gateway.enabled: true` config option. #8824
 * [ENHANCEMENT] Dashboards: add panels to show writes to experimental ingest storage backend in the "Mimir / Ruler" dashboard, when `_config.show_ingest_storage_panels` is enabled. #8732


### PR DESCRIPTION
#### What this PR does

This PR is a follow up of #8808. In this PR I'm adding panels to display metrics about strong read consistency enforcement in the query-frontend. We already have the same panels for ingesters, but since part of the enforcement is done in the query-frontend I'm adding them for it too.

**New panels** (query-frontend):
![Screenshot 2024-07-26 at 10 36 36](https://github.com/user-attachments/assets/3e3d5dd7-f265-4559-8d28-3d3d86748f9e)

**Already existing panels** (ingester):
![Screenshot 2024-07-26 at 10 36 46](https://github.com/user-attachments/assets/8d37d5c0-4497-4c05-9e34-4d0106dbb22b)


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
