### PR TITLE
Chore: replace store_query_gate_ismyturn span with a log

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -746,7 +746,7 @@ func (s *BucketStore) limitConcurrentQueries(ctx context.Context, stats *safeQue
 	waited := time.Since(waitStart)
 
 	stats.update(func(stats *queryStats) { stats.streamingSeriesConcurrencyLimitWaitDuration = waited })
-	level.Info(spanlogger.FromContext(ctx, s.logger)).Log("msg", "waited for turn", "duration", waited)
+	level.Info(spanlogger.FromContext(ctx, s.logger)).Log("msg", "waited for turn on query concurrency gate", "duration", waited)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to wait for turn")

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -741,14 +741,13 @@ func (s *BucketStore) recordRequestAmbientTime(stats *safeQueryStats, requestSta
 }
 
 func (s *BucketStore) limitConcurrentQueries(ctx context.Context, stats *safeQueryStats) (done func(), err error) {
-	span, spanCtx := opentracing.StartSpanFromContext(ctx, "store_query_gate_ismyturn")
-	defer span.Finish()
-
 	waitStart := time.Now()
-	err = s.queryGate.Start(spanCtx)
-	stats.update(func(stats *queryStats) {
-		stats.streamingSeriesConcurrencyLimitWaitDuration = time.Since(waitStart)
-	})
+	err = s.queryGate.Start(ctx)
+	waited := time.Since(waitStart)
+
+	stats.update(func(stats *queryStats) { stats.streamingSeriesConcurrencyLimitWaitDuration = waited })
+	level.Info(spanlogger.FromContext(ctx, s.logger)).Log("msg", "waited for turn", "duration", waited)
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to wait for turn")
 	}


### PR DESCRIPTION
There's no need for this verbose span that is almost always just a few microseconds log. We can just log on the parent span how much time we spent waiting.

I was also tempted to avoid logging at all if it was <1ms wait, but finally preferred to be consistent.

