### PR TITLE
Purge ConcurrencyController on membership changes

### DIFF
--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -348,10 +348,10 @@ func (r *DefaultMultiTenantManager) removeUsersIf(shouldRemove func(userID strin
 		// Stop manager in the background, so we don't block further resharding operations.
 		// The manager won't terminate until any inflight evaluations are complete.
 		// Only once the manager has been stopped we should remove the user from the concurrencyController.
-		go func(userID string) {
-			mngr.Stop()
+		go func(userID string, manager RulesManager) {
+			manager.Stop()
 			r.concurrencyController.RemoveTenant(userID)
-		}(userID)
+		}(userID, mngr)
 
 		delete(r.userManagers, userID)
 

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -347,7 +347,12 @@ func (r *DefaultMultiTenantManager) removeUsersIf(shouldRemove func(userID strin
 
 		// Stop manager in the background, so we don't block further resharding operations.
 		// The manager won't terminate until any inflight evaluations are complete.
-		go mngr.Stop()
+		// Only once the manager has been stopped we should remove the user from the concurrencyController.
+		go func() {
+			mngr.Stop()
+			r.concurrencyController.RemoveTenant(userID)
+		}()
+
 		delete(r.userManagers, userID)
 
 		r.mapper.cleanupUser(userID)

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -348,10 +348,10 @@ func (r *DefaultMultiTenantManager) removeUsersIf(shouldRemove func(userID strin
 		// Stop manager in the background, so we don't block further resharding operations.
 		// The manager won't terminate until any inflight evaluations are complete.
 		// Only once the manager has been stopped we should remove the user from the concurrencyController.
-		go func() {
-			mngr.Stop()
+		go func(userID string, rm RulesManager) {
+			rm.Stop()
 			r.concurrencyController.RemoveTenant(userID)
-		}()
+		}(userID, mngr)
 
 		delete(r.userManagers, userID)
 

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -348,10 +348,10 @@ func (r *DefaultMultiTenantManager) removeUsersIf(shouldRemove func(userID strin
 		// Stop manager in the background, so we don't block further resharding operations.
 		// The manager won't terminate until any inflight evaluations are complete.
 		// Only once the manager has been stopped we should remove the user from the concurrencyController.
-		go func(userID string, rm RulesManager) {
-			rm.Stop()
+		go func(userID string) {
+			mngr.Stop()
 			r.concurrencyController.RemoveTenant(userID)
-		}(userID, mngr)
+		}(userID)
 
 		delete(r.userManagers, userID)
 

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -489,10 +489,10 @@ func (cm *controllerMock) Allow(_ context.Context, _ *promRules.Group, _ promRul
 func (cm *controllerMock) Done(_ context.Context) {
 }
 
-func (cm *controllerMock) RemoveTenant(UserID string) {
+func (cm *controllerMock) MarkTenantForRemoval(userID string, _ chan struct{}) {
 	cm.mtx.Lock()
 	defer cm.mtx.Unlock()
-	cm.removed = append(cm.removed, UserID)
+	cm.removed = append(cm.removed, userID)
 }
 
 func (cm *controllerMock) Removed() []string {

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -418,8 +418,9 @@ func assertManagerMockStopped(t *testing.T, m *managerMock) {
 func assertUserRemovedFromConcurrencyController(t *testing.T, c *controllerMock, userID string) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		return slices.Contains(c.removed, userID)
+		return slices.Contains(c.Removed(), userID)
 	}, 2*time.Second, 100*time.Millisecond)
+
 }
 
 func assertRuleGroupsMappedOnDisk(t *testing.T, m *DefaultMultiTenantManager, userID string, expectedRuleGroups rulespb.RuleGroupList) {

--- a/pkg/ruler/manager_test.go
+++ b/pkg/ruler/manager_test.go
@@ -69,8 +69,9 @@ func TestDefaultMultiTenantManager_SyncFullRuleGroups(t *testing.T) {
 
 		// Ensure the ruler manager has been stopped for all users.
 		assertManagerMockStopped(t, initialUser1Manager)
-		// assertUserRemovedFromConcurrencyController(t, concurrencyController, user1)
+		assertUserRemovedFromConcurrencyController(t, concurrencyController, user1)
 		assertManagerMockStopped(t, initialUser2Manager)
+		assertUserRemovedFromConcurrencyController(t, concurrencyController, user2)
 		assertManagerMockNotRunningForUser(t, m, user1)
 		assertManagerMockNotRunningForUser(t, m, user2)
 
@@ -135,7 +136,8 @@ func TestDefaultMultiTenantManager_SyncPartialRuleGroups(t *testing.T) {
 		user2Group1 = createRuleGroup("group-1", user2, createRecordingRule("sum:metric_1", "sum(metric_1)"))
 	)
 
-	m, err := NewDefaultMultiTenantManager(Config{RulePath: t.TempDir()}, managerMockFactory, nil, logger, nil, nil)
+	concurrencyController := &controllerMock{}
+	m, err := NewDefaultMultiTenantManager(Config{RulePath: t.TempDir()}, managerMockFactory, nil, logger, nil, concurrencyController)
 	require.NoError(t, err)
 	t.Cleanup(m.Stop)
 
@@ -197,6 +199,7 @@ func TestDefaultMultiTenantManager_SyncPartialRuleGroups(t *testing.T) {
 		// Ensure the ruler manager has been stopped for the user with no rule groups.
 		assertManagerMockStopped(t, initialUser1Manager)
 		assertManagerMockNotRunningForUser(t, m, user1)
+		assertUserRemovedFromConcurrencyController(t, concurrencyController, user1)
 
 		// Ensure the ruler manager is still running for other users.
 		currUser2Manager := assertManagerMockRunningForUser(t, m, user2)

--- a/pkg/ruler/rule_concurrency_test.go
+++ b/pkg/ruler/rule_concurrency_test.go
@@ -187,6 +187,13 @@ cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use 0
 # TYPE cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total counter
 cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total 4
 `)))
+
+	// Remove both tenants.
+	controller.RemoveTenant("user1")
+	controller.RemoveTenant("user2")
+	controller.tenantConcurrencyMtx.Lock()
+	require.Len(t, controller.tenantConcurrency, 0)
+	controller.tenantConcurrencyMtx.Unlock()
 }
 
 func TestIsRuleIndependent(t *testing.T) {

--- a/pkg/ruler/rule_concurrency_test.go
+++ b/pkg/ruler/rule_concurrency_test.go
@@ -188,8 +188,17 @@ cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use 0
 cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total 4
 `)))
 
-	// Remove both tenants.
+	// Make the rule independent again.
+	rule1.SetNoDependencyRules(true)
+
+	// Let's test removing a user in the middle of the lock acquisition.
+	require.True(t, controller.Allow(user1Ctx, rg, rule1))
 	controller.RemoveTenant("user1")
+	require.NotPanics(t, func() {
+		controller.Done(user1Ctx)
+	})
+
+	// Remove both tenants.
 	controller.RemoveTenant("user2")
 	controller.tenantConcurrencyMtx.Lock()
 	require.Len(t, controller.tenantConcurrency, 0)


### PR DESCRIPTION
#### What this PR does

This introduces a way to remove users from concurrencyController on membership changes in a safe way.

We need to wait until the manager is fully stopped to know that rule evaluation has completed, even if the manager for that user has been deleted already.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
