### PR TITLE
Jsonnet: configure experimental ingest storage on query-frontend too when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 * [ENHANCEMENT] Rollout-operator: Allow the rollout-operator to be used as Kubernetes statefulset webhook to enable `no-downscale` and `prepare-downscale` annotations to be used on ingesters or store-gateways. #8743
 * [ENHANCEMENT] Do not deploy ingester-zone-c when experimental ingest storage is enabled and `ingest_storage_ingester_zones` is configured to `2`. #8776
 * [ENHANCEMENT] Added the config option `ingest_storage_migration_classic_ingesters_no_scale_down_delay` to disable the downscale delay on classic ingesters when migrating to experimental ingest storage. #8775
+* [ENHANCEMENT] Configure experimental ingest storage on query-frontend too when enabled. #8843
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -1043,6 +1043,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
@@ -1460,6 +1461,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -1043,6 +1043,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
@@ -1460,6 +1461,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -1074,6 +1074,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10
@@ -1484,6 +1489,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -1073,6 +1073,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10
@@ -1482,6 +1487,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -1073,6 +1073,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10
@@ -1482,6 +1487,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -1073,6 +1073,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10
@@ -1482,6 +1487,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -1004,6 +1004,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10
@@ -1413,6 +1418,11 @@ spec:
     spec:
       containers:
       - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -1007,6 +1007,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
@@ -1424,6 +1425,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -1007,6 +1007,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
@@ -1424,6 +1425,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -984,6 +984,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
@@ -1401,6 +1402,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -1066,6 +1066,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
@@ -1483,6 +1484,7 @@ spec:
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m

--- a/operations/mimir/ingest-storage-migration.libsonnet
+++ b/operations/mimir/ingest-storage-migration.libsonnet
@@ -148,8 +148,18 @@
     (if !$._config.ingest_storage_migration_write_to_classic_ingesters_enabled then {} else writeToClassicIngestersArgs),
 
   //
-  // Read path (components reading from ingesters): querier, ruler-querier.
+  // Read path. Affected components:
   //
+  // - Querier, ruler-querier: read from ingesters
+  // - Query-frontend: fetch partition offsets to enforce strong read consistency
+  //
+
+  query_frontend_args+:: if !$._config.ingest_storage_migration_querier_enabled then {} else
+    // Explicitly include all the ingest storage config because during the migration the ingest storage
+    // may not be enabled globally yet.
+    $.ingest_storage_args +
+    $.ingest_storage_kafka_consumer_args +
+    $.ingest_storage_query_frontend_args,
 
   querier_args+:: if !$._config.ingest_storage_migration_querier_enabled then {} else
     // Explicitly include all the ingest storage config because during the migration the ingest storage

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -14,7 +14,7 @@
     commonConfig+:: if !$._config.ingest_storage_enabled then {} else
       $.ingest_storage_args +
 
-      // The following should only be configured on distributors and ingesters, but it's currently required to pass
+      // The following should only be configured on distributors, ingesters and query-frontends, but it's currently required to pass
       // config validation when ingest storage is enabled.
       // TODO remove once we've improved the config validation.
       $.ingest_storage_kafka_consumer_args,
@@ -78,6 +78,12 @@
     $.ingest_storage_kafka_producer_args +
     $.ingest_storage_ruler_args,
 
+  ingester_args+:: if !$._config.ingest_storage_enabled then {} else
+    $.ingest_storage_ingester_args,
+
+  query_frontend_args+:: if !$._config.ingest_storage_enabled then {} else
+    $.ingest_storage_query_frontend_args,
+
   ingest_storage_distributor_args+:: {
     // Increase the default remote write timeout (applied to writing to Kafka too) because writing
     // to Kafka-compatible backend may be slower than writing to ingesters.
@@ -110,7 +116,10 @@
     }
   ),
 
-  ingester_args+:: if !$._config.ingest_storage_enabled then {} else $.ingest_storage_ingester_args,
+  ingest_storage_query_frontend_args+:: {
+    // Reduce the LPO polling interval to improve latency of strong consistency reads.
+    'ingest-storage.kafka.last-produced-offset-poll-interval': '500ms',
+  },
 
   //
   // Enforce the configured ingester zones.


### PR DESCRIPTION
#### What this PR does

After https://github.com/grafana/mimir/pull/8808 we need to configure ingest storage (specifically Kafka and `-ingest-storage.kafka.last-produced-offset-poll-interval`) on query-frontend too. Ingest storage was already configured, but there are a couple of things that were missing and I'm fixing in this PR:

1. Set `-ingest-storage.kafka.last-produced-offset-poll-interval` like we do in ingesters
2. Configure ingest storage in query-frontend during a migration, when `ingest_storage_migration_querier_enabled` is `true`

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
