### PR TITLE
docs: define ALLOY_VERSION

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -10,6 +10,7 @@ keywords:
 cascade:
   MIMIR_VERSION: "v2.13.x"
   GEM_VERSION: "v2.13.x"
+  ALLOY_VERSION: "latest"
 ---
 
 # Grafana mimir-distributed Helm chart documentation

--- a/docs/sources/mimir/_index.md
+++ b/docs/sources/mimir/_index.md
@@ -13,6 +13,8 @@ keywords:
   - metrics storage
   - metrics datastore
   - observability
+cascade:
+  ALLOY_VERSION: "latest"
 menuTitle: Grafana Mimir
 title: Grafana Mimir documentation
 hero:


### PR DESCRIPTION
Otherwise defaults to current mimir or helm chart version, see https://grafana.com/docs/writers-toolkit/write/shortcodes/#about-version-substitution
