### PR TITLE
Alerts: add MimirStrongConsistencyOffsetNotPropagatedToIngesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * [ENHANCEMENT] Dashboards: add compactor autoscaling panels to "Mimir / Compactor" dashboard. The panels are disabled by default, but can be enabled setting `_config.autoscaling.compactor.enabled` to `true`. #8777
 * [ENHANCEMENT] Alerts: added `MimirKafkaClientBufferedProduceBytesTooHigh` alert. #8763
 * [ENHANCEMENT] Dashboards: added "Kafka produced records / sec" panel to "Mimir / Writes" dashboard. #8763
+* [ENHANCEMENT] Alerts: added `MimirStrongConsistencyOffsetNotPropagatedToIngesters` alert, and rename `MimirIngesterFailsEnforceStrongConsistencyOnReadPath` alert to `MimirStrongConsistencyEnforcementFailed`. #8831
 * [BUGFIX] Dashboards: fix "current replicas" in autoscaling panels when HPA is not active. #8566
 * [BUGFIX] Alerts: do not fire `MimirRingMembersMismatch` during the migration to experimental ingest storage. #8727
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1486,6 +1486,18 @@ How to **investigate**:
 - Check if ingesters are processing too many records, and they need to be scaled up (vertically or horizontally).
 - Check actual error in the query-frontend and/or ingester logs to see whether the `-ingest-storage.kafka.wait-strong-read-consistency-timeout` or the request timeout has been hit first.
 
+### MimirStrongConsistencyOffsetNotPropagatedToIngesters
+
+This alert fires when ingesters receive an unexpected high number of strongly consistent requests without an offset specified.
+
+How it **works**:
+
+- See [`MimirStrongConsistencyEnforcementFailed`](#MimirStrongConsistencyEnforcementFailed).
+
+How to **investigate**:
+
+- We expect query-frontend to fetch the last produced offsets and then propagate it down to ingesters. If it's not happening, then it's likely we introduced a bug in Mimir that's breaking the propagation of offsets from query-frontend to ingester. You should investigate the Mimir code changes and fix it.
+
 ### MimirKafkaClientBufferedProduceBytesTooHigh
 
 This alert fires when the Kafka client buffer, used to write incoming write requests to Kafka, is getting full.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1038,15 +1038,27 @@ spec:
             for: 5m
             labels:
               severity: critical
-          - alert: MimirIngesterFailsEnforceStrongConsistencyOnReadPath
+          - alert: MimirStrongConsistencyEnforcementFailed
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to enforce strong-consistency on read-path.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterfailsenforcestrongconsistencyonreadpath
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
             expr: |
               sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_strong_consistency_failures_total[1m])) > 0
             for: 5m
             labels:
               severity: critical
+          - alert: MimirStrongConsistencyOffsetNotPropagatedToIngesters
+            annotations:
+              message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyoffsetnotpropagatedtoingesters
+            expr: |
+              sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="false"}[1m]))
+              /
+              sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"}[1m]))
+              * 100 > 5
+            for: 5m
+            labels:
+              severity: warning
           - alert: MimirKafkaClientBufferedProduceBytesTooHigh
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} Kafka client produce buffer utilization is {{ printf "%.2f" $value }}%.

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1012,10 +1012,10 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirIngesterFailsEnforceStrongConsistencyOnReadPath
+        - alert: MimirStrongConsistencyEnforcementFailed
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to enforce strong-consistency on read-path.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterfailsenforcestrongconsistencyonreadpath
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
           expr: |
             sum by (cluster, namespace, instance) (rate(cortex_ingest_storage_strong_consistency_failures_total[1m])) > 0
           for: 5m

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1021,6 +1021,18 @@ groups:
           for: 5m
           labels:
             severity: critical
+        - alert: MimirStrongConsistencyOffsetNotPropagatedToIngesters
+          annotations:
+            message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyoffsetnotpropagatedtoingesters
+          expr: |
+            sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="false"}[1m]))
+            /
+            sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"}[1m]))
+            * 100 > 5
+          for: 5m
+          labels:
+            severity: warning
         - alert: MimirKafkaClientBufferedProduceBytesTooHigh
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} Kafka client produce buffer utilization is {{ printf "%.2f" $value }}%.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1035,6 +1035,18 @@ groups:
           for: 5m
           labels:
             severity: critical
+        - alert: MimirStrongConsistencyOffsetNotPropagatedToIngesters
+          annotations:
+            message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyoffsetnotpropagatedtoingesters
+          expr: |
+            sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="false"}[1m]))
+            /
+            sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"}[1m]))
+            * 100 > 5
+          for: 5m
+          labels:
+            severity: warning
         - alert: MimirKafkaClientBufferedProduceBytesTooHigh
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} Kafka client produce buffer utilization is {{ printf "%.2f" $value }}%.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1026,10 +1026,10 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirIngesterFailsEnforceStrongConsistencyOnReadPath
+        - alert: MimirStrongConsistencyEnforcementFailed
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to enforce strong-consistency on read-path.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterfailsenforcestrongconsistencyonreadpath
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
           expr: |
             sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_strong_consistency_failures_total[1m])) > 0
           for: 5m

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -153,7 +153,7 @@
         },
 
         {
-          alert: $.alertName('IngesterFailsEnforceStrongConsistencyOnReadPath'),
+          alert: $.alertName('StrongConsistencyEnforcementFailed'),
           'for': '5m',
           expr: |||
             sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ingest_storage_strong_consistency_failures_total[1m])) > 0

--- a/pkg/frontend/querymiddleware/read_consistency.go
+++ b/pkg/frontend/querymiddleware/read_consistency.go
@@ -57,7 +57,7 @@ func (r *readConsistencyRoundTripper) RoundTrip(req *http.Request) (_ *http.Resp
 		return r.next.RoundTrip(req)
 	}
 
-	return r.metrics.Observe(func() (*http.Response, error) {
+	return r.metrics.Observe(false, func() (*http.Response, error) {
 		// Fetch last produced offsets.
 		offsets, err := r.offsetsReader.WaitNextFetchLastProducedOffset(ctx)
 		if err != nil {

--- a/pkg/frontend/querymiddleware/read_consistency_test.go
+++ b/pkg/frontend/querymiddleware/read_consistency_test.go
@@ -132,9 +132,10 @@ func TestReadConsistencyRoundTripper(t *testing.T) {
 			}
 
 			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-				# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested.
+				# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 				# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-				cortex_ingest_storage_strong_consistency_requests_total{component="query-frontend"} %d
+				cortex_ingest_storage_strong_consistency_requests_total{component="query-frontend", with_offset="false"} %d
+				cortex_ingest_storage_strong_consistency_requests_total{component="query-frontend", with_offset="true"} 0
 
 				# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 				# TYPE cortex_ingest_storage_strong_consistency_failures_total counter

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -219,15 +219,18 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 				assert.Equal(t, int64(2), consumedRecords.Load())
 				t.Log("finished waiting for read consistency")
 
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested.
+				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
 		
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 0
-				`), "cortex_ingest_storage_strong_consistency_requests_total", "cortex_ingest_storage_strong_consistency_failures_total"))
+				`, withOffset, !withOffset)),
+					"cortex_ingest_storage_strong_consistency_requests_total",
+					"cortex_ingest_storage_strong_consistency_failures_total"))
 			})
 		}
 
@@ -268,19 +271,22 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 				assert.NoError(t, err)
 				assert.Equal(t, [][]byte{[]byte("record-1")}, records)
 
-				// Now the WaitReadConsistencyUntilLastProducedOffset() should return soon.
-				err = reader.WaitReadConsistencyUntilLastProducedOffset(createTestContextWithTimeout(t, time.Second))
-				require.NoError(t, err)
-
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested.
+				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"} 2
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
 		
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 1
-				`), "cortex_ingest_storage_strong_consistency_requests_total", "cortex_ingest_storage_strong_consistency_failures_total"))
+				`, withOffset, !withOffset)),
+					"cortex_ingest_storage_strong_consistency_requests_total",
+					"cortex_ingest_storage_strong_consistency_failures_total"))
+
+				// Now the WaitReadConsistencyUntilLastProducedOffset() should return soon.
+				err = reader.WaitReadConsistencyUntilLastProducedOffset(createTestContextWithTimeout(t, time.Second))
+				require.NoError(t, err)
 			})
 		}
 	})
@@ -320,19 +326,22 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 				assert.NoError(t, err)
 				assert.Equal(t, [][]byte{[]byte("record-1")}, records)
 
-				// Now the WaitReadConsistencyUntilLastProducedOffset() should return soon.
-				err = reader.WaitReadConsistencyUntilLastProducedOffset(ctx)
-				require.NoError(t, err)
-
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested.
+				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"} 2
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
 		
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 1
-				`), "cortex_ingest_storage_strong_consistency_requests_total", "cortex_ingest_storage_strong_consistency_failures_total"))
+				`, withOffset, !withOffset)),
+					"cortex_ingest_storage_strong_consistency_requests_total",
+					"cortex_ingest_storage_strong_consistency_failures_total"))
+
+				// Now the WaitReadConsistencyUntilLastProducedOffset() should return soon.
+				err = reader.WaitReadConsistencyUntilLastProducedOffset(ctx)
+				require.NoError(t, err)
 			})
 		}
 	})
@@ -356,15 +365,18 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 					require.NoError(t, reader.WaitReadConsistencyUntilLastProducedOffset(waitCtx))
 				}
 
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested.
+				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
 		
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 0
-				`), "cortex_ingest_storage_strong_consistency_requests_total", "cortex_ingest_storage_strong_consistency_failures_total"))
+				`, withOffset, !withOffset)),
+					"cortex_ingest_storage_strong_consistency_requests_total",
+					"cortex_ingest_storage_strong_consistency_failures_total"))
 			})
 		}
 	})
@@ -392,15 +404,18 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 
 				require.ErrorContains(t, err, "partition reader service is not running")
 
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested.
+				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader"} 1
-		
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
+
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 1
-				`), "cortex_ingest_storage_strong_consistency_requests_total", "cortex_ingest_storage_strong_consistency_failures_total"))
+				`, withOffset, !withOffset)),
+					"cortex_ingest_storage_strong_consistency_requests_total",
+					"cortex_ingest_storage_strong_consistency_failures_total"))
 			})
 		}
 	})


### PR DESCRIPTION
#### What this PR does

This PR is a follow up of #8808. In this PR:

- [Renamed MimirIngesterFailsEnforceStrongConsistencyOnReadPath alert to MimirStrongConsistencyEnforcementFailed, and improved its runbook](https://github.com/grafana/mimir/commit/c02698a81c8cc775c5a3779e176b911c700cd8c3). Why? Because after https://github.com/grafana/mimir/pull/8808 this alert can also fire due to errors in query-frontend (now responsible to fetch offsets).
- [Added MimirStrongConsistencyOffsetNotPropagatedToIngesters](https://github.com/grafana/mimir/commit/d08aedec30faa68e19f29c4d0f32974531f37ec6) alert. Why? Because Mimir is a complex system and we may undetect if we stop propagating offsets from query-frontend to ingesters just relying on unit / integration tests. I feel more comfortable if we have an alert on it. It's a warning because I want to gain confidence on it first. To introduce this alert, I've introduced a new label (`with_offset`) to the `cortex_ingest_storage_strong_consistency_requests_total` metric.

I locally tested the queries and looks good:

- Left panel: rate of ingesters requests without offset (0 as expected)
- Right panel: rate of ingesters requests split by with and without offset

![Screenshot 2024-07-26 at 11 49 24](https://github.com/user-attachments/assets/0a65dfd7-240f-467c-bf94-a2894ba292bc)


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
