### PR TITLE
End to end test rule concurrency

### DIFF
--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1509,7 +1509,7 @@ func TestRulerPerRuleConcurrency(t *testing.T) {
 	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags)
 	require.NoError(t, s.StartAndWaitReady(ruler))
 
-	// Upload rule groups to one of the rulers for two users
+	// Upload rule groups to one of the rulers for two users.
 	c, err := e2emimir.NewClient("", "", "", ruler.HTTPEndpoint(), "user-1")
 	require.NoError(t, err)
 	c2, err := e2emimir.NewClient("", "", "", ruler.HTTPEndpoint(), "user-2")

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1502,8 +1502,15 @@ func TestRulerPerRuleConcurrency(t *testing.T) {
 		"-ruler.poll-interval":                                                   "2s",
 		"-ruler.max-independent-rule-evaluation-concurrency":                     "4",
 		"-ruler.max-independent-rule-evaluation-concurrency-per-tenant":          "2",
-		`-ruler.independent-rule-evaluation-concurrency-min-duration-percentage`: "0", // This makes sure no matter the ratio, we will attempt concurrency.
+		"-ruler.independent-rule-evaluation-concurrency-min-duration-percentage": "0", // This makes sure no matter the ratio, we will attempt concurrency.
 	})
+
+	// Test with an invalid -ruler.independent-rule-evaluation-concurrency-min-duration-percentage.
+	invalidRulerFlags := e2e.MergeFlags(rulerFlags, map[string]string{
+		"-ruler.independent-rule-evaluation-concurrency-min-duration-percentage": "-10",
+	})
+	invalidRuler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), invalidRulerFlags)
+	require.Error(t, s.Start(invalidRuler))
 
 	// Start Mimir components.
 	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags)

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1538,7 +1538,7 @@ func TestRulerPerRuleConcurrency(t *testing.T) {
 	// Wait until rulers have loaded all rules.
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(20), []string{"cortex_prometheus_rule_group_rules"}, e2e.WaitMissingMetrics))
 
-	// We should have 20 attempts and 20 or less for failed or successful attempts to acquire the lock
+	// We should have 20 attempts and 20 or less for failed or successful attempts to acquire the lock.
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(20), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total"}, e2e.WaitMissingMetrics))
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Less(21), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total"}, e2e.WaitMissingMetrics))
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Less(21), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total"}, e2e.WaitMissingMetrics))

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1550,12 +1550,7 @@ func TestRulerPerRuleConcurrency(t *testing.T) {
 	// The magic number here is because we have a maximum per tenant concurrency of 2. So we expect at least 4 (2 slots * 2 tenants) to complete successfully.
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(4), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total"}, e2e.WaitMissingMetrics))
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(func(sums ...float64) bool {
-		var total float64
-		for _, sum := range sums {
-			total += sum
-		}
-
-		return total == 20
+		return e2e.SumValues(sums) == 20
 	}, []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total", "cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total"}, e2e.WaitMissingMetrics))
 }
 

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1538,10 +1538,10 @@ func TestRulerPerRuleConcurrency(t *testing.T) {
 	// Wait until rulers have loaded all rules.
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(20), []string{"cortex_prometheus_rule_group_rules"}, e2e.WaitMissingMetrics))
 
-	// We should have at least 10 attempts.
+	// We should have 20 attempts and 20 or less for failed or successful attempts to acquire the lock
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(20), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total"}, e2e.WaitMissingMetrics))
-	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Less(20), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total"}, e2e.WaitMissingMetrics))
-	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Less(20), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total"}, e2e.WaitMissingMetrics))
+	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Less(21), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total"}, e2e.WaitMissingMetrics))
+	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Less(21), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total"}, e2e.WaitMissingMetrics))
 
 	// We should never have more than the allowed concurrency slots at the same time.
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Less(4), []string{"cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use"}, e2e.WaitMissingMetrics))


### PR DESCRIPTION
#### What this PR does

Adds an end to ends test to ensure rule concurrency is working correctly. A follow up to https://github.com/grafana/mimir/pull/8146

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
