### PR TITLE
Query Scheduler: Assign Querier-Worker Connection Integer IDs

### DIFF
--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -232,7 +232,7 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 	}
 
 	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(queue.QuerierID(querierID))
-	querierWorkerConn, err = f.requestQueue.AwaitRegisterQuerierWorkerConn(server.Context(), querierWorkerConn)
+	err = f.requestQueue.AwaitRegisterQuerierWorkerConn(server.Context(), querierWorkerConn)
 	defer f.requestQueue.SubmitUnregisterQuerierWorkerConn(server.Context(), querierWorkerConn)
 
 	lastTenantIndex := queue.FirstTenant()

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -232,7 +232,7 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 	}
 
 	f.requestQueue.SubmitRegisterQuerierConnection(querierID)
-	defer f.requestQueue.SubmitUnregisterQuerierConnection(querierID)
+	defer f.requestQueue.SubmitUnregisterQuerierworkerConn(querierID)
 
 	lastTenantIndex := queue.FirstTenant()
 

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -232,8 +232,8 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 	}
 
 	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(queue.QuerierID(querierID))
-	registeredQuerierWorkerConn, err := f.requestQueue.AwaitRegisterQuerierWorkerConn(server.Context(), querierWorkerConn)
-	defer f.requestQueue.SubmitUnregisterQuerierWorkerConn(server.Context(), registeredQuerierWorkerConn)
+	querierWorkerConn, err = f.requestQueue.AwaitRegisterQuerierWorkerConn(server.Context(), querierWorkerConn)
+	defer f.requestQueue.SubmitUnregisterQuerierWorkerConn(server.Context(), querierWorkerConn)
 
 	lastTenantIndex := queue.FirstTenant()
 

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -231,12 +231,12 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 		return err
 	}
 
-	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(queue.QuerierID(querierID))
-	err = f.requestQueue.AwaitRegisterQuerierWorkerConn(server.Context(), querierWorkerConn)
+	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(server.Context(), queue.QuerierID(querierID))
+	err = f.requestQueue.AwaitRegisterQuerierWorkerConn(querierWorkerConn)
 	if err != nil {
 		return err
 	}
-	defer f.requestQueue.SubmitUnregisterQuerierWorkerConn(server.Context(), querierWorkerConn)
+	defer f.requestQueue.SubmitUnregisterQuerierWorkerConn(querierWorkerConn)
 
 	lastTenantIndex := queue.FirstTenant()
 

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -233,6 +233,9 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 
 	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(queue.QuerierID(querierID))
 	err = f.requestQueue.AwaitRegisterQuerierWorkerConn(server.Context(), querierWorkerConn)
+	if err != nil {
+		return err
+	}
 	defer f.requestQueue.SubmitUnregisterQuerierWorkerConn(server.Context(), querierWorkerConn)
 
 	lastTenantIndex := queue.FirstTenant()

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -145,7 +145,7 @@ func TestFrontendCheckReady(t *testing.T) {
 
 			for i := 0; i < tt.connectedClients; i++ {
 				querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn("test")
-				querierWorkerConn, err := f.requestQueue.AwaitRegisterQuerierWorkerConn(context.Background(), querierWorkerConn)
+				querierWorkerConn, err = f.requestQueue.AwaitRegisterQuerierWorkerConn(context.Background(), querierWorkerConn)
 				require.NoError(t, err)
 			}
 			err = f.CheckReady(context.Background())

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -144,8 +144,8 @@ func TestFrontendCheckReady(t *testing.T) {
 			}()
 
 			for i := 0; i < tt.connectedClients; i++ {
-				querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn("test")
-				require.NoError(t, f.requestQueue.AwaitRegisterQuerierWorkerConn(context.Background(), querierWorkerConn))
+				querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(context.Background(), "test")
+				require.NoError(t, f.requestQueue.AwaitRegisterQuerierWorkerConn(querierWorkerConn))
 			}
 			err = f.CheckReady(context.Background())
 			errMsg := ""

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/v1/frontendv1pb"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	querier_worker "github.com/grafana/mimir/pkg/querier/worker"
+	"github.com/grafana/mimir/pkg/scheduler/queue"
 )
 
 const (
@@ -143,7 +144,9 @@ func TestFrontendCheckReady(t *testing.T) {
 			}()
 
 			for i := 0; i < tt.connectedClients; i++ {
-				f.requestQueue.SubmitRegisterQuerierConnection("test")
+				querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn("test")
+				querierWorkerConn, err := f.requestQueue.AwaitRegisterQuerierWorkerConn(context.Background(), querierWorkerConn)
+				require.NoError(t, err)
 			}
 			err = f.CheckReady(context.Background())
 			errMsg := ""

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -145,8 +145,7 @@ func TestFrontendCheckReady(t *testing.T) {
 
 			for i := 0; i < tt.connectedClients; i++ {
 				querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn("test")
-				querierWorkerConn, err = f.requestQueue.AwaitRegisterQuerierWorkerConn(context.Background(), querierWorkerConn)
-				require.NoError(t, err)
+				require.NoError(t, f.requestQueue.AwaitRegisterQuerierWorkerConn(context.Background(), querierWorkerConn))
 			}
 			err = f.CheckReady(context.Background())
 			errMsg := ""

--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_test.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_test.go
@@ -17,13 +17,6 @@ type enqueueObj struct {
 	path QueuePath
 }
 
-func newTenantQuerierAssignments() *tenantQuerierAssignments {
-	return &tenantQuerierAssignments{
-		tenantQuerierIDs: make(map[TenantID]map[QuerierID]struct{}),
-		tenantNodes:      make(map[string][]*Node),
-	}
-}
-
 func Test_NewTree(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -78,7 +71,7 @@ func Test_EnqueueBackByPath(t *testing.T) {
 		{
 			name: "enqueue round-robin node to tenant-querier node",
 			treeAlgosByDepth: []QueuingAlgorithm{
-				newTenantQuerierAssignments(),
+				newTenantQuerierAssignments(0),
 				&roundRobinState{},
 			},
 			childPathsToEnqueue: []QueuePath{{"child-1"}, {"child-2"}},
@@ -86,17 +79,17 @@ func Test_EnqueueBackByPath(t *testing.T) {
 		{
 			name: "enqueue tenant-querier node to tenant-querier node",
 			treeAlgosByDepth: []QueuingAlgorithm{
-				newTenantQuerierAssignments(),
-				newTenantQuerierAssignments(),
+				newTenantQuerierAssignments(0),
+				newTenantQuerierAssignments(0),
 			},
 			childPathsToEnqueue: []QueuePath{{"child-1"}},
 		},
 		{
 			name: "fail to enqueue to a node at depth 1 in tree with max-depth of 2",
 			treeAlgosByDepth: []QueuingAlgorithm{
-				newTenantQuerierAssignments(),
+				newTenantQuerierAssignments(0),
 				&roundRobinState{},
-				newTenantQuerierAssignments(),
+				newTenantQuerierAssignments(0),
 			},
 			childPathsToEnqueue: []QueuePath{{"child"}},
 			expectErr:           true,
@@ -187,7 +180,7 @@ func Test_Dequeue_RootNode(t *testing.T) {
 		},
 		{
 			name:     "dequeue from empty tenant-querier root node",
-			rootAlgo: newTenantQuerierAssignments(),
+			rootAlgo: newTenantQuerierAssignments(0),
 		},
 		{
 			name:          "dequeue from non-empty round-robin root node",
@@ -196,7 +189,7 @@ func Test_Dequeue_RootNode(t *testing.T) {
 		},
 		{
 			name:          "dequeue from non-empty tenant-querier root node",
-			rootAlgo:      newTenantQuerierAssignments(),
+			rootAlgo:      newTenantQuerierAssignments(0),
 			enqueueToRoot: []any{"something-else-in-root"},
 		},
 	}

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -146,11 +146,6 @@ type RequestQueue struct {
 	queueBroker *queueBroker
 }
 
-type querierOperation struct {
-	querierID QuerierID
-	operation QuerierOperationType
-}
-
 type QuerierOperationType int
 
 const (

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -217,6 +217,9 @@ func (qwo *querierWorkerOperation) AwaitQuerierWorkerConnUpdate() error {
 
 	select {
 	case <-qwo.conn.ctx.Done():
+		// context done case serves as a default case to bail out
+		// if the waiting querier-worker connection's context times out or is canceled,
+		// allowing the dispatcherLoop to proceed with its next iteration
 		return qwo.conn.ctx.Err()
 	case <-qwo.recvChan:
 		return nil
@@ -303,6 +306,9 @@ func (q *RequestQueue) running(ctx context.Context) error {
 		case <-inflightRequestsTicker.C:
 			q.QueryComponentUtilization.ObserveInflightRequests()
 		case <-ctx.Done():
+			// context done case serves as a default case to bail out
+			// if the waiting querier-worker connection's context times out or is canceled,
+			// allowing the dispatcherLoop to proceed with its next iteration
 			return nil
 		}
 	}
@@ -493,6 +499,9 @@ func (q *RequestQueue) WaitForRequestForQuerier(ctx context.Context, last Tenant
 		recvChan:        make(chan requestForQuerier),
 	}
 
+	// context done cases serves as a default case to bail out
+	// if the waiting querier-worker connection's context times out or is canceled,
+	// allowing the dispatcherLoop to proceed with its next iteration
 	select {
 	case q.waitingQuerierConns <- waitingConn:
 		select {
@@ -677,6 +686,9 @@ func (wqc *waitingQuerierConn) send(req requestForQuerier) bool {
 	case wqc.recvChan <- req:
 		return true
 	case <-wqc.querierConnCtx.Done():
+		// context done case serves as a default case to bail out
+		// if the waiting querier-worker connection's context times out or is canceled,
+		// allowing the dispatcherLoop to proceed with its next iteration
 		return false
 	}
 }

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -162,10 +162,15 @@ const (
 )
 
 type querierWorkerOperation struct {
-	//ctx                   context.Context
 	conn      *QuerierWorkerConn
 	operation querierOperationType
-	recvChan  chan struct{}
+	// Initializing recvChan as nil indicates that the operation is not awaitable,
+	// indicating the caller does not care to wait for the result to be written
+	// and the processor will not bother to write the result.
+	//
+	// If the operation is awaitable, recvChan is written to when the operation is processed.
+	// Updates are reflected on the referenced QuerierWorkerConn.
+	recvChan chan struct{}
 }
 
 func newQuerierWorkerOperation(

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -98,6 +98,10 @@ func NewUnregisteredQuerierWorkerConn(querierID QuerierID) *QuerierWorkerConn {
 	}
 }
 
+func (qwc *QuerierWorkerConn) IsRegistered() bool {
+	return qwc.WorkerID != unregisteredWorkerID
+}
+
 // RequestQueue holds incoming requests in queues, split by multiple dimensions based on properties of the request.
 // Dequeuing selects the next request from an appropriate queue given the state of the system.
 // Two separate system states are managed by the RequestQueue and used to select the next request:

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -614,8 +614,7 @@ func (q *RequestQueue) processQuerierWorkerOperation(querierWorkerOp *querierWor
 
 func (q *RequestQueue) processRegisterQuerierWorkerConn(conn *QuerierWorkerConn) (resharded bool) {
 	q.connectedQuerierWorkers.Inc()
-	q.queueBroker.addQuerierWorkerConn(conn)
-	return resharded
+	return q.queueBroker.addQuerierWorkerConn(conn)
 }
 
 func (q *RequestQueue) processUnregisterQuerierWorkerConn(conn *QuerierWorkerConn) (resharded bool) {

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -636,7 +636,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnAfterContextCancelled
 			})
 
 			querier1Conn := NewUnregisteredQuerierWorkerConn(querierID)
-			querier1Conn, err = queue.AwaitRegisterQuerierWorkerConn(context.Background(), querier1Conn)
+			_, err = queue.AwaitRegisterQuerierWorkerConn(context.Background(), querier1Conn)
 			require.NoError(t, err)
 
 			// Calling WaitForRequestForQuerier with a context that is already cancelled should fail immediately.
@@ -699,7 +699,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnImmediatelyIfQuerierI
 			})
 
 			querierConn := NewUnregisteredQuerierWorkerConn(querierID)
-			querierConn, err = queue.AwaitRegisterQuerierWorkerConn(ctx, querierConn)
+			_, err = queue.AwaitRegisterQuerierWorkerConn(ctx, querierConn)
 			require.NoError(t, err)
 
 			queue.SubmitNotifyQuerierShutdown(ctx, querierID)

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -6,7 +6,6 @@ package queue
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -18,6 +17,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
@@ -95,16 +95,17 @@ func makeSchedulerRequest(tenantID string, additionalQueueDimensions []string) *
 //
 // In this scenario, one category of queue item causes the queue consumer to slow down, introducing a
 // significant delay while the queue consumer processes it and before the consumer can dequeue the next item.
-// This emulates a situation where one of the query components - the ingesters or store-gateways - is under load.
+// This simulates a situation where one of the query components - the ingesters or store-gateways - is under load.
 //
-// If queue items belonging to the slow category are in the same queue in front of the normal queue items,
-// the normal queue items must wait for all slow queue items to be cleared before they can be serviced.
+// If queue items belonging to the slow category are in the same queue ("normal-channel") in front of the normal queue
+// items, the normal queue items must wait for all slow queue items to be cleared before they can be serviced.
 // In this way, the degraded performance of the slow query component equally degrades the performance of the
 // queries which *could* be serviced quickly, but are waiting behind the slow queries in the queue.
 //
-// With the additional queue dimensions enabled, the queues are split by which query component the query will utilize.
-// The queue broker then round-robins between the split queues, which has the effect of alternating between
-// dequeuing the slow queries and normal queries rather than blocking normal queries behind slow queries.
+// When using multiple queue dimensions, the queues are split by which "component" the query will utilize -- in this
+// test, those components are called "normal-channel" and "slow-channel" for clarity. The queue broker then
+// round-robins between the multiple queues, which has the effect of alternately dequeuing from the slow queries
+// and normal queries rather than blocking normal queries behind slow queries.
 func TestMultiDimensionalQueueFairnessSlowConsumerEffects(t *testing.T) {
 	treeTypes := buildTreeTestsStruct()
 
@@ -124,16 +125,22 @@ func TestMultiDimensionalQueueFairnessSlowConsumerEffects(t *testing.T) {
 			normalQueueDimension := "normal-request"
 			slowConsumerLatency := 20 * time.Millisecond
 			slowConsumerQueueDimension := "slow-request"
-			normalQueueDimensionFunc := func() []string { return []string{normalQueueDimension} }
-			slowQueueDimensionFunc := func() []string { return []string{slowConsumerQueueDimension} }
+			normalQueueDimensionFunc := func(_ bool) []string { return []string{"normal-channel"} }
+			slowQueueDimensionFunc := func(usingMultipleDimensions bool) []string {
+				if usingMultipleDimensions {
+					return []string{"slow-channel"}
+				}
+				return []string{"normal-channel"}
+			}
 
-			additionalQueueDimensionsEnabledCases := []bool{false, true}
+			useMultipleDimensions := []bool{false, true}
 			queueDurationTotals := map[bool]map[string]float64{
 				false: {normalQueueDimension: 0.0, slowConsumerQueueDimension: 0.0},
 				true:  {normalQueueDimension: 0.0, slowConsumerQueueDimension: 0.0},
 			}
 
-			for _, additionalQueueDimensionsEnabled := range additionalQueueDimensionsEnabledCases {
+			for _, multipleDimensionsUsed := range useMultipleDimensions {
+
 				// Scheduler code uses a histogram for queue duration, but a counter is a more direct metric
 				// for this test, as we are concerned with the total or average wait time for all queue items.
 				// Prometheus histograms also lack support for test assertions via prometheus/testutil.
@@ -145,7 +152,6 @@ func TestMultiDimensionalQueueFairnessSlowConsumerEffects(t *testing.T) {
 				queue, err := NewRequestQueue(
 					log.NewNopLogger(),
 					maxOutstandingRequestsPerTenant,
-					additionalQueueDimensionsEnabled,
 					tt.useMultiAlgoTreeQueue,
 					forgetQuerierDelay,
 					promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
@@ -162,12 +168,12 @@ func TestMultiDimensionalQueueFairnessSlowConsumerEffects(t *testing.T) {
 				})
 
 				// fill queue first with the slow queries, then the normal queries
-				for _, queueDimensionFunc := range []func() []string{slowQueueDimensionFunc, normalQueueDimensionFunc} {
+				for _, queueDimensionFunc := range []func(bool) []string{slowQueueDimensionFunc, normalQueueDimensionFunc} {
 					startProducersChan := make(chan struct{})
 					producersErrGroup, _ := errgroup.WithContext(ctx)
 
 					runProducer := runQueueProducerIters(
-						queue, maxQueriersPerTenant, totalRequests/2, numProducers, numTenants, startProducersChan, queueDimensionFunc,
+						queue, maxQueriersPerTenant, totalRequests/2, numProducers, numTenants, startProducersChan, multipleDimensionsUsed, queueDimensionFunc,
 					)
 					for producerIdx := 0; producerIdx < numProducers; producerIdx++ {
 						producerIdx := producerIdx
@@ -211,7 +217,7 @@ func TestMultiDimensionalQueueFairnessSlowConsumerEffects(t *testing.T) {
 
 				// record total queue duration by queue dimensions and whether the queue splitting was enabled
 				for _, queueDimension := range []string{normalQueueDimension, slowConsumerQueueDimension} {
-					queueDurationTotals[additionalQueueDimensionsEnabled][queueDimension] = promtest.ToFloat64(
+					queueDurationTotals[multipleDimensionsUsed][queueDimension] = promtest.ToFloat64(
 						queueDuration.With(prometheus.Labels{"additional_queue_dimensions": queueDimension}),
 					)
 				}
@@ -257,7 +263,6 @@ func BenchmarkConcurrentQueueOperations(b *testing.B) {
 									queue, err := NewRequestQueue(
 										log.NewNopLogger(),
 										maxOutstandingRequestsPerTenant,
-										true,
 										t.useMultiAlgoTreeQueue,
 										forgetQuerierDelay,
 										promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
@@ -276,7 +281,7 @@ func BenchmarkConcurrentQueueOperations(b *testing.B) {
 									})
 
 									runProducer := runQueueProducerIters(
-										queue, maxQueriersPerTenant, b.N, numProducers, numTenants, startSignalChan, nil,
+										queue, maxQueriersPerTenant, b.N, numProducers, numTenants, startSignalChan, true, nil,
 									)
 
 									for producerIdx := 0; producerIdx < numProducers; producerIdx++ {
@@ -337,7 +342,8 @@ func runQueueProducerIters(
 	numProducers int,
 	numTenants int,
 	start chan struct{},
-	additionalQueueDimensionFunc func() []string,
+	usingMultipleDimensions bool,
+	additionalQueueDimensionFunc func(bool) []string,
 ) func(producerIdx int) error {
 	return func(producerIdx int) error {
 		producerIters := queueActorIterationCount(totalIters, numProducers, producerIdx)
@@ -346,7 +352,7 @@ func runQueueProducerIters(
 		<-start
 
 		for i := 0; i < producerIters; i++ {
-			err := queueProduce(queue, maxQueriersPerTenant, tenantIDStr, additionalQueueDimensionFunc)
+			err := queueProduce(queue, maxQueriersPerTenant, tenantIDStr, usingMultipleDimensions, additionalQueueDimensionFunc)
 			if err != nil {
 				return err
 			}
@@ -359,11 +365,15 @@ func runQueueProducerIters(
 }
 
 func queueProduce(
-	queue *RequestQueue, maxQueriersPerTenant int, tenantID string, additionalQueueDimensionFunc func() []string,
+	queue *RequestQueue,
+	maxQueriersPerTenant int,
+	tenantID string,
+	usingMultipleDimensions bool,
+	additionalQueueDimensionFunc func(bool) []string,
 ) error {
 	var additionalQueueDimensions []string
 	if additionalQueueDimensionFunc != nil {
-		additionalQueueDimensions = additionalQueueDimensionFunc()
+		additionalQueueDimensions = additionalQueueDimensionFunc(usingMultipleDimensions)
 	}
 	req := makeSchedulerRequest(tenantID, additionalQueueDimensions)
 	for {
@@ -439,7 +449,6 @@ func TestRequestQueue_RegisterAndUnregisterQuerierWorkerConnections(t *testing.T
 			queue, err := NewRequestQueue(
 				log.NewNopLogger(),
 				1,
-				true,
 				tt.useMultiAlgoTreeQueue,
 				forgetDelay,
 				promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
@@ -532,7 +541,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBe
 		t.Run(tt.name, func(t *testing.T) {
 			queue, err := NewRequestQueue(
 				log.NewNopLogger(),
-				1, true,
+				1,
 				tt.useMultiAlgoTreeQueue,
 				forgetDelay,
 				promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
@@ -611,7 +620,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ReshardNotifiedCorrectlyForMultip
 		t.Run(tt.name, func(t *testing.T) {
 			queue, err := NewRequestQueue(
 				log.NewNopLogger(),
-				1, true,
+				1,
 				tt.useMultiAlgoTreeQueue,
 				forgetDelay,
 				promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
@@ -707,7 +716,6 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnAfterContextCancelled
 			queue, err := NewRequestQueue(
 				log.NewNopLogger(),
 				1,
-				true,
 				tt.useMultiAlgoTreeQueue,
 				forgetDelay,
 				promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
@@ -768,7 +776,6 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnImmediatelyIfQuerierI
 			queue, err := NewRequestQueue(
 				log.NewNopLogger(),
 				1,
-				true,
 				tt.useMultiAlgoTreeQueue,
 				forgetDelay,
 				promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
@@ -806,7 +813,6 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 			queue, err := NewRequestQueue(
 				log.NewNopLogger(),
 				1,
-				true,
 				tt.useMultiAlgoTreeQueue,
 				forgetDelay,
 				promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
@@ -818,7 +824,7 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 
 			// bypassing queue dispatcher loop for direct usage of the queueBroker and
 			// passing a waitingQuerierConn for a canceled querier connection
-			queueBroker := newQueueBroker(queue.maxOutstandingPerTenant, queue.additionalQueueDimensionsEnabled, false, queue.forgetDelay)
+			queueBroker := newQueueBroker(queue.maxOutstandingPerTenant, false, queue.forgetDelay)
 			queueBroker.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(context.Background(), querierID))
 
 			tenantMaxQueriers := 0 // no sharding

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -392,11 +392,11 @@ func runQueueConsumerIters(
 		lastTenantIndex := FirstTenant()
 		querierID := fmt.Sprintf("consumer-%v", consumerIdx)
 		querierWorkerConn := NewUnregisteredQuerierWorkerConn(QuerierID(querierID))
-		registeredQuerierWorkerConn, err := queue.AwaitRegisterQuerierWorkerConn(ctx, querierWorkerConn)
+		err := queue.AwaitRegisterQuerierWorkerConn(ctx, querierWorkerConn)
 		if err != nil {
 			return err
 		}
-		defer queue.SubmitUnregisterQuerierWorkerConn(ctx, registeredQuerierWorkerConn)
+		defer queue.SubmitUnregisterQuerierWorkerConn(ctx, querierWorkerConn)
 
 		<-start
 
@@ -456,11 +456,9 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBe
 
 			// Two queriers connect.
 			querier1Conn := NewUnregisteredQuerierWorkerConn("querier-1")
-			querier1Conn, err = queue.AwaitRegisterQuerierWorkerConn(ctx, querier1Conn)
-			require.NoError(t, err)
+			require.NoError(t, queue.AwaitRegisterQuerierWorkerConn(ctx, querier1Conn))
 			querier2Conn := NewUnregisteredQuerierWorkerConn("querier-2")
-			querier2Conn, err = queue.AwaitRegisterQuerierWorkerConn(ctx, querier2Conn)
-			require.NoError(t, err)
+			require.NoError(t, queue.AwaitRegisterQuerierWorkerConn(ctx, querier2Conn))
 
 			t.Cleanup(func() {
 				// if the test has failed and the queue does not get cleared,
@@ -550,14 +548,11 @@ func TestRequestQueue_GetNextRequestForQuerier_ReshardNotifiedCorrectlyForMultip
 			// when not all querier forget operations in a single run of forgetDisconnectedQueriers caused a reshard.
 			// Two queriers connect.
 			querier1Conn := NewUnregisteredQuerierWorkerConn("querier-1")
-			querier1Conn, err = queue.AwaitRegisterQuerierWorkerConn(ctx, querier1Conn)
-			require.NoError(t, err)
+			require.NoError(t, queue.AwaitRegisterQuerierWorkerConn(ctx, querier1Conn))
 			querier2Conn := NewUnregisteredQuerierWorkerConn("querier-2")
-			querier2Conn, err = queue.AwaitRegisterQuerierWorkerConn(ctx, querier2Conn)
-			require.NoError(t, err)
+			require.NoError(t, queue.AwaitRegisterQuerierWorkerConn(ctx, querier2Conn))
 			querier3Conn := NewUnregisteredQuerierWorkerConn("querier-3")
-			querier3Conn, err = queue.AwaitRegisterQuerierWorkerConn(ctx, querier3Conn)
-			require.NoError(t, err)
+			require.NoError(t, queue.AwaitRegisterQuerierWorkerConn(ctx, querier3Conn))
 
 			t.Cleanup(func() {
 				// if the test has failed and the queue does not get cleared,
@@ -636,8 +631,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnAfterContextCancelled
 			})
 
 			querier1Conn := NewUnregisteredQuerierWorkerConn(querierID)
-			_, err = queue.AwaitRegisterQuerierWorkerConn(context.Background(), querier1Conn)
-			require.NoError(t, err)
+			require.NoError(t, queue.AwaitRegisterQuerierWorkerConn(context.Background(), querier1Conn))
 
 			// Calling WaitForRequestForQuerier with a context that is already cancelled should fail immediately.
 			deadCtx, cancel := context.WithCancel(context.Background())
@@ -699,8 +693,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnImmediatelyIfQuerierI
 			})
 
 			querierConn := NewUnregisteredQuerierWorkerConn(querierID)
-			_, err = queue.AwaitRegisterQuerierWorkerConn(ctx, querierConn)
-			require.NoError(t, err)
+			require.NoError(t, queue.AwaitRegisterQuerierWorkerConn(ctx, querierConn))
 
 			queue.SubmitNotifyQuerierShutdown(ctx, querierID)
 

--- a/pkg/scheduler/queue/tenant_querier_assignment_test.go
+++ b/pkg/scheduler/queue/tenant_querier_assignment_test.go
@@ -138,7 +138,7 @@ func TestQueues_QuerierWorkerIDAssignment(t *testing.T) {
 	require.Equal(t, 2, querier1Conn3.WorkerID)
 
 	// The next connection should get the next available worker ID;
-	// since worker ID 1 was deregistered, the next connection will get worker ID 1.
+	// since worker ID 0 was deregistered, the next connection will get worker ID 0.
 	querier1Conn4 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-1")
 	tqa.addQuerierWorkerConn(querier1Conn4)
 	require.Equal(t, 0, querier1Conn4.WorkerID)

--- a/pkg/scheduler/queue/tenant_querier_assignment_test.go
+++ b/pkg/scheduler/queue/tenant_querier_assignment_test.go
@@ -102,55 +102,80 @@ func TestShuffleQueriersCorrectness(t *testing.T) {
 }
 
 func TestQueues_QuerierWorkerIDAssignment(t *testing.T) {
-	treeTypes := buildTreeTestsStruct()
-	for _, tt := range treeTypes {
-		t.Run(tt.name, func(t *testing.T) {
-			tqas := newTenantQuerierAssignments(0)
+	tqa := newTenantQuerierAssignments(0)
 
-			// 2 queriers open 3 connections each.
-			// Each querier's worker IDs should be assigned in order,
-			// assuming no disconnects between registering connections
-			querier1Conn1 := NewUnregisteredQuerierWorkerConn("querier-1")
-			tqas.addQuerierWorkerConn(querier1Conn1)
-			require.Equal(t, 0, querier1Conn1.WorkerID)
-			querier1Conn2 := NewUnregisteredQuerierWorkerConn("querier-1")
-			tqas.addQuerierWorkerConn(querier1Conn2)
-			require.Equal(t, 1, querier1Conn2.WorkerID)
-			querier1Conn3 := NewUnregisteredQuerierWorkerConn("querier-1")
-			tqas.addQuerierWorkerConn(querier1Conn3)
-			require.Equal(t, 2, querier1Conn3.WorkerID)
+	// 2 queriers open 3 connections each.
+	// Each querier's worker IDs should be assigned in order,
+	// assuming no disconnects between registering connections
+	querier1Conn1 := NewUnregisteredQuerierWorkerConn("querier-1")
+	tqa.addQuerierWorkerConn(querier1Conn1)
+	require.Equal(t, 0, querier1Conn1.WorkerID)
+	querier1Conn2 := NewUnregisteredQuerierWorkerConn("querier-1")
+	tqa.addQuerierWorkerConn(querier1Conn2)
+	require.Equal(t, 1, querier1Conn2.WorkerID)
+	querier1Conn3 := NewUnregisteredQuerierWorkerConn("querier-1")
+	tqa.addQuerierWorkerConn(querier1Conn3)
+	require.Equal(t, 2, querier1Conn3.WorkerID)
 
-			// The second querier's worker IDs again start at 0 and are independent of any other queriers
-			querier2Conn1 := NewUnregisteredQuerierWorkerConn("querier-2")
-			tqas.addQuerierWorkerConn(querier2Conn1)
-			require.Equal(t, 0, querier2Conn1.WorkerID)
-			querier2Conn2 := NewUnregisteredQuerierWorkerConn("querier-2")
-			tqas.addQuerierWorkerConn(querier2Conn2)
-			require.Equal(t, 1, querier2Conn2.WorkerID)
-			querier2Conn3 := NewUnregisteredQuerierWorkerConn("querier-2")
-			tqas.addQuerierWorkerConn(querier2Conn3)
-			require.Equal(t, 2, querier2Conn3.WorkerID)
+	// The second querier's worker IDs again start at 0 and are independent of any other queriers
+	querier2Conn1 := NewUnregisteredQuerierWorkerConn("querier-2")
+	tqa.addQuerierWorkerConn(querier2Conn1)
+	require.Equal(t, 0, querier2Conn1.WorkerID)
+	querier2Conn2 := NewUnregisteredQuerierWorkerConn("querier-2")
+	tqa.addQuerierWorkerConn(querier2Conn2)
+	require.Equal(t, 1, querier2Conn2.WorkerID)
+	querier2Conn3 := NewUnregisteredQuerierWorkerConn("querier-2")
+	tqa.addQuerierWorkerConn(querier2Conn3)
+	require.Equal(t, 2, querier2Conn3.WorkerID)
 
-			// Unregister two of querier-1's connection
-			tqas.removeQuerierWorkerConn(querier1Conn2, time.Now())
-			require.False(t, querier1Conn2.IsRegistered())
-			tqas.removeQuerierWorkerConn(querier1Conn1, time.Now())
-			require.False(t, querier1Conn1.IsRegistered())
-			// Remaining connections should keep their worker IDs
-			require.Equal(t, 2, querier1Conn3.WorkerID)
+	// Unregister two of querier-1's connection
+	tqa.removeQuerierWorkerConn(querier1Conn2, time.Now())
+	require.False(t, querier1Conn2.IsRegistered())
+	tqa.removeQuerierWorkerConn(querier1Conn1, time.Now())
+	require.False(t, querier1Conn1.IsRegistered())
+	// Remaining connections should keep their worker IDs
+	require.Equal(t, 2, querier1Conn3.WorkerID)
 
-			// The next connection should get the next available worker ID;
-			// since worker ID 1 was deregistered, the next connection will get worker ID 1.
-			querier1Conn4 := NewUnregisteredQuerierWorkerConn("querier-1")
-			tqas.addQuerierWorkerConn(querier1Conn4)
-			require.Equal(t, 0, querier1Conn4.WorkerID)
+	// The next connection should get the next available worker ID;
+	// since worker ID 1 was deregistered, the next connection will get worker ID 1.
+	querier1Conn4 := NewUnregisteredQuerierWorkerConn("querier-1")
+	tqa.addQuerierWorkerConn(querier1Conn4)
+	require.Equal(t, 0, querier1Conn4.WorkerID)
 
-			// A previous connection can re-register and get a different worker ID
-			// This does not happen in practice, as the de-registration only happens
-			// when a QuerierLoop exits, after which the querierWorkerConn falls out of scope.
-			// Regardless, once the connection is deregistered it acts as a new unregistered connection.
-			tqas.addQuerierWorkerConn(querier1Conn1)
-			require.Equal(t, 1, querier1Conn1.WorkerID)
-		})
-	}
+	// A previous connection can re-register and get a different worker ID
+	// This does not happen in practice, as the de-registration only happens
+	// when a QuerierLoop exits, after which the querierWorkerConn falls out of scope.
+	// Regardless, once the connection is deregistered it acts as a new unregistered connection.
+	tqa.addQuerierWorkerConn(querier1Conn1)
+	require.Equal(t, 1, querier1Conn1.WorkerID)
+}
+
+func TestQueues_QuerierWorkerIDAssignment_Panics(t *testing.T) {
+	// test with forget delay so the querier is not removed when its last connection is deregistered;
+	// a registered querier with no registered connections allows the test to reach some panic cases
+	tqa := newTenantQuerierAssignments(10 * time.Second)
+
+	querierConn := NewUnregisteredQuerierWorkerConn("")
+
+	// the querier has never had any connections registered, so it is not tracked by TenantQuerierAssignments
+	// de-registering any querier connection should panic with a message about the querier
+	require.PanicsWithValue(
+		t, "unexpected number of connections for querier",
+		func() { tqa.removeQuerierWorkerConn(querierConn, time.Now()) },
+	)
+	// now register the first worker for the querier
+	tqa.addQuerierWorkerConn(querierConn)
+
+	// double-registering a querier connection should panic
+	require.PanicsWithValue(
+		t, "received request to register a querier-worker which was already registered",
+		func() { tqa.addQuerierWorkerConn(querierConn) },
+	)
+
+	// the querier has active connections, so it is tracked by TenantQuerierAssignments
+	// de-registering any unregistered querier connection should panic with a message about the querier-worker
+	require.PanicsWithValue(
+		t, "received request to deregister a querier-worker which was not already registered",
+		func() { tqa.removeQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(""), time.Now()) },
+	)
 }

--- a/pkg/scheduler/queue/tenant_querier_assignment_test.go
+++ b/pkg/scheduler/queue/tenant_querier_assignment_test.go
@@ -100,3 +100,57 @@ func TestShuffleQueriersCorrectness(t *testing.T) {
 		}
 	}
 }
+
+func TestQueues_QuerierWorkerIDAssignment(t *testing.T) {
+	treeTypes := buildTreeTestsStruct()
+	for _, tt := range treeTypes {
+		t.Run(tt.name, func(t *testing.T) {
+			tqas := newTenantQuerierAssignments(0)
+
+			// 2 queriers open 3 connections each.
+			// Each querier's worker IDs should be assigned in order,
+			// assuming no disconnects between registering connections
+			querier1Conn1 := NewUnregisteredQuerierWorkerConn("querier-1")
+			tqas.addQuerierWorkerConn(querier1Conn1)
+			require.Equal(t, 0, querier1Conn1.WorkerID)
+			querier1Conn2 := NewUnregisteredQuerierWorkerConn("querier-1")
+			tqas.addQuerierWorkerConn(querier1Conn2)
+			require.Equal(t, 1, querier1Conn2.WorkerID)
+			querier1Conn3 := NewUnregisteredQuerierWorkerConn("querier-1")
+			tqas.addQuerierWorkerConn(querier1Conn3)
+			require.Equal(t, 2, querier1Conn3.WorkerID)
+
+			// The second querier's worker IDs again start at 0 and are independent of any other queriers
+			querier2Conn1 := NewUnregisteredQuerierWorkerConn("querier-2")
+			tqas.addQuerierWorkerConn(querier2Conn1)
+			require.Equal(t, 0, querier2Conn1.WorkerID)
+			querier2Conn2 := NewUnregisteredQuerierWorkerConn("querier-2")
+			tqas.addQuerierWorkerConn(querier2Conn2)
+			require.Equal(t, 1, querier2Conn2.WorkerID)
+			querier2Conn3 := NewUnregisteredQuerierWorkerConn("querier-2")
+			tqas.addQuerierWorkerConn(querier2Conn3)
+			require.Equal(t, 2, querier2Conn3.WorkerID)
+
+			// Unregister two of querier-1's connection
+			tqas.removeQuerierWorkerConn(querier1Conn2, time.Now())
+			require.False(t, querier1Conn2.IsRegistered())
+			tqas.removeQuerierWorkerConn(querier1Conn1, time.Now())
+			require.False(t, querier1Conn1.IsRegistered())
+			// Remaining connections should keep their worker IDs
+			require.Equal(t, 2, querier1Conn3.WorkerID)
+
+			// The next connection should get the next available worker ID;
+			// since worker ID 1 was deregistered, the next connection will get worker ID 1.
+			querier1Conn4 := NewUnregisteredQuerierWorkerConn("querier-1")
+			tqas.addQuerierWorkerConn(querier1Conn4)
+			require.Equal(t, 0, querier1Conn4.WorkerID)
+
+			// A previous connection can re-register and get a different worker ID
+			// This does not happen in practice, as the de-registration only happens
+			// when a QuerierLoop exits, after which the querierWorkerConn falls out of scope.
+			// Regardless, once the connection is deregistered it acts as a new unregistered connection.
+			tqas.addQuerierWorkerConn(querier1Conn1)
+			require.Equal(t, 1, querier1Conn1.WorkerID)
+		})
+	}
+}

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -40,7 +40,7 @@ func newQueueBroker(
 ) *queueBroker {
 	currentQuerier := QuerierID("")
 	tqas := &tenantQuerierAssignments{
-		queriersByID:       map[QuerierID]*querierConn{},
+		queriersByID:       map[QuerierID]*querierConns{},
 		querierIDsSorted:   nil,
 		querierForgetDelay: forgetDelay,
 		tenantIDOrder:      nil,
@@ -217,12 +217,15 @@ func (qb *queueBroker) dequeueRequestForQuerier(
 	return request, tenant, qb.tenantQuerierAssignments.tenantOrderIndex, nil
 }
 
-func (qb *queueBroker) addQuerierConnection(querierID QuerierID) (resharded bool) {
-	return qb.tenantQuerierAssignments.addQuerierConnection(querierID)
+// below methods simply pass through to the queueBroker's tenantQuerierAssignments; this layering could be skipped
+// but there is no reason to make consumers know that they need to call through to the tenantQuerierAssignments.
+
+func (qb *queueBroker) addQuerierWorkerConn(conn *QuerierWorkerConn) (resharded bool) {
+	return qb.tenantQuerierAssignments.addQuerierWorkerConn(conn)
 }
 
-func (qb *queueBroker) removeQuerierConnection(querierID QuerierID, now time.Time) (resharded bool) {
-	return qb.tenantQuerierAssignments.removeQuerierConnection(querierID, now)
+func (qb *queueBroker) removeQuerierWorkerConn(conn *QuerierWorkerConn, now time.Time) (resharded bool) {
+	return qb.tenantQuerierAssignments.removeQuerierWorkerConn(conn, now)
 }
 
 func (qb *queueBroker) notifyQuerierShutdown(querierID QuerierID) (resharded bool) {

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -38,19 +38,7 @@ func newQueueBroker(
 	useMultiAlgoTreeQueue bool,
 	forgetDelay time.Duration,
 ) *queueBroker {
-	currentQuerier := QuerierID("")
-	tqas := &tenantQuerierAssignments{
-		queriersByID:       map[QuerierID]*querierConns{},
-		querierIDsSorted:   nil,
-		querierForgetDelay: forgetDelay,
-		tenantIDOrder:      nil,
-		tenantsByID:        map[TenantID]*queueTenant{},
-		tenantQuerierIDs:   map[TenantID]map[QuerierID]struct{}{},
-		tenantNodes:        map[string][]*Node{},
-		currentQuerier:     currentQuerier,
-		tenantOrderIndex:   localQueueIndex,
-	}
-
+	tqas := newTenantQuerierAssignments(forgetDelay)
 	var tree Tree
 	var err error
 	if useMultiAlgoTreeQueue {

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -394,7 +394,6 @@ func TestQueues_QuerierDistribution(t *testing.T) {
 			for ix := 0; ix < queriers; ix++ {
 				qid := QuerierID(fmt.Sprintf("querier-%d", ix))
 				qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(qid))
-				//qb.addQuerierConnection(qid)
 
 				// No querier has any queues yet.
 				req, tenant, _, err := qb.dequeueRequestForQuerier(-1, QuerierID(qid))
@@ -544,15 +543,6 @@ func TestQueues_ForgetDelay(t *testing.T) {
 			querier3Conn2 := NewUnregisteredQuerierWorkerConn("querier-3")
 			qb.addQuerierWorkerConn(querier3Conn2)
 
-			//for i := 1; i <= 3; i++ {
-			//	qb.addQuerierWorkerConn()
-			//	qb.addQuerierWorkerConn(
-			//		NewUnregisteredQuerierWorkerConn(fmt.Sprintf("querier-%d", i)),
-			//	)
-			//	//qb.addQuerierConnection(QuerierID(fmt.Sprintf("querier-%d", i)))
-			//	//qb.addQuerierConnection(QuerierID(fmt.Sprintf("querier-%d", i)))
-			//}
-
 			// Add tenant queues.
 			for i := 0; i < numTenants; i++ {
 				tenantID := TenantID(fmt.Sprintf("tenant-%d", i))
@@ -585,8 +575,6 @@ func TestQueues_ForgetDelay(t *testing.T) {
 			}
 
 			// Querier-1 reconnects.
-			//qb.addQuerierConnection("querier-1")
-			//qb.addQuerierConnection("querier-1")
 			qb.addQuerierWorkerConn(querier1Conn1)
 			qb.addQuerierWorkerConn(querier1Conn2)
 

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -561,8 +561,6 @@ func TestQueues_ForgetDelay(t *testing.T) {
 			// Gracefully shutdown querier-1.
 			qb.removeQuerierWorkerConn(querier1Conn1, now.Add(20*time.Second))
 			qb.removeQuerierWorkerConn(querier1Conn2, now.Add(21*time.Second))
-			//qb.removeQuerierConnection("querier-1", now.Add(20*time.Second))
-			//qb.removeQuerierConnection("querier-1", now.Add(21*time.Second))
 			qb.notifyQuerierShutdown("querier-1")
 
 			// We expect querier-1 has been removed.
@@ -586,8 +584,6 @@ func TestQueues_ForgetDelay(t *testing.T) {
 			}
 
 			// Querier-1 abruptly terminates (no shutdown notification received).
-			//qb.removeQuerierConnection("querier-1", now.Add(40*time.Second))
-			//qb.removeQuerierConnection("querier-1", now.Add(41*time.Second))
 			qb.removeQuerierWorkerConn(querier1Conn1, now.Add(40*time.Second))
 			qb.removeQuerierWorkerConn(querier1Conn2, now.Add(41*time.Second))
 

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -86,8 +86,8 @@ func TestQueues_NoShuffleSharding(t *testing.T) {
 			assert.NotNil(t, qb)
 			assert.NoError(t, isConsistent(qb))
 
-			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-1"))
-			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-2"))
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(context.Background(), "querier-1"))
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(context.Background(), "querier-2"))
 
 			req, tenant, lastTenantIndexQuerierOne, err := qb.dequeueRequestForQuerier(-1, "querier-1")
 			assert.Nil(t, req)
@@ -287,7 +287,7 @@ func TestQueuesRespectMaxTenantQueueSizeWithSubQueues(t *testing.T) {
 			}
 
 			// dequeue a request
-			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-1"))
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(context.Background(), "querier-1"))
 			dequeuedTenantReq, _, _, err := qb.dequeueRequestForQuerier(-1, "querier-1")
 			assert.NoError(t, err)
 			assert.NotNil(t, dequeuedTenantReq)
@@ -312,8 +312,8 @@ func TestQueuesOnTerminatingQuerier(t *testing.T) {
 			assert.NotNil(t, qb)
 			assert.NoError(t, isConsistent(qb))
 
-			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-1"))
-			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-2"))
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(context.Background(), "querier-1"))
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(context.Background(), "querier-2"))
 
 			// Add queues: [one two]
 			err := qb.tenantQuerierAssignments.createOrUpdateTenant("one", 0)
@@ -393,7 +393,7 @@ func TestQueues_QuerierDistribution(t *testing.T) {
 			// Add some queriers.
 			for ix := 0; ix < queriers; ix++ {
 				qid := QuerierID(fmt.Sprintf("querier-%d", ix))
-				qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(qid))
+				qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(context.Background(), qid))
 
 				// No querier has any queues yet.
 				req, tenant, _, err := qb.dequeueRequestForQuerier(-1, QuerierID(qid))
@@ -486,7 +486,7 @@ func TestQueuesConsistency(t *testing.T) {
 							qb.removeTenantQueue(generateTenant(r))
 						case 3:
 							querierID := generateQuerier(r)
-							conn := NewUnregisteredQuerierWorkerConn(querierID)
+							conn := NewUnregisteredQuerierWorkerConn(context.Background(), querierID)
 							qb.addQuerierWorkerConn(conn)
 							conns[querierID] = append(conns[querierID], conn)
 						case 4:
@@ -528,19 +528,19 @@ func TestQueues_ForgetDelay(t *testing.T) {
 			assert.NoError(t, isConsistent(qb))
 
 			// 3 queriers open 2 connections each.
-			querier1Conn1 := NewUnregisteredQuerierWorkerConn("querier-1")
+			querier1Conn1 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-1")
 			qb.addQuerierWorkerConn(querier1Conn1)
-			querier1Conn2 := NewUnregisteredQuerierWorkerConn("querier-1")
+			querier1Conn2 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-1")
 			qb.addQuerierWorkerConn(querier1Conn2)
 
-			querier2Conn1 := NewUnregisteredQuerierWorkerConn("querier-2")
+			querier2Conn1 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-2")
 			qb.addQuerierWorkerConn(querier2Conn1)
-			querier2Conn2 := NewUnregisteredQuerierWorkerConn("querier-2")
+			querier2Conn2 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-2")
 			qb.addQuerierWorkerConn(querier2Conn2)
 
-			querier3Conn1 := NewUnregisteredQuerierWorkerConn("querier-3")
+			querier3Conn1 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-3")
 			qb.addQuerierWorkerConn(querier3Conn1)
-			querier3Conn2 := NewUnregisteredQuerierWorkerConn("querier-3")
+			querier3Conn2 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-3")
 			qb.addQuerierWorkerConn(querier3Conn2)
 
 			// Add tenant queues.
@@ -641,19 +641,19 @@ func TestQueues_ForgetDelay_ShouldCorrectlyHandleQuerierReconnectingBeforeForget
 			assert.NoError(t, isConsistent(qb))
 
 			// 3 queriers open 2 connections each.
-			querier1Conn1 := NewUnregisteredQuerierWorkerConn("querier-1")
+			querier1Conn1 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-1")
 			qb.addQuerierWorkerConn(querier1Conn1)
-			querier1Conn2 := NewUnregisteredQuerierWorkerConn("querier-1")
+			querier1Conn2 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-1")
 			qb.addQuerierWorkerConn(querier1Conn2)
 
-			querier2Conn1 := NewUnregisteredQuerierWorkerConn("querier-2")
+			querier2Conn1 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-2")
 			qb.addQuerierWorkerConn(querier2Conn1)
-			querier2Conn2 := NewUnregisteredQuerierWorkerConn("querier-2")
+			querier2Conn2 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-2")
 			qb.addQuerierWorkerConn(querier2Conn2)
 
-			querier3Conn1 := NewUnregisteredQuerierWorkerConn("querier-3")
+			querier3Conn1 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-3")
 			qb.addQuerierWorkerConn(querier3Conn1)
-			querier3Conn2 := NewUnregisteredQuerierWorkerConn("querier-3")
+			querier3Conn2 := NewUnregisteredQuerierWorkerConn(context.Background(), "querier-3")
 			qb.addQuerierWorkerConn(querier3Conn2)
 
 			// Add tenant queues.

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -86,8 +86,8 @@ func TestQueues_NoShuffleSharding(t *testing.T) {
 			assert.NotNil(t, qb)
 			assert.NoError(t, isConsistent(qb))
 
-			qb.addQuerierConnection("querier-1")
-			qb.addQuerierConnection("querier-2")
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-1"))
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-2"))
 
 			req, tenant, lastTenantIndexQuerierOne, err := qb.dequeueRequestForQuerier(-1, "querier-1")
 			assert.Nil(t, req)
@@ -287,7 +287,7 @@ func TestQueuesRespectMaxTenantQueueSizeWithSubQueues(t *testing.T) {
 			}
 
 			// dequeue a request
-			qb.addQuerierConnection("querier-1")
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-1"))
 			dequeuedTenantReq, _, _, err := qb.dequeueRequestForQuerier(-1, "querier-1")
 			assert.NoError(t, err)
 			assert.NotNil(t, dequeuedTenantReq)
@@ -312,8 +312,8 @@ func TestQueuesOnTerminatingQuerier(t *testing.T) {
 			assert.NotNil(t, qb)
 			assert.NoError(t, isConsistent(qb))
 
-			qb.addQuerierConnection("querier-1")
-			qb.addQuerierConnection("querier-2")
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-1"))
+			qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn("querier-2"))
 
 			// Add queues: [one two]
 			err := qb.tenantQuerierAssignments.createOrUpdateTenant("one", 0)
@@ -393,10 +393,11 @@ func TestQueues_QuerierDistribution(t *testing.T) {
 			// Add some queriers.
 			for ix := 0; ix < queriers; ix++ {
 				qid := QuerierID(fmt.Sprintf("querier-%d", ix))
-				qb.addQuerierConnection(qid)
+				qb.addQuerierWorkerConn(NewUnregisteredQuerierWorkerConn(qid))
+				//qb.addQuerierConnection(qid)
 
 				// No querier has any queues yet.
-				req, tenant, _, err := qb.dequeueRequestForQuerier(-1, qid)
+				req, tenant, _, err := qb.dequeueRequestForQuerier(-1, QuerierID(qid))
 				assert.Nil(t, req)
 				assert.Nil(t, tenant)
 				assert.NoError(t, err)
@@ -470,7 +471,8 @@ func TestQueuesConsistency(t *testing.T) {
 
 					lastTenantIndexes := map[QuerierID]int{}
 
-					conns := map[QuerierID]int{}
+					// track active querier-worker connections to use worker IDs for removal
+					conns := map[QuerierID][]*QuerierWorkerConn{}
 
 					for i := 0; i < 100; i++ {
 						switch r.Int() % 6 {
@@ -484,14 +486,18 @@ func TestQueuesConsistency(t *testing.T) {
 						case 2:
 							qb.removeTenantQueue(generateTenant(r))
 						case 3:
-							q := generateQuerier(r)
-							qb.addQuerierConnection(q)
-							conns[q]++
+							querierID := generateQuerier(r)
+							conn := NewUnregisteredQuerierWorkerConn(querierID)
+							qb.addQuerierWorkerConn(conn)
+							conns[querierID] = append(conns[querierID], conn)
 						case 4:
-							q := generateQuerier(r)
-							if conns[q] > 0 {
-								qb.removeQuerierConnection(q, time.Now())
-								conns[q]--
+							querierID := generateQuerier(r)
+							if len(conns[querierID]) > 0 {
+								// does not matter which connection is removed; just choose the last one in the list
+								conn := conns[querierID][len(conns[querierID])-1]
+								qb.removeQuerierWorkerConn(conn, time.Now())
+								// slice removed connection off end of tracking list
+								conns[querierID] = conns[querierID][:len(conns[querierID])-1]
 							}
 						case 5:
 							q := generateQuerier(r)
@@ -523,10 +529,29 @@ func TestQueues_ForgetDelay(t *testing.T) {
 			assert.NoError(t, isConsistent(qb))
 
 			// 3 queriers open 2 connections each.
-			for i := 1; i <= 3; i++ {
-				qb.addQuerierConnection(QuerierID(fmt.Sprintf("querier-%d", i)))
-				qb.addQuerierConnection(QuerierID(fmt.Sprintf("querier-%d", i)))
-			}
+			querier1Conn1 := NewUnregisteredQuerierWorkerConn("querier-1")
+			qb.addQuerierWorkerConn(querier1Conn1)
+			querier1Conn2 := NewUnregisteredQuerierWorkerConn("querier-1")
+			qb.addQuerierWorkerConn(querier1Conn2)
+
+			querier2Conn1 := NewUnregisteredQuerierWorkerConn("querier-2")
+			qb.addQuerierWorkerConn(querier2Conn1)
+			querier2Conn2 := NewUnregisteredQuerierWorkerConn("querier-2")
+			qb.addQuerierWorkerConn(querier2Conn2)
+
+			querier3Conn1 := NewUnregisteredQuerierWorkerConn("querier-3")
+			qb.addQuerierWorkerConn(querier3Conn1)
+			querier3Conn2 := NewUnregisteredQuerierWorkerConn("querier-3")
+			qb.addQuerierWorkerConn(querier3Conn2)
+
+			//for i := 1; i <= 3; i++ {
+			//	qb.addQuerierWorkerConn()
+			//	qb.addQuerierWorkerConn(
+			//		NewUnregisteredQuerierWorkerConn(fmt.Sprintf("querier-%d", i)),
+			//	)
+			//	//qb.addQuerierConnection(QuerierID(fmt.Sprintf("querier-%d", i)))
+			//	//qb.addQuerierConnection(QuerierID(fmt.Sprintf("querier-%d", i)))
+			//}
 
 			// Add tenant queues.
 			for i := 0; i < numTenants; i++ {
@@ -544,8 +569,10 @@ func TestQueues_ForgetDelay(t *testing.T) {
 			require.NotEmpty(t, querier1Tenants)
 
 			// Gracefully shutdown querier-1.
-			qb.removeQuerierConnection("querier-1", now.Add(20*time.Second))
-			qb.removeQuerierConnection("querier-1", now.Add(21*time.Second))
+			qb.removeQuerierWorkerConn(querier1Conn1, now.Add(20*time.Second))
+			qb.removeQuerierWorkerConn(querier1Conn2, now.Add(21*time.Second))
+			//qb.removeQuerierConnection("querier-1", now.Add(20*time.Second))
+			//qb.removeQuerierConnection("querier-1", now.Add(21*time.Second))
 			qb.notifyQuerierShutdown("querier-1")
 
 			// We expect querier-1 has been removed.
@@ -558,8 +585,10 @@ func TestQueues_ForgetDelay(t *testing.T) {
 			}
 
 			// Querier-1 reconnects.
-			qb.addQuerierConnection("querier-1")
-			qb.addQuerierConnection("querier-1")
+			//qb.addQuerierConnection("querier-1")
+			//qb.addQuerierConnection("querier-1")
+			qb.addQuerierWorkerConn(querier1Conn1)
+			qb.addQuerierWorkerConn(querier1Conn2)
 
 			// We expect the initial querier-1 tenants have got back to querier-1.
 			for _, tenantID := range querier1Tenants {
@@ -569,8 +598,10 @@ func TestQueues_ForgetDelay(t *testing.T) {
 			}
 
 			// Querier-1 abruptly terminates (no shutdown notification received).
-			qb.removeQuerierConnection("querier-1", now.Add(40*time.Second))
-			qb.removeQuerierConnection("querier-1", now.Add(41*time.Second))
+			//qb.removeQuerierConnection("querier-1", now.Add(40*time.Second))
+			//qb.removeQuerierConnection("querier-1", now.Add(41*time.Second))
+			qb.removeQuerierWorkerConn(querier1Conn1, now.Add(40*time.Second))
+			qb.removeQuerierWorkerConn(querier1Conn2, now.Add(41*time.Second))
 
 			// We expect querier-1 has NOT been removed.
 			assert.Contains(t, qb.tenantQuerierAssignments.queriersByID, QuerierID("querier-1"))
@@ -626,10 +657,20 @@ func TestQueues_ForgetDelay_ShouldCorrectlyHandleQuerierReconnectingBeforeForget
 			assert.NoError(t, isConsistent(qb))
 
 			// 3 queriers open 2 connections each.
-			for i := 1; i <= 3; i++ {
-				qb.addQuerierConnection(QuerierID(fmt.Sprintf("querier-%d", i)))
-				qb.addQuerierConnection(QuerierID(fmt.Sprintf("querier-%d", i)))
-			}
+			querier1Conn1 := NewUnregisteredQuerierWorkerConn("querier-1")
+			qb.addQuerierWorkerConn(querier1Conn1)
+			querier1Conn2 := NewUnregisteredQuerierWorkerConn("querier-1")
+			qb.addQuerierWorkerConn(querier1Conn2)
+
+			querier2Conn1 := NewUnregisteredQuerierWorkerConn("querier-2")
+			qb.addQuerierWorkerConn(querier2Conn1)
+			querier2Conn2 := NewUnregisteredQuerierWorkerConn("querier-2")
+			qb.addQuerierWorkerConn(querier2Conn2)
+
+			querier3Conn1 := NewUnregisteredQuerierWorkerConn("querier-3")
+			qb.addQuerierWorkerConn(querier3Conn1)
+			querier3Conn2 := NewUnregisteredQuerierWorkerConn("querier-3")
+			qb.addQuerierWorkerConn(querier3Conn2)
 
 			// Add tenant queues.
 			for i := 0; i < numTenants; i++ {
@@ -647,8 +688,8 @@ func TestQueues_ForgetDelay_ShouldCorrectlyHandleQuerierReconnectingBeforeForget
 			require.NotEmpty(t, querier1Tenants)
 
 			// Querier-1 abruptly terminates (no shutdown notification received).
-			qb.removeQuerierConnection("querier-1", now.Add(40*time.Second))
-			qb.removeQuerierConnection("querier-1", now.Add(41*time.Second))
+			qb.removeQuerierWorkerConn(querier1Conn1, now.Add(40*time.Second))
+			qb.removeQuerierWorkerConn(querier1Conn2, now.Add(41*time.Second))
 
 			// We expect querier-1 has NOT been removed.
 			assert.Contains(t, qb.tenantQuerierAssignments.queriersByID, QuerierID("querier-1"))
@@ -665,8 +706,8 @@ func TestQueues_ForgetDelay_ShouldCorrectlyHandleQuerierReconnectingBeforeForget
 			qb.forgetDisconnectedQueriers(now.Add(90 * time.Second))
 
 			// Querier-1 reconnects.
-			qb.addQuerierConnection("querier-1")
-			qb.addQuerierConnection("querier-1")
+			qb.addQuerierWorkerConn(querier1Conn1)
+			qb.addQuerierWorkerConn(querier1Conn2)
 
 			assert.Contains(t, qb.tenantQuerierAssignments.queriersByID, QuerierID("querier-1"))
 			assert.NoError(t, isConsistent(qb))

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -426,11 +426,11 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 
 	querierID := resp.GetQuerierID()
 	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(queue.QuerierID(querierID))
-	registeredQuerierWorkerConn, err := s.requestQueue.AwaitRegisterQuerierWorkerConn(querier.Context(), querierWorkerConn)
+	err = s.requestQueue.AwaitRegisterQuerierWorkerConn(querier.Context(), querierWorkerConn)
 	if err != nil {
 		return s.transformRequestQueueError(err)
 	}
-	defer s.requestQueue.SubmitUnregisterQuerierWorkerConn(querier.Context(), registeredQuerierWorkerConn)
+	defer s.requestQueue.SubmitUnregisterQuerierWorkerConn(querier.Context(), querierWorkerConn)
 
 	lastUserIndex := queue.FirstTenant()
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -412,7 +412,7 @@ func (s *Scheduler) transformRequestQueueError(err error) error {
 
 	// the main other error we receive here is if the querier itself is ErrQuerierShuttingDown;
 	// this information was submitted via another endpoint and processed internally
-	// by the RequestQueue's tracking of querier connections. The error bubbles up here
+	// by the RequestQueue's tracking of querier connections. ErrQuerierShuttingDown bubbles up here
 	// as a way to exit this loop and allow the querier to shut down gracefully.
 	return err
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -425,12 +425,12 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 	}
 
 	querierID := resp.GetQuerierID()
-	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(queue.QuerierID(querierID))
-	err = s.requestQueue.AwaitRegisterQuerierWorkerConn(querier.Context(), querierWorkerConn)
+	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(querier.Context(), queue.QuerierID(querierID))
+	err = s.requestQueue.AwaitRegisterQuerierWorkerConn(querierWorkerConn)
 	if err != nil {
 		return s.transformRequestQueueError(err)
 	}
-	defer s.requestQueue.SubmitUnregisterQuerierWorkerConn(querier.Context(), querierWorkerConn)
+	defer s.requestQueue.SubmitUnregisterQuerierWorkerConn(querierWorkerConn)
 
 	lastUserIndex := queue.FirstTenant()
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -523,7 +523,7 @@ func TestSchedulerQuerierMetrics(t *testing.T) {
 		return err == nil
 	}, time.Second, 10*time.Millisecond, "expected cortex_query_scheduler_connected_querier_clients metric to be incremented after querier connected")
 
-	cancel()
+	cancel() // FIND WHERE THIS CANCEL GOES
 	require.NoError(t, util.CloseAndExhaust[*schedulerpb.SchedulerToQuerier](querierLoop))
 
 	require.Eventually(t, func() bool {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -523,7 +523,7 @@ func TestSchedulerQuerierMetrics(t *testing.T) {
 		return err == nil
 	}, time.Second, 10*time.Millisecond, "expected cortex_query_scheduler_connected_querier_clients metric to be incremented after querier connected")
 
-	cancel() // FIND WHERE THIS CANCEL GOES
+	cancel()
 	require.NoError(t, util.CloseAndExhaust[*schedulerpb.SchedulerToQuerier](querierLoop))
 
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR introduces the querier-worker integer ID assignment by the `RequestQueue` via its internal querier-connection tracking `tenantQuerierAssignments`.

The goal is to assign querier-worker connections sequential integer IDs to allow modulo operations to distribute the workers across different request queues in the upcoming version of our request queue tree.

"Missing" IDs from previous disconnections will be allocated to the next connecting worker.

**Example:**
At time _t<sub>0</sub>_, workers, all from the same querier, with IDs 0, 1, 2, 3, and 4 (w<sub>0</sub>, ..., w<sub>4</sub>) are connected to the scheduler.
* _t<sub>1</sub>_: w<sub>0</sub> and w<sub>2</sub> disconnect. 
    * Connected workers: w<sub>1</sub>, w<sub>3</sub>, w<sub>4</sub>
* _t<sub>2</sub>_: a worker connects to the scheduler. It may or may not be the same worker as w<sub>0</sub> @ t<sub>0</sub>. It is assigned ID 0. 
    * Connected workers: w<sub>0'</sub>, w<sub>1</sub>, w<sub>3</sub>, w<sub>4</sub>
* _t<sub>3</sub>_: a worker connects to the scheduler. It is assigned ID 2. 
    * Connected workers: w<sub>0'</sub>, w<sub>1</sub>, w<sub>2'</sub>, w<sub>3</sub>, w<sub>4</sub>
* _t<sub>4</sub>_: a worker connects to the scheduler. It is assigned ID 5. 
    * Connected workers: w<sub>0'</sub>, w<sub>1</sub>, w<sub>2'</sub>, w<sub>3</sub>, w<sub>4</sub>, w<sub>5</sub>

---
This required that a caller submitting a `querierOperation` to the RequestQueue must be able to wait for the operation to be processed before proceeding. For this I introduced an awaitable `querierWorkerOperation` type to replace `querierOperation`, which uses a similar pattern as the `waitingQuerierConn` type, communicating through channels as the indicator that the `dispatcherLoop` has completed processing the request.

I originally made both the `registerConnection` and `unregisterConnection` operation types to be awaitable, but there is no technical reason why un-registering needs to be awaited. Not waiting on `unregisterConnection` makes some of the tests a little nicer to look at and may very very slightly speed up the querier shutdown process, but it's not a big deal in either direction - I leave it up to whoever carries this PR across the line.

---
Similarly I am not strongly opinionated on the pattern I used where the `querierWorkerOperation` uses an empty struct channel to indicate completion and the update is reflected on the `querierWorkerOperation`'s `conn` member that is a pointer to the `QuerierWorkerConn`.
Originally I wanted to just use value types and read the entire full updated value through the channel like this:

```golang
querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(querier.Context(), queue.QuerierID(querierID))
 // registeredQuerierWorkerConn is a different object
registeredQuerierWorkerConn, err = s.requestQueue.AwaitRegisterQuerierWorkerConn(querierWorkerConn)
if err != nil {
	return s.transformRequestQueueError(err)
}
defer s.requestQueue.SubmitUnregisterQuerierWorkerConn(registeredQuerierWorkerConn)
```

instead of what is currently there, which is:

```golang
querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(querier.Context(), queue.QuerierID(querierID))
err = s.requestQueue.AwaitRegisterQuerierWorkerConn(querierWorkerConn)
if err != nil {
	return s.transformRequestQueueError(err)
}
defer s.requestQueue.SubmitUnregisterQuerierWorkerConn(querierWorkerConn)
```

I couldn't really decide which I liked more
When using value types, we need to assign a new value variable and remember not to use the old unregistered one, or reassign the new value to the old variable.
When using the pointer, it just kind of magically updates under our feet which I do not love either.
Not having a second return value from `AwaitRegisterQuerierWorkerConn` also make tests a little nicer, but again I do not have a strong opinion on which pattern is better.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
