### PR TITLE
Alertmanager: Use default Mimir globals in Grafana configuration

### DIFF
--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -18,7 +18,7 @@ import (
 // createUsableGrafanaConfig creates an amConfig from a GrafanaAlertConfigDesc.
 // If provided, it assigns the global section from the Mimir config to the Grafana config.
 // The SMTP and HTTP settings in this section can be used to configure Grafana receivers.
-func createUsableGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc, mCfg *alertspb.AlertConfigDesc) (amConfig, error) {
+func createUsableGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc, rawMimirConfig string) (amConfig, error) {
 	externalURL, err := url.Parse(gCfg.ExternalUrl)
 	if err != nil {
 		return amConfig{}, err
@@ -26,11 +26,11 @@ func createUsableGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc, mCfg *alert
 
 	var amCfg GrafanaAlertmanagerConfig
 	if err := json.Unmarshal([]byte(gCfg.RawConfig), &amCfg); err != nil {
-		return amConfig{}, fmt.Errorf("failed to unmarshal Grafana Alertmanager configuration %w", err)
+		return amConfig{}, fmt.Errorf("failed to unmarshal Grafana Alertmanager configuration: %w", err)
 	}
 
-	if mCfg != nil {
-		cfg, err := definition.LoadCompat([]byte(mCfg.RawConfig))
+	if rawMimirConfig != "" {
+		cfg, err := definition.LoadCompat([]byte(rawMimirConfig))
 		if err != nil {
 			return amConfig{}, fmt.Errorf("failed to unmarshal Mimir Alertmanager configuration: %w", err)
 		}

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package alertmanager
 
 import (

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -20,7 +20,6 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 			"empty grafana config",
 			alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl:   "http://test:3000",
-				Hash:          "abc123",
 				RawConfig:     "",
 				StaticHeaders: map[string]string{"test": "test"},
 			},
@@ -31,7 +30,6 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 			"invalid grafana config",
 			alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl:   "http://test:3000",
-				Hash:          "abc123",
 				RawConfig:     "invalid",
 				StaticHeaders: map[string]string{"test": "test"},
 			},
@@ -42,7 +40,6 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 			"no mimir config",
 			alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl:   "http://test:3000",
-				Hash:          "abc123",
 				RawConfig:     grafanaConfig,
 				StaticHeaders: map[string]string{"test": "test"},
 			},
@@ -53,7 +50,6 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 			"non-empty mimir config",
 			alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl:   "http://test:3000",
-				Hash:          "abc123",
 				RawConfig:     grafanaConfig,
 				StaticHeaders: map[string]string{"test": "test"},
 			},

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/grafana/alerting/definition"
-	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
 )
 
 func TestCreateUsableGrafanaConfig(t *testing.T) {

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -1,0 +1,96 @@
+package alertmanager
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/alerting/definition"
+	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateUsableGrafanaConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		grafanaConfig alertspb.GrafanaAlertConfigDesc
+		mimirConfig   string
+		expErr        string
+	}{
+		{
+			"empty grafana config",
+			alertspb.GrafanaAlertConfigDesc{
+				ExternalUrl:   "http://test:3000",
+				Hash:          "abc123",
+				RawConfig:     "",
+				StaticHeaders: map[string]string{"test": "test"},
+			},
+			simpleConfigOne,
+			"failed to unmarshal Grafana Alertmanager configuration: unexpected end of JSON input",
+		},
+		{
+			"invalid grafana config",
+			alertspb.GrafanaAlertConfigDesc{
+				ExternalUrl:   "http://test:3000",
+				Hash:          "abc123",
+				RawConfig:     "invalid",
+				StaticHeaders: map[string]string{"test": "test"},
+			},
+			simpleConfigOne,
+			"failed to unmarshal Grafana Alertmanager configuration: invalid character 'i' looking for beginning of value",
+		},
+		{
+			"no mimir config",
+			alertspb.GrafanaAlertConfigDesc{
+				ExternalUrl:   "http://test:3000",
+				Hash:          "abc123",
+				RawConfig:     grafanaConfig,
+				StaticHeaders: map[string]string{"test": "test"},
+			},
+			"",
+			"",
+		},
+		{
+			"non-empty mimir config",
+			alertspb.GrafanaAlertConfigDesc{
+				ExternalUrl:   "http://test:3000",
+				Hash:          "abc123",
+				RawConfig:     grafanaConfig,
+				StaticHeaders: map[string]string{"test": "test"},
+			},
+			simpleConfigOne,
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, err := createUsableGrafanaConfig(test.grafanaConfig, test.mimirConfig)
+			if test.expErr != "" {
+				require.Error(t, err)
+				require.Equal(t, test.expErr, err.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.grafanaConfig.StaticHeaders, cfg.staticHeaders)
+			require.Equal(t, test.grafanaConfig.User, cfg.User)
+			require.Equal(t, test.grafanaConfig.ExternalUrl, cfg.tmplExternalURL.String())
+			require.True(t, cfg.usingGrafanaConfig)
+
+			if test.mimirConfig != "" {
+				// The resulting config should contain Mimir's globals.
+				mCfg, err := definition.LoadCompat([]byte(test.mimirConfig))
+				require.NoError(t, err)
+
+				var gCfg GrafanaAlertmanagerConfig
+				require.NoError(t, json.Unmarshal([]byte(test.grafanaConfig.RawConfig), &gCfg))
+
+				gCfg.AlertmanagerConfig.Global = mCfg.Config.Global
+				b, err := json.Marshal(gCfg.AlertmanagerConfig)
+				require.NoError(t, err)
+
+				require.Equal(t, string(b), cfg.RawConfig)
+			}
+		})
+	}
+
+}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -712,11 +712,11 @@ func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs)
 	// Grafana configuration.
 	case cfgs.Mimir.RawConfig == am.fallbackConfig:
 		level.Debug(am.logger).Log("msg", "mimir configuration is default, using grafana config with the default globals", "user", cfgs.Mimir.User)
-		return createUsableGrafanaConfig(cfgs.Grafana, &cfgs.Mimir)
+		return createUsableGrafanaConfig(cfgs.Grafana, cfgs.Mimir.RawConfig)
 
 	case cfgs.Mimir.RawConfig == "":
-		level.Debug(am.logger).Log("msg", "mimir configuration is empty, using grafana config", "user", cfgs.Grafana.User)
-		return createUsableGrafanaConfig(cfgs.Grafana, nil)
+		level.Debug(am.logger).Log("msg", "mimir configuration is empty, using grafana config with the default globals", "user", cfgs.Grafana.User)
+		return createUsableGrafanaConfig(cfgs.Grafana, am.fallbackConfig)
 
 	// Both configurations.
 	// TODO: merge configurations.

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -400,7 +400,7 @@ templates:
 	require.Len(t, am.alertmanagers, 4)
 
 	// The Mimir configuration was empty, so the Grafana configuration should be chosen for user 4.
-	amCfg, err := createUsableGrafanaConfig(userGrafanaCfg, nil)
+	amCfg, err := createUsableGrafanaConfig(userGrafanaCfg, am.fallbackConfig)
 	require.NoError(t, err)
 	grafanaAlertConfigDesc := amCfg.AlertConfigDesc
 	require.Equal(t, grafanaAlertConfigDesc, am.cfgs["user4"])

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2452,9 +2452,6 @@ func TestComputeConfig(t *testing.T) {
 	var grafanaCfg GrafanaAlertmanagerConfig
 	require.NoError(t, json.Unmarshal([]byte(grafanaConfig), &grafanaCfg))
 
-	rawGrafanaCfg, err := json.Marshal(grafanaCfg.AlertmanagerConfig)
-	require.NoError(t, err)
-
 	grafanaExternalURL := "https://grafana.com"
 
 	fallbackCfg, err := definition.LoadCompat([]byte(am.fallbackConfig))
@@ -2567,7 +2564,7 @@ func TestComputeConfig(t *testing.T) {
 			},
 			expCfg: alertspb.AlertConfigDesc{
 				User:      "user",
-				RawConfig: string(rawGrafanaCfg),
+				RawConfig: string(combinedCfg),
 				Templates: []*alertspb.TemplateDesc{},
 			},
 			expURL:     grafanaExternalURL,
@@ -2591,7 +2588,7 @@ func TestComputeConfig(t *testing.T) {
 			},
 			expCfg: alertspb.AlertConfigDesc{
 				User:      "user",
-				RawConfig: string(rawGrafanaCfg),
+				RawConfig: string(combinedCfg),
 				Templates: []*alertspb.TemplateDesc{},
 			},
 			expURL:     grafanaExternalURL,


### PR DESCRIPTION
This PR updates the `computeConfig()` method to use the Alertmanager's default global configuration even if the current config is empty. This allows the Alertmanager to use the default SMTP configuration in the email sender.